### PR TITLE
feat: differentiate opportunity CTA for ghost vs onboarded users (IND-161)

### DIFF
--- a/docs/plans/2026-03-14-ghost-invite-cta-design.md
+++ b/docs/plans/2026-03-14-ghost-invite-cta-design.md
@@ -1,0 +1,94 @@
+# Ghost vs Onboarded User CTA Design
+
+**Issue**: IND-161 — Opportunity card CTA should differ for ghost vs onboarded users
+**Date**: 2026-03-14
+**Status**: Approved
+
+## Summary
+
+The primary action on an opportunity card should differ based on whether the matched user is a ghost (imported contact, not yet signed up) or a fully onboarded user. Ghost users receive an "Invite to chat" flow with an AI-generated, editable invite message sent via email. Onboarded users get the existing "Start chat" flow.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Invite message generation | Backend LLM agent | Contextual messages referencing shared intents/opportunity |
+| Chat session for ghost | Create real DB-backed session immediately | Simplest; transfers via existing ghost claim flow |
+| XMTP handling | Skip for ghost users | Ghost can't authenticate XMTP; kicks in after onboarding |
+| Referrer line | Include from introducer actor | Data already available in opportunity actors |
+| UI after sending invite | Navigate to chat view | Reinforces conversation started; user can add more context |
+| Message editing | Pre-fill chat input (no modal) | Reuses existing chat UI, simpler |
+| Email trigger | On first message send to ghost | Email always contains what user actually sent |
+| Ghost unsubscribe | Soft-delete ghost, prevent re-import | Respects opt-out; direct signup still allowed |
+
+## Design
+
+### 1. API Changes
+
+**Opportunity response** — Add `isGhost` boolean to opportunity presentation data. The service layer resolves this by looking up the counterpart user's `isGhost` flag.
+
+**Invite generation endpoint** — `GET /opportunities/:id/invite-message`:
+1. Loads opportunity (actors, intents, interpretation, context)
+2. Calls `invite.generator` agent to produce contextual invite message
+3. Returns `{ message: string }`
+
+**Ghost email trigger** — No new endpoint. Chat service detects ghost recipient on message creation and queues email via existing Resend infra.
+
+### 2. Invite Generator Agent
+
+**File**: `protocol/src/lib/protocol/agents/invite.generator.ts`
+
+**Input** (Zod schema):
+- `recipientName` — ghost user's name
+- `senderName` — inviter's name
+- `opportunityInterpretation` — why they matched
+- `senderIntents` — relevant intents from the sender
+- `recipientIntents` — relevant intents/profile info from the ghost
+- `referrerName` — optional, from introducer actor if present
+
+**Output**: `{ message: string }` — invite text ready to edit
+
+**Behavior**: Generates a warm, concise message (~3-5 sentences) referencing why they were matched, what the sender is looking for, and optionally who referred them. Conversational tone, no subject line (it's a chat message).
+
+**Model config**: Lightweight model, low temperature.
+
+### 3. Ghost Email Flow
+
+**Trigger**: Chat service detects ghost recipient on message send (`isGhost === true`), queues email.
+
+**Email template**: `ghost-invite.template.ts`:
+- Sender's name and context ("reached out to you on Index")
+- The actual message content the sender wrote
+- CTA button: "Reply on Index" → deep-link to signup with redirect to chat
+- Unsubscribe link
+
+**Rate limiting**: Only the first message triggers an email. Tracked via `ghostInviteSent: boolean` in chat session metadata.
+
+**Unsubscribe flow**:
+- Endpoint: `POST /unsubscribe/:token` (token encodes ghost user ID)
+- Action: soft-delete the ghost user (`deletedAt` timestamp set)
+- Soft-deleted ghosts are excluded from contact import — `ContactService.importContacts` filters out emails belonging to soft-deleted ghost users, preventing re-creation
+- Direct signup still allowed — if a soft-deleted ghost registers, normal auth flow proceeds; ghost claim skips since ghost row is soft-deleted
+
+### 4. Ghost Claim Extension
+
+Extend `claimGhostUser()` in `auth.adapter.ts` to transfer:
+- `chat_sessions.userId` from ghost ID to real user ID
+- `chat_messages` transfer implicitly (tied to sessions)
+- `chat_session_metadata` and `chat_message_metadata` transfer with sessions
+
+Post-claim: user sees the chat session with the invite as the first message. XMTP kicks in for subsequent messages.
+
+### 5. Frontend Changes
+
+**OpportunityCardData** — Add `isGhost?: boolean`.
+
+**CTA label** — Server-driven via `primaryActionLabel`. Backend sets "Invite to chat" for ghost, "Start chat" for onboarded. No frontend label logic.
+
+**Click handler** — In `ChatContent.tsx`:
+- Ghost: call `GET /opportunities/:id/invite-message`, navigate to `/u/${userId}/chat?prefill={encodedMessage}`
+- Onboarded: existing flow (navigate to `/u/${userId}/chat`)
+
+**Chat input pre-fill** — Chat page reads `prefill` query param, populates message input with decoded text. User edits and sends. Query param cleared after populating.
+
+**No new components** — no modals, no drawers. Reuses existing chat UI.

--- a/docs/plans/2026-03-14-ghost-invite-cta-design.md
+++ b/docs/plans/2026-03-14-ghost-invite-cta-design.md
@@ -54,7 +54,7 @@ The primary action on an opportunity card should differ based on whether the mat
 
 ### 3. Ghost Email Flow
 
-**Trigger**: Chat service detects ghost recipient on message send (`isGhost === true`), queues email.
+**Trigger**: Chat service detects ghost recipient on message send (`isGhost === true AND deletedAt == null`), queues email.
 
 **Email template**: `ghost-invite.template.ts`:
 - Sender's name and context ("reached out to you on Index")
@@ -65,15 +65,15 @@ The primary action on an opportunity card should differ based on whether the mat
 **Rate limiting**: Only the first message triggers an email. Tracked via `ghostInviteSent: boolean` in chat session metadata.
 
 **Unsubscribe flow**:
-- Endpoint: `POST /unsubscribe/:token` (token encodes ghost user ID)
+- Endpoint: `GET /unsubscribe/:token` (token encodes ghost user ID)
 - Action: soft-delete the ghost user (`deletedAt` timestamp set)
 - Soft-deleted ghosts are excluded from contact import — `ContactService.importContacts` filters out emails belonging to soft-deleted ghost users, preventing re-creation
 - Direct signup still allowed — if a soft-deleted ghost registers, normal auth flow proceeds; ghost claim skips since ghost row is soft-deleted
 
 ### 4. Ghost Claim Extension
 
-Extend `claimGhostUser()` in `auth.adapter.ts` to transfer:
-- `chat_sessions.userId` from ghost ID to real user ID
+The existing `claimGhostUser()` in `auth.adapter.ts` already transfers `chatSessions.userId`. This extension adds the transfer to the claim transaction alongside the existing transfers:
+- `chat_sessions.userId` from ghost ID to real user ID (added to claim transaction)
 - `chat_messages` transfer implicitly (tied to sessions)
 - `chat_session_metadata` and `chat_message_metadata` transfer with sessions
 

--- a/docs/plans/2026-03-14-ghost-invite-cta-design.md
+++ b/docs/plans/2026-03-14-ghost-invite-cta-design.md
@@ -86,9 +86,9 @@ Post-claim: user sees the chat session with the invite as the first message. XMT
 **CTA label** — Server-driven via `primaryActionLabel`. Backend sets "Invite to chat" for ghost, "Start chat" for onboarded. No frontend label logic.
 
 **Click handler** — In `ChatContent.tsx`:
-- Ghost: call `GET /opportunities/:id/invite-message`, navigate to `/u/${userId}/chat?prefill={encodedMessage}`
+- Ghost: call `GET /opportunities/:id/invite-message`, navigate to `/u/${userId}/chat` with `{ state: { prefill: message } }` via React Router navigation state
 - Onboarded: existing flow (navigate to `/u/${userId}/chat`)
 
-**Chat input pre-fill** — Chat page reads `prefill` query param, populates message input with decoded text. User edits and sends. Query param cleared after populating.
+**Chat input pre-fill** — Chat page reads `location.state.prefill`, passes it as `initialMessage` to `ChatView`. User edits and sends.
 
 **No new components** — no modals, no drawers. Reuses existing chat UI.

--- a/docs/plans/2026-03-14-ghost-invite-cta.md
+++ b/docs/plans/2026-03-14-ghost-invite-cta.md
@@ -1,0 +1,842 @@
+# Ghost Invite CTA Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use executing-plans to implement this plan task-by-task.
+
+**Goal:** Differentiate the opportunity card CTA for ghost vs onboarded users — ghost users get "Invite to chat" with an AI-generated, editable invite message sent via email; onboarded users keep the existing "Start chat" flow.
+
+**Architecture:** Backend exposes `isGhost` on opportunity responses and a new invite-message generation endpoint. Chat service detects ghost recipients and queues email on first message. Frontend reads `isGhost` to route between existing chat flow and a prefill-based invite flow. Ghost claim extended to transfer chat sessions.
+
+**Tech Stack:** TypeScript, Drizzle ORM, BullMQ, LangChain (OpenRouter), Resend, React, React Router
+
+**Design doc:** `docs/plans/2026-03-14-ghost-invite-cta-design.md`
+
+---
+
+### Task 1: Expose `isGhost` in opportunity API response
+
+**Files:**
+- Modify: `protocol/src/services/opportunity.service.ts:176-242` (getOpportunityWithPresentation)
+- Modify: `protocol/src/lib/protocol/support/opportunity.presentation.ts:24-30` (presentOpportunity)
+
+**Step 1: Add `isGhost` to the opportunity presentation response**
+
+In `opportunity.service.ts`, the `getOpportunityWithPresentation()` method already fetches user records for `otherPartyIds` at line 204. The user record includes `isGhost`. Add it to the response object.
+
+```typescript
+// In getOpportunityWithPresentation(), after line 217 (otherPartyInfo assignment):
+const counterpartUser = userRecords[0];
+const isCounterpartGhost = counterpartUser?.isGhost ?? false;
+
+// In the return object (after line 238), add:
+isGhost: isCounterpartGhost,
+```
+
+**Step 2: Set `primaryActionLabel` based on ghost status**
+
+In `opportunity.service.ts`, in the `getOpportunityWithPresentation()` return block, the `presentation` object is built at line 218. After it, add label logic:
+
+```typescript
+// After line 218 (presentation = presentOpportunity(...))
+const primaryActionLabel = isCounterpartGhost ? 'Invite to chat' : 'Start chat';
+```
+
+Add `primaryActionLabel` to the return object alongside `isGhost`.
+
+**Step 3: Verify the change**
+
+Run: `cd protocol && npx tsc --noEmit`
+Expected: No type errors.
+
+**Step 4: Commit**
+
+```bash
+git add protocol/src/services/opportunity.service.ts
+git commit -m "feat(opportunity): expose isGhost and primaryActionLabel in opportunity response"
+```
+
+---
+
+### Task 2: Create invite generator agent
+
+**Files:**
+- Create: `protocol/src/lib/protocol/agents/invite.generator.ts`
+- Modify: `protocol/src/lib/protocol/agents/model.config.ts:15-31`
+
+**Step 1: Add model config entry**
+
+In `model.config.ts`, add to `MODEL_CONFIG` (line 28, before `chatTitleGenerator`):
+
+```typescript
+inviteGenerator:      { model: "google/gemini-2.5-flash", temperature: 0.3, maxTokens: 512 },
+```
+
+**Step 2: Create the invite generator agent**
+
+Create `protocol/src/lib/protocol/agents/invite.generator.ts`:
+
+```typescript
+/**
+ * Invite Generator Agent
+ *
+ * Generates contextual, editable invite messages for ghost users.
+ * Produces warm, concise messages (~3-5 sentences) referencing why two
+ * users were matched, with optional referrer mention.
+ */
+
+import { HumanMessage, SystemMessage } from "@langchain/core/messages";
+import { z } from "zod";
+
+import { createModel } from "./model.config";
+
+const model = createModel("inviteGenerator");
+
+const InviteInputSchema = z.object({
+  recipientName: z.string(),
+  senderName: z.string(),
+  opportunityInterpretation: z.string(),
+  senderIntents: z.array(z.string()),
+  recipientIntents: z.array(z.string()),
+  referrerName: z.string().optional(),
+});
+
+const InviteOutputSchema = z.object({
+  message: z.string().describe("The invite message text, ready to edit and send"),
+});
+
+export type InviteInput = z.infer<typeof InviteInputSchema>;
+export type InviteOutput = z.infer<typeof InviteOutputSchema>;
+
+const SYSTEM_PROMPT = `You generate short, warm invite messages for a professional networking platform called Index.
+
+The sender wants to reach out to someone whose profile matched theirs. Generate a conversational message (~3-5 sentences) that:
+- Greets the recipient by name
+- Briefly explains why they were matched (reference the opportunity interpretation)
+- Mentions the sender's relevant intent or interest
+- If a referrer is provided, naturally mentions that the referrer suggested they connect
+- Ends with an open question or gentle CTA
+- Uses a warm but professional tone — not salesy, not stiff
+
+Do NOT include a subject line. This is a chat message, not an email.
+Do NOT use placeholder brackets like [Name]. Use the actual names provided.`;
+
+/**
+ * Generates a contextual invite message for a ghost user.
+ * @param input - Context about sender, recipient, and opportunity
+ * @returns Generated invite message text
+ */
+export async function generateInviteMessage(input: InviteInput): Promise<InviteOutput> {
+  const validated = InviteInputSchema.parse(input);
+
+  const structuredModel = model.withStructuredOutput(InviteOutputSchema);
+
+  const userPrompt = `Generate an invite message with this context:
+- Sender: ${validated.senderName}
+- Recipient: ${validated.recipientName}
+- Why they matched: ${validated.opportunityInterpretation}
+- Sender's interests: ${validated.senderIntents.join(', ') || 'Not specified'}
+- Recipient's interests: ${validated.recipientIntents.join(', ') || 'Not specified'}${validated.referrerName ? `\n- Referred by: ${validated.referrerName}` : ''}`;
+
+  const result = await structuredModel.invoke([
+    new SystemMessage(SYSTEM_PROMPT),
+    new HumanMessage(userPrompt),
+  ]);
+
+  return result;
+}
+```
+
+**Step 3: Verify**
+
+Run: `cd protocol && npx tsc --noEmit`
+Expected: No type errors.
+
+**Step 4: Commit**
+
+```bash
+git add protocol/src/lib/protocol/agents/invite.generator.ts protocol/src/lib/protocol/agents/model.config.ts
+git commit -m "feat(agent): add invite message generator for ghost user outreach"
+```
+
+---
+
+### Task 3: Add invite-message endpoint to opportunity controller
+
+**Files:**
+- Modify: `protocol/src/controllers/opportunity.controller.ts:24-213`
+- Modify: `protocol/src/services/opportunity.service.ts`
+
+**Step 1: Add `generateInviteMessage` method to OpportunityService**
+
+In `opportunity.service.ts`, add a new method that:
+1. Loads the opportunity
+2. Validates the viewer is an actor
+3. Finds the ghost counterpart
+4. Gathers context (intents, interpretation, introducer)
+5. Calls the invite generator agent
+6. Returns the message
+
+```typescript
+/**
+ * Generate an invite message for a ghost user counterpart in an opportunity.
+ * @param opportunityId - The opportunity ID
+ * @param viewerId - The authenticated user requesting the invite
+ * @returns Generated invite message or error
+ */
+async generateInviteMessage(opportunityId: string, viewerId: string) {
+  const opp = await this.db.getOpportunity(opportunityId);
+  if (!opp) {
+    return { error: 'Opportunity not found', status: 404 };
+  }
+
+  const isActor = opp.actors.some((a) => a.userId === viewerId);
+  if (!isActor) {
+    return { error: 'Not authorized', status: 403 };
+  }
+
+  const counterpart = opp.actors.find(
+    (a) => a.role !== 'introducer' && a.userId !== viewerId
+  ) ?? opp.actors.find((a) => a.userId !== viewerId);
+
+  if (!counterpart) {
+    return { error: 'No counterpart found', status: 400 };
+  }
+
+  const [viewer, recipient] = await Promise.all([
+    this.db.getUser(viewerId),
+    this.db.getUser(counterpart.userId),
+  ]);
+
+  if (!recipient?.isGhost) {
+    return { error: 'Counterpart is not a ghost user', status: 400 };
+  }
+
+  const introducer = opp.actors.find((a) => a.role === 'introducer');
+  const introducerUser = introducer ? await this.db.getUser(introducer.userId) : null;
+
+  // Gather intents for context
+  const [senderIntents, recipientIntents] = await Promise.all([
+    this.db.getActiveIntents(viewerId).then(intents => intents.map(i => i.title)),
+    this.db.getActiveIntents(counterpart.userId).then(intents => intents.map(i => i.title)),
+  ]);
+
+  const { generateInviteMessage: generate } = await import('../lib/protocol/agents/invite.generator');
+
+  const result = await generate({
+    recipientName: recipient.name ?? 'there',
+    senderName: viewer?.name ?? 'Someone',
+    opportunityInterpretation: opp.interpretation.reasoning,
+    senderIntents,
+    recipientIntents,
+    referrerName: introducerUser?.name ?? undefined,
+  });
+
+  return { message: result.message };
+}
+```
+
+Note: Use dynamic import for the agent to keep the service layer lightweight. The `getActiveIntents` method should already exist on the database adapter — verify during implementation. If not, use whatever method returns user intents.
+
+**Step 2: Add controller endpoint**
+
+In `opportunity.controller.ts`, add before the `getOpportunity` route (before line 100, since `:id` is a catch-all pattern and `/invite-message` must come before it — actually we need `/:id/invite-message` which is fine after `:id`):
+
+```typescript
+/**
+ * GET /opportunities/:id/invite-message — generate an invite message for a ghost counterpart.
+ */
+@Get('/:id/invite-message')
+@UseGuards(AuthGuard)
+async getInviteMessage(req: Request, user: AuthenticatedUser, params?: RouteParams) {
+  const id = params?.id;
+  if (!id) {
+    return Response.json({ error: 'Missing opportunity id' }, { status: 400 });
+  }
+
+  const result = await opportunityService.generateInviteMessage(id, user.id);
+
+  if ('error' in result && 'status' in result && typeof result.status === 'number') {
+    return Response.json({ error: result.error }, { status: result.status });
+  }
+
+  return Response.json(result);
+}
+```
+
+**Step 3: Verify**
+
+Run: `cd protocol && npx tsc --noEmit`
+
+**Step 4: Commit**
+
+```bash
+git add protocol/src/services/opportunity.service.ts protocol/src/controllers/opportunity.controller.ts
+git commit -m "feat(opportunity): add invite-message generation endpoint for ghost users"
+```
+
+---
+
+### Task 4: Create ghost invite email template
+
+**Files:**
+- Create: `protocol/src/lib/email/templates/ghost-invite.template.ts`
+- Modify: `protocol/src/lib/email/templates/index.ts`
+
+**Step 1: Create the email template**
+
+Create `protocol/src/lib/email/templates/ghost-invite.template.ts` following the pattern from `opportunity-notification.template.ts`:
+
+```typescript
+import { escapeHtml, sanitizeUrlForHref } from '../../escapeHtml';
+
+/**
+ * Email template for ghost user invite — sent when an onboarded user
+ * messages a ghost user for the first time.
+ */
+export function ghostInviteTemplate(
+  recipientName: string,
+  senderName: string,
+  messageContent: string,
+  replyUrl: string,
+  unsubscribeUrl: string
+) {
+  const subject = `${senderName} reached out to you on Index`;
+
+  const safeReplyUrl = escapeHtml(sanitizeUrlForHref(replyUrl));
+  const safeUnsubscribeUrl = escapeHtml(sanitizeUrlForHref(unsubscribeUrl));
+  const sanitizedReplyUrlForText = sanitizeUrlForHref(replyUrl);
+
+  const html = `
+    <div style="font-family: Arial, sans-serif;">
+      <p>Hey ${escapeHtml(recipientName)},</p>
+      <p><strong>${escapeHtml(senderName)}</strong> reached out to you on Index:</p>
+      <div style="margin: 16px 0; padding: 16px; background-color: #f9f9f9; border-left: 3px solid #041729; border-radius: 4px;">
+        <p style="margin: 0; white-space: pre-wrap;">${escapeHtml(messageContent)}</p>
+      </div>
+      <div style="margin: 20px 0;">
+        <a href="${safeReplyUrl}" style="text-decoration: none; font-weight: bold; color: #FFFFFF; background-color: #0A0A0A; font-size: 1.1em; padding: 10px 20px; border-radius: 5px; display: inline-block;">Reply on Index</a>
+      </div>
+      <p>—Index</p>
+      <div style="margin-top: 40px; border-top: 1px solid #eee; padding-top: 20px; font-size: 0.8em; color: #888;">
+        <p><a href="${safeUnsubscribeUrl}" style="color: #888; text-decoration: underline;">Unsubscribe</a></p>
+      </div>
+    </div>
+  `;
+
+  const text = `Hey ${recipientName},
+
+${senderName} reached out to you on Index:
+
+"${messageContent}"
+
+Reply on Index: ${sanitizedReplyUrlForText}
+
+—Index
+`;
+
+  return { subject, html, text };
+}
+```
+
+**Step 2: Export from barrel**
+
+In `protocol/src/lib/email/templates/index.ts`, add:
+
+```typescript
+export * from './ghost-invite.template';
+```
+
+**Step 3: Verify**
+
+Run: `cd protocol && npx tsc --noEmit`
+
+**Step 4: Commit**
+
+```bash
+git add protocol/src/lib/email/templates/ghost-invite.template.ts protocol/src/lib/email/templates/index.ts
+git commit -m "feat(email): add ghost invite email template"
+```
+
+---
+
+### Task 5: Ghost email trigger in chat service
+
+**Files:**
+- Modify: `protocol/src/services/chat.service.ts:159-189` (addMessage)
+- Modify: `protocol/src/queues/email.queue.ts` (if needed for helpers)
+
+**Step 1: Add ghost detection and email queueing to `addMessage`**
+
+In `chat.service.ts`, after the message is created and session timestamp updated (line 186), add logic to detect ghost recipient and queue email. The chat service needs access to the database adapter to look up user info and the email queue.
+
+The chat service constructor already receives a `db` adapter. Check if it can look up users. If `getUser` is available on the db adapter, use it. Otherwise, add the needed method.
+
+```typescript
+// After line 186 (updateSessionTimestamp), add:
+
+// Ghost invite email: on first user message in a DM, check if the peer is a ghost
+if (params.role === 'user' && params.recipientUserId) {
+  try {
+    const recipient = await this.db.getUser(params.recipientUserId);
+    if (recipient?.isGhost && !recipient.deletedAt) {
+      // Check if we already sent a ghost invite for this session
+      const metadata = await this.db.getSessionMetadata(params.sessionId);
+      if (!metadata?.ghostInviteSent) {
+        const sender = await this.db.getUser(params.sessionUserId ?? '');
+        if (sender && recipient.email) {
+          const { ghostInviteTemplate } = await import('../lib/email/templates');
+          const appUrl = process.env.APP_URL || 'https://index.network';
+          const replyUrl = `${appUrl}/onboarding?ref=invite`;
+          const unsubscribeUrl = `${appUrl}/api/unsubscribe/${recipient.id}`;
+
+          const email = ghostInviteTemplate(
+            recipient.name ?? 'there',
+            sender.name ?? 'Someone',
+            params.content,
+            replyUrl,
+            unsubscribeUrl,
+          );
+
+          const { emailQueue } = await import('../queues/email.queue');
+          await emailQueue.addJob({
+            to: recipient.email,
+            subject: email.subject,
+            html: email.html,
+            text: email.text,
+          });
+
+          await this.db.updateSessionMetadata(params.sessionId, { ghostInviteSent: true });
+        }
+      }
+    }
+  } catch (err) {
+    // Log but don't fail the message creation
+    logger.error('Failed to send ghost invite email', { error: err, sessionId: params.sessionId });
+  }
+}
+```
+
+Note: The exact implementation depends on how `addMessage` receives the recipient user ID. Since this is a DM-style chat (navigated via `/u/:id/chat`), the recipient is implicit from the chat session. During implementation, check how the chat controller passes this context. You may need to:
+- Add `recipientUserId` as an optional param to `addMessage`
+- Or look up the DM peer from the session/route context
+
+The `sessionMetadata` table already exists (`chat_session_metadata`). Check if `updateSessionMetadata` exists on the db adapter; if not, add a simple upsert.
+
+**Step 2: Verify**
+
+Run: `cd protocol && npx tsc --noEmit`
+
+**Step 3: Commit**
+
+```bash
+git add protocol/src/services/chat.service.ts
+git commit -m "feat(chat): trigger ghost invite email on first message to ghost user"
+```
+
+---
+
+### Task 6: Ghost unsubscribe endpoint and contact import filter
+
+**Files:**
+- Modify: `protocol/src/controllers/opportunity.controller.ts` (or create a new controller)
+- Modify: `protocol/src/services/contact.service.ts:118-238`
+
+**Step 1: Add unsubscribe endpoint**
+
+Create a simple unsubscribe route. This can be a new lightweight controller or added to an existing one. Since it's public (no auth needed — ghost users aren't logged in), it should NOT use AuthGuard.
+
+Option: Add to a new `UnsubscribeController` or add as a public route. For simplicity, add to the opportunity controller or create a minimal controller.
+
+```typescript
+// New file: protocol/src/controllers/unsubscribe.controller.ts
+
+import { Controller, Post } from '../lib/router/router.decorators';
+import { db } from '../adapters/database.adapter'; // or inject via service
+import { log } from '../lib/log';
+
+const logger = log.controller.from('unsubscribe');
+
+/**
+ * Handles ghost user unsubscribe requests.
+ * Public endpoint — no auth required (ghost users can't log in).
+ */
+@Controller('/unsubscribe')
+export class UnsubscribeController {
+  /**
+   * POST /unsubscribe/:token — soft-delete a ghost user to opt out of emails.
+   */
+  @Post('/:token')
+  async unsubscribe(req: Request, _user: unknown, params?: Record<string, string>) {
+    const token = params?.token;
+    if (!token) {
+      return Response.json({ error: 'Missing token' }, { status: 400 });
+    }
+
+    try {
+      // Token is the ghost user ID
+      const result = await db.softDeleteGhostUser(token);
+      if (!result) {
+        return Response.json({ error: 'Not found' }, { status: 404 });
+      }
+
+      // Return a simple HTML page confirming unsubscribe
+      return new Response(
+        '<html><body style="font-family:Arial,sans-serif;text-align:center;padding:60px"><h2>Unsubscribed</h2><p>You will no longer receive emails from Index.</p></body></html>',
+        { headers: { 'Content-Type': 'text/html' } }
+      );
+    } catch (err) {
+      logger.error('Unsubscribe failed', { token, error: err });
+      return Response.json({ error: 'Internal error' }, { status: 500 });
+    }
+  }
+}
+```
+
+Register this controller in `main.ts`.
+
+The `softDeleteGhostUser` method on the database adapter should:
+1. Find user by ID where `isGhost = true`
+2. Set `deletedAt = now()`
+3. Return true/false
+
+**Step 2: Filter soft-deleted ghosts from contact import**
+
+In `contact.service.ts`, at line 178-179, `getUsersByEmails` returns existing users. Soft-deleted ghost users should be treated as if they don't exist — BUT we must NOT re-create them as ghosts.
+
+Modify the `needGhosts` filter (lines 182-187) to also exclude emails of soft-deleted ghost users:
+
+```typescript
+// After line 179 (existingByEmail map), add a check for soft-deleted ghosts:
+const softDeletedGhosts = await this.db.getSoftDeletedGhostEmails(emails);
+const softDeletedSet = new Set(softDeletedGhosts.map(e => e.toLowerCase()));
+
+// Modify needGhosts filter (line 183-186):
+for (const contact of validContacts) {
+  if (!existingByEmail.has(contact.email) && !softDeletedSet.has(contact.email)) {
+    needGhosts.push(contact);
+  }
+}
+```
+
+Note: The `getSoftDeletedGhostEmails` method needs to be added to the database adapter. It queries users where `isGhost = true AND deletedAt IS NOT NULL` and returns their emails. Since ghost emails get renamed on claim (`__ghost_claimed_xxx`), we need to also store the original email somewhere or check by the original email. During implementation, verify the exact mechanism — the simplest approach may be to check if any user (ghost or not, deleted or not) already has that email, and skip ghost creation for those.
+
+Actually, a simpler approach: modify `getUsersByEmails` to also return soft-deleted users (or do a separate query). Then in the `needGhosts` loop, also check if the email belongs to a soft-deleted ghost and skip it.
+
+**Step 3: Verify**
+
+Run: `cd protocol && npx tsc --noEmit`
+
+**Step 4: Commit**
+
+```bash
+git add protocol/src/controllers/unsubscribe.controller.ts protocol/src/services/contact.service.ts protocol/src/main.ts
+git commit -m "feat(unsubscribe): add ghost unsubscribe endpoint and prevent re-import of opted-out ghosts"
+```
+
+---
+
+### Task 7: Extend ghost claim to transfer chat sessions
+
+**Files:**
+- Modify: `protocol/src/adapters/auth.adapter.ts:70-79` (claimGhostUser)
+
+**Step 1: Add chat session transfer to the claim transaction**
+
+In `auth.adapter.ts`, inside the `claimGhostUser` transaction (lines 71-78), add transfers for chat sessions. Chat messages are tied to sessions via `sessionId`, so transferring session ownership is sufficient.
+
+```typescript
+// Add inside the transaction, after line 76 (userContacts update):
+await tx.update(schema.chatSessions).set({ userId: realUserId }).where(eq(schema.chatSessions.userId, ghostId));
+```
+
+Also handle `chatSessionMetadata` if it has a userId reference (check schema). The `chatMessages` table references `sessionId` not `userId`, so those transfer implicitly.
+
+**Step 2: Verify**
+
+Run: `cd protocol && npx tsc --noEmit`
+
+**Step 3: Commit**
+
+```bash
+git add protocol/src/adapters/auth.adapter.ts
+git commit -m "feat(auth): transfer chat sessions during ghost claim"
+```
+
+---
+
+### Task 8: Frontend — add `isGhost` to OpportunityCardData and prefill flow
+
+**Files:**
+- Modify: `frontend/src/components/chat/OpportunityCardInChat.tsx:14-44` (OpportunityCardData interface)
+- Modify: `frontend/src/components/ChatContent.tsx:649-716` (handleHomeOpportunityAction)
+- Modify: `frontend/src/services/opportunities.ts` (add getInviteMessage method)
+- Modify: `frontend/src/app/u/[id]/chat/page.tsx:1-92` (read prefill param)
+
+**Step 1: Add `isGhost` to OpportunityCardData**
+
+In `OpportunityCardInChat.tsx`, add to the interface (after line 37):
+
+```typescript
+isGhost?: boolean;
+```
+
+**Step 2: Add `getInviteMessage` to opportunities service**
+
+In `frontend/src/services/opportunities.ts`, add a method to the service factory:
+
+```typescript
+async getInviteMessage(opportunityId: string): Promise<{ message: string }> {
+  const response = await fetchWithAuth(`/opportunities/${opportunityId}/invite-message`);
+  if (!response.ok) throw new Error('Failed to generate invite message');
+  return response.json();
+},
+```
+
+**Step 3: Modify the click handler for ghost users**
+
+In `ChatContent.tsx`, modify `handleHomeOpportunityAction` (lines 649-716). When action is "accepted" and the counterpart is a ghost, fetch the invite message and navigate with prefill:
+
+The handler currently receives `viewerRole` but not `isGhost`. The `onPrimaryAction` callback in `OpportunityCardInChat.tsx` passes `card.viewerRole` (line 201). We need to also pass `card.isGhost`.
+
+Update `OpportunityCardInChat.tsx` `handlePrimaryAction` (lines 194-209) to also pass `isGhost`:
+
+```typescript
+await onPrimaryAction(
+  card.opportunityId,
+  card.userId,
+  card.viewerRole,
+  card.name,
+  card.isGhost,  // Add this parameter
+);
+```
+
+Update the `onPrimaryAction` type to include `isGhost?: boolean`.
+
+Then in `ChatContent.tsx`, update `handleHomeOpportunityAction` signature and body:
+
+```typescript
+const handleHomeOpportunityAction = useCallback(
+  async (
+    opportunityId: string,
+    action: "accepted" | "rejected",
+    fallbackUserId?: string,
+    viewerRole?: string,
+    counterpartName?: string,
+    isGhost?: boolean,
+  ) => {
+    // ... existing code ...
+
+    // Replace the navigation block (lines 680-687):
+    if (action === "accepted" && !isIntroducer && counterpartUserId) {
+      if (isGhost) {
+        // Fetch invite message and navigate with prefill
+        try {
+          const { message } = await opportunitiesService.getInviteMessage(opportunityId);
+          navigate(`/u/${counterpartUserId}/chat?prefill=${encodeURIComponent(message)}`);
+        } catch {
+          // Fallback: navigate without prefill
+          navigate(`/u/${counterpartUserId}/chat`);
+        }
+      } else {
+        navigate(`/u/${counterpartUserId}/chat`);
+      }
+    }
+    // ... rest stays the same
+  },
+  [opportunitiesService, navigate, showError, showSuccess],
+);
+```
+
+**Step 4: Read prefill param in chat page**
+
+In `frontend/src/app/u/[id]/chat/page.tsx`, read the `prefill` query param and pass it to `ChatView`:
+
+```typescript
+const prefillMessage = searchParams.get('prefill') ?? undefined;
+
+// In the return, pass to ChatView:
+<ChatView
+  userId={profileData.id}
+  userName={profileData.name}
+  userAvatar={profileData.avatar || undefined}
+  userTitle={profileData.location || undefined}
+  initialGroupId={initialGroupId}
+  initialMessage={prefillMessage}
+  onClose={handleClose}
+  onBack={handleBack}
+/>
+```
+
+Then in `ChatView`, accept `initialMessage` prop and populate the input field with it on mount. The exact implementation depends on ChatView's input mechanism — check how it handles the message input state and pre-fill it.
+
+**Step 5: Verify**
+
+Run: `cd frontend && npx tsc --noEmit`
+
+**Step 6: Commit**
+
+```bash
+git add frontend/src/components/chat/OpportunityCardInChat.tsx frontend/src/components/ChatContent.tsx frontend/src/services/opportunities.ts frontend/src/app/u/\\[id\\]/chat/page.tsx
+git commit -m "feat(frontend): differentiate CTA for ghost vs onboarded users with prefill invite flow"
+```
+
+---
+
+### Task 9: Wire up the home view to pass `isGhost` through
+
+**Files:**
+- Modify: `protocol/src/services/opportunity.service.ts` (home view builder)
+- Modify: `frontend/src/components/ChatContent.tsx` (home view card mapping)
+
+**Step 1: Ensure `isGhost` flows through the home view API**
+
+The home view endpoint (`GET /opportunities/home`) builds card data differently than the single-opportunity endpoint. Check how `getHomeView()` in `opportunity.service.ts` constructs cards and ensure `isGhost` is included. The home view likely uses the opportunity presenter or a card-building helper — trace the code path and add `isGhost` to each card in the response.
+
+**Step 2: Ensure the frontend maps `isGhost` from home view response to `OpportunityCardData`**
+
+In `ChatContent.tsx`, find where `HomeViewCardItem` data is mapped to `OpportunityCardData` for rendering. Add the `isGhost` field to that mapping.
+
+**Step 3: Verify**
+
+Run both: `cd protocol && npx tsc --noEmit` and `cd frontend && npx tsc --noEmit`
+
+**Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "feat: wire isGhost through home view API and frontend card mapping"
+```
+
+---
+
+### Task 10: Database adapter methods for ghost operations
+
+**Files:**
+- Modify: `protocol/src/adapters/database.adapter.ts`
+
+This task covers any database adapter methods needed by Tasks 5, 6, and 7 that don't already exist:
+
+**Step 1: Add `softDeleteGhostUser` method**
+
+```typescript
+async softDeleteGhostUser(userId: string): Promise<boolean> {
+  const result = await db.update(schema.users)
+    .set({ deletedAt: new Date() })
+    .where(and(eq(schema.users.id, userId), eq(schema.users.isGhost, true), isNull(schema.users.deletedAt)))
+    .returning({ id: schema.users.id });
+  return result.length > 0;
+}
+```
+
+**Step 2: Add `getSoftDeletedGhostEmails` method (if needed)**
+
+```typescript
+async getSoftDeletedGhostEmails(emails: string[]): Promise<string[]> {
+  if (emails.length === 0) return [];
+  const results = await db.select({ email: schema.users.email })
+    .from(schema.users)
+    .where(and(
+      inArray(schema.users.email, emails),
+      eq(schema.users.isGhost, true),
+      isNotNull(schema.users.deletedAt),
+    ));
+  return results.map(r => r.email);
+}
+```
+
+**Step 3: Add/verify `updateSessionMetadata` method for ghost invite tracking**
+
+Check if `updateSessionMetadata` exists. If not, add a simple upsert for the `chat_session_metadata` table that merges a JSON field.
+
+**Step 4: Verify**
+
+Run: `cd protocol && npx tsc --noEmit`
+
+**Step 5: Commit**
+
+```bash
+git add protocol/src/adapters/database.adapter.ts
+git commit -m "feat(db): add ghost user soft-delete and metadata methods"
+```
+
+---
+
+### Task 11: Register UnsubscribeController in main.ts
+
+**Files:**
+- Modify: `protocol/src/main.ts`
+
+**Step 1: Import and register the controller**
+
+Add the `UnsubscribeController` import and register it alongside other controllers in `main.ts`.
+
+**Step 2: Verify**
+
+Run: `cd protocol && npx tsc --noEmit`
+
+**Step 3: Commit**
+
+```bash
+git add protocol/src/main.ts
+git commit -m "feat: register UnsubscribeController in server"
+```
+
+---
+
+### Task 12: Integration test
+
+**Files:**
+- Create: `protocol/tests/ghost-invite.spec.ts`
+
+**Step 1: Write test for the invite generation endpoint**
+
+```typescript
+import { loadEnv } from '../src/lib/env';
+loadEnv();
+
+import { describe, test, expect } from 'bun:test';
+
+describe('Ghost Invite CTA', () => {
+  test('invite-message endpoint returns message for ghost counterpart', async () => {
+    // This test requires a running server with seeded data
+    // Adjust based on your test infrastructure
+    // Test that GET /opportunities/:id/invite-message returns { message: string }
+  }, 30_000);
+
+  test('ghost unsubscribe sets deletedAt', async () => {
+    // Test POST /unsubscribe/:ghostId soft-deletes the ghost user
+  });
+
+  test('soft-deleted ghosts are not re-imported as contacts', async () => {
+    // Test that importContacts skips emails of soft-deleted ghosts
+  });
+});
+```
+
+**Step 2: Run tests**
+
+Run: `cd protocol && bun test tests/ghost-invite.spec.ts`
+
+**Step 3: Commit**
+
+```bash
+git add protocol/tests/ghost-invite.spec.ts
+git commit -m "test: add integration tests for ghost invite flow"
+```
+
+---
+
+## Execution Order
+
+Tasks can be partially parallelized:
+
+```
+Task 10 (DB adapter methods) ──┐
+Task 2 (invite agent) ─────────┤
+Task 4 (email template) ───────┼── Task 3 (endpoint) ── Task 5 (email trigger) ── Task 12 (tests)
+Task 1 (isGhost in API) ───────┤
+Task 7 (ghost claim) ──────────┘
+Task 6 (unsubscribe + import filter) ── Task 11 (register controller)
+Task 8 (frontend changes) ── Task 9 (home view wiring)
+```
+
+Independent tasks (1, 2, 4, 7, 10) can run in parallel. Tasks 3, 5, 6 depend on earlier tasks. Frontend tasks (8, 9) can run in parallel with backend once Task 1 is done.

