### PR TITLE
feat(debug-meta): add tool/graph/agent timing to debug meta

### DIFF
--- a/docs/plans/2026-03-17-debug-meta-timing-design.md
+++ b/docs/plans/2026-03-17-debug-meta-timing-design.md
@@ -1,0 +1,164 @@
+# Debug Meta Timing: Tools, Graphs, and Agents
+
+**Date**: 2026-03-17
+**Status**: Approved
+
+## Overview
+
+Extend the debug meta payload (returned by `/debug/chat/:sessionId`) to include wall-clock timing for every tool call, every graph invoked by a tool, and every agent invoked within those graphs. This gives a full three-level execution profile per chat turn.
+
+## Data Structures
+
+New and modified types in `protocol/src/types/chat-streaming.types.ts`:
+
+```typescript
+// Modified — add durationMs and graphs
+interface DebugMetaToolCall {
+  name: string;
+  args: Record<string, unknown>;
+  resultSummary: string;
+  success: boolean;
+  durationMs: number;          // wall-clock ms for full tool execution
+  steps?: DebugMetaStep[];
+  graphs?: DebugMetaGraph[];   // graphs invoked by this tool
+}
+
+// New
+interface DebugMetaGraph {
+  name: string;
+  durationMs: number;
+  agents: DebugMetaAgent[];
+}
+
+// New
+interface DebugMetaAgent {
+  name: string;
+  durationMs: number;
+}
+```
+
+### Example debug JSON output
+
+```json
+{
+  "graph": "agent_loop",
+  "iterations": 2,
+  "tools": [
+    {
+      "name": "discover_opportunities",
+      "durationMs": 1842,
+      "resultSummary": "Found 3 matches",
+      "success": true,
+      "graphs": [
+        {
+          "name": "opportunity",
+          "durationMs": 1701,
+          "agents": [
+            { "name": "opportunity.evaluator", "durationMs": 890 },
+            { "name": "opportunity.presenter", "durationMs": 311 }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Data Flow
+
+Timing propagates bottom-up:
+
+### Layer 3 — Agent timing (graph nodes)
+
+Each of the 6 affected graph state files gains an `agentTimings` reducer field:
+
+```typescript
+agentTimings: Annotation<DebugMetaAgent[]>({
+  reducer: (acc, val) => [...acc, ...val],
+  default: () => [],
+})
+```
+
+Graph nodes wrap agent calls:
+
+```typescript
+const t = Date.now();
+const result = await agent.run(input);
+return {
+  ...,
+  agentTimings: [{ name: "opportunity.evaluator", durationMs: Date.now() - t }],
+};
+```
+
+### Layer 2 — Graph timing (tool implementations)
+
+Tool files that invoke graphs wrap the graph call and return a `_graphTimings` field alongside the normal result:
+
+```typescript
+const t = Date.now();
+const result = await graphs.opportunityGraph.invoke(state);
+const durationMs = Date.now() - t;
+return {
+  ...formattedResult,
+  _graphTimings: [{
+    name: "opportunity",
+    durationMs,
+    agents: result.agentTimings ?? [],
+  }],
+};
+```
+
+`_graphTimings` is a protocol-internal field stripped by `chat.agent.ts` before the result is treated as tool output.
+
+### Layer 1 — Tool timing (`chat.agent.ts`)
+
+The existing tool-execution block wraps each tool call with `Date.now()` and extracts `_graphTimings`:
+
+```typescript
+const t = Date.now();
+const toolResult = await executeTool(tool, args);
+const durationMs = Date.now() - t;
+const graphTimings = toolResult._graphTimings ?? [];
+// strip _graphTimings from toolResult before using as LLM tool response
+toolsDebug.push({ name, args, resultSummary, success, durationMs, graphs: graphTimings, steps });
+```
+
+## Scope of Changes
+
+### Types (1 file)
+- `protocol/src/types/chat-streaming.types.ts` — add `durationMs` + `DebugMetaGraph` + `DebugMetaAgent`
+
+### Chat agent (1 file)
+- `protocol/src/lib/protocol/agents/chat.agent.ts` — wrap tool calls with timing, extract `_graphTimings`
+
+### Graph states (6 files)
+Add `agentTimings: DebugMetaAgent[]` reducer to:
+- `protocol/src/lib/protocol/states/opportunity.state.ts`
+- `protocol/src/lib/protocol/states/intent.state.ts`
+- `protocol/src/lib/protocol/states/profile.state.ts`
+- `protocol/src/lib/protocol/states/hyde.state.ts`
+- `protocol/src/lib/protocol/states/home.state.ts`
+- `protocol/src/lib/protocol/states/intent_index.state.ts`
+
+### Graph nodes (6 files)
+Wrap agent `.invoke()` / `.run()` calls and append to `agentTimings`:
+- `protocol/src/lib/protocol/graphs/opportunity.graph.ts` — `OpportunityEvaluator`, `OpportunityPresenter`
+- `protocol/src/lib/protocol/graphs/intent.graph.ts` — `ExplicitIntentInferrer`, `SemanticVerifier`, `IntentReconciler`
+- `protocol/src/lib/protocol/graphs/profile.graph.ts` — `ProfileGenerator`, `HydeGenerator`
+- `protocol/src/lib/protocol/graphs/hyde.graph.ts` — `LensInferrer`, `HydeGenerator`
+- `protocol/src/lib/protocol/graphs/home.graph.ts` — `OpportunityPresenter`, `HomeCategorizerAgent`
+- `protocol/src/lib/protocol/graphs/intent_index.graph.ts` — `IntentIndexer`
+
+### Tool files (4 files)
+Wrap graph `.invoke()` calls and return `_graphTimings`:
+- `protocol/src/lib/protocol/tools/opportunity.tools.ts`
+- `protocol/src/lib/protocol/tools/intent.tools.ts`
+- `protocol/src/lib/protocol/tools/profile.tools.ts`
+- `protocol/src/lib/protocol/tools/index.tools.ts`
+
+## Out of Scope
+
+- `index.graph.ts` and `index_membership.graph.ts` — pure DB operations, no agents
+- Frontend UI changes — timing visible in debug JSON only
+- Token counts or LLM API latency breakdown
+- `timed()` decorator from `lib/performance` — unrelated monitoring path, not modified

--- a/docs/plans/2026-03-17-debug-meta-timing.md
+++ b/docs/plans/2026-03-17-debug-meta-timing.md
@@ -1,0 +1,477 @@
+# Debug Meta Timing: Tools, Graphs, Agents Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use executing-plans to implement this plan task-by-task.
+
+**Goal:** Extend `debugMeta` (surfaced by `/debug/chat/:sessionId`) with wall-clock `durationMs` at three levels: tool call → graph invoked by tool → agent invoked inside graph.
+
+**Architecture:** Types first, then bottom-up: add `agentTimings` reducer to 6 graph states, wrap agent calls in graph nodes, wrap graph calls in tool files with `_graphTimings`, finally wrap tool dispatch in `chat.agent.ts` and extract the timing data.
+
+**Tech Stack:** TypeScript, LangGraph (`Annotation.Root`), Bun test
+
+---
+
+## Task 1: Extend types
+
+**Files:**
+- Modify: `protocol/src/types/chat-streaming.types.ts:288-305`
+
+**Step 1: Add the two new interfaces and update `DebugMetaToolCall`**
+
+In `chat-streaming.types.ts`, after the existing `DebugMetaStep` interface (line 293), add:
+
+```typescript
+/**
+ * One agent invocation recorded inside a graph run.
+ */
+export interface DebugMetaAgent {
+  name: string;
+  durationMs: number;
+}
+
+/**
+ * One graph invocation recorded by a tool that calls a LangGraph graph.
+ */
+export interface DebugMetaGraph {
+  name: string;
+  durationMs: number;
+  agents: DebugMetaAgent[];
+}
+```
+
+Then update `DebugMetaToolCall` (currently lines 298-305) to:
+
+```typescript
+export interface DebugMetaToolCall {
+  name: string;
+  args: Record<string, unknown>;
+  resultSummary: string;
+  success: boolean;
+  /** Wall-clock milliseconds for the full tool execution. */
+  durationMs: number;
+  /** Internal steps (subgraphs, subtasks) when the tool reports debugSteps in its result. */
+  steps?: DebugMetaStep[];
+  /** LangGraph graphs invoked by this tool, with their agent timings. */
+  graphs?: DebugMetaGraph[];
+}
+```
+
+**Step 2: Run tsc to verify no type errors**
+
+```bash
+cd protocol && npx tsc --noEmit
+```
+
+Expected: zero errors. Fix any before continuing.
+
+**Step 3: Commit**
+
+```bash
+git add protocol/src/types/chat-streaming.types.ts
+git commit -m "feat(debug-meta): add DebugMetaGraph, DebugMetaAgent types and durationMs to DebugMetaToolCall"
+```
+
+---
+
+## Task 2: Tool timing in `chat.agent.ts`
+
+**Files:**
+- Modify: `protocol/src/lib/protocol/agents/chat.agent.ts:602-739`
+
+The tool dispatch loop starts at line 602 (`for (const tc of toolCalls)`). We need to:
+1. Capture `toolStart` before `tool.invoke()`
+2. Extract `_graphTimings` from the parsed result
+3. Pass `durationMs` and `graphs` into both `toolsDebug.push()` calls (success and failure paths)
+
+**Step 1: Capture tool start time and extract `_graphTimings`**
+
+Around line 638, change:
+
+```typescript
+// BEFORE
+let result = await tool.invoke(tc.args);
+```
+
+```typescript
+// AFTER
+const toolStart = Date.now();
+let result = await tool.invoke(tc.args);
+const toolDurationMs = Date.now() - toolStart;
+```
+
+In the `try` block, extend the result-parsing section (currently lines 661-687). After extracting `debugSteps`, also extract `_graphTimings`:
+
+```typescript
+// Add after the debugSteps extraction (inside the try/catch JSON parse block)
+type GraphTiming = { name: string; durationMs: number; agents: Array<{ name: string; durationMs: number }> };
+let graphTimings: GraphTiming[] | undefined;
+const rawGraphTimings = payload._graphTimings ?? parsed._graphTimings;
+if (Array.isArray(rawGraphTimings) && rawGraphTimings.length > 0) {
+  graphTimings = rawGraphTimings as GraphTiming[];
+  // Strip _graphTimings from the result string sent back to the LLM
+  try {
+    const cleanedResult = JSON.parse(resultStr) as Record<string, unknown>;
+    delete cleanedResult._graphTimings;
+    if (cleanedResult.data && typeof cleanedResult.data === 'object') {
+      delete (cleanedResult.data as Record<string, unknown>)._graphTimings;
+    }
+    resultStr = JSON.stringify(cleanedResult);
+    result = resultStr;
+  } catch { /* keep original if can't clean */ }
+}
+```
+
+**Step 2: Add `durationMs` and `graphs` to the success push (line ~689)**
+
+```typescript
+// BEFORE
+toolsDebug.push({
+  name: tc.name,
+  args: sanitizeForDebugMeta(tc.args) as Record<string, unknown>,
+  resultSummary: summary,
+  success: true,
+  ...(debugSteps?.length ? { steps: debugSteps } : {}),
+});
+```
+
+```typescript
+// AFTER
+toolsDebug.push({
+  name: tc.name,
+  args: sanitizeForDebugMeta(tc.args) as Record<string, unknown>,
+  resultSummary: summary,
+  success: true,
+  durationMs: toolDurationMs,
+  ...(debugSteps?.length ? { steps: debugSteps } : {}),
+  ...(graphTimings?.length ? { graphs: graphTimings } : {}),
+});
+```
+
+**Step 3: Add `durationMs` to the unknown tool path (line ~615) and failure path (line ~717)**
+
+For the unknown tool case (around line 615), add `durationMs: 0` (no real timing possible):
+```typescript
+toolsDebug.push({
+  name: tc.name,
+  args: sanitizeForDebugMeta(tc.args) as Record<string, unknown>,
+  resultSummary: "Unknown tool",
+  success: false,
+  durationMs: 0,
+});
+```
+
+For the catch block failure case (around line 717), the `toolStart` is in scope, so use it:
+```typescript
+toolsDebug.push({
+  name: tc.name,
+  args: sanitizeForDebugMeta(tc.args) as Record<string, unknown>,
+  resultSummary: errMsg,
+  success: false,
+  durationMs: Date.now() - toolStart,
+});
+```
+
+**Step 4: Run tsc**
+
+```bash
+cd protocol && npx tsc --noEmit
+```
+
+**Step 5: Commit**
+
+```bash
+git add protocol/src/lib/protocol/agents/chat.agent.ts
+git commit -m "feat(debug-meta): capture tool durationMs and extract _graphTimings in chat agent"
+```
+
+---
+
+## Task 3: `agentTimings` in `opportunity.state.ts` + timing in `opportunity.graph.ts`
+
+**Files:**
+- Modify: `protocol/src/lib/protocol/states/opportunity.state.ts`
+- Modify: `protocol/src/lib/protocol/graphs/opportunity.graph.ts`
+
+**Step 1: Add import and `agentTimings` field to `OpportunityGraphState`**
+
+In `opportunity.state.ts`, add the import at the top:
+
+```typescript
+import type { DebugMetaAgent } from '../../../types/chat-streaming.types';
+```
+
+Then add this field to the `Annotation.Root({...})` block (at the end, before the closing `})`):
+
+```typescript
+/** Timing records for each agent invocation within this graph run. */
+agentTimings: Annotation<DebugMetaAgent[]>({
+  reducer: (acc, val) => [...acc, ...val],
+  default: () => [],
+}),
+```
+
+**Step 2: Wrap `evaluator.invokeEntityBundle()` calls in `opportunity.graph.ts`**
+
+There are three invocation sites (lines ~1139, ~1161, ~1509). For each, wrap:
+
+```typescript
+// BEFORE (example, line ~1161)
+const opportunitiesWithActors = await evaluator.invokeEntityBundle(input, { minScore, returnAll: true });
+
+// AFTER
+const _evalStart = Date.now();
+const opportunitiesWithActors = await evaluator.invokeEntityBundle(input, { minScore, returnAll: true });
+agentTimingsAccum.push({ name: 'opportunity.evaluator', durationMs: Date.now() - _evalStart });
+```
+
+Where `agentTimingsAccum` is declared at the top of the node function:
+```typescript
+const agentTimingsAccum: import('../../../types/chat-streaming.types').DebugMetaAgent[] = [];
+```
+
+At the node's return statement, include `agentTimings: agentTimingsAccum`.
+
+Do the same for `OpportunityPresenter` calls (search for `presenter.` in the graph file):
+```typescript
+const _presenterStart = Date.now();
+const cardTexts = await presenter.generateCardTexts(...);
+agentTimingsAccum.push({ name: 'opportunity.presenter', durationMs: Date.now() - _presenterStart });
+```
+
+**Step 3: Run tsc**
+
+```bash
+cd protocol && npx tsc --noEmit
+```
+
+**Step 4: Commit**
+
+```bash
+git add protocol/src/lib/protocol/states/opportunity.state.ts \
+        protocol/src/lib/protocol/graphs/opportunity.graph.ts
+git commit -m "feat(debug-meta): track agent timings in opportunity graph"
+```
+
+---
+
+## Task 4: `agentTimings` in `intent_index.state.ts` + timing in `intent_index.graph.ts`
+
+**Files:**
+- Modify: `protocol/src/lib/protocol/states/intent_index.state.ts`
+- Modify: `protocol/src/lib/protocol/graphs/intent_index.graph.ts`
+
+**Step 1: Add import and field to `IntentIndexGraphState` in `intent_index.state.ts`**
+
+```typescript
+import type { DebugMetaAgent } from '../../../types/chat-streaming.types';
+```
+
+Add to `Annotation.Root`:
+
+```typescript
+agentTimings: Annotation<DebugMetaAgent[]>({
+  reducer: (acc, val) => [...acc, ...val],
+  default: () => [],
+}),
+```
+
+**Step 2: Wrap `indexer.evaluate()` in `intent_index.graph.ts`**
+
+The call is at line ~111:
+
+```typescript
+// BEFORE
+const result = await indexer.evaluate(
+  intentForIndexing.payload,
+  indexContext.indexPrompt,
+  indexContext.memberPrompt,
+  sourceName
+);
+```
+
+```typescript
+// AFTER
+const _indexerStart = Date.now();
+const result = await indexer.evaluate(
+  intentForIndexing.payload,
+  indexContext.indexPrompt,
+  indexContext.memberPrompt,
+  sourceName
+);
+const _indexerMs = Date.now() - _indexerStart;
+```
+
+Then in the return statements that follow (the `shouldAssign` branches), add `agentTimings: [{ name: 'intent.indexer', durationMs: _indexerMs }]`. For the early-return branch (no evaluation), return `agentTimings: []`.
+
+**Step 3: Run tsc**
+
+```bash
+cd protocol && npx tsc --noEmit
+```
+
+**Step 4: Commit**
+
+```bash
+git add protocol/src/lib/protocol/states/intent_index.state.ts \
+        protocol/src/lib/protocol/graphs/intent_index.graph.ts
+git commit -m "feat(debug-meta): track agent timings in intent_index graph"
+```
+
+---
+
+## Task 5: `agentTimings` in remaining 4 graph states + nodes
+
+**Files (state):**
+- Modify: `protocol/src/lib/protocol/states/intent.state.ts`
+- Modify: `protocol/src/lib/protocol/states/profile.state.ts`
+- Modify: `protocol/src/lib/protocol/states/hyde.state.ts`
+- Modify: `protocol/src/lib/protocol/states/home.state.ts`
+
+**Files (graph):**
+- Modify: `protocol/src/lib/protocol/graphs/intent.graph.ts`
+- Modify: `protocol/src/lib/protocol/graphs/profile.graph.ts`
+- Modify: `protocol/src/lib/protocol/graphs/hyde.graph.ts`
+- Modify: `protocol/src/lib/protocol/graphs/home.graph.ts`
+
+**Step 1: Add `agentTimings` to all 4 state files**
+
+Repeat the same pattern from Tasks 3–4 for each state file: add the import and the `agentTimings` `Annotation` field.
+
+**Step 2: Wrap agent calls in each graph**
+
+Apply the same `_start = Date.now()` / `agentTimings: [{ name, durationMs }]` pattern:
+
+| Graph | Agent calls to wrap |
+|---|---|
+| `intent.graph.ts` | `inferrer.invoke()` → `'intent.inferrer'`, `verifier.invoke()` → `'intent.verifier'`, `reconciler.invoke()` → `'intent.reconciler'` |
+| `profile.graph.ts` | `profileGenerator.run()` / `.invoke()` → `'profile.generator'`, `hydeGenerator.run()` → `'hyde.generator'` |
+| `hyde.graph.ts` | `lensInferrer.infer()` → `'lens.inferrer'`, `hydeGenerator.run()` → `'hyde.generator'` |
+| `home.graph.ts` | `presenter.generateCardTexts()` → `'opportunity.presenter'`, `categorizer.run()` → `'home.categorizer'` |
+
+Each node must declare `const agentTimingsAccum: DebugMetaAgent[] = []` at the top, push timing entries after each agent call, and return `agentTimings: agentTimingsAccum` at the end.
+
+**Step 3: Run tsc**
+
+```bash
+cd protocol && npx tsc --noEmit
+```
+
+**Step 4: Commit**
+
+```bash
+git add \
+  protocol/src/lib/protocol/states/intent.state.ts \
+  protocol/src/lib/protocol/states/profile.state.ts \
+  protocol/src/lib/protocol/states/hyde.state.ts \
+  protocol/src/lib/protocol/states/home.state.ts \
+  protocol/src/lib/protocol/graphs/intent.graph.ts \
+  protocol/src/lib/protocol/graphs/profile.graph.ts \
+  protocol/src/lib/protocol/graphs/hyde.graph.ts \
+  protocol/src/lib/protocol/graphs/home.graph.ts
+git commit -m "feat(debug-meta): track agent timings in intent, profile, hyde, home graphs"
+```
+
+---
+
+## Task 6: Graph timing in tool files
+
+**Files:**
+- Modify: `protocol/src/lib/protocol/tools/opportunity.tools.ts`
+- Modify: `protocol/src/lib/protocol/tools/intent.tools.ts`
+- Modify: `protocol/src/lib/protocol/tools/profile.tools.ts`
+- Modify: `protocol/src/lib/protocol/tools/index.tools.ts`
+
+**Pattern for every `graphs.<name>.invoke(...)` call in each tool file:**
+
+```typescript
+// BEFORE
+const result = await graphs.opportunity.invoke({ ... });
+
+// AFTER
+const _graphStart = Date.now();
+const result = await graphs.opportunity.invoke({ ... });
+const _graphMs = Date.now() - _graphStart;
+```
+
+Then in the tool's return value (the JSON object passed to `success()`), add `_graphTimings` at the **top level** (not inside `data`), so `chat.agent.ts` can find and strip it:
+
+```typescript
+return success({
+  data: { /* existing result data */ },
+  _graphTimings: [{
+    name: 'opportunity',           // graph name — match the design doc table
+    durationMs: _graphMs,
+    agents: result.agentTimings ?? [],
+  }],
+});
+```
+
+**Graph name strings to use per file:**
+
+| Tool file | Graph call | `name` string |
+|---|---|---|
+| `opportunity.tools.ts` | `graphs.opportunity.invoke(...)` | `"opportunity"` |
+| `intent.tools.ts` | `graphs.intent.invoke(...)` | `"intent"` |
+| `intent.tools.ts` | `graphs.intentIndex.invoke(...)` | `"intent_index"` |
+| `intent.tools.ts` | `graphs.profile.invoke(...)` | `"profile"` |
+| `profile.tools.ts` | `graphs.profile.invoke(...)` | `"profile"` |
+| `index.tools.ts` | `graphs.index.invoke(...)` | `"index"` |
+| `index.tools.ts` | `graphs.indexMembership.invoke(...)` | `"index_membership"` |
+| `index.tools.ts` | `graphs.intentIndex.invoke(...)` | `"intent_index"` |
+
+**Note on `index` and `index_membership` graphs:** These have no agents, so `agentTimings` will not be on their result. Use `result.agentTimings ?? []` safely — it will just be an empty array.
+
+**Note on multiple `graphs.opportunity.invoke()` calls in one tool function:** Each call site gets its own `_graphStart`/`_graphMs` locals (use unique variable names: `_graphStart1`, `_graphMs1`, etc.), and the tool collects all of them into a single `_graphTimings` array:
+
+```typescript
+_graphTimings: [
+  { name: 'opportunity', durationMs: _graphMs1, agents: result1.agentTimings ?? [] },
+  { name: 'opportunity', durationMs: _graphMs2, agents: result2.agentTimings ?? [] },
+]
+```
+
+**Step 1: Apply the pattern to all 4 tool files**
+
+**Step 2: Run tsc**
+
+```bash
+cd protocol && npx tsc --noEmit
+```
+
+**Step 3: Smoke test**
+
+Start the server (`bun run dev` in `protocol/`) and send a chat message that triggers opportunity discovery. Then hit the debug endpoint:
+
+```bash
+curl -s "http://localhost:3001/debug/chat/<sessionId>" | jq '.turns[0].debugMeta.tools[0]'
+```
+
+Expected output shape:
+```json
+{
+  "name": "discover_opportunities",
+  "durationMs": 1842,
+  "resultSummary": "Found 3 matches",
+  "success": true,
+  "graphs": [
+    {
+      "name": "opportunity",
+      "durationMs": 1701,
+      "agents": [
+        { "name": "opportunity.evaluator", "durationMs": 890 },
+        { "name": "opportunity.presenter", "durationMs": 311 }
+      ]
+    }
+  ]
+}
+```
+
+**Step 4: Commit**
+
+```bash
+git add \
+  protocol/src/lib/protocol/tools/opportunity.tools.ts \
+  protocol/src/lib/protocol/tools/intent.tools.ts \
+  protocol/src/lib/protocol/tools/profile.tools.ts \
+  protocol/src/lib/protocol/tools/index.tools.ts
+git commit -m "feat(debug-meta): add _graphTimings to tool results for debug meta timing"
+```

--- a/protocol/src/lib/protocol/agents/chat.agent.ts
+++ b/protocol/src/lib/protocol/agents/chat.agent.ts
@@ -617,6 +617,7 @@ export class ChatAgent {
               args: sanitizeForDebugMeta(tc.args) as Record<string, unknown>,
               resultSummary: "Unknown tool",
               success: false,
+              durationMs: 0,
             });
             emit({
               type: "tool_activity",
@@ -691,6 +692,7 @@ export class ChatAgent {
               args: sanitizeForDebugMeta(tc.args) as Record<string, unknown>,
               resultSummary: summary,
               success: true,
+              durationMs: 0,
               ...(debugSteps?.length ? { steps: debugSteps } : {}),
             });
             emit({
@@ -719,6 +721,7 @@ export class ChatAgent {
               args: sanitizeForDebugMeta(tc.args) as Record<string, unknown>,
               resultSummary: errMsg,
               success: false,
+              durationMs: 0,
             });
             emit({
               type: "tool_activity",

--- a/protocol/src/lib/protocol/agents/chat.agent.ts
+++ b/protocol/src/lib/protocol/agents/chat.agent.ts
@@ -634,9 +634,11 @@ export class ChatAgent {
             continue;
           }
 
+          const toolStart = Date.now();
           try {
             logger.verbose("Streaming: executing tool", { name: tc.name });
             let result = await tool.invoke(tc.args);
+            const toolDurationMs = Date.now() - toolStart;
             let resultStr =
               typeof result === "string" ? result : JSON.stringify(result);
 
@@ -658,16 +660,20 @@ export class ChatAgent {
             let summary = "Done";
             type StepData = Record<string, unknown>;
             type DebugStep = { step: string; detail?: string; data?: StepData };
+            type GraphTiming = { name: string; durationMs: number; agents: Array<{ name: string; durationMs: number }> };
             let debugSteps: DebugStep[] | undefined;
+            let graphTimings: GraphTiming[] | undefined;
             try {
               const parsed = JSON.parse(resultStr) as {
                 success?: boolean;
                 data?: {
                   summary?: string;
                   debugSteps?: DebugStep[];
+                  _graphTimings?: GraphTiming[];
                 };
                 summary?: string;
                 debugSteps?: DebugStep[];
+                _graphTimings?: GraphTiming[];
               };
               const payload = parsed.success && parsed.data != null ? parsed.data : parsed;
               summary = payload.summary ?? parsed.summary ?? "Done";
@@ -683,6 +689,20 @@ export class ChatAgent {
                   ...(s.data && typeof s.data === "object" ? { data: s.data } : {}),
                 }));
               }
+              const rawGraphTimings = payload._graphTimings ?? parsed._graphTimings;
+              if (Array.isArray(rawGraphTimings) && rawGraphTimings.length > 0) {
+                graphTimings = rawGraphTimings as GraphTiming[];
+                // Strip _graphTimings from the result string sent back to the LLM
+                try {
+                  const cleanedResult = JSON.parse(resultStr) as Record<string, unknown>;
+                  delete cleanedResult._graphTimings;
+                  if (cleanedResult.data && typeof cleanedResult.data === 'object') {
+                    delete (cleanedResult.data as Record<string, unknown>)._graphTimings;
+                  }
+                  resultStr = JSON.stringify(cleanedResult);
+                  result = resultStr;
+                } catch { /* keep original if can't clean */ }
+              }
             } catch {
               /* not JSON, keep default */
             }
@@ -692,8 +712,9 @@ export class ChatAgent {
               args: sanitizeForDebugMeta(tc.args) as Record<string, unknown>,
               resultSummary: summary,
               success: true,
-              durationMs: 0,
+              durationMs: toolDurationMs,
               ...(debugSteps?.length ? { steps: debugSteps } : {}),
+              ...(graphTimings?.length ? { graphs: graphTimings } : {}),
             });
             emit({
               type: "tool_activity",
@@ -721,7 +742,7 @@ export class ChatAgent {
               args: sanitizeForDebugMeta(tc.args) as Record<string, unknown>,
               resultSummary: errMsg,
               success: false,
-              durationMs: 0,
+              durationMs: Date.now() - toolStart,
             });
             emit({
               type: "tool_activity",

--- a/protocol/src/lib/protocol/graphs/home.graph.ts
+++ b/protocol/src/lib/protocol/graphs/home.graph.ts
@@ -296,7 +296,7 @@ export class HomeGraphFactory {
       logger.verbose('[HomeGraph:generateCardText] entry', { opportunitiesLength: opportunities.length, userId: state.userId });
       if (opportunities.length === 0) {
         logger.verbose('[HomeGraph:generateCardText] exit', { totalOpportunities: 0, totalSections: 0 });
-        return { cards: [], meta: { totalOpportunities: 0, totalSections: 0 } };
+        return { cards: [], agentTimings: [], meta: { totalOpportunities: 0, totalSections: 0 } };
       }
       const db = this.database as PresenterDatabase;
       const cards: HomeCardItem[] = [];
@@ -322,6 +322,8 @@ export class HomeGraphFactory {
       const oppIndexMap = new Map(
         state.opportunities.map((opp, idx) => [opp.id, idx])
       );
+
+      const agentTimingsAccum: import('../../../types/chat-streaming.types').DebugMetaAgent[] = [];
 
       for (let i = 0; i < opportunities.length; i += PRESENTATION_CONCURRENCY) {
         const chunk = opportunities.slice(i, i + PRESENTATION_CONCURRENCY);
@@ -403,7 +405,9 @@ export class HomeGraphFactory {
                 mutualIntentCount,
                 opportunityStatus: opportunity.status,
               };
+              const presenterStart = Date.now();
               const presentation = await presenter.presentHomeCard(homeInput);
+              agentTimingsAccum.push({ name: 'opportunity.presenter', durationMs: Date.now() - presenterStart });
               let narratorChip: { name: string; text: string; avatar?: string | null; userId?: string } | undefined;
               // Only show a person as narrator when they are the introducer and not the display counterpart
               // (bad data can have same user as introducer and party, e.g. "Amina introduced you to Amina")
@@ -447,6 +451,7 @@ export class HomeGraphFactory {
       logger.verbose('[HomeGraph:generateCardText] exit', { totalOpportunities: state.opportunities.length, totalSections: 0 });
       return {
         cards,
+        agentTimings: agentTimingsAccum,
         meta: { totalOpportunities: state.opportunities.length, totalSections: 0 },
       };
       });
@@ -536,8 +541,9 @@ export class HomeGraphFactory {
         logger.verbose('[HomeGraph:categorizeDynamically] entry', { cardsLength: state.cards.length });
         if (state.cards.length === 0) {
           logger.verbose('[HomeGraph:categorizeDynamically] exit', { sectionProposalsCount: 0 });
-          return { sectionProposals: [] };
+          return { sectionProposals: [], agentTimings: [] };
         }
+        const agentTimingsAccum: import('../../../types/chat-streaming.types').DebugMetaAgent[] = [];
         const categorizerInput = state.cards.map((c) => ({
           index: c._cardIndex,
           headline: c.headline,
@@ -552,13 +558,15 @@ export class HomeGraphFactory {
               ? 'pending'
               : undefined,
         }));
+        const categorizerStart = Date.now();
         const { sections } = await categorizer.categorize(categorizerInput);
+        agentTimingsAccum.push({ name: 'home.categorizer', durationMs: Date.now() - categorizerStart });
         const proposals: HomeSectionProposal[] = sections.map((s) => ({
           ...s,
           itemIndices: s.itemIndices.filter((i) => i >= 0 && i < state.cards.length),
         }));
         logger.verbose('[HomeGraph:categorizeDynamically] exit', { sectionProposalsCount: proposals.length });
-        return { sectionProposals: proposals };
+        return { sectionProposals: proposals, agentTimings: agentTimingsAccum };
       });
     };
 

--- a/protocol/src/lib/protocol/graphs/hyde.graph.ts
+++ b/protocol/src/lib/protocol/graphs/hyde.graph.ts
@@ -63,22 +63,26 @@ export class HydeGraphFactory {
 
         logger.verbose('Inferring lenses', { sourceTextLength: sourceText.length, hasProfileContext: !!profileContext });
 
+        const agentTimingsAccum: import('../../../types/chat-streaming.types').DebugMetaAgent[] = [];
+
         try {
+          const inferrerStart = Date.now();
           const result = await self.inferrer.infer({
             sourceText,
             profileContext,
             maxLenses,
           });
+          agentTimingsAccum.push({ name: 'lens.inferrer', durationMs: Date.now() - inferrerStart });
 
           logger.verbose('Lenses inferred', {
             count: result.lenses.length,
             lenses: result.lenses.map(l => ({ label: l.label, corpus: l.corpus })),
           });
 
-          return { lenses: result.lenses };
+          return { lenses: result.lenses, agentTimings: agentTimingsAccum };
         } catch (error) {
           logger.error('Lens inference failed in graph node', { error });
-          return { lenses: [] };
+          return { lenses: [], agentTimings: agentTimingsAccum };
         }
       });
     };
@@ -155,15 +159,18 @@ export class HydeGraphFactory {
           lenses: missing.map(l => l.label),
         });
 
+        const agentTimingsAccum: import('../../../types/chat-streaming.types').DebugMetaAgent[] = [];
         const generated: Record<string, HydeDocumentState> = {};
 
         await Promise.all(
           missing.map(async (lens) => {
+            const generatorStart = Date.now();
             const out = await self.generator.generate({
               sourceText,
               lens: lens.label,
               corpus: lens.corpus,
             });
+            agentTimingsAccum.push({ name: 'hyde.generator', durationMs: Date.now() - generatorStart });
             generated[lens.label] = {
               lens: lens.label,
               targetCorpus: lens.corpus,
@@ -173,7 +180,7 @@ export class HydeGraphFactory {
           })
         );
 
-        return { hydeDocuments: { ...state.hydeDocuments, ...generated } };
+        return { hydeDocuments: { ...state.hydeDocuments, ...generated }, agentTimings: agentTimingsAccum };
       });
     };
 

--- a/protocol/src/lib/protocol/graphs/intent.graph.ts
+++ b/protocol/src/lib/protocol/graphs/intent.graph.ts
@@ -187,6 +187,8 @@ export class IntentGraphFactory {
           conversationMessagesCount: state.conversationContext?.length || 0
         });
 
+        const agentTimingsAccum: import('../../../types/chat-streaming.types').DebugMetaAgent[] = [];
+
         // Phase 4: Control profile fallback based on operation mode
         // Only allow for create operations without explicit content
         const allowProfileFallback = state.operationMode === 'create' && !state.inputContent;
@@ -194,6 +196,7 @@ export class IntentGraphFactory {
         // Cast operationMode: 'read' and 'propose' map to 'create' for the inferrer
         // (inference node is never called in read mode; propose behaves like create for inference)
         const inferrerMode = (state.operationMode === 'read' || state.operationMode === 'propose') ? 'create' : state.operationMode;
+        const inferrerStart = Date.now();
         const result = await inferrer.invoke(
           state.inputContent || null,
           state.userProfile,
@@ -203,6 +206,7 @@ export class IntentGraphFactory {
             conversationContext: state.conversationContext  // Phase 5: Pass conversation history
           }
         );
+        agentTimingsAccum.push({ name: 'intent.inferrer', durationMs: Date.now() - inferrerStart });
 
         logger.verbose("Inference complete", {
           inferredCount: result.intents.length,
@@ -214,6 +218,7 @@ export class IntentGraphFactory {
 
         return {
           inferredIntents: result.intents,
+          agentTimings: agentTimingsAccum,
           trace: [{
             node: "inference",
             detail: result.intents.length === 0
@@ -240,17 +245,21 @@ export class IntentGraphFactory {
 
         if (intents.length === 0) {
           logger.verbose("No intents to verify");
-          return { verifiedIntents: [] };
+          return { verifiedIntents: [], agentTimings: [] };
         }
 
         logger.verbose(`Verifying ${intents.length} intents in parallel...`);
+
+        const agentTimingsAccum: import('../../../types/chat-streaming.types').DebugMetaAgent[] = [];
 
         // Parallel Execution
         const verificationResults = await Promise.all(
           intents.map(async (intent): Promise<VerifiedIntent | null> => {
             try {
               let description = intent.description;
+              const verifierStart1 = Date.now();
               let verdict = await verifier.invoke(description, state.userProfile);
+              agentTimingsAccum.push({ name: 'intent.verifier', durationMs: Date.now() - verifierStart1 });
 
               if (isVague(description, verdict.semantic_entropy, verdict.felicity_scores.clarity)) {
                 const enrichedDescription = enrichVagueIntentWithProfile(description, state.userProfile);
@@ -259,7 +268,9 @@ export class IntentGraphFactory {
                     before: description,
                     after: enrichedDescription,
                   });
+                  const verifierStart2 = Date.now();
                   const enrichedVerdict = await verifier.invoke(enrichedDescription, state.userProfile);
+                  agentTimingsAccum.push({ name: 'intent.verifier', durationMs: Date.now() - verifierStart2 });
                   const becameClear =
                     enrichedVerdict.semantic_entropy < verdict.semantic_entropy ||
                     enrichedVerdict.felicity_scores.clarity > verdict.felicity_scores.clarity;
@@ -349,7 +360,7 @@ export class IntentGraphFactory {
           });
         }
 
-        return { verifiedIntents: verified, trace: traceEntries };
+        return { verifiedIntents: verified, agentTimings: agentTimingsAccum, trace: traceEntries };
       });
     };
 
@@ -366,12 +377,15 @@ export class IntentGraphFactory {
           targetIntentIds: state.targetIntentIds
         });
 
+        const agentTimingsAccum: import('../../../types/chat-streaming.types').DebugMetaAgent[] = [];
+
         // Phase 4: Handle delete operations directly
         if (state.operationMode === 'delete') {
           if (!state.targetIntentIds || state.targetIntentIds.length === 0) {
             logger.warn("Delete mode with no target IDs");
             return {
               actions: [],
+              agentTimings: agentTimingsAccum,
               trace: [{ node: "reconciler", detail: "Delete mode with no target IDs" }],
             };
           }
@@ -388,6 +402,7 @@ export class IntentGraphFactory {
 
           return {
             actions,
+            agentTimings: agentTimingsAccum,
             trace: [{
               node: "reconciler",
               detail: `Actions: expire=${actions.length}`,
@@ -401,6 +416,7 @@ export class IntentGraphFactory {
           logger.verbose("No verified intents to reconcile");
           return {
             actions: [],
+            agentTimings: agentTimingsAccum,
             trace: [{ node: "reconciler", detail: "No intents to reconcile" }],
           };
         }
@@ -417,7 +433,9 @@ export class IntentGraphFactory {
           operationMode: state.operationMode
         });
 
+        const reconcilerStart = Date.now();
         const result = await reconciler.invoke(formattedCandidates, state.activeIntents);
+        agentTimingsAccum.push({ name: 'intent.reconciler', durationMs: Date.now() - reconcilerStart });
 
         logger.verbose("Reconciliation complete", {
           actionCount: result.actions.length,
@@ -432,6 +450,7 @@ export class IntentGraphFactory {
 
         return {
           actions: result.actions,
+          agentTimings: agentTimingsAccum,
           trace: [{
             node: "reconciler",
             detail: `Actions: create=${counts.create}, update=${counts.update}, expire=${counts.expire}`,

--- a/protocol/src/lib/protocol/graphs/intent_index.graph.ts
+++ b/protocol/src/lib/protocol/graphs/intent_index.graph.ts
@@ -45,34 +45,37 @@ export class IntentIndexGraphFactory {
         const indexId = state.indexId;
         logger.verbose("Assign intent to index", { userId: state.userId, intentId, indexId, skipEvaluation: state.skipEvaluation });
 
+        const agentTimingsAccum: import('../../../types/chat-streaming.types').DebugMetaAgent[] = [];
+
         if (!intentId || !indexId) {
-          return { mutationResult: { success: false, error: "Both intentId and indexId are required." } };
+          return { agentTimings: agentTimingsAccum, mutationResult: { success: false, error: "Both intentId and indexId are required." } };
         }
 
         try {
           // Validate ownership and membership
           const intent = await this.database.getIntent(intentId);
           if (!intent) {
-            return { mutationResult: { success: false, error: "Intent not found." } };
+            return { agentTimings: agentTimingsAccum, mutationResult: { success: false, error: "Intent not found." } };
           }
           if (intent.userId !== state.userId) {
-            return { mutationResult: { success: false, error: "You can only add your own intents to an index." } };
+            return { agentTimings: agentTimingsAccum, mutationResult: { success: false, error: "You can only add your own intents to an index." } };
           }
           const isMember = await this.database.isIndexMember(indexId, state.userId);
           if (!isMember) {
-            return { mutationResult: { success: false, error: "You are not a member of that index." } };
+            return { agentTimings: agentTimingsAccum, mutationResult: { success: false, error: "You are not a member of that index." } };
           }
 
           // Check if already assigned
           const alreadyAssigned = await this.database.isIntentAssignedToIndex(intentId, indexId);
           if (alreadyAssigned) {
-            return { mutationResult: { success: true, message: "That intent is already in this index." } };
+            return { agentTimings: agentTimingsAccum, mutationResult: { success: true, message: "That intent is already in this index." } };
           }
 
           // Direct assignment (skip evaluation)
           if (state.skipEvaluation) {
             await this.database.assignIntentToIndex(intentId, indexId, 1.0);
             return {
+              agentTimings: agentTimingsAccum,
               assignmentResult: { indexId, assigned: true, success: true } as AssignmentResult,
               mutationResult: { success: true, message: "Intent saved to the index." },
             };
@@ -81,7 +84,7 @@ export class IntentIndexGraphFactory {
           // Evaluated assignment (migrated from old Index Graph)
           const intentForIndexing = await this.database.getIntentForIndexing(intentId);
           if (!intentForIndexing) {
-            return { mutationResult: { success: false, error: "Intent not found for indexing." } };
+            return { agentTimings: agentTimingsAccum, mutationResult: { success: false, error: "Intent not found for indexing." } };
           }
 
           const indexContext = await this.database.getIndexMemberContext(indexId, intentForIndexing.userId);
@@ -89,6 +92,7 @@ export class IntentIndexGraphFactory {
             // No prompts or not eligible - auto-assign
             await this.database.assignIntentToIndex(intentId, indexId, 1.0);
             return {
+              agentTimings: agentTimingsAccum,
               assignmentResult: { indexId, assigned: true, success: true } as AssignmentResult,
               mutationResult: { success: true, message: "Intent assigned to index (auto-assign, no prompts)." },
             };
@@ -98,6 +102,7 @@ export class IntentIndexGraphFactory {
           if (hasNoPrompts) {
             await this.database.assignIntentToIndex(intentId, indexId, 1.0);
             return {
+              agentTimings: agentTimingsAccum,
               assignmentResult: { indexId, assigned: true, success: true } as AssignmentResult,
               mutationResult: { success: true, message: "Intent assigned to index (no prompts, auto-assign)." },
             };
@@ -108,15 +113,19 @@ export class IntentIndexGraphFactory {
             ? `${intentForIndexing.sourceType}:${intentForIndexing.sourceId ?? ""}`
             : undefined;
 
+          const _indexerStart = Date.now();
           const result = await indexer.evaluate(
             intentForIndexing.payload,
             indexContext.indexPrompt,
             indexContext.memberPrompt,
             sourceName
           );
+          const _indexerMs = Date.now() - _indexerStart;
+          agentTimingsAccum.push({ name: 'intent.indexer', durationMs: _indexerMs });
 
           if (!result) {
             return {
+              agentTimings: agentTimingsAccum,
               evaluation: null,
               shouldAssign: false,
               finalScore: 0,
@@ -154,6 +163,7 @@ export class IntentIndexGraphFactory {
           if (shouldAssign) {
             await this.database.assignIntentToIndex(intentId, indexId, finalScore);
             return {
+              agentTimings: agentTimingsAccum,
               evaluation: result,
               shouldAssign: true,
               finalScore,
@@ -163,6 +173,7 @@ export class IntentIndexGraphFactory {
           }
 
           return {
+            agentTimings: agentTimingsAccum,
             evaluation: result,
             shouldAssign: false,
             finalScore,
@@ -171,7 +182,7 @@ export class IntentIndexGraphFactory {
           };
         } catch (err) {
           logger.error("Assign failed", { error: err });
-          return { mutationResult: { success: false, error: "Failed to assign intent to index." } };
+          return { agentTimings: agentTimingsAccum, mutationResult: { success: false, error: "Failed to assign intent to index." } };
         }
       });
     };

--- a/protocol/src/lib/protocol/graphs/opportunity.graph.ts
+++ b/protocol/src/lib/protocol/graphs/opportunity.graph.ts
@@ -287,6 +287,7 @@ export class OpportunityGraphFactory {
             // Chat path: score query against target indexes in parallel
             try {
               const indexer = new IntentIndexer();
+              const scopeAgentTimings: import('../../../types/chat-streaming.types').DebugMetaAgent[] = [];
               const scorableIndexes = targetIndexes.filter(ti => ti.title !== 'Unknown');
               const scoringPromises = scorableIndexes.map(async (ti) => {
                 try {
@@ -294,11 +295,13 @@ export class OpportunityGraphFactory {
                   if (!ctx?.indexPrompt?.trim() && !ctx?.memberPrompt?.trim()) {
                     return { indexId: ti.indexId, score: 1.0 };
                   }
+                  const _indexerStart = Date.now();
                   const result = await indexer.invoke(
                     state.searchQuery!,
                     ctx?.indexPrompt ?? null,
                     ctx?.memberPrompt ?? null,
                   );
+                  scopeAgentTimings.push({ name: 'intent.indexer', durationMs: Date.now() - _indexerStart });
                   if (!result) return { indexId: ti.indexId, score: 1.0 };
                   const score = ctx?.indexPrompt && ctx?.memberPrompt
                     ? result.indexScore * 0.6 + result.memberScore * 0.4
@@ -311,6 +314,19 @@ export class OpportunityGraphFactory {
               const results = await Promise.all(scoringPromises);
               for (const { indexId, score } of results) {
                 indexRelevancyScores[indexId] = score;
+              }
+              // Accumulate indexer timings into graph state
+              if (scopeAgentTimings.length > 0) {
+                return {
+                  targetIndexes,
+                  indexRelevancyScores,
+                  agentTimings: scopeAgentTimings,
+                  trace: [{
+                    node: "scope",
+                    detail: `Searching ${targetIndexes.length} index(es): ${targetIndexes.map(i => `${i.title} (${i.memberCount})`).join(', ')}`,
+                    data: { totalMembers: targetIndexes.reduce((sum, i) => sum + i.memberCount, 0) },
+                  }],
+                };
               }
             } catch (err) {
               logger.warn('[Graph:Scope] Failed to score query against indexes', { error: err });

--- a/protocol/src/lib/protocol/graphs/opportunity.graph.ts
+++ b/protocol/src/lib/protocol/graphs/opportunity.graph.ts
@@ -14,6 +14,7 @@
 
 import { StateGraph, START, END, Annotation } from '@langchain/langgraph';
 import type { Id } from '../../../types/common.types';
+import type { DebugMetaAgent } from '../../../types/chat-streaming.types';
 import {
   OpportunityGraphState,
   type IndexedIntent,
@@ -987,7 +988,7 @@ export class OpportunityGraphFactory {
 
         if (state.candidates.length === 0) {
           logger.verbose('[Graph:Evaluation] No candidates to evaluate');
-          return { evaluatedOpportunities: [] };
+          return { evaluatedOpportunities: [], agentTimings: [] };
         }
 
         // Batch candidates to avoid timeout - evaluate top 25 per batch, store remaining
@@ -1052,6 +1053,8 @@ export class OpportunityGraphFactory {
             total: sortedCandidates.length,
           });
         }
+
+        const agentTimingsAccum: DebugMetaAgent[] = [];
 
         try {
           const discoveryUserId = state.onBehalfOfUserId ?? state.userId;
@@ -1136,8 +1139,14 @@ export class OpportunityGraphFactory {
                   existingOpportunities: state.options.existingOpportunities,
                   ...(state.searchQuery?.trim() ? { discoveryQuery: state.searchQuery.trim() } : {}),
                 };
+                const _evalStart = Date.now();
                 return evaluator.invokeEntityBundle(input, { minScore, returnAll: true })
+                  .then((res) => {
+                    agentTimingsAccum.push({ name: 'opportunity.evaluator', durationMs: Date.now() - _evalStart });
+                    return res;
+                  })
                   .catch((err) => {
+                    agentTimingsAccum.push({ name: 'opportunity.evaluator', durationMs: Date.now() - _evalStart });
                     logger.warn('[Graph:Evaluation] Parallel eval failed for candidate', {
                       candidateUserId: candidateEntity.userId,
                       error: err,
@@ -1158,7 +1167,9 @@ export class OpportunityGraphFactory {
               ...(state.searchQuery?.trim() ? { discoveryQuery: state.searchQuery.trim() } : {}),
             };
             // Get ALL scored results for tracing (returnAll: true), filter for persistence later
+            const _evalStart = Date.now();
             const opportunitiesWithActors = await evaluator.invokeEntityBundle(input, { minScore, returnAll: true });
+            agentTimingsAccum.push({ name: 'opportunity.evaluator', durationMs: Date.now() - _evalStart });
 
             // Split multi-actor evaluator results into pairwise (viewer + candidate).
             // Each persisted discovery opportunity should have exactly 2 actors.
@@ -1333,12 +1344,14 @@ export class OpportunityGraphFactory {
             evaluatedOpportunities: passedOpportunities,
             remainingCandidates: effectiveRemaining,
             trace: traceEntries,
+            agentTimings: agentTimingsAccum,
           };
         } catch (error) {
           logger.error('[Graph:Evaluation] Failed', { error });
           return {
             evaluatedOpportunities: [],
             error: 'Failed to evaluate candidates.',
+            agentTimings: agentTimingsAccum,
           };
         }
       });
@@ -1481,15 +1494,16 @@ export class OpportunityGraphFactory {
         logger.verbose('[Graph:IntroEvaluation] Starting', { userId: state.userId });
 
         if (state.error) {
-          return { evaluatedOpportunities: [] };
+          return { evaluatedOpportunities: [], agentTimings: [] };
         }
 
         const entities = state.introductionEntities ?? [];
         const primaryIndexId = (state.indexId ?? entities[0]?.indexId) as Id<'indexes'> | undefined;
         if (!primaryIndexId || entities.length < 2) {
-          return { evaluatedOpportunities: [], error: 'Missing entities or index for introduction.' };
+          return { evaluatedOpportunities: [], error: 'Missing entities or index for introduction.', agentTimings: [] };
         }
 
+        const agentTimingsAccum: DebugMetaAgent[] = [];
         let introducerName: string | undefined;
         let reasoning: string;
         let score: number;
@@ -1506,7 +1520,9 @@ export class OpportunityGraphFactory {
             introductionHint: state.introductionHint ?? undefined,
           };
 
+          const _evalStart = Date.now();
           const evaluated = await (evaluatorAgent as OpportunityEvaluator).invokeEntityBundle(input, { minScore: 0 });
+          agentTimingsAccum.push({ name: 'opportunity.evaluator', durationMs: Date.now() - _evalStart });
           if (evaluated.length > 0) {
             const best = evaluated[0];
             reasoning = best.reasoning;
@@ -1541,6 +1557,7 @@ export class OpportunityGraphFactory {
           evaluatedOpportunities: [evaluatedOpportunity],
           introductionContext: { createdByName: introducerName },
           options: { ...state.options, initialStatus: state.options.initialStatus ?? 'latent' },
+          agentTimings: agentTimingsAccum,
         };
       });
     };

--- a/protocol/src/lib/protocol/graphs/profile.graph.ts
+++ b/protocol/src/lib/protocol/graphs/profile.graph.ts
@@ -536,6 +536,8 @@ export class ProfileGraphFactory {
           inputLength: state.input.length
         });
 
+        const agentTimingsAccum: import('../../../types/chat-streaming.types').DebugMetaAgent[] = [];
+
         try {
           // If updating existing profile, include it in the input for context
           let inputWithContext = state.input;
@@ -544,7 +546,9 @@ export class ProfileGraphFactory {
             logger.verbose("Merging with existing profile");
           }
 
+          const profileGeneratorStart = Date.now();
           const result = await profileGenerator.invoke(inputWithContext);
+          agentTimingsAccum.push({ name: 'profile.generator', durationMs: Date.now() - profileGeneratorStart });
 
           logger.verbose("✅ Profile generated successfully", {
             name: result.output.identity.name,
@@ -560,6 +564,7 @@ export class ProfileGraphFactory {
             },
             // Mark that hyde needs regeneration since profile was updated
             needsHydeGeneration: true,
+            agentTimings: agentTimingsAccum,
             operationsPerformed: { generatedProfile: true }
           };
         } catch (error) {
@@ -654,9 +659,13 @@ export class ProfileGraphFactory {
           profileName: state.profile.identity.name
         });
 
+        const agentTimingsAccum: import('../../../types/chat-streaming.types').DebugMetaAgent[] = [];
+
         try {
           const profileString = JSON.stringify(state.profile, null, 2);
+          const hydeGeneratorStart = Date.now();
           const result = await hydeGenerator.invoke(profileString);
+          agentTimingsAccum.push({ name: 'hyde.generator', durationMs: Date.now() - hydeGeneratorStart });
 
           logger.verbose("✅ HyDE generated successfully", {
             descriptionLength: result.textToEmbed.length
@@ -664,6 +673,7 @@ export class ProfileGraphFactory {
 
           return {
             hydeDescription: result.textToEmbed,
+            agentTimings: agentTimingsAccum,
             operationsPerformed: { generatedHyde: true }
           };
         } catch (error) {

--- a/protocol/src/lib/protocol/graphs/profile.graph.ts
+++ b/protocol/src/lib/protocol/graphs/profile.graph.ts
@@ -572,7 +572,8 @@ export class ProfileGraphFactory {
             error: error instanceof Error ? error.message : String(error)
           });
           return {
-            error: "Profile generation failed"
+            error: "Profile generation failed",
+            agentTimings: agentTimingsAccum
           };
         }
       });

--- a/protocol/src/lib/protocol/states/home.state.ts
+++ b/protocol/src/lib/protocol/states/home.state.ts
@@ -1,5 +1,6 @@
 import { Annotation } from '@langchain/langgraph';
 import type { Opportunity } from '../interfaces/database.interface';
+import type { DebugMetaAgent } from '../../../types/chat-streaming.types';
 
 /**
  * Home view card item: one opportunity with full presenter-driven display contract.
@@ -127,5 +128,11 @@ export const HomeGraphState = Annotation.Root({
   meta: Annotation<{ totalOpportunities: number; totalSections: number }>({
     reducer: (curr, next) => next ?? curr,
     default: () => ({ totalOpportunities: 0, totalSections: 0 }),
+  }),
+
+  /** Timing records for each agent invocation within this graph run. */
+  agentTimings: Annotation<DebugMetaAgent[]>({
+    reducer: (acc, val) => [...acc, ...val],
+    default: () => [],
   }),
 });

--- a/protocol/src/lib/protocol/states/hyde.state.ts
+++ b/protocol/src/lib/protocol/states/hyde.state.ts
@@ -6,6 +6,7 @@
 import { Annotation } from '@langchain/langgraph';
 import type { Id } from '../../../types/common.types';
 import type { Lens, HydeTargetCorpus } from '../agents/lens.inferrer';
+import type { DebugMetaAgent } from '../../../types/chat-streaming.types';
 
 /** Single HyDE document (text + embedding) for one lens. */
 export interface HydeDocumentState {
@@ -79,5 +80,11 @@ export const HydeGraphState = Annotation.Root({
   error: Annotation<string | undefined>({
     reducer: (curr, next) => next ?? curr,
     default: () => undefined,
+  }),
+
+  /** Timing records for each agent invocation within this graph run. */
+  agentTimings: Annotation<DebugMetaAgent[]>({
+    reducer: (acc, val) => [...acc, ...val],
+    default: () => [],
   }),
 });

--- a/protocol/src/lib/protocol/states/intent.state.ts
+++ b/protocol/src/lib/protocol/states/intent.state.ts
@@ -3,6 +3,7 @@ import { BaseMessage } from "@langchain/core/messages";
 import { InferredIntent } from "../agents/intent.inferrer";
 import { SemanticVerifierOutput } from "../agents/intent.verifier";
 import { IntentReconcilerOutput } from "../agents/intent.reconciler";
+import type { DebugMetaAgent } from '../../../types/chat-streaming.types';
 
 /**
  * Extended InferredIntent that includes verification results.
@@ -168,6 +169,12 @@ export const IntentGraphState = Annotation.Root({
    */
   trace: Annotation<Array<{ node: string; detail?: string; data?: Record<string, unknown> }>>({
     reducer: (curr, next) => [...curr, ...(next || [])],
+    default: () => [],
+  }),
+
+  /** Timing records for each agent invocation within this graph run. */
+  agentTimings: Annotation<DebugMetaAgent[]>({
+    reducer: (acc, val) => [...acc, ...val],
     default: () => [],
   }),
 

--- a/protocol/src/lib/protocol/states/intent_index.state.ts
+++ b/protocol/src/lib/protocol/states/intent_index.state.ts
@@ -1,5 +1,6 @@
 import { Annotation } from "@langchain/langgraph";
 import type { IntentIndexerOutput } from "../agents/intent.indexer";
+import type { DebugMetaAgent } from '../../../types/chat-streaming.types';
 
 /**
  * Intent payload and metadata loaded for index evaluation.
@@ -160,5 +161,11 @@ export const IntentIndexGraphState = Annotation.Root({
   error: Annotation<string | null>({
     reducer: (_, next) => next,
     default: () => null,
+  }),
+
+  /** Timing records for each agent invocation within this graph run. */
+  agentTimings: Annotation<DebugMetaAgent[]>({
+    reducer: (acc, val) => [...acc, ...val],
+    default: () => [],
   }),
 });

--- a/protocol/src/lib/protocol/states/opportunity.state.ts
+++ b/protocol/src/lib/protocol/states/opportunity.state.ts
@@ -3,6 +3,7 @@ import type { Id } from '../../../types/common.types';
 import type { OpportunityStatus, Opportunity } from '../interfaces/database.interface';
 import type { Lens } from '../interfaces/embedder.interface';
 import type { EvaluatorEntity } from '../agents/opportunity.evaluator';
+import type { DebugMetaAgent } from '../../../types/chat-streaming.types';
 
 /**
  * Opportunity Graph State (Linear Multi-Step Workflow)
@@ -375,6 +376,12 @@ export const OpportunityGraphState = Annotation.Root({
    */
   trace: Annotation<Array<{ node: string; detail?: string; data?: Record<string, unknown> }>>({
     reducer: (curr, next) => [...curr, ...(next || [])],
+    default: () => [],
+  }),
+
+  /** Timing records for each agent invocation within this graph run. */
+  agentTimings: Annotation<DebugMetaAgent[]>({
+    reducer: (acc, val) => [...acc, ...val],
     default: () => [],
   }),
 });

--- a/protocol/src/lib/protocol/states/profile.state.ts
+++ b/protocol/src/lib/protocol/states/profile.state.ts
@@ -1,5 +1,6 @@
 import { Annotation } from "@langchain/langgraph";
 import { ProfileDocument } from "../agents/profile.generator";
+import type { DebugMetaAgent } from '../../../types/chat-streaming.types';
 
 /**
  * The Graph State for Profile Generation.
@@ -156,6 +157,12 @@ export const ProfileGraphState = Annotation.Root({
   }>({
     reducer: (curr, next) => ({ ...curr, ...next }),
     default: () => ({}),
+  }),
+
+  /** Timing records for each agent invocation within this graph run. */
+  agentTimings: Annotation<DebugMetaAgent[]>({
+    reducer: (acc, val) => [...acc, ...val],
+    default: () => [],
   }),
 
   /**

--- a/protocol/src/lib/protocol/tools/index.tools.ts
+++ b/protocol/src/lib/protocol/tools/index.tools.ts
@@ -16,12 +16,14 @@ export function createIndexTools(defineTool: DefineTool, deps: ToolDeps) {
         return error("You can only list your own indexes. Omit userId to see the current user's indexes.");
       }
 
+      const _readIndexGraphStart = Date.now();
       const result = await graphs.index.invoke({
         userId: context.userId,
         indexId: context.indexId || undefined,
         operationMode: 'read' as const,
         showAll: false, // Never allow bypass - strict scope enforcement
       });
+      const _readIndexGraphMs = Date.now() - _readIndexGraphStart;
 
       if (result.error) {
         return error(result.error);
@@ -36,9 +38,10 @@ export function createIndexTools(defineTool: DefineTool, deps: ToolDeps) {
               scopedToIndex: context.indexName ?? context.indexId,
               message: `Results are limited to "${context.indexName ?? 'this index'}" because this chat is scoped to that community. The user may belong to other communities not shown here.`,
             },
+            _graphTimings: [{ name: 'index', durationMs: _readIndexGraphMs, agents: result.agentTimings ?? [] }],
           });
         }
-        return success(result.readResult);
+        return success({ ...result.readResult, _graphTimings: [{ name: 'index', durationMs: _readIndexGraphMs, agents: result.agentTimings ?? [] }] });
       }
       return error("Failed to fetch index information.");
     },
@@ -69,17 +72,19 @@ export function createIndexTools(defineTool: DefineTool, deps: ToolDeps) {
           );
         }
 
+        const _readMembersGraphStart = Date.now();
         const result = await graphs.indexMembership.invoke({
           userId: context.userId,
           indexId,
           operationMode: 'read' as const,
         });
+        const _readMembersGraphMs = Date.now() - _readMembersGraphStart;
 
         if (result.error) {
           return error(result.error);
         }
         if (result.readResult) {
-          return success(result.readResult);
+          return success({ ...result.readResult, _graphTimings: [{ name: 'index_membership', durationMs: _readMembersGraphMs, agents: result.agentTimings ?? [] }] });
         }
         return error("Failed to fetch index members.");
       }
@@ -266,17 +271,19 @@ export function createIndexTools(defineTool: DefineTool, deps: ToolDeps) {
         );
       }
 
+      const _updateIndexGraphStart = Date.now();
       const result = await graphs.index.invoke({
         userId: context.userId,
         indexId: effectiveIndexId,
         operationMode: 'update' as const,
         updateInput: query.settings,
       });
+      const _updateIndexGraphMs = Date.now() - _updateIndexGraphStart;
 
       if (result.mutationResult && !result.mutationResult.success) {
         return error(result.mutationResult.error || "Failed to update index.");
       }
-      return success({ message: "Index updated.", settings: Object.keys(query.settings) });
+      return success({ message: "Index updated.", settings: Object.keys(query.settings), _graphTimings: [{ name: 'index', durationMs: _updateIndexGraphMs, agents: result.agentTimings ?? [] }] });
     },
   });
 
@@ -294,6 +301,7 @@ export function createIndexTools(defineTool: DefineTool, deps: ToolDeps) {
         return error("Title is required.");
       }
 
+      const _createIndexGraphStart = Date.now();
       const result = await graphs.index.invoke({
         userId: context.userId,
         operationMode: 'create' as const,
@@ -304,6 +312,7 @@ export function createIndexTools(defineTool: DefineTool, deps: ToolDeps) {
           joinPolicy: query.joinPolicy,
         },
       });
+      const _createIndexGraphMs = Date.now() - _createIndexGraphStart;
 
       if (result.mutationResult) {
         if (result.mutationResult.success) {
@@ -312,6 +321,7 @@ export function createIndexTools(defineTool: DefineTool, deps: ToolDeps) {
             indexId: result.mutationResult.indexId,
             title: result.mutationResult.title,
             message: result.mutationResult.message,
+            _graphTimings: [{ name: 'index', durationMs: _createIndexGraphMs, agents: result.agentTimings ?? [] }],
           });
         }
         return error(result.mutationResult.error || "Failed to create index.");
@@ -339,16 +349,18 @@ export function createIndexTools(defineTool: DefineTool, deps: ToolDeps) {
         );
       }
 
+      const _deleteIndexGraphStart = Date.now();
       const result = await graphs.index.invoke({
         userId: context.userId,
         indexId,
         operationMode: 'delete' as const,
       });
+      const _deleteIndexGraphMs = Date.now() - _deleteIndexGraphStart;
 
       if (result.mutationResult && !result.mutationResult.success) {
         return error(result.mutationResult.error || "Failed to delete index.");
       }
-      return success({ message: "Index deleted." });
+      return success({ message: "Index deleted.", _graphTimings: [{ name: 'index', durationMs: _deleteIndexGraphMs, agents: result.agentTimings ?? [] }] });
     },
   });
 
@@ -373,12 +385,14 @@ export function createIndexTools(defineTool: DefineTool, deps: ToolDeps) {
         );
       }
 
+      const _createMembershipGraphStart = Date.now();
       const result = await graphs.indexMembership.invoke({
         userId: context.userId,
         indexId,
         targetUserId,
         operationMode: 'create' as const,
       });
+      const _createMembershipGraphMs = Date.now() - _createMembershipGraphStart;
 
       if (result.mutationResult) {
         if (result.mutationResult.success) {
@@ -386,6 +400,7 @@ export function createIndexTools(defineTool: DefineTool, deps: ToolDeps) {
           return success({
             created: !alreadyMember,
             message: result.mutationResult.message,
+            _graphTimings: [{ name: 'index_membership', durationMs: _createMembershipGraphMs, agents: result.agentTimings ?? [] }],
           });
         }
         return error(result.mutationResult.error || "Failed to add member.");
@@ -419,18 +434,21 @@ export function createIndexTools(defineTool: DefineTool, deps: ToolDeps) {
         );
       }
 
+      const _deleteMembershipGraphStart = Date.now();
       const result = await graphs.indexMembership.invoke({
         userId: context.userId,
         indexId,
         targetUserId,
         operationMode: 'delete' as const,
       });
+      const _deleteMembershipGraphMs = Date.now() - _deleteMembershipGraphStart;
 
       if (result.mutationResult) {
         if (result.mutationResult.success) {
           return success({
             removed: true,
             message: result.mutationResult.message,
+            _graphTimings: [{ name: 'index_membership', durationMs: _deleteMembershipGraphMs, agents: result.agentTimings ?? [] }],
           });
         }
         return error(result.mutationResult.error || "Failed to remove member.");

--- a/protocol/src/lib/protocol/tools/intent.tools.ts
+++ b/protocol/src/lib/protocol/tools/intent.tools.ts
@@ -93,6 +93,7 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       // When scoped, we should NOT return all user intents across indexes - only those in the scoped index
       const allUserIntents = !context.indexId && !effectiveIndexId && (!queryUserId || queryUserId === context.userId);
 
+      const _readIntentGraphStart = Date.now();
       const result = await graphs.intent.invoke({
         userId: context.userId,
         userProfile: "",
@@ -101,6 +102,7 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
         queryUserId,
         allUserIntents,
       });
+      const _readIntentGraphMs = Date.now() - _readIntentGraphStart;
 
       if (result.readResult) {
         if (result.readResult.count === 0 && result.readResult.message && /not a member|Index not found/i.test(result.readResult.message)) {
@@ -121,10 +123,11 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
             page,
             totalPages: Math.ceil(result.readResult.intents.length / limit),
             intents: pagedIntents,
+            _graphTimings: [{ name: 'intent', durationMs: _readIntentGraphMs, agents: result.agentTimings ?? [] }],
           });
         }
 
-        return success(result.readResult);
+        return success({ ...result.readResult, _graphTimings: [{ name: 'intent', durationMs: _readIntentGraphMs, agents: result.agentTimings ?? [] }] });
       }
       return error("Failed to fetch intents.");
     },
@@ -155,10 +158,13 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       const effectiveIndexId = context.indexId || query.indexId?.trim() || undefined;
 
       // Fetch profile (the intent graph needs it for inference)
+      const _profileGraphStart1 = Date.now();
       const profileResult = await graphs.profile.invoke({ userId: context.userId, operationMode: 'query' as const });
+      const _profileGraphMs1 = Date.now() - _profileGraphStart1;
       const userProfile = profileResult.profile ? JSON.stringify(profileResult.profile) : "";
 
       // Run inference + verification only (propose mode — no DB persistence)
+      const _intentGraphStart1 = Date.now();
       const result = await graphs.intent.invoke({
         userId: context.userId,
         userProfile,
@@ -166,6 +172,7 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
         operationMode: 'propose' as const,
         ...(effectiveIndexId ? { indexId: effectiveIndexId } : {}),
       });
+      const _intentGraphMs1 = Date.now() - _intentGraphStart1;
       logger.debug("Intent graph propose response", { result });
 
       const verified = result.verifiedIntents || [];
@@ -232,6 +239,10 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
         count: verified.length,
         message: `IMPORTANT: Include the following \`\`\`intent_proposal code blocks EXACTLY as-is in your response (they render as interactive cards for the user to approve or skip):\n\n${blocksText}`,
         debugSteps,
