### PR TITLE
fix: hide other users' personal indexes from contacts

### DIFF
--- a/protocol/src/adapters/database.adapter.ts
+++ b/protocol/src/adapters/database.adapter.ts
@@ -1299,7 +1299,13 @@ export class ChatDatabaseAdapter {
       .where(
         and(
           isNull(schema.indexes.deletedAt),
-          inArray(schema.indexes.id, ids)
+          inArray(schema.indexes.id, ids),
+          // Only include personal indexes owned by the requesting user;
+          // contacts in someone else's personal index must not see it.
+          or(
+            eq(schema.indexes.isPersonal, false),
+            eq(ownerMembers.userId, userId)
+          )
         )
       )
       .orderBy(desc(schema.indexes.isPersonal), desc(schema.indexes.createdAt));


### PR DESCRIPTION
## Bug Fixes

- **Personal index visibility leak**: Users who were added as a `contact` in another user's personal index ("My Network") could see that index in their own My Networks list. This violated the rule that only the owner of a personal index should see it.

## Root Cause

`getIndexesForUser` in `database.adapter.ts` collected all `index_members` rows for the requesting user — which includes personal indexes of other people where the user is a `contact` — then returned them all with no ownership check on `isPersonal` indexes.

## Fix

Added an `OR` guard to the `WHERE` clause of the index fetch query:

```
isPersonal = false  OR  ownerMembers.userId = :userId
```

This ensures personal indexes are only returned to their owner. Non-personal (community) indexes are unaffected. The `ownerMembers` subquery was already being left-joined, so no additional query cost.

## Test plan

- [ ] Log in as User A; confirm "My Network" (personal index) appears in their My Networks list
- [ ] Log in as User B who is a contact in User A's personal index; confirm User A's "My Network" does **not** appear in User B's My Networks list
- [ ] Confirm User B's own "My Network" still appears in their list
- [ ] Confirm shared community indexes (non-personal) still appear for both users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated index visibility filtering—personal indexes are now only visible to their owners, while non-personal indexes remain accessible to all users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->