### PR TITLE
fix: empty discover page when all opportunities are draft or expired

### DIFF
--- a/docs/plans/2026-03-17-contacts-simplification-design.md
+++ b/docs/plans/2026-03-17-contacts-simplification-design.md
@@ -1,0 +1,138 @@
+# Contacts Simplification Design
+
+## Problem
+
+Contacts are tracked in two parallel systems: a `user_contacts` table and `index_members` rows with `'contact'` permission on personal indexes. This duplication adds complexity with no benefit. The ghost user claim flow is also unnecessarily complex — creating a new user, transferring all data, then deleting the ghost.
+
+## Design
+
+### Core Primitive: `addContact(email, { restore? })`
+
+Single entry point for all contact creation. Handles both ghost and real users.
+
+```typescript
+addContact(
+  ownerId: string,
+  email: string,
+  options?: { name?: string; restore?: boolean }
+): Promise<ContactResult>
+```
+
+**Flow:**
+
+1. Look up email in `users` table
+2. If not found, create ghost user via Better Auth adapter (with `isGhost: true`)
+3. Get owner's personal index ID
+4. Upsert `index_members` row with `permissions: ['contact']`, `autoAssign: false`
+   - If `restore: true` — set `deletedAt = null` (reactivates soft-deleted memberships)
+   - If `restore: false` (default) — skip if soft-deleted row exists
+5. Side effect: if the contact has a personal index where the owner is soft-deleted, hard-delete that row (clears reverse opt-out)
+6. If ghost was newly created, enqueue `ghost.enrich` job
+7. Return `{ userId, isNew, isGhost }`
+
+**Callers:**
+
+- `importContacts` — bulk orchestrator, delegates to `addContact` for each valid contact
+- `opportunity.service.ts` — on opportunity acceptance, calls `addContact(email, { restore: true })`
+- Chat tools — `add_contact`, `import_contacts`
+
+### `importContacts` Changes
+
+Keeps its bulk filtering/dedup responsibilities:
+
+1. Normalize, filter non-human emails, deduplicate
+2. Check for soft-deleted ghosts (opted-out contacts — skip them)
+3. Bulk resolve existing users by email
+4. Bulk create ghosts for unknown emails
+5. For each valid contact — call the same adapter method `addContact` uses (upsert `index_members` with `'contact'` permission), batched for performance
+6. Enqueue enrichment for newly created ghosts
+7. Return `ImportResult`
+
+### Contact Removal
+
+Two deletion paths:
+
+| Action | Type | Restorable by |
+|--------|------|---------------|
+| `removeContact(ownerId, contactUserId)` — owner removes contact | Hard delete | Re-import or `addContact` |
+| Email opt-out — ghost clicks unsubscribe | Soft delete (`deletedAt`) | Only `addContact({ restore: true })` from opportunity acceptance |
+
+Note: `removeContact` signature changes from `(ownerId, contactId)` to `(ownerId, contactUserId)` — no separate contact record ID.
+
+### Contacts Are One-Way
+
+If User B is a contact of User A, it does not make User A a contact of User B.
+
+### Ghost User Simplification
+
+**Ghost creation** — ghosts are created through Better Auth's adapter like normal users, with `isGhost: true`. No separate ghost creation code path.
+
+**Ghost claim on signup** — handled by a custom `create` override in the Drizzle adapter:
+
+```sql
+INSERT INTO users (...) VALUES (...)
+ON CONFLICT (email) DO UPDATE SET
+  isGhost = false,
+  name = EXCLUDED.name,
+  avatar = EXCLUDED.avatar,
+  updatedAt = now()
+WHERE users.isGhost = true
+RETURNING *
+```
+
+- `WHERE users.isGhost = true` ensures only ghosts are upserted, not real users
+- `.returning()` gives Better Auth the ghost's original ID
+- Session is created for the correct user
+- All existing data (index memberships, intents, profiles, HyDE docs) already references that ID — no data transfer needed
+
+**Eliminated:**
+
+- `prepareGhostClaim()`
+- `claimGhostUser()`
+- `restoreGhostEmail()`
+- `pendingGhostClaims` map
+- `AuthDbContract` ghost claim methods
+
+### Migration
+
+Single migration that:
+
+1. Deletes all rows referencing ghost user IDs from: `opportunities` (actors), `user_profiles`, `index_members`, `intents`, `intent_indexes`, `hyde_documents`, `chat_sessions`, `chat_messages`, `chat_message_metadata`, `chat_session_metadata`
+2. Deletes all ghost user rows (`WHERE isGhost = true`)
+3. Drops `user_contacts` table
+4. Drops `contactSourceEnum`
+
+## Changes Summary
+
+**Drop:**
+
+- `user_contacts` table (migration)
+- `contactSourceEnum` from schema
+- `prepareGhostClaim`, `claimGhostUser`, `restoreGhostEmail` from `auth.adapter.ts`
+- `pendingGhostClaims` map from `betterauth.ts`
+- `AuthDbContract` ghost claim methods
+- All existing ghost users and their data (migration)
+
+**Modify:**
+
+- `ContactService` — `addContact(email, { restore? })` as core primitive; `importContacts` delegates to it; `removeContact` hard-deletes `index_members`
+- Drizzle adapter for Better Auth — custom `create` for `user` model with `onConflictDoUpdate` on email
+- Ghost creation — via Better Auth adapter instead of manual inserts
+- `opportunity.service.ts` — calls `addContact(email, { restore: true })` on acceptance
+- `UnsubscribeController` — opt-out soft-deletes `index_members` row
+- Chat tools (`contact.tools.ts`) — updated signatures
+- Integration tools (`integration.tools.ts`) — Gmail import uses updated `importContacts`
+- `database.adapter.ts` — remove `user_contacts` methods, add/update `index_members` contact methods
+
+**Tests:**
+
+- `addContact` — creates ghost via Better Auth, adds to personal index
+- `addContact` — finds existing real user, adds to personal index
+- `addContact({ restore: true })` — restores soft-deleted membership
+- `addContact({ restore: false })` — skips soft-deleted membership
+- `addContact` — clears reverse opt-out when adding back
+- `importContacts` — bulk flow with filtering, dedup, delegation to `addContact`
+- Ghost claim via adapter upsert — signup with ghost email reuses ghost row
+- Ghost claim — existing data (index memberships, intents, profiles) stays intact
+- `removeContact` — hard deletes `index_members` row
+- Email opt-out — soft deletes `index_members` row

