### PR TITLE
fix: propagate isGhost to chat opportunity cards (IND-161)

### DIFF
--- a/protocol/src/lib/protocol/support/opportunity.discover.ts
+++ b/protocol/src/lib/protocol/support/opportunity.discover.ts
@@ -95,6 +95,8 @@ export interface FormattedDiscoveryCandidate {
   homeCardPresentation?: HomeCardPresentationResult;
   /** Viewer's role in this opportunity. */
   viewerRole?: string;
+  /** Whether the counterpart is a ghost (not yet onboarded) user. */
+  isGhost?: boolean;
   /** Narrator chip for home card display (name + remark, with optional avatar/userId for introducer). */
   narratorChip?: {
     name: string;
@@ -228,10 +230,12 @@ async function enrichOpportunities(
   ]);
   const avatarByUserId = new Map<string, string | null>();
   const nameByUserId = new Map<string, string | null>();
+  const isGhostByUserId = new Map<string, boolean>();
   candidateUserIds.forEach((id, i) => {
     const user = userResults[i] ?? null;
     avatarByUserId.set(id, user?.avatar ?? null);
     nameByUserId.set(id, user?.name ?? null);
+    isGhostByUserId.set(id, user?.isGhost ?? false);
   });
   const viewerName = viewerUser?.name ?? undefined;
 
@@ -301,6 +305,7 @@ async function enrichOpportunities(
         }
       }
 
+      const isCounterpartGhost = isGhostByUserId.get(item.candidateUserId) ?? false;
       return {
         headline: viewerIsIntroducer && secondPartyName
           ? `${name} → ${secondPartyName}`
@@ -315,7 +320,7 @@ async function enrichOpportunities(
           ),
         suggestedAction: "Start a conversation to connect.",
         narratorRemark: narratorRemarkFromReasoning(reasoning, name, viewerName),
-        primaryActionLabel: viewerIsIntroducer ? "Introduce Them" : "Start Chat",
+        primaryActionLabel: viewerIsIntroducer ? "Introduce Them" : (isCounterpartGhost ? "Invite to chat" : "Start Chat"),
         secondaryActionLabel: "Skip",
         mutualIntentsLabel: "Suggested connection",
       };
@@ -410,6 +415,7 @@ async function enrichOpportunities(
         }
       }
 
+      const isGhost = isGhostByUserId.get(item.candidateUserId) ?? false;
       return {
         opportunityId: item.opportunity.id,
         userId: item.candidateUserId,
@@ -423,8 +429,17 @@ async function enrichOpportunities(
         score: item.confidence,
         status: chatSessionId && !existingOpportunityIds?.has(item.opportunity.id) ? "draft" : item.opportunity.status,
         viewerRole: item.viewerRole,
+        isGhost,
         ...(presentations?.[idx] && { presentation: presentations[idx] }),
-        ...(homeCard && { homeCardPresentation: homeCard }),
+        ...(homeCard && {
+          homeCardPresentation: {
+            ...homeCard,
+            // Override primaryActionLabel for ghost counterparts (LLM doesn't know ghost status)
+            primaryActionLabel: isGhost && item.viewerRole !== 'introducer'
+              ? 'Invite to chat'
+              : homeCard.primaryActionLabel,
+          },
+        }),
         ...(narratorChip && { narratorChip }),
       };
     },

--- a/protocol/src/lib/protocol/support/tests/opportunity.discover.spec.ts
+++ b/protocol/src/lib/protocol/support/tests/opportunity.discover.spec.ts
@@ -512,6 +512,94 @@ describe("opportunity.discover", () => {
       expect(deletedMatch).toBeUndefined();
     });
 
