### PR TITLE
fix: serialize Error instances in logger sanitizer

### DIFF
--- a/protocol/src/lib/log.ts
+++ b/protocol/src/lib/log.ts
@@ -278,6 +278,17 @@ function sanitizeForLogInternal(value: unknown): unknown {
     if (value.length > 0 && typeof value[0] === 'number') return `[redacted: ${value.length} values]`;
     return value.map(sanitizeForLogInternal);
   }
+  if (value instanceof Error) {
+    const out: Record<string, unknown> = {
+      message: value.message,
+      name: value.name,
+    };
+    // Capture any extra enumerable own properties (e.g. Drizzle/postgres driver fields: query, parameters, code, constraint)
+    for (const [k, v] of Object.entries(value as unknown as Record<string, unknown>)) {
+      if (!(k in out)) out[k] = sanitizeForLogInternal(v);
+    }
+    return out;
+  }
   if (typeof value === 'object' && value.constructor === Object) {
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(value as Record<string, unknown>)) {


### PR DESCRIPTION
## Bug Fixes

- Fix `sanitizeForLogInternal` in `log.ts` to properly handle `Error` instances

**Before:** Passing an `Error` to any `logger.error(..., { error })` call only captured the database driver's enumerable own-properties (e.g. `query`, `params`) because `Error.message` and `Error.name` are non-enumerable and were silently dropped.

**After:** Errors are serialized as `{ message, name, ...extraEnumerableProps }`, so Drizzle/postgres driver fields like `code`, `constraint`, `query`, and `parameters` are all captured alongside the actual error message.

## Test Plan
- [ ] Trigger the failing `POST /api/chat/message/:id/metadata` path and verify the Railway log now shows `error.message` and `error.code`