### PR TITLE
unified async sync engine, HTTP/CLI triggers, and UI progress

### DIFF
--- a/docs/unified-sync.md
+++ b/docs/unified-sync.md
@@ -1,0 +1,105 @@
+# Unified Sync System
+
+This repository includes a shared, idempotent sync framework for Links (web crawl), Notion, Gmail, Slack (and room for more). All providers use the same engine and expose two triggers: an async HTTP API and a CLI suited for CronJobs.
+
+## How It Works
+- Queue: in‑process queue with concurrency (`SYNC_CONCURRENCY`, default 2).
+- Run store: DB‑backed by default (table `sync_runs`), in‑memory fallback. Set `SYNC_USE_DB_STORE=0` to disable.
+- Progress: poll `GET /api/sync/runs/:runId` or subscribe to SSE at `GET /api/sync/runs/:runId/events`.
+- Idempotency: dedupe by existing intent payloads; providers use delta sync via cursors (`provider_cursors`) and per‑integration `lastSyncAt`.
+
+## HTTP API
+- Enqueue immediate sync
+  - POST `/api/sync/now` body: `{ "provider": "links|notion|gmail|slack", "params": { "indexId?": "<uuid>" } }`
+  - Response: `202 { runId }`
+- Links (shortcut): `POST /api/indexes/:indexId/links/sync` → `202 { runId, status: "queued", links, filesImported: 0, intentsGenerated: 0 }`
+- Run status: `GET /api/sync/runs/:runId`
+- SSE stream: `GET /api/sync/runs/:runId/events`
+
+## CLI
+- `cd protocol && SYNC_USER_ID=<userId> yarn sync-all links --index <indexId> --wait`
+- Other providers: `yarn sync-all notion|gmail|slack --index <indexId> [--wait]`
+
+## Environment
+- `SYNC_USE_DB_STORE=1` (default) — persist runs.
+- `SYNC_CONCURRENCY=2` — max concurrent jobs.
+- For Links crawling: `CRAWL4AI_*` variables.
+- Composio: `COMPOSIO_API_KEY` and provider connections.
+
+## Kubernetes CronJob Examples
+
+Links (every 30m)
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sync-links
+spec:
+  schedule: "*/30 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: sync
+              image: node:20
+              workingDir: /app/protocol
+              command: ["yarn","sync-all","links","--index","<INDEX_ID>"]
+              env:
+                - { name: SYNC_USER_ID, value: "<USER_ID>" }
+                - { name: SYNC_USE_DB_STORE, value: "1" }
+                - { name: DATABASE_URL, valueFrom: { secretKeyRef: { name: db, key: url } } }
+```
+
+Notion (hourly)
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sync-notion
+spec:
+  schedule: "0 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: sync
+              image: node:20
+              workingDir: /app/protocol
+              command: ["yarn","sync-all","notion","--index","<INDEX_ID>"]
+              env:
+                - { name: SYNC_USER_ID, value: "<USER_ID>" }
+                - { name: COMPOSIO_API_KEY, valueFrom: { secretKeyRef: { name: composio, key: apiKey } } }
+                - { name: DATABASE_URL, valueFrom: { secretKeyRef: { name: db, key: url } } }
+```
+
+Gmail (twice daily)
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sync-gmail
+spec:
+  schedule: "0 */12 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: sync
+              image: node:20
+              workingDir: /app/protocol
+              command: ["yarn","sync-all","gmail","--index","<INDEX_ID>"]
+              env:
+                - { name: SYNC_USER_ID, value: "<USER_ID>" }
+                - { name: COMPOSIO_API_KEY, valueFrom: { secretKeyRef: { name: composio, key: apiKey } } }
+                - { name: DATABASE_URL, valueFrom: { secretKeyRef: { name: db, key: url } } }
+```
+
+Notes
+- The Links provider skips unchanged pages via content hash; Notion/Gmail/Slack use time‑based cursors in `provider_cursors`.
+- Prefer SSE for progress in the web UI; fall back to polling if the network blocks EventSource.

--- a/docs/unified-sync.md
+++ b/docs/unified-sync.md
@@ -1,39 +1,56 @@
-# Unified Sync System
+# Unified Sync System (current)
 
-This repository includes a shared, idempotent sync framework for Links (web crawl), Notion, Gmail, Slack (and room for more). All providers use the same engine and expose two triggers: an async HTTP API and a CLI suited for CronJobs.
+One engine powers sync for Links (web crawl), Notion, Gmail, Slack, Discord, Calendar. It exposes two triggers: an async HTTP API and a Cron‑friendly CLI. The engine is idempotent (dedupes intent payloads), rate‑limited, and observable (runs + progress).
 
-## How It Works
-- Queue: in‑process queue with concurrency (`SYNC_CONCURRENCY`, default 2).
-- Run store: DB‑backed by default (table `sync_runs`), in‑memory fallback. Set `SYNC_USE_DB_STORE=0` to disable.
-- Progress: poll `GET /api/sync/runs/:runId` or subscribe to SSE at `GET /api/sync/runs/:runId/events`.
-- Idempotency: dedupe by existing intent payloads; providers use delta sync via cursors (`provider_cursors`) and per‑integration `lastSyncAt`.
+## Overview
+
+- Queue + Concurrency: in‑process queue (`SYNC_CONCURRENCY`, default 2).
+- Run Store: DB by default (`sync_runs`); set `SYNC_USE_DB_STORE=0` to use in‑memory for dev.
+- Progress: poll `GET /api/sync/runs/:runId` or stream SSE `GET /api/sync/runs/:runId/events`.
+- Cursors: `provider_cursors` stores per‑provider checkpoints (time‑based `lastSyncAt` for now; upgradeable to native tokens).
+- Idempotency: no duplicate intents for the same payload within an index.
 
 ## HTTP API
-- Enqueue immediate sync
-  - POST `/api/sync/now` body: `{ "provider": "links|notion|gmail|slack", "params": { "indexId?": "<uuid>" } }`
-  - Response: `202 { runId }`
-- Links (shortcut): `POST /api/indexes/:indexId/links/sync` → `202 { runId, status: "queued", links, filesImported: 0, intentsGenerated: 0 }`
-- Run status: `GET /api/sync/runs/:runId`
-- SSE stream: `GET /api/sync/runs/:runId/events`
 
-## CLI
-- `cd protocol && SYNC_USER_ID=<userId> yarn sync-all links --index <indexId> --wait`
-- Other providers: `yarn sync-all notion|gmail|slack --index <indexId> [--wait]`
+- Enqueue: `POST /api/sync/now`
+  - Body: `{ "provider": "links|notion|gmail|slack|discord|calendar", "params": { "indexId?": "<uuid>" } }`
+  - Response: `202 { runId }`
+- Links shortcut: `POST /api/indexes/:indexId/links/sync?all=true|false&skipBrokers=true|false`
+  - Default (no `all`): processes only links that have never been synced (lastSyncAt is null).
+  - `all=true`: processes every link in the index.
+  - Response: `202 { runId, status: "queued", links, filesImported: 0, intentsGenerated: 0 }`
+- Run status: `GET /api/sync/runs/:runId`
+- SSE (optional): `GET /api/sync/runs/:runId/events`
+
+## CLI (Cron‑friendly)
+
+- Usage: `yarn sync-all <provider> [options]`
+- Help: `yarn sync-all --help`
+- Examples
+  - `SYNC_USER_ID=<userId> yarn sync-all links --index <indexId> --wait`
+  - `yarn sync-all notion --index <indexId> --user <userId>`
+
+## Links Behavior (what gets synced)
+
+- Default “Sync now”: only links that have never been synced are processed.
+- “Sync all”: include `?all=true` (or use the UI button) to process all links.
+- Dedupe: if a generated intent payload already exists for the index, it is not re‑inserted.
 
 ## Environment
-- `SYNC_USE_DB_STORE=1` (default) — persist runs.
-- `SYNC_CONCURRENCY=2` — max concurrent jobs.
-- For Links crawling: `CRAWL4AI_*` variables.
-- Composio: `COMPOSIO_API_KEY` and provider connections.
 
-## Kubernetes CronJob Examples
+- `SYNC_USE_DB_STORE=1` (default) — persist runs in DB.
+- `SYNC_CONCURRENCY=2` — max concurrent jobs.
+- Crawl4AI service: `CRAWL4AI_*` variables.
+- Composio for providers: `COMPOSIO_API_KEY` and a connected account per provider.
+
+## Kubernetes CronJob (examples)
 
 Links (every 30m)
+
 ```yaml
 apiVersion: batch/v1
 kind: CronJob
-metadata:
-  name: sync-links
+metadata: { name: sync-links }
 spec:
   schedule: "*/30 * * * *"
   jobTemplate:
@@ -48,16 +65,15 @@ spec:
               command: ["yarn","sync-all","links","--index","<INDEX_ID>"]
               env:
                 - { name: SYNC_USER_ID, value: "<USER_ID>" }
-                - { name: SYNC_USE_DB_STORE, value: "1" }
                 - { name: DATABASE_URL, valueFrom: { secretKeyRef: { name: db, key: url } } }
 ```
 
 Notion (hourly)
+
 ```yaml
 apiVersion: batch/v1
 kind: CronJob
-metadata:
-  name: sync-notion
+metadata: { name: sync-notion }
 spec:
   schedule: "0 * * * *"
   jobTemplate:
@@ -77,11 +93,11 @@ spec:
 ```
 
 Gmail (twice daily)
+
 ```yaml
 apiVersion: batch/v1
 kind: CronJob
-metadata:
-  name: sync-gmail
+metadata: { name: sync-gmail }
 spec:
   schedule: "0 */12 * * *"
   jobTemplate:
