### PR TITLE
refactor(discovery): remove Index Global concept

### DIFF
--- a/frontend/src/app/networks/page.tsx
+++ b/frontend/src/app/networks/page.tsx
@@ -26,12 +26,7 @@ export default function NetworksPage() {
   const [loadingPublic, setLoadingPublic] = useState(false);
   const [joiningNetwork, setJoiningNetwork] = useState<string | null>(null);
 
-  const allNetworks = [...(rawIndexes || [])].sort((a, b) => {
-    // Global indexes first, then by creation date
-    if (a.isGlobal && !b.isGlobal) return -1;
-    if (!a.isGlobal && b.isGlobal) return 1;
-    return 0;
-  });
+  const allNetworks = [...(rawIndexes || [])];
 
   useEffect(() => {
     if (activeTab === 'discover') loadPublicNetworks();

--- a/frontend/src/components/ChatContent.tsx
+++ b/frontend/src/components/ChatContent.tsx
@@ -1059,7 +1059,6 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
 
   // HOME STATE - No messages yet
   if (messages.length === 0) {
-    const globalIndex = indexes.find((i) => i.isGlobal);
     const selectedIndex = indexes.find((i) => selectedIndexIds.includes(i.id));
 
     const renderScopeDropdown = () => {
@@ -1076,9 +1075,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
           >
             {contactsOnly ? (
               <Users className="w-4 h-4" />
-            ) : selectedIndex?.isGlobal ||
-              selectedIndex?.permissions?.joinPolicy ===
-                "invite_only" ? (
+            ) : selectedIndex?.permissions?.joinPolicy === "invite_only" ? (
               <Lock className="w-4 h-4" />
             ) : (
               <Globe className="w-4 h-4" />
@@ -1129,25 +1126,8 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
                 >
                   <Users className="w-4 h-4" /> My Contacts
                 </button>
-                {globalIndex && (
-                  <button
-                    type="button"
-                    onClick={() => {
-                      handleIndexSelect(globalIndex.id);
-                      setIsIndexDropdownOpen(false);
-                    }}
-                    className={cn(
-                      "w-full px-3 py-2 text-left text-sm text-[#3D3D3D] hover:bg-gray-50 flex items-center gap-2",
-                      selectedIndexIds.includes(globalIndex.id) &&
-                        "text-gray-900 font-medium",
-                    )}
-                  >
-                    <Lock className="w-4 h-4" /> {globalIndex.title}
-                  </button>
-                )}
                 <div className="my-1 border-t border-gray-200" />
                 {[...indexes]
-                  .filter((i) => !i.isGlobal)
                   .sort(
                     (a, b) =>
                       (a.permissions?.joinPolicy === "invite_only"

--- a/protocol/src/adapters/database.adapter.ts
+++ b/protocol/src/adapters/database.adapter.ts
@@ -16,84 +16,6 @@ import { IndexMembershipEvents } from '../events/index_membership.event';
 
 const logger = log.lib.from('database.adapter');
 
-/** Cached global index ID (queried once, reused). */
-let _globalIndexId: string | null | undefined;
-
-/** Returns the ID of the single index with isGlobal=true, or null if none exists. */
-async function getGlobalIndexId(): Promise<string | null> {
-  if (_globalIndexId !== undefined) return _globalIndexId;
-  const row = await db
-    .select({ id: schema.indexes.id })
-    .from(schema.indexes)
-    .where(eq(schema.indexes.isGlobal, true))
-    .limit(1)
-    .then((rows) => rows[0]);
-  _globalIndexId = row?.id ?? null;
-  return _globalIndexId;
-}
-
-/**
- * Ensures a global index exists in the database. Creates one if missing.
- * Also backfills any users (real or ghost) who are not yet members.
- * Should be called once at server startup before accepting requests.
- */
-export async function ensureGlobalIndex(): Promise<string> {
-  let globalId = await getGlobalIndexId();
-
-  if (!globalId) {
-    globalId = crypto.randomUUID();
-    await db.insert(schema.indexes).values({
-      id: globalId,
-      title: 'Index Global',
-      prompt: 'The global index containing all users for network-wide discovery.',
-      isGlobal: true,
-    });
-    _globalIndexId = globalId;
-    logger.info('Global index created', { id: globalId });
-  }
-
-  // Backfill: register every non-deleted user who isn't already a member
-  const missing = await db
-    .select({ id: schema.users.id })
-    .from(schema.users)
-    .leftJoin(
-      schema.indexMembers,
-      and(
-        eq(schema.indexMembers.userId, schema.users.id),
-        eq(schema.indexMembers.indexId, globalId),
-      ),
-    )
-    .where(and(
-      isNull(schema.users.deletedAt),
-      isNull(schema.indexMembers.userId),
-    ));
-
-  if (missing.length > 0) {
-    await db
-      .insert(schema.indexMembers)
-      .values(missing.map(u => ({ indexId: globalId, userId: u.id, permissions: ['member'] as string[] })))
-      .onConflictDoNothing();
-    logger.info('Global index backfill complete', { added: missing.length });
-  } else {
-    logger.info('Global index up to date, no backfill needed', { id: globalId });
-  }
-
-  return globalId;
-}
-
-/**
- * Adds a user to the global index if they are not already a member.
- * Safe to call for any user (ghost or real) — uses onConflictDoNothing.
- */
-export async function ensureGlobalIndexMembership(userId: string): Promise<void> {
-  const globalIndexId = await getGlobalIndexId();
-  if (!globalIndexId) return;
-  await db
-    .insert(schema.indexMembers)
-    .values({ indexId: globalIndexId, userId, permissions: ['member'] })
-    .onConflictDoNothing();
-}
-
 // Local types used by adapters (shapes only; protocol layer defines the contracts)
 interface ActiveIntentRow {
   id: string;
@@ -1057,7 +979,6 @@ export class ChatDatabaseAdapter {
           and(
             eq(schema.indexMembers.userId, userId),
             isNull(schema.indexes.deletedAt),
-            eq(schema.indexes.isGlobal, false),
           )
         );
       return result;
@@ -2348,24 +2269,12 @@ export class ChatDatabaseAdapter {
       isGhost: true,
     });
 
-    // Create empty profile
+    // Create empty profile (embedding will be added by enrichment job)
     await db.insert(schema.userProfiles).values({
       userId: id,
     });
 
-    // Add to Index Global if one exists
-    const globalIndexId = await getGlobalIndexId();
-    if (globalIndexId) {
-      await db
-        .insert(schema.indexMembers)
-        .values({
-          indexId: globalIndexId,
-          userId: id,
-          permissions: ['member'],
-        })
-        .onConflictDoNothing();
-    }
-
+    // Ghost users have no index membership - they are discovered via user_contacts table
     return { id };
   }
 
@@ -2513,14 +2422,14 @@ export class ChatDatabaseAdapter {
   }
 
   /**
-   * Bulk create ghost users with empty profiles and Index Global membership.
+   * Bulk create ghost users with empty profiles.
+   * Ghost users have no index membership - they are discovered via user_contacts table.
    * @param data - Array of {name, email} for ghost users
    * @returns Array of created ghost users with their IDs
    */
   async createGhostUsersBulk(data: Array<{ name: string; email: string }>): Promise<Array<{ id: string; name: string; email: string }>> {
     if (data.length === 0) return [];
 
-    const globalIndexId = await getGlobalIndexId();
     const results: Array<{ id: string; name: string; email: string }> = [];
 
     // Create users
@@ -2548,24 +2457,12 @@ export class ChatDatabaseAdapter {
         .map(u => u.id)
     );
 
-    // Create empty profiles only for newly created users
+    // Create empty profiles only for newly created users (embedding added by enrichment job)
     if (actuallyCreatedIds.size > 0) {
       const profilesToInsert = usersToInsert
         .filter(u => actuallyCreatedIds.has(u.id))
         .map(u => ({ userId: u.id }));
       await db.insert(schema.userProfiles).values(profilesToInsert);
-
-      // Add to Index Global if configured
-      if (globalIndexId) {
-        const membersToInsert = usersToInsert
-          .filter(u => actuallyCreatedIds.has(u.id))
-          .map(u => ({
-            indexId: globalIndexId,
-            userId: u.id,
-            permissions: ['member'] as string[],
-          }));
-        await db.insert(schema.indexMembers).values(membersToInsert).onConflictDoNothing();
-      }
     }
 
     // Return results with correct IDs (actual DB IDs, not our generated ones)
@@ -2611,6 +2508,8 @@ export class ChatDatabaseAdapter {
    * Ghost users are created first, then all contacts (both existing-user and ghost-user)
    * are upserted together, ensuring the write path is atomic.
    *
+   * Ghost users have no index membership - they are discovered via user_contacts table.
+   *
    * @param ownerId - The user importing contacts
    * @param ghosts - Array of ghost user data to create
    * @param validContacts - All validated contacts with resolved emails
@@ -2626,11 +2525,9 @@ export class ChatDatabaseAdapter {
     source: 'gmail' | 'google_calendar' | 'manual'
   ): Promise<{ newGhosts: Array<{ id: string; name: string; email: string }>; newContacts: number }> {
     return await db.transaction(async (tx) => {
-      // Create ghost users
+      // Create ghost users (no index membership - discovered via user_contacts)
       const newGhosts: Array<{ id: string; name: string; email: string }> = [];
       if (ghosts.length > 0) {
-        const globalIndexId = await getGlobalIndexId();
-
         const usersToInsert = ghosts.map(d => ({
           id: crypto.randomUUID(),
           name: d.name,
@@ -2653,22 +2550,12 @@ export class ChatDatabaseAdapter {
             .map(u => u.id)
         );
 
+        // Create empty profiles (embedding added by enrichment job)
         if (actuallyCreatedIds.size > 0) {
           const profilesToInsert = usersToInsert
             .filter(u => actuallyCreatedIds.has(u.id))
             .map(u => ({ userId: u.id }));
           await tx.insert(schema.userProfiles).values(profilesToInsert);
-
-          if (globalIndexId) {
-            const membersToInsert = usersToInsert
-              .filter(u => actuallyCreatedIds.has(u.id))
-              .map(u => ({
-                indexId: globalIndexId,
-                userId: u.id,
-                permissions: ['member'] as string[],
-              }));
-            await tx.insert(schema.indexMembers).values(membersToInsert).onConflictDoNothing();
-          }
         }
 
         for (const u of usersToInsert) {
@@ -4321,21 +4208,18 @@ export function createSystemDatabase(
   };
 
   /**
-   * Verify that a user shares at least one index with the auth user.
-   * Returns true if they share an index, false otherwise.
+   * Verify that a user shares at least one index with the auth user,
+   * or is a contact of the auth user (for ghost users who have no index membership).
+   * Returns true if access is allowed, false otherwise.
    */
   const verifySharedIndex = async (userId: string): Promise<boolean> => {
     if (userId === authUserId) return true;
+    // Check if they share any index
     const theirMemberships = await db.getIndexMemberships(userId);
     if (theirMemberships.some((m) => indexScope.includes(m.indexId))) return true;
-    // getIndexMemberships excludes the global index from user-facing listings,
-    // but both users may share only the global index (e.g. ghost contacts).
-    const globalId = await getGlobalIndexId();
-    if (!globalId) return false;
-    const theirGlobalMembership = await db.getIndexMembership(globalId, userId);
-    if (!theirGlobalMembership) return false;
-    const myGlobalMembership = await db.getIndexMembership(globalId, authUserId);
-    return !!myGlobalMembership;
+    // Check if the user is a contact of the auth user (covers ghost users with no index membership)
+    const contactUserIds = await db.getContactUserIds(authUserId);
+    return contactUserIds.includes(userId);
   };
 
   return {

--- a/protocol/src/adapters/embedder.adapter.ts
+++ b/protocol/src/adapters/embedder.adapter.ts
@@ -195,6 +195,54 @@ export class EmbedderAdapter {
     return this.mergeAndRankCandidates(flatResults, limit);
   }
 
+  /**
+   * Search for contact profiles by embedding similarity.
+   * Unlike searchWithProfileEmbedding, this filters by user_contacts table instead of index_members.
+   * Used for contactsOnly discovery where contacts may not have index membership (ghost users).
+   *
+   * @param ownerId - The user whose contacts to search within
+   * @param embedding - The embedding vector to search with
+   * @param options - Search options (limit, minScore, excludeUserId)
+   * @returns Array of matching contact profiles with similarity scores
+   */
+  async searchContactProfiles(
+    ownerId: string,
+    embedding: number[],
+    options: { limit?: number; minScore?: number; excludeUserId?: string } = {}
+  ): Promise<HydeCandidate[]> {
+    const { limit = 40, minScore = 0.25, excludeUserId } = options;
+    const vectorStr = `[${embedding.join(',')}]`;
+    const { userProfiles, userContacts } = schema;
+
+    const conditions = [
+      eq(userContacts.ownerId, ownerId),
+      isNull(userContacts.deletedAt),
+      isNotNull(userProfiles.embedding),
+      sql`1 - (${userProfiles.embedding} <=> ${vectorStr}::vector) >= ${minScore}`,
+      ...(excludeUserId ? [ne(userProfiles.userId, excludeUserId)] : []),
+    ];
+
+    const results = await db
+      .select({
+        userId: userProfiles.userId,
+        similarity: sql<number>`1 - (${userProfiles.embedding} <=> ${vectorStr}::vector)`.as('similarity'),
+      })
+      .from(userProfiles)
+      .innerJoin(userContacts, eq(userProfiles.userId, userContacts.userId))
+      .where(and(...conditions))
+      .orderBy(sql`${userProfiles.embedding} <=> ${vectorStr}::vector`)
+      .limit(limit);
+
+    return results.map((r) => ({
+      type: 'profile' as const,
+      id: r.userId,
+      userId: r.userId,
+      score: r.similarity,
+      matchedVia: 'contact-profile',
+      indexId: '', // Contacts don't have an index association
+    }));
+  }
+
   // ─────────────────────────────────────────────────────────────────────────
   // Private: profile/intent search for HyDE
   // ─────────────────────────────────────────────────────────────────────────

--- a/protocol/src/lib/betterauth/betterauth.ts
+++ b/protocol/src/lib/betterauth/betterauth.ts
@@ -26,7 +26,6 @@ export interface AuthDeps {
   getTrustedOrigins: (req?: Request) => Promise<string[]> | string[];
   sendMagicLinkEmail: (email: string, url: string) => Promise<void>;
   ensureWallet?: (userId: string) => Promise<void>;
-  ensureGlobalIndexMembership?: (userId: string) => Promise<void>;
 }
 
 /**
@@ -35,7 +34,7 @@ export interface AuthDeps {
  * follows the project layering rules (lib receives adapters via injection).
  */
 export function createAuth(deps: AuthDeps) {
-  const { authDb, getTrustedOrigins, sendMagicLinkEmail, ensureWallet, ensureGlobalIndexMembership } = deps;
+  const { authDb, getTrustedOrigins, sendMagicLinkEmail, ensureWallet } = deps;
 
   /**
    * Tracks ghost IDs that were freed in `create.before` so `create.after` can claim them.
@@ -66,10 +65,6 @@ export function createAuth(deps: AuthDeps) {
             try {
               if (ensureWallet) await ensureWallet(user.id);
             } catch (_) { /* wallet generation failure shouldn't block registration */ }
-
-            try {
-              if (ensureGlobalIndexMembership) await ensureGlobalIndexMembership(user.id);
-            } catch (_) { /* global index membership failure shouldn't block registration */ }
 
             const ghostId = pendingGhostClaims.get(user.id);
             if (ghostId) {

--- a/protocol/src/lib/protocol/graphs/opportunity.graph.ts
+++ b/protocol/src/lib/protocol/graphs/opportunity.graph.ts
@@ -336,17 +336,36 @@ export class OpportunityGraphFactory {
         });
 
         try {
-          if (state.targetIndexes.length === 0) {
-            logger.warn('[Graph:Discovery] No target indexes for search');
-            return { candidates: [] };
-          }
-
           // Search limits - fixed values for candidate retrieval
           // (The options.limit controls final output, not search pool)
           const limitPerStrategy = 30;
           const perIndexLimit = 80;
           // Similarity threshold for recall (0.30 = 30% similarity)
           const minScore = 0.3;
+
+          // Handle contactsOnly with no target indexes: search contacts directly
+          if (state.targetIndexes.length === 0) {
+            if (state.contactsOnly) {
+              logger.verbose('[Graph:Discovery] contactsOnly=true with no indexes → running contact-only discovery');
+              const embedding = state.sourceProfile?.embedding ?? null;
+              const vector = Array.isArray(embedding) && embedding.length > 0 && typeof embedding[0] === 'number'
+                ? (embedding as number[])
+                : null;
+              if (!vector) {
+                logger.warn('[Graph:Discovery] No profile embedding for contact discovery');
+                return { candidates: [] };
+              }
+              const contactCandidates = await runContactDiscovery(vector);
+              const traceEntries = [{
+                node: "discovery",
+                detail: `Contact-only search → ${contactCandidates.length} candidate(s)`,
+                data: { candidateCount: contactCandidates.length, contactsOnly: true },
+              }];
+              return { candidates: filterByTarget(contactCandidates), trace: traceEntries };
+            }
+            logger.warn('[Graph:Discovery] No target indexes for search');
+            return { candidates: [] };
+          }
 
           if (state.discoverySource === 'profile') {
             const embedding = state.sourceProfile?.embedding ?? null;
@@ -363,8 +382,10 @@ export class OpportunityGraphFactory {
                 searchQuery: state.searchQuery.trim().substring(0, 80),
                 hasProfileVector: !!vector,
               });
-              const queryCandidates = await runQueryHydeDiscovery();
-              logger.verbose('[Graph:Discovery] Query HyDE path complete', { candidatesFound: queryCandidates.length });
+              const hydeResult = await runQueryHydeDiscovery();
+              const queryCandidates = hydeResult.candidates;
+              const queryEmbedding = hydeResult.queryEmbedding;
+              logger.verbose('[Graph:Discovery] Query HyDE path complete', { candidatesFound: queryCandidates.length, hasQueryEmbedding: !!queryEmbedding });
               
               // Build trace entries for this path
               const traceEntries: Array<{ node: string; detail?: string; data?: Record<string, unknown> }> = [];
@@ -439,11 +460,59 @@ export class OpportunityGraphFactory {
                     merged: merged.length,
                   },
                 });
+
+                // When contactsOnly=true, also search contacts directly and merge
+                // Use query embedding (HyDE) for semantic contact search, fall back to profile embedding
+                let finalMerged = merged;
+                const contactSearchVector = queryEmbedding ?? vector;
+                if (state.contactsOnly && contactSearchVector) {
+                  const contactCandidates = await runContactDiscovery(contactSearchVector);
+                  if (contactCandidates.length > 0) {
+                    const allMerged = [...merged, ...contactCandidates];
+                    const byUser = new Map<string, CandidateMatch>();
+                    for (const c of allMerged) {
+                      const existing = byUser.get(c.candidateUserId);
+                      if (!existing || c.similarity > existing.similarity) {
+                        byUser.set(c.candidateUserId, c);
+                      }
+                    }
+                    finalMerged = Array.from(byUser.values());
+                    traceEntries.push({
+                      node: "discovery",
+                      detail: `+ Contact search → ${contactCandidates.length} contacts, merged to ${finalMerged.length}`,
+                      data: { contactCandidates: contactCandidates.length, merged: finalMerged.length, usedQueryEmbedding: !!queryEmbedding },
+                    });
+                  }
+                }
                 
-                return { candidates: filterByTarget(merged), trace: traceEntries };
+                return { candidates: filterByTarget(finalMerged), trace: traceEntries };
               }
 
-              return { candidates: filterByTarget(queryCandidates), trace: traceEntries };
+              // When contactsOnly=true, also search contacts directly
+              // Use query embedding (HyDE) for semantic contact search, fall back to profile embedding
+              let finalQueryCandidates = queryCandidates;
+              const contactSearchVector = queryEmbedding ?? vector;
+              if (state.contactsOnly && contactSearchVector) {
+                const contactCandidates = await runContactDiscovery(contactSearchVector);
+                if (contactCandidates.length > 0) {
+                  const merged = [...queryCandidates, ...contactCandidates];
+                  const byUser = new Map<string, CandidateMatch>();
+                  for (const c of merged) {
+                    const existing = byUser.get(c.candidateUserId);
+                    if (!existing || c.similarity > existing.similarity) {
+                      byUser.set(c.candidateUserId, c);
+                    }
+                  }
+                  finalQueryCandidates = Array.from(byUser.values());
+                  traceEntries.push({
+                    node: "discovery",
+                    detail: `+ Contact search → ${contactCandidates.length} contacts, merged to ${finalQueryCandidates.length}`,
+                    data: { contactCandidates: contactCandidates.length, merged: finalQueryCandidates.length, usedQueryEmbedding: !!queryEmbedding },
+                  });
+                }
+              }
+
+              return { candidates: filterByTarget(finalQueryCandidates), trace: traceEntries };
             }
 
             // No search query - use profile embedding directly (mirror-only)
@@ -550,15 +619,38 @@ export class OpportunityGraphFactory {
               });
             }
 
+            // When contactsOnly=true, also search contacts directly and merge
+            let finalCandidates = candidates;
+            if (state.contactsOnly && vector) {
+              const contactCandidates = await runContactDiscovery(vector);
+              if (contactCandidates.length > 0) {
+                const merged = [...candidates, ...contactCandidates];
+                // Dedupe by userId (keep highest similarity)
+                const byUser = new Map<string, CandidateMatch>();
+                for (const c of merged) {
+                  const existing = byUser.get(c.candidateUserId);
+                  if (!existing || c.similarity > existing.similarity) {
+                    byUser.set(c.candidateUserId, c);
+                  }
+                }
+                finalCandidates = Array.from(byUser.values());
+                traceEntries.push({
+                  node: "discovery",
+                  detail: `+ Contact search → ${contactCandidates.length} contacts, merged to ${finalCandidates.length}`,
+                  data: { contactCandidates: contactCandidates.length, merged: finalCandidates.length },
+                });
+              }
+            }
+
             return {
-              candidates: filterByTarget(candidates),
+              candidates: filterByTarget(finalCandidates),
               trace: traceEntries,
             };
           }
 
-          async function runQueryHydeDiscovery(): Promise<CandidateMatch[]> {
+          async function runQueryHydeDiscovery(): Promise<{ candidates: CandidateMatch[]; queryEmbedding: number[] | null }> {
             const searchText = state.searchQuery?.trim() ?? '';
-            if (!searchText) return [];
+            if (!searchText) return { candidates: [], queryEmbedding: null };
             logger.verbose('[Graph:Discovery] runQueryHydeDiscovery start', { searchText: searchText.slice(0, 80) });
             const hydeResult = await self.hydeGenerator.invoke({
               sourceType: 'query',
@@ -572,7 +664,7 @@ export class OpportunityGraphFactory {
               lensCount: embeddingKeys.length,
               lenses: embeddingKeys,
             });
-            if (!hydeEmbeddings || Object.keys(hydeEmbeddings).length === 0) return [];
+            if (!hydeEmbeddings || Object.keys(hydeEmbeddings).length === 0) return { candidates: [], queryEmbedding: null };
             const lensMap = new Map(lenses.map(l => [l.label, l]));
             const lensEmbeddings: LensEmbedding[] = [];
             for (const [label, emb] of Object.entries(hydeEmbeddings)) {
@@ -581,6 +673,8 @@ export class OpportunityGraphFactory {
                 lensEmbeddings.push({ lens: label, corpus: lens?.corpus ?? 'profiles', embedding: emb });
               }
             }
+            // Use the first HyDE embedding as the query embedding for contact search
+            const queryEmbedding = lensEmbeddings[0]?.embedding ?? null;
             const all: CandidateMatch[] = [];
             await Promise.all(
               state.targetIndexes.map(async (targetIndex) => {
@@ -630,7 +724,39 @@ export class OpportunityGraphFactory {
                 byKey.set(key, c);
               }
             }
-            return Array.from(byKey.values());
+            return { candidates: Array.from(byKey.values()), queryEmbedding };
+          }
+
+          /**
+           * Contact discovery: search user's contacts by profile embedding.
+           * Used when contactsOnly=true to find contacts who may not have index membership (ghost users).
+           */
+          async function runContactDiscovery(embedding: number[]): Promise<CandidateMatch[]> {
+            if (!state.contactsOnly || !embedding || embedding.length === 0) {
+              return [];
+            }
+            logger.verbose('[Graph:Discovery] runContactDiscovery start', { contactsOnly: state.contactsOnly });
+            const results = await self.embedder.searchContactProfiles(
+              state.userId,
+              embedding,
+              {
+                limit: perIndexLimit,
+                minScore,
+                excludeUserId: state.userId,
+              }
+            );
+            const candidates: CandidateMatch[] = results.map((r) => ({
+              candidateUserId: r.userId as Id<'users'>,
+              candidateIntentId: undefined,
+              indexId: '', // Contacts don't necessarily belong to an index
+              similarity: r.score,
+              lens: r.matchedVia,
+              candidatePayload: '',
+              candidateSummary: undefined,
+              discoverySource: 'contact' as const,
+            }));
+            logger.verbose('[Graph:Discovery] runContactDiscovery complete', { candidatesFound: candidates.length });
+            return candidates;
           }
 
           const resolvedIntent = state.resolvedTriggerIntentId
@@ -765,9 +891,42 @@ export class OpportunityGraphFactory {
             });
           }
 
+          // When contactsOnly=true, also search contacts directly and merge
+          let finalCandidates = candidates;
+          if (state.contactsOnly) {
+            // Use HyDE lens embedding for contact search (query-semantic), falling back to profile embedding
+            // HyDE embeddings are better for query-driven searches like "people from USV"
+            const hydeVector = lensEmbeddings[0]?.embedding ?? null;
+            const profileEmbedding = state.sourceProfile?.embedding;
+            const profileVector = Array.isArray(profileEmbedding) && profileEmbedding.length > 0 && typeof profileEmbedding[0] === 'number'
+              ? (profileEmbedding as number[])
+              : null;
+            const vector = hydeVector ?? profileVector;
+            if (vector) {
+              const contactCandidates = await runContactDiscovery(vector);
+              if (contactCandidates.length > 0) {
+                const merged = [...candidates, ...contactCandidates];
+                // Dedupe by userId (keep highest similarity)
+                const byUser = new Map<string, CandidateMatch>();
+                for (const c of merged) {
+                  const existing = byUser.get(c.candidateUserId);
+                  if (!existing || c.similarity > existing.similarity) {
+                    byUser.set(c.candidateUserId, c);
+                  }
+                }
+                finalCandidates = Array.from(byUser.values());
+                traceEntries.push({
+                  node: "discovery",
+                  detail: `+ Contact search → ${contactCandidates.length} contacts, merged to ${finalCandidates.length}`,
+                  data: { contactCandidates: contactCandidates.length, merged: finalCandidates.length, usedHydeEmbedding: !!hydeVector },
+                });
+              }
+            }
+          }
+
           return {
             hydeEmbeddings: hydeEmbeddings as Record<string, number[]>,
-            candidates: filterByTarget(candidates),
+            candidates: filterByTarget(finalCandidates),
             trace: traceEntries,
           };
         } catch (error) {

--- a/protocol/src/lib/protocol/interfaces/embedder.interface.ts
+++ b/protocol/src/lib/protocol/interfaces/embedder.interface.ts
@@ -110,4 +110,20 @@ export interface Embedder extends EmbeddingGenerator, VectorStore {
     profileEmbedding: number[],
     options: ProfileEmbeddingSearchOptions
   ): Promise<HydeCandidate[]>;
+
+  /**
+   * Contact profile search: run vector search with the given embedding
+   * against profiles of the user's contacts (via user_contacts table).
+   * Used for contactsOnly discovery where contacts may not have index membership.
+   *
+   * @param ownerId - The user whose contacts to search within
+   * @param embedding - The embedding vector to search with
+   * @param options - limit, minScore, excludeUserId
+   * @returns Matching contact profiles with similarity scores
+   */
+  searchContactProfiles(
+    ownerId: string,
+    embedding: number[],
+    options?: { limit?: number; minScore?: number; excludeUserId?: string }
+  ): Promise<HydeCandidate[]>;
 }

--- a/protocol/src/lib/protocol/states/opportunity.state.ts
+++ b/protocol/src/lib/protocol/states/opportunity.state.ts
@@ -48,14 +48,14 @@ export interface TargetIndex {
 export interface CandidateMatch {
   candidateUserId: Id<'users'>;
   candidateIntentId?: Id<'intents'>;
-  indexId: Id<'indexes'>;
+  indexId: Id<'indexes'> | '';
   similarity: number;
   /** Free-text lens label that produced this match. */
   lens: string;
   candidatePayload: string;
   candidateSummary?: string;
-  /** How this candidate was found: 'query' (HyDE from search text) or 'profile-similarity'. */
-  discoverySource?: 'query' | 'profile-similarity';
+  /** How this candidate was found: 'query' (HyDE), 'profile-similarity', or 'contact' (direct contact search). */
+  discoverySource?: 'query' | 'profile-similarity' | 'contact';
 }
 
 /**

--- a/protocol/src/main.ts
+++ b/protocol/src/main.ts
@@ -13,7 +13,7 @@ import { StorageController } from './controllers/storage.controller';
 import { SubscribeController } from './controllers/subscribe.controller';
 import { fileService } from './services/file.service';
 import { MessagingController } from './controllers/messaging.controller';
-import { MessagingDatabaseAdapter, ensureGlobalIndex, ensureGlobalIndexMembership } from './adapters/database.adapter';
+import { MessagingDatabaseAdapter } from './adapters/database.adapter';
 import { MessagingService } from './services/messaging.service';
 import path from 'path';
 import { RouteRegistry } from './lib/router/router.decorators';
@@ -103,17 +103,12 @@ const walletMasterKey = Buffer.from(walletMasterKeyHex, 'hex');
 
 const messagingStore = new MessagingDatabaseAdapter(walletMasterKey);
 
-// Ensure the global index exists before accepting requests.
-// All users (real and ghost) are automatically added to this index.
-await ensureGlobalIndex();
-
 const authDb = new AuthDatabaseAdapter();
 const auth = createAuth({
   authDb,
   getTrustedOrigins,
   sendMagicLinkEmail,
   ensureWallet: (userId) => messagingStore.ensureWallet(userId),
-  ensureGlobalIndexMembership,
 });
 const messagingService = new MessagingService(messagingStore, {
   xmtpEnv: (process.env.XMTP_ENV as 'dev' | 'production' | 'local') || 'dev',


### PR DESCRIPTION
## Summary

Remove the Index Global concept and replace with direct contact search. Fixes contact-only discovery which was broken because ghost users were only in Index Global but that index was filtered out.

Closes IND-147

## Refactors

- Remove `ensureGlobalIndex()` and `ensureGlobalIndexMembership()` from server startup
- Ghost users no longer added to Index Global on creation
- Add `searchContactProfiles()` method to embedder for direct contact search
- Update opportunity graph to search contacts directly when `contactsOnly=true`
- Merge contact results with network results in discovery
- Update `verifySharedIndex()` to check `user_contacts` for access control
- Remove `isGlobal` references from frontend network/chat components

## New Discovery Model

Discovery now has two independent dimensions:
- **Contacts**: searched via `user_contacts` + `user_profiles.embedding`
- **Networks**: searched via `index_members` + `user_profiles.embedding`

Ghost users are visible only to users who imported them as contacts.

## Test Plan

- [ ] Import a new contact (creates ghost user)
- [ ] Verify ghost has NO index membership
- [ ] Verify contactsOnly search finds the ghost via embeddings
- [ ] Verify network search does NOT find the ghost
- [ ] Verify combined filter (contacts + network) works

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced contact-based profile discovery, enabling discovery of relevant profiles through your contact network using embedding similarity.

* **UI/UX Improvements**
  * Simplified chat scope selector by streamlining dropdown options.
  * Updated network ordering in the My Networks tab.

* **Performance**
  * Optimized discovery mechanisms and simplified signup flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->