### PR TITLE
refactor(integrations): flatten structure and centralize providers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `protocol/`: TypeScript Express server, LangGraph agents, Drizzle migrations, Redis/Postgres integration.
+- `frontend/`: Next.js app (App Router) with Tailwind and ESLint.
+- `docs/`, `README.md`, `HOWITWORKS.md`: Architecture and usage.
+- `scripts/`: Utility scripts (e.g., `generate-ctx.sh`, optional `hooks/pre-commit`).
+- Top-level `Makefile`: LLM context helpers (`ctx`, `ctx-full`, `ctx-public`, `ctx-clean`).
+
+## Build, Test, and Development Commands
+- Protocol:
+  - `cd protocol && yarn dev`: Start API with nodemon.
+  - `yarn build && yarn start`: Compile TypeScript then run from `dist/`.
+  - `yarn lint`: Lint server code.
+  - `yarn db:generate | db:migrate | db:studio`: Drizzle operations.
+- Frontend:
+  - `cd frontend && yarn dev`: Start Next.js (Turbopack).
+  - `yarn build && yarn start`: Production build and serve.
+  - `yarn lint`: Lint UI code.
+- Convenience:
+  - `./dev.local.sh`: Run protocol and frontend together.
+  - `make ctx` / `make ctx-public`: Generate and publish `llms-ctx*.txt` assets.
+
+## Coding Style & Naming Conventions
+- Language: TypeScript with `strict` mode enabled in both apps.
+- Formatting/Linting: ESLint (`frontend` extends Next core web vitals). Run `yarn lint` before PRs.
+- Indentation: 2 spaces; semicolons standard TS defaults.
+- Naming: 
+  - Files/folders: lower-case for routes and libs (`protocol/src/routes/*.ts`); React components PascalCase (`frontend/src/components/*`).
+  - Variables/functions camelCase; types/interfaces PascalCase.
+
+## Testing Guidelines
+- No formal test framework configured yet. For changes, include manual verification steps in the PR.
+- If adding tests, prefer Vitest + Testing Library (frontend) and lightweight integration tests (protocol). Keep coverage for new logic ≥80% when feasible.
+
+## Commit & Pull Request Guidelines
+- Commits: Imperative, concise. Conventional prefixes encouraged: `feat:`, `fix:`, `chore:`, `docs:`, `ci:` (seen in history).
+- PRs must include: clear description, scope, rationale, manual test notes; link issues. Add screenshots/GIFs for UI changes.
+- Before opening: `yarn lint` in both apps; run `make ctx` if `llms*.txt` changed (pre-commit hook can help).
+
+## Security & Configuration Tips
+- Copy envs: `cp protocol/env.example protocol/.env` and configure DB/keys (OpenAI, Resend, Redis). Do not commit secrets.
+- Postgres is required for protocol; confirm migrations run before `yarn start`.

--- a/protocol/src/lib/integrations/core/composio.ts
+++ b/protocol/src/lib/integrations/core/composio.ts
@@ -21,4 +21,4 @@ export async function getClient(): Promise<ComposioClient> {
   singleton = new Composio({ apiKey }) as unknown as ComposioClient;
   return singleton;
 }
-import { log } from '../log';
+import { log } from '../../log';

--- a/protocol/src/lib/integrations/core/integration-sync.ts
+++ b/protocol/src/lib/integrations/core/integration-sync.ts
@@ -1,11 +1,11 @@
 import fs from 'fs';
 import path from 'path';
-import db from './db';
-import { userIntegrations, intents, intentIndexes } from './schema';
+import db from '../../db';
+import { userIntegrations, intents, intentIndexes } from '../../schema';
 import { eq, and, isNull } from 'drizzle-orm';
