### PR TITLE
fix: retry intent generation when Bedrock omits tool call

### DIFF
--- a/protocol/src/agents/core/intent_inferrer/index.ts
+++ b/protocol/src/agents/core/intent_inferrer/index.ts
@@ -233,11 +233,6 @@ ${concatenatedContent.substring(0, 15000)}${concatenatedContent.length > 15000 ?
 
 `;
 
-    // Set up timeout
-    const timeoutPromise = new Promise<never>((_, reject) => {
-      setTimeout(() => reject(new Error('Intent generation timeout')), timeoutMs);
-    });
-
     const intentInferCall = traceableStructuredLlm(
       "intent-inferrer",
       ["structured-output"],
@@ -248,10 +243,35 @@ ${concatenatedContent.substring(0, 15000)}${concatenatedContent.length > 15000 ?
         requested_count: count
       }
     );
-    const response = await Promise.race([
-      intentInferCall(prompt, IntentSchema),
-      timeoutPromise
-    ]);
+    const runWithTimeout = () => {
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error('Intent generation timeout')), timeoutMs);
+      });
+      return Promise.race([
+        intentInferCall(prompt, IntentSchema),
+        timeoutPromise
+      ]);
+    };
+
+    let response: z.infer<typeof IntentSchema> | undefined;
+    let lastError: unknown;
+    for (let attempt = 0; attempt < 2; attempt++) {
+      try {
+        response = await runWithTimeout();
+        break;
+      } catch (err) {
+        lastError = err;
+        if (err instanceof Error && err.message.includes('No tool calls found in the response.') && attempt === 0) {
+          console.warn('⚠️  Structured output missing tool call, retrying once...');
+          continue;
+        }
+        throw err;
+      }
+    }
+
+    if (!response) {
+      throw lastError instanceof Error ? lastError : new Error('Intent inference failed');
+    }
 
     console.log(`✅ Generated ${response.intents.length} intents`);
 

--- a/protocol/src/lib/agents.ts
+++ b/protocol/src/lib/agents.ts
@@ -20,6 +20,7 @@ export const llm = new ChatBedrockConverse({
   temperature: 0.1,
   disableStreaming: true,
   region: "us-west-2",
+  supportsToolChoiceValues: ["auto", "any", "tool"],
   credentials: {
     accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,


### PR DESCRIPTION
Added retry logic in intent inference to handle 'No tool calls found' errors. Ensures link ingestion does not fail silently when structured output is missing. Background crawl now retries once before surfacing failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added configuration to control tool-choice behavior for Bedrock-based chats with options: auto, any, or tool.

- Bug Fixes
  - Improved reliability of intent inference with a built-in timeout and a targeted single retry when no tool calls are detected.
  - Enhanced error handling to surface clearer failures if inference does not return a result.

- Chores
  - Minor formatting update to ensure files end with a newline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->