### PR TITLE
Unique emails, also non-null

### DIFF
--- a/protocol/drizzle/0005_wild_captain_britain.sql
+++ b/protocol/drizzle/0005_wild_captain_britain.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "users" ALTER COLUMN "email" SET NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "users_email_unique" ON "users" USING btree ("email");

--- a/protocol/src/lib/schema.ts
+++ b/protocol/src/lib/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, pgEnum, text, uuid, timestamp, bigint, boolean, json, varchar, integer } from 'drizzle-orm/pg-core';
+import { pgTable, pgEnum, text, uuid, timestamp, bigint, boolean, json, varchar, integer, uniqueIndex } from 'drizzle-orm/pg-core';
 import { relations } from 'drizzle-orm';
 
 // Enums
@@ -10,14 +10,18 @@ export const connectionAction = pgEnum('connection_action', [
 export const users = pgTable('users', {
   id: uuid('id').primaryKey().defaultRandom(),
   privyId: text('privy_id').notNull().unique(),
-  email: text('email'),
+  // Email is required and must be unique.
+  email: text('email').notNull(),
   name: text('name').notNull(),
   intro: text('intro'),
   avatar: text('avatar'),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
   deletedAt: timestamp('deleted_at'),
-});
+}, (table) => ({
+  // Enforce uniqueness on all emails (email is NOT NULL).
+  usersEmailUnique: uniqueIndex('users_email_unique').on(table.email),
+}));
 
 export const intents = pgTable('intents', {
   id: uuid('id').primaryKey().defaultRandom(),

--- a/protocol/src/middleware/auth.ts
+++ b/protocol/src/middleware/auth.ts
@@ -72,21 +72,32 @@ export const authenticatePrivy = async (req: AuthRequest, res: Response, next: N
         }
       }
 
-      const newUser = await db.insert(users).values({
-        privyId: claims.userId,
-        email: userEmail,
-        name: userName,
-        intro: null,
-        avatar: null
-      }).returning({
-        id: users.id,
-        privyId: users.privyId,
-        email: users.email,
-        name: users.name,
-        deletedAt: users.deletedAt
-      });
-      
-      user = newUser;
+      // Require an email to create a user
+      if (!userEmail) {
+        return res.status(400).json({ error: 'Email required from identity provider' });
+      }
+
+      try {
+        const newUser = await db.insert(users).values({
+          privyId: claims.userId,
+          email: userEmail,
+          name: userName,
+          intro: null,
+          avatar: null
+        }).returning({
+          id: users.id,
+          privyId: users.privyId,
+          email: users.email,
+          name: users.name,
+          deletedAt: users.deletedAt
+        });
+        user = newUser;
+      } catch (e: any) {
+        if (e && (e.code === '23505' || String(e?.message || '').includes('users_email_unique'))) {
+          return res.status(409).json({ error: 'Email already in use' });
+        }
+        throw e;
+      }
     } else {
       // Update existing user's email if it has changed
       const existingUser = user[0];
@@ -94,13 +105,21 @@ export const authenticatePrivy = async (req: AuthRequest, res: Response, next: N
       
       if (privyUser.email?.address && privyUser.email.address !== existingUser.email) {
         updatedEmail = privyUser.email.address;
-        
-        await db.update(users)
-          .set({ 
-            email: updatedEmail,
-            updatedAt: new Date()
-          })
-          .where(eq(users.id, existingUser.id));
+        try {
+          await db.update(users)
+            .set({ 
+              email: updatedEmail,
+              updatedAt: new Date()
+            })
+            .where(eq(users.id, existingUser.id));
+        } catch (e: any) {
+          if (e && (e.code === '23505' || String(e?.message || '').includes('users_email_unique'))) {
+            // Another account already has this email; keep existing email unchanged
+            updatedEmail = existingUser.email;
+          } else {
+            throw e;
+          }
+        }
           
         // Update the user object for the response
         user[0].email = updatedEmail;


### PR DESCRIPTION
 - Schema: make users.email NOT NULL and add unique index.
 - Auth: require email on user creation; 409 on duplicate.
  
  Note:
  Sentinel user email was NULL before, it has changed to everyone@system.invalid because we can not have NULL emails anymore.