+    test("ghost counterpart gets 'Invite to chat' primaryActionLabel in minimalForChat path (IND-161)", async () => {
+      const ghostId = "ghost-user-1";
+      const mockGraph = {
+        invoke: async () => ({
+          opportunities: [
+            {
+              id: "opp-ghost",
+              actors: [
+                { indexId: "idx-1", userId: "u1", role: "patient" },
+                { indexId: "idx-1", userId: ghostId, role: "agent" },
+              ],
+              interpretation: { reasoning: "Great match.", confidence: 0.88 },
+              detection: { source: "opportunity_graph", createdBy: "agent", timestamp: new Date().toISOString() },
+              status: "latent",
+            },
+          ],
+        }),
+      };
+      const dbWithGhostUser = {
+        ...mockDatabase,
+        getProfile: async () => null,
+        getUser: async (userId: string) =>
+          userId === ghostId
+            ? { id: ghostId, name: "Ghost User", avatar: null, isGhost: true }
+            : userId === "u1"
+              ? { id: "u1", name: "Viewer", avatar: null, isGhost: false }
+              : null,
+      } as unknown as ChatGraphCompositeDatabase;
+
+      const result = await runDiscoverFromQuery({
+        opportunityGraph: mockGraph as any,
+        database: dbWithGhostUser,
+        userId: "u1",
+        query: "find connections",
+        indexScope: ["idx1"],
+        minimalForChat: true,
+      });
+
+      expect(result.found).toBe(true);
+      const card = result.opportunities![0];
+      expect(card.isGhost).toBe(true);
+      expect(card.homeCardPresentation?.primaryActionLabel).toBe("Invite to chat");
+    });
+
+    test("non-ghost counterpart keeps 'Start Chat' primaryActionLabel in minimalForChat path (IND-161)", async () => {
+      const onboardedId = "onboarded-user-1";
+      const mockGraph = {
+        invoke: async () => ({
+          opportunities: [
+            {
+              id: "opp-onboarded",
+              actors: [
+                { indexId: "idx-1", userId: "u1", role: "patient" },
+                { indexId: "idx-1", userId: onboardedId, role: "agent" },
+              ],
+              interpretation: { reasoning: "Good match.", confidence: 0.82 },
+              detection: { source: "opportunity_graph", createdBy: "agent", timestamp: new Date().toISOString() },
+              status: "latent",
+            },
+          ],
+        }),
+      };
+      const dbWithOnboardedUser = {
+        ...mockDatabase,
+        getProfile: async () => null,
+        getUser: async (userId: string) =>
+          userId === onboardedId
+            ? { id: onboardedId, name: "Onboarded User", avatar: null, isGhost: false }
+            : userId === "u1"
+              ? { id: "u1", name: "Viewer", avatar: null, isGhost: false }
+              : null,
+      } as unknown as ChatGraphCompositeDatabase;
+
+      const result = await runDiscoverFromQuery({
+        opportunityGraph: mockGraph as any,
+        database: dbWithOnboardedUser,
+        userId: "u1",
+        query: "find connections",
+        indexScope: ["idx1"],
+        minimalForChat: true,
+      });
+
+      expect(result.found).toBe(true);
+      const card = result.opportunities![0];
+      expect(card.isGhost).toBe(false);
+      expect(card.homeCardPresentation?.primaryActionLabel).toBe("Start Chat");
+    });
+
     test("returns createIntentSuggested and suggestedIntentDescription when graph returns create-intent signal", async () => {
       const mockGraph = {
         invoke: async () => ({

--- a/protocol/src/lib/protocol/tools/opportunity.tools.ts
+++ b/protocol/src/lib/protocol/tools/opportunity.tools.ts
@@ -47,6 +47,7 @@ export function buildMinimalOpportunityCard(
   introducerAvatar?: string | null,
   viewerName?: string,
   secondPartyName?: string,
+  isCounterpartGhost?: boolean,
 ): {
   opportunityId: string;
   userId: string;
@@ -62,6 +63,7 @@ export function buildMinimalOpportunityCard(
   viewerRole: string;
   score: number | undefined;
   status: string;
+  isGhost: boolean;
 } {
   const viewerActor = opp.actors.find((a) => a.userId === viewerId);
   const viewerRole = viewerActor?.role ?? "party";
@@ -89,7 +91,7 @@ export function buildMinimalOpportunityCard(
   const primaryActionLabel =
     viewerRole === "introducer"
       ? "Introduce Them"
-      : "Start Chat";
+      : (isCounterpartGhost ? "Invite to chat" : "Start Chat");
   return {
     opportunityId: opp.id,
     userId: counterpartUserId,
@@ -115,6 +117,7 @@ export function buildMinimalOpportunityCard(
     viewerRole,
     score,
     status: opp.status ?? "latent",
+    isGhost: isCounterpartGhost ?? false,
   };
 }
 
@@ -265,6 +268,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
             mutualIntentsLabel: opp.homeCardPresentation?.mutualIntentsLabel,
             narratorChip: opp.narratorChip,
             viewerRole: opp.viewerRole,
+            isGhost: opp.isGhost ?? false,
             score: opp.score,
             status: opp.status,
           };
@@ -395,8 +399,9 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
 
         const viewerIsParty = effectivePartyUserIds.includes(context.userId);
         const viewerRole = viewerIsParty ? "party" : "introducer";
+        const isCounterpartGhost = counterpartUser?.isGhost ?? false;
         const primaryActionLabel = viewerIsParty
-          ? "Start Chat"
+          ? (isCounterpartGhost ? "Invite to chat" : "Start Chat")
           : "Introduce Them";
         const narratorChip = viewerIsParty
           ? {
@@ -437,6 +442,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
           mutualIntentsLabel: "Suggested connection",
           narratorChip,
           viewerRole,
+          isGhost: isCounterpartGhost,
           score: confidence,
           status: created.status ?? "draft",
         };
@@ -595,6 +601,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
           mutualIntentsLabel: opp.homeCardPresentation?.mutualIntentsLabel,
           narratorChip: opp.narratorChip,
           viewerRole: opp.viewerRole,
+          isGhost: opp.isGhost ?? false,
           score: opp.score,
           status: opp.status,
         };

--- a/protocol/src/lib/protocol/tools/tests/opportunity.tools.spec.ts
+++ b/protocol/src/lib/protocol/tools/tests/opportunity.tools.spec.ts
@@ -84,6 +84,61 @@ describe("buildMinimalOpportunityCard - IND-113", () => {
   });
 });
 
+describe('buildMinimalOpportunityCard - ghost user CTA (IND-161)', () => {
+  const baseOpp = {
+    id: 'opp-ghost',
+    status: 'latent',
+    interpretation: { reasoning: 'Strong match on AI interests.', confidence: 0.9 },
+    actors: [
+      { userId: 'viewer-1', role: 'party' },
+      { userId: 'ghost-user', role: 'party' },
+    ],
+    detection: { source: 'opportunity_graph' },
+  } as unknown as Opportunity;
+
+  it('uses "Invite to chat" as primaryActionLabel when counterpart is a ghost user', () => {
+    const card = buildMinimalOpportunityCard(
+      baseOpp, 'viewer-1', 'ghost-user', 'Ghost User', null,
+      undefined, null, undefined, undefined, true,
+    );
+    expect(card.primaryActionLabel).toBe('Invite to chat');
+    expect(card.isGhost).toBe(true);
+  });
+
+  it('uses "Start Chat" as primaryActionLabel when counterpart is not a ghost user', () => {
+    const card = buildMinimalOpportunityCard(
+      baseOpp, 'viewer-1', 'ghost-user', 'Real User', null,
+      undefined, null, undefined, undefined, false,
+    );
+    expect(card.primaryActionLabel).toBe('Start Chat');
+    expect(card.isGhost).toBe(false);
+  });
+
+  it('uses "Start Chat" as primaryActionLabel when isCounterpartGhost is not provided', () => {
+    const card = buildMinimalOpportunityCard(
+      baseOpp, 'viewer-1', 'ghost-user', 'Real User', null,
+    );
+    expect(card.primaryActionLabel).toBe('Start Chat');
+    expect(card.isGhost).toBe(false);
+  });
+
+  it('never uses "Invite to chat" when viewer is the introducer, even for ghost counterpart', () => {
+    const introOpp = {
+      ...baseOpp,
+      actors: [
+        { userId: 'introducer-1', role: 'introducer' },
+        { userId: 'ghost-user', role: 'party' },
+        { userId: 'other-party', role: 'party' },
+      ],
+    } as unknown as Opportunity;
+    const card = buildMinimalOpportunityCard(
+      introOpp, 'introducer-1', 'ghost-user', 'Ghost User', null,
+      undefined, null, undefined, undefined, true,
+    );
+    expect(card.primaryActionLabel).toBe('Introduce Them');
+  });
+});
+
 describe('buildMinimalOpportunityCard - introducer discovery (IND-140)', () => {
   const mockIntroducerOpp = {
     id: 'opp-intro-disc',


### PR DESCRIPTION
## Bug Fixes

- **Ghost user CTA not shown in chat cards**: `isGhost` was fetched from the DB in `enrichOpportunities` but never stored — only `name` and `avatar` were captured from the batch user lookup. Ghost counterparts always received `"Start Chat"` and `isGhost: false` when opportunities were surfaced via chat, even though the home view worked correctly.

## Root Cause

`opportunity.discover.ts` built `avatarByUserId` and `nameByUserId` maps from the batch user fetch but discarded `isGhost`. As a result:
- `primaryActionLabel` was hardcoded to `"Start Chat"` for non-introducers in both the minimal and full-presenter paths
- `isGhost` was never included in `FormattedDiscoveryCandidate`, so the field was absent from every chat opportunity card payload

The home graph (`home.graph.ts`) independently fetched and applied `isGhost` correctly, which is why the home view was unaffected.

## Changes

**`opportunity.discover.ts`**
- Add `isGhost?: boolean` to `FormattedDiscoveryCandidate`
- Build `isGhostByUserId` map alongside `avatarByUserId`/`nameByUserId`
- Minimal path: `primaryActionLabel` → `"Invite to chat"` for ghost counterparts
- Full-presenter path: override `homeCardPresentation.primaryActionLabel` when `isGhost`
- Return object: include `isGhost`

**`opportunity.tools.ts`**
- `buildMinimalOpportunityCard`: add optional `isCounterpartGhost` param; set correct label and `isGhost` in return
- Both discovery card-payload blocks: add `isGhost: opp.isGhost ?? false`
- Introduction creation path: check `counterpartUser?.isGhost` for `primaryActionLabel`

## Tests

- `opportunity.tools.spec.ts`: 4 new tests covering ghost/non-ghost/no-param/introducer cases for `buildMinimalOpportunityCard`
- `opportunity.discover.spec.ts`: 2 new tests verifying `isGhost` propagation and correct `primaryActionLabel` in `runDiscoverFromQuery` (minimalForChat path)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Updated action labels in discovery and chat flows based on user onboarding status
- Newly registered users now display "Invite to chat" instead of "Start Chat" as the primary action
- User onboarding status is now tracked consistently across discovery, introduction, and listing experiences

<!-- end of auto-generated comment: release notes by coderabbit.ai -->