### PR TITLE
fix(chat): detect and reject hallucinated opportunity blocks

### DIFF
--- a/frontend/src/contexts/AIChatContext.tsx
+++ b/frontend/src/contexts/AIChatContext.tsx
@@ -341,6 +341,17 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
                       ),
                     );
                     break;
+                  case "response_reset":
+                    // Discard all previously streamed tokens — the agent detected
+                    // hallucinated code blocks and is forcing a correction iteration.
+                    setMessages((prev) =>
+                      prev.map((msg) =>
+                        msg.id === assistantMessageId
+                          ? { ...msg, content: "" }
+                          : msg,
+                      ),
+                    );
+                    break;
                   case "llm_end": {
                     const llmEndEvent: TraceEvent = {
                       type: "llm_end",

--- a/protocol/src/lib/protocol/agents/chat.agent.ts
+++ b/protocol/src/lib/protocol/agents/chat.agent.ts
@@ -61,6 +61,7 @@ export type AgentStreamEvent =
       summary?: string;
       steps?: Array<{ step: string; detail?: string; data?: Record<string, unknown> }>;
     }
+  | { type: "response_reset"; reason: string }
   | { type: "graph_start"; name: string }
   | { type: "graph_end"; name: string; durationMs: number }
   | { type: "agent_start"; name: string }
@@ -412,10 +413,13 @@ export class ChatAgent {
     text: string,
     toolsUsed: Array<{ name: string; success: boolean }>,
   ): { type: string; tool: string; description: string } | null {
-    // Only trust successful create_intent calls — a failed attempt doesn't produce
-    // a valid proposalId, so a subsequent inline block is still hallucinated.
+    // Only trust successful tool calls — a failed attempt doesn't produce
+    // a valid proposalId / data, so a subsequent inline block is still hallucinated.
     const hasSuccessfulCreateIntent = toolsUsed.some(
       (t) => t.name === "create_intent" && t.success,
+    );
+    const hasSuccessfulCreateOpportunities = toolsUsed.some(
+      (t) => t.name === "create_opportunities" && t.success,
     );
 
     // Check for hallucinated intent_proposal
@@ -426,7 +430,52 @@ export class ChatAgent {
       }
     }
 
+    // Check for hallucinated opportunity blocks
+    if (text.includes("```opportunity") && !hasSuccessfulCreateOpportunities) {
+      // Extract a search query from the hallucinated block for the correction call
+      const nameMatch = text.match(/```opportunity\s*\n\s*\{[^}]*"name"\s*:\s*"([^"]+)"/);
+      const reasoningMatch = text.match(/```opportunity\s*\n\s*\{[^}]*"reasoning"\s*:\s*"([^"]+)"/);
+      const description = nameMatch?.[1] || reasoningMatch?.[1] || "find connections";
+      return { type: "opportunity", tool: "create_opportunities", description };
+    }
+
     return null;