--- a/frontend/src/app/u/[id]/chat/page.tsx
+++ b/frontend/src/app/u/[id]/chat/page.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useNavigate, useSearchParams, useParams } from "react-router";
+import { useNavigate, useSearchParams, useParams, useLocation } from "react-router";
 import { Loader2 } from "lucide-react";
 import { useAuthContext } from "@/contexts/AuthContext";
 import { useUsers } from "@/contexts/APIContext";
@@ -10,8 +10,9 @@ export default function ChatPage() {
   const { id } = useParams();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const location = useLocation();
   const initialGroupId = searchParams.get('groupId') ?? undefined;
-  const prefillMessage = searchParams.get('prefill') ?? undefined;
+  const prefillMessage = (location.state as { prefill?: string } | null)?.prefill ?? undefined;
   const { isAuthenticated, isLoading: authLoading } = useAuthContext();
   const usersService = useUsers();
 

--- a/frontend/src/app/u/[id]/chat/page.tsx
+++ b/frontend/src/app/u/[id]/chat/page.tsx
@@ -11,6 +11,7 @@ export default function ChatPage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const initialGroupId = searchParams.get('groupId') ?? undefined;
+  const prefillMessage = searchParams.get('prefill') ?? undefined;
   const { isAuthenticated, isLoading: authLoading } = useAuthContext();
   const usersService = useUsers();
 
@@ -82,6 +83,7 @@ export default function ChatPage() {
       userAvatar={profileData.avatar || undefined}
       userTitle={profileData.location || undefined}
       initialGroupId={initialGroupId}
+      initialMessage={prefillMessage}
       onClose={handleClose}
       onBack={handleBack}
     />

--- a/frontend/src/components/ChatContent.tsx
+++ b/frontend/src/components/ChatContent.tsx
@@ -685,7 +685,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
             // Fetch invite message and navigate with prefill for ghost users
             try {
               const { message } = await opportunitiesService.getInviteMessage(opportunityId);
-              navigate(`/u/${counterpartUserId}/chat?prefill=${encodeURIComponent(message)}`);
+              navigate(`/u/${counterpartUserId}/chat`, { state: { prefill: message } });
             } catch {
               // Fallback: navigate without prefill
               navigate(`/u/${counterpartUserId}/chat`);

--- a/frontend/src/components/ChatContent.tsx
+++ b/frontend/src/components/ChatContent.tsx
@@ -223,12 +223,14 @@ function AssistantMessageContent({
     userId: string,
     viewerRole?: string,
     counterpartName?: string,
+    isGhost?: boolean,
   ) => void;
   onOpportunitySecondaryAction?: (
     opportunityId: string,
     userId: string,
     viewerRole?: string,
     counterpartName?: string,
+    isGhost?: boolean,
   ) => void;
   opportunityLoadingMap?: Record<string, boolean>;
   /** Map of opportunityId -> current status from server */
@@ -653,6 +655,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
       fallbackUserId?: string,
       viewerRole?: string,
       counterpartName?: string,
+      isGhost?: boolean,
     ) => {
       setOpportunityActionLoading((prev) => ({
         ...prev,
@@ -678,7 +681,18 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
         const counterpartUserId =
           result.counterpartUserId ?? fallbackUserId;
         if (action === "accepted" && !isIntroducer && counterpartUserId) {
-          navigate(`/u/${counterpartUserId}/chat`);
+          if (isGhost) {
+            // Fetch invite message and navigate with prefill for ghost users
+            try {
+              const { message } = await opportunitiesService.getInviteMessage(opportunityId);
+              navigate(`/u/${counterpartUserId}/chat?prefill=${encodeURIComponent(message)}`);
+            } catch {
+              // Fallback: navigate without prefill
+              navigate(`/u/${counterpartUserId}/chat`);
+            }
+          } else {
+            navigate(`/u/${counterpartUserId}/chat`);
+          }
         } else if (action === "accepted" && isIntroducer) {
           showSuccess(
             "Introduction sent",
@@ -1251,6 +1265,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
                             userId,
                             viewerRole,
                             counterpartName,
+                            isGhost,
                           ) =>
                             handleHomeOpportunityAction(
                               oppId,
@@ -1258,6 +1273,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
                               userId,
                               viewerRole,
                               counterpartName,
+                              isGhost,
                             )
                           }
                           onSecondaryAction={(
@@ -1265,6 +1281,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
                             userId,
                             viewerRole,
                             counterpartName,
+                            isGhost,
                           ) =>
                             handleHomeOpportunityAction(
                               oppId,
@@ -1272,6 +1289,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
                               userId,
                               viewerRole,
                               counterpartName,
+                              isGhost,
                             )
                           }
                           isLoading={
@@ -1540,6 +1558,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
                               userId,
                               viewerRole,
                               counterpartName,
+                              isGhost,
                             ) =>
                               handleHomeOpportunityAction(
                                 oppId,
@@ -1547,6 +1566,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
                                 userId,
                                 viewerRole,
                                 counterpartName,
+                                isGhost,
                               )
                             }
                             onOpportunitySecondaryAction={(
@@ -1554,6 +1574,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
                               userId,
                               viewerRole,
                               counterpartName,
+                              isGhost,
                             ) =>
                               handleHomeOpportunityAction(
                                 oppId,
@@ -1561,6 +1582,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
                                 userId,
                                 viewerRole,
                                 counterpartName,
+                                isGhost,
                               )
                             }
                             opportunityLoadingMap={opportunityActionLoading}

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -16,16 +16,18 @@ interface ChatViewProps {
   userAvatar?: string;
   userTitle?: string;
   initialGroupId?: string;
+  /** Pre-fill the message input (e.g. invite text for ghost users). */
+  initialMessage?: string;
   onClose: () => void;
   onBack?: () => void;
 }
 
-export default function ChatView({ userId, userName, userAvatar, initialGroupId, onClose, onBack }: ChatViewProps) {
+export default function ChatView({ userId, userName, userAvatar, initialGroupId, initialMessage, onClose, onBack }: ChatViewProps) {
   const { user } = useAuthContext();
   const { isConnected, myInboxId, sendMessage: xmtpSend, loadMessages, messages: allMessages, getChatContext, deleteConversation } = useXMTP();
   const [groupId, setGroupId] = useState<string | null>(initialGroupId ?? null);
   const [chatContext, setChatContext] = useState<XmtpChatContext | null>(null);
-  const [messageText, setMessageText] = useState('');
+  const [messageText, setMessageText] = useState(initialMessage ?? '');
   const [messagesLoading, setMessagesLoading] = useState(true);
   const [contextLoading, setContextLoading] = useState(true);
   const [sending, setSending] = useState(false);

--- a/frontend/src/components/chat/OpportunityCardInChat.tsx
+++ b/frontend/src/components/chat/OpportunityCardInChat.tsx
@@ -41,6 +41,8 @@ export interface OpportunityCardData {
   score?: number;
   /** Opportunity status at the time the card was created. */
   status?: string;
+  /** Whether the counterpart is a ghost (not yet onboarded) user. */
+  isGhost?: boolean;
 }
 
 /** Status values that allow user actions (accept/reject). Matches DB opportunity_status enum. */
@@ -110,6 +112,7 @@ interface OpportunityCardProps {
     userId: string,
     viewerRole?: string,
     counterpartName?: string,
+    isGhost?: boolean,
   ) => void | Promise<void>;
   /** Handler for secondary action (reject/skip). */
   onSecondaryAction?: (
@@ -117,6 +120,7 @@ interface OpportunityCardProps {
     userId: string,
     viewerRole?: string,
     counterpartName?: string,
+    isGhost?: boolean,
   ) => void | Promise<void>;
   /** Whether an action is currently loading for this card. */
   isLoading?: boolean;
@@ -200,6 +204,7 @@ export default function OpportunityCard({
           card.userId,
           card.viewerRole,
           card.name,
+          card.isGhost,
         );
         setActionTaken("accepted");
       } catch {
@@ -217,6 +222,7 @@ export default function OpportunityCard({
           card.userId,
           card.viewerRole,
           card.name,
+          card.isGhost,
         );
         setActionTaken("rejected");
       } catch {

--- a/frontend/src/services/opportunities.ts
+++ b/frontend/src/services/opportunities.ts
@@ -54,6 +54,8 @@ export interface HomeViewCardItem {
   narratorChip?: { name: string; text: string; avatar?: string | null; userId?: string };
   /** Viewer's role in this opportunity (e.g. 'introducer', 'party', 'agent', 'patient', 'peer'). */
   viewerRole?: string;
+  /** Whether the counterpart is a ghost (not yet onboarded) user. */
+  isGhost?: boolean;
 }
 
 /** Home view section (dynamic title, icon, items). */

--- a/frontend/src/services/opportunities.ts
+++ b/frontend/src/services/opportunities.ts
@@ -166,4 +166,9 @@ export const createOpportunitiesService = (
   getOpportunity: async (opportunityId: string): Promise<OpportunityDetailResponse> => {
     return api.get<OpportunityDetailResponse>(`/opportunities/${opportunityId}`);
   },
+
+  /** Fetch a pre-generated invite message for a ghost user opportunity. */
+  getInviteMessage: async (opportunityId: string): Promise<{ message: string }> => {
+    return api.get<{ message: string }>(`/opportunities/${opportunityId}/invite-message`);
+  },
 });

--- a/protocol/src/adapters/auth.adapter.ts
+++ b/protocol/src/adapters/auth.adapter.ts
@@ -62,8 +62,8 @@ export class AuthDatabaseAdapter {
 
   /**
    * Claims a ghost user's data after a real user has been created.
-   * Transfers all ghost data (profiles, intents, index memberships, contacts, HyDE documents)
-   * to the real user, then deletes the ghost row.
+   * Transfers all ghost data (profiles, intents, index memberships, contacts, HyDE documents,
+   * chat sessions) to the real user, then deletes the ghost row.
    * @param realUserId - The real user's ID
    * @param ghostId - The ghost user's ID (from prepareGhostClaim)
    */
@@ -74,6 +74,7 @@ export class AuthDatabaseAdapter {
       await tx.update(schema.indexMembers).set({ userId: realUserId }).where(eq(schema.indexMembers.userId, ghostId));
       await tx.update(schema.hydeDocuments).set({ sourceId: realUserId }).where(eq(schema.hydeDocuments.sourceId, ghostId));
       await tx.update(schema.userContacts).set({ userId: realUserId }).where(eq(schema.userContacts.userId, ghostId));
+      await tx.update(schema.chatSessions).set({ userId: realUserId }).where(eq(schema.chatSessions.userId, ghostId));
       await tx.delete(schema.users).where(eq(schema.users.id, ghostId));
     });
   }

--- a/protocol/src/adapters/database.adapter.ts
+++ b/protocol/src/adapters/database.adapter.ts
@@ -571,6 +571,7 @@ export class IntentDatabaseAdapter {
       socials: user.socials ?? null,
       onboarding: user.onboarding ?? null,
       isGhost: user.isGhost ?? false,
+      deletedAt: user.deletedAt ?? null,
     };
   }
 

--- a/protocol/src/adapters/database.adapter.ts
+++ b/protocol/src/adapters/database.adapter.ts
@@ -2661,6 +2661,58 @@ export class ChatDatabaseAdapter {
   }
 
   /**
+   * Soft-delete a ghost user by unsubscribe token.
+   * Looks up the user via userNotificationSettings.unsubscribeToken,
+   * then soft-deletes if the user is a ghost and not already deleted.
+   * @param token - The unsubscribe token from the email link
+   * @returns true if user was soft-deleted, false if not found or not eligible
+   */
+  async softDeleteGhostByUnsubscribeToken(token: string): Promise<boolean> {
+    const [settings] = await db.select({ userId: schema.userNotificationSettings.userId })
+      .from(schema.userNotificationSettings)
+      .where(eq(schema.userNotificationSettings.unsubscribeToken, token))
+      .limit(1);
+    if (!settings) return false;
+
+    const result = await db.update(schema.users)
+      .set({ deletedAt: new Date() })
+      .where(and(
+        eq(schema.users.id, settings.userId),
+        eq(schema.users.isGhost, true),
+        isNull(schema.users.deletedAt)
+      ))
+      .returning({ id: schema.users.id });
+    return result.length > 0;
+  }
+
+  /**
+   * Get or create notification settings for a user.
+   * If no row exists, creates one with default preferences.
+   * @param userId - The user's ID
+   * @returns The notification settings row (includes unsubscribeToken)
+   */
+  async getOrCreateNotificationSettings(userId: string): Promise<{ id: string; userId: string; unsubscribeToken: string }> {
+    const [existing] = await db.select({
+      id: schema.userNotificationSettings.id,
+      userId: schema.userNotificationSettings.userId,
+      unsubscribeToken: schema.userNotificationSettings.unsubscribeToken,
+    })
+      .from(schema.userNotificationSettings)
+      .where(eq(schema.userNotificationSettings.userId, userId))
+      .limit(1);
+    if (existing) return existing;
+
+    const [created] = await db.insert(schema.userNotificationSettings)
+      .values({ userId })
+      .returning({
+        id: schema.userNotificationSettings.id,
+        userId: schema.userNotificationSettings.userId,
+        unsubscribeToken: schema.userNotificationSettings.unsubscribeToken,
+      });
+    return created;
+  }
+
+  /**
    * Get emails of soft-deleted ghost users from a list of emails.
    * Used to prevent re-importing opted-out ghost contacts.
    * @param emails - List of emails to check

--- a/protocol/src/adapters/database.adapter.ts
+++ b/protocol/src/adapters/database.adapter.ts
@@ -2642,6 +2642,42 @@ export class ChatDatabaseAdapter {
   }
 
   /**
+   * Soft-delete a ghost user (opt-out from emails).
+   * Only deletes users where isGhost=true and not already deleted.
+   * @param userId - The ghost user's ID
+   * @returns true if user was soft-deleted, false if not found or not eligible
+   */
+  async softDeleteGhostUser(userId: string): Promise<boolean> {
+    const result = await db.update(schema.users)
+      .set({ deletedAt: new Date() })
+      .where(and(
+        eq(schema.users.id, userId),
+        eq(schema.users.isGhost, true),
+        isNull(schema.users.deletedAt)
+      ))
+      .returning({ id: schema.users.id });
+    return result.length > 0;
+  }
+
+  /**
+   * Get emails of soft-deleted ghost users from a list of emails.
+   * Used to prevent re-importing opted-out ghost contacts.
+   * @param emails - List of emails to check
+   * @returns Emails belonging to soft-deleted ghost users
+   */
+  async getSoftDeletedGhostEmails(emails: string[]): Promise<string[]> {
+    if (emails.length === 0) return [];
+    const results = await db.select({ email: schema.users.email })
+      .from(schema.users)
+      .where(and(
+        inArray(schema.users.email, emails),
+        eq(schema.users.isGhost, true),
+        isNotNull(schema.users.deletedAt),
+      ));
+    return results.map(r => r.email);
+  }
+
+  /**
    * Upsert a contact record (idempotent via unique constraint).
    * @param data - Contact data with ownerId, userId, and source
    */

--- a/protocol/src/adapters/database.adapter.ts
+++ b/protocol/src/adapters/database.adapter.ts
@@ -2692,24 +2692,22 @@ export class ChatDatabaseAdapter {
    * @returns The notification settings row (includes unsubscribeToken)
    */
   async getOrCreateNotificationSettings(userId: string): Promise<{ id: string; userId: string; unsubscribeToken: string }> {
-    const [existing] = await db.select({
+    const projection = {
       id: schema.userNotificationSettings.id,
       userId: schema.userNotificationSettings.userId,
       unsubscribeToken: schema.userNotificationSettings.unsubscribeToken,
-    })
+    };
+
+    // Atomic upsert: insert with onConflictDoNothing, then select
+    await db.insert(schema.userNotificationSettings)
+      .values({ userId })
+      .onConflictDoNothing({ target: schema.userNotificationSettings.userId });
+
+    const [row] = await db.select(projection)
       .from(schema.userNotificationSettings)
       .where(eq(schema.userNotificationSettings.userId, userId))
       .limit(1);
-    if (existing) return existing;
-
-    const [created] = await db.insert(schema.userNotificationSettings)
-      .values({ userId })
-      .returning({
-        id: schema.userNotificationSettings.id,
-        userId: schema.userNotificationSettings.userId,
-        unsubscribeToken: schema.userNotificationSettings.unsubscribeToken,
-      });
-    return created;
+    return row;
   }
 
   /**

--- a/protocol/src/adapters/database.adapter.ts
+++ b/protocol/src/adapters/database.adapter.ts
@@ -2707,6 +2707,9 @@ export class ChatDatabaseAdapter {
       .from(schema.userNotificationSettings)
       .where(eq(schema.userNotificationSettings.userId, userId))
       .limit(1);
+    if (!row) {
+      throw new Error(`Failed to get or create notification settings for user ${userId}`);
+    }
     return row;
   }
 

--- a/protocol/src/adapters/database.adapter.ts
+++ b/protocol/src/adapters/database.adapter.ts
@@ -570,6 +570,7 @@ export class IntentDatabaseAdapter {
       location: user.location ?? null,
       socials: user.socials ?? null,
       onboarding: user.onboarding ?? null,
+      isGhost: user.isGhost ?? false,
     };
   }
 

--- a/protocol/src/controllers/chat.controller.ts
+++ b/protocol/src/controllers/chat.controller.ts
@@ -29,6 +29,8 @@ const streamBodySchema = z.object({
   useCheckpointer: z.boolean().optional(),
   fileIds: z.array(z.string()).optional(),
   indexId: z.string().nullish(),
+  /** The recipient user ID for DM-style chats (used for ghost invite emails). */
+  recipientUserId: z.string().nullish(),
   prefillMessages: z.array(z.object({
     role: z.enum(["assistant", "user"]),
     content: z.string().max(10000),
@@ -300,10 +302,16 @@ export class ChatController {
           }
 
           // Persist user message and assistant response
+          const recipientUserId =
+            typeof body.recipientUserId === "string" && body.recipientUserId.trim()
+              ? body.recipientUserId.trim()
+              : undefined;
           await chatSessionService.addMessage({
             sessionId,
             role: "user",
             content: messageContent,
+            recipientUserId,
+            senderUserId: user.id,
           });
           let assistantMessageId: string | undefined;
           if (fullResponse) {

--- a/protocol/src/controllers/chat.controller.ts
+++ b/protocol/src/controllers/chat.controller.ts
@@ -302,10 +302,13 @@ export class ChatController {
           }
 
           // Persist user message and assistant response
-          const recipientUserId =
+          let recipientUserId: string | undefined =
             typeof body.recipientUserId === "string" && body.recipientUserId.trim()
               ? body.recipientUserId.trim()
               : undefined;
+          if (recipientUserId && recipientUserId === user.id) {
+            recipientUserId = undefined; // Can't be your own recipient
+          }
           await chatSessionService.addMessage({
             sessionId,
             role: "user",

--- a/protocol/src/controllers/opportunity.controller.ts
+++ b/protocol/src/controllers/opportunity.controller.ts
@@ -95,6 +95,26 @@ export class OpportunityController {
   }
 
   /**
+   * GET /opportunities/:id/invite-message — generate an invite message for a ghost counterpart.
+   */
+  @Get('/:id/invite-message')
+  @UseGuards(AuthGuard)
+  async getInviteMessage(req: Request, user: AuthenticatedUser, params?: RouteParams) {
+    const id = params?.id;
+    if (!id) {
+      return Response.json({ error: 'Missing opportunity id' }, { status: 400 });
+    }
+
+    const result = await opportunityService.generateInviteMessage(id, user.id);
+
+    if ('error' in result && 'status' in result && typeof result.status === 'number') {
+      return Response.json({ error: result.error }, { status: result.status });
+    }
+
+    return Response.json(result);
+  }
+
+  /**
    * GET /opportunities/:id — get one opportunity with presentation for the viewer.
    */
   @Get('/:id')

--- a/protocol/src/controllers/unsubscribe.controller.ts
+++ b/protocol/src/controllers/unsubscribe.controller.ts
@@ -1,7 +1,7 @@
-import { Controller, Post } from '../lib/router/router.decorators';
+import { Controller, Get } from '../lib/router/router.decorators';
 import { log } from '../lib/log';
 
-import { ChatDatabaseAdapter } from '../adapters/database.adapter';
+import { UnsubscribeService } from '../services/unsubscribe.service';
 
 const logger = log.controller.from('unsubscribe');
 
@@ -11,17 +11,17 @@ const logger = log.controller.from('unsubscribe');
  */
 @Controller('/unsubscribe')
 export class UnsubscribeController {
-  private db = new ChatDatabaseAdapter();
+  private service = new UnsubscribeService();
 
   /**
-   * POST /unsubscribe/:token — soft-delete a ghost user to opt out of emails.
+   * GET /unsubscribe/:token — soft-delete a ghost user to opt out of emails.
    * The token is the ghost user's ID, included in invite email unsubscribe links.
    * @param _req - Unused request object
    * @param _user - Unused (no auth guard)
    * @param params - Route params containing the unsubscribe token (ghost user ID)
    * @returns HTML response confirming unsubscribe or indicating not found
    */
-  @Post('/:token')
+  @Get('/:token')
   async unsubscribe(_req: Request, _user: unknown, params?: Record<string, string>) {
     const token = params?.token;
     if (!token) {
@@ -29,7 +29,7 @@ export class UnsubscribeController {
     }
 
     try {
-      const result = await this.db.softDeleteGhostUser(token);
+      const result = await this.service.softDeleteGhostUser(token);
       if (!result) {
         return new Response(
           '<html><body style="font-family:Arial,sans-serif;text-align:center;padding:60px"><h2>Not Found</h2><p>This unsubscribe link is no longer valid.</p></body></html>',

--- a/protocol/src/controllers/unsubscribe.controller.ts
+++ b/protocol/src/controllers/unsubscribe.controller.ts
@@ -15,10 +15,10 @@ export class UnsubscribeController {
 
   /**
    * GET /unsubscribe/:token — soft-delete a ghost user to opt out of emails.
-   * The token is the ghost user's ID, included in invite email unsubscribe links.
+   * The token is the unsubscribeToken from userNotificationSettings, included in invite email unsubscribe links.
    * @param _req - Unused request object
    * @param _user - Unused (no auth guard)
-   * @param params - Route params containing the unsubscribe token (ghost user ID)
+   * @param params - Route params containing the unsubscribe token
    * @returns HTML response confirming unsubscribe or indicating not found
    */
   @Get('/:token')
@@ -29,7 +29,7 @@ export class UnsubscribeController {
     }
 
     try {
-      const result = await this.service.softDeleteGhostUser(token);
+      const result = await this.service.softDeleteGhostByToken(token);
       if (!result) {
         return new Response(
           '<html><body style="font-family:Arial,sans-serif;text-align:center;padding:60px"><h2>Not Found</h2><p>This unsubscribe link is no longer valid.</p></body></html>',

--- a/protocol/src/controllers/unsubscribe.controller.ts
+++ b/protocol/src/controllers/unsubscribe.controller.ts
@@ -33,7 +33,7 @@ export class UnsubscribeController {
       if (!result) {
         return new Response(
           '<html><body style="font-family:Arial,sans-serif;text-align:center;padding:60px"><h2>Not Found</h2><p>This unsubscribe link is no longer valid.</p></body></html>',
-          { headers: { 'Content-Type': 'text/html' } }
+          { status: 404, headers: { 'Content-Type': 'text/html' } }
         );
       }
 
@@ -42,7 +42,7 @@ export class UnsubscribeController {
         { headers: { 'Content-Type': 'text/html' } }
       );
     } catch (err) {
-      logger.error('Unsubscribe failed', { token, error: err });
+      logger.error('Unsubscribe failed', { error: err });
       return Response.json({ error: 'Internal error' }, { status: 500 });
     }
   }

--- a/protocol/src/controllers/unsubscribe.controller.ts
+++ b/protocol/src/controllers/unsubscribe.controller.ts
@@ -1,0 +1,49 @@
+import { Controller, Post } from '../lib/router/router.decorators';
+import { log } from '../lib/log';
+
+import { ChatDatabaseAdapter } from '../adapters/database.adapter';
+
+const logger = log.controller.from('unsubscribe');
+
+/**
+ * Handles ghost user unsubscribe requests.
+ * Public endpoint — no auth required (ghost users cannot log in).
+ */
+@Controller('/unsubscribe')
+export class UnsubscribeController {
+  private db = new ChatDatabaseAdapter();
+
+  /**
+   * POST /unsubscribe/:token — soft-delete a ghost user to opt out of emails.
+   * The token is the ghost user's ID, included in invite email unsubscribe links.
+   * @param _req - Unused request object
+   * @param _user - Unused (no auth guard)
+   * @param params - Route params containing the unsubscribe token (ghost user ID)
+   * @returns HTML response confirming unsubscribe or indicating not found
+   */
+  @Post('/:token')
+  async unsubscribe(_req: Request, _user: unknown, params?: Record<string, string>) {
+    const token = params?.token;
+    if (!token) {
+      return Response.json({ error: 'Missing token' }, { status: 400 });
+    }
+
+    try {
+      const result = await this.db.softDeleteGhostUser(token);
+      if (!result) {
+        return new Response(
+          '<html><body style="font-family:Arial,sans-serif;text-align:center;padding:60px"><h2>Not Found</h2><p>This unsubscribe link is no longer valid.</p></body></html>',
+          { headers: { 'Content-Type': 'text/html' } }
+        );
+      }
+
+      return new Response(
+        '<html><body style="font-family:Arial,sans-serif;text-align:center;padding:60px"><h2>Unsubscribed</h2><p>You will no longer receive emails from Index.</p></body></html>',
+        { headers: { 'Content-Type': 'text/html' } }
+      );
+    } catch (err) {
+      logger.error('Unsubscribe failed', { token, error: err });
+      return Response.json({ error: 'Internal error' }, { status: 500 });
+    }
+  }
+}

--- a/protocol/src/lib/email/templates/ghost-invite.template.ts
+++ b/protocol/src/lib/email/templates/ghost-invite.template.ts
@@ -1,0 +1,49 @@
+import { escapeHtml, sanitizeUrlForHref } from '../../escapeHtml';
+
+/**
+ * Email template for ghost user invite — sent when an onboarded user
+ * messages a ghost user for the first time.
+ */
+export function ghostInviteTemplate(
+  recipientName: string,
+  senderName: string,
+  messageContent: string,
+  replyUrl: string,
+  unsubscribeUrl: string
+) {
+  const subject = `${senderName} reached out to you on Index`;
+
+  const safeReplyUrl = escapeHtml(sanitizeUrlForHref(replyUrl));
+  const safeUnsubscribeUrl = escapeHtml(sanitizeUrlForHref(unsubscribeUrl));
+  const sanitizedReplyUrlForText = sanitizeUrlForHref(replyUrl);
+
+  const html = `
+    <div style="font-family: Arial, sans-serif;">
+      <p>Hey ${escapeHtml(recipientName)},</p>
+      <p><strong>${escapeHtml(senderName)}</strong> reached out to you on Index:</p>
+      <div style="margin: 16px 0; padding: 16px; background-color: #f9f9f9; border-left: 3px solid #041729; border-radius: 4px;">
+        <p style="margin: 0; white-space: pre-wrap;">${escapeHtml(messageContent)}</p>
+      </div>
+      <div style="margin: 20px 0;">
+        <a href="${safeReplyUrl}" style="text-decoration: none; font-weight: bold; color: #FFFFFF; background-color: #0A0A0A; font-size: 1.1em; padding: 10px 20px; border-radius: 5px; display: inline-block;">Reply on Index</a>
+      </div>
+      <p>—Index</p>
+      <div style="margin-top: 40px; border-top: 1px solid #eee; padding-top: 20px; font-size: 0.8em; color: #888;">
+        <p><a href="${safeUnsubscribeUrl}" style="color: #888; text-decoration: underline;">Unsubscribe</a></p>
+      </div>
+    </div>
+  `;
+
+  const text = `Hey ${recipientName},
+
+${senderName} reached out to you on Index:
+
+"${messageContent}"
+
+Reply on Index: ${sanitizedReplyUrlForText}
+
+—Index
+`;
+
+  return { subject, html, text };
+}

--- a/protocol/src/lib/email/templates/ghost-invite.template.ts
+++ b/protocol/src/lib/email/templates/ghost-invite.template.ts
@@ -16,6 +16,7 @@ export function ghostInviteTemplate(
   const safeReplyUrl = escapeHtml(sanitizeUrlForHref(replyUrl));
   const safeUnsubscribeUrl = escapeHtml(sanitizeUrlForHref(unsubscribeUrl));
   const sanitizedReplyUrlForText = sanitizeUrlForHref(replyUrl);
+  const sanitizedUnsubscribeUrlForText = sanitizeUrlForHref(unsubscribeUrl);
 
   const html = `
     <div style="font-family: Arial, sans-serif;">
@@ -43,6 +44,8 @@ ${senderName} reached out to you on Index:
 Reply on Index: ${sanitizedReplyUrlForText}
 
 —Index
+
+To unsubscribe: ${sanitizedUnsubscribeUrlForText}
 `;
 
   return { subject, html, text };

--- a/protocol/src/lib/email/templates/index.ts
+++ b/protocol/src/lib/email/templates/index.ts
@@ -2,3 +2,4 @@ export * from './connection-request.template';
 export * from './connection-accepted.template';
 
 export * from './weekly-newsletter.template';
+export * from './ghost-invite.template';

--- a/protocol/src/lib/protocol/agents/invite.generator.ts
+++ b/protocol/src/lib/protocol/agents/invite.generator.ts
@@ -1,0 +1,68 @@
+/**
+ * Invite Generator Agent
+ *
+ * Generates contextual, editable invite messages for ghost users.
+ * Produces warm, concise messages (~3-5 sentences) referencing why two
+ * users were matched, with optional referrer mention.
+ */
+
+import { HumanMessage, SystemMessage } from "@langchain/core/messages";
+import { z } from "zod";
+
+import { createModel } from "./model.config";
+
+const model = createModel("inviteGenerator");
+
+const InviteInputSchema = z.object({
+  recipientName: z.string(),
+  senderName: z.string(),
+  opportunityInterpretation: z.string(),
+  senderIntents: z.array(z.string()),
+  recipientIntents: z.array(z.string()),
+  referrerName: z.string().optional(),
+});
+
+const InviteOutputSchema = z.object({
+  message: z.string().describe("The invite message text, ready to edit and send"),
+});
+
+export type InviteInput = z.infer<typeof InviteInputSchema>;
+export type InviteOutput = z.infer<typeof InviteOutputSchema>;
+
+const SYSTEM_PROMPT = `You generate short, warm invite messages for a professional networking platform called Index.
+
+The sender wants to reach out to someone whose profile matched theirs. Generate a conversational message (~3-5 sentences) that:
+- Greets the recipient by name
+- Briefly explains why they were matched (reference the opportunity interpretation)
+- Mentions the sender's relevant intent or interest
+- If a referrer is provided, naturally mentions that the referrer suggested they connect
+- Ends with an open question or gentle CTA
+- Uses a warm but professional tone — not salesy, not stiff
+
+Do NOT include a subject line. This is a chat message, not an email.
+Do NOT use placeholder brackets like [Name]. Use the actual names provided.`;
+
+/**
+ * Generates a contextual invite message for a ghost user.
+ * @param input - Context about sender, recipient, and opportunity
+ * @returns Generated invite message text
+ */
+export async function generateInviteMessage(input: InviteInput): Promise<InviteOutput> {
+  const validated = InviteInputSchema.parse(input);
+
+  const structuredModel = model.withStructuredOutput(InviteOutputSchema);
+
+  const userPrompt = `Generate an invite message with this context:
+- Sender: ${validated.senderName}
+- Recipient: ${validated.recipientName}
+- Why they matched: ${validated.opportunityInterpretation}
+- Sender's interests: ${validated.senderIntents.join(', ') || 'Not specified'}
+- Recipient's interests: ${validated.recipientIntents.join(', ') || 'Not specified'}${validated.referrerName ? `\n- Referred by: ${validated.referrerName}` : ''}`;
+
+  const result = await structuredModel.invoke([
+    new SystemMessage(SYSTEM_PROMPT),
+    new HumanMessage(userPrompt),
+  ]);
+
+  return result;
+}

--- a/protocol/src/lib/protocol/agents/model.config.ts
+++ b/protocol/src/lib/protocol/agents/model.config.ts
@@ -27,6 +27,7 @@ export const MODEL_CONFIG = {
   homeCategorizer:      { model: "google/gemini-2.5-flash" },
   suggestionGenerator:  { model: "google/gemini-2.5-flash", temperature: 0.4, maxTokens: 512 },
   chatTitleGenerator:   { model: "google/gemini-2.5-flash", temperature: 0.3, maxTokens: 32 },
+  inviteGenerator:      { model: "google/gemini-2.5-flash", temperature: 0.3, maxTokens: 512 },
   chat:                 { model: process.env.CHAT_MODEL ?? "google/gemini-3-pro-preview", maxTokens: 8192, reasoning: { effort: (process.env.CHAT_REASONING_EFFORT ?? "low") as NonNullable<ModelSettings["reasoning"]>["effort"], exclude: true } },
 } as const satisfies Record<string, ModelSettings>;
 

--- a/protocol/src/lib/protocol/graphs/home.graph.ts
+++ b/protocol/src/lib/protocol/graphs/home.graph.ts
@@ -371,6 +371,7 @@ export class HomeGraphFactory {
                 ? opportunity.interpretation.reasoning.replace(/\s+/g, ' ').trim().slice(0, MAX_REASONING_SNIPPET_LENGTH)
                 : '') || 'A promising connection.';
 
+            const isCounterpartGhost = otherUser?.isGhost ?? false;
             const fallbackCard = (): HomeCardItem => ({
               opportunityId: opportunity.id,
               userId: otherActor?.userId ?? '',
@@ -380,11 +381,12 @@ export class HomeGraphFactory {
               cta: isIntroducer
                 ? 'Share this introduction to get things started.'
                 : 'Take a look and decide whether to reach out.',
-              primaryActionLabel: isIntroducer ? 'Good match' : 'Start Chat',
+              primaryActionLabel: isIntroducer ? 'Good match' : (isCounterpartGhost ? 'Invite to chat' : 'Start Chat'),
               secondaryActionLabel: isIntroducer ? 'Pass' : 'Skip',
               mutualIntentsLabel: isIntroducer ? 'Connector match' : 'Shared interests',
               narratorChip: { name: 'Index', text: 'Worth a look.' },
               viewerRole,
+              isGhost: isCounterpartGhost,
               _cardIndex: cardIndex,
             });
 
@@ -426,11 +428,12 @@ export class HomeGraphFactory {
                 mainText: presentation.personalizedSummary,
                 cta: presentation.suggestedAction,
                 headline: presentation.headline,
-                primaryActionLabel: presentation.primaryActionLabel,
+                primaryActionLabel: isCounterpartGhost && !isIntroducer ? 'Invite to chat' : presentation.primaryActionLabel,
                 secondaryActionLabel: presentation.secondaryActionLabel,
                 mutualIntentsLabel: presentation.mutualIntentsLabel,
                 narratorChip,
                 viewerRole,
+                isGhost: isCounterpartGhost,
                 _cardIndex: cardIndex,
               } satisfies HomeCardItem;
             } catch (e) {

--- a/protocol/src/lib/protocol/interfaces/database.interface.ts
+++ b/protocol/src/lib/protocol/interfaces/database.interface.ts
@@ -20,6 +20,7 @@ export interface UserRecord {
   socials?: UserSocials | null;
   onboarding?: OnboardingState | null;
   isGhost?: boolean;
+  deletedAt?: Date | null;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/protocol/src/lib/protocol/interfaces/database.interface.ts
+++ b/protocol/src/lib/protocol/interfaces/database.interface.ts
@@ -19,6 +19,7 @@ export interface UserRecord {
   location?: string | null;
   socials?: UserSocials | null;
   onboarding?: OnboardingState | null;
+  isGhost?: boolean;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/protocol/src/lib/protocol/states/home.state.ts
+++ b/protocol/src/lib/protocol/states/home.state.ts
@@ -21,6 +21,8 @@ export interface HomeCardItem {
   narratorChip?: { name: string; text: string; avatar?: string | null; userId?: string };
   /** Viewer's role in this opportunity (e.g. 'introducer', 'party', 'agent', 'patient', 'peer'). */
   viewerRole?: string;
+  /** Whether the counterpart is a ghost (not yet onboarded) user. */
+  isGhost?: boolean;
   /** For section assignment from LLM */
   _cardIndex: number;
 }

--- a/protocol/src/main.ts
+++ b/protocol/src/main.ts
@@ -12,6 +12,7 @@ import { ProfileController } from './controllers/profile.controller';
 import { UserController } from './controllers/user.controller';
 import { StorageController } from './controllers/storage.controller';
 import { SubscribeController } from './controllers/subscribe.controller';
+import { UnsubscribeController } from './controllers/unsubscribe.controller';
 import { fileService } from './services/file.service';
 import { MessagingController } from './controllers/messaging.controller';
 import { MessagingDatabaseAdapter, ensurePersonalIndex } from './adapters/database.adapter';
@@ -133,6 +134,7 @@ controllerInstances.set(UserController, new UserController());
 controllerInstances.set(MessagingController, new MessagingController(messagingService));
 controllerInstances.set(StorageController, new StorageController(storageAdapter));
 controllerInstances.set(SubscribeController, new SubscribeController());
+controllerInstances.set(UnsubscribeController, new UnsubscribeController());
 controllerInstances.set(DebugController, new DebugController());
 
 logger.info('Routes registered', { prefix: GLOBAL_PREFIX });

--- a/protocol/src/services/chat.service.ts
+++ b/protocol/src/services/chat.service.ts
@@ -208,7 +208,9 @@ export class ChatSessionService {
               const { ghostInviteTemplate } = await import('../lib/email/templates');
               const appUrl = process.env.APP_URL || 'https://index.network';
               const replyUrl = `${appUrl}/onboarding?ref=invite`;
-              const unsubscribeUrl = `${appUrl}/api/unsubscribe/${recipient.id}`;
+              // Use unsubscribe token instead of raw user ID
+              const notifSettings = await this.db.getOrCreateNotificationSettings(recipient.id);
+              const unsubscribeUrl = `${appUrl}/api/unsubscribe/${notifSettings.unsubscribeToken}`;
 
               const email = ghostInviteTemplate(
                 recipient.name ?? 'there',

--- a/protocol/src/services/chat.service.ts
+++ b/protocol/src/services/chat.service.ts
@@ -163,15 +163,19 @@ export class ChatSessionService {
     routingDecision?: Record<string, unknown>;
     subgraphResults?: Record<string, unknown>;
     tokenCount?: number;
+    /** When set, triggers a ghost invite email if the recipient is a ghost user. */
+    recipientUserId?: string;
+    /** The sender's user ID (needed for ghost invite email context). */
+    senderUserId?: string;
   }): Promise<string> {
     logger.verbose('Adding message', {
       sessionId: params.sessionId,
       role: params.role,
       contentLength: params.content.length,
     });
-    
+
     const id = generateSnowflakeId();
-    
+
     await this.db.createMessage({
       id,
       sessionId: params.sessionId,
@@ -181,10 +185,74 @@ export class ChatSessionService {
       subgraphResults: params.subgraphResults,
       tokenCount: params.tokenCount,
     });
-    
+
     // Update session timestamp
     await this.db.updateSessionTimestamp(params.sessionId);
-    
+
+    // Ghost invite email: on first user message to a ghost, send email notification
+    if (params.role === 'user' && params.recipientUserId) {
+      try {
+        const recipient = await this.db.getUser(params.recipientUserId);
+        if (recipient?.isGhost && !recipient.deletedAt) {
+          // Check if we already sent a ghost invite for this session
+          const sessionMeta = await this.db.getSessionMetadata(params.sessionId);
+          const metadataObj = sessionMeta?.metadata as Record<string, unknown> | null;
+          const alreadySent = metadataObj?.ghostInviteSent === true;
+
+          if (!alreadySent) {
+            const sender = params.senderUserId
+              ? await this.db.getUser(params.senderUserId)
+              : null;
+
+            if (sender && recipient.email) {
+              const { ghostInviteTemplate } = await import('../lib/email/templates');
+              const appUrl = process.env.APP_URL || 'https://index.network';
+              const replyUrl = `${appUrl}/onboarding?ref=invite`;
+              const unsubscribeUrl = `${appUrl}/api/unsubscribe/${recipient.id}`;
+
+              const email = ghostInviteTemplate(
+                recipient.name ?? 'there',
+                sender.name ?? 'Someone',
+                params.content,
+                replyUrl,
+                unsubscribeUrl,
+              );
+
+              const { emailQueue } = await import('../queues/email.queue');
+              await emailQueue.addJob({
+                to: recipient.email,
+                subject: email.subject,
+                html: email.html,
+                text: email.text,
+              });
+
+              // Mark as sent so we don't send again for this session
+              const metaId = generateSnowflakeId();
+              await this.db.upsertSessionMetadata({
+                id: metaId,
+                sessionId: params.sessionId,
+                metadata: {
+                  ...(metadataObj ?? {}),
+                  ghostInviteSent: true,
+                },
+              });
+
+              logger.verbose('Ghost invite email queued', {
+                sessionId: params.sessionId,
+                recipientId: params.recipientUserId,
+              });
+            }
+          }
+        }
+      } catch (err) {
+        // Log but don't fail the message creation
+        logger.error('Failed to send ghost invite email', {
+          error: err,
+          sessionId: params.sessionId,
+        });
+      }
+    }
+
     return id;
   }
 

--- a/protocol/src/services/chat.service.ts
+++ b/protocol/src/services/chat.service.ts
@@ -241,7 +241,6 @@ export class ChatSessionService {
 
               logger.verbose('Ghost invite email queued', {
                 sessionId: params.sessionId,
-                recipientId: params.recipientUserId,
               });
             }
           }

--- a/protocol/src/services/contact.service.ts
+++ b/protocol/src/services/contact.service.ts
@@ -178,10 +178,14 @@ export class ContactService {
     const existingUsers = await this.db.getUsersByEmails(emails);
     const existingByEmail = new Map(existingUsers.map(u => [u.email.toLowerCase(), u]));
 
-    // Identify contacts that need ghost users
+    // Check for soft-deleted ghosts (opted out of emails — must not be re-created)
+    const softDeletedEmails = await this.db.getSoftDeletedGhostEmails(emails);
+    const softDeletedSet = new Set(softDeletedEmails.map(e => e.toLowerCase()));
+
+    // Identify contacts that need ghost users (excluding soft-deleted ghosts)
     const needGhosts: Array<{ name: string; email: string }> = [];
     for (const contact of validContacts) {
-      if (!existingByEmail.has(contact.email)) {
+      if (!existingByEmail.has(contact.email) && !softDeletedSet.has(contact.email)) {
         needGhosts.push(contact);
       }
     }

--- a/protocol/src/services/opportunity.service.ts
+++ b/protocol/src/services/opportunity.service.ts
@@ -550,6 +550,63 @@ export class OpportunityService {
   }
 
   /**
+   * Generate an invite message for a ghost user counterpart in an opportunity.
+   * @param opportunityId - The opportunity ID
+   * @param viewerId - The authenticated user requesting the invite
+   * @returns Generated invite message or error
+   */
+  async generateInviteMessage(opportunityId: string, viewerId: string) {
+    const opp = await this.db.getOpportunity(opportunityId);
+    if (!opp) {
+      return { error: 'Opportunity not found', status: 404 };
+    }
+
+    const isActor = opp.actors.some((a) => a.userId === viewerId);
+    if (!isActor) {
+      return { error: 'Not authorized', status: 403 };
+    }
+
+    const counterpart = opp.actors.find(
+      (a) => a.role !== 'introducer' && a.userId !== viewerId
+    ) ?? opp.actors.find((a) => a.userId !== viewerId);
+
+    if (!counterpart) {
+      return { error: 'No counterpart found', status: 400 };
+    }
+
+    const [viewer, recipient] = await Promise.all([
+      this.db.getUser(viewerId),
+      this.db.getUser(counterpart.userId),
+    ]);
+
+    if (!recipient?.isGhost) {
+      return { error: 'Counterpart is not a ghost user', status: 400 };
+    }
+
+    const introducer = opp.actors.find((a) => a.role === 'introducer');
+    const introducerUser = introducer ? await this.db.getUser(introducer.userId) : null;
+
+    // Gather intents for context
+    const [senderIntents, recipientIntents] = await Promise.all([
+      this.db.getActiveIntents(viewerId).then(intents => intents.map(i => i.payload)),
+      this.db.getActiveIntents(counterpart.userId).then(intents => intents.map(i => i.payload)),
+    ]);
+
+    const { generateInviteMessage: generate } = await import('../lib/protocol/agents/invite.generator');
+
+    const result = await generate({
+      recipientName: recipient.name ?? 'there',
+      senderName: viewer?.name ?? 'Someone',
+      opportunityInterpretation: opp.interpretation.reasoning,
+      senderIntents,
+      recipientIntents,
+      referrerName: introducerUser?.name ?? undefined,
+    });
+
+    return { message: result.message };
+  }
+
+  /**
    * Check if user has permission to create opportunities in an index.
    * 
    * @param creatorId - User creating the opportunity

--- a/protocol/src/services/opportunity.service.ts
+++ b/protocol/src/services/opportunity.service.ts
@@ -216,7 +216,7 @@ export class OpportunityService {
 
     const otherPartyInfo = otherPartyIds[0] ? userMap.get(otherPartyIds[0])! : { id: '', name: 'Unknown', avatar: null as string | null };
     const counterpartUser = userRecords[0];
-    const isCounterpartGhost = counterpartUser?.isGhost ?? false;
+    const isCounterpartGhost = counterpartUser?.isGhost === true && counterpartUser?.deletedAt == null;
     const presentation = presentOpportunity(opp, viewerId, otherPartyInfo, introducerInfo, 'card');
 
     const otherParties = nonIntroducerActors.map((a) => {
@@ -565,6 +565,9 @@ export class OpportunityService {
     if (!isActor) {
       return { error: 'Not authorized', status: 403 };
     }
+    if (!canUserSeeOpportunity(opp.actors, opp.status, viewerId)) {
+      return { error: 'Not authorized to view this opportunity', status: 403 };
+    }
 
     const counterpart = opp.actors.find(
       (a) => a.role !== 'introducer' && a.userId !== viewerId
@@ -579,7 +582,7 @@ export class OpportunityService {
       this.db.getUser(counterpart.userId),
     ]);
 
-    if (!recipient?.isGhost) {
+    if (!recipient?.isGhost || recipient.deletedAt != null) {
       return { error: 'Counterpart is not a ghost user', status: 400 };
     }
 

--- a/protocol/src/services/opportunity.service.ts
+++ b/protocol/src/services/opportunity.service.ts
@@ -215,6 +215,8 @@ export class OpportunityService {
     });
 
     const otherPartyInfo = otherPartyIds[0] ? userMap.get(otherPartyIds[0])! : { id: '', name: 'Unknown', avatar: null as string | null };
+    const counterpartUser = userRecords[0];
+    const isCounterpartGhost = counterpartUser?.isGhost ?? false;
     const presentation = presentOpportunity(opp, viewerId, otherPartyInfo, introducerInfo, 'card');
 
     const otherParties = nonIntroducerActors.map((a) => {
@@ -236,6 +238,8 @@ export class OpportunityService {
       confidence: confidenceNum,
       index: indexRecord ? { id: indexRecord.id, title: indexRecord.title } : (indexIdForDisplay ? { id: indexIdForDisplay, title: '' } : { id: '', title: '' }),
       status: opp.status,
+      isGhost: isCounterpartGhost,
+      primaryActionLabel: isCounterpartGhost ? 'Invite to chat' : 'Start chat',
       createdAt: opp.createdAt instanceof Date ? opp.createdAt.toISOString() : opp.createdAt,
       expiresAt: opp.expiresAt ? (opp.expiresAt instanceof Date ? opp.expiresAt.toISOString() : opp.expiresAt) : undefined,
     };

--- a/protocol/src/services/unsubscribe.service.ts
+++ b/protocol/src/services/unsubscribe.service.ts
@@ -14,17 +14,18 @@ export class UnsubscribeService {
   constructor(private db = new ChatDatabaseAdapter()) {}
 
   /**
-   * Soft-delete a ghost user so they stop receiving emails.
-   * @param userId - The ghost user's ID (used as unsubscribe token)
+   * Soft-delete a ghost user by their unsubscribe token.
+   * Looks up the user via userNotificationSettings, then soft-deletes if eligible.
+   * @param token - The unsubscribe token from the email link
    * @returns true if the user was soft-deleted, false if not found or ineligible
    */
-  async softDeleteGhostUser(userId: string): Promise<boolean> {
-    logger.verbose('Soft-deleting ghost user', { userId });
-    const result = await this.db.softDeleteGhostUser(userId);
+  async softDeleteGhostByToken(token: string): Promise<boolean> {
+    logger.verbose('Soft-deleting ghost user by token');
+    const result = await this.db.softDeleteGhostByUnsubscribeToken(token);
     if (result) {
-      logger.info('Ghost user unsubscribed', { userId });
+      logger.info('Ghost user unsubscribed via token');
     } else {
-      logger.verbose('Ghost user not found or already deleted', { userId });
+      logger.verbose('Ghost user not found or already deleted for token');
     }
     return result;
   }

--- a/protocol/src/services/unsubscribe.service.ts
+++ b/protocol/src/services/unsubscribe.service.ts
@@ -1,0 +1,31 @@
+import { log } from '../lib/log';
+
+import { ChatDatabaseAdapter } from '../adapters/database.adapter';
+
+const logger = log.service.from('UnsubscribeService');
+
+/**
+ * UnsubscribeService
+ *
+ * Handles ghost user opt-out (unsubscribe) logic.
+ * Delegates to the database adapter for soft-deletion.
+ */
+export class UnsubscribeService {
+  constructor(private db = new ChatDatabaseAdapter()) {}
+
+  /**
+   * Soft-delete a ghost user so they stop receiving emails.
+   * @param userId - The ghost user's ID (used as unsubscribe token)
+   * @returns true if the user was soft-deleted, false if not found or ineligible
+   */
+  async softDeleteGhostUser(userId: string): Promise<boolean> {
+    logger.verbose('Soft-deleting ghost user', { userId });
+    const result = await this.db.softDeleteGhostUser(userId);
+    if (result) {
+      logger.info('Ghost user unsubscribed', { userId });
+    } else {
+      logger.verbose('Ghost user not found or already deleted', { userId });
+    }
+    return result;
+  }
+}


### PR DESCRIPTION
## Summary

- **Invite generator agent** — LLM-generated contextual invite messages for ghost user outreach (`invite.generator.ts`)
- **Ghost invite email** — Email template with "Reply on Index" CTA and unsubscribe link, triggered on first message to a ghost user
- **Unsubscribe flow** — `GET /unsubscribe/:token` soft-deletes ghost users, contact import prevents re-creation of opted-out ghosts
- **Differentiated CTA** — Opportunity cards show "Invite to chat" for ghost users (server-driven via `primaryActionLabel`), "Start chat" for onboarded users
- **Prefill chat flow** — Frontend fetches AI-generated invite, navigates to chat with prefilled message input
- **Ghost claim extension** — Chat sessions transfer to real user when ghost onboards

## New Features

- `GET /opportunities/:id/invite-message` — generates contextual invite message via LLM agent
- `GET /unsubscribe/:token` — public endpoint for ghost user email opt-out
- `isGhost` and `primaryActionLabel` exposed in opportunity API responses (single + home view)
- Ghost invite email queued on first chat message to ghost recipient
- Chat sessions included in ghost → real user claim transfer

## Test plan

- [ ] Seed database with ghost contacts, verify opportunity cards show "Invite to chat"
- [ ] Click "Invite to chat", verify invite message is generated and pre-filled in chat input
- [ ] Send the invite message, verify email is queued and delivered to ghost user
- [ ] Click unsubscribe link in email, verify ghost is soft-deleted
- [ ] Re-import contacts, verify soft-deleted ghost is not re-created
- [ ] Sign up as the ghost user, verify chat session transfers and is visible
- [ ] Verify onboarded user opportunities still show "Start chat" with normal flow
- [ ] `tsc --noEmit` passes in both protocol and frontend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CTA now shows "Invite to chat" for imported (ghost) contacts and "Start chat" for onboarded users
  * AI-generated, editable invite messages fetchable before sending
  * Prefilled chat input when inviting an imported contact
  * Email invitations sent on first invite to imported contacts, with unsubscribe support and send-once safeguards
  * Claiming an imported contact transfers chat sessions and messages to the real user upon signup
<!-- end of auto-generated comment: release notes by coderabbit.ai -->