+        _graphTimings: [
+          { name: 'profile', durationMs: _profileGraphMs1, agents: profileResult.agentTimings ?? [] },
+          { name: 'intent', durationMs: _intentGraphMs1, agents: result.agentTimings ?? [] },
+        ],
       });
     },
   });
@@ -262,9 +273,12 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
         }
       }
 
+      const _profileGraphStart2 = Date.now();
       const profileResult = await graphs.profile.invoke({ userId: context.userId, operationMode: 'query' as const });
+      const _profileGraphMs2 = Date.now() - _profileGraphStart2;
       const userProfile = profileResult.profile ? JSON.stringify(profileResult.profile) : "";
 
+      const _intentGraphStart2 = Date.now();
       const result = await graphs.intent.invoke({
         userId: context.userId,
         userProfile,
@@ -273,11 +287,18 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
         targetIntentIds: [intentId],
         ...(context.indexId && { indexId: context.indexId }),
       });
+      const _intentGraphMs2 = Date.now() - _intentGraphStart2;
 
       if (result.executionResults?.some((r: ExecutionResult) => !r.success)) {
         return error("Failed to update intent.");
       }
-      return success({ message: "Intent updated." });
+      return success({
+        message: "Intent updated.",
+        _graphTimings: [
+          { name: 'profile', durationMs: _profileGraphMs2, agents: profileResult.agentTimings ?? [] },
+          { name: 'intent', durationMs: _intentGraphMs2, agents: result.agentTimings ?? [] },
+        ],
+      });
     },
   });
 