--- a/docs/plans/2026-03-17-contacts-simplification.md
+++ b/docs/plans/2026-03-17-contacts-simplification.md
@@ -1,0 +1,1471 @@
+# Contacts Simplification Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the dual contact storage system (`user_contacts` table + `index_members` with `'contact'` permission) with a single `index_members`-based approach, and simplify the ghost user claim flow to use adapter-level upsert instead of data transfer.
+
+**Architecture:** `addContact(email)` becomes the single primitive — finds or creates a user (ghost or real), upserts an `index_members` row with `'contact'` permission on the owner's personal index. Ghost users are created via Better Auth's adapter. Ghost claim on signup is handled by `onConflictDoUpdate` in the Drizzle adapter's `create` method, eliminating the `prepareGhostClaim`/`claimGhostUser` flow.
+
+**Tech Stack:** Bun, Drizzle ORM, PostgreSQL, Better Auth, BullMQ
+
+**Design doc:** `docs/plans/2026-03-17-contacts-simplification-design.md`
+
+---
+
+### Task 1: Migration — Drop Ghost Data and `user_contacts` Table
+
+**Files:**
+- Create: `protocol/drizzle/0017_drop_ghost_users_and_user_contacts.sql`
+- Modify: `protocol/drizzle/meta/_journal.json` (add entry for 0017)
+
+**Step 1: Write the migration SQL**
+
+Create `protocol/drizzle/0017_drop_ghost_users_and_user_contacts.sql`:
+
+```sql
+-- Step 1: Collect ghost user IDs
+CREATE TEMP TABLE ghost_ids AS
+SELECT id FROM "users" WHERE "is_ghost" = true;
+
+-- Step 2: Delete all rows referencing ghost users
+DELETE FROM "chat_message_metadata" WHERE "message_id" IN (
+  SELECT "id" FROM "chat_messages" WHERE "session_id" IN (
+    SELECT "id" FROM "chat_sessions" WHERE "user_id" IN (SELECT id FROM ghost_ids)
+  )
+);
+DELETE FROM "chat_messages" WHERE "session_id" IN (
+  SELECT "id" FROM "chat_sessions" WHERE "user_id" IN (SELECT id FROM ghost_ids)
+);
+DELETE FROM "chat_session_metadata" WHERE "session_id" IN (
+  SELECT "id" FROM "chat_sessions" WHERE "user_id" IN (SELECT id FROM ghost_ids)
+);
+DELETE FROM "chat_sessions" WHERE "user_id" IN (SELECT id FROM ghost_ids);
+DELETE FROM "intent_indexes" WHERE "intent_id" IN (
+  SELECT "id" FROM "intents" WHERE "user_id" IN (SELECT id FROM ghost_ids)
+);
+DELETE FROM "intents" WHERE "user_id" IN (SELECT id FROM ghost_ids);
+DELETE FROM "index_members" WHERE "user_id" IN (SELECT id FROM ghost_ids);
+DELETE FROM "hyde_documents" WHERE "source_id" IN (SELECT id FROM ghost_ids);
+DELETE FROM "user_profiles" WHERE "user_id" IN (SELECT id FROM ghost_ids);
+DELETE FROM "user_notification_settings" WHERE "user_id" IN (SELECT id FROM ghost_ids);
+DELETE FROM "opportunities" WHERE "id" IN (
+  SELECT "id" FROM "opportunities" WHERE EXISTS (
+    SELECT 1 FROM jsonb_array_elements("actors") AS actor
+    WHERE actor->>'userId' IN (SELECT id FROM ghost_ids)
+  )
+);
+
+-- Step 3: Delete ghost users
+DELETE FROM "users" WHERE "is_ghost" = true;
+
+-- Step 4: Drop user_contacts table
+DROP TABLE IF EXISTS "user_contacts";
+
+-- Step 5: Drop contact source enum
+DROP TYPE IF EXISTS "contact_source";
+
+-- Cleanup
+DROP TABLE IF EXISTS ghost_ids;
+```
+
+**Step 2: Update the journal**
+
+Add the entry in `protocol/drizzle/meta/_journal.json` for migration `0017` with tag `0017_drop_ghost_users_and_user_contacts`.
+
+**Step 3: Run the migration**
+
+Run: `cd protocol && bun run db:migrate`
+Expected: Migration applies successfully.
+
+**Step 4: Verify no schema diff**
+
+Run: `cd protocol && bun run db:generate`
+Expected: Reports schema changes (because we haven't updated the schema file yet — that's Task 2).
+
+**Step 5: Commit**
+
+```bash
+git add protocol/drizzle/0017_drop_ghost_users_and_user_contacts.sql protocol/drizzle/meta/_journal.json
+git commit -m "feat(db): migration to drop ghost user data and user_contacts table"
+```
+
+---
+
+### Task 2: Update Database Schema — Remove `user_contacts`
+
+**Files:**
+- Modify: `protocol/src/schemas/database.schema.ts:437-438,581-608,638-640`
+
+**Step 1: Remove `contactSourceEnum`, `userContacts` table, `userContactsRelations`, and type exports**
+
+In `protocol/src/schemas/database.schema.ts`:
+
+1. Remove `contactSourceEnum` (line 581)
+2. Remove `userContacts` table definition (lines 583-595)
+3. Remove `userContactsRelations` (lines 597-608)
+4. Remove type exports `UserContact`, `NewUserContact`, `ContactSource` (lines 638-640)
+5. Remove `ownedContacts` and `contactOf` relation references from `usersRelations` (lines 437-438)
+
+**Step 2: Verify schema generates clean**
+
+Run: `cd protocol && bun run db:generate`
+Expected: "No schema changes" (migration already dropped the table).
+
+**Step 3: Fix any import errors**
+
+Run: `cd protocol && npx tsc --noEmit`
+Expected: Type errors in files that import `ContactSource`, `UserContact`, etc. — these will be fixed in subsequent tasks.
+
+**Step 4: Commit**
+
+```bash
+git add protocol/src/schemas/database.schema.ts
+git commit -m "feat(schema): remove user_contacts table and contactSourceEnum"
+```
+
+---
+
+### Task 3: Simplify Ghost Claim — Adapter-Level Upsert
+
+**Files:**
+- Modify: `protocol/src/adapters/auth.adapter.ts:35-91`
+- Modify: `protocol/src/lib/betterauth/betterauth.ts:12-19,44,63-101`
+- Test: `protocol/src/adapters/tests/auth.adapter.spec.ts` (create new)
+
+**Step 1: Write the failing test for ghost claim via upsert**
+
+Create `protocol/src/adapters/tests/auth.adapter.spec.ts`:
+
+```typescript
+import { loadEnv } from '../../lib/env';
+loadEnv();
+
+import { describe, it, expect, afterAll } from 'bun:test';
+import { db } from '../../lib/drizzle/drizzle';
+import * as schema from '../../schemas/database.schema';
+import { eq } from 'drizzle-orm';
+import { AuthDatabaseAdapter } from '../auth.adapter';
+
+describe('AuthDatabaseAdapter', () => {
+  const adapter = new AuthDatabaseAdapter();
+  const testIds: string[] = [];
+
+  afterAll(async () => {
+    for (const id of testIds) {
+      await db.delete(schema.users).where(eq(schema.users.id, id));
+    }
+  });
+
+  describe('ghost claim via adapter upsert', () => {
+    it('should create a ghost user normally', async () => {
+      const ghostId = crypto.randomUUID();
+      testIds.push(ghostId);
+
+      const drizzleAdapter = adapter.createDrizzleAdapter();
+      const adapterFn = typeof drizzleAdapter === 'function'
+        ? drizzleAdapter({} as any)
+        : drizzleAdapter;
+
+      await (adapterFn as any).create({
+        model: 'user',
+        data: {
+          id: ghostId,
+          name: 'Ghost User',
+          email: `ghost-test-${ghostId}@example.com`,
+          isGhost: true,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      });
+
+      const [ghost] = await db.select().from(schema.users).where(eq(schema.users.id, ghostId));
+      expect(ghost).toBeDefined();
+      expect(ghost.isGhost).toBe(true);
+      expect(ghost.name).toBe('Ghost User');
+    });
+
+    it('should convert ghost to real user on email conflict', async () => {
+      // Create ghost first
+      const ghostId = crypto.randomUUID();
+      testIds.push(ghostId);
+      const email = `claim-test-${ghostId}@example.com`;
+
+      await db.insert(schema.users).values({
+        id: ghostId,
+        name: 'Ghost Before',
+        email,
+        isGhost: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      // Simulate Better Auth signup with same email
+      const drizzleAdapter = adapter.createDrizzleAdapter();
+      const adapterFn = typeof drizzleAdapter === 'function'
+        ? drizzleAdapter({} as any)
+        : drizzleAdapter;
+
+      const newId = crypto.randomUUID();
+      // Don't track newId — the upsert should reuse ghostId
+      const result = await (adapterFn as any).create({
+        model: 'user',
+        data: {
+          id: newId,
+          name: 'Real User',
+          email,
+          isGhost: false,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      });
+
+      // Should return the ghost's original ID, not the new one
+      expect(result.id).toBe(ghostId);
+      expect(result.isGhost).toBe(false);
+      expect(result.name).toBe('Real User');
+
+      // New ID should NOT exist
+      const [shouldNotExist] = await db.select().from(schema.users).where(eq(schema.users.id, newId));
+      expect(shouldNotExist).toBeUndefined();
+    });
+
+    it('should not upsert over a real user with same email', async () => {
+      const realId = crypto.randomUUID();
+      testIds.push(realId);
+      const email = `real-test-${realId}@example.com`;
+
+      await db.insert(schema.users).values({
+        id: realId,
+        name: 'Real Existing',
+        email,
+        isGhost: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const drizzleAdapter = adapter.createDrizzleAdapter();
+      const adapterFn = typeof drizzleAdapter === 'function'
+        ? drizzleAdapter({} as any)
+        : drizzleAdapter;
+
+      const newId = crypto.randomUUID();
+      // This should throw or fail — duplicate email on a non-ghost user
+      try {
+        await (adapterFn as any).create({
+          model: 'user',
+          data: {
+            id: newId,
+            name: 'Duplicate',
+            email,
+            isGhost: false,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        });
+        // If it doesn't throw, the original user should be unchanged
+        const [user] = await db.select().from(schema.users).where(eq(schema.users.id, realId));
+        expect(user.name).toBe('Real Existing');
+      } catch (e) {
+        // Expected — unique constraint violation
+        expect(e).toBeDefined();
+      }
+    });
+  });
+}, { timeout: 30_000 });
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd protocol && bun test src/adapters/tests/auth.adapter.spec.ts`
+Expected: FAIL — `createDrizzleAdapter` doesn't have upsert behavior yet.
+
+**Step 3: Modify `AuthDatabaseAdapter.createDrizzleAdapter` to wrap the adapter**
+
+In `protocol/src/adapters/auth.adapter.ts`, replace the current implementation:
+
+```typescript
+import { drizzleAdapter } from 'better-auth/adapters/drizzle';
+import { eq, and, sql } from 'drizzle-orm';
+
+import { db } from '../lib/drizzle/drizzle';
+import * as schema from '../schemas/database.schema';
+import { ensurePersonalIndex } from './database.adapter';
+
+/**
+ * Database adapter for Better Auth integration.
+ * Provides the drizzle adapter config with ghost-claim-via-upsert
+ * and personal index creation hooks.
+ */
+export class AuthDatabaseAdapter {
+  /**
+   * Returns a configured drizzle adapter for Better Auth's `database` option.
+   * Wraps the default adapter to handle ghost user claims via ON CONFLICT:
+   * when a real user signs up with an email that belongs to a ghost,
+   * the ghost row is converted in-place (isGhost=false) instead of
+   * creating a new row and transferring data.
+   */
+  createDrizzleAdapter() {
+    const baseAdapter = drizzleAdapter(db, {
+      provider: 'pg',
+      schema: {
+        ...schema,
+        user: schema.users,
+        session: schema.sessions,
+        account: schema.accounts,
+        verification: schema.verifications,
+        jwks: schema.jwks,
+      },
+    });
+
+    // Wrap the adapter to intercept user creation
+    return (options: any) => {
+      const resolved = typeof baseAdapter === 'function' ? baseAdapter(options) : baseAdapter;
+      const originalCreate = resolved.create.bind(resolved);
+
+      return {
+        ...resolved,
+        create: async (params: { model: string; data: any; [key: string]: any }) => {
+          if (params.model === 'user') {
+            const result = await db
+              .insert(schema.users)
+              .values(params.data)
+              .onConflictDoUpdate({
+                target: schema.users.email,
+                set: {
+                  name: sql`EXCLUDED."name"`,
+                  avatar: sql`EXCLUDED."avatar"`,
+                  isGhost: sql`false`,
+                  updatedAt: sql`now()`,
+                },
+                setWhere: eq(schema.users.isGhost, true),
+              })
+              .returning();
+            return result[0];
+          }
+          return originalCreate(params);
+        },
+      };
+    };
+  }
+
+  /**
+   * Creates a personal index for the user if one doesn't exist.
+   * Idempotent — safe to call on every sign-in.
+   * @param userId - The authenticated user
+   * @returns The personal index ID
+   */
+  async ensurePersonalIndex(userId: string): Promise<string> {
+    return ensurePersonalIndex(userId);
+  }
+}
+```
+
+**Step 4: Simplify `AuthDbContract` and `createAuth`**
+
+In `protocol/src/lib/betterauth/betterauth.ts`:
+
+1. Remove `prepareGhostClaim`, `claimGhostUser`, `restoreGhostEmail` from `AuthDbContract`
+2. Remove `pendingGhostClaims` map
+3. Remove ghost claim logic from `create.before` and `create.after` hooks
+4. Keep `ensurePersonalIndex` in `create.after` and `session.create.after`
+
+Updated `AuthDbContract`:
+
+```typescript
+export interface AuthDbContract {
+  /** Returns a configured adapter object for Better Auth's `database` option. */
+  createDrizzleAdapter(): unknown;
+  ensurePersonalIndex(userId: string): Promise<string>;
+}
+```
+
+Updated `createAuth` — remove lines 44, 63-73, 87-101. The `user.create` hooks become:
+
+```typescript
+user: {
+  create: {
+    after: async (user) => {
+      try {
+        if (ensureWallet) await ensureWallet(user.id);
+      } catch (_) { /* wallet generation failure shouldn't block registration */ }
+
+      try {
+        await authDb.ensurePersonalIndex(user.id);
+      } catch (err) {
+        logger.error('Failed to create personal index on registration', { userId: user.id, error: err });
+      }
+    },
+  },
+},
+```
+
+**Step 5: Run tests to verify they pass**
+
+Run: `cd protocol && bun test src/adapters/tests/auth.adapter.spec.ts`
+Expected: PASS
+
+**Step 6: Run tsc to verify no type errors**
+
+Run: `cd protocol && npx tsc --noEmit`
+Expected: May have errors from removed `AuthDbContract` methods in `main.ts` — fix by removing references.
+
+**Step 7: Commit**
+
+```bash
+git add protocol/src/adapters/auth.adapter.ts protocol/src/lib/betterauth/betterauth.ts protocol/src/adapters/tests/auth.adapter.spec.ts
+git commit -m "feat(auth): simplify ghost claim to adapter-level upsert on email conflict"
+```
+
+---
+
+### Task 4: Rewrite `ContactService` with `addContact` Primitive
+
+**Files:**
+- Modify: `protocol/src/services/contact.service.ts` (full rewrite)
+- Modify: `protocol/src/adapters/database.adapter.ts` (add new methods, remove old)
+- Modify: `protocol/src/lib/protocol/interfaces/database.interface.ts:1156-1178,1594,1672,1696`
+- Test: `protocol/src/services/tests/contact.service.spec.ts` (full rewrite)
+
+**Step 1: Write the failing tests for the new `addContact` primitive**
+
+Rewrite `protocol/src/services/tests/contact.service.spec.ts`:
+
+```typescript
+import { loadEnv } from '../../lib/env';
+loadEnv();
+
+import { describe, it, expect, afterAll, beforeAll } from 'bun:test';
+import { db } from '../../lib/drizzle/drizzle';
+import * as schema from '../../schemas/database.schema';
+import { eq, and, sql } from 'drizzle-orm';
+import { ContactService } from '../contact.service';
+
+describe('ContactService', () => {
+  const service = new ContactService();
+  const testUserIds: string[] = [];
+  const testIndexIds: string[] = [];
+  let ownerId: string;
+  let ownerPersonalIndexId: string;
+
+  beforeAll(async () => {
+    // Create test owner with personal index
+    ownerId = crypto.randomUUID();
+    testUserIds.push(ownerId);
+    await db.insert(schema.users).values({
+      id: ownerId,
+      name: 'Test Owner',
+      email: `owner-${ownerId}@test.com`,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    ownerPersonalIndexId = crypto.randomUUID();
+    testIndexIds.push(ownerPersonalIndexId);
+    await db.insert(schema.indexes).values({
+      id: ownerPersonalIndexId,
+      title: 'Personal',
+      isPersonal: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await db.insert(schema.personalIndexes).values({
+      userId: ownerId,
+      indexId: ownerPersonalIndexId,
+    });
+    await db.insert(schema.indexMembers).values({
+      indexId: ownerPersonalIndexId,
+      userId: ownerId,
+      permissions: ['owner'],
+    });
+  });
+
+  afterAll(async () => {
+    // Cleanup in reverse dependency order
+    for (const indexId of testIndexIds) {
+      await db.delete(schema.indexMembers).where(eq(schema.indexMembers.indexId, indexId));
+      await db.delete(schema.personalIndexes).where(eq(schema.personalIndexes.indexId, indexId));
+      await db.delete(schema.indexes).where(eq(schema.indexes.id, indexId));
+    }
+    for (const userId of testUserIds) {
+      await db.delete(schema.users).where(eq(schema.users.id, userId));
+    }
+  });
+
+  describe('addContact', () => {
+    it('should add an existing real user as contact', async () => {
+      const contactId = crypto.randomUUID();
+      testUserIds.push(contactId);
+      const email = `real-${contactId}@test.com`;
+      await db.insert(schema.users).values({
+        id: contactId,
+        name: 'Real Contact',
+        email,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const result = await service.addContact(ownerId, email);
+      expect(result.userId).toBe(contactId);
+      expect(result.isGhost).toBe(false);
+      expect(result.isNew).toBe(false);
+
+      // Verify index_members row
+      const [member] = await db.select()
+        .from(schema.indexMembers)
+        .where(and(
+          eq(schema.indexMembers.indexId, ownerPersonalIndexId),
+          eq(schema.indexMembers.userId, contactId),
+        ));
+      expect(member).toBeDefined();
+      expect(member.permissions).toEqual(['contact']);
+    });
+
+    it('should create ghost user for unknown email and add as contact', async () => {
+      const email = `ghost-${crypto.randomUUID()}@test.com`;
+      const result = await service.addContact(ownerId, email);
+
+      expect(result.isGhost).toBe(true);
+      expect(result.isNew).toBe(true);
+      testUserIds.push(result.userId);
+
+      // Verify ghost user created
+      const [ghost] = await db.select().from(schema.users).where(eq(schema.users.id, result.userId));
+      expect(ghost).toBeDefined();
+      expect(ghost.isGhost).toBe(true);
+      expect(ghost.email).toBe(email);
+
+      // Verify index_members row
+      const [member] = await db.select()
+        .from(schema.indexMembers)
+        .where(and(
+          eq(schema.indexMembers.indexId, ownerPersonalIndexId),
+          eq(schema.indexMembers.userId, result.userId),
+        ));
+      expect(member).toBeDefined();
+      expect(member.permissions).toEqual(['contact']);
+    });
+
+    it('should not restore soft-deleted contact by default', async () => {
+      const contactId = crypto.randomUUID();
+      testUserIds.push(contactId);
+      const email = `softdel-${contactId}@test.com`;
+      await db.insert(schema.users).values({
+        id: contactId, name: 'Soft Del', email,
+        createdAt: new Date(), updatedAt: new Date(),
+      });
+      // Create soft-deleted membership
+      await db.insert(schema.indexMembers).values({
+        indexId: ownerPersonalIndexId,
+        userId: contactId,
+        permissions: ['contact'],
+        deletedAt: new Date(),
+      });
+
+      const result = await service.addContact(ownerId, email);
+      expect(result.userId).toBe(contactId);
+
+      // Should still be soft-deleted
+      const [member] = await db.select()
+        .from(schema.indexMembers)
+        .where(and(
+          eq(schema.indexMembers.indexId, ownerPersonalIndexId),
+          eq(schema.indexMembers.userId, contactId),
+        ));
+      expect(member.deletedAt).not.toBeNull();
+    });
+
+    it('should restore soft-deleted contact when restore=true', async () => {
+      const contactId = crypto.randomUUID();
+      testUserIds.push(contactId);
+      const email = `restore-${contactId}@test.com`;
+      await db.insert(schema.users).values({
+        id: contactId, name: 'Restore Me', email,
+        createdAt: new Date(), updatedAt: new Date(),
+      });
+      await db.insert(schema.indexMembers).values({
+        indexId: ownerPersonalIndexId,
+        userId: contactId,
+        permissions: ['contact'],
+        deletedAt: new Date(),
+      });
+
+      const result = await service.addContact(ownerId, email, { restore: true });
+      expect(result.userId).toBe(contactId);
+
+      const [member] = await db.select()
+        .from(schema.indexMembers)
+        .where(and(
+          eq(schema.indexMembers.indexId, ownerPersonalIndexId),
+          eq(schema.indexMembers.userId, contactId),
+        ));
+      expect(member.deletedAt).toBeNull();
+    });
+
+    it('should clear reverse opt-out when adding contact', async () => {
+      // User B has owner in their personal index as soft-deleted contact
+      const userBId = crypto.randomUUID();
+      testUserIds.push(userBId);
+      const email = `reverse-${userBId}@test.com`;
+      await db.insert(schema.users).values({
+        id: userBId, name: 'User B', email,
+        createdAt: new Date(), updatedAt: new Date(),
+      });
+      const userBPersonalIndexId = crypto.randomUUID();
+      testIndexIds.push(userBPersonalIndexId);
+      await db.insert(schema.indexes).values({
+        id: userBPersonalIndexId, title: 'B Personal', isPersonal: true,
+        createdAt: new Date(), updatedAt: new Date(),
+      });
+      await db.insert(schema.personalIndexes).values({
+        userId: userBId, indexId: userBPersonalIndexId,
+      });
+      // Owner is soft-deleted in B's personal index
+      await db.insert(schema.indexMembers).values({
+        indexId: userBPersonalIndexId,
+        userId: ownerId,
+        permissions: ['contact'],
+        deletedAt: new Date(),
+      });
+
+      // User B adds owner as contact
+      await service.addContact(userBId, `owner-${ownerId}@test.com`);
+
+      // The soft-deleted membership of owner in B's index should be cleared
+      // (but that's handled by B calling addContact for owner)
+      // The REVERSE: owner's soft-deleted membership in B's index should be hard-deleted
+      const [member] = await db.select()
+        .from(schema.indexMembers)
+        .where(and(
+          eq(schema.indexMembers.indexId, userBPersonalIndexId),
+          eq(schema.indexMembers.userId, ownerId),
+        ));
+      expect(member).toBeUndefined();
+    });
+  });
+
+  describe('removeContact', () => {
+    it('should hard-delete the index_members row', async () => {
+      const contactId = crypto.randomUUID();
+      testUserIds.push(contactId);
+      const email = `remove-${contactId}@test.com`;
+      await db.insert(schema.users).values({
+        id: contactId, name: 'To Remove', email,
+        createdAt: new Date(), updatedAt: new Date(),
+      });
+      await service.addContact(ownerId, email);
+
+      await service.removeContact(ownerId, contactId);
+
+      const [member] = await db.select()
+        .from(schema.indexMembers)
+        .where(and(
+          eq(schema.indexMembers.indexId, ownerPersonalIndexId),
+          eq(schema.indexMembers.userId, contactId),
+        ));
+      expect(member).toBeUndefined();
+    });
+  });
+
+  describe('listContacts', () => {
+    it('should return contacts with user details', async () => {
+      const contactId = crypto.randomUUID();
+      testUserIds.push(contactId);
+      const email = `list-${contactId}@test.com`;
+      await db.insert(schema.users).values({
+        id: contactId, name: 'Listed Contact', email,
+        createdAt: new Date(), updatedAt: new Date(),
+      });
+      await service.addContact(ownerId, email);
+
+      const contacts = await service.listContacts(ownerId);
+      const found = contacts.find(c => c.userId === contactId);
+      expect(found).toBeDefined();
+      expect(found!.user.name).toBe('Listed Contact');
+      expect(found!.user.email).toBe(email);
+    });
+
+    it('should not return soft-deleted contacts', async () => {
+      const contactId = crypto.randomUUID();
+      testUserIds.push(contactId);
+      const email = `hidden-${contactId}@test.com`;
+      await db.insert(schema.users).values({
+        id: contactId, name: 'Hidden', email,
+        createdAt: new Date(), updatedAt: new Date(),
+      });
+      await db.insert(schema.indexMembers).values({
+        indexId: ownerPersonalIndexId,
+        userId: contactId,
+        permissions: ['contact'],
+        deletedAt: new Date(),
+      });
+
+      const contacts = await service.listContacts(ownerId);
+      const found = contacts.find(c => c.userId === contactId);
+      expect(found).toBeUndefined();
+    });
+  });
+}, { timeout: 60_000 });
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd protocol && bun test src/services/tests/contact.service.spec.ts`
+Expected: FAIL
+
+**Step 3: Add new database adapter methods**
+
+In `protocol/src/adapters/database.adapter.ts`, add these new methods and remove old ones:
+
+**Remove** (old contact methods):
+- `upsertContact` (~lines 2750-2767)
+- `getContacts` (~lines 2774-2815)
+- `removeContact` (~lines 2822-2877)
+- `upsertContactsBulk` (~lines 3011-3032)
+- `importContactsBulk` (~lines 3046-3164)
+- `getUsersByEmails` (~lines 2922-2934) — keep, still needed
+- `getSoftDeletedGhostEmails` (~lines 2734-2744) — keep, still needed
+
+**Add** new methods:
+
+```typescript
+/**
+ * Upsert a contact as an index_members row on the owner's personal index.
+ * @param ownerId - The user adding the contact
+ * @param contactUserId - The contact's user ID
+ * @param options - { restore?: boolean } — if true, clears deletedAt on soft-deleted rows
+ */
+async upsertContactMembership(
+  ownerId: string,
+  contactUserId: string,
+  options?: { restore?: boolean }
+): Promise<void> {
+  const personalIndex = await this.getPersonalIndex(ownerId);
+  if (!personalIndex) throw new Error(`No personal index found for user ${ownerId}`);
+
+  if (options?.restore) {
+    await db.insert(schema.indexMembers)
+      .values({
+        indexId: personalIndex.indexId,
+        userId: contactUserId,
+        permissions: ['contact'],
+        autoAssign: false,
+      })
+      .onConflictDoUpdate({
+        target: [schema.indexMembers.indexId, schema.indexMembers.userId],
+        set: { deletedAt: null },
+      });
+  } else {
+    // Check if soft-deleted row exists — if so, skip
+    const existing = await db.select({ deletedAt: schema.indexMembers.deletedAt })
+      .from(schema.indexMembers)
+      .where(and(
+        eq(schema.indexMembers.indexId, personalIndex.indexId),
+        eq(schema.indexMembers.userId, contactUserId),
+      ))
+      .limit(1);
+
+    if (existing.length > 0 && existing[0].deletedAt !== null) {
+      return; // Soft-deleted — don't restore
+    }
+
+    await db.insert(schema.indexMembers)
+      .values({
+        indexId: personalIndex.indexId,
+        userId: contactUserId,
+        permissions: ['contact'],
+        autoAssign: false,
+      })
+      .onConflictDoNothing();
+  }
+}
+
+/**
+ * Hard-delete a contact's index_members row from the owner's personal index.
+ * @param ownerId - The user removing the contact
+ * @param contactUserId - The contact's user ID
+ */
+async hardDeleteContactMembership(ownerId: string, contactUserId: string): Promise<void> {
+  const personalIndex = await this.getPersonalIndex(ownerId);
+  if (!personalIndex) return;
+
+  await db.delete(schema.indexMembers)
+    .where(and(
+      eq(schema.indexMembers.indexId, personalIndex.indexId),
+      eq(schema.indexMembers.userId, contactUserId),
+      sql`'contact' = ANY(${schema.indexMembers.permissions})`,
+    ));
+}
+
+/**
+ * Hard-delete any soft-deleted membership where contactUserId is a contact
+ * in the other user's personal index. Used to clear reverse opt-outs.
+ * @param contactUserId - The user who is adding someone as contact
+ * @param otherUserId - The user whose personal index may have a soft-deleted row
+ */
+async clearReverseOptOut(contactUserId: string, otherUserId: string): Promise<void> {
+  const personalIndexes = await this.getPersonalIndexesForContact(contactUserId);
+  // Find personal indexes owned by otherUserId where contactUserId is soft-deleted
+  for (const { indexId } of personalIndexes) {
+    // Not quite right — we need otherUserId's personal index
+  }
+  // Simpler: query directly
+  const otherPersonalIndex = await this.getPersonalIndex(otherUserId);
+  if (!otherPersonalIndex) return;
+
+  await db.delete(schema.indexMembers)
+    .where(and(
+      eq(schema.indexMembers.indexId, otherPersonalIndex.indexId),
+      eq(schema.indexMembers.userId, contactUserId),
+      sql`'contact' = ANY(${schema.indexMembers.permissions})`,
+      sql`${schema.indexMembers.deletedAt} IS NOT NULL`,
+    ));
+}
+
+/**
+ * Get all contacts for a user (non-soft-deleted index_members with 'contact' permission
+ * on their personal index).
+ * @param ownerId - The user whose contacts to list
+ * @returns Array of contacts with user details
+ */
+async getContactMembers(ownerId: string): Promise<Array<{
+  userId: string;
+  user: { id: string; name: string; email: string; avatar: string | null; isGhost: boolean };
+}>> {
+  const personalIndex = await this.getPersonalIndex(ownerId);
+  if (!personalIndex) return [];
+
+  return db.select({
+    userId: schema.indexMembers.userId,
+    user: {
+      id: schema.users.id,
+      name: schema.users.name,
+      email: schema.users.email,
+      avatar: schema.users.avatar,
+      isGhost: schema.users.isGhost,
+    },
+  })
+  .from(schema.indexMembers)
+  .innerJoin(schema.users, eq(schema.indexMembers.userId, schema.users.id))
+  .where(and(
+    eq(schema.indexMembers.indexId, personalIndex.indexId),
+    sql`'contact' = ANY(${schema.indexMembers.permissions})`,
+    sql`${schema.indexMembers.deletedAt} IS NULL`,
+  ));
+}
+```
+
+Also check if `getPersonalIndex(userId)` exists. If not, add a helper:
+
+```typescript
+/**
+ * Get the personal index ID for a user.
+ * @param userId - The user's ID
+ * @returns The personal index record or null
+ */
+async getPersonalIndex(userId: string): Promise<{ indexId: string } | null> {
+  const [result] = await db.select({ indexId: schema.personalIndexes.indexId })
+    .from(schema.personalIndexes)
+    .where(eq(schema.personalIndexes.userId, userId))
+    .limit(1);
+  return result ?? null;
+}
+```
+
+**Step 4: Update the database interface**
+
+In `protocol/src/lib/protocol/interfaces/database.interface.ts`:
+
+- Remove `upsertContact` from the interface (~line 1157)
+- Remove `getContacts` (~line 1160)
+- Remove `removeContact` (~line 1169)
+- Update type unions that reference these methods (~lines 1594, 1672)
+- Add `upsertContactMembership`, `hardDeleteContactMembership`, `getContactMembers`, `clearReverseOptOut` to the interface
+
+**Step 5: Rewrite `ContactService`**
+
+Replace `protocol/src/services/contact.service.ts`:
+
+```typescript
+import { log } from '../lib/log';
+import { ChatDatabaseAdapter } from '../adapters/database.adapter';
+import { profileQueue } from '../queues/profile.queue';
+
+const logger = log.service.from('ContactService');
+
+/** Email prefixes that indicate automated/service accounts. */
+const NON_HUMAN_PREFIXES = new Set([
+  'noreply', 'no-reply', 'no_reply', 'donotreply', 'do-not-reply',
+  'support', 'info', 'help', 'sales', 'marketing', 'hello',
+  'notifications', 'notification', 'alerts', 'alert',
+  'newsletter', 'newsletters', 'news', 'updates', 'update',
+  'billing', 'invoices', 'receipts', 'orders',
+  'admin', 'administrator', 'system', 'mailer', 'mailer-daemon',
+  'daemon', 'postmaster', 'webmaster', 'hostmaster',
+  'feedback', 'contact', 'team', 'service', 'services',
+  'security', 'privacy', 'legal', 'compliance',
+  'calendar', 'calendar-server', 'calendar-notification',
+]);
+
+/** Domain patterns that indicate automated/service emails. */
+const NON_HUMAN_DOMAIN_PATTERNS = [
+  /calendar-notification\.google\.com$/i,
+  /accounts\.google\.com$/i,
+  /notifications\..+\.com$/i,
+  /noreply\..+$/i,
+  /mailer\..+$/i,
+  /^test\.(com|dev|local|internal)$/i,
+];
+
+/** Name patterns that indicate non-human contacts. */
+const NON_HUMAN_NAME_PATTERNS = [
+  /^no[ -_]?reply$/i,
+  /support$/i,
+  /team$/i,
+  /^(the )?.+ (team|support|notifications|alerts)$/i,
+];
+
+/**
+ * Determines if a contact appears to be a human (not a service/automated account).
+ * @param email - The contact's email address
+ * @param name - The contact's name (may be empty)
+ * @returns true if the contact appears to be human
+ */
+export function isHumanContact(email: string, name: string): boolean {
+  const [prefix, domain] = email.toLowerCase().split('@');
+  if (NON_HUMAN_PREFIXES.has(prefix)) return false;
+  if (NON_HUMAN_DOMAIN_PATTERNS.some(p => p.test(domain))) return false;
+  if (name && NON_HUMAN_NAME_PATTERNS.some(p => p.test(name))) return false;
+  return true;
+}
+
+/** Result of adding a single contact. */
+export interface ContactResult {
+  userId: string;
+  isNew: boolean;
+  isGhost: boolean;
+}
+
+/** Contact with user details (for listing). */
+export interface Contact {
+  userId: string;
+  user: {
+    id: string;
+    name: string;
+    email: string;
+    avatar: string | null;
+    isGhost: boolean;
+  };
+}
+
+/** Result of bulk importing contacts. */
+export interface ImportResult {
+  imported: number;
+  skipped: number;
+  newContacts: number;
+  existingContacts: number;
+  details: Array<{ email: string; userId: string; isNew: boolean }>;
+}
+
+/**
+ * Manages user contacts ("My Network").
+ *
+ * Contacts are stored as `index_members` rows with `'contact'` permission
+ * on the owner's personal index. No separate `user_contacts` table.
+ *
+ * @remarks
+ * - `addContact` is the single primitive for all contact creation
+ * - Ghost users are created for unknown emails and enriched asynchronously
+ * - Contacts are one-way: A adding B does not make A a contact of B
+ */
+export class ContactService {
+  constructor(private db = new ChatDatabaseAdapter()) {}
+
+  /**
+   * Add a single contact by email. Creates a ghost user if the email is unknown.
+   * Adds the user to the owner's personal index with `'contact'` permission.
+   *
+   * @param ownerId - The user adding the contact
+   * @param email - Email of the contact to add
+   * @param options - { name?: string, restore?: boolean }
+   *   - `name`: Optional display name for ghost creation
+   *   - `restore`: If true, reactivates soft-deleted memberships (e.g. from opportunity acceptance).
+   *     Defaults to false.
+   * @returns The contact result with userId, isNew, isGhost
+   */
+  async addContact(
+    ownerId: string,
+    email: string,
+    options?: { name?: string; restore?: boolean }
+  ): Promise<ContactResult> {
+    const normalizedEmail = email.toLowerCase().trim();
+    logger.info('[ContactService] Adding contact', { ownerId, email: normalizedEmail });
+
+    // Resolve user
+    let user = await this.db.getUserByEmail(normalizedEmail);
+    let isNew = false;
+
+    if (!user) {
+      // Create ghost user
+      const ghostId = crypto.randomUUID();
+      const name = options?.name || normalizedEmail.split('@')[0];
+      await this.db.createGhostUser(ghostId, name, normalizedEmail);
+      user = { id: ghostId, name, email: normalizedEmail, isGhost: true };
+      isNew = true;
+    }
+
+    // Upsert index_members row
+    await this.db.upsertContactMembership(ownerId, user.id, { restore: options?.restore });
+
+    // Clear reverse opt-out: if the contact has a personal index where
+    // the owner is soft-deleted, hard-delete that row
+    await this.db.clearReverseOptOut(ownerId, user.id);
+
+    // Enqueue enrichment for new ghosts
+    if (isNew && user.isGhost) {
+      await profileQueue.addEnrichGhostJob({ userId: user.id });
+      logger.info('[ContactService] Enrichment job enqueued for new ghost', { userId: user.id });
+    }
+
+    return { userId: user.id, isNew, isGhost: user.isGhost };
+  }
+
+  /**
+   * Import contacts in bulk from an integration or manual input.
+   * Filters non-human emails, deduplicates, and delegates to addContact for each.
+   *
+   * @param ownerId - The user importing contacts
+   * @param contacts - Array of { name, email }
+   * @returns Import statistics
+   */
+  async importContacts(
+    ownerId: string,
+    contacts: Array<{ name: string; email: string }>
+  ): Promise<ImportResult> {
+    logger.info('[ContactService] Importing contacts', { ownerId, count: contacts.length });
+
+    const result: ImportResult = {
+      imported: 0,
+      skipped: 0,
+      newContacts: 0,
+      existingContacts: 0,
+      details: [],
+    };
+
+    const owner = await this.db.getUser(ownerId);
+    const ownerEmail = owner?.email?.toLowerCase();
+
+    // Normalize, filter, deduplicate
+    const seenEmails = new Set<string>();
+    const validContacts: Array<{ name: string; email: string }> = [];
+    for (const contact of contacts) {
+      const email = contact.email.toLowerCase().trim();
+      if (!email || !email.includes('@')) { result.skipped++; continue; }
+      if (ownerEmail === email) { result.skipped++; continue; }
+      if (seenEmails.has(email)) { result.skipped++; continue; }
+      const name = contact.name?.trim() || '';
+      if (!isHumanContact(email, name)) { result.skipped++; continue; }
+      seenEmails.add(email);
+      validContacts.push({ name: name || email.split('@')[0], email });
+    }
+
+    if (validContacts.length === 0) {
+      logger.info('[ContactService] No valid contacts to import', { ownerId });
+      return result;
+    }
+
+    // Process each contact (restore=false — bulk imports don't restore opt-outs)
+    for (const contact of validContacts) {
+      const contactResult = await this.addContact(ownerId, contact.email, {
+        name: contact.name,
+        restore: false,
+      });
+      result.details.push({
+        email: contact.email,
+        userId: contactResult.userId,
+        isNew: contactResult.isNew,
+      });
+      if (contactResult.isNew) result.newContacts++;
+      else result.existingContacts++;
+    }
+    result.imported = result.details.length;
+
+    logger.info('[ContactService] Import completed', {
+      ownerId,
+      imported: result.imported,
+      skipped: result.skipped,
+      newContacts: result.newContacts,
+      existingContacts: result.existingContacts,
+    });
+
+    return result;
+  }
+
+  /**
+   * List all contacts for a user (non-soft-deleted members with 'contact' permission).
+   *
+   * @param ownerId - The user whose contacts to list
+   * @returns Array of contacts with user details
+   */
+  async listContacts(ownerId: string): Promise<Contact[]> {
+    logger.verbose('[ContactService] Listing contacts', { ownerId });
+    return this.db.getContactMembers(ownerId);
+  }
+
+  /**
+   * Remove a contact from the user's network (hard delete).
+   *
+   * @param ownerId - The user removing the contact
+   * @param contactUserId - The contact's user ID
+   */
+  async removeContact(ownerId: string, contactUserId: string): Promise<void> {
+    logger.info('[ContactService] Removing contact', { ownerId, contactUserId });
+    await this.db.hardDeleteContactMembership(ownerId, contactUserId);
+  }
+}
+
+export const contactService = new ContactService();
+```
+
+**Step 6: Add `createGhostUser` to database adapter**
+
+In `protocol/src/adapters/database.adapter.ts`, add:
+
+```typescript
+/**
+ * Create a ghost user directly in the users table.
+ * @param id - The ghost user's ID
+ * @param name - Display name
+ * @param email - Email address
+ */
+async createGhostUser(id: string, name: string, email: string): Promise<void> {
+  await db.insert(schema.users).values({
+    id,
+    name,
+    email,
+    isGhost: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  }).onConflictDoNothing();
+}
+```
+
+**Step 7: Run tests**
+
+Run: `cd protocol && bun test src/services/tests/contact.service.spec.ts`
+Expected: PASS
+
+**Step 8: Run tsc**
+
+Run: `cd protocol && npx tsc --noEmit`
+Expected: PASS (or errors from downstream consumers — fixed in subsequent tasks)
+
+**Step 9: Commit**
+
+```bash
+git add protocol/src/services/contact.service.ts protocol/src/services/tests/contact.service.spec.ts protocol/src/adapters/database.adapter.ts protocol/src/lib/protocol/interfaces/database.interface.ts
+git commit -m "feat(contacts): rewrite ContactService with addContact primitive on index_members"
+```
+
+---
+
+### Task 5: Update Contact Chat Tools
+
+**Files:**
+- Modify: `protocol/src/lib/protocol/tools/contact.tools.ts:14-151`
+
+**Step 1: Update tool implementations**
+
+In `protocol/src/lib/protocol/tools/contact.tools.ts`:
+
+- `import_contacts` — remove `source` parameter, call `contactService.importContacts(userId, contacts)`
+- `list_contacts` — update return shape (no more `source`, `importedAt`, `id` fields)
+- `add_contact` — call `contactService.addContact(userId, email, { name })`
+- `remove_contact` — change input from `contactId` (record ID) to `contactUserId` (user ID), call `contactService.removeContact(userId, contactUserId)`
+
+**Step 2: Run tsc**
+
+Run: `cd protocol && npx tsc --noEmit`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add protocol/src/lib/protocol/tools/contact.tools.ts
+git commit -m "refactor(tools): update contact tools for index_members-based contacts"
+```
+
+---
+
+### Task 6: Update Integration Tools (Gmail Import)
+
+**Files:**
+- Modify: `protocol/src/lib/protocol/tools/integration.tools.ts:109-113`
+
+**Step 1: Update Gmail import call**
+
+In `protocol/src/lib/protocol/tools/integration.tools.ts`, change:
+
+```typescript
+// Before:
+const result = await contactService.importContacts(context.userId, contacts, 'gmail');
+
+// After:
+const result = await contactService.importContacts(context.userId, contacts);
+```
+
+Remove the `source` parameter.
+
+**Step 2: Run tsc**
+
+Run: `cd protocol && npx tsc --noEmit`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add protocol/src/lib/protocol/tools/integration.tools.ts
+git commit -m "refactor(tools): remove source param from gmail contact import"
+```
+
+---
+
+### Task 7: Update Opportunity Service
+
+**Files:**
+- Modify: `protocol/src/services/opportunity.service.ts:~291`
+
+**Step 1: Replace `db.upsertContact` with `contactService.addContact`**
+
+In `protocol/src/services/opportunity.service.ts`, change the opportunity acceptance handler:
+
+```typescript
+// Before:
+await this.db.upsertContact({ ownerId: userId, userId: counterpart.userId, source: 'manual' });
+
+// After:
+import { contactService } from './contact.service';
+// ...
+const counterpartUser = await this.db.getUser(counterpart.userId);
+if (counterpartUser) {
+  await contactService.addContact(userId, counterpartUser.email, { restore: true });
+}
+```
+
+Note: `restore: true` because opportunity acceptance should reactivate soft-deleted contacts.
+
+**Step 2: Run existing opportunity tests**
+
+Run: `cd protocol && bun test src/services/tests/opportunity.service.updateStatus.spec.ts`
+Expected: PASS (may need test adjustments)
+
+**Step 3: Run tsc**
+
+Run: `cd protocol && npx tsc --noEmit`
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add protocol/src/services/opportunity.service.ts
+git commit -m "refactor(opportunity): use addContact with restore on acceptance"
+```
+
+---
+
+### Task 8: Update Unsubscribe Flow
+
+**Files:**
+- Modify: `protocol/src/services/unsubscribe.service.ts`
+- Modify: `protocol/src/adapters/database.adapter.ts` (`softDeleteGhostByUnsubscribeToken` ~line 2682)
+
+**Step 1: Update `softDeleteGhostByUnsubscribeToken`**
+
+The current implementation soft-deletes the ghost **user row** (`users.deletedAt`). In the new design, it should soft-delete all `index_members` rows where this ghost is a contact (i.e., soft-delete in every personal index where they appear).
+
+In `protocol/src/adapters/database.adapter.ts`, update `softDeleteGhostByUnsubscribeToken`:
+
+```typescript
+async softDeleteGhostByUnsubscribeToken(token: string): Promise<boolean> {
+  const [settings] = await db.select({ userId: schema.userNotificationSettings.userId })
+    .from(schema.userNotificationSettings)
+    .where(eq(schema.userNotificationSettings.unsubscribeToken, token))
+    .limit(1);
+  if (!settings) return false;
+
+  // Verify user is a ghost
+  const [user] = await db.select({ id: schema.users.id, isGhost: schema.users.isGhost })
+    .from(schema.users)
+    .where(eq(schema.users.id, settings.userId))
+    .limit(1);
+  if (!user || !user.isGhost) return false;
+
+  // Soft-delete all index_members rows where this ghost is a contact
+  const result = await db.update(schema.indexMembers)
+    .set({ deletedAt: new Date() })
+    .where(and(
+      eq(schema.indexMembers.userId, settings.userId),
+      sql`'contact' = ANY(${schema.indexMembers.permissions})`,
+      isNull(schema.indexMembers.deletedAt),
+    ))
+    .returning({ indexId: schema.indexMembers.indexId });
+
+  return result.length > 0;
+}
+```
+
+**Step 2: Run tsc**
+
+Run: `cd protocol && npx tsc --noEmit`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add protocol/src/adapters/database.adapter.ts protocol/src/services/unsubscribe.service.ts
+git commit -m "refactor(unsubscribe): soft-delete index_members instead of user row"
+```
+
+---
+
+### Task 9: Clean Up Old Code
+
+**Files:**
+- Modify: `protocol/src/adapters/database.adapter.ts` — remove old contact methods
+- Modify: `protocol/src/lib/protocol/interfaces/database.interface.ts` — remove old contact method signatures
+- Remove: `protocol/src/services/tests/contact.filter.spec.ts` — keep (still valid, tests `isHumanContact`)
+- Modify: `protocol/src/adapters/tests/personal-index.adapter.spec.ts` — update contact-related tests
+- Modify: `protocol/src/adapters/tests/database.adapter.spec.ts` — remove ghost transfer tests
+
+**Step 1: Remove old database adapter methods**
+
+Remove from `protocol/src/adapters/database.adapter.ts`:
+- `upsertContact` (~lines 2750-2767)
+- Old `getContacts` (~lines 2774-2815)
+- Old `removeContact` (~lines 2822-2877)
+- `upsertContactsBulk` (~lines 3011-3032)
+- `importContactsBulk` (~lines 3046-3164)
+
+**Step 2: Remove old interface methods**
+
+Remove from `protocol/src/lib/protocol/interfaces/database.interface.ts`:
+- `upsertContact` (~line 1157)
+- Old `getContacts` (~line 1160)
+- Old `removeContact` (~line 1169)
+- References in type unions (~lines 1594, 1672)
+
+**Step 3: Update adapter tests**
+
+In `protocol/src/adapters/tests/personal-index.adapter.spec.ts`:
+- Update tests that reference `user_contacts` or `importContactsBulk` to use new `upsertContactMembership` / `getContactMembers` methods
+
+In `protocol/src/adapters/tests/database.adapter.spec.ts`:
+- Remove ghost transfer tests (~lines 937-1011) that test `claimGhostUser` data transfer
+- Add test for `upsertContactMembership`, `hardDeleteContactMembership`, `getContactMembers`, `clearReverseOptOut`
+
+**Step 4: Run all affected tests**
+
+Run: `cd protocol && bun test src/services/tests/contact.service.spec.ts src/services/tests/contact.filter.spec.ts src/adapters/tests/auth.adapter.spec.ts src/adapters/tests/personal-index.adapter.spec.ts src/adapters/tests/database.adapter.spec.ts`
+Expected: PASS
+
+**Step 5: Run tsc**
+
+Run: `cd protocol && npx tsc --noEmit`
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+git add protocol/src/adapters/database.adapter.ts protocol/src/lib/protocol/interfaces/database.interface.ts protocol/src/adapters/tests/personal-index.adapter.spec.ts protocol/src/adapters/tests/database.adapter.spec.ts
+git commit -m "refactor: remove old user_contacts methods and update adapter tests"
+```
+
+---
+
+### Task 10: Update `main.ts` and Fix Remaining References
+
+**Files:**
+- Modify: `protocol/src/main.ts:108` — `AuthDatabaseAdapter` no longer needs ghost claim methods
+- Any remaining files that import `ContactSource`, `UserContact`, `NewUserContact`
+
+**Step 1: Fix `main.ts`**
+
+The `AuthDatabaseAdapter` instantiation in `main.ts` should work as-is since we simplified the class. Verify no errors.
+
+**Step 2: Search for remaining references**
+
+Run: `cd protocol && npx tsc --noEmit 2>&1 | head -50`
+
+Fix any remaining type errors from removed types/methods.
+
+**Step 3: Run full test suite**
+
+Run: `cd protocol && bun test`
+Expected: PASS (all tests)
+
+**Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "fix: resolve remaining type errors from contacts simplification"
+```
+
+---
+
+### Task 11: Verify `deletedAt` Column on `index_members`
+
+**Files:**
+- Check: `protocol/src/schemas/database.schema.ts` — verify `index_members` has a `deletedAt` column
+
+**Step 1: Check if `deletedAt` exists on `index_members`**
+
+If `index_members` does not have a `deletedAt` column, we need to add it via migration.
+
+If missing:
+1. Add `deletedAt: timestamp('deleted_at')` to the `indexMembers` schema
+2. Create migration `0018_add_index_members_deleted_at.sql`
+3. Run `bun run db:generate` then rename, update journal, `bun run db:migrate`
+
+**Step 2: Verify**
+
+Run: `cd protocol && bun run db:generate`
+Expected: "No schema changes"
+
+**Step 3: Commit (if changes needed)**
+
+```bash
+git add protocol/src/schemas/database.schema.ts protocol/drizzle/
+git commit -m "feat(schema): add deletedAt to index_members for contact soft-delete"
+```
+
+---
+
+### Task 12: Final Integration Test
+
+**Files:**
+- Test: `protocol/src/services/tests/contact.service.spec.ts` (already written in Task 4)
+
+**Step 1: Run all tests**
+
+Run: `cd protocol && bun test`
+Expected: PASS
+
+**Step 2: Run tsc**
+
+Run: `cd protocol && npx tsc --noEmit`
+Expected: PASS
+
+**Step 3: Manual smoke test**
+
+Start the dev server and verify:
+1. Gmail contact import works through chat
+2. Adding a single contact works through chat
+3. Listing contacts works through chat
+4. Removing a contact works through chat
+
+Run: `cd protocol && bun run dev`
+
+**Step 4: Final commit (if any fixes needed)**
+
+```bash
+git add -A
+git commit -m "fix: integration fixes for contacts simplification"
+```

