### PR TITLE
Enable intent broadcast with empty index IDs

### DIFF
--- a/frontend/src/components/modals/CreateIntentModal.tsx
+++ b/frontend/src/components/modals/CreateIntentModal.tsx
@@ -576,7 +576,7 @@ export default function CreateIntentModal({
                   e.preventDefault();
                   handleSubmit(e);
                 }}
-                disabled={finalIndexIds.length === 0 || !payload.trim()}
+                disabled={!payload.trim()}
               >
                 Broadcast Intent
               </Button>


### PR DESCRIPTION
Removes the restriction that required at least one index ID to enable the Broadcast Intent button. The button is now only disabled if the payload is empty.