@@ -306,6 +327,7 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
         }
       }
 
+      const _deleteIntentGraphStart = Date.now();
       const result = await graphs.intent.invoke({
         userId: context.userId,
         userProfile: "",
@@ -313,11 +335,15 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
         targetIntentIds: [intentId],
         ...(context.indexId && { indexId: context.indexId }),
       });
+      const _deleteIntentGraphMs = Date.now() - _deleteIntentGraphStart;
 
       if (result.executionResults?.some((r: ExecutionResult) => !r.success)) {
         return error("Failed to delete intent.");
       }
-      return success({ message: "Intent archived." });
+      return success({
+        message: "Intent archived.",
+        _graphTimings: [{ name: 'intent', durationMs: _deleteIntentGraphMs, agents: result.agentTimings ?? [] }],
+      });
     },
   });
 
@@ -348,6 +374,7 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
         );
       }
 
+      const _createIntentIndexGraphStart = Date.now();
       const result = await graphs.intentIndex.invoke({
         userId: context.userId,
         indexId,
@@ -355,10 +382,15 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
         operationMode: 'create' as const,
         skipEvaluation: true,
       });
+      const _createIntentIndexGraphMs = Date.now() - _createIntentIndexGraphStart;
 
       if (result.mutationResult) {
         if (result.mutationResult.success) {
-          return success({ created: true, message: result.mutationResult.message });
+          return success({
+            created: true,
+            message: result.mutationResult.message,
+            _graphTimings: [{ name: 'intent_index', durationMs: _createIntentIndexGraphMs, agents: result.agentTimings ?? [] }],
+          });
         }
         return error(result.mutationResult.error || "Failed to link intent to index.");
       }
