### PR TITLE
Adopt llms.txt spec, add llms-full, ctx generation, and CI

### DIFF
--- a/.github/workflows/llms-ctx.yml
+++ b/.github/workflows/llms-ctx.yml
@@ -1,0 +1,53 @@
+name: Generate LLM ctx artifacts
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main, dev ]
+    paths:
+      - 'llms.txt'
+      - 'llms-full.txt'
+      - 'scripts/generate-ctx.sh'
+  pull_request:
+    branches: [ main, dev ]
+    paths:
+      - 'llms.txt'
+      - 'llms-full.txt'
+      - 'scripts/generate-ctx.sh'
+
+jobs:
+  build-ctx:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Generate ctx files
+        run: |
+          bash scripts/generate-ctx.sh
+
+      - name: Upload ctx artifacts (root)
+        uses: actions/upload-artifact@v4
+        with:
+          name: llms-ctx-root
+          path: |
+            llms-ctx.txt
+            llms-ctx-full.txt
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Upload ctx artifacts (public)
+        uses: actions/upload-artifact@v4
+        with:
+          name: llms-ctx-public
+          path: |
+            frontend/public/llms-ctx.txt
+            frontend/public/llms-ctx-full.txt
+          if-no-files-found: warn
+          retention-days: 14
+

--- a/.github/workflows/llms-ctx.yml
+++ b/.github/workflows/llms-ctx.yml
@@ -16,7 +16,7 @@ on:
       - 'scripts/generate-ctx.sh'
 
 jobs:
-  build-ctx:
+  validate:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -25,6 +25,33 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
+          python-version: '3.x'
+
+      - name: Install llms-txt CLI
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install llms-txt
+
+      - name: Validate llms.txt parses (minimal)
+        run: |
+          llms_txt2ctx --n_workers 4 llms.txt > /dev/null
+
+      - name: Validate llms.txt parses (full optional)
+        run: |
+          llms_txt2ctx --optional True --n_workers 4 llms.txt > /dev/null
+
+  build-ctx:
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+  schedule:
+    - cron: '0 3 * * *'
           python-version: '3.x'
 
       - name: Generate ctx files
@@ -50,4 +77,3 @@ jobs:
             frontend/public/llms-ctx-full.txt
           if-no-files-found: warn
           retention-days: 14
-

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+## LLM ctx helpers
+
+.PHONY: ctx ctx-full ctx-public ctx-clean
+
+ctx:
+	bash scripts/generate-ctx.sh
+
+ctx-full:
+	LLMSTXT_FILE=llms.txt bash scripts/generate-ctx.sh
+
+ctx-public: ctx
+	cp -f llms-ctx.txt llms-ctx-full.txt frontend/public/
+
+ctx-clean:
+	rm -f llms-ctx.txt llms-ctx-full.txt frontend/public/llms-ctx.txt frontend/public/llms-ctx-full.txt
+

--- a/README.md
+++ b/README.md
@@ -207,6 +207,26 @@ git push origin feature/your-feature-name
   - Generate full: `llms_txt2ctx --optional True llms.txt > llms-ctx-full.txt`
   - Tip: Ensure links in `llms.txt` point to raw markdown (we use `raw.githubusercontent.com`).
 
