### PR TITLE
fix(contacts): ghost user deduplication

### DIFF
--- a/protocol/src/adapters/database.adapter.ts
+++ b/protocol/src/adapters/database.adapter.ts
@@ -2638,20 +2638,48 @@ export class ChatDatabaseAdapter {
    * @returns The created ghost user's ID
    */
   async createGhostUser(data: { name: string; email: string }): Promise<{ id: string }> {
+    const email = data.email.toLowerCase().trim();
+
+    // Check existing user by email
+    const byEmail = await db.select({ id: schema.users.id })
+      .from(schema.users)
+      .where(eq(schema.users.email, email))
+      .limit(1)
+      .then(r => r[0]);
+    if (byEmail) return byEmail;
+
+    // Check existing ghost by name
+    const byName = await db.select({ id: schema.users.id })
+      .from(schema.users)
+      .where(and(
+        eq(sql`lower(${schema.users.name})`, data.name.toLowerCase()),
+        eq(schema.users.isGhost, true),
+        isNull(schema.users.deletedAt)
+      ))
+      .limit(1)
+      .then(r => r[0]);
+    if (byName) return byName;
+
     const id = crypto.randomUUID();
     await db.insert(schema.users).values({
       id,
       name: data.name,
-      email: data.email,
+      email,
       isGhost: true,
-    });
+    }).onConflictDoNothing({ target: schema.users.email });
 
-    // Create empty profile
+    // Re-query to handle race conditions
+    const [row] = await db.select({ id: schema.users.id })
+      .from(schema.users)
+      .where(eq(schema.users.email, email));
+
+    const actualId = row?.id ?? id;
+
     await db.insert(schema.userProfiles).values({
-      userId: id,
-    });
+      userId: actualId,
+    }).onConflictDoNothing({ target: schema.userProfiles.userId });
 
-    return { id };
+    return { id: actualId };
   }
 
   /**
@@ -2951,6 +2979,23 @@ export class ChatDatabaseAdapter {
   }
 
   /**
+   * Bulk lookup ghost users by name (case-insensitive, non-deleted only).
+   * @param names - Array of names to search for
+   * @returns Array of matching ghost user records
+   */
+  async getGhostUsersByNames(names: string[]): Promise<Array<{ id: string; name: string; email: string }>> {
+    if (names.length === 0) return [];
+    return db
+      .select({ id: schema.users.id, name: schema.users.name, email: schema.users.email })
+      .from(schema.users)
+      .where(and(
+        inArray(sql`lower(${schema.users.name})`, names.map(n => n.toLowerCase())),
+        eq(schema.users.isGhost, true),
+        isNull(schema.users.deletedAt)
+      ));
+  }
+
+  /**
    * Bulk create ghost users with empty profiles.
    * @param data - Array of {name, email} for ghost users
    * @returns Array of created ghost users with their IDs
@@ -2960,15 +3005,14 @@ export class ChatDatabaseAdapter {
 
     const results: Array<{ id: string; name: string; email: string }> = [];
 
-    // Create users
     const usersToInsert = data.map(d => ({
       id: crypto.randomUUID(),
       name: d.name,
-      email: d.email,
+      email: d.email.toLowerCase().trim(),
       isGhost: true,
     }));
 
-    await db.insert(schema.users).values(usersToInsert).onConflictDoNothing();
+    await db.insert(schema.users).values(usersToInsert).onConflictDoNothing({ target: schema.users.email });
 
     // Re-query to find which users actually exist (created now vs already existed)
     const insertedEmails = new Set(usersToInsert.map(u => u.email));
@@ -3057,11 +3101,11 @@ export class ChatDatabaseAdapter {
         const usersToInsert = ghosts.map(d => ({
           id: crypto.randomUUID(),
           name: d.name,
-          email: d.email,
+          email: d.email.toLowerCase().trim(),
           isGhost: true,
         }));
 
-        await tx.insert(schema.users).values(usersToInsert).onConflictDoNothing();
+        await tx.insert(schema.users).values(usersToInsert).onConflictDoNothing({ target: schema.users.email });
 
         const insertedEmails = new Set(usersToInsert.map(u => u.email));
         const existingAfterInsert = await tx

--- a/protocol/src/lib/protocol/interfaces/database.interface.ts
+++ b/protocol/src/lib/protocol/interfaces/database.interface.ts
@@ -1153,6 +1153,9 @@ export interface Database {
   /** Create a ghost user (unregistered contact) with empty profile. */
   createGhostUser(data: { name: string; email: string }): Promise<{ id: string }>;
 
+  /** Bulk lookup ghost users by name (case-insensitive, non-deleted only). */
+  getGhostUsersByNames(names: string[]): Promise<Array<{ id: string; name: string; email: string }>>;
+
   /** Upsert a contact (idempotent; unique constraint on ownerId+userId). */
   upsertContact(data: { ownerId: string; userId: string; source: 'gmail' | 'google_calendar' | 'manual' }): Promise<void>;
 

--- a/protocol/src/services/contact.service.ts
+++ b/protocol/src/services/contact.service.ts
@@ -182,10 +182,25 @@ export class ContactService {
     const softDeletedEmails = await this.db.getSoftDeletedGhostEmails(emails);
     const softDeletedSet = new Set(softDeletedEmails.map(e => e.toLowerCase()));
 
-    // Identify contacts that need ghost users (excluding soft-deleted ghosts)
+    // Contacts not matched by email and not soft-deleted
+    const unmatchedContacts = validContacts.filter(
+      c => !existingByEmail.has(c.email) && !softDeletedSet.has(c.email)
+    );
+
+    // Name-based ghost dedup: reuse existing ghost if same name exists
+    const unmatchedNames = [...new Set(unmatchedContacts.map(c => c.name))];
+    const ghostsByName = await this.db.getGhostUsersByNames(unmatchedNames);
+    const ghostByName = new Map(ghostsByName.map(g => [g.name.toLowerCase(), g]));
+
     const needGhosts: Array<{ name: string; email: string }> = [];
-    for (const contact of validContacts) {
-      if (!existingByEmail.has(contact.email) && !softDeletedSet.has(contact.email)) {
+    for (const contact of unmatchedContacts) {
+      const existingGhost = ghostByName.get(contact.name.toLowerCase());
+      if (existingGhost) {
+        existingByEmail.set(contact.email, {
+          id: existingGhost.id, email: existingGhost.email,
+          name: existingGhost.name, isGhost: true,
+        });
+      } else {
         needGhosts.push(contact);
       }
     }


### PR DESCRIPTION
## Bug Fixes

- **Name-based ghost dedup**: before creating a new ghost user, check if a ghost with the same name already exists and reuse it instead of creating a duplicate
- **Fix `onConflictDoNothing` target**: was targeting primary key (`id`) instead of `email`, so email-based conflict detection never fired — ghost users with the same email could be inserted as duplicates
- **Lowercase emails**: normalize emails to lowercase in all ghost creation paths (`createGhostUser`, `createGhostUsersBulk`, `importContactsBulk`) to prevent case-sensitive duplicates
- **Idempotent `createGhostUser`**: standalone method now does find-or-create (check email, then name) instead of raw insert that throws on duplicates

## New Features

- Add `getGhostUsersByNames` bulk lookup query to database adapter and interface for name-based ghost dedup

Closes IND-155

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed race condition issues in ghost user creation for more reliable operations
  * Improved duplicate detection for ghost users during contact processing to prevent unintended duplicates
  * Enhanced email handling consistency across ghost user operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->