@@ -412,6 +444,7 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
         }
       }
 
+      const _readIntentIndexGraphStart = Date.now();
       const result = await graphs.intentIndex.invoke({
         userId: context.userId,
         indexId,
@@ -419,12 +452,13 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
         operationMode: 'read' as const,
         queryUserId,
       });
+      const _readIntentIndexGraphMs = Date.now() - _readIntentIndexGraphStart;
 
       if (result.error) {
         return error(result.error);
       }
       if (result.readResult) {
-        return success(result.readResult);
+        return success({ ...result.readResult, _graphTimings: [{ name: 'intent_index', durationMs: _readIntentIndexGraphMs, agents: result.agentTimings ?? [] }] });
       }
       return error("Failed to fetch intent-index links.");
     },
@@ -453,16 +487,22 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
         );
       }
 
+      const _deleteIntentIndexGraphStart = Date.now();
       const result = await graphs.intentIndex.invoke({
         userId: context.userId,
         indexId,
         intentId,
         operationMode: 'delete' as const,
       });
+      const _deleteIntentIndexGraphMs = Date.now() - _deleteIntentIndexGraphStart;
 
       if (result.mutationResult) {
         if (result.mutationResult.success) {
-          return success({ deleted: true, message: result.mutationResult.message });
+          return success({
+            deleted: true,
+            message: result.mutationResult.message,
+            _graphTimings: [{ name: 'intent_index', durationMs: _deleteIntentIndexGraphMs, agents: result.agentTimings ?? [] }],
+          });
         }
         return error(result.mutationResult.error || "Failed to unlink.");
       }

