### PR TITLE
fix(sync-all): adapt to indexId drop; add --all and index-scoped dedupe

### DIFF
--- a/protocol/src/cli/sync-all.ts
+++ b/protocol/src/cli/sync-all.ts
@@ -1,19 +1,5 @@
 #!/usr/bin/env node
-/**
- * sync-all.ts — Unified Sync CLI
- *
- * Purpose
- * - Trigger the same sync providers used by the HTTP API (links/gmail/notion/...)
- * - Suitable for Kubernetes CronJobs and local/manual runs
- *
- * Behavior
- * - Runs provider synchronously and exits 0 on success / 1 on failure
- *
- * Examples
- *   yarn sync-all links --index 00000000-0000-0000-0000-000000000000 --user <USER_ID>
- *   yarn sync-all notion --index <INDEX_ID> --user <USER_ID>
- *   SYNC_USER_ID=<USER_ID> yarn sync-all gmail --index <INDEX_ID>
- */
+// Tiny CLI to run sync providers from the shell.
 import 'dotenv/config';
 import { runSync } from '../lib/sync/runner';
 
@@ -27,6 +13,7 @@ Providers:
 Options:
   -u, --user <id>      User ID (or set SYNC_USER_ID env)
   -i, --index <id>     Index ID (where intents are attached, when applicable)
+      --all            Process all (provider-specific; e.g. re-process all links)
   -h, --help           Show this help
 
 Examples:
@@ -36,6 +23,7 @@ Examples:
   console.log(text);
 }
 
+// Parse minimal flags into { provider, userId, params }
 function parseArgs(argv: string[]) {
   const args = argv.slice(2);
   let provider = (args[0] || '').toLowerCase();
@@ -50,12 +38,14 @@ function parseArgs(argv: string[]) {
     const a = args[i];
     if (a === '--index' || a === '-i') out.params.indexId = args[++i];
     else if (a === '--user' || a === '-u') out.userId = args[++i];
+    else if (a === '--all') out.params.all = true;
     else if (a === '--help' || a === '-h') out.help = true;
     else if (a.startsWith('--')) { const k = a.slice(2); out.params[k] = args[++i]; }
   }
   return out;
 }
 
+// Run the provider and print a compact JSON result
 async function main() {
   const { provider, params, userId, help } = parseArgs(process.argv);
   if (help || provider === 'help') { usage(); process.exit(0); }

--- a/protocol/src/lib/sync/providers.ts
+++ b/protocol/src/lib/sync/providers.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 import db from '../db';
-import { indexLinks, intents, userIntegrations } from '../schema';
+import { indexLinks, intents, intentIndexes, userIntegrations } from '../schema';
 import { eq, and, isNull } from 'drizzle-orm';
 import { analyzeFolder } from '../../agents/core/intent_inferrer';
 import { summarizeIntent } from '../../agents/core/intent_summarizer';
@@ -19,7 +19,7 @@ export interface SyncProvider<Params extends Record<string, any> = any> {
   start(run: any, params: Params, update: (patch: any) => Promise<void>): Promise<void>;
 }
 
-type LinksParams = { count?: number; skipBrokers?: boolean; all?: boolean };
+type LinksParams = { count?: number; skipBrokers?: boolean; all?: boolean; indexId?: string };
 
 export const linksProvider: SyncProvider<LinksParams> = {
   name: 'links',
@@ -59,9 +59,17 @@ export const linksProvider: SyncProvider<LinksParams> = {
     const requestedCount = Math.max(1, Math.min(1, params.count ?? 1));
     const skipBrokers = params.skipBrokers === true || !config.linksSync.triggerBrokers;
 
-    const existingIntentRows = await db.select({ payload: intents.payload })
-      .from(intents)
-      .where(and(eq(intents.userId, userId), isNull(intents.archivedAt)));
+    // If an indexId is provided, dedupe only against intents already in that index.
+    const existingIntentRows = params.indexId
+      ? await db
+          .select({ payload: intents.payload })
+          .from(intents)
+          .innerJoin(intentIndexes, eq(intents.id, intentIndexes.intentId))
+          .where(and(eq(intentIndexes.indexId, params.indexId), eq(intents.userId, userId), isNull(intents.archivedAt)))
+      : await db
+          .select({ payload: intents.payload })
+          .from(intents)
+          .where(and(eq(intents.userId, userId), isNull(intents.archivedAt)));
     const existingIntents = new Set(existingIntentRows.map(r => r.payload));
 
     let intentsGenerated = 0;
@@ -104,6 +112,10 @@ export const linksProvider: SyncProvider<LinksParams> = {
               sourceType: 'link',
             }).returning({ id: intents.id });
             const intentId = inserted[0].id;
+            // Optionally attach to a specific index using the join table.
+            if (params.indexId) {
+              await db.insert(intentIndexes).values({ intentId, indexId: params.indexId });
+            }
             existingIntents.add(intentData.payload);
             if (!skipBrokers) {
               triggerBrokersOnIntentCreated(intentId).catch(() => void 0);


### PR DESCRIPTION
- Update links sync to use intentIndexes join table; support params.indexId.
 - Dedupe only within the specified index; attach new intents to that index.
 - CLI polish: concise help and new --all flag.
  
  Test plan:
  - yarn sync-all links -u <USER_ID> -i <INDEX_ID>
  - yarn sync-all links -u <USER_ID> --all