### PR TITLE
fix: auto-create signal without asking user

### DIFF
--- a/protocol/src/lib/protocol/agents/chat.prompt.ts
+++ b/protocol/src/lib/protocol/agents/chat.prompt.ts
@@ -265,8 +265,8 @@ For open-ended connection-seeking ("find me a mentor", "who needs a React dev", 
 - Do NOT call \`create_intent\` unless the user **explicitly** asks to "create", "save", "add", or "remember" an intent/priority.
 - Phrases like "looking for X", "find me X", "I want to meet X", "I need X" are discovery requests — NOT intent creation requests.
 - If the tool returns \`createIntentSuggested\` and \`suggestedIntentDescription\`, the system will create an intent and retry discovery automatically; use the final result (candidates or "no matches") for your reply.
-- If the tool returns \`suggestIntentCreationForVisibility: true\` and \`suggestedIntentDescription\`, after presenting the opportunity cards ask the user whether they'd also like to create a signal so others can find them (e.g. *"Would you also like to create a signal for this so others can find you?"*). If the user agrees, call \`create_intent(description=suggestedIntentDescription)\` and include the returned \`\`\`intent_proposal block verbatim — this is the same proposal flow as explicit intent creation; the user approves or skips via the card. Ask only once per conversation; do not repeat the question on follow-up turns.
-- When the tool indicates all results are exhausted (no remaining candidates), do NOT offer to "show more". Instead suggest the user create a signal so others can find them. This uses the same \`create_intent\` flow as above.
+- If the tool returns \`suggestIntentCreationForVisibility: true\` and \`suggestedIntentDescription\`, after presenting the opportunity cards, automatically call \`create_intent(description=suggestedIntentDescription)\` to create a visibility signal. Tell the user: *"I'm creating a signal so others can find you."* Include the returned \`\`\`intent_proposal block verbatim — the user approves or skips via the card. Do not ask for permission; the card itself is the confirmation step. Only do this once per conversation.
+- When the tool indicates all results are exhausted (no remaining candidates), do NOT offer to "show more". Instead automatically create a signal using the same \`create_intent\` flow as above.
 - If the user **explicitly** says they want to create/save an intent (e.g. "add a priority", "create an intent", "save that I'm looking for X", "remember this"), use pattern 2 instead.
 
 ### 1a. User wants to connect with a specific mentioned person
@@ -408,8 +408,8 @@ Index and community membership is background: handle it without talking about in
 ### Discovery-first; intent as follow-up
 - For connection-seeking (find connections, discover, who's looking for X), use \`create_opportunities(searchQuery=...)\` first. Do not lead with \`create_intent\` unless the user explicitly asks to create or save an intent.
 - When the tool returns \`createIntentSuggested\`, the system may create an intent and retry; respond from the final discovery result.
-- Visibility-signal follow-up: apply the Pattern 1 rule above (\`suggestIntentCreationForVisibility\` → ask once; on yes, call \`create_intent(description=suggestedIntentDescription)\` and include the returned \`\`\`intent_proposal block).
-- When the tool response says "These are all the connections I found", suggest the user create a signal so others can discover them. Use the existing \`suggestIntentCreationForVisibility\` flow: call \`create_intent(description=suggestedIntentDescription)\` if the user agrees. Do not ask "Would you like to see more?" when there are no more candidates.
+- Visibility-signal follow-up: when \`suggestIntentCreationForVisibility\` is true, automatically call \`create_intent(description=suggestedIntentDescription)\` and include the returned \`\`\`intent_proposal block. Tell the user you're creating a signal so others can find them. Do not ask — the proposal card serves as the confirmation step.
+- When the tool response says "These are all the connections I found", automatically create a signal using the same flow. Do not ask "Would you like to see more?" when there are no more candidates.
 - Only call \`create_opportunities\` for: (a) discovery ("find me connections"), (b) introductions between two other people, or (c) direct connection with a specific mentioned person (Pattern 1a).
 
 ### @Mentions

--- a/protocol/src/lib/protocol/tools/opportunity.tools.ts
+++ b/protocol/src/lib/protocol/tools/opportunity.tools.ts
@@ -276,7 +276,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         if (totalRemaining > 0 && result.pagination?.discoveryId) {
           message += `\n\nThere are ${totalRemaining} more candidates. Ask if the user wants to see more — they can say "show me more" and you should call create_opportunities with continueFrom="${result.pagination.discoveryId}".`;
         } else {
-          message += `\n\nThese are all the connections I found. If the user wants to attract more connections, suggest they create a signal — e.g. "Would you like to create a signal so others looking for someone like you can find you?" If they agree, call create_intent with a description based on what they were searching for.`;
+          message += `\n\nThese are all the connections I found. To help others find the user, automatically call create_intent with a description based on what they were searching for. Tell the user: "I'm creating a signal so others can find you." Do not ask for permission first — the user can approve or skip via the proposal card.`;
         }
 
         return success({
@@ -606,7 +606,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
       if (totalRemaining > 0 && result.pagination?.discoveryId) {
         message += `\n\nThere are ${totalRemaining} more candidates. Ask if the user wants to see more — they can say "show me more" and you should call create_opportunities with continueFrom="${result.pagination.discoveryId}".`;
       } else {
-        message += `\n\nThese are all the connections I found. If the user wants to attract more connections, suggest they create a signal — e.g. "Would you like to create a signal so others looking for someone like you can find you?" If they agree, call create_intent with a description based on what they were searching for.`;
+        message += `\n\nThese are all the connections I found. To help others find the user, automatically call create_intent with a description based on what they were searching for. Tell the user: "I'm creating a signal so others can find you." Do not ask for permission first — the user can approve or skip via the proposal card.`;
       }
 
       return success({
@@ -618,7 +618,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         debugSteps: allDebugSteps,
         // Distinct from `createIntentSuggested` (no-results path) intentionally:
         // `handleCreateIntentCallback` in chat.agent.ts auto-creates for that key.
-        // This flag is for the results-found path where the agent must ask the user first.
+        // This flag is for the results-found path where the agent auto-creates and informs the user.
         ...(searchQuery && !query.targetUserId
           ? {
               suggestIntentCreationForVisibility: true,


### PR DESCRIPTION
## Summary

- Change chat agent behavior from asking "Would you like to create a signal?" to automatically creating it
- Agent now says "I'm creating a signal so others can find you" instead of asking for permission
- User can still approve/skip via the intent proposal card

## Problem

The agent had inconsistent behavior:
1. It asked "Would you also like to create a signal so others can find you?"
2. But then auto-created the signal anyway in the same turn
3. This resulted in confusing UX like: "Oops, I should have waited for your answer!"

## Solution

Made the behavior consistent: auto-create the signal without asking, and inform the user what's happening. The proposal card itself serves as the confirmation step.

## Files Changed

- `protocol/src/lib/protocol/tools/opportunity.tools.ts` - Updated tool messages to instruct auto-creation
- `protocol/src/lib/protocol/agents/chat.prompt.ts` - Updated system prompt to match auto-create behavior

## Test Plan

- [ ] Start a chat and request "find AI investors" or similar
- [ ] Verify the agent presents results
- [ ] Verify the agent auto-creates the signal and says "I'm creating a signal so others can find you"
- [ ] Verify the intent proposal card appears for user to approve/skip
- [ ] Verify no "Would you like to..." question is asked

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Visibility signals now automatically created during search discovery when suggested (limited to once per conversation)
  * Automatic signal creation triggered when search results are exhausted
  * Signal confirmations now displayed via card instead of requiring explicit user approval

<!-- end of auto-generated comment: release notes by coderabbit.ai -->