### PR TITLE
Refactor integration sync to pluggable handlers

### DIFF
--- a/protocol/src/lib/integration-sync.ts
+++ b/protocol/src/lib/integration-sync.ts
@@ -1,210 +1,16 @@
 import fs from 'fs';
 import path from 'path';
 import db from './db';
-import { userIntegrations, intents, intentIndexes, files } from './schema';
-import { eq, and, isNull, gte, desc } from 'drizzle-orm';
+import { userIntegrations, intents, intentIndexes } from './schema';
+import { eq, and, isNull } from 'drizzle-orm';
 import { analyzeFolder } from '../agents/core/intent_inferrer';
-
-// Initialize Composio SDK
-let composio: any;
-const initComposio = async () => {
-  if (!composio) {
-    const { Composio } = await import('@composio/core');
-    composio = new Composio({
-      apiKey: process.env.COMPOSIO_API_KEY,
-    });
-  }
-  return composio;
-};
-
+import { handlers, IntegrationFile } from './integrations';
 
 interface SyncResult {
   success: boolean;
   filesImported: number;
   intentsGenerated: number;
   error?: string;
-}
-
-interface IntegrationFile {
-  id: string;
-  name: string;
-  content: string;
-  lastModified: Date;
-  type: string;
-  size: number;
-}
-
-// Convert Notion blocks to markdown
-function blocksToMarkdown(blocks: any[]): string {
-  let markdown = '';
-
-  for (const block of blocks) {
-    switch (block.type) {
-      case 'paragraph':
-        const text = block.paragraph?.rich_text?.map((t: any) => t.plain_text).join('') || '';
-        markdown += `${text}\n\n`;
-        break;
-      case 'heading_1':
-        const h1Text = block.heading_1?.rich_text?.map((t: any) => t.plain_text).join('') || '';
-        markdown += `# ${h1Text}\n\n`;
-        break;
-      case 'heading_2':
-        const h2Text = block.heading_2?.rich_text?.map((t: any) => t.plain_text).join('') || '';
-        markdown += `## ${h2Text}\n\n`;
-        break;
-      case 'heading_3':
-        const h3Text = block.heading_3?.rich_text?.map((t: any) => t.plain_text).join('') || '';
-        markdown += `### ${h3Text}\n\n`;
-        break;
-      case 'bulleted_list_item':
-        const bulletText = block.bulleted_list_item?.rich_text?.map((t: any) => t.plain_text).join('') || '';
-        markdown += `- ${bulletText}\n`;
-        break;
-      case 'numbered_list_item':
-        const numberText = block.numbered_list_item?.rich_text?.map((t: any) => t.plain_text).join('') || '';
-        markdown += `1. ${numberText}\n`;
-        break;
-      case 'to_do':
-        const todoText = block.to_do?.rich_text?.map((t: any) => t.plain_text).join('') || '';
-        const checked = block.to_do?.checked ? '[x]' : '[ ]';
-        markdown += `${checked} ${todoText}\n`;
-        break;
-      case 'code':
-        const codeText = block.code?.rich_text?.map((t: any) => t.plain_text).join('') || '';
-        const language = block.code?.language || '';
-        markdown += `\`\`\`${language}\n${codeText}\n\`\`\`\n\n`;
-        break;
-      case 'quote':
-        const quoteText = block.quote?.rich_text?.map((t: any) => t.plain_text).join('') || '';
-        markdown += `> ${quoteText}\n\n`;
-        break;
-      case 'divider':
-        markdown += `---\n\n`;
-        break;
-      default:
-        // For other block types, try to extract text content
-        const blockText = block[block.type]?.rich_text?.map((t: any) => t.plain_text).join('') || '';
-        if (blockText) {
-          markdown += `${blockText}\n\n`;
-        }
-        break;
-    }
-  }
-
-  return markdown.trim();
-}
-
-async function fetchNotionFiles(userId: string, lastSyncAt?: Date): Promise<IntegrationFile[]> {
-  try {
-    console.log(`[Integration Sync] Fetching Notion files for user ${userId}. Last sync: ${lastSyncAt?.toISOString() ?? 'never'}`);
-    const composio = await initComposio();
-
-    // Get connected accounts for this user and Notion toolkit
-    const connectedAccounts = await composio.connectedAccounts.list({
-      userIds: [userId],
-      toolkitSlugs: ['notion']
-    });
-    console.log(`[Integration Sync] Connected Notion accounts: ${connectedAccounts.items.length}`);
-
-    if (!connectedAccounts || connectedAccounts.items.length === 0) {
-      console.warn('No connected Notion accounts found for user');
-      return [];
-    }
-
-    const connectedAccountId = connectedAccounts.items[0]?.id;
-    const files: IntegrationFile[] = [];
-
-    try {
-      // Execute Notion search action to get pages
-      const response = await composio.tools.execute("NOTION_SEARCH_NOTION_PAGE", {
-        userId: userId,
-        connectedAccountId,
-        arguments: {
-          query: "",
-          sort: {
-            timestamp: "last_edited_time",
-            direction: "descending"
-          },
-          page_size: 100
-        }
-      });
-
-      // Parse results
-      const results = response.data?.response_data?.results;
-      console.log(`[Integration Sync] Notion search returned ${Array.isArray(results) ? results.length : 0} pages`);
-
-      if (Array.isArray(results)) {
-        for (const item of results) {
-          const lastModified = new Date(item.last_edited_time || new Date());
-          console.log(`[Integration Sync] Processing page ${item.id} last edited ${lastModified.toISOString()}`);
-
-          // Skip if not modified since last sync
-          if (lastSyncAt && lastModified <= lastSyncAt) {
-            console.log(`[Integration Sync] Skipping page ${item.id} - not modified since last sync`);
-            continue;
-          }
-
-          try {
-            // Fetch child blocks for each page
-            const blocksResponse = await composio.tools.execute("NOTION_FETCH_BLOCK_CONTENTS", {
-              userId: userId,
-              connectedAccountId,
-              arguments: {
-                block_id: item.id,
-                page_size: 100
-              }
-            });
-
-            const blocks = blocksResponse.data?.block_child_data?.results || [];
-            console.log(`[Integration Sync] Retrieved ${blocks.length} blocks for page ${item.id}`);
-
-            // Convert blocks to markdown
-            let markdownContent = '';
-
-            // Add page title as main heading
-            const pageTitle = item.properties?.title?.title?.[0]?.plain_text ||
-              item.title?.[0]?.plain_text ||
-              `Notion Page ${item.id}`;
-            markdownContent += `# ${pageTitle}\n\n`;
-
-            // Add page metadata
-            markdownContent += `*Created: ${new Date(item.created_time).toLocaleDateString()}*\n`;
-            markdownContent += `*Last edited: ${new Date(item.last_edited_time).toLocaleDateString()}*\n\n`;
-            markdownContent += `---\n\n`;
-
-            // Convert blocks to markdown
-            if (blocks.length > 0) {
-              markdownContent += blocksToMarkdown(blocks);
-            } else {
-              markdownContent += '*This page has no content blocks.*\n';
-            }
-
-            files.push({
-              id: item.id || `item-${Date.now()}`,
-              name: `${item.id}.md`,
-              content: markdownContent,
-              lastModified,
-              type: 'text/markdown',
-              size: markdownContent.length
-            });
-            console.log(`[Integration Sync] Added file ${item.id}.md (${markdownContent.length} chars)`);
-
-          } catch (blockError) {
-            console.warn(`[Integration Sync] Error fetching blocks for page ${item.id}`, blockError);
-          }
-        }
-      }
-
-    } catch (error) {
-      console.warn('Error executing Notion action:', error);
-    }
-    console.log(`[Integration Sync] Total Notion files fetched: ${files.length}`);
-    return files;
-
-  } catch (error) {
-    console.error('Error fetching Notion files:', error);
-    return [];
-  }
 }
 
 // Save files to temp directory