--- a/protocol/src/lib/protocol/tools/opportunity.tools.ts
+++ b/protocol/src/lib/protocol/tools/opportunity.tools.ts
@@ -486,7 +486,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
       }
 
       let indexScope: string[];
-      const _scopeGraphTimings: Array<{ name: string; durationMs: number; agents: never[] }> = [];
+      const _scopeGraphTimings: Array<{ name: string; durationMs: number; agents: Array<{ name: string; durationMs: number }> }> = [];
       if (effectiveIndexId) {
         if (!UUID_REGEX.test(effectiveIndexId)) {
           return error("Invalid index ID format.");
@@ -550,7 +550,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
       const _discoverGraphMs = Date.now() - _discoverGraphStart;
       const _discoverGraphTimings = [
         ..._scopeGraphTimings,
-        { name: 'opportunity', durationMs: _discoverGraphMs, agents: [] as never[] },
+        { name: 'opportunity', durationMs: _discoverGraphMs, agents: [] },
       ];
 
       const allDebugSteps = [

--- a/protocol/src/lib/protocol/tools/opportunity.tools.ts
+++ b/protocol/src/lib/protocol/tools/opportunity.tools.ts
@@ -228,6 +228,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
 
       // ── Continuation mode ── (must take strict precedence — it's a pagination token)
       if (query.continueFrom) {
+        const _graphStart = Date.now();
         const result = await continueDiscovery({
           opportunityGraph: graphs.opportunity,
           database,
@@ -239,6 +240,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
           minimalForChat: true,
           ...(context.sessionId ? { chatSessionId: context.sessionId } : {}),
         });
+        const _graphMs = Date.now() - _graphStart;
 
         const allDebugSteps = [...(result.debugSteps ?? [])];
 
@@ -250,6 +252,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
             summary: "No more matches found",
             ...(result.pagination ? { pagination: result.pagination } : {}),
             debugSteps: allDebugSteps,
+            _graphTimings: [{ name: 'opportunity', durationMs: _graphMs, agents: [] }],
           });
         }
 
@@ -302,6 +305,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
           summary: `Found ${displayedBlocks.length} more match(es)`,
           ...(result.pagination ? { pagination: result.pagination } : {}),
           debugSteps: allDebugSteps,
+          _graphTimings: [{ name: 'opportunity', durationMs: _graphMs, agents: [] }],
         });
       }
 