+  }
+
+  /**
+   * Strip ```opportunity and ```intent_proposal code blocks from text
+   * when no corresponding successful tool call was made.
+   * Defense-in-depth: catches hallucinated blocks that slip past detectHallucinatedBlock
+   * (e.g. after a correction iteration that still hallucinates).
+   *
+   * @param text - The response text to sanitize
+   * @param toolsUsed - Tool call records from the agent loop
+   * @returns Sanitized text with unbacked blocks removed
+   */
+  private stripUnbackedBlocks(
+    text: string,
+    toolsUsed: Array<{ name: string; success: boolean }>,
+  ): string {
+    let result = text;
+
+    const hasSuccessfulCreateOpportunities = toolsUsed.some(
+      (t) => t.name === "create_opportunities" && t.success,
+    );
+    const hasSuccessfulCreateIntent = toolsUsed.some(
+      (t) => t.name === "create_intent" && t.success,
+    );
+
+    if (!hasSuccessfulCreateOpportunities && result.includes("```opportunity")) {
+      result = result.replace(/```opportunity\s*\n[\s\S]*?```/g, "");
+    }
+    if (!hasSuccessfulCreateIntent && result.includes("```intent_proposal")) {
+      result = result.replace(/```intent_proposal\s*\n[\s\S]*?```/g, "");
+    }
+
+    // Clean up leftover double blank lines from block removal
+    result = result.replace(/\n{3,}/g, "\n\n").trim();
+
+    return result;
   }
 
   /**
@@ -806,13 +855,20 @@ export class ChatAgent {
           blockType: hallucinatedBlock.type,
           extractedDescription: hallucinatedBlock.description,
         });
+        // Tell the frontend to discard all streamed tokens from this iteration
+        emit({ type: "response_reset", reason: `Hallucinated ${hallucinatedBlock.type} block detected` });
+
+        const correctionHint = hallucinatedBlock.type === "opportunity"
+          ? `You MUST call ${hallucinatedBlock.tool}(searchQuery="${hallucinatedBlock.description}") now.`
+          : `You MUST call ${hallucinatedBlock.tool}(description="${hallucinatedBlock.description}") now.`;
+
         messages = [
           ...messages,
           accumulated,
           new SystemMessage(
             `CORRECTION: You wrote a \`\`\`${hallucinatedBlock.type} block in your response without calling the required tool. ` +
-            `That block is INVALID — it has no proposalId and will not work. ` +
-            `You MUST call ${hallucinatedBlock.tool}(description="${hallucinatedBlock.description}") now. ` +
+            `That block is INVALID — it contains fabricated data and will not work. ` +
+            `${correctionHint} ` +
             `Only the tool generates valid blocks. Do NOT write the block yourself again.`
           ),
         ];
@@ -821,15 +877,30 @@ export class ChatAgent {
       }
 
       // ── Final response already streamed ─────────────────────────────
+      // Defense-in-depth: strip any code blocks that require tool backing
+      // but slipped through without a successful tool call.
+      const sanitizedText = this.stripUnbackedBlocks(iterationText, toolsDebug);
+      if (sanitizedText !== iterationText) {
+        logger.warn("Streaming: stripped unbacked code blocks from final response", {
+          originalLength: iterationText.length,
+          sanitizedLength: sanitizedText.length,
+        });
+        emit({ type: "response_reset", reason: "Sanitized unbacked blocks from response" });
+        // Re-emit the sanitized text so the frontend displays clean content
+        if (sanitizedText.trim()) {
+          emit({ type: "text_chunk", content: sanitizedText });
+        }
+      }
+
       logger.verbose("Streaming: agent produced response", {
         iteration: iterationCount,
-        responseLength: iterationText.length,
+        responseLength: sanitizedText.length,
       });
       messages = [...messages, accumulated];
       iterationCount++;
 
       return {
-        responseText: iterationText,
+        responseText: sanitizedText,
         messages,
         iterationCount,
         debugMeta: { graph: "agent_loop", iterations: iterationCount, tools: toolsDebug },

--- a/protocol/src/lib/protocol/agents/chat.agent.ts
+++ b/protocol/src/lib/protocol/agents/chat.agent.ts
@@ -457,6 +457,7 @@ export class ChatAgent {
     toolsUsed: Array<{ name: string; success: boolean }>,
   ): string {
     let result = text;
+    let removedBlock = false;
 
     const hasSuccessfulCreateOpportunities = toolsUsed.some(
       (t) => t.name === "create_opportunities" && t.success,
@@ -466,14 +467,20 @@ export class ChatAgent {
     );
 
     if (!hasSuccessfulCreateOpportunities && result.includes("```opportunity")) {
-      result = result.replace(/```opportunity\s*\n[\s\S]*?```/g, "");
+      const next = result.replace(/```opportunity\s*\n[\s\S]*?```/g, "");
+      removedBlock ||= next !== result;
+      result = next;
     }
     if (!hasSuccessfulCreateIntent && result.includes("```intent_proposal")) {
-      result = result.replace(/```intent_proposal\s*\n[\s\S]*?```/g, "");
+      const next = result.replace(/```intent_proposal\s*\n[\s\S]*?```/g, "");
+      removedBlock ||= next !== result;
+      result = next;
     }
 
-    // Clean up leftover double blank lines from block removal
-    result = result.replace(/\n{3,}/g, "\n\n").trim();
+    // Clean up leftover double blank lines only when a block was actually removed
+    if (removedBlock) {
+      result = result.replace(/\n{3,}/g, "\n\n").trim();
+    }
 
     return result;
   }

--- a/protocol/src/lib/protocol/streamers/chat.streamer.ts
+++ b/protocol/src/lib/protocol/streamers/chat.streamer.ts
@@ -17,6 +17,7 @@ import {
   createLlmStartEvent,
   createLlmEndEvent,
   createResponseCompleteEvent,
+  createResponseResetEvent,
   createStatusEvent,
   createTokenEvent,
   createToolActivityEvent,
@@ -194,6 +195,10 @@ export class ChatStreamer {
 
           if (event.type === "text_chunk" && event.content) {
             yield createTokenEvent(sessionId, event.content);
+          }
+
+          if (event.type === "response_reset") {
+            yield createResponseResetEvent(sessionId, event.reason);
           }
 
           if (event.type === "llm_end") {

--- a/protocol/src/types/chat-streaming.types.ts
+++ b/protocol/src/types/chat-streaming.types.ts
@@ -27,6 +27,7 @@ export type ChatStreamEventType =
   | "llm_end"
   // Internal response tracking events
   | "response_complete"
+  | "response_reset"
   // Debug meta (per-turn graph/tool usage for copy debug)
   | "debug_meta"
   | "graph_start"
@@ -287,6 +288,16 @@ export interface ResponseCompleteEvent extends ChatStreamEventBase {
 }
 
 /**
+ * Response reset event — tells the frontend to discard all previously streamed tokens.
+ * Emitted when the agent detects hallucinated code blocks and forces a correction iteration.
+ */
+export interface ResponseResetEvent extends ChatStreamEventBase {
+  type: "response_reset";
+  /** Human-readable reason for the reset */
+  reason: string;
+}
+
+/**
  * One internal step reported by a tool for debug visibility (e.g. subgraph, subtask).
  */
 export interface DebugMetaStep {
@@ -396,6 +407,7 @@ export type ChatStreamEvent =
   | LlmEndEvent
   // Internal response tracking events
   | ResponseCompleteEvent
+  | ResponseResetEvent
   // Debug meta
   | DebugMetaEvent
   // Trace hierarchy events
@@ -708,6 +720,17 @@ export function createResponseCompleteEvent(
   response: string,
 ): ResponseCompleteEvent {
   return createStreamEvent<ResponseCompleteEvent>("response_complete", sessionId, { response });
+}
+
+/**
+ * Creates a formatted response reset event.
+ * Tells the frontend to discard all previously streamed tokens.
+ */
+export function createResponseResetEvent(
+  sessionId: string,
+  reason: string,
+): ResponseResetEvent {
+  return createStreamEvent<ResponseResetEvent>("response_reset", sessionId, { reason });
 }
 
 // ════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- **Critical bug**: The chat agent could skip tool calls and directly generate fake `opportunity` code blocks with fabricated UUIDs, names, and profiles. The existing hallucination detection only caught `intent_proposal` blocks — opportunity blocks had zero detection.
- Adds three-layer defense: detection + correction iteration, streaming `response_reset` event, and defense-in-depth sanitization of the final response text.

## Bug Fixes
- Extend `detectHallucinatedBlock` to detect `opportunity` blocks when no successful `create_opportunities` tool call was made, forcing a correction iteration
- Add `response_reset` SSE event so the frontend discards already-streamed hallucinated tokens before the correction iteration re-streams real data
- Add `stripUnbackedBlocks` defense-in-depth: sanitizes final `responseText` to remove any `opportunity` or `intent_proposal` code blocks not backed by a successful tool call

## Files Changed
- `protocol/src/lib/protocol/agents/chat.agent.ts` — opportunity block detection, `response_reset` emission, `stripUnbackedBlocks` sanitizer
- `protocol/src/types/chat-streaming.types.ts` — `ResponseResetEvent` type + creator function
- `protocol/src/lib/protocol/streamers/chat.streamer.ts` — forwards `response_reset` events to SSE stream
- `frontend/src/contexts/AIChatContext.tsx` — handles `response_reset` by clearing accumulated `msg.content`

## Test plan
- [x] `tsc --noEmit` passes (protocol)
- [x] `bun test chat.graph.streaming.spec.ts` — 5/5 pass
- [x] `bun test chat.graph.spec.ts` — 3/3 pass
- [ ] Manual test: send a discovery query ("Any 3D artists around?") and verify the agent calls `create_opportunities` tool instead of hallucinating blocks
- [ ] Manual test: verify `response_reset` clears streamed content if hallucination detected mid-stream

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added response reset capability to correct and re-stream responses when issues are detected.

* **Bug Fixes**
  * Enhanced detection of fabricated content blocks that lack proper validation.
  * Automatic removal and correction of unbacked content from final responses before delivery to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->