--- a/protocol/src/lib/protocol/support/opportunity.enricher.ts
+++ b/protocol/src/lib/protocol/support/opportunity.enricher.ts
@@ -57,18 +57,19 @@ function cosineSimilarity(a: number[], b: number[]): number {
 
 /**
  * Resolve enriched opportunity status from related opportunities' statuses and the incoming status.
- * Priority: accepted > pending > rejected > draft (preserve chat drafts) > latent.
+ * Priority: accepted > pending > rejected > draft (only when incoming is draft) > latent.
  * The incoming status is included so we do not wrongly downgrade when the new opportunity has a higher-priority status.
  * When incoming is 'draft' (e.g. from in-chat discovery), we preserve draft so the opportunity stays chat-only and
- * does not appear on the home view (home excludes draft). This holds even when merging with expired (or latent)
- * opportunities: the result stays draft so it remains chat-only.
+ * does not appear on the home view (home excludes draft).
+ * When incoming is NOT draft (e.g. 'latent' from the background broker), existing draft status does NOT contaminate
+ * the result — the broker-created opportunity retains its own status and can appear on the home view.
  */
 function resolveEnrichedStatus(relatedStatuses: string[], incomingStatus?: string): OpportunityStatus {
   const statuses = incomingStatus ? [...relatedStatuses, incomingStatus] : relatedStatuses;
   if (statuses.includes('accepted')) return 'accepted';
   if (statuses.includes('pending')) return 'pending';
   if (statuses.includes('rejected')) return 'rejected';
-  if (incomingStatus === 'draft' || statuses.includes('draft')) return 'draft';
+  if (incomingStatus === 'draft') return 'draft';
   return 'latent';
 }
 

--- a/protocol/src/lib/protocol/support/tests/opportunity.enricher.spec.ts
+++ b/protocol/src/lib/protocol/support/tests/opportunity.enricher.spec.ts
@@ -78,7 +78,7 @@ function existingOpportunity(
   id: string,
   actors: Array<{ indexId: string; userId: string; role: string; intent?: string }>,
   reasoning: string,
-  status: 'latent' | 'pending' | 'viewed' | 'accepted' | 'rejected' | 'expired' = 'pending'
+  status: 'latent' | 'draft' | 'pending' | 'viewed' | 'accepted' | 'rejected' | 'expired' = 'pending'
 ): Opportunity {
   return {
     id,
@@ -367,6 +367,35 @@ describe('Opportunity enricher', () => {
     if (result.enriched) {
       expect(result.expiredIds).toEqual(['opp-expired']);
       expect(result.resolvedStatus).toBe('draft');
+    }
+  });
+
+  test('when incoming status is latent and enrichment merges with draft, resolved status stays latent (broker not downgraded by chat draft)', async () => {
+    const sharedIntent = MEANINGFUL.intentIds.aliceMlCofounder;
+    const existing = existingOpportunity(
+      'opp-draft',
+      [
+        { indexId: 'idx-1', userId: 'user-a', role: 'agent', intent: sharedIntent },
+        { indexId: 'idx-1', userId: 'user-b', role: 'patient' },
+      ],
+      'Short.',
+      'draft'
+    );
+    const db = { findOverlappingOpportunities: async () => [existing] };
+    const embedder = { generate: async () => [] } as unknown as Embedder;
+    const newData: CreateOpportunityData = {
+      ...minimalNewData(['user-a', 'user-b'], 'idx-1', 'Hi'),
+      status: 'latent',
+      actors: [
+        { indexId: 'idx-1', userId: 'user-a', role: 'party', intent: sharedIntent },
+        { indexId: 'idx-1', userId: 'user-b', role: 'party' },
+      ],
+    };
+    const result = await enrichOrCreate(db, embedder, newData);
+    expect(result.enriched).toBe(true);
+    if (result.enriched) {
+      expect(result.expiredIds).toEqual(['opp-draft']);
+      expect(result.resolvedStatus).toBe('latent');
     }
   });
 

--- a/protocol/src/services/opportunity.service.ts
+++ b/protocol/src/services/opportunity.service.ts
@@ -17,6 +17,7 @@ import { canUserSeeOpportunity, validateOpportunityActors } from '../lib/protoco
 import { persistOpportunities } from '../lib/protocol/support/opportunity.persist';
 import { OpportunityPresenter, gatherPresenterContext, type PresenterDatabase } from '../lib/protocol/agents/opportunity.presenter';
 import { stripUuids, stripIntroducerMentions } from '../lib/protocol/support/opportunity.sanitize';
+import { opportunityQueue } from '../queues/opportunity.queue';
 
 const logger = log.service.from("OpportunityService");
 const presenter = new OpportunityPresenter();
@@ -135,10 +136,20 @@ export class OpportunityService {
       if (result.error) {
         return { error: result.error };
       }
-      return {
-        sections: result.sections ?? [],
-        meta: result.meta ?? { totalOpportunities: 0, totalSections: 0 },
-      };
+      const sections = result.sections ?? [];
+      const meta = result.meta ?? { totalOpportunities: 0, totalSections: 0 };
+
+      // Self-healing: when no actionable opportunities exist, re-queue discovery for active intents
+      const totalItems = sections.reduce(
+        (sum: number, s: { items: unknown[] }) => sum + (s.items?.length ?? 0), 0
+      );
+      if (totalItems === 0) {
+        this.triggerRediscoveryIfNeeded(userId).catch((err) =>
+          logger.warn('[OpportunityService] Rediscovery trigger failed', { userId, error: err })
+        );
+      }
+
+      return { sections, meta };
     } catch (e) {
       logger.error('[OpportunityService] getHomeView failed', { userId, error: e });
       return { error: 'Failed to load home view' };
@@ -610,8 +621,47 @@ export class OpportunityService {
   }
 
   /**
+   * Re-queue opportunity discovery for a user's active intents when no actionable
+   * opportunities exist. Throttled to once per 6 hours per user via cache key.
+   */
+  private async triggerRediscoveryIfNeeded(userId: string): Promise<void> {
+    const cacheKey = `rediscovery:throttle:${userId}`;
+    const existing = await this.cache.get(cacheKey);
+    if (existing) return;
+
+    const activeIntents = await this.db.getActiveIntents(userId);
+    if (!activeIntents?.length) return;
+
+    // Set throttle before enqueuing (6-hour cooldown)
+    await this.cache.set(cacheKey, { triggeredAt: new Date().toISOString() }, { ttl: 6 * 60 * 60 });
+
+    logger.info('[OpportunityService] Triggering rediscovery for stale user', {
+      userId,
+      intentCount: activeIntents.length,
+    });
+
+    const results = await Promise.allSettled(
+      activeIntents.map((intent) =>
+        opportunityQueue.addJob(
+          { intentId: intent.id, userId },
+          { priority: 10, jobId: `rediscovery:${userId}:${intent.id}` },
+        )
+      )
+    );
+
+    const failed = results.filter((r) => r.status === 'rejected');
+    if (failed.length > 0) {
+      logger.warn('[OpportunityService] Some rediscovery jobs failed to enqueue', {
+        userId,
+        failedCount: failed.length,
+        totalCount: activeIntents.length,
+      });
+    }
+  }
+
+  /**
    * Check if user has permission to create opportunities in an index.
-   * 
+   *
    * @param creatorId - User creating the opportunity
    * @param parties - Parties involved
    * @param indexId - The index ID

--- a/protocol/src/services/opportunity.service.ts
+++ b/protocol/src/services/opportunity.service.ts
@@ -78,9 +78,10 @@ export class OpportunityService {
 
   constructor(
     database?: OpportunityControllerDatabase,
+    cache?: OpportunityCache,
   ) {
     this.db = database ?? (new ChatDatabaseAdapter() as OpportunityControllerDatabase);
-    this.cache = new RedisCacheAdapter();
+    this.cache = cache ?? new RedisCacheAdapter();
 
     // Lazy-build graph for discover when adapter supports it
     if (this.db && 'getHydeDocument' in this.db) {

--- a/protocol/src/services/opportunity.service.ts
+++ b/protocol/src/services/opportunity.service.ts
@@ -627,8 +627,14 @@ export class OpportunityService {
    */
   private async triggerRediscoveryIfNeeded(userId: string): Promise<void> {
     const cacheKey = `rediscovery:throttle:${userId}`;
-    const existing = await this.cache.get(cacheKey);
-    if (existing) return;
+
+    // Best-effort throttle: cache errors should not block self-healing
+    try {
+      const existing = await this.cache.get(cacheKey);
+      if (existing) return;
+    } catch (err) {
+      logger.warn('[OpportunityService] Rediscovery throttle read failed; continuing without cooldown', { userId, error: err });
+    }
 
     const activeIntents = await this.db.getActiveIntents(userId);
     if (!activeIntents?.length) return;
@@ -663,7 +669,11 @@ export class OpportunityService {
     // Only arm cooldown if all jobs were enqueued; partial failures should allow
     // retries on the next home view load (bucketed jobId deduplicates the successful ones)
     if (succeeded > 0 && failedCount === 0) {
-      await this.cache.set(cacheKey, { triggeredAt: new Date().toISOString() }, { ttl: 6 * 60 * 60 });
+      try {
+        await this.cache.set(cacheKey, { triggeredAt: new Date().toISOString() }, { ttl: 6 * 60 * 60 });
+      } catch (err) {
+        logger.warn('[OpportunityService] Rediscovery throttle write failed', { userId, error: err });
+      }
     }
   }
 

--- a/protocol/src/services/opportunity.service.ts
+++ b/protocol/src/services/opportunity.service.ts
@@ -660,8 +660,9 @@ export class OpportunityService {
       });
     }
 
-    // Only arm cooldown if at least one job was enqueued
-    if (succeeded > 0) {
+    // Only arm cooldown if all jobs were enqueued; partial failures should allow
+    // retries on the next home view load (bucketed jobId deduplicates the successful ones)
+    if (succeeded > 0 && failedCount === 0) {
       await this.cache.set(cacheKey, { triggeredAt: new Date().toISOString() }, { ttl: 6 * 60 * 60 });
     }
   }

--- a/protocol/src/services/opportunity.service.ts
+++ b/protocol/src/services/opportunity.service.ts
@@ -632,30 +632,36 @@ export class OpportunityService {
     const activeIntents = await this.db.getActiveIntents(userId);
     if (!activeIntents?.length) return;
 
-    // Set throttle before enqueuing (6-hour cooldown)
-    await this.cache.set(cacheKey, { triggeredAt: new Date().toISOString() }, { ttl: 6 * 60 * 60 });
-
     logger.info('[OpportunityService] Triggering rediscovery for stale user', {
       userId,
       intentCount: activeIntents.length,
     });
 
+    // Bucket jobId by 6-hour window so completed/failed job retention (24h) doesn't block the next cycle
+    const bucket = Math.floor(Date.now() / (6 * 60 * 60 * 1000));
     const results = await Promise.allSettled(
       activeIntents.map((intent) =>
         opportunityQueue.addJob(
           { intentId: intent.id, userId },
-          { priority: 10, jobId: `rediscovery:${userId}:${intent.id}` },
+          { priority: 10, jobId: `rediscovery:${userId}:${intent.id}:${bucket}` },
         )
       )
     );
 
-    const failed = results.filter((r) => r.status === 'rejected');
-    if (failed.length > 0) {
+    const succeeded = results.filter((r) => r.status === 'fulfilled').length;
+    const failedCount = results.length - succeeded;
+
+    if (failedCount > 0) {
       logger.warn('[OpportunityService] Some rediscovery jobs failed to enqueue', {
         userId,
-        failedCount: failed.length,
+        failedCount,
         totalCount: activeIntents.length,
       });
+    }
+
+    // Only arm cooldown if at least one job was enqueued
+    if (succeeded > 0) {
+      await this.cache.set(cacheKey, { triggeredAt: new Date().toISOString() }, { ttl: 6 * 60 * 60 });
     }
   }
 

--- a/protocol/src/services/tests/opportunity.service.rediscovery.spec.ts
+++ b/protocol/src/services/tests/opportunity.service.rediscovery.spec.ts
@@ -1,0 +1,190 @@
+/** Config */
+import { config } from "dotenv";
+config({ path: ".env.test", override: true });
+
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+import type { OpportunityCache } from "../../lib/protocol/interfaces/cache.interface";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Module mocks — must be set up before importing OpportunityService
+// ─────────────────────────────────────────────────────────────────────────────
+
+const mockAddJob = mock(() => Promise.resolve({ id: "job-1" }));
+
+mock.module("../../queues/opportunity.queue", () => ({
+  opportunityQueue: { addJob: mockAddJob },
+}));
+
+mock.module("../../adapters/database.adapter", () => ({
+  ChatDatabaseAdapter: class {
+    getHydeDocument() { return null; }
+  },
+}));
+mock.module("../../adapters/embedder.adapter", () => ({
+  EmbedderAdapter: class {},
+}));
+mock.module("../../adapters/cache.adapter", () => ({
+  RedisCacheAdapter: class {
+    get = mock(() => Promise.resolve(null));
+    set = mock(() => Promise.resolve());
+    mget = mock(() => Promise.resolve([]));
+  },
+}));
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Import service AFTER mocks
+// ─────────────────────────────────────────────────────────────────────────────
+
+const { OpportunityService } = await import("../opportunity.service");
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+const USER_ID = "user-rediscovery-001";
+
+const activeIntents = [
+  { id: "intent-1", payload: "Looking for ML engineers", summary: "ML engineers", createdAt: new Date() },
+  { id: "intent-2", payload: "Seeking co-founders", summary: "Co-founders", createdAt: new Date() },
+];
+
+function createMockCache(overrides?: { getReturn?: unknown }): OpportunityCache {
+  return {
+    get: mock((_key: string) =>
+      Promise.resolve(overrides?.getReturn ?? null)
+    ) as unknown as OpportunityCache['get'],
+    set: mock((_key: string, _value: unknown, _options?: { ttl?: number }) =>
+      Promise.resolve()
+    ) as unknown as OpportunityCache['set'],
+    mget: mock((_keys: string[]) =>
+      Promise.resolve([])
+    ) as unknown as OpportunityCache['mget'],
+  };
+}
+
+function createService(opts: {
+  homeGraphResult?: Record<string, unknown>;
+  activeIntents?: typeof activeIntents;
+  cache?: OpportunityCache;
+}) {
+  const cache: OpportunityCache = opts.cache ?? createMockCache();
+  const service = new OpportunityService(undefined, cache);
+
+  // Override db with mock methods
+  const mockGetActiveIntents = mock(() => Promise.resolve(opts.activeIntents ?? []));
+  (service as unknown as Record<string, unknown>).db = {
+    getActiveIntents: mockGetActiveIntents,
+  };
+
+  // Override homeGraph with a mock that returns the specified result
+  const graphResult = opts.homeGraphResult ?? { sections: [], meta: { totalOpportunities: 0, totalSections: 0 } };
+  (service as unknown as Record<string, unknown>).homeGraph = {
+    invoke: mock(() => Promise.resolve(graphResult)),
+  };
+
+  return { service, cache, mockGetActiveIntents };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("OpportunityService.getHomeView — rediscovery trigger", () => {
+  beforeEach(() => {
+    mockAddJob.mockClear();
+  });
+
+  it("triggers rediscovery when home view returns 0 items and user has active intents", async () => {
+    const { service } = createService({
+      homeGraphResult: { sections: [], meta: { totalOpportunities: 0, totalSections: 0 } },
+      activeIntents,
+    });
+
+    await service.getHomeView(USER_ID);
+    // Allow fire-and-forget promise to settle
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mockAddJob).toHaveBeenCalledTimes(2);
+    // Verify job data
+    const calls = mockAddJob.mock.calls as unknown as Array<[{ intentId: string; userId: string }, { priority: number; jobId: string }]>;
+    expect(calls[0][0]).toEqual({ intentId: "intent-1", userId: USER_ID });
+    expect(calls[0][1].priority).toBe(10);
+    // Verify jobId includes 6h bucket
+    expect(calls[0][1].jobId).toMatch(/^rediscovery:user-rediscovery-001:intent-1:\d+$/);
+  });
+
+  it("does NOT trigger rediscovery when home view returns items", async () => {
+    const { service } = createService({
+      homeGraphResult: {
+        sections: [{ id: "s1", title: "For You", iconName: "sparkles", items: [{ id: "opp-1" }] }],
+        meta: { totalOpportunities: 1, totalSections: 1 },
+      },
+      activeIntents,
+    });
+
+    await service.getHomeView(USER_ID);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mockAddJob).not.toHaveBeenCalled();
+  });
+
+  it("does NOT trigger rediscovery when user has no active intents", async () => {
+    const { service } = createService({
+      homeGraphResult: { sections: [], meta: { totalOpportunities: 0, totalSections: 0 } },
+      activeIntents: [],
+    });
+
+    await service.getHomeView(USER_ID);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mockAddJob).not.toHaveBeenCalled();
+  });
+
+  it("throttles rediscovery via cache — does not trigger if cooldown is active", async () => {
+    const cache = createMockCache({ getReturn: { triggeredAt: new Date().toISOString() } });
+    const { service } = createService({
+      homeGraphResult: { sections: [], meta: { totalOpportunities: 0, totalSections: 0 } },
+      activeIntents,
+      cache,
+    });
+
+    await service.getHomeView(USER_ID);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mockAddJob).not.toHaveBeenCalled();
+  });
+
+  it("sets cooldown cache key only after at least one job is enqueued", async () => {
+    const { service, cache } = createService({
+      homeGraphResult: { sections: [], meta: { totalOpportunities: 0, totalSections: 0 } },
+      activeIntents,
+    });
+
+    await service.getHomeView(USER_ID);
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Cooldown should be set with 6h TTL
+    expect(cache.set).toHaveBeenCalledTimes(1);
+    const setCalls = (cache.set as ReturnType<typeof mock>).mock.calls as Array<[string, unknown, { ttl: number }]>;
+    expect(setCalls[0][0]).toBe(`rediscovery:throttle:${USER_ID}`);
+    expect(setCalls[0][2]).toEqual({ ttl: 6 * 60 * 60 });
+  });
+
+  it("does NOT set cooldown when all enqueues fail", async () => {
+    mockAddJob.mockImplementation(() => Promise.reject(new Error("Redis down")));
+
+    const { service, cache } = createService({
+      homeGraphResult: { sections: [], meta: { totalOpportunities: 0, totalSections: 0 } },
+      activeIntents,
+    });
+
+    await service.getHomeView(USER_ID);
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Jobs were attempted
+    expect(mockAddJob).toHaveBeenCalledTimes(2);
+    // But cooldown should NOT be set since all failed
+    expect(cache.set).not.toHaveBeenCalled();
+  });
+});

--- a/protocol/src/services/tests/opportunity.service.rediscovery.spec.ts
+++ b/protocol/src/services/tests/opportunity.service.rediscovery.spec.ts
@@ -49,10 +49,10 @@ const activeIntents = [
   { id: "intent-2", payload: "Seeking co-founders", summary: "Co-founders", createdAt: new Date() },
 ];
 
-function createMockCache(overrides?: { getReturn?: unknown }): OpportunityCache {
+function createMockCache(overrides?: { getReturn?: unknown; getThrows?: boolean }): OpportunityCache {
   return {
     get: mock((_key: string) =>
-      Promise.resolve(overrides?.getReturn ?? null)
+      overrides?.getThrows ? Promise.reject(new Error("Redis connection lost")) : Promise.resolve(overrides?.getReturn ?? null)
     ) as unknown as OpportunityCache['get'],
     set: mock((_key: string, _value: unknown, _options?: { ttl?: number }) =>
       Promise.resolve()
@@ -92,7 +92,8 @@ function createService(opts: {
 
 describe("OpportunityService.getHomeView — rediscovery trigger", () => {
   beforeEach(() => {
-    mockAddJob.mockClear();
+    mockAddJob.mockReset();
+    mockAddJob.mockImplementation(() => Promise.resolve({ id: "job-1" }));
   });
 
   it("triggers rediscovery when home view returns 0 items and user has active intents", async () => {
@@ -209,5 +210,20 @@ describe("OpportunityService.getHomeView — rediscovery trigger", () => {
     expect(mockAddJob).toHaveBeenCalledTimes(2);
     // Cooldown should NOT be set — partial failure means retry is needed
     expect(cache.set).not.toHaveBeenCalled();
+  });
+
+  it("still triggers rediscovery when cache.get throws (Redis down)", async () => {
+    const cache = createMockCache({ getThrows: true });
+    const { service } = createService({
+      homeGraphResult: { sections: [], meta: { totalOpportunities: 0, totalSections: 0 } },
+      activeIntents,
+      cache,
+    });
+
+    await service.getHomeView(USER_ID);
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Should proceed past the failed cache read and enqueue jobs
+    expect(mockAddJob).toHaveBeenCalledTimes(2);
   });
 });

--- a/protocol/src/services/tests/opportunity.service.rediscovery.spec.ts
+++ b/protocol/src/services/tests/opportunity.service.rediscovery.spec.ts
@@ -187,4 +187,27 @@ describe("OpportunityService.getHomeView — rediscovery trigger", () => {
     // But cooldown should NOT be set since all failed
     expect(cache.set).not.toHaveBeenCalled();
   });
+
+  it("does NOT set cooldown on partial failure — allows retry for failed intents", async () => {
+    // First intent succeeds, second fails
+    let callCount = 0;
+    mockAddJob.mockImplementation(() => {
+      callCount++;
+      return callCount === 1
+        ? Promise.resolve({ id: "job-1" })
+        : Promise.reject(new Error("Queue full"));
+    });
+
+    const { service, cache } = createService({
+      homeGraphResult: { sections: [], meta: { totalOpportunities: 0, totalSections: 0 } },
+      activeIntents,
+    });
+
+    await service.getHomeView(USER_ID);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mockAddJob).toHaveBeenCalledTimes(2);
+    // Cooldown should NOT be set — partial failure means retry is needed
+    expect(cache.set).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

- **Bug fix**: `resolveEnrichedStatus` no longer downgrades broker-created `latent` opportunities to `draft` when merging with existing chat drafts. Previously, `statuses.includes('draft')` matched related opportunity statuses, causing broker opportunities to become invisible on the home page.
- **Self-healing**: When `getHomeView()` returns zero actionable opportunities for a user with active intents, automatically re-queues opportunity discovery jobs (throttled to once per 6h per user via cache key, with deterministic `jobId` for BullMQ dedup).

## Bug Fixes

- Fix `resolveEnrichedStatus` to only check `incomingStatus === 'draft'`, not existing related statuses — broker `latent` opportunities now correctly appear on home view
- Add test covering the latent→draft downgrade regression

## New Features

- Add `triggerRediscoveryIfNeeded()` in `OpportunityService` — fires parallel `Promise.allSettled` enqueue when home view is empty but user has active intents

## Test plan

- [x] New enricher test: incoming latent + existing draft → resolved status stays `latent`
- [x] All 32 enricher tests pass
- [x] Type check clean (only pre-existing error in `user.controller.ts`)
- [ ] Smoke test: verify home page populates for user with expired opportunities after deploy

Fixes IND-183

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic opportunity rediscovery when home view is empty, with per-user throttling and background enqueueing.
  * Added comprehensive contacts simplification design and implementation plan to documentation.

* **Bug Fixes**
  * Merge logic updated so an existing draft no longer forces a non-draft incoming opportunity to resolve as "draft".

* **Tests**
  * Added/updated tests for opportunity status merge and rediscovery enqueue/throttle behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->