@@ -357,6 +361,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
           }),
         );
 
+        const _introGraphStart = Date.now();
         const result = await graphs.opportunity.invoke({
           operationMode: "create_introduction",
           userId: context.userId,
@@ -369,6 +374,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
             ...(context.sessionId ? { conversationId: context.sessionId } : {}),
           },
         });
+        const _introGraphMs = Date.now() - _introGraphStart;
 
         if (result.error || !result.opportunities?.length) {
           return error(
@@ -468,6 +474,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
               status: created.status ?? "draft",
             },
           ],
+          _graphTimings: [{ name: 'opportunity', durationMs: _introGraphMs, agents: result.agentTimings ?? [] }],
         });
       }
 
@@ -479,15 +486,18 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
       }
 
       let indexScope: string[];
+      const _scopeGraphTimings: Array<{ name: string; durationMs: number; agents: never[] }> = [];
       if (effectiveIndexId) {
         if (!UUID_REGEX.test(effectiveIndexId)) {
           return error("Invalid index ID format.");
         }
+        const _scopeGraphStart = Date.now();
         const memberResult = await graphs.indexMembership.invoke({
           userId: context.userId,
           indexId: effectiveIndexId,
           operationMode: "read" as const,
         });
+        _scopeGraphTimings.push({ name: 'index_membership', durationMs: Date.now() - _scopeGraphStart, agents: [] });
         if (memberResult.error) {
           return error("Index not found or you are not a member.");
         }
@@ -497,11 +507,13 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         indexScope = [context.indexId];
       } else {
         // No scope - use all indexes (only in unscoped chat)
+        const _scopeGraphStart = Date.now();
         const indexResult = await graphs.index.invoke({
           userId: context.userId,
           operationMode: "read" as const,
           showAll: true,
         });
+        _scopeGraphTimings.push({ name: 'index', durationMs: Date.now() - _scopeGraphStart, agents: [] });
         indexScope = (indexResult.readResult?.memberOf || []).map(
           (m: { indexId: string }) => m.indexId,
         );
@@ -520,6 +532,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         return error("You cannot discover introductions for yourself. Try regular discovery instead.");
       }
 