-import { analyzeFolder } from '../agents/core/intent_inferrer';
-import { handlers } from './integrations';
-import { log } from './log';
+import { analyzeFolder } from '../../../agents/core/intent_inferrer';
+import { handlers } from '../index';
+import { log } from '../../log';
 
 interface SyncResult {
   success: boolean;

--- a/protocol/src/lib/integrations/core/util.ts
+++ b/protocol/src/lib/integrations/core/util.ts
@@ -1,4 +1,4 @@
-import type { IntegrationFile } from './index';
+import type { IntegrationFile } from '../index';
 
 export type RetryOptions = {
   retries?: number;

--- a/protocol/src/lib/integrations/index.ts
+++ b/protocol/src/lib/integrations/index.ts
@@ -11,13 +11,13 @@ export interface IntegrationHandler {
   fetchFiles(userId: string, lastSyncAt?: Date): Promise<IntegrationFile[]>;
 }
 
-import { notionHandler } from './notion';
-import { slackHandler } from './slack';
-import { discordHandler } from './discord';
+import { notionHandler } from './providers/notion';
+import { slackHandler } from './providers/slack';
+import { discordHandler } from './providers/discord';
 
-export { notionHandler } from './notion';
-export { slackHandler } from './slack';
-export { discordHandler } from './discord';
+export { notionHandler } from './providers/notion';
+export { slackHandler } from './providers/slack';
+export { discordHandler } from './providers/discord';
 
 const registry: Record<string, IntegrationHandler> = {
   notion: notionHandler,

--- a/protocol/src/lib/integrations/providers/discord.ts
+++ b/protocol/src/lib/integrations/providers/discord.ts
@@ -1,7 +1,7 @@
-import type { IntegrationHandler, IntegrationFile } from './index';
-import { getClient } from './composio';
-import { log } from '../log';
-import { withRetry, concurrencyLimit, mapDiscordMessageToFile } from './util';
+import type { IntegrationHandler, IntegrationFile } from '../index';
+import { getClient } from '../core/composio';
+import { log } from '../../log';
+import { withRetry, concurrencyLimit, mapDiscordMessageToFile } from '../core/util';
 
 async function fetchFiles(userId: string, lastSyncAt?: Date): Promise<IntegrationFile[]> {
   try {

--- a/protocol/src/lib/integrations/providers/notion.ts
+++ b/protocol/src/lib/integrations/providers/notion.ts
@@ -1,7 +1,7 @@
-import type { IntegrationHandler, IntegrationFile } from './index';
-import { getClient } from './composio';
-import { log } from '../log';
-import { withRetry, concurrencyLimit, mapNotionToFile } from './util';
+import type { IntegrationHandler, IntegrationFile } from '../index';
+import { getClient } from '../core/composio';
+import { log } from '../../log';
+import { withRetry, concurrencyLimit, mapNotionToFile } from '../core/util';
 
 async function fetchFiles(userId: string, lastSyncAt?: Date): Promise<IntegrationFile[]> {
   try {

--- a/protocol/src/lib/integrations/providers/slack.ts
+++ b/protocol/src/lib/integrations/providers/slack.ts
@@ -1,7 +1,7 @@
-import type { IntegrationHandler, IntegrationFile } from './index';
-import { getClient } from './composio';
-import { log } from '../log';
-import { paginate, withRetry, concurrencyLimit, mapSlackMessageToFile } from './util';
+import type { IntegrationHandler, IntegrationFile } from '../index';
+import { getClient } from '../core/composio';
+import { log } from '../../log';
+import { paginate, withRetry, concurrencyLimit, mapSlackMessageToFile } from '../core/util';
 
 async function fetchFiles(userId: string, lastSyncAt?: Date): Promise<IntegrationFile[]> {
   try {

--- a/protocol/src/routes/integrations.ts
+++ b/protocol/src/routes/integrations.ts
@@ -5,7 +5,7 @@ import { authenticatePrivy, AuthRequest } from '../middleware/auth';
 import db from '../lib/db';
 import { userIntegrations } from '../lib/schema';
 import { eq, and, isNull } from 'drizzle-orm';
-import { syncIntegration } from '../lib/integration-sync';
+import { syncIntegration } from '../lib/integrations/core/integration-sync';
 
 const router = Router();
 


### PR DESCRIPTION
Summary
- Keep only `integrations/index.ts` at top-level.
- Move provider handlers into `integrations/providers/`: `notion.ts`, `slack.ts`, `discord.ts`.
- Move shared helpers and sync into `integrations/core/`: `util.ts`, `composio.ts`, `integration-sync.ts`.

Changes
- Updated all relevant imports and the integrations route to reference new paths.
- No logic changes; this is a pure structure refactor.

Rationale
- Cleaner, more scalable layout: providers isolated; shared logic centralized.
- Easier to navigate and extend integrations without top-level clutter.

Manual Verification
- Protocol lint passes: `cd protocol && yarn lint`.
- Protocol compiles: `yarn build`.
- Sync endpoint still imports from `../lib/integrations/core/integration-sync`.

Notes
- Target base branch: `dev`.
- Follow-ups: none required.