### PR TITLE
Feat/db flush

### DIFF
--- a/protocol/package.json
+++ b/protocol/package.json
@@ -12,6 +12,7 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:studio": "drizzle-kit studio",
+    "db:flush": "TS_NODE_TRANSPILE_ONLY=1 node -r ts-node/register ./src/cli/db-flush.ts",
     "sync-all": "TS_NODE_TRANSPILE_ONLY=1 node -r ts-node/register ./src/cli/sync-all.ts"
   },
   "dependencies": {

--- a/protocol/src/cli/db-flush.ts
+++ b/protocol/src/cli/db-flush.ts
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+import 'dotenv/config';
+import { Command } from 'commander';
+import { performance } from 'node:perf_hooks';
+import { sql } from 'drizzle-orm';
+
+import db, { closeDb } from '../lib/db';
+
+const DEFAULT_TABLES = [
+  'intent_indexes',
+  'intent_stakes',
+  'index_members',
+  'intents',
+  'files',
+  'user_connection_events',
+  'integrations',
+  'links',
+  'indexes',
+  'agents',
+  'users',
+] as const;
+
+type CliOptions = {
+  force: boolean;
+  json: boolean;
+  silent: boolean;
+  tables?: string[];
+};
+
+type FlushResult = {
+  tables: ReadonlyArray<string>;
+  durationMs: number;
+};
+
+async function flushDatabase(tables: ReadonlyArray<string>): Promise<FlushResult> {
+  if (tables.length === 0) {
+    return { tables, durationMs: 0 };
+  }
+
+  const identifiers = tables.map((table) => sql.identifier(table));
+  const truncateStatement = sql`TRUNCATE TABLE ${sql.join(identifiers, sql`, `)} RESTART IDENTITY CASCADE;`;
+
+  const start = performance.now();
+  await db.execute(truncateStatement);
+  const durationMs = Math.round(performance.now() - start);
+
+  return { tables, durationMs };
+}
+
+function resolveTables(optTables: string[] | undefined): ReadonlyArray<string> {
+  if (!optTables || optTables.length === 0) return DEFAULT_TABLES;
+  return Array.from(new Set(optTables.map((name) => name.trim()).filter(Boolean)));
+}
+
+async function main(): Promise<void> {
+  const program = new Command();
+
+  program
+    .name('db:flush')
+    .description('Truncate application tables and reset identity sequences')
+    .option('--force', 'Skip safety check (required to run)')
+    .option('--json', 'Output machine-readable JSON (no extra text)')
+    .option('--silent', 'Suppress non-error output')
+    .option('--tables <names...>', 'Target subset of tables (defaults to all)');
+
+  let opts: CliOptions | undefined;
+
+  try {
+    await program.parseAsync(process.argv);
+    opts = program.opts<CliOptions>();
+    const tables = resolveTables(opts.tables);
+
+    if (!opts.force) {
+      const message = 'Add --force to confirm destructive flush operation.';
+      if (opts.json) {
+        console.log(JSON.stringify({ ok: false, error: message }));
+      } else {
+        console.error(message);
+      }
+      process.exitCode = 1;
+      return;
+    }
+
+    const result = await flushDatabase(tables);
+
+    if (opts.json) {
+      console.log(JSON.stringify({ ok: true, ...result }));
+    } else if (!opts.silent) {
+      console.log(`Flushed ${result.tables.length} table(s) in ${result.durationMs}ms.`);
+      result.tables.forEach((table) => console.log(`- ${table}`));
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : `${error}`;
+    try {
+      const shouldJson = typeof opts?.json === 'boolean' ? opts.json : false;
+      if (shouldJson) {
+        console.error(JSON.stringify({ ok: false, error: message }));
+      } else {
+        console.error(`db:flush error: ${message}`);
+      }
+    } catch {
+      console.error(`db:flush error: ${message}`);
+    }
+    process.exitCode = 1;
+  } finally {
+    await closeDb().catch(() => undefined);
+  }
+}
+
+main();

--- a/protocol/src/cli/db-flush.ts
+++ b/protocol/src/cli/db-flush.ts
@@ -16,9 +16,10 @@ const DEFAULT_TABLES = [
   'integrations',
   'links',
   'indexes',
-  'agents',
   'users',
 ] as const;
+
+const PROTECTED_TABLES = new Set(['agents']);
 
 type CliOptions = {
   force: boolean;
@@ -49,7 +50,17 @@ async function flushDatabase(tables: ReadonlyArray<string>): Promise<FlushResult
 
 function resolveTables(optTables: string[] | undefined): ReadonlyArray<string> {
   if (!optTables || optTables.length === 0) return DEFAULT_TABLES;
-  return Array.from(new Set(optTables.map((name) => name.trim()).filter(Boolean)));
+
+  const tables = Array.from(new Set(optTables.map((name) => name.trim()).filter(Boolean)));
+  const blocked = tables.filter((name) => PROTECTED_TABLES.has(name));
+
+  if (blocked.length > 0) {
+    const tableList = blocked.join(', ');
+    const descriptor = blocked.length > 1 ? 'tables' : 'table';
+    throw new Error(`Protected ${descriptor} cannot be flushed: ${tableList}`);
+  }
+
+  return tables;
 }
 
 async function main(): Promise<void> {

--- a/protocol/src/lib/db.ts
+++ b/protocol/src/lib/db.ts
@@ -13,4 +13,8 @@ if (process.env.NODE_ENV === 'development') {
   globalThis.__db = db;
 }
 
-export default db; 
+export async function closeDb(): Promise<void> {
+  await client.end({ timeout: 5 });
+}
+
+export default db;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a CLI command to flush selected database tables.
  - Supports specifying target tables and prevents flushing protected tables.
  - Requires a --force flag to execute; otherwise provides a dry-run warning and exits.
  - Offers JSON (--json) or plain-text output, with optional silent mode.
  - Displays the list of flushed tables and total duration.
  - Intended for safe, repeatable environment resets with clear feedback and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->