+      const _discoverGraphStart = Date.now();
       const result = await runDiscoverFromQuery({
         opportunityGraph: graphs.opportunity,
         database,
@@ -534,6 +547,11 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         cache,
         ...(context.sessionId ? { chatSessionId: context.sessionId } : {}),
       });
+      const _discoverGraphMs = Date.now() - _discoverGraphStart;
+      const _discoverGraphTimings = [
+        ..._scopeGraphTimings,
+        { name: 'opportunity', durationMs: _discoverGraphMs, agents: [] as never[] },
+      ];
 
       const allDebugSteps = [
         ...toolDebugSteps,
@@ -551,6 +569,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
           summary: "No matches found",
           ...(result.pagination ? { pagination: result.pagination } : {}),
           debugSteps: allDebugSteps,
+          _graphTimings: _discoverGraphTimings,
         });
       }
 
@@ -562,6 +581,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
           summary: "No matches found",
           ...(result.pagination ? { pagination: result.pagination } : {}),
           debugSteps: allDebugSteps,
+          _graphTimings: _discoverGraphTimings,
         });
       }
 
@@ -579,6 +599,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
           existingConnections: result.existingConnections,
           summary: "No new matches (existing connections only)",
           debugSteps: allDebugSteps,
+          _graphTimings: _discoverGraphTimings,
         });
       }
 