@@ -100,6 +116,13 @@ spec:
                 - { name: DATABASE_URL, valueFrom: { secretKeyRef: { name: db, key: url } } }
 ```
 
-Notes
-- The Links provider skips unchanged pages via content hash; Notion/Gmail/Slack use time‑based cursors in `provider_cursors`.
-- Prefer SSE for progress in the web UI; fall back to polling if the network blocks EventSource.
+## Thoughts
+
+- Per-item outcomes: write one row per processed item to `sync_run_items` (external_id, status=new|unchanged|error, meta). Expose `GET /api/sync/runs/:runId/items`. UI: small drawer grouped by status.
+- Queue backend: consider BullMQ/Redis for multi-instance workers; idempotent job keys; at-least-once semantics with dedupe window.
+- Rate limiting/backoff: per-provider dynamic limiter, 429-aware backoff, circuit-breakers, quotas per user/index.
+- Observability: counters (runs started/completed, error rate), latency histograms, trace spans keyed by `runId`; structured logs (provider, userId, runId).
+- Security/auth: tokenized SSE (query param) or cookie-based auth; enforce run ownership in all run/item endpoints; PII scrubbing in logs.
+- CLI ergonomics: flags like `--all` (links), `--since <ts>`, `--reset-cursor`, machine-readable logs, stable exit codes; `--json` output.
+- Data model hygiene: unique(run_id, external_id) on `sync_run_items`; consider dropping `last_content_hash` if it remains unused.
+- Testing: provider stubs, contract tests for handlers, queue transition tests, and smoke tests with mocked Crawl4AI/Composio.

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -91,3 +91,11 @@ a#protected-by-privy {
   display: none;
 }
 
+@layer utilities {
+  .line-clamp-2 {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+}

--- a/frontend/src/app/indexes/[id]/page.tsx
+++ b/frontend/src/app/indexes/[id]/page.tsx
@@ -12,6 +12,7 @@ import Link from "next/link";
 import { useIndexes, useIntents } from "@/contexts/APIContext";
 import { useAuthenticatedAPI } from "@/lib/api";
 import { createSyncService, type SyncRun } from "@/services/sync";
+import { useNotifications } from "@/contexts/NotificationContext";
 import { Index, Intent } from "@/lib/types";
 import ClientLayout from "@/components/ClientLayout";
 import { usePrivy } from "@privy-io/react-auth";
@@ -71,6 +72,7 @@ export default function IndexDetailPage({ params }: IndexDetailPageProps) {
   const [syncProgress, setSyncProgress] = useState<{ completed?: number; total?: number; status?: string } | null>(null);
   const api = useAuthenticatedAPI();
   const syncService = useMemo(() => createSyncService(api), [api]);
+  const { success: notifySuccess, error: notifyError, info: notifyInfo } = useNotifications();
 
   const fetchLinks = useCallback(async () => {
     try {
@@ -301,8 +303,10 @@ export default function IndexDetailPage({ params }: IndexDetailPageProps) {
       await indexesService.addIndexLink(resolvedParams.id, { url: linkUrl.trim() });
       setLinkUrl("");
       await fetchLinks();
+      notifySuccess('Link added', 'Your URL was added to this index.');
     } catch (e) {
       console.error('Error adding link:', e);
+      notifyError('Failed to add link');
     } finally {
       setAddingLink(false);
     }
@@ -327,6 +331,7 @@ export default function IndexDetailPage({ params }: IndexDetailPageProps) {
       if (!runId) {
         setLastSyncSummary("Failed to enqueue sync");
         setSyncingLinks(false);
+        notifyError('Sync failed to start');
         return;
       }
       // Poll for status (SSE alternative)
@@ -351,12 +356,14 @@ export default function IndexDetailPage({ params }: IndexDetailPageProps) {
             await fetchIndexIntents();
             setSyncProgress(null);
             setSyncingLinks(false);
+            notifySuccess('Links synced', `Files ${stats?.filesImported ?? 0}, intents ${stats?.intentsGenerated ?? 0}`);
             return;
           }
           if (status === 'failed') {
             setLastSyncSummary(`Sync failed`);
             setSyncProgress(null);
             setSyncingLinks(false);
+            notifyError('Links sync failed');
             return;
           }
         } catch (err) {
@@ -368,6 +375,7 @@ export default function IndexDetailPage({ params }: IndexDetailPageProps) {
     } catch (e) {
       console.error('Error syncing links:', e);
       setSyncingLinks(false);
+      notifyError('Links sync error');
     }
   };
 
@@ -730,18 +738,31 @@ export default function IndexDetailPage({ params }: IndexDetailPageProps) {
           ) : (
             <ul className="divide-y">
               {links.map(link => (
-                <li key={link.id} className="py-2 flex items-center justify-between">
-                  <div className="flex-1 mr-3 text-sm text-gray-800">
-                    <a href={link.url} target="_blank" rel="noreferrer" className="text-black underline-offset-2 hover:underline font-ibm-plex-mono">{link.url}</a>
+                <li key={link.id} className="py-2 flex items-start justify-between gap-2">
+                  <div className="flex-1 min-w-0 mr-3 text-sm text-gray-800 overflow-hidden">
+                    <a
+                      href={link.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-black underline-offset-2 hover:underline font-ibm-plex-mono break-words"
+                    >
+                      {link.url}
+                    </a>
                     {/* per-link depth/pages removed; now using global defaults */}
                     {link.lastSyncAt && (
                       <span className="text-gray-500 ml-2">last: {new Date(link.lastSyncAt).toLocaleString()}</span>
                     )}
-                    {link.lastStatus && (
-                      <div className="text-gray-500 ml-2">status: {link.lastStatus}</div>
-                    )}
+                    <div className="inline-flex items-center gap-2 ml-2">
+                      {link.lastError ? (
+                        <span className="px-1.5 py-0.5 text-[10px] font-medium text-red-700 bg-red-100 border border-red-200 rounded-full">Error</span>
+                      ) : link.lastSyncAt ? (
+                        <span className="px-1.5 py-0.5 text-[10px] font-medium text-green-700 bg-green-100 border border-green-200 rounded-full">Synced</span>
+                      ) : (
+                        <span className="px-1.5 py-0.5 text-[10px] font-medium text-gray-600 bg-gray-100 border border-gray-200 rounded-full">Never</span>
+                      )}
+                    </div>
                   </div>
-                  <div className="flex items-center gap-2">
+                  <div className="flex items-center gap-2 shrink-0">
                     {/* edit controls removed with per-link settings */}
                     <Button
                       variant="outline"

--- a/frontend/src/app/indexes/[id]/page.tsx
+++ b/frontend/src/app/indexes/[id]/page.tsx
@@ -321,12 +321,12 @@ export default function IndexDetailPage({ params }: IndexDetailPageProps) {
     }
   };
 
-  const handleSyncLinks = async () => {
+  const handleSyncLinks = async (opts?: { all?: boolean }) => {
     try {
       setSyncingLinks(true);
-      setLastSyncSummary("Queued…");
+      setLastSyncSummary("");
       setSyncProgress({ status: 'queued' });
-      const res = await indexesService.syncIndexLinks(resolvedParams.id, { skipBrokers: true });
+      const res = await indexesService.syncIndexLinks(resolvedParams.id, { skipBrokers: true, all: !!opts?.all });
       const runId = (res as any).runId as string;
       if (!runId) {
         setLastSyncSummary("Failed to enqueue sync");
@@ -345,9 +345,6 @@ export default function IndexDetailPage({ params }: IndexDetailPageProps) {
           const { progress, stats, status } = run;
           if (progress && (progress.completed !== undefined || progress.total !== undefined)) {
             setSyncProgress({ completed: progress.completed, total: progress.total, status });
-            setLastSyncSummary(`${status === 'running' ? 'Running' : status}: ${progress.completed ?? 0}/${progress.total ?? 0}`);
-          } else {
-            setLastSyncSummary(`${status}`);
           }
           if (status === 'succeeded') {
             const dur = Date.now() - start;
@@ -684,7 +681,7 @@ export default function IndexDetailPage({ params }: IndexDetailPageProps) {
               )}
               <Button
                 variant="outline"
-                onClick={handleSyncLinks}
+                onClick={() => handleSyncLinks()}
                 disabled={syncingLinks}
                 className="border-black text-black hover:bg-gray-100"
               >
@@ -695,6 +692,14 @@ export default function IndexDetailPage({ params }: IndexDetailPageProps) {
                         ? `Running ${syncProgress?.completed ?? 0}/${syncProgress?.total ?? 0}`
                         : 'Syncing…')
                   : 'Sync now'}
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => handleSyncLinks({ all: true })}
+                disabled={syncingLinks}
+                className="border-black text-black hover:bg-gray-100"
+              >
+                {syncingLinks ? 'Working…' : 'Sync all'}
               </Button>
             </div>
           </div>

--- a/frontend/src/app/indexes/[id]/page.tsx
+++ b/frontend/src/app/indexes/[id]/page.tsx
@@ -744,7 +744,8 @@ export default function IndexDetailPage({ params }: IndexDetailPageProps) {
                       href={link.url}
                       target="_blank"
                       rel="noreferrer"
-                      className="text-black underline-offset-2 hover:underline font-ibm-plex-mono break-words"
+                      title={link.url}
+                      className="text-black underline-offset-2 hover:underline font-ibm-plex-mono break-words line-clamp-2 block"
                     >
                       {link.url}
                     </a>
@@ -754,9 +755,9 @@ export default function IndexDetailPage({ params }: IndexDetailPageProps) {
                     )}
                     <div className="inline-flex items-center gap-2 ml-2">
                       {link.lastError ? (
-                        <span className="px-1.5 py-0.5 text-[10px] font-medium text-red-700 bg-red-100 border border-red-200 rounded-full">Error</span>
+                        <span title={link.lastError || undefined} className="px-1.5 py-0.5 text-[10px] font-medium text-red-700 bg-red-100 border border-red-200 rounded-full">Error</span>
                       ) : link.lastSyncAt ? (
-                        <span className="px-1.5 py-0.5 text-[10px] font-medium text-green-700 bg-green-100 border border-green-200 rounded-full">Synced</span>
+                        <span title={link.lastStatus || undefined} className="px-1.5 py-0.5 text-[10px] font-medium text-green-700 bg-green-100 border border-green-200 rounded-full">Synced</span>
                       ) : (
                         <span className="px-1.5 py-0.5 text-[10px] font-medium text-gray-600 bg-gray-100 border border-gray-200 rounded-full">Never</span>
                       )}

--- a/frontend/src/app/indexes/[id]/page.tsx
+++ b/frontend/src/app/indexes/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, use, useRef } from "react";
+import { useState, useEffect, useCallback, use, useRef, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Upload, Trash2, ArrowUpRight, Share2, ArrowLeft, MoreVertical } from "lucide-react";
@@ -10,6 +10,8 @@ import DeleteIndexModal from "@/components/modals/DeleteIndexModal";
 
 import Link from "next/link";
 import { useIndexes, useIntents } from "@/contexts/APIContext";
+import { useAuthenticatedAPI } from "@/lib/api";
+import { createSyncService, type SyncRun } from "@/services/sync";
 import { Index, Intent } from "@/lib/types";
 import ClientLayout from "@/components/ClientLayout";
 import { usePrivy } from "@privy-io/react-auth";
@@ -66,6 +68,9 @@ export default function IndexDetailPage({ params }: IndexDetailPageProps) {
   const [addingLink, setAddingLink] = useState(false);
   const [syncingLinks, setSyncingLinks] = useState(false);
   const [lastSyncSummary, setLastSyncSummary] = useState<string>("");
+  const [syncProgress, setSyncProgress] = useState<{ completed?: number; total?: number; status?: string } | null>(null);
+  const api = useAuthenticatedAPI();
+  const syncService = useMemo(() => createSyncService(api), [api]);
 
   const fetchLinks = useCallback(async () => {
     try {
@@ -315,13 +320,53 @@ export default function IndexDetailPage({ params }: IndexDetailPageProps) {
   const handleSyncLinks = async () => {
     try {
       setSyncingLinks(true);
+      setLastSyncSummary("Queued…");
+      setSyncProgress({ status: 'queued' });
       const res = await indexesService.syncIndexLinks(resolvedParams.id, { skipBrokers: true });
-      setLastSyncSummary(`Synced: pages=${res.pagesVisited}, files=${res.filesImported}, intents=${res.intentsGenerated}, ${Math.round(res.durationMs)}ms`);
-      await fetchLinks();
-      await fetchIndexIntents();
+      const runId = (res as any).runId as string;
+      if (!runId) {
+        setLastSyncSummary("Failed to enqueue sync");
+        setSyncingLinks(false);
+        return;
+      }
+      // Poll for status (SSE alternative)
+      const start = Date.now();
+      let stop = false;
+      const poll = async () => {
+        if (stop) return;
+        try {
+          const data = await syncService.getRun(runId);
+          const run = data.run as SyncRun;
+          const { progress, stats, status } = run;
+          if (progress && (progress.completed !== undefined || progress.total !== undefined)) {
+            setSyncProgress({ completed: progress.completed, total: progress.total, status });
+            setLastSyncSummary(`${status === 'running' ? 'Running' : status}: ${progress.completed ?? 0}/${progress.total ?? 0}`);
+          } else {
+            setLastSyncSummary(`${status}`);
+          }
+          if (status === 'succeeded') {
+            const dur = Date.now() - start;
+            setLastSyncSummary(`Synced: pages=${stats?.pagesVisited ?? 0}, files=${stats?.filesImported ?? 0}, intents=${stats?.intentsGenerated ?? 0}, ${dur}ms`);
+            await fetchLinks();
+            await fetchIndexIntents();
+            setSyncProgress(null);
+            setSyncingLinks(false);
+            return;
+          }
+          if (status === 'failed') {
+            setLastSyncSummary(`Sync failed`);
+            setSyncProgress(null);
+            setSyncingLinks(false);
+            return;
+          }
+        } catch (err) {
+          console.error('Polling error:', err);
+        }
+        setTimeout(poll, 1000);
+      };
+      poll();
     } catch (e) {
       console.error('Error syncing links:', e);
-    } finally {
       setSyncingLinks(false);
     }
   };
@@ -617,7 +662,17 @@ export default function IndexDetailPage({ params }: IndexDetailPageProps) {
             <h2 className="text-xl mt-2 font-semibold text-gray-900">Index Links</h2>
             <div className="flex items-center gap-2">
               {lastSyncSummary && (
-                <span className="text-xs text-gray-500">{lastSyncSummary}</span>
+                <span className="text-xs text-gray-500">
+                  {lastSyncSummary}
+                  {syncProgress && syncProgress.total ? (
+                    <>
+                      {" "}
+                      <span>
+                        ({syncProgress.completed ?? 0}/{syncProgress.total})
+                      </span>
+                    </>
+                  ) : null}
+                </span>
               )}
               <Button
                 variant="outline"
@@ -625,10 +680,25 @@ export default function IndexDetailPage({ params }: IndexDetailPageProps) {
                 disabled={syncingLinks}
                 className="border-black text-black hover:bg-gray-100"
               >
-                {syncingLinks ? 'Syncing…' : 'Sync now'}
+                {syncingLinks
+                  ? (syncProgress?.status === 'queued'
+                      ? 'Queued…'
+                      : syncProgress?.status === 'running'
+                        ? `Running ${syncProgress?.completed ?? 0}/${syncProgress?.total ?? 0}`
+                        : 'Syncing…')
+                  : 'Sync now'}
               </Button>
             </div>
           </div>
+
+          {syncProgress?.status === 'running' && (syncProgress?.total ?? 0) > 0 && (
+            <div className="w-full h-1 bg-gray-200 rounded overflow-hidden mb-3">
+              <div
+                className="h-full bg-black transition-all"
+                style={{ width: `${Math.min(100, Math.round(((syncProgress.completed ?? 0) / (syncProgress.total ?? 0)) * 100))}%` }}
+              />
+            </div>
+          )}
 
           <div className="flex gap-2 mb-3">
             <input
@@ -637,11 +707,18 @@ export default function IndexDetailPage({ params }: IndexDetailPageProps) {
               onChange={e => setLinkUrl(e.target.value)}
               placeholder="https://example.com/docs"
               className="flex-1 border border-black px-3 py-2 rounded text-sm text-black font-ibm-plex-mono"
+              disabled={addingLink || syncingLinks}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && linkUrl && !addingLink && !syncingLinks) {
+                  e.preventDefault();
+                  handleAddLink();
+                }
+              }}
             />
             <Button
               variant="outline"
               onClick={handleAddLink}
-              disabled={addingLink || !linkUrl}
+              disabled={addingLink || !linkUrl || syncingLinks}
               className="border-black text-black hover:bg-gray-100"
             >
               {addingLink ? 'Adding…' : 'Add link'}

--- a/frontend/src/app/indexes/private/page.tsx
+++ b/frontend/src/app/indexes/private/page.tsx
@@ -7,6 +7,7 @@ import { Google, Notion } from "@lobehub/icons";
 import { useAPI } from "@/contexts/APIContext";
 import { useAuthenticatedAPI } from "@/lib/api";
 import { createSyncService, type SyncRun } from "@/services/sync";
+import { useNotifications } from "@/contexts/NotificationContext";
 import { useEffect, useState, useCallback } from "react";
 import { Integration } from "@/services/integrations";
 
@@ -27,6 +28,7 @@ export default function PrivateIndexPage() {
   const [syncProgress, setSyncProgress] = useState<Record<string, { status?: string; completed?: number; total?: number }>>({});
   const api = useAuthenticatedAPI();
   const syncService = createSyncService(api);
+  const { success: notifySuccess, error: notifyError } = useNotifications();
 
   const integrationConfigs: IntegrationConfig[] = [
     {
@@ -188,11 +190,15 @@ export default function PrivateIndexPage() {
             await loadIntegrations();
             stopped = true;
             setSyncingIntegration(null);
+            const files = run.stats?.filesImported ?? 0;
+            const intents = run.stats?.intentsGenerated ?? 0;
+            notifySuccess(`${integrationType} synced`, `Files ${files}, intents ${intents}`);
             return;
           }
           if (status === 'failed') {
             stopped = true;
             setSyncingIntegration(null);
+            notifyError(`${integrationType} sync failed`);
             return;
           }
         } catch (e) {

--- a/frontend/src/app/indexes/private/page.tsx
+++ b/frontend/src/app/indexes/private/page.tsx
@@ -5,6 +5,8 @@ import Link from "next/link";
 import ClientLayout from "@/components/ClientLayout";
 import { Google, Notion } from "@lobehub/icons";
 import { useAPI } from "@/contexts/APIContext";
+import { useAuthenticatedAPI } from "@/lib/api";
+import { createSyncService, type SyncRun } from "@/services/sync";
 import { useEffect, useState, useCallback } from "react";
 import { Integration } from "@/services/integrations";
 
@@ -22,6 +24,9 @@ export default function PrivateIndexPage() {
   const [connectingIntegration, setConnectingIntegration] = useState<string | null>(null);
   const [connectionStatuses, setConnectionStatuses] = useState<Record<string, string>>({});
   const [syncingIntegration, setSyncingIntegration] = useState<string | null>(null);
+  const [syncProgress, setSyncProgress] = useState<Record<string, { status?: string; completed?: number; total?: number }>>({});
+  const api = useAuthenticatedAPI();
+  const syncService = createSyncService(api);
 
   const integrationConfigs: IntegrationConfig[] = [
     {
@@ -165,19 +170,41 @@ export default function PrivateIndexPage() {
   const handleSync = async (integrationType: string) => {
     try {
       setSyncingIntegration(integrationType);
-      const result = await integrationsService.syncIntegration(integrationType);
-      
-      if (result.success) {
-        console.log(`Sync complete: ${result.filesImported} files, ${result.intentsGenerated} intents`);
-        // Refresh integrations to get updated lastSyncAt
-        await loadIntegrations();
-      } else {
-        console.error('Sync failed:', result.error);
-      }
+      // enqueue async run
+      const enq = await integrationsService.syncIntegration(integrationType);
+      const runId = (enq as any).runId as string;
+      if (!runId) throw new Error('Failed to enqueue sync');
+      setSyncProgress(prev => ({ ...prev, [integrationType]: { status: 'queued' } }));
+      const started = Date.now();
+      let stopped = false;
+      const poll = async () => {
+        if (stopped) return;
+        try {
+          const data = await syncService.getRun(runId);
+          const run = data.run as SyncRun;
+          const { progress, stats, status } = run;
+          setSyncProgress(prev => ({ ...prev, [integrationType]: { status, completed: progress?.completed, total: progress?.total } }));
+          if (status === 'succeeded') {
+            await loadIntegrations();
+            stopped = true;
+            setSyncingIntegration(null);
+            return;
+          }
+          if (status === 'failed') {
+            stopped = true;
+            setSyncingIntegration(null);
+            return;
+          }
+        } catch (e) {
+          // keep polling a few times even if errors
+        }
+        setTimeout(poll, 1000);
+      };
+      poll();
     } catch (error) {
       console.error('Failed to sync integration:', error);
     } finally {
-      setSyncingIntegration(null);
+      // keep spinner controlled by poller
     }
   };
 
@@ -276,9 +303,9 @@ export default function PrivateIndexPage() {
                       Connecting...
                     </span>
                   )}
-                  {syncingIntegration === config.id && (
+                  {syncProgress[config.id]?.status && (
                     <span className="px-2 py-0.5 text-xs font-medium text-orange-700 bg-orange-50 border border-orange-200 rounded-full">
-                      Syncing...
+                      {syncProgress[config.id]?.status === 'queued' ? 'Queued…' : syncProgress[config.id]?.status === 'running' ? `Running ${syncProgress[config.id]?.completed ?? 0}/${syncProgress[config.id]?.total ?? 0}` : syncProgress[config.id]?.status}
                     </span>
                   )}
                 </div>

--- a/frontend/src/services/indexes.ts
+++ b/frontend/src/services/indexes.ts
@@ -223,7 +223,7 @@ export const createIndexesService = (api: ReturnType<typeof useAuthenticatedAPI>
 
   syncIndexLinks: async (
     indexId: string,
-    opts?: { skipBrokers?: boolean; count?: number }
+    opts?: { skipBrokers?: boolean; count?: number; all?: boolean }
   ): Promise<{
     runId: string;
     success: boolean;
@@ -238,6 +238,7 @@ export const createIndexesService = (api: ReturnType<typeof useAuthenticatedAPI>
     const params = new URLSearchParams();
     if (opts?.skipBrokers !== undefined) params.set('skipBrokers', String(opts.skipBrokers));
     if (opts?.count !== undefined) params.set('count', String(opts.count));
+    if (opts?.all !== undefined) params.set('all', String(opts.all));
     const res = await api.post<{
       runId: string;
       success: boolean;

--- a/frontend/src/services/indexes.ts
+++ b/frontend/src/services/indexes.ts
@@ -221,11 +221,34 @@ export const createIndexesService = (api: ReturnType<typeof useAuthenticatedAPI>
     return res.link;
   },
 
-  syncIndexLinks: async (indexId: string, opts?: { skipBrokers?: boolean; count?: number }) => {
+  syncIndexLinks: async (
+    indexId: string,
+    opts?: { skipBrokers?: boolean; count?: number }
+  ): Promise<{
+    runId: string;
+    success: boolean;
+    status: string;
+    links: number;
+    filesImported: number;
+    intentsGenerated: number;
+    pagesVisited?: number;
+    durationMs?: number;
+    message?: string;
+  }> => {
     const params = new URLSearchParams();
     if (opts?.skipBrokers !== undefined) params.set('skipBrokers', String(opts.skipBrokers));
     if (opts?.count !== undefined) params.set('count', String(opts.count));
-    const res = await api.post<{ success: boolean; filesImported: number; intentsGenerated: number; links: number; pagesVisited: number; durationMs: number }>(`/indexes/${indexId}/links/sync${params.toString() ? `?${params.toString()}` : ''}`, {});
+    const res = await api.post<{
+      runId: string;
+      success: boolean;
+      status: string;
+      links: number;
+      filesImported: number;
+      intentsGenerated: number;
+      pagesVisited?: number;
+      durationMs?: number;
+      message?: string;
+    }>(`/indexes/${indexId}/links/sync${params.toString() ? `?${params.toString()}` : ''}`, {});
     return res;
   },
 

--- a/frontend/src/services/integrations.ts
+++ b/frontend/src/services/integrations.ts
@@ -41,9 +41,26 @@ export function createIntegrationsService(api: ReturnType<typeof useAuthenticate
       return api.delete<{ success: boolean }>(`/integrations/${integrationType}`);
     },
 
-    // Sync specific integration
-    async syncIntegration(integrationType: string, indexId?: string): Promise<{ success: boolean; filesImported: number; intentsGenerated: number; error?: string }> {
-      return api.post<{ success: boolean; filesImported: number; intentsGenerated: number; error?: string }>(`/integrations/sync/${integrationType}`, indexId ? { indexId } : {});
+    // Sync specific integration (async run)
+    async syncIntegration(
+      integrationType: string,
+      indexId?: string
+    ): Promise<{
+      runId: string;
+      success: boolean;
+      status: string;
+      filesImported: number;
+      intentsGenerated: number;
+      message?: string;
+    }> {
+      return api.post<{
+        runId: string;
+        success: boolean;
+        status: string;
+        filesImported: number;
+        intentsGenerated: number;
+        message?: string;
+      }>(`/integrations/sync/${integrationType}`, indexId ? { indexId } : {});
     },
 
   };

--- a/frontend/src/services/sync.ts
+++ b/frontend/src/services/sync.ts
@@ -1,0 +1,17 @@
+import { useAuthenticatedAPI } from '@/lib/api';
+
+export type SyncRun = {
+  id: string;
+  status: 'queued' | 'running' | 'succeeded' | 'failed';
+  progress?: { total?: number; completed?: number; notes?: string[] };
+  stats?: { filesImported?: number; intentsGenerated?: number; pagesVisited?: number; [k: string]: any };
+  error?: string | null;
+};
+
+export const createSyncService = (api: ReturnType<typeof useAuthenticatedAPI>) => ({
+  getRun: async (runId: string): Promise<{ run: SyncRun }> => {
+    const res = await api.get<{ run: SyncRun }>(`/sync/runs/${runId}`);
+    return res;
+  },
+});
+

--- a/protocol/drizzle/0003_clammy_sunfire.sql
+++ b/protocol/drizzle/0003_clammy_sunfire.sql
@@ -1,0 +1,50 @@
+CREATE TABLE IF NOT EXISTS "provider_cursors" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"provider" varchar(50) NOT NULL,
+	"cursor" json DEFAULT 'null'::json,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "sync_run_items" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"run_id" uuid NOT NULL,
+	"external_id" text NOT NULL,
+	"status" varchar(20) DEFAULT 'pending' NOT NULL,
+	"error" text,
+	"meta" json DEFAULT 'null'::json,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "sync_runs" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"provider" varchar(50) NOT NULL,
+	"status" varchar(20) DEFAULT 'queued' NOT NULL,
+	"params" json DEFAULT '{}'::json,
+	"progress" json DEFAULT 'null'::json,
+	"stats" json DEFAULT 'null'::json,
+	"error" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"started_at" timestamp,
+	"finished_at" timestamp
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "provider_cursors" ADD CONSTRAINT "provider_cursors_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "sync_run_items" ADD CONSTRAINT "sync_run_items_run_id_sync_runs_id_fk" FOREIGN KEY ("run_id") REFERENCES "public"."sync_runs"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "sync_runs" ADD CONSTRAINT "sync_runs_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/protocol/drizzle/0004_striped_rogue.sql
+++ b/protocol/drizzle/0004_striped_rogue.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "index_links" ADD COLUMN "last_content_hash" text;

--- a/protocol/env.example
+++ b/protocol/env.example
@@ -27,3 +27,11 @@ LANGFUSE_BASE_URL="https://us.cloud.langfuse.com"
 
 # Composio Integration
 COMPOSIO_API_KEY=your_composio_api_key_here 
+
+# Unified Sync
+# Use DB-backed run store by default (set to 0 to disable)
+SYNC_USE_DB_STORE=1
+# Max concurrent sync jobs
+SYNC_CONCURRENCY=2
+# Optional default user for CLI
+# SYNC_USER_ID=

--- a/protocol/package.json
+++ b/protocol/package.json
@@ -10,7 +10,8 @@
     "test:crawl4ai": "TS_NODE_TRANSPILE_ONLY=1 node -r ts-node/register ./tests/crawl4ai.smoke.test.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
-    "db:studio": "drizzle-kit studio"
+    "db:studio": "drizzle-kit studio",
+    "sync-all": "TS_NODE_TRANSPILE_ONLY=1 node -r ts-node/register ./src/cli/sync-all.ts"
   },
   "dependencies": {
     "@composio/core": "^0.1.44",
@@ -36,6 +37,7 @@
     "openai": "^4.103.0",
     "postgres": "^3.4.7",
     "resend": "^4.0.1",
+    "p-queue": "^7.4.1",
     "tiktoken": "^1.0.21",
     "unstructured-client": "0.24.1",
     "uuid": "^11.1.0",

--- a/protocol/src/cli/sync-all.ts
+++ b/protocol/src/cli/sync-all.ts
@@ -62,7 +62,8 @@ function parseArgs(argv: string[]) {
 
 async function main() {
   const { provider, params, userId, wait, help } = parseArgs(process.argv);
-  if (!provider || provider === 'help' || help) { usage(); process.exit(provider ? 0 : 1); }
+  if (help || provider === 'help') { usage(); process.exit(0); }
+  if (!provider) { usage(); process.exit(1); }
   registerSyncProviders();
   const uid = userId || process.env.SYNC_USER_ID;
   if (!uid) {

--- a/protocol/src/cli/sync-all.ts
+++ b/protocol/src/cli/sync-all.ts
@@ -1,35 +1,72 @@
 #!/usr/bin/env node
+/**
+ * sync-all.ts — Unified Sync CLI
+ *
+ * Purpose
+ * - Trigger the same sync providers used by the HTTP API (links/gmail/notion/...)
+ * - Suitable for Kubernetes CronJobs and local/manual runs
+ *
+ * Behavior
+ * - Enqueues a run and prints { runId }
+ * - With --wait, polls run status once per second and exits 0 on success / 1 on failure
+ *
+ * Examples
+ *   yarn sync-all links --index 00000000-0000-0000-0000-000000000000 --user <USER_ID> --wait
+ *   yarn sync-all notion --index <INDEX_ID> --user <USER_ID>
+ *   SYNC_USER_ID=<USER_ID> yarn sync-all gmail --index <INDEX_ID> --wait
+ */
 import 'dotenv/config';
 import { registerSyncProviders } from '../lib/sync/register';
 import { enqueue, getRun } from '../lib/sync/queue';
 
+function usage() {
+  const text = `
+Usage: yarn sync-all <provider> [options]
+
+Providers:
+  links | gmail | notion | slack | discord | calendar
+
+Options:
+  -u, --user <id>      User ID (or set SYNC_USER_ID env)
+  -i, --index <id>     Index ID (where intents are attached, when applicable)
+      --wait           Block and exit 0 on success / 1 on failure
+  -h, --help           Show this help
+
+Examples:
+  SYNC_USER_ID=123 yarn sync-all links --index 111 --wait
+  yarn sync-all notion --index 111 --user 123
+`;
+  console.log(text);
+}
+
 function parseArgs(argv: string[]) {
   const args = argv.slice(2);
-  const provider = (args[0] || '').toLowerCase();
+  let provider = (args[0] || '').toLowerCase();
   const out: any = { provider, params: {} };
+  // Handle help as the first arg (e.g., `yarn sync-all --help`)
+  if (provider === '--help' || provider === '-h') {
+    out.help = true;
+    out.provider = '';
+    provider = '';
+  }
   for (let i = 1; i < args.length; i++) {
     const a = args[i];
     if (a === '--index' || a === '-i') out.params.indexId = args[++i];
     else if (a === '--user' || a === '-u') out.userId = args[++i];
     else if (a === '--wait') out.wait = true;
-    else if (a.startsWith('--')) {
-      const k = a.slice(2);
-      out.params[k] = args[++i];
-    }
+    else if (a === '--help' || a === '-h') out.help = true;
+    else if (a.startsWith('--')) { const k = a.slice(2); out.params[k] = args[++i]; }
   }
   return out;
 }
 
 async function main() {
-  const { provider, params, userId, wait } = parseArgs(process.argv);
-  if (!provider) {
-    console.error('Usage: yarn sync-all <links|gmail|notion|slack|discord|calendar> [--index <id>] [--user <id>] [--wait]');
-    process.exit(1);
-  }
+  const { provider, params, userId, wait, help } = parseArgs(process.argv);
+  if (!provider || provider === 'help' || help) { usage(); process.exit(provider ? 0 : 1); }
   registerSyncProviders();
   const uid = userId || process.env.SYNC_USER_ID;
   if (!uid) {
-    console.error('Missing user id. Provide --user or SYNC_USER_ID env.');
+    console.error('Missing user id. Provide --user or set SYNC_USER_ID env.');
     process.exit(1);
   }
   const runId = await enqueue(provider as any, uid, params);

--- a/protocol/src/cli/sync-all.ts
+++ b/protocol/src/cli/sync-all.ts
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+import 'dotenv/config';
+import { registerSyncProviders } from '../lib/sync/register';
+import { enqueue, getRun } from '../lib/sync/queue';
+
+function parseArgs(argv: string[]) {
+  const args = argv.slice(2);
+  const provider = (args[0] || '').toLowerCase();
+  const out: any = { provider, params: {} };
+  for (let i = 1; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--index' || a === '-i') out.params.indexId = args[++i];
+    else if (a === '--user' || a === '-u') out.userId = args[++i];
+    else if (a === '--wait') out.wait = true;
+    else if (a.startsWith('--')) {
+      const k = a.slice(2);
+      out.params[k] = args[++i];
+    }
+  }
+  return out;
+}
+
+async function main() {
+  const { provider, params, userId, wait } = parseArgs(process.argv);
+  if (!provider) {
+    console.error('Usage: yarn sync-all <links|gmail|notion|slack|discord|calendar> [--index <id>] [--user <id>] [--wait]');
+    process.exit(1);
+  }
+  registerSyncProviders();
+  const uid = userId || process.env.SYNC_USER_ID;
+  if (!uid) {
+    console.error('Missing user id. Provide --user or SYNC_USER_ID env.');
+    process.exit(1);
+  }
+  const runId = await enqueue(provider as any, uid, params);
+  console.log(JSON.stringify({ runId }));
+  if (wait) {
+    // naive poll
+    for (;;) {
+      const run = await getRun(runId);
+      if (!run) throw new Error('Run disappeared');
+      if (run.status === 'succeeded' || run.status === 'failed') {
+        console.log(JSON.stringify({ run }));
+        process.exit(run.status === 'succeeded' ? 0 : 1);
+      }
+      await new Promise(r => setTimeout(r, 1000));
+    }
+  }
+}
+
+main().catch((e) => {
+  console.error('sync-all error:', e?.message || String(e));
+  process.exit(1);
+});

--- a/protocol/src/index.ts
+++ b/protocol/src/index.ts
@@ -18,6 +18,8 @@ import vibecheckRoutes from './routes/vibecheck';
 import synthesisRoutes from './routes/synthesis';
 import integrationRoutes from './routes/integrations';
 import indexLinksRoutes from './routes/index_links';
+import syncRoutes from './routes/sync';
+import { registerSyncProviders } from './lib/sync/register';
 
 const app = express();
 const PORT = process.env.PORT || 3001;
@@ -52,6 +54,7 @@ app.use('/api/indexes/:indexId/files', fileRoutes);
 app.use('/api/indexes/:indexId/links', indexLinksRoutes);
 app.use('/api/indexes', indexRoutes);
 app.use('/api/integrations', integrationRoutes);
+app.use('/api/sync', syncRoutes);
 
 app.use('/api/vibecheck', vibecheckRoutes);
 app.use('/api/synthesis', synthesisRoutes);
@@ -76,6 +79,13 @@ app.use('*', (req, res) => {
     console.log('🟢 Context brokers initialized');
   } catch (err) {
     console.error('🔴 Failed to initialize context brokers:', err);
+  }
+
+  try {
+    registerSyncProviders();
+    console.log('🟢 Sync providers registered');
+  } catch (err) {
+    console.error('🔴 Failed to register sync providers:', err);
   }
 
   app.listen(PORT, () => {

--- a/protocol/src/lib/schema.ts
+++ b/protocol/src/lib/schema.ts
@@ -191,6 +191,7 @@ export const indexLinks = pgTable('index_links', {
   id: uuid('id').primaryKey().defaultRandom(),
   indexId: uuid('index_id').notNull().references(() => indexes.id, { onDelete: 'cascade' }),
   url: text('url').notNull(),
+  lastContentHash: text('last_content_hash'),
   lastSyncAt: timestamp('last_sync_at'),
   lastStatus: text('last_status'),
   lastError: text('last_error'),
@@ -238,4 +239,41 @@ export type NewFile = typeof files.$inferInsert;
 export type IntentStake = typeof intentStakes.$inferSelect;
 export type NewIntentStake = typeof intentStakes.$inferInsert;
 export type UserConnectionEvent = typeof userConnectionEvents.$inferSelect;
+
+// Unified Sync tables
+export const syncRuns = pgTable('sync_runs', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  userId: uuid('user_id').notNull().references(() => users.id),
+  provider: varchar('provider', { length: 50 }).notNull(),
+  status: varchar('status', { length: 20 }).notNull().default('queued'),
+  params: json('params').$type<Record<string, any>>().default({}),
+  progress: json('progress').$type<{ total?: number; completed?: number; notes?: string[] } | null>().default(null),
+  stats: json('stats').$type<Record<string, any> | null>().default(null),
+  error: text('error'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  startedAt: timestamp('started_at'),
+  finishedAt: timestamp('finished_at'),
+});
+
+export const syncRunItems = pgTable('sync_run_items', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  runId: uuid('run_id').notNull().references(() => syncRuns.id, { onDelete: 'cascade' }),
+  externalId: text('external_id').notNull(),
+  status: varchar('status', { length: 20 }).notNull().default('pending'),
+  error: text('error'),
+  meta: json('meta').$type<Record<string, any> | null>().default(null),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+});
+
+export const providerCursors = pgTable('provider_cursors', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  userId: uuid('user_id').notNull().references(() => users.id),
+  provider: varchar('provider', { length: 50 }).notNull(),
+  cursor: json('cursor').$type<Record<string, any> | null>().default(null),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+});
+
+export type SyncRun = typeof syncRuns.$inferSelect;
+export type NewSyncRun = typeof syncRuns.$inferInsert;
 export type NewUserConnectionEvent = typeof userConnectionEvents.$inferInsert;

--- a/protocol/src/lib/sync/events.ts
+++ b/protocol/src/lib/sync/events.ts
@@ -1,0 +1,18 @@
+import { EventEmitter } from 'events';
+import type { SyncRun } from './types';
+
+const emitter = new EventEmitter();
+emitter.setMaxListeners(1000);
+
+export function emitRunUpdate(runId: string, run: SyncRun) {
+  emitter.emit(`run:${runId}`, run);
+}
+
+export function onRunUpdate(runId: string, listener: (run: SyncRun) => void) {
+  emitter.on(`run:${runId}`, listener);
+}
+
+export function offRunUpdate(runId: string, listener: (run: SyncRun) => void) {
+  emitter.off(`run:${runId}`, listener);
+}
+

--- a/protocol/src/lib/sync/process.ts
+++ b/protocol/src/lib/sync/process.ts
@@ -1,0 +1,86 @@
+import fs from 'fs';
+import path from 'path';
+import db from '../db';
+import { intents, intentIndexes } from '../schema';
+import { and, eq, isNull } from 'drizzle-orm';
+import { analyzeFolder } from '../../agents/core/intent_inferrer';
+import { summarizeIntent } from '../../agents/core/intent_summarizer';
+
+import type { IntegrationFile } from '../integrations';
+
+export async function getExistingPayloads(userId: string, indexId?: string): Promise<Set<string>> {
+  if (indexId) {
+    const rows = await db
+      .select({ payload: intents.payload })
+      .from(intents)
+      .innerJoin(intentIndexes, eq(intents.id, intentIndexes.intentId))
+      .where(and(eq(intentIndexes.indexId, indexId), eq(intents.userId, userId), isNull(intents.archivedAt)));
+    return new Set(rows.map((r) => r.payload));
+  }
+  const rows = await db
+    .select({ payload: intents.payload })
+    .from(intents)
+    .where(and(eq(intents.userId, userId), isNull(intents.archivedAt)));
+  return new Set(rows.map((r) => r.payload));
+}
+
+export async function processFilesToIntents(options: {
+  userId: string;
+  indexId?: string;
+  files: IntegrationFile[];
+  textInstruction: string;
+  count: number;
+  timeoutMs?: number;
+  summarize?: boolean;
+  onProgress?: (completed: number, total: number, note?: string) => Promise<void> | void;
+}): Promise<{ intentsGenerated: number; filesImported: number }>{
+  const { userId, indexId, files, textInstruction, count, summarize = false, timeoutMs = 60000, onProgress } = options;
+  if (!files.length) return { intentsGenerated: 0, filesImported: 0 };
+
+  const baseTempDir = path.join(process.cwd(), 'temp-uploads', `sync-${userId}-${Date.now()}`);
+  await fs.promises.mkdir(baseTempDir, { recursive: true });
+  try {
+    // Write all files into a single temp folder and call analyze once
+    const fileIds: string[] = [];
+    let completed = 0;
+    for (const f of files) {
+      await fs.promises.writeFile(path.join(baseTempDir, `${f.id}.md`), f.content);
+      fileIds.push(f.id);
+      completed += 1;
+      await onProgress?.(completed, files.length, `saved ${completed}/${files.length}`);
+    }
+
+    const existingPayloads = await getExistingPayloads(userId, indexId);
+    const result = await analyzeFolder(
+      baseTempDir,
+      fileIds,
+      textInstruction,
+      Array.from(existingPayloads),
+      [],
+      Math.max(1, count),
+      timeoutMs
+    );
+
+    let intentsGenerated = 0;
+    if (result.success && result.intents.length > 0) {
+      for (const intentData of result.intents) {
+        if (existingPayloads.has(intentData.payload)) continue;
+        const summary = summarize ? await summarizeIntent(intentData.payload) : undefined;
+        const inserted = await db
+          .insert(intents)
+          .values({ payload: intentData.payload, userId, isIncognito: false, summary: summary })
+          .returning({ id: intents.id });
+        const intentId = inserted[0].id;
+        if (indexId) {
+          await db.insert(intentIndexes).values({ intentId, indexId });
+        }
+        existingPayloads.add(intentData.payload);
+        intentsGenerated += 1;
+      }
+    }
+    return { intentsGenerated, filesImported: files.length };
+  } finally {
+    await fs.promises.rm(baseTempDir, { recursive: true, force: true });
+  }
+}
+

--- a/protocol/src/lib/sync/providers/integrations.ts
+++ b/protocol/src/lib/sync/providers/integrations.ts
@@ -1,0 +1,78 @@
+import db from '../../db';
+import { userIntegrations, providerCursors } from '../../schema';
+import { eq, and, isNull } from 'drizzle-orm';
+import { handlers } from '../../integrations';
+import { log } from '../../log';
+import { processFilesToIntents } from '../process';
+import type { SyncProvider, SyncRun } from '../types';
+
+type IntegrationType = 'notion' | 'gmail' | 'slack' | 'discord' | 'calendar';
+
+type Params = { indexId?: string };
+
+async function getConnectedIntegration(userId: string, integrationType: IntegrationType) {
+  const rows = await db
+    .select()
+    .from(userIntegrations)
+    .where(
+      and(
+        eq(userIntegrations.userId, userId),
+        eq(userIntegrations.integrationType, integrationType),
+        eq(userIntegrations.status, 'connected'),
+        isNull(userIntegrations.deletedAt)
+      )
+    )
+    .limit(1);
+  return rows[0] || null;
+}
+
+export function createIntegrationProvider(type: IntegrationType): SyncProvider<Params> {
+  return {
+    name: type,
+    async start(run: SyncRun, params: Params, update) {
+      const integrationRec = await getConnectedIntegration(run.userId, type);
+      if (!integrationRec) throw new Error('Integration not connected');
+
+      const handler = handlers[type];
+      if (!handler) throw new Error('Unsupported integration type');
+
+      // Load provider cursor (store lastSyncAt as a simple delta cursor for now)
+      const cursorRows = await db.select().from(providerCursors).where(and(eq(providerCursors.userId, run.userId), eq(providerCursors.provider, type))).limit(1);
+      const cursor = cursorRows[0]?.cursor as any | undefined;
+      const lastSyncAt = cursor?.lastSyncAt ? new Date(cursor.lastSyncAt) : integrationRec.lastSyncAt || undefined;
+
+      await update({ progress: { notes: [`fetching ${type} files`] } });
+      const files = await handler.fetchFiles(run.userId, lastSyncAt || undefined);
+      await update({ progress: { total: files.length, completed: 0, notes: [`fetched ${files.length} files`] } });
+
+      const { intentsGenerated, filesImported } = await processFilesToIntents({
+        userId: run.userId,
+        indexId: params.indexId,
+        files,
+        textInstruction: `Generate intents based on content from ${type} integration`,
+        count: 30,
+        summarize: false,
+        onProgress: async (completed, total, note) => {
+          await update({ progress: { total, completed, notes: note ? [note] : [] } });
+        },
+      });
+
+      const finishedAt = new Date();
+      await db
+        .update(userIntegrations)
+        .set({ lastSyncAt: finishedAt })
+        .where(eq(userIntegrations.id, integrationRec.id));
+
+      // Persist provider cursor
+      const newCursor = { lastSyncAt: finishedAt.toISOString() } as any;
+      if (cursorRows.length) {
+        await db.update(providerCursors).set({ cursor: newCursor, updatedAt: finishedAt }).where(eq(providerCursors.id, cursorRows[0].id));
+      } else {
+        await db.insert(providerCursors).values({ userId: run.userId, provider: type, cursor: newCursor });
+      }
+
+      log.info(`${type}-sync-run`, { runId: run.id, filesImported, intentsGenerated });
+      await update({ stats: { filesImported, intentsGenerated } });
+    },
+  };
+}

--- a/protocol/src/lib/sync/providers/links.ts
+++ b/protocol/src/lib/sync/providers/links.ts
@@ -64,20 +64,6 @@ export const linksProvider: SyncProvider<Params> = {
       .where(eq(intentIndexes.indexId, indexId));
     const existingPayloads = new Set(existingIntentRows.map(r => r.payload));
 
-    // Simple semantic-similarity guardrail to avoid near-duplicates
-    function jaccard(a: string, b: string): number {
-      const toTokens = (s: string) => Array.from(new Set(s.toLowerCase().replace(/[^a-z0-9\s]/g, ' ').split(/\s+/).filter(Boolean)));
-      const A = toTokens(a); const B = toTokens(b);
-      const setA = new Set(A); const setB = new Set(B);
-      let inter = 0; for (const t of setA) if (setB.has(t)) inter++;
-      const uni = setA.size + setB.size - inter;
-      return uni === 0 ? 1 : inter / uni;
-    }
-    function isTooSimilar(payload: string): boolean {
-      for (const p of existingPayloads) { if (jaccard(p, payload) >= 0.9) return true; }
-      return false;
-    }
-
     let intentsGenerated = 0;
     let filesImported = 0;
     let skippedUnchanged = 0;
@@ -113,7 +99,7 @@ export const linksProvider: SyncProvider<Params> = {
 
         if (result.success && result.intents.length > 0) {
           const intentData = result.intents[0];
-          if (!existingPayloads.has(intentData.payload) && !isTooSimilar(intentData.payload)) {
+          if (!existingPayloads.has(intentData.payload)) {
             const summary = await summarizeIntent(intentData.payload);
             const inserted = await db.insert(intents).values({
               payload: intentData.payload,

--- a/protocol/src/lib/sync/providers/links.ts
+++ b/protocol/src/lib/sync/providers/links.ts
@@ -12,7 +12,7 @@ import { config } from '../../crawl/config';
 import { log } from '../../log';
 import type { SyncProvider, SyncRun } from '../types';
 
-type Params = { indexId: string; count?: number; skipBrokers?: boolean };
+type Params = { indexId: string; count?: number; skipBrokers?: boolean; all?: boolean };
 
 export const linksProvider: SyncProvider<Params> = {
   name: 'links',
@@ -22,14 +22,32 @@ export const linksProvider: SyncProvider<Params> = {
     const access = await checkIndexAccess(indexId, run.userId);
     if (!access.hasAccess) throw new Error(access.error || 'No access to index');
 
-    const links = await db.select().from(indexLinks).where(eq(indexLinks.indexId, indexId));
-    if (links.length === 0) {
+    const allLinks = await db.select().from(indexLinks).where(eq(indexLinks.indexId, indexId));
+    if (allLinks.length === 0) {
       await update({ stats: { filesImported: 0, intentsGenerated: 0, links: 0, pagesVisited: 0 } });
+      return;
+    }
+    // Process only never-synced links unless 'all' is set
+    const processAll = params.all === true;
+    const links = processAll ? allLinks : allLinks.filter(l => !l.lastSyncAt);
+    if (links.length === 0) {
+      await update({ stats: { filesImported: 0, intentsGenerated: 0, links: 0, pagesVisited: 0, note: processAll ? 'nothing-to-do' : 'no-new-links' } });
       return;
     }
 
     const urls = links.map(l => l.url);
     const byUrl = new Map(links.map(l => [l.url, l] as const));
+    const normalize = (u: string) => {
+      try {
+        const x = new URL(u);
+        const host = x.hostname.toLowerCase();
+        const pathname = x.pathname.replace(/\/+$/, '');
+        return `${x.protocol}//${host}${pathname || ''}`;
+      } catch {
+        return u;
+      }
+    };
+    const byNorm = new Map(links.map(l => [normalize(l.url), l] as const));
     const startedAt = Date.now();
     await update({ progress: { total: urls.length, completed: 0, notes: [`starting crawl (${urls.length} urls)`] } });
 