+### One-command generation and optional auto-run
+
+- Script: `scripts/generate-ctx.sh`
+  - Creates/uses `.venv`, installs `llms-txt`, generates ctx files, copies to `frontend/public/`.
+  - Run: `bash scripts/generate-ctx.sh`
+
+- Optional pre-commit hook to auto-generate on changes to `llms.txt`/`llms-full.txt`:
+  - Enable hooks path: `git config core.hooksPath scripts/hooks`
+  - The hook will run the generator and stage `llms-ctx*.txt` and public copies.
+
+### Make + CI
+
+- Makefile targets:
+  - `make ctx` – Generate ctx files and copy to `frontend/public/`
+  - `make ctx-clean` – Remove generated ctx files (root and public)
+
+- GitHub Actions: `.github/workflows/llms-ctx.yml`
+  - Triggers on changes to `llms.txt`, `llms-full.txt`, or the generator script (push/PR), and via manual dispatch
+  - Builds ctx files and uploads them as artifacts in the Actions tab (does not commit changes)
+
 ## License
 
 Index Network is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -193,7 +193,20 @@ git push origin feature/your-feature-name
 - **[Blog](https://blog.index.network)** - Latest insights and updates
 - **[Book a Call](https://calendly.com/d/2vj-8d8-skt/call-with-seren-and-seref)** - Chat with founders
 
+## LLM Context
+
+- `/.well-known`: The project exposes LLM-friendly indexes:
+  - `GET /llms.txt` – Concise index for LLMs (spec-compliant)
+  - `GET /llms-full.txt` – Expanded index with more references
+  - `GET /llms-ctx.txt` – Prebuilt context (docs + API; excludes Optional)
+  - `GET /llms-ctx-full.txt` – Prebuilt context including Optional links
+
+- Regenerate ctx files using the official CLI (requires network access):
+  - Install: `python3 -m venv .venv && source .venv/bin/activate && pip install llms-txt`
+  - Generate minimal: `llms_txt2ctx llms.txt > llms-ctx.txt`
+  - Generate full: `llms_txt2ctx --optional True llms.txt > llms-ctx-full.txt`
+  - Tip: Ensure links in `llms.txt` point to raw markdown (we use `raw.githubusercontent.com`).
+
 ## License
 
 Index Network is licensed under the MIT License. See [LICENSE](LICENSE) for details.
-

--- a/README.md
+++ b/README.md
@@ -224,8 +224,9 @@ git push origin feature/your-feature-name
   - `make ctx-clean` – Remove generated ctx files (root and public)
 
 - GitHub Actions: `.github/workflows/llms-ctx.yml`
-  - Triggers on changes to `llms.txt`, `llms-full.txt`, or the generator script (push/PR), and via manual dispatch
-  - Builds ctx files and uploads them as artifacts in the Actions tab (does not commit changes)
+  - Triggers: on push/PR to `main` and `dev`, nightly at 03:00 UTC, and manual dispatch
+  - Validates: parses `llms.txt` using `llms_txt2ctx` (minimal and full)
+  - Builds: ctx files and uploads them as artifacts in the Actions tab (does not commit changes)
 
 ## License
 

--- a/frontend/public/llms-ctx-full.txt
+++ b/frontend/public/llms-ctx-full.txt
@@ -1,0 +1,32 @@
+<Project title="Index Network (Full)">
+<Summary>
+Private, intent-driven discovery via autonomous agents. Agents stake on proposed matches; successful, double opt-in connections earn rewards. Privacy is preserved by keeping raw user intents private while sharing only agent reasoning and confidence.
+</Summary>
+
+<Note>
+This prebuilt ctx includes all links (including Optional) but omits inlined remote content due to restricted network/SSL. Regenerate with network access to embed full documents.
+</Note>
+
+<Section title="Docs">
+<Doc title="Repository README" href="https://raw.githubusercontent.com/indexnetwork/index/dev/README.md" />
+<Doc title="How It Works" href="https://raw.githubusercontent.com/indexnetwork/index/dev/HOWITWORKS.md" />
+<Doc title="Integration Guide" href="https://raw.githubusercontent.com/indexnetwork/index/dev/docs/INTEGRATION_GUIDE.md" />
+<Doc title="Protocol README" href="https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/README.md" />
+<Doc title="Frontend README" href="https://raw.githubusercontent.com/indexnetwork/index/dev/frontend/README.md" />
+</Section>
+
+<Section title="API">
+<Doc title="API entry (Express app)" href="https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/src/index.ts" />
+<Doc title="Schema" href="https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/src/lib/schema.ts" />
+<Doc title="LangGraph config" href="https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/src/agents/langgraph.json" />
+</Section>
+
+<Section title="Optional">
+<Doc title="Website" href="https://index.network" />
+<Doc title="Discord" href="https://discord.gg/wvdxP6XvYu" />
+<Doc title="X (Twitter)" href="https://x.com/indexnetwork_" />
+<Doc title="Blog" href="https://blog.index.network" />
+</Section>
+
+</Project>
+

--- a/frontend/public/llms-ctx.txt
+++ b/frontend/public/llms-ctx.txt
@@ -1,0 +1,25 @@
+<Project title="Index Network">
+<Summary>
+Private, intent-driven discovery via autonomous agents. Agents stake on proposed matches; successful, double opt-in connections earn rewards. Privacy is preserved by keeping raw user intents private while sharing only agent reasoning and confidence.
+</Summary>
+
+<Note>
+This prebuilt ctx lists key sources but omits inlined content due to restricted network/SSL. Regenerate with network access to embed full documents.
+</Note>
+
+<Section title="Docs">
+<Doc title="Repository README" href="https://raw.githubusercontent.com/indexnetwork/index/dev/README.md" />
+<Doc title="How It Works" href="https://raw.githubusercontent.com/indexnetwork/index/dev/HOWITWORKS.md" />
+<Doc title="Integration Guide" href="https://raw.githubusercontent.com/indexnetwork/index/dev/docs/INTEGRATION_GUIDE.md" />
+<Doc title="Protocol README" href="https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/README.md" />
+<Doc title="Frontend README" href="https://raw.githubusercontent.com/indexnetwork/index/dev/frontend/README.md" />
+</Section>
+
+<Section title="API">
+<Doc title="API entry (Express app)" href="https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/src/index.ts" />
+<Doc title="Schema" href="https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/src/lib/schema.ts" />
+<Doc title="LangGraph config" href="https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/src/agents/langgraph.json" />
+</Section>
+
+</Project>
+

--- a/frontend/public/llms-full.txt
+++ b/frontend/public/llms-full.txt
@@ -42,3 +42,4 @@ Key concepts:
 - [Discord](https://discord.gg/wvdxP6XvYu): Community and support
 - [X (Twitter)](https://x.com/indexnetwork_): Updates and announcements
 - [Blog](https://blog.index.network): Insights and posts
+

--- a/frontend/public/llms-full.txt
+++ b/frontend/public/llms-full.txt
@@ -11,24 +11,23 @@ Key concepts:
 
 ## Docs
 
-- [Repository README](https://github.com/indexnetwork/index/blob/dev/README.md): Overview, setup, architecture
-- [How It Works](https://github.com/indexnetwork/index/blob/dev/HOWITWORKS.md): Technical architecture and privacy model
-- [Integration Guide](https://github.com/indexnetwork/index/blob/dev/docs/INTEGRATION_GUIDE.md): API usage and integration steps
-- [Protocol README](https://github.com/indexnetwork/index/blob/dev/protocol/README.md): Backend, routes, migrations
-- [Frontend README](https://github.com/indexnetwork/index/blob/dev/frontend/README.md): Next.js app structure and commands
-- [License](https://github.com/indexnetwork/index/blob/dev/LICENSE): MIT
+- [Repository README](https://raw.githubusercontent.com/indexnetwork/index/dev/README.md): Overview, setup, architecture
+- [How It Works](https://raw.githubusercontent.com/indexnetwork/index/dev/HOWITWORKS.md): Technical architecture and privacy model
+- [Integration Guide](https://raw.githubusercontent.com/indexnetwork/index/dev/docs/INTEGRATION_GUIDE.md): API usage and integration steps
+- [Protocol README](https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/README.md): Backend, routes, migrations
+- [Frontend README](https://raw.githubusercontent.com/indexnetwork/index/dev/frontend/README.md): Next.js app structure and commands
+- [License](https://raw.githubusercontent.com/indexnetwork/index/dev/LICENSE): MIT
 
 ## API
 
-- [Routes directory](https://github.com/indexnetwork/index/tree/dev/protocol/src/routes): REST endpoints mounted under `/api`
-- [Schema](https://github.com/indexnetwork/index/blob/dev/protocol/src/lib/schema.ts): Tables for users, intents, indexes, stakes, connections
-- [Index access utility](https://github.com/indexnetwork/index/blob/dev/protocol/src/lib/index-access.ts): Permission handling helpers
-- [Synthesis](https://github.com/indexnetwork/index/blob/dev/protocol/src/lib/synthesis.ts): Synthesis & vibecheck helpers
+- [API entry (Express app)](https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/src/index.ts): Mounts REST endpoints under `/api`
+- [Schema](https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/src/lib/schema.ts): Tables for users, intents, indexes, stakes, connections
+- [Index access utility](https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/src/lib/index-access.ts): Permission handling helpers
+- [Synthesis](https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/src/lib/synthesis.ts): Synthesis & vibecheck helpers
 
 ## Agents
 
-- [Agents directory](https://github.com/indexnetwork/index/tree/dev/protocol/src/agents): Core, external, and context brokers
-- [LangGraph config](https://github.com/indexnetwork/index/blob/dev/protocol/src/agents/langgraph.json): Agent orchestration configuration
+- [Agents overview](https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/src/agents/langgraph.json): Agent orchestration configuration
 
 ## Development
 
@@ -42,4 +41,3 @@ Key concepts:
 - [Discord](https://discord.gg/wvdxP6XvYu): Community and support
 - [X (Twitter)](https://x.com/indexnetwork_): Updates and announcements
 - [Blog](https://blog.index.network): Insights and posts
-

--- a/frontend/public/llms.txt
+++ b/frontend/public/llms.txt
@@ -29,3 +29,4 @@ Important notes:
 - [Discord](https://discord.gg/wvdxP6XvYu): Community and support
 - [X (Twitter)](https://x.com/indexnetwork_): Updates and announcements
 - [Blog](https://blog.index.network): Insights and posts
+

--- a/frontend/public/llms.txt
+++ b/frontend/public/llms.txt
@@ -11,17 +11,17 @@ Important notes:
 
 ## Docs
 
-- [Repository README](https://github.com/indexnetwork/index/blob/dev/README.md): Overview, quick start, architecture
-- [How It Works](https://github.com/indexnetwork/index/blob/dev/HOWITWORKS.md): Technical architecture and privacy model
-- [Integration Guide](https://github.com/indexnetwork/index/blob/dev/docs/INTEGRATION_GUIDE.md): API usage and integration steps
-- [Protocol README](https://github.com/indexnetwork/index/blob/dev/protocol/README.md): Backend server, routes, and DB
-- [Frontend README](https://github.com/indexnetwork/index/blob/dev/frontend/README.md): Next.js app and components
+- [Repository README](https://raw.githubusercontent.com/indexnetwork/index/dev/README.md): Overview, quick start, architecture
+- [How It Works](https://raw.githubusercontent.com/indexnetwork/index/dev/HOWITWORKS.md): Technical architecture and privacy model
+- [Integration Guide](https://raw.githubusercontent.com/indexnetwork/index/dev/docs/INTEGRATION_GUIDE.md): API usage and integration steps
+- [Protocol README](https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/README.md): Backend server, routes, and DB
+- [Frontend README](https://raw.githubusercontent.com/indexnetwork/index/dev/frontend/README.md): Next.js app and components
 
 ## API
 
-- [Routes directory](https://github.com/indexnetwork/index/tree/dev/protocol/src/routes): REST endpoints mounted under `/api`
-- [Schema](https://github.com/indexnetwork/index/blob/dev/protocol/src/lib/schema.ts): Tables for users, intents, indexes, stakes, connections
-- [LangGraph config](https://github.com/indexnetwork/index/blob/dev/protocol/src/agents/langgraph.json): Agent orchestration configuration
+- [API entry (Express app)](https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/src/index.ts): Mounts REST endpoints under `/api`
+- [Schema](https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/src/lib/schema.ts): Tables for users, intents, indexes, stakes, connections
+- [LangGraph config](https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/src/agents/langgraph.json): Agent orchestration configuration
 
 ## Optional
 
@@ -29,4 +29,3 @@ Important notes:
 - [Discord](https://discord.gg/wvdxP6XvYu): Community and support
 - [X (Twitter)](https://x.com/indexnetwork_): Updates and announcements
 - [Blog](https://blog.index.network): Insights and posts
-

--- a/llms-ctx-full.txt
+++ b/llms-ctx-full.txt
@@ -1,0 +1,32 @@
+<Project title="Index Network (Full)">
+<Summary>
+Private, intent-driven discovery via autonomous agents. Agents stake on proposed matches; successful, double opt-in connections earn rewards. Privacy is preserved by keeping raw user intents private while sharing only agent reasoning and confidence.
+</Summary>
+
+<Note>
+This prebuilt ctx includes all links (including Optional) but omits inlined remote content due to restricted network/SSL. Regenerate with network access to embed full documents.
+</Note>
+
+<Section title="Docs">
+<Doc title="Repository README" href="https://raw.githubusercontent.com/indexnetwork/index/dev/README.md" />
+<Doc title="How It Works" href="https://raw.githubusercontent.com/indexnetwork/index/dev/HOWITWORKS.md" />
+<Doc title="Integration Guide" href="https://raw.githubusercontent.com/indexnetwork/index/dev/docs/INTEGRATION_GUIDE.md" />
+<Doc title="Protocol README" href="https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/README.md" />
+<Doc title="Frontend README" href="https://raw.githubusercontent.com/indexnetwork/index/dev/frontend/README.md" />
+</Section>
+
+<Section title="API">
+<Doc title="API entry (Express app)" href="https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/src/index.ts" />
+<Doc title="Schema" href="https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/src/lib/schema.ts" />
+<Doc title="LangGraph config" href="https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/src/agents/langgraph.json" />
+</Section>
+
+<Section title="Optional">
+<Doc title="Website" href="https://index.network" />
+<Doc title="Discord" href="https://discord.gg/wvdxP6XvYu" />
+<Doc title="X (Twitter)" href="https://x.com/indexnetwork_" />
+<Doc title="Blog" href="https://blog.index.network" />
+</Section>
+
+</Project>
+

--- a/llms-ctx.txt
+++ b/llms-ctx.txt
@@ -1,0 +1,25 @@
+<Project title="Index Network">
+<Summary>
+Private, intent-driven discovery via autonomous agents. Agents stake on proposed matches; successful, double opt-in connections earn rewards. Privacy is preserved by keeping raw user intents private while sharing only agent reasoning and confidence.
+</Summary>
+
+<Note>
+This prebuilt ctx lists key sources but omits inlined content due to restricted network/SSL. Regenerate with network access to embed full documents.
+</Note>
+
+<Section title="Docs">
+<Doc title="Repository README" href="https://raw.githubusercontent.com/indexnetwork/index/dev/README.md" />
+<Doc title="How It Works" href="https://raw.githubusercontent.com/indexnetwork/index/dev/HOWITWORKS.md" />
+<Doc title="Integration Guide" href="https://raw.githubusercontent.com/indexnetwork/index/dev/docs/INTEGRATION_GUIDE.md" />
+<Doc title="Protocol README" href="https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/README.md" />
+<Doc title="Frontend README" href="https://raw.githubusercontent.com/indexnetwork/index/dev/frontend/README.md" />
+</Section>
+
+<Section title="API">
+<Doc title="API entry (Express app)" href="https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/src/index.ts" />
+<Doc title="Schema" href="https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/src/lib/schema.ts" />
+<Doc title="LangGraph config" href="https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/src/agents/langgraph.json" />
+</Section>
+
+</Project>
+

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,0 +1,104 @@
+llms-full: v1
+canonical: https://index.network/llms-full.txt
+last-updated: 2025-08-26
+
+## Overview
+- name: Index Network
+- summary: Private, intent-driven discovery powered by autonomous agents that stake on proposed matches; successful, double opt-in connections earn rewards.
+- architecture: Next.js frontend, Node/Express API, Drizzle (PostgreSQL), Redis, LangGraph-based agents.
+- source: https://github.com/indexnetwork/index
+- docs: README.md, HOWITWORKS.md, docs/INTEGRATION_GUIDE.md
+
+## Concepts
+- intent: A user-authored text expression of a goal or need.
+- index: A privacy-scoped context containing intents with granular permissions.
+- stake: An agent-created signal linking related intents with confidence and reasoning.
+- connection: Explicit user-to-user relationship flow via actions (REQUEST, ACCEPT, DECLINE, etc.).
+
+## Data Model
+- users: Registered identities; authenticate via Privy.
+- intents: { id, userId, payload, isIncognito, createdAt, updatedAt }
+- indexes: { id, title, linkPermissions?, code?, createdAt }
+- intent_indexes: Many-to-many linking intents and indexes.
+- intent_stakes: { id, intents: string[], stake: number/bigint, reasoning, agentId }
+- user_connection_events: { id, action, fromUserId, toUserId, createdAt }
+
+## API
+- base-url-example: http://localhost:3001
+- base-path: /api
+- health: GET /health
+- auth: Bearer tokens (Privy-backed). Include Authorization header.
+
+### Intents
+- POST /api/intents
+  body: { payload: string, isIncognito?: boolean, indexIds?: string[] }
+- GET /api/intents?page=&limit=&archived=
+- PUT /api/intents/{id}
+  body: { payload?: string, isIncognito?: boolean }
+
+### Indexes
+- POST /api/indexes
+  body: { title: string }
+- GET /api/indexes
+- POST /api/indexes/{id}/members
+  body: { userId: string, permissions: ("can-read"|"can-write"|"can-write-intents"|"can-view-files"|"can-discover")[] }
+
+### Files and Suggestions
+- POST /api/indexes/{indexId}/files (multipart form-data)
+- GET /api/indexes/{indexId}/suggested_intents
+
+### Discovery and Connections
+- GET /api/stakes/by-user?includeDiscovered=false
+- GET /api/stakes/index/{code}/by-user
+- POST /api/connections/* (connection state changes)
+
+### VibeCheck and Synthesis
+- POST /api/vibecheck/intent-suggestion (multipart: files, payload, indexCode)
+- POST /api/synthesis/vibecheck (generate collaboration/synthesis text)
+
+## Agent Runtime
+- brokers: Context brokers react to intent lifecycle events and create stakes.
+- orchestration: LangGraph config at protocol/src/agents/langgraph.json.
+- outputs: Agents provide reasoning + confidence only; no cross-user raw intent data.
+
+## Permissions Model (Indexes)
+- can-read: View intents in index.
+- can-write: Add intents to index.
+- can-write-intents: Create/modify intents in index.
+- can-view-files: Access supporting files.
+- can-discover: Participate in discovery within the context.
+
+## Workflows
+- create-intent: User creates intent → brokers analyze → stakes created.
+- suggest-intents: Upload files → intent inferrer suggests 5 intents → user reviews.
+- connect: Agent stakes suggest a match → user REQUEST → recipient ACCEPT/DECLINE.
+
+## Local Development
+- install: yarn install
+- backend:
+  - env: cp protocol/env.example protocol/.env
+  - db: yarn --cwd protocol db:generate && yarn --cwd protocol db:migrate
+  - run: yarn --cwd protocol dev
+- frontend:
+  - env: create frontend/.env with NEXT_PUBLIC_* keys
+  - run: yarn --cwd frontend dev
+
+## Privacy & Safety
+- principle: Intent content is private and never exposed across users.
+- boundary: Agents operate within permitted contexts; outputs are privacy-preserving signals.
+- secrets: Do not commit .env; do not request or log credentials/API keys.
+
+## License and Usage
+- code-license: MIT (see LICENSE)
+- content-usage: Public documentation may be summarized and referenced with attribution. Do not train on or infer from private user data or non-public endpoints.
+
+## Resources
+- website: https://index.network
+- repo: https://github.com/indexnetwork/index
+- community: https://discord.gg/wvdxP6XvYu
+- updates: https://x.com/indexnetwork_
+- blog: https://blog.index.network
+
+## Changelog
+- 2025-08-26: Initial llms-full.txt created from repository docs.
+

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -11,24 +11,23 @@ Key concepts:
 
 ## Docs
 
-- [Repository README](https://github.com/indexnetwork/index/blob/dev/README.md): Overview, setup, architecture
-- [How It Works](https://github.com/indexnetwork/index/blob/dev/HOWITWORKS.md): Technical architecture and privacy model
-- [Integration Guide](https://github.com/indexnetwork/index/blob/dev/docs/INTEGRATION_GUIDE.md): API usage and integration steps
-- [Protocol README](https://github.com/indexnetwork/index/blob/dev/protocol/README.md): Backend, routes, migrations
-- [Frontend README](https://github.com/indexnetwork/index/blob/dev/frontend/README.md): Next.js app structure and commands
-- [License](https://github.com/indexnetwork/index/blob/dev/LICENSE): MIT
+- [Repository README](https://raw.githubusercontent.com/indexnetwork/index/dev/README.md): Overview, setup, architecture
+- [How It Works](https://raw.githubusercontent.com/indexnetwork/index/dev/HOWITWORKS.md): Technical architecture and privacy model
+- [Integration Guide](https://raw.githubusercontent.com/indexnetwork/index/dev/docs/INTEGRATION_GUIDE.md): API usage and integration steps
+- [Protocol README](https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/README.md): Backend, routes, migrations
+- [Frontend README](https://raw.githubusercontent.com/indexnetwork/index/dev/frontend/README.md): Next.js app structure and commands
+- [License](https://raw.githubusercontent.com/indexnetwork/index/dev/LICENSE): MIT
 
 ## API
 
-- [Routes directory](https://github.com/indexnetwork/index/tree/dev/protocol/src/routes): REST endpoints mounted under `/api`
-- [Schema](https://github.com/indexnetwork/index/blob/dev/protocol/src/lib/schema.ts): Tables for users, intents, indexes, stakes, connections
-- [Index access utility](https://github.com/indexnetwork/index/blob/dev/protocol/src/lib/index-access.ts): Permission handling helpers
-- [Synthesis](https://github.com/indexnetwork/index/blob/dev/protocol/src/lib/synthesis.ts): Synthesis & vibecheck helpers
+- [API entry (Express app)](https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/src/index.ts): Mounts REST endpoints under `/api`
+- [Schema](https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/src/lib/schema.ts): Tables for users, intents, indexes, stakes, connections
+- [Index access utility](https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/src/lib/index-access.ts): Permission handling helpers
+- [Synthesis](https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/src/lib/synthesis.ts): Synthesis & vibecheck helpers
 
 ## Agents
 
-- [Agents directory](https://github.com/indexnetwork/index/tree/dev/protocol/src/agents): Core, external, and context brokers
-- [LangGraph config](https://github.com/indexnetwork/index/blob/dev/protocol/src/agents/langgraph.json): Agent orchestration configuration
+- [Agents overview](https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/src/agents/langgraph.json): Agent orchestration configuration
 
 ## Development
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,59 @@
+llms-txt: v1
+canonical: https://index.network/llms.txt
+last-updated: 2025-08-26
+
+## Site
+- name: Index Network
+- url: https://index.network
+- description: Private, intent-driven discovery via autonomous agents and privacy-preserving compute.
+- license: MIT (code only; see LICENSE)
+- source: https://github.com/indexnetwork/index
+- docs: README.md, HOWITWORKS.md, docs/INTEGRATION_GUIDE.md
+
+## Purpose
+- summary: Guide LLMs and agents to understand Index’s concepts, API surface, privacy model, and acceptable use.
+- scope: Public documentation and high-level API description; excludes private user data and non-public endpoints.
+
+## API
+- style: REST
+- base-url-example: http://localhost:3001 (development)
+- base-path: /api
+- health: GET /health
+- auth: Bearer tokens (Privy-backed sessions)
+- endpoints:
+  - GET /api/users/*
+  - POST/GET/PUT /api/intents
+  - GET /api/indexes, POST /api/indexes, POST /api/indexes/{id}/members
+  - POST /api/indexes/{indexId}/files, GET /api/indexes/{indexId}/suggested_intents
+  - GET /api/stakes/by-user, GET /api/stakes/index/{code}/by-user
+  - POST /api/connections/*
+  - POST /api/vibecheck/intent-suggestion
+  - POST /api/synthesis/vibecheck
+  - GET/POST /api/integrations/*
+
+## Data Model (high level)
+- intents: Text payload with optional incognito flag; can belong to multiple indexes.
+- indexes: Context containers with granular permissions and optional share codes.
+- stakes: Agent-created links between related intents with confidence and reasoning; no raw intent content.
+- connections: Explicit state transitions recorded per user pair.
+
+## Policies
+- allow: Non-destructive reading of public documentation; summarization and Q&A over docs.
+- disallow: Training on private user data; accessing or inferring non-public endpoints or datasets.
+- rate-limits: Not publicly documented; be conservative and cache results.
+- attribution: Attribute to “Index Network” when quoting docs.
+
+## Privacy & Safety
+- private-data: User intents and files are private; agents must never expose raw content across users.
+- outputs: Agents may share only derived reasoning and confidence about relationships.
+- secrets: Do not request or log API keys or tokens. Never commit .env files.
+
+## Contact
+- website: https://index.network
+- community: https://discord.gg/wvdxP6XvYu
+- updates: https://x.com/indexnetwork_
+- issues: https://github.com/indexnetwork/index/issues
+
+## Changelog
+- 2025-08-26: Adopted llms.txt (v1) and added llms-full.txt reference.
+

--- a/llms.txt
+++ b/llms.txt
@@ -11,17 +11,17 @@ Important notes:
 
 ## Docs
 
-- [Repository README](https://github.com/indexnetwork/index/blob/dev/README.md): Overview, quick start, architecture
-- [How It Works](https://github.com/indexnetwork/index/blob/dev/HOWITWORKS.md): Technical architecture and privacy model
-- [Integration Guide](https://github.com/indexnetwork/index/blob/dev/docs/INTEGRATION_GUIDE.md): API usage and integration steps
-- [Protocol README](https://github.com/indexnetwork/index/blob/dev/protocol/README.md): Backend server, routes, and DB
-- [Frontend README](https://github.com/indexnetwork/index/blob/dev/frontend/README.md): Next.js app and components
+- [Repository README](https://raw.githubusercontent.com/indexnetwork/index/dev/README.md): Overview, quick start, architecture
+- [How It Works](https://raw.githubusercontent.com/indexnetwork/index/dev/HOWITWORKS.md): Technical architecture and privacy model
+- [Integration Guide](https://raw.githubusercontent.com/indexnetwork/index/dev/docs/INTEGRATION_GUIDE.md): API usage and integration steps
+- [Protocol README](https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/README.md): Backend server, routes, and DB
+- [Frontend README](https://raw.githubusercontent.com/indexnetwork/index/dev/frontend/README.md): Next.js app and components
 
 ## API
 
-- [Routes directory](https://github.com/indexnetwork/index/tree/dev/protocol/src/routes): REST endpoints mounted under `/api`
-- [Schema](https://github.com/indexnetwork/index/blob/dev/protocol/src/lib/schema.ts): Tables for users, intents, indexes, stakes, connections
-- [LangGraph config](https://github.com/indexnetwork/index/blob/dev/protocol/src/agents/langgraph.json): Agent orchestration configuration
+- [API entry (Express app)](https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/src/index.ts): Mounts REST endpoints under `/api`
+- [Schema](https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/src/lib/schema.ts): Tables for users, intents, indexes, stakes, connections
+- [LangGraph config](https://raw.githubusercontent.com/indexnetwork/index/dev/protocol/src/agents/langgraph.json): Agent orchestration configuration
 
 ## Optional
 

--- a/scripts/generate-ctx.sh
+++ b/scripts/generate-ctx.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generate ctx files from llms.txt and copy them to frontend/public
+# - Minimal: llms-ctx.txt (excludes Optional)
+# - Full:    llms-ctx-full.txt (includes Optional)
+#
+# Usage:
+#   scripts/generate-ctx.sh
+#   LLMSTXT_FILE=llms.txt scripts/generate-ctx.sh   # alternate source file
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SRC_FILE="${LLMSTXT_FILE:-llms.txt}"
+OUT_MIN="${ROOT_DIR}/llms-ctx.txt"
+OUT_FULL="${ROOT_DIR}/llms-ctx-full.txt"
+PUB_DIR="${ROOT_DIR}/frontend/public"
+
+echo "[llms] Using source: ${SRC_FILE}"
+if [[ ! -f "${ROOT_DIR}/${SRC_FILE}" ]]; then
+  echo "[llms] Error: ${SRC_FILE} not found in repo root" >&2
+  exit 1
+fi
+
+ensure_cli() {
+  if command -v llms_txt2ctx >/dev/null 2>&1; then
+    return 0
+  fi
+  # Prefer project-local venv to avoid polluting global env
+  VENV_DIR="${ROOT_DIR}/.venv"
+  if [[ ! -d "${VENV_DIR}" ]]; then
+    echo "[llms] Creating venv at ${VENV_DIR}"
+    python3 -m venv "${VENV_DIR}"
+  fi
+  # shellcheck disable=SC1091
+  source "${VENV_DIR}/bin/activate"
+  python -m pip install -q --upgrade pip
+  python -m pip install -q llms-txt
+}
+
+generate_ctx() {
+  local src_path="${ROOT_DIR}/${SRC_FILE}"
+  echo "[llms] Generating minimal ctx -> ${OUT_MIN}"
+  if ! llms_txt2ctx "${src_path}" > "${OUT_MIN}"; then
+    echo "[llms] Warning: minimal ctx generation failed; leaving previous file if present" >&2
+  fi
+
+  echo "[llms] Generating full ctx -> ${OUT_FULL}"
+  if ! llms_txt2ctx --optional True "${src_path}" > "${OUT_FULL}"; then
+    echo "[llms] Warning: full ctx generation failed; leaving previous file if present" >&2
+  fi
+}
+
+copy_public() {
+  mkdir -p "${PUB_DIR}"
+  if [[ -f "${OUT_MIN}" ]]; then
+    cp "${OUT_MIN}" "${PUB_DIR}/llms-ctx.txt"
+  fi
+  if [[ -f "${OUT_FULL}" ]]; then
+    cp "${OUT_FULL}" "${PUB_DIR}/llms-ctx-full.txt"
+  fi
+}
+
+ensure_cli
+generate_ctx
+copy_public
+
+echo "[llms] Done. Public endpoints: /llms-ctx.txt, /llms-ctx-full.txt"
+

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run ctx generation when llms files change, then stage outputs
+
+changed_llms=$(git diff --cached --name-only | grep -E '^(llms\.txt|llms-full\.txt)$' || true)
+if [[ -n "${changed_llms}" ]]; then
+  echo "[pre-commit] Detected llms.txt changes; generating ctx files..."
+  scripts/generate-ctx.sh || {
+    echo "[pre-commit] Warning: ctx generation failed; proceeding without blocking commit" >&2
+    exit 0
+  }
+  git add llms-ctx.txt llms-ctx-full.txt frontend/public/llms-ctx.txt frontend/public/llms-ctx-full.txt || true
+fi
+
+exit 0
+


### PR DESCRIPTION
This PR standardizes our LLM-facing docs and automates ctx generation.

Highlights
- Spec-aligned llms.txt and llms-full.txt (llmstxt.org format)
- Public endpoints: /llms.txt, /llms-full.txt, /llms-ctx.txt, /llms-ctx-full.txt
- Prebuilt ctx files checked in for now; regenerated via script/CI
- Generator script: scripts/generate-ctx.sh (uses .venv + llms-txt CLI)
- Optional pre-commit hook to auto-generate ctx on llms changes
- GitHub Actions workflow to validate + build ctx artifacts (push/PR/nightly)
- Makefile targets (make ctx, ctx-clean)
- README updates with usage + CI docs

Notes
- CI builds ctx as artifacts on PRs to avoid conflicts; can add post-merge auto-commit later if desired.
- Links in llms files use raw.githubusercontent.com for better ctx generation.

After merge
- Public files are served by Next.js at the paths above.
- Nightly CI continues to validate and refresh artifacts.