### PR TITLE
Comment out global discovery logic in index IDs

### DIFF
--- a/frontend/src/components/modals/CreateIntentModal.tsx
+++ b/frontend/src/components/modals/CreateIntentModal.tsx
@@ -54,9 +54,12 @@ export default function CreateIntentModal({
 
   // Compute final index IDs including global discovery
   const finalIndexIds = useMemo(() => {
+    return selectedIndexIds
+    /*
     return isGlobalDiscoveryEnabled && globalIndexId 
       ? [...selectedIndexIds, globalIndexId] 
       : selectedIndexIds;
+      */
   }, [isGlobalDiscoveryEnabled, globalIndexId, selectedIndexIds]);
 
   // Initialize form data when modal opens


### PR DESCRIPTION
Temporarily disables the addition of the global index ID to the finalIndexIds array by commenting out the related logic. Only selectedIndexIds are now used, possibly for debugging or to address an issue with global discovery.