@@ -286,16 +92,11 @@ export async function syncIntegration(
     const { lastSyncAt } = integration[0];
     console.log(`[Integration Sync] Last sync timestamp: ${lastSyncAt?.toISOString() ?? 'never'}`);
 
-    // Fetch files based on integration type
-    let files: IntegrationFile[] = [];
-
-    switch (integrationType) {
-      case 'notion':
-        files = await fetchNotionFiles(userId, lastSyncAt || undefined);
-        break;
-      default:
-        return { success: false, filesImported: 0, intentsGenerated: 0, error: 'Unsupported integration type' };
+    const handler = handlers[integrationType];
+    if (!handler) {
+      return { success: false, filesImported: 0, intentsGenerated: 0, error: 'Unsupported integration type' };
     }
+    const files = await handler.fetchFiles(userId, lastSyncAt || undefined);
 
     console.log(`[Integration Sync] Retrieved ${files.length} file(s) from ${integrationType}`);
 

--- a/protocol/src/lib/integrations/index.ts
+++ b/protocol/src/lib/integrations/index.ts
@@ -1,0 +1,19 @@
+export interface IntegrationFile {
+  id: string;
+  name: string;
+  content: string;
+  lastModified: Date;
+  type: string;
+  size: number;
+}
+
+export interface IntegrationHandler {
+  fetchFiles(userId: string, lastSyncAt?: Date): Promise<IntegrationFile[]>;
+}
+
+import { notionHandler } from './notion';
+
+export const handlers: Record<string, IntegrationHandler> = {
+  notion: notionHandler,
+};
+

--- a/protocol/src/lib/integrations/notion.ts
+++ b/protocol/src/lib/integrations/notion.ts
@@ -1,0 +1,179 @@
+import type { IntegrationHandler, IntegrationFile } from './index';
+
+let composio: any;
+const initComposio = async () => {
+  if (!composio) {
+    const { Composio } = await import('@composio/core');
+    composio = new Composio({
+      apiKey: process.env.COMPOSIO_API_KEY,
+    });
+  }
+  return composio;
+};
+
+function blocksToMarkdown(blocks: any[]): string {
+  let markdown = '';
+
+  for (const block of blocks) {
+    switch (block.type) {
+      case 'paragraph':
+        const text = block.paragraph?.rich_text?.map((t: any) => t.plain_text).join('') || '';
+        markdown += `${text}\n\n`;
+        break;
+      case 'heading_1':
+        const h1Text = block.heading_1?.rich_text?.map((t: any) => t.plain_text).join('') || '';
+        markdown += `# ${h1Text}\n\n`;
+        break;
+      case 'heading_2':
+        const h2Text = block.heading_2?.rich_text?.map((t: any) => t.plain_text).join('') || '';
+        markdown += `## ${h2Text}\n\n`;
+        break;
+      case 'heading_3':
+        const h3Text = block.heading_3?.rich_text?.map((t: any) => t.plain_text).join('') || '';
+        markdown += `### ${h3Text}\n\n`;
+        break;
+      case 'bulleted_list_item':
+        const bulletText = block.bulleted_list_item?.rich_text?.map((t: any) => t.plain_text).join('') || '';
+        markdown += `- ${bulletText}\n`;
+        break;
+      case 'numbered_list_item':
+        const numberText = block.numbered_list_item?.rich_text?.map((t: any) => t.plain_text).join('') || '';
+        markdown += `1. ${numberText}\n`;
+        break;
+      case 'to_do':
+        const todoText = block.to_do?.rich_text?.map((t: any) => t.plain_text).join('') || '';
+        const checked = block.to_do?.checked ? '[x]' : '[ ]';
+        markdown += `${checked} ${todoText}\n`;
+        break;
+      case 'code':
+        const codeText = block.code?.rich_text?.map((t: any) => t.plain_text).join('') || '';
+        const language = block.code?.language || '';
+        markdown += `\`\`\`${language}\n${codeText}\n\`\`\`\n\n`;
+        break;
+      case 'quote':
+        const quoteText = block.quote?.rich_text?.map((t: any) => t.plain_text).join('') || '';
+        markdown += `> ${quoteText}\n\n`;
+        break;
+      case 'divider':
+        markdown += `---\n\n`;
+        break;
+      default:
+        const blockText = block[block.type]?.rich_text?.map((t: any) => t.plain_text).join('') || '';
+        if (blockText) {
+          markdown += `${blockText}\n\n`;
+        }
+        break;
+    }
+  }
+
+  return markdown.trim();
+}
+
+async function fetchFiles(userId: string, lastSyncAt?: Date): Promise<IntegrationFile[]> {
+  try {
+    console.log(`[Integration Sync] Fetching Notion files for user ${userId}. Last sync: ${lastSyncAt?.toISOString() ?? 'never'}`);
+    const composio = await initComposio();
+
+    const connectedAccounts = await composio.connectedAccounts.list({
+      userIds: [userId],
+      toolkitSlugs: ['notion']
+    });
+    console.log(`[Integration Sync] Connected Notion accounts: ${connectedAccounts.items.length}`);
+
+    if (!connectedAccounts || connectedAccounts.items.length === 0) {
+      console.warn('No connected Notion accounts found for user');
+      return [];
+    }
+
+    const connectedAccountId = connectedAccounts.items[0]?.id;
+    const files: IntegrationFile[] = [];
+
+    try {
+      const response = await composio.tools.execute("NOTION_SEARCH_NOTION_PAGE", {
+        userId: userId,
+        connectedAccountId,
+        arguments: {
+          query: "",
+          sort: {
+            timestamp: "last_edited_time",
+            direction: "descending"
+          },
+          page_size: 100
+        }
+      });
+
+      const results = response.data?.response_data?.results;
+      console.log(`[Integration Sync] Notion search returned ${Array.isArray(results) ? results.length : 0} pages`);
+
+      if (Array.isArray(results)) {
+        for (const item of results) {
+          const lastModified = new Date(item.last_edited_time || new Date());
+          console.log(`[Integration Sync] Processing page ${item.id} last edited ${lastModified.toISOString()}`);
+
+          if (lastSyncAt && lastModified <= lastSyncAt) {
+            console.log(`[Integration Sync] Skipping page ${item.id} - not modified since last sync`);
+            continue;
+          }
+
+          try {
+            const blocksResponse = await composio.tools.execute("NOTION_FETCH_BLOCK_CONTENTS", {
+              userId: userId,
+              connectedAccountId,
+              arguments: {
+                block_id: item.id,
+                page_size: 100
+              }
+            });
+
+            const blocks = blocksResponse.data?.block_child_data?.results || [];
+            console.log(`[Integration Sync] Retrieved ${blocks.length} blocks for page ${item.id}`);
+
+            let markdownContent = '';
+
+            const pageTitle = item.properties?.title?.title?.[0]?.plain_text ||
+              item.title?.[0]?.plain_text ||
+              `Notion Page ${item.id}`;
+            markdownContent += `# ${pageTitle}\n\n`;
+
+            markdownContent += `*Created: ${new Date(item.created_time).toLocaleDateString()}*\n`;
+            markdownContent += `*Last edited: ${new Date(item.last_edited_time).toLocaleDateString()}*\n\n`;
+            markdownContent += `---\n\n`;
+
+            if (blocks.length > 0) {
+              markdownContent += blocksToMarkdown(blocks);
+            } else {
+              markdownContent += '*This page has no content blocks.*\n';
+            }
+
+            files.push({
+              id: item.id || `item-${Date.now()}`,
+              name: `${item.id}.md`,
+              content: markdownContent,
+              lastModified,
+              type: 'text/markdown',
+              size: markdownContent.length
+            });
+            console.log(`[Integration Sync] Added file ${item.id}.md (${markdownContent.length} chars)`);
+
+          } catch (blockError) {
+            console.warn(`[Integration Sync] Error fetching blocks for page ${item.id}`, blockError);
+          }
+        }
+      }
+
+    } catch (error) {
+      console.warn('Error executing Notion action:', error);
+    }
+    console.log(`[Integration Sync] Total Notion files fetched: ${files.length}`);
+    return files;
+
+  } catch (error) {
+    console.error('Error fetching Notion files:', error);
+    return [];
+  }
+}
+
+export const notionHandler: IntegrationHandler = {
+  fetchFiles,
+};
+


### PR DESCRIPTION
## Summary
- add `IntegrationHandler` interface and handler map
- extract Notion sync logic into `integrations/notion`
- switch to handler lookup in `syncIntegration`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: ESLint couldn't find the config "next/core-web-vitals")*


------
https://chatgpt.com/codex/tasks/task_e_68a0d001119483248edf1156f72310d8