@@ -46,6 +64,20 @@ export const linksProvider: SyncProvider<Params> = {
       .where(eq(intentIndexes.indexId, indexId));
     const existingPayloads = new Set(existingIntentRows.map(r => r.payload));
 
+    // Simple semantic-similarity guardrail to avoid near-duplicates
+    function jaccard(a: string, b: string): number {
+      const toTokens = (s: string) => Array.from(new Set(s.toLowerCase().replace(/[^a-z0-9\s]/g, ' ').split(/\s+/).filter(Boolean)));
+      const A = toTokens(a); const B = toTokens(b);
+      const setA = new Set(A); const setB = new Set(B);
+      let inter = 0; for (const t of setA) if (setB.has(t)) inter++;
+      const uni = setA.size + setB.size - inter;
+      return uni === 0 ? 1 : inter / uni;
+    }
+    function isTooSimilar(payload: string): boolean {
+      for (const p of existingPayloads) { if (jaccard(p, payload) >= 0.9) return true; }
+      return false;
+    }
+
     let intentsGenerated = 0;
     let filesImported = 0;
     let skippedUnchanged = 0;
@@ -57,7 +89,7 @@ export const linksProvider: SyncProvider<Params> = {
       for (const f of crawl.files) {
         const meta = crawl.urlMap[f.id];
         if (!meta) continue;
-        const linkRow = byUrl.get(meta.url);
+        const linkRow = byUrl.get(meta.url) || byNorm.get(normalize(meta.url));
         if (linkRow && linkRow.lastContentHash && linkRow.lastContentHash === meta.contentHash) {
           skippedUnchanged += 1;
           completed += 1;
@@ -81,7 +113,7 @@ export const linksProvider: SyncProvider<Params> = {
 
         if (result.success && result.intents.length > 0) {
           const intentData = result.intents[0];
-          if (!existingPayloads.has(intentData.payload)) {
+          if (!existingPayloads.has(intentData.payload) && !isTooSimilar(intentData.payload)) {
             const summary = await summarizeIntent(intentData.payload);
             const inserted = await db.insert(intents).values({
               payload: intentData.payload,

--- a/protocol/src/lib/sync/providers/links.ts
+++ b/protocol/src/lib/sync/providers/links.ts
@@ -1,0 +1,123 @@
+import path from 'path';
+import fs from 'fs';
+import db from '../../db';
+import { indexLinks, intents, intentIndexes } from '../../schema';
+import { eq, and } from 'drizzle-orm';
+import { analyzeFolder } from '../../../agents/core/intent_inferrer';
+import { summarizeIntent } from '../../../agents/core/intent_summarizer';
+import { crawlLinksForIndex } from '../../crawl/web_crawler';
+import { checkIndexAccess } from '../../index-access';
+import { triggerBrokersOnIntentCreated } from '../../../agents/context_brokers/connector';
+import { config } from '../../crawl/config';
+import { log } from '../../log';
+import type { SyncProvider, SyncRun } from '../types';
+
+type Params = { indexId: string; count?: number; skipBrokers?: boolean };
+
+export const linksProvider: SyncProvider<Params> = {
+  name: 'links',
+  async start(run: SyncRun, params: Params, update) {
+    const { indexId } = params;
+
+    const access = await checkIndexAccess(indexId, run.userId);
+    if (!access.hasAccess) throw new Error(access.error || 'No access to index');
+
+    const links = await db.select().from(indexLinks).where(eq(indexLinks.indexId, indexId));
+    if (links.length === 0) {
+      await update({ stats: { filesImported: 0, intentsGenerated: 0, links: 0, pagesVisited: 0 } });
+      return;
+    }
+
+    const urls = links.map(l => l.url);
+    const byUrl = new Map(links.map(l => [l.url, l] as const));
+    const startedAt = Date.now();
+    await update({ progress: { total: urls.length, completed: 0, notes: [`starting crawl (${urls.length} urls)`] } });
+
+    const crawl = await crawlLinksForIndex(urls);
+
+    const userId = run.userId;
+    const requestedCount = Math.max(1, Math.min(1, params.count ?? 1));
+    const skipBrokers = params.skipBrokers === true || !config.linksSync.triggerBrokers;
+
+    // Existing intents for dedupe by payload
+    const existingIntentRows = await db.select({ payload: intents.payload })
+      .from(intents)
+      .innerJoin(intentIndexes, eq(intents.id, intentIndexes.intentId))
+      .where(eq(intentIndexes.indexId, indexId));
+    const existingPayloads = new Set(existingIntentRows.map(r => r.payload));
+
+    let intentsGenerated = 0;
+    let filesImported = 0;
+    let skippedUnchanged = 0;
+
+    const baseTempDir = path.join(process.cwd(), 'temp-uploads', `links-${userId}-${Date.now()}`);
+    await fs.promises.mkdir(baseTempDir, { recursive: true });
+    try {
+      let completed = 0;
+      for (const f of crawl.files) {
+        const meta = crawl.urlMap[f.id];
+        if (!meta) continue;
+        const linkRow = byUrl.get(meta.url);
+        if (linkRow && linkRow.lastContentHash && linkRow.lastContentHash === meta.contentHash) {
+          skippedUnchanged += 1;
+          completed += 1;
+          await update({ progress: { total: crawl.files.length, completed, notes: [`skipped unchanged ${completed}/${crawl.files.length}`] } });
+          continue;
+        }
+        const tempDir = path.join(baseTempDir, f.id);
+        await fs.promises.mkdir(tempDir, { recursive: true });
+        await fs.promises.writeFile(path.join(tempDir, `${f.id}.md`), f.content);
+        filesImported += 1;
+
+        const result = await analyzeFolder(
+          tempDir,
+          [f.id],
+          `Generate intents based on content from ${meta.url}`,
+          Array.from(existingPayloads),
+          [],
+          requestedCount,
+          60000
+        );
+
+        if (result.success && result.intents.length > 0) {
+          const intentData = result.intents[0];
+          if (!existingPayloads.has(intentData.payload)) {
+            const summary = await summarizeIntent(intentData.payload);
+            const inserted = await db.insert(intents).values({
+              payload: intentData.payload,
+              summary: summary || intentData.payload.slice(0, 150),
+              userId,
+              isIncognito: false,
+            }).returning({ id: intents.id });
+            const intentId = inserted[0].id;
+            await db.insert(intentIndexes).values({ intentId, indexId });
+            existingPayloads.add(intentData.payload);
+            if (!skipBrokers) {
+              triggerBrokersOnIntentCreated(intentId).catch(() => void 0);
+            }
+            intentsGenerated += 1;
+          }
+        }
+        // Update last content hash for this link if we can map it
+        if (linkRow) {
+          await db.update(indexLinks).set({ lastContentHash: meta.contentHash }).where(eq(indexLinks.id, linkRow.id));
+        }
+        completed += 1;
+        await update({ progress: { total: crawl.files.length, completed, notes: [`processed ${completed}/${crawl.files.length}`] } });
+      }
+    } finally {
+      await fs.promises.rm(baseTempDir, { recursive: true, force: true });
+    }
+
+    const finishedAt = Date.now();
+    const statusText = `ok: pages=${crawl.pagesVisited} files=${filesImported} intents=${intentsGenerated} skipped=${skippedUnchanged} duration=${finishedAt - startedAt}ms`;
+    for (const l of links) {
+      await db.update(indexLinks)
+        .set({ lastSyncAt: new Date(), lastStatus: statusText, lastError: null })
+        .where(eq(indexLinks.id, l.id));
+    }
+
+    log.info('links-sync-run', { runId: run.id, indexId, pagesVisited: crawl.pagesVisited, filesImported, intentsGenerated, durationMs: finishedAt - startedAt });
+    await update({ stats: { filesImported, intentsGenerated, links: links.length, pagesVisited: crawl.pagesVisited } });
+  },
+};

--- a/protocol/src/lib/sync/queue.ts
+++ b/protocol/src/lib/sync/queue.ts
@@ -1,0 +1,43 @@
+import PQueue from 'p-queue';
+import { runStore } from './run-store';
+import { SyncProvider, SyncRun, SyncProviderName } from './types';
+import { emitRunUpdate } from './events';
+
+const queue = new PQueue({ concurrency: Number(process.env.SYNC_CONCURRENCY || '2') });
+
+const providers = new Map<SyncProviderName, SyncProvider>();
+
+export function registerProvider(p: SyncProvider) {
+  providers.set(p.name, p);
+}
+
+export async function enqueue(provider: SyncProviderName, userId: string, params: Record<string, any>) {
+  const p = providers.get(provider);
+  if (!p) throw new Error(`Unknown provider: ${provider}`);
+  const run = await runStore.create({ provider, userId, params, status: 'queued' });
+  emitRunUpdate(run.id, run);
+
+  queue.add(async () => {
+    const start = Date.now();
+    const started = await runStore.update(run.id, { status: 'running', startedAt: start });
+    if (started) emitRunUpdate(run.id, started);
+    const update = async (patch: Partial<SyncRun>) => {
+      const updated = await runStore.update(run.id, patch);
+      if (updated) emitRunUpdate(run.id, updated);
+    };
+    try {
+      await p.start(run, params, update);
+      const finishedAt = Date.now();
+      await update({ status: 'succeeded', finishedAt });
+    } catch (e: any) {
+      const finishedAt = Date.now();
+      await update({ status: 'failed', finishedAt, error: e?.message || String(e) });
+    }
+  }).catch(() => void 0);
+
+  return run.id;
+}
+
+export async function getRun(runId: string) {
+  return runStore.get(runId);
+}

--- a/protocol/src/lib/sync/register.ts
+++ b/protocol/src/lib/sync/register.ts
@@ -1,0 +1,12 @@
+import { registerProvider } from './queue';
+import { linksProvider } from './providers/links';
+import { createIntegrationProvider } from './providers/integrations';
+
+export function registerSyncProviders() {
+  registerProvider(linksProvider);
+  registerProvider(createIntegrationProvider('notion'));
+  registerProvider(createIntegrationProvider('gmail'));
+  registerProvider(createIntegrationProvider('slack'));
+  registerProvider(createIntegrationProvider('discord'));
+  registerProvider(createIntegrationProvider('calendar'));
+}

--- a/protocol/src/lib/sync/run-store.db.ts
+++ b/protocol/src/lib/sync/run-store.db.ts
@@ -1,0 +1,59 @@
+import db from '../db';
+import { syncRuns } from '../schema';
+import { eq } from 'drizzle-orm';
+import type { SyncRun as ModelSyncRun } from '../schema';
+import type { SyncRun } from './types';
+
+function mapToSyncRun(m: ModelSyncRun): SyncRun {
+  return {
+    id: m.id,
+    userId: m.userId,
+    provider: m.provider as any,
+    status: (m.status as any),
+    createdAt: m.createdAt?.getTime?.() || Date.now(),
+    startedAt: m.startedAt?.getTime?.(),
+    finishedAt: m.finishedAt?.getTime?.(),
+    params: (m as any).params || {},
+    progress: (m as any).progress || undefined,
+    stats: (m as any).stats || undefined,
+    error: (m as any).error || null,
+  };
+}
+
+export class DBRunStore {
+  async create(initial: Omit<SyncRun, 'id' | 'createdAt' | 'status'> & Partial<Pick<SyncRun, 'status'>>): Promise<SyncRun> {
+    const rows = await db.insert(syncRuns).values({
+      userId: initial.userId,
+      provider: initial.provider,
+      status: initial.status ?? 'queued',
+      params: initial.params || {},
+      progress: initial.progress || null,
+      stats: initial.stats || null,
+      error: initial.error || null,
+    }).returning();
+    return mapToSyncRun(rows[0]);
+  }
+
+  async update(runId: string, patch: Partial<SyncRun>): Promise<SyncRun | null> {
+    const current = await this.get(runId);
+    if (!current) return null;
+    const next: Partial<ModelSyncRun> = {
+      status: (patch.status as any) ?? (current.status as any),
+      startedAt: patch.startedAt ? new Date(patch.startedAt) : (current.startedAt ? new Date(current.startedAt) : null) as any,
+      finishedAt: patch.finishedAt ? new Date(patch.finishedAt) : (current.finishedAt ? new Date(current.finishedAt) : null) as any,
+      error: patch.error ?? current.error ?? null,
+      params: patch.params ? { ...(current.params || {}), ...patch.params } : current.params || {},
+      progress: patch.progress ? { ...(current.progress || {}), ...patch.progress } : (current.progress || null) as any,
+      stats: patch.stats ? { ...(current.stats || {}), ...patch.stats } : (current.stats || null) as any,
+    } as any;
+    const rows = await db.update(syncRuns).set(next).where(eq(syncRuns.id, runId)).returning();
+    return rows.length ? mapToSyncRun(rows[0]) : null;
+  }
+
+  async get(runId: string): Promise<SyncRun | null> {
+    const rows = await db.select().from(syncRuns).where(eq(syncRuns.id, runId)).limit(1);
+    if (!rows.length) return null;
+    return mapToSyncRun(rows[0]);
+  }
+}
+

--- a/protocol/src/lib/sync/run-store.ts
+++ b/protocol/src/lib/sync/run-store.ts
@@ -1,3 +1,13 @@
+/**
+ * Run Store
+ *
+ * Responsibility: persist SyncRun state (id, status, progress, stats) so
+ * HTTP clients and the CLI can query progress and survive restarts.
+ *
+ * Modes:
+ * - DB-backed (default): uses run-store.db.ts (Drizzle) when SYNC_USE_DB_STORE != '0'
+ * - In-memory fallback: useful in local dev or tests
+ */
 import { SyncRun } from './types';
 import crypto from 'crypto';
 

--- a/protocol/src/lib/sync/run-store.ts
+++ b/protocol/src/lib/sync/run-store.ts
@@ -1,0 +1,45 @@
+import { SyncRun } from './types';
+import crypto from 'crypto';
+
+function id(): string {
+  return crypto.randomUUID ? crypto.randomUUID() : crypto.randomBytes(16).toString('hex');
+}
+
+class InMemoryRunStore {
+  private runs = new Map<string, SyncRun>();
+
+  async create(initial: Omit<SyncRun, 'id' | 'createdAt' | 'status'> & Partial<Pick<SyncRun, 'status'>>): Promise<SyncRun> {
+    const run: SyncRun = {
+      id: id(),
+      createdAt: Date.now(),
+      status: initial.status ?? 'queued',
+      ...initial,
+    } as SyncRun;
+    this.runs.set(run.id, run);
+    return run;
+  }
+
+  async update(runId: string, patch: Partial<SyncRun>): Promise<SyncRun | null> {
+    const curr = this.runs.get(runId);
+    if (!curr) return null;
+    const next = { ...curr, ...patch } as SyncRun;
+    this.runs.set(runId, next);
+    return next;
+  }
+
+  async get(runId: string): Promise<SyncRun | null> {
+    return this.runs.get(runId) ?? null;
+  }
+}
+
+let store: any;
+try {
+  // Default to DB store unless explicitly disabled
+  if (process.env.SYNC_USE_DB_STORE !== '0') {
+    const { DBRunStore } = require('./run-store.db');
+    store = new DBRunStore();
+  }
+} catch {
+  // fall back to memory
+}
+export const runStore = store || new InMemoryRunStore();

--- a/protocol/src/lib/sync/types.ts
+++ b/protocol/src/lib/sync/types.ts
@@ -1,0 +1,26 @@
+export type SyncProviderName = 'links' | 'gmail' | 'notion' | 'slack' | 'discord' | 'calendar';
+
+export type RunStatus = 'queued' | 'running' | 'succeeded' | 'failed';
+
+export type SyncRun = {
+  id: string;
+  provider: SyncProviderName;
+  userId: string;
+  params: Record<string, any>;
+  status: RunStatus;
+  createdAt: number;
+  startedAt?: number;
+  finishedAt?: number;
+  progress?: {
+    total?: number;
+    completed?: number;
+    notes?: string[];
+  };
+  stats?: Record<string, any>;
+  error?: string | null;
+};
+
+export interface SyncProvider<Params extends Record<string, any> = any> {
+  name: SyncProviderName;
+  start(run: SyncRun, params: Params, update: (patch: Partial<SyncRun>) => Promise<void>): Promise<void>;
+}

--- a/protocol/src/routes/index_links.ts
+++ b/protocol/src/routes/index_links.ts
@@ -176,11 +176,12 @@ router.post('/sync',
       const access = await checkIndexAccess(indexId, req.user!.id);
       if (!access.hasAccess) return res.status(access.status!).json({ error: access.error });
       // Enqueue async run using unified sync engine
-      const skipBrokersQ = ((req.query as any).skipBrokers || '').toString().toLowerCase();
-      const skipBrokers = skipBrokersQ === '1' || skipBrokersQ === 'true';
+      const q = (req.query as any) || {};
+      const skipBrokers = ['1','true'].includes(String(q.skipBrokers || '').toLowerCase());
+      const all = ['1','true'].includes(String(q.all || '').toLowerCase());
       // Provide quick UX-friendly placeholder stats for compatibility
       const links = await db.select().from(indexLinks).where(eq(indexLinks.indexId, indexId));
-      const runId = await enqueue('links', req.user!.id, { indexId, skipBrokers });
+      const runId = await enqueue('links', req.user!.id, { indexId, skipBrokers, all });
       return res.status(202).json({
         runId,
         success: true,

--- a/protocol/src/routes/index_links.ts
+++ b/protocol/src/routes/index_links.ts
@@ -1,18 +1,13 @@
 import { Router, Response } from 'express';
 import { body, param, validationResult } from 'express-validator';
 import db from '../lib/db';
-import { indexLinks, intents, intentIndexes } from '../lib/schema';
+import { indexLinks } from '../lib/schema';
 import { authenticatePrivy, AuthRequest } from '../middleware/auth';
-import { and, desc, eq, isNull } from 'drizzle-orm';
+import { and, desc, eq } from 'drizzle-orm';
 import { checkIndexAccess } from '../lib/index-access';
-import { crawlLinksForIndex } from '../lib/crawl/web_crawler';
-import path from 'path';
-import fs from 'fs';
-import { analyzeFolder } from '../agents/core/intent_inferrer';
-import { summarizeIntent } from '../agents/core/intent_summarizer';
-import { config } from '../lib/crawl/config';
-import { triggerBrokersOnIntentCreated } from '../agents/context_brokers/connector';
-import { log } from '../lib/log';
+// unified sync engine
+import { enqueue } from '../lib/sync/queue';
+ 
 
 const router = Router({ mergeParams: true });
 
@@ -180,99 +175,22 @@ router.post('/sync',
       const { indexId } = req.params;
       const access = await checkIndexAccess(indexId, req.user!.id);
       if (!access.hasAccess) return res.status(access.status!).json({ error: access.error });
-
-      const links = await db.select().from(indexLinks).where(eq(indexLinks.indexId, indexId));
-      if (links.length === 0) return res.json({ success: true, filesImported: 0, intentsGenerated: 0, links: 0 });
-
-      // Crawl with global defaults (config.webCrawl)
-      const urls = links.map(l => l.url);
-      const startedAt = Date.now();
-      const crawl = await crawlLinksForIndex(urls);
-
-      // Per-file processing (1 page -> 1 intent) with dedupe
-      const userId = req.user!.id;
-      const requestedCount = Number((req.query as any).count) || 1; // per page, cap to 1
+      // Enqueue async run using unified sync engine
       const skipBrokersQ = ((req.query as any).skipBrokers || '').toString().toLowerCase();
-      const skipBrokers = skipBrokersQ === '1' || skipBrokersQ === 'true' || !config.linksSync.triggerBrokers;
-
-      let intentsGenerated = 0;
-      let filesImported = 0;
-
-      // Create base temp dir
-      const baseTempDir = path.join(process.cwd(), 'temp-uploads', `links-${userId}-${Date.now()}`);
-      await fs.promises.mkdir(baseTempDir, { recursive: true });
-
-      // Existing intents for dedupe by payload (once per sync)
-      const existingIntentRows = await db.select({ payload: intents.payload })
-        .from(intents)
-        .innerJoin(intentIndexes, eq(intents.id, intentIndexes.intentId))
-        .where(eq(intentIndexes.indexId, indexId));
-      const existingPayloads = new Set(existingIntentRows.map(r => r.payload));
-
-      for (const f of crawl.files) {
-        const meta = crawl.urlMap[f.id];
-        if (!meta) continue;
-        // Write one file
-        const tempDir = path.join(baseTempDir, f.id);
-        await fs.promises.mkdir(tempDir, { recursive: true });
-        await fs.promises.writeFile(path.join(tempDir, `${f.id}.md`), f.content);
-        filesImported += 1;
-
-        // Analyze just this page (count=1)
-        const result = await analyzeFolder(
-          tempDir,
-          [f.id],
-          `Generate intents based on content from ${meta.url}`,
-          Array.from(existingPayloads),
-          [],
-          Math.max(1, Math.min(1, requestedCount)),
-          60000
-        );
-
-        if (result.success && result.intents.length > 0) {
-          const intentData = result.intents[0];
-          if (existingPayloads.has(intentData.payload)) {
-            continue; // dedupe: already have this payload for the index
-          }
-          // Generate summary for better UI display
-          const summary = await summarizeIntent(intentData.payload);
-          const inserted = await db.insert(intents).values({
-            payload: intentData.payload,
-            summary: summary || intentData.payload.slice(0, 150),
-            userId,
-            isIncognito: false,
-          }).returning({ id: intents.id });
-          const intentId = inserted[0].id;
-          await db.insert(intentIndexes).values({ intentId, indexId });
-          existingPayloads.add(intentData.payload);
-
-          if (!skipBrokers) {
-            triggerBrokersOnIntentCreated(intentId).catch(() => void 0);
-          }
-          intentsGenerated += 1;
-        }
-      }
-
-      // Cleanup temp
-      await fs.promises.rm(baseTempDir, { recursive: true, force: true });
-
-      const finishedAt = Date.now();
-      const statusText = `ok: pages=${crawl.pagesVisited} files=${filesImported} intents=${intentsGenerated} duration=${finishedAt - startedAt}ms`;
-      for (const l of links) {
-        await db.update(indexLinks)
-          .set({ lastSyncAt: new Date(), lastStatus: statusText, lastError: null })
-          .where(eq(indexLinks.id, l.id));
-      }
-
-      // Structured log
-      log.info('links-sync', { indexId, pagesVisited: crawl.pagesVisited, filesImported, intentsGenerated, durationMs: finishedAt - startedAt });
-      return res.json({
+      const skipBrokers = skipBrokersQ === '1' || skipBrokersQ === 'true';
+      // Provide quick UX-friendly placeholder stats for compatibility
+      const links = await db.select().from(indexLinks).where(eq(indexLinks.indexId, indexId));
+      const runId = await enqueue('links', req.user!.id, { indexId, skipBrokers });
+      return res.status(202).json({
+        runId,
         success: true,
-        filesImported,
-        intentsGenerated,
+        status: 'queued',
         links: links.length,
-        pagesVisited: crawl.pagesVisited,
-        durationMs: finishedAt - startedAt,
+        filesImported: 0,
+        intentsGenerated: 0,
+        pagesVisited: 0,
+        durationMs: 0,
+        message: 'Sync queued; polling run status.'
       });
     } catch (err) {
       console.error('Sync index links error:', err);

--- a/protocol/src/routes/integrations.ts
+++ b/protocol/src/routes/integrations.ts
@@ -5,7 +5,7 @@ import { authenticatePrivy, AuthRequest } from '../middleware/auth';
 import db from '../lib/db';
 import { userIntegrations } from '../lib/schema';
 import { eq, and, isNull } from 'drizzle-orm';
-import { syncIntegration } from '../lib/integrations/core/integration-sync';
+import { enqueue } from '../lib/sync/queue';
 
 const router = Router();
 
@@ -289,13 +289,21 @@ router.post('/sync/:integrationType',
       const integrationType = req.params.integrationType;
       const { indexId } = req.body;
 
-      const result = await syncIntegration(userId, integrationType, indexId);
-
-      if (!result.success) {
-        return res.status(400).json({ error: result.error });
+      // Map integrationType to sync provider names (same slug here)
+      const provider = integrationType as any;
+      try {
+        const runId = await enqueue(provider, userId, { indexId });
+        return res.status(202).json({
+          runId,
+          success: true,
+          status: 'queued',
+          filesImported: 0,
+          intentsGenerated: 0,
+          message: 'Sync queued; polling run status.'
+        });
+      } catch (e: any) {
+        return res.status(400).json({ error: e?.message || 'Failed to enqueue integration sync' });
       }
-
-      return res.json(result);
     } catch (error) {
       log.error('Sync integration error', { error: error instanceof Error ? error.message : String(error) });
       return res.status(500).json({ error: 'Failed to sync integration' });

--- a/protocol/src/routes/sync.ts
+++ b/protocol/src/routes/sync.ts
@@ -1,0 +1,84 @@
+import { Router, Response } from 'express';
+import { body, param, validationResult } from 'express-validator';
+import { authenticatePrivy, AuthRequest } from '../middleware/auth';
+import { enqueue, getRun } from '../lib/sync/queue';
+import { SyncProviderName } from '../lib/sync/types';
+import { onRunUpdate, offRunUpdate } from '../lib/sync/events';
+
+const router = Router();
+
+router.post('/now',
+  authenticatePrivy,
+  [
+    body('provider').isString().isIn(['links','gmail','notion','slack','discord','calendar']),
+    body('params').optional().isObject(),
+  ],
+  async (req: AuthRequest, res: Response) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) return res.status(400).json({ errors: errors.array() });
+    try {
+      const provider = req.body.provider as SyncProviderName;
+      const params = (req.body.params || {}) as Record<string, any>;
+      const runId = await enqueue(provider, req.user!.id, params);
+      return res.status(202).json({ runId });
+    } catch (err) {
+      return res.status(500).json({ error: 'Failed to enqueue sync' });
+    }
+  }
+);
+
+router.get('/runs/:runId',
+  authenticatePrivy,
+  [param('runId').isString()],
+  async (req: AuthRequest, res: Response) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) return res.status(400).json({ errors: errors.array() });
+    try {
+      const run = await getRun(req.params.runId);
+      if (!run) return res.status(404).json({ error: 'Run not found' });
+      if (run.userId !== req.user!.id) return res.status(403).json({ error: 'Forbidden' });
+      return res.json({ run });
+    } catch (err) {
+      return res.status(500).json({ error: 'Failed to fetch run' });
+    }
+  }
+);
+
+export default router;
+
+// Server-Sent Events for live progress
+router.get('/runs/:runId/events',
+  authenticatePrivy,
+  [param('runId').isString()],
+  async (req: AuthRequest, res: Response) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) return res.status(400).json({ errors: errors.array() });
+
+    const { runId } = req.params as any;
+    const run = await getRun(runId);
+    if (!run) return res.status(404).json({ error: 'Run not found' });
+    if (run.userId !== req.user!.id) return res.status(403).json({ error: 'Forbidden' });
+
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+    res.flushHeaders?.();
+
+    const send = (r: any) => {
+      res.write(`data: ${JSON.stringify({ run: r })}\n\n`);
+    };
+
+    const listener = (r: any) => send(r);
+    onRunUpdate(runId, listener);
+    // Send initial snapshot
+    send(run);
+
+    const heartbeat = setInterval(() => res.write(': ping\n\n'), 15000);
+    req.on('close', () => {
+      clearInterval(heartbeat);
+      offRunUpdate(runId, listener);
+      res.end();
+    });
+    return;
+  }
+);


### PR DESCRIPTION
# Summary

Introduces a shared async sync engine used by **Links**, **Notion**, and **Gmail**.  
All syncs enqueue and return a `runId`; runs are stored in DB with progress available via polling (and SSE).

- **Links**: adds “Sync now” (only never-synced) and “Sync all”, with live progress and toasts.  
- **CLI**: Cron-friendly command `yarn sync-all` included.

---

# Highlights

- **Routes**
  - `POST /indexes/:id/links/sync (?all=true)`
  - `POST /integrations/sync/:type → 202 { runId }`
  - `GET /sync/runs/:runId` for status

- **CLI**
  - `yarn sync-all <links|notion|gmail> --index <ID> --user <ID> [--wait]`
  - `yarn sync-all --help` for usage

- **Frontend**
  - Progress UI for Links and Integrations
  - Long-URL layout fix
  - Toasts on completion/failure

- **Engine**
  - Queue with concurrency
  - DB-backed run store
  - Intent dedupe by payload

- **Docs**
  - Updated `docs/unified-sync.md` with HTTP/CLI and Cron examples

---

# Usage (Quick)

- **CLI**  
  ```bash
  SYNC_USER_ID=<USER_ID> yarn sync-all links --index <INDEX_ID> --wait
  ```
- **HTTP**  
```bash
  curl -X POST \
  -H "Authorization: Bearer <TOKEN>" \
  http://localhost:3001/api/indexes/<INDEX_ID>/links/sync
  ```
  
 # Note
 **Links sync endpoint is now async (returns 202 + runId) instead of immediate counts.**