@@ -655,6 +676,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
               suggestedIntentDescription: searchQuery,
             }
           : {}),
+        _graphTimings: _discoverGraphTimings,
       });
     },
   });
@@ -879,12 +901,14 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
       }
 
       const isSend = query.status === "pending";
+      const _updateGraphStart = Date.now();
       const result = await graphs.opportunity.invoke({
         userId: context.userId,
         operationMode: isSend ? ("send" as const) : ("update" as const),
         opportunityId: query.opportunityId,
         ...(isSend ? {} : { newStatus: query.status }),
       });
+      const _updateGraphMs = Date.now() - _updateGraphStart;
 
       if (result.mutationResult) {
         if (result.mutationResult.success) {
@@ -895,6 +919,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
             ...(result.mutationResult.notified && {
               notified: result.mutationResult.notified,
             }),
+            _graphTimings: [{ name: 'opportunity', durationMs: _updateGraphMs, agents: result.agentTimings ?? [] }],
           });
         }
         return error(

--- a/protocol/src/lib/protocol/tools/profile.tools.ts
+++ b/protocol/src/lib/protocol/tools/profile.tools.ts
@@ -377,7 +377,7 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
 
       // Execute update directly
       const _updateWriteProfileGraphStart = Date.now();
-      await graphs.profile.invoke({
+      const _writeResult = await graphs.profile.invoke({
         userId: context.userId,
         operationMode: "write",
         input: inputForProfile,
@@ -388,7 +388,7 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
         message: "Profile updated.",
         _graphTimings: [
           { name: 'profile', durationMs: _updateQueryProfileGraphMs, agents: queryResult.agentTimings ?? [] },
-          { name: 'profile', durationMs: _updateWriteProfileGraphMs, agents: [] },
+          { name: 'profile', durationMs: _updateWriteProfileGraphMs, agents: _writeResult.agentTimings ?? [] },
         ],
       });
     },

--- a/protocol/src/lib/protocol/tools/profile.tools.ts
+++ b/protocol/src/lib/protocol/tools/profile.tools.ts
@@ -384,6 +384,9 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
         forceUpdate: true,
       });
       const _updateWriteProfileGraphMs = Date.now() - _updateWriteProfileGraphStart;
+      if (_writeResult.error) {
+        return error(_writeResult.error);
+      }
       return success({
         message: "Profile updated.",
         _graphTimings: [

--- a/protocol/src/lib/protocol/tools/profile.tools.ts
+++ b/protocol/src/lib/protocol/tools/profile.tools.ts
@@ -175,13 +175,15 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
       }
 
       // --- Mode 1: No args / self → use profileGraph query (returns id for updates) ---
+      const _readProfileGraphStart = Date.now();
       const result = await graphs.profile.invoke({
         userId: context.userId,
         operationMode: 'query' as const,
       });
+      const _readProfileGraphMs = Date.now() - _readProfileGraphStart;
 
       if (result.readResult) {
-        return success(result.readResult);
+        return success({ ...result.readResult, _graphTimings: [{ name: 'profile', durationMs: _readProfileGraphMs, agents: result.agentTimings ?? [] }] });
       }
       if (result.profile) {
         return success({
@@ -193,11 +195,13 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
             skills: result.profile.attributes.skills,
             interests: result.profile.attributes.interests,
           },
+          _graphTimings: [{ name: 'profile', durationMs: _readProfileGraphMs, agents: result.agentTimings ?? [] }],
         });
       }
       return success({
         hasProfile: false,
         message: "You don't have a profile yet. Would you like to create one? You can share your LinkedIn, GitHub, or X/Twitter profile, or just tell me about yourself.",
+        _graphTimings: [{ name: 'profile', durationMs: _readProfileGraphMs, agents: result.agentTimings ?? [] }],
       });
     },
   });
@@ -222,7 +226,9 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
         (onboarding.flow != null || onboarding.currentStep != null) &&
         !onboarding.completedAt;
       if (isOnboarding) {
+        const _onboardingProfileGraphStart = Date.now();
         const existing = await graphs.profile.invoke({ userId: context.userId, operationMode: 'query' as const });
+        const _onboardingProfileGraphMs = Date.now() - _onboardingProfileGraphStart;
         if (existing.readResult?.hasProfile && existing.readResult.profile) {
           const p = existing.readResult.profile;
           return success({
@@ -235,6 +241,7 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
               skills: p.skills,
               interests: p.interests,
             },
+            _graphTimings: [{ name: 'profile', durationMs: _onboardingProfileGraphMs, agents: existing.agentTimings ?? [] }],
           });
         }
       }
@@ -250,12 +257,14 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
         inputParts.push(query.bioOrDescription!.trim());
         const profileInput = inputParts.join('\n');
         
+        const _bioProfileGraphStart = Date.now();
         const result = await graphs.profile.invoke({
           userId: context.userId,
           operationMode: 'write' as const,
           input: profileInput,
           forceUpdate: true,
         });
+        const _bioProfileGraphMs = Date.now() - _bioProfileGraphStart;
         if (result.error) {
           return error(result.error);
         }
@@ -270,11 +279,13 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
               skills: result.profile.attributes.skills,
               interests: result.profile.attributes.interests,
             },
+            _graphTimings: [{ name: 'profile', durationMs: _bioProfileGraphMs, agents: result.agentTimings ?? [] }],
           });
         }
         return success({
           created: true,
           message: "Profile created/updated with the information you provided.",
+          _graphTimings: [{ name: 'profile', durationMs: _bioProfileGraphMs, agents: result.agentTimings ?? [] }],
         });
       }
 
@@ -297,11 +308,13 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
       }
 
       // Invoke profile graph in generate mode (uses user table data + Parallels searchUser)
+      const _generateProfileGraphStart = Date.now();
       const result = await graphs.profile.invoke({
         userId: context.userId,
         operationMode: 'generate' as const,
         forceUpdate: true,
       });
+      const _generateProfileGraphMs = Date.now() - _generateProfileGraphStart;
 
       // If user info is insufficient, ask conversationally
       if (result.needsUserInfo) {
@@ -326,6 +339,7 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
             skills: result.profile.attributes.skills,
             interests: result.profile.attributes.interests,
           },
+          _graphTimings: [{ name: 'profile', durationMs: _generateProfileGraphMs, agents: result.agentTimings ?? [] }],
         });
       }
 
@@ -344,7 +358,9 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
     }),
     handler: async ({ context, query }) => {
       // Use profileGraph query mode to validate profile existence and get id
+      const _updateQueryProfileGraphStart = Date.now();
       const queryResult = await graphs.profile.invoke({ userId: context.userId, operationMode: 'query' as const });
+      const _updateQueryProfileGraphMs = Date.now() - _updateQueryProfileGraphStart;
       if (!queryResult.readResult?.hasProfile && !queryResult.profile) {
         return error("You don't have a profile yet. Use create_user_profile first.");
       }
@@ -360,13 +376,21 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
       }
 
       // Execute update directly
+      const _updateWriteProfileGraphStart = Date.now();
       await graphs.profile.invoke({
         userId: context.userId,
         operationMode: "write",
         input: inputForProfile,
         forceUpdate: true,
       });
-      return success({ message: "Profile updated." });
+      const _updateWriteProfileGraphMs = Date.now() - _updateWriteProfileGraphStart;
+      return success({
+        message: "Profile updated.",
+        _graphTimings: [
+          { name: 'profile', durationMs: _updateQueryProfileGraphMs, agents: queryResult.agentTimings ?? [] },
+          { name: 'profile', durationMs: _updateWriteProfileGraphMs, agents: [] },
+        ],
+      });
     },
   });
 

--- a/protocol/src/types/chat-streaming.types.ts
+++ b/protocol/src/types/chat-streaming.types.ts
@@ -296,7 +296,9 @@ export interface DebugMetaStep {
  * One agent invocation recorded inside a graph run.
  */
 export interface DebugMetaAgent {
+  /** Name of the agent (e.g. "opportunity.evaluator"). */
   name: string;
+  /** Wall-clock milliseconds for this agent invocation. */
   durationMs: number;
 }
 
@@ -304,8 +306,11 @@ export interface DebugMetaAgent {
  * One graph invocation recorded by a tool that calls a LangGraph graph.
  */
 export interface DebugMetaGraph {
+  /** Name of the graph (e.g. "opportunity"). */
   name: string;
+  /** Wall-clock milliseconds for the full graph run. */
   durationMs: number;
+  /** Agent invocations recorded inside this graph run. */
   agents: DebugMetaAgent[];
 }
 

--- a/protocol/src/types/chat-streaming.types.ts
+++ b/protocol/src/types/chat-streaming.types.ts
@@ -293,6 +293,23 @@ export interface DebugMetaStep {
 }
 
 /**
+ * One agent invocation recorded inside a graph run.
+ */
+export interface DebugMetaAgent {
+  name: string;
+  durationMs: number;
+}
+
+/**
+ * One graph invocation recorded by a tool that calls a LangGraph graph.
+ */
+export interface DebugMetaGraph {
+  name: string;
+  durationMs: number;
+  agents: DebugMetaAgent[];
+}
+
+/**
  * One tool call entry in debug meta (sanitized args, result summary, optional steps).
  */
 export interface DebugMetaToolCall {
@@ -300,8 +317,12 @@ export interface DebugMetaToolCall {
   args: Record<string, unknown>;
   resultSummary: string;
   success: boolean;
+  /** Wall-clock milliseconds for the full tool execution. */
+  durationMs: number;
   /** Internal steps (subgraphs, subtasks) when the tool reports debugSteps in its result. */
   steps?: DebugMetaStep[];
+  /** LangGraph graphs invoked by this tool, with their agent timings. */
+  graphs?: DebugMetaGraph[];
 }
 
 /**


### PR DESCRIPTION
## Summary

- Extends `debugMeta` (returned by `/debug/chat/:sessionId`) with wall-clock `durationMs` at three levels: tool call → graph invoked by tool → agent invoked inside graph
- Adds `DebugMetaAgent` and `DebugMetaGraph` types; adds `durationMs` (required) and `graphs?` to `DebugMetaToolCall`
- All 6 LangGraph graphs (opportunity, intent, intent_index, profile, hyde, home) now accumulate `agentTimings` in state and return it from instrumented nodes
- All 4 tool files return `_graphTimings` which `chat.agent.ts` extracts, strips from the LLM-visible result, and attaches to debug meta

## New debug JSON shape

\`\`\`json
{
  "graph": "agent_loop",
  "iterations": 2,
  "tools": [
    {
      "name": "discover_opportunities",
      "durationMs": 1842,
      "success": true,
      "graphs": [
        {
          "name": "opportunity",
          "durationMs": 1701,
          "agents": [
            { "name": "opportunity.evaluator", "durationMs": 890 }
          ]
        }
      ]
    }
  ]
}
\`\`\`

## Test Plan

- [ ] Run \`cd protocol && npx tsc --noEmit\` — must pass with zero errors
- [ ] Send a chat message that triggers opportunity discovery, then \`curl /debug/chat/:sessionId | jq '.turns[0].debugMeta.tools'\` — verify \`durationMs\` and \`graphs\` are present
- [ ] Confirm \`_graphTimings\` does not appear in any LLM-facing tool result

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Debug metadata now records wall-clock durations at tool, graph, and agent levels, surfacing nested timing arrays in debug output.
  * Tool responses can include per-graph timing summaries (name, duration, agent timings) alongside overall tool duration.
* **Documentation**
  * Added design notes and examples showing the timing propagation from agents → graphs → tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->