### PR TITLE
feat: bilateral agent-to-agent negotiation

### DIFF
--- a/docs/superpowers/plans/2026-03-23-bilateral-negotiation.md
+++ b/docs/superpowers/plans/2026-03-23-bilateral-negotiation.md
@@ -1,0 +1,1335 @@
+# Bilateral Agent Negotiation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add bilateral agent-to-agent negotiation as a consensus gate between opportunity evaluation and ranking, using A2A conversation primitives.
+
+**Architecture:** A new `negotiation.graph.ts` LangGraph state machine (init → turn → evaluate → finalize) is invoked per candidate from a new `negotiateNode` in the opportunity graph. Two agents (proposer/responder) exchange structured turns via A2A messages within a dedicated conversation. The negotiation outcome (consensus yes/no) determines whether the candidate proceeds to ranking.
+
+**Tech Stack:** LangGraph, Zod, Drizzle ORM (existing A2A tables), OpenRouter via `createModel()`, bun:test
+
+**Spec:** `docs/superpowers/specs/2026-03-23-bilateral-negotiation-design.md`
+
+---
+
+## File Structure
+
+### New Files
+
+| File | Responsibility |
+|------|---------------|
+| `protocol/src/lib/protocol/states/negotiation.state.ts` | Annotation.Root state, Zod schemas for NegotiationTurn and NegotiationOutcome, UserNegotiationContext type |
+| `protocol/src/lib/protocol/agents/negotiation.proposer.ts` | Agent that argues for the match — system prompt, structured output, invoke method |
+| `protocol/src/lib/protocol/agents/negotiation.responder.ts` | Agent that evaluates against its user's interests — system prompt, structured output, invoke method |
+| `protocol/src/lib/protocol/graphs/negotiation.graph.ts` | LangGraph state machine: NegotiationGraphFactory with initNode, turnNode, evaluateNode, finalizeNode |
+| `protocol/tests/negotiation.graph.spec.ts` | Unit tests for negotiation graph routing and state transitions |
+| `protocol/tests/negotiation.agents.spec.ts` | Unit tests for proposer and responder agents with mocked LLM |
+| `protocol/tests/opportunity.negotiation.spec.ts` | Integration test for negotiateNode in opportunity graph |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `protocol/src/lib/protocol/agents/model.config.ts` | Add `negotiationProposer` and `negotiationResponder` entries |
+| `protocol/src/lib/protocol/graphs/opportunity.graph.ts` | Add `negotiateNode`, rewire `evaluation → negotiate → ranking` edge, skip for continue_discovery and introduction modes |
+
+---
+
+## Task 1: Negotiation State & Zod Schemas
+
+**Files:**
+- Create: `protocol/src/lib/protocol/states/negotiation.state.ts`
+
+- [ ] **Step 1: Create the Zod schemas and types**
+
+```typescript
+// protocol/src/lib/protocol/states/negotiation.state.ts
+import { Annotation } from "@langchain/langgraph";
+import { z } from "zod";
+
+/** Zod schema for a single negotiation turn (DataPart payload in A2A message). */
+export const NegotiationTurnSchema = z.object({
+  action: z.enum(["propose", "accept", "reject", "counter"]),
+  assessment: z.object({
+    fitScore: z.number().min(0).max(100),
+    reasoning: z.string(),
+    suggestedRoles: z.object({
+      ownUser: z.enum(["agent", "patient", "peer"]),
+      otherUser: z.enum(["agent", "patient", "peer"]),
+    }),
+  }),
+});
+
+export type NegotiationTurn = z.infer<typeof NegotiationTurnSchema>;
+
+/** Zod schema for the negotiation outcome (Artifact payload on COMPLETED task). */
+export const NegotiationOutcomeSchema = z.object({
+  consensus: z.boolean(),
+  finalScore: z.number().min(0).max(100),
+  agreedRoles: z.array(z.object({
+    userId: z.string(),
+    role: z.enum(["agent", "patient", "peer"]),
+  })),
+  reasoning: z.string(),
+  turnCount: z.number(),
+  reason: z.string().optional(),
+});
+
+export type NegotiationOutcome = z.infer<typeof NegotiationOutcomeSchema>;
+
+/** Context each agent receives about its user. */
+export interface UserNegotiationContext {
+  id: string;
+  intents: Array<{ id: string; title: string; description: string; confidence: number }>;
+  profile: { name?: string; bio?: string; location?: string; interests?: string[]; skills?: string[] };
+  hydeDocuments: string[];
+}
+
+/** Seed assessment from the evaluator pre-filter. */
+export interface SeedAssessment {
+  score: number;
+  reasoning: string;
+  valencyRole: string;
+  actors?: Array<{ userId: string; role: string }>;
+}
+
+/** A2A message record shape (matches messages table). */
+interface NegotiationMessage {
+  id: string;
+  senderId: string;
+  role: "agent";
+  parts: unknown[];
+  createdAt: Date;
+}
+
+/** LangGraph state annotation for the negotiation graph. */
+export const NegotiationGraphState = Annotation.Root({
+  sourceUser: Annotation<UserNegotiationContext>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => ({} as UserNegotiationContext),
+  }),
+  candidateUser: Annotation<UserNegotiationContext>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => ({} as UserNegotiationContext),
+  }),
+  indexContext: Annotation<{ indexId: string; prompt: string }>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => ({ indexId: "", prompt: "" }),
+  }),
+  seedAssessment: Annotation<SeedAssessment>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => ({ score: 0, reasoning: "", valencyRole: "" }),
+  }),
+
+  conversationId: Annotation<string>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => "",
+  }),
+  taskId: Annotation<string>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => "",
+  }),
+  messages: Annotation<NegotiationMessage[]>({
+    reducer: (curr, next) => [...curr, ...(next || [])],
+    default: () => [],
+  }),
+  turnCount: Annotation<number>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => 0,
+  }),
+  maxTurns: Annotation<number>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => 6,
+  }),
+
+  currentSpeaker: Annotation<"source" | "candidate">({
+    reducer: (curr, next) => next ?? curr,
+    default: () => "source" as const,
+  }),
+  lastTurn: Annotation<NegotiationTurn | null>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => null,
+  }),
+
+  outcome: Annotation<NegotiationOutcome | null>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => null,
+  }),
+  error: Annotation<string | null>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => null,
+  }),
+});
+```
+
+- [ ] **Step 2: Verify the file compiles**
+
+Run: `cd protocol && npx tsc --noEmit src/lib/protocol/states/negotiation.state.ts`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add protocol/src/lib/protocol/states/negotiation.state.ts
+git commit -m "feat(negotiation): add state annotation and Zod schemas"
+```
+
+---
+
+## Task 2: Model Config Entries
+
+**Files:**
+- Modify: `protocol/src/lib/protocol/agents/model.config.ts`
+
+- [ ] **Step 1: Add negotiation agent entries to MODEL_CONFIG**
+
+Add these two entries to the `MODEL_CONFIG` object (after the `opportunityPresenter` entry):
+
+```typescript
+negotiationProposer:  { model: "google/gemini-2.5-flash" },
+negotiationResponder: { model: "google/gemini-2.5-flash" },
+```
+
+- [ ] **Step 2: Verify the file compiles**
+
+Run: `cd protocol && npx tsc --noEmit src/lib/protocol/agents/model.config.ts`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add protocol/src/lib/protocol/agents/model.config.ts
+git commit -m "feat(negotiation): add model config for proposer and responder agents"
+```
+
+---
+
+## Task 3: Negotiation Proposer Agent
+
+**Files:**
+- Create: `protocol/src/lib/protocol/agents/negotiation.proposer.ts`
+- Test: `protocol/tests/negotiation.agents.spec.ts`
+
+- [ ] **Step 1: Write the failing test for the proposer**
+
+```typescript
+// protocol/tests/negotiation.agents.spec.ts
+import { config } from "dotenv";
+config({ path: ".env.development" });
+
+import { describe, it, expect } from "bun:test";
+import { NegotiationProposer } from "../src/lib/protocol/agents/negotiation.proposer";
+import type { UserNegotiationContext, SeedAssessment, NegotiationTurn } from "../src/lib/protocol/states/negotiation.state";
+
+const sourceUser: UserNegotiationContext = {
+  id: "user-source",
+  intents: [{ id: "i1", title: "Looking for ML engineer", description: "Need ML expertise for recommendation system", confidence: 0.9 }],
+  profile: { name: "Alice", bio: "Product manager at a startup", skills: ["product management", "AI strategy"] },
+  hydeDocuments: ["A product leader seeking technical ML collaboration"],
+};
+
+const candidateUser: UserNegotiationContext = {
+  id: "user-candidate",
+  intents: [{ id: "i2", title: "Seeking PM collaboration", description: "ML engineer looking for product-minded co-founder", confidence: 0.85 }],
+  profile: { name: "Bob", bio: "Senior ML engineer", skills: ["machine learning", "PyTorch", "recommendations"] },
+  hydeDocuments: ["An ML engineer seeking product leadership for a startup venture"],
+};
+
+const seedAssessment: SeedAssessment = {
+  score: 78,
+  reasoning: "Strong complementary skills between product management and ML engineering",
+  valencyRole: "Peer",
+};
+
+describe("NegotiationProposer", () => {
+  it("generates a valid proposal turn", async () => {
+    const proposer = new NegotiationProposer();
+    const result = await proposer.invoke({
+      ownUser: sourceUser,
+      otherUser: candidateUser,
+      indexContext: { indexId: "idx-1", prompt: "AI startup co-founders" },
+      seedAssessment,
+      history: [],
+    });
+
+    expect(result.action).toBe("propose");
+    expect(result.assessment.fitScore).toBeGreaterThanOrEqual(0);
+    expect(result.assessment.fitScore).toBeLessThanOrEqual(100);
+    expect(result.assessment.reasoning).toBeTruthy();
+    expect(["agent", "patient", "peer"]).toContain(result.assessment.suggestedRoles.ownUser);
+    expect(["agent", "patient", "peer"]).toContain(result.assessment.suggestedRoles.otherUser);
+  }, 30_000);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd protocol && bun test tests/negotiation.agents.spec.ts`
+Expected: FAIL — cannot find module `negotiation.proposer`
+
+- [ ] **Step 3: Implement the proposer agent**
+
+```typescript
+// protocol/src/lib/protocol/agents/negotiation.proposer.ts
+import { createModel } from "./model.config";
+import { NegotiationTurnSchema, type NegotiationTurn, type UserNegotiationContext, type SeedAssessment } from "../states/negotiation.state";
+
+const SYSTEM_PROMPT = `You are a negotiation agent representing your user in an opportunity matching system.
+Your role is to PROPOSE and ARGUE FOR a potential match between your user and another user.
+
+You will receive:
+- Your user's profile, intents, and context
+- The other user's profile, intents, and context
+- An initial assessment from a pre-screening evaluator
+- Any prior negotiation history
+
+Your job:
+1. On the FIRST turn: Propose the match. Explain why this connection would benefit both parties. Set action to "propose".
+2. On SUBSEQUENT turns (after a counter from the other agent): Address their objections. Either:
+   - "counter" with updated reasoning if you still believe in the match
+   - "accept" if the other agent's counter is reasonable and you agree
+   - "reject" if their objections reveal this is genuinely not a good match
+
+Rules:
+- Be honest. Do not hallucinate fit where there is none.
+- Focus on concrete intent alignment, not vague similarities.
+- If the evaluator pre-screen score was low, acknowledge weaknesses.
+- Your fitScore should reflect YOUR honest assessment, not just echo the seed score.
+- suggestedRoles: "agent" = can help, "patient" = seeks help, "peer" = mutual benefit.`;
+
+export interface NegotiationProposerInput {
+  ownUser: UserNegotiationContext;
+  otherUser: UserNegotiationContext;
+  indexContext: { indexId: string; prompt: string };
+  seedAssessment: SeedAssessment;
+  history: NegotiationTurn[];
+}
+
+/**
+ * Negotiation agent that argues for the match.
+ * @remarks Uses structured output to produce a NegotiationTurn.
+ */
+export class NegotiationProposer {
+  private model;
+
+  constructor() {
+    this.model = createModel("negotiationProposer").withStructuredOutput(
+      NegotiationTurnSchema,
+      { name: "negotiation_proposer" },
+    );
+  }
+
+  /**
+   * Generate a proposal or counter-proposal turn.
+   * @param input - User contexts, seed assessment, and negotiation history
+   * @returns A structured NegotiationTurn
+   */
+  async invoke(input: NegotiationProposerInput): Promise<NegotiationTurn> {
+    const historyText = input.history.length > 0
+      ? `\n\nNegotiation history:\n${input.history.map((t, i) => `Turn ${i + 1}: ${t.action} — fitScore: ${t.assessment.fitScore}, reasoning: ${t.assessment.reasoning}`).join("\n")}`
+      : "";
+
+    const userMessage = `YOUR USER:
+Name: ${input.ownUser.profile.name ?? "Unknown"}
+Bio: ${input.ownUser.profile.bio ?? "N/A"}
+Skills: ${input.ownUser.profile.skills?.join(", ") ?? "N/A"}
+Intents: ${input.ownUser.intents.map((i) => `- ${i.title}: ${i.description} (confidence: ${i.confidence})`).join("\n")}
+
+OTHER USER:
+Name: ${input.otherUser.profile.name ?? "Unknown"}
+Bio: ${input.otherUser.profile.bio ?? "N/A"}
+Skills: ${input.otherUser.profile.skills?.join(", ") ?? "N/A"}
+Intents: ${input.otherUser.intents.map((i) => `- ${i.title}: ${i.description} (confidence: ${i.confidence})`).join("\n")}
+
+INDEX CONTEXT: ${input.indexContext.prompt || "General discovery"}
+
+EVALUATOR PRE-SCREEN: Score ${input.seedAssessment.score}/100 — ${input.seedAssessment.reasoning}
+Suggested role: ${input.seedAssessment.valencyRole}${historyText}
+
+${input.history.length === 0 ? "This is the opening turn. Propose the match." : "The other agent countered. Respond to their objections."}`;
+
+    const result = await this.model.invoke([
+      { role: "system", content: SYSTEM_PROMPT },
+      { role: "user", content: userMessage },
+    ]);
+
+    return result;
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd protocol && bun test tests/negotiation.agents.spec.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add protocol/src/lib/protocol/agents/negotiation.proposer.ts protocol/tests/negotiation.agents.spec.ts
+git commit -m "feat(negotiation): add proposer agent with LLM test"
+```
+
+---
+
+## Task 4: Negotiation Responder Agent
+
+**Files:**
+- Create: `protocol/src/lib/protocol/agents/negotiation.responder.ts`
+- Modify: `protocol/tests/negotiation.agents.spec.ts`
+
+- [ ] **Step 1: Add the failing test for the responder**
+
+Append to `protocol/tests/negotiation.agents.spec.ts`:
+
+```typescript
+import { NegotiationResponder } from "../src/lib/protocol/agents/negotiation.responder";
+
+describe("NegotiationResponder", () => {
+  it("evaluates a proposal and responds with accept, reject, or counter", async () => {
+    const responder = new NegotiationResponder();
+
+    const proposal: NegotiationTurn = {
+      action: "propose",
+      assessment: {
+        fitScore: 78,
+        reasoning: "Strong complementary skills — Alice needs ML, Bob needs product leadership",
+        suggestedRoles: { ownUser: "peer", otherUser: "peer" },
+      },
+    };
+
+    const result = await responder.invoke({
+      ownUser: candidateUser,
+      otherUser: sourceUser,
+      indexContext: { indexId: "idx-1", prompt: "AI startup co-founders" },
+      seedAssessment,
+      history: [proposal],
+    });
+
+    expect(["accept", "reject", "counter"]).toContain(result.action);
+    expect(result.assessment.fitScore).toBeGreaterThanOrEqual(0);
+    expect(result.assessment.fitScore).toBeLessThanOrEqual(100);
+    expect(result.assessment.reasoning).toBeTruthy();
+  }, 30_000);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd protocol && bun test tests/negotiation.agents.spec.ts`
+Expected: FAIL — cannot find module `negotiation.responder`
+
+- [ ] **Step 3: Implement the responder agent**
+
+```typescript
+// protocol/src/lib/protocol/agents/negotiation.responder.ts
+import { createModel } from "./model.config";
+import { NegotiationTurnSchema, type NegotiationTurn, type UserNegotiationContext, type SeedAssessment } from "../states/negotiation.state";
+
+const SYSTEM_PROMPT = `You are a negotiation agent representing your user in an opportunity matching system.
+Your role is to EVALUATE proposals and PROTECT your user from poor matches.
+
+You will receive:
+- Your user's profile, intents, and context
+- The other user's profile, intents, and context
+- The proposal or counter-proposal from the other agent
+- Full negotiation history
+
+Your job:
+1. Critically evaluate whether this match genuinely serves YOUR user's intents.
+2. Respond with one of:
+   - "accept" — the match is genuinely valuable for your user. Both sides benefit.
+   - "reject" — the match does not serve your user's needs. Explain clearly why.
+   - "counter" — partially convinced but have specific objections. State what's missing or weak.
+
+Rules:
+- Be skeptical. Your job is to protect your user from noise.
+- Don't accept just because the other agent is enthusiastic.
+- Look for concrete intent alignment, not vague overlap.
+- If the other agent addressed your previous objections well, acknowledge it.
+- If their counter didn't address your concerns, reject.
+- Your fitScore should reflect YOUR independent assessment.
+- suggestedRoles: "agent" = can help, "patient" = seeks help, "peer" = mutual benefit.`;
+
+export interface NegotiationResponderInput {
+  ownUser: UserNegotiationContext;
+  otherUser: UserNegotiationContext;
+  indexContext: { indexId: string; prompt: string };
+  seedAssessment: SeedAssessment;
+  history: NegotiationTurn[];
+}
+
+/**
+ * Negotiation agent that evaluates proposals against its user's interests.
+ * @remarks Uses structured output to produce a NegotiationTurn.
+ */
+export class NegotiationResponder {
+  private model;
+
+  constructor() {
+    this.model = createModel("negotiationResponder").withStructuredOutput(
+      NegotiationTurnSchema,
+      { name: "negotiation_responder" },
+    );
+  }
+
+  /**
+   * Evaluate a proposal/counter and respond.
+   * @param input - User contexts, seed assessment, and negotiation history
+   * @returns A structured NegotiationTurn (accept/reject/counter)
+   */
+  async invoke(input: NegotiationResponderInput): Promise<NegotiationTurn> {
+    const historyText = input.history
+      .map((t, i) => `Turn ${i + 1}: ${t.action} — fitScore: ${t.assessment.fitScore}, reasoning: ${t.assessment.reasoning}`)
+      .join("\n");
+
+    const userMessage = `YOUR USER:
+Name: ${input.ownUser.profile.name ?? "Unknown"}
+Bio: ${input.ownUser.profile.bio ?? "N/A"}
+Skills: ${input.ownUser.profile.skills?.join(", ") ?? "N/A"}
+Intents: ${input.ownUser.intents.map((i) => `- ${i.title}: ${i.description} (confidence: ${i.confidence})`).join("\n")}
+
+OTHER USER (proposing the match):
+Name: ${input.otherUser.profile.name ?? "Unknown"}
+Bio: ${input.otherUser.profile.bio ?? "N/A"}
+Skills: ${input.otherUser.profile.skills?.join(", ") ?? "N/A"}
+Intents: ${input.otherUser.intents.map((i) => `- ${i.title}: ${i.description} (confidence: ${i.confidence})`).join("\n")}
+
+INDEX CONTEXT: ${input.indexContext.prompt || "General discovery"}
+
+EVALUATOR PRE-SCREEN: Score ${input.seedAssessment.score}/100 — ${input.seedAssessment.reasoning}
+
+NEGOTIATION HISTORY:
+${historyText}
+
+Evaluate the latest proposal/counter from the other agent. Does this match genuinely serve your user?`;
+
+    const result = await this.model.invoke([
+      { role: "system", content: SYSTEM_PROMPT },
+      { role: "user", content: userMessage },
+    ]);
+
+    return result;
+  }
+}
+```
+
+- [ ] **Step 4: Run all agent tests to verify they pass**
+
+Run: `cd protocol && bun test tests/negotiation.agents.spec.ts`
+Expected: PASS (both proposer and responder tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add protocol/src/lib/protocol/agents/negotiation.responder.ts protocol/tests/negotiation.agents.spec.ts
+git commit -m "feat(negotiation): add responder agent with LLM test"
+```
+
+---
+
+## Task 5: Negotiation Graph
+
+**Files:**
+- Create: `protocol/src/lib/protocol/graphs/negotiation.graph.ts`
+- Test: `protocol/tests/negotiation.graph.spec.ts`
+
+- [ ] **Step 1: Write the failing test for graph routing**
+
+```typescript
+// protocol/tests/negotiation.graph.spec.ts
+import { config } from "dotenv";
+config({ path: ".env.development" });
+
+import { describe, it, expect, mock } from "bun:test";
+import { NegotiationGraphFactory } from "../src/lib/protocol/graphs/negotiation.graph";
+import type { UserNegotiationContext, SeedAssessment } from "../src/lib/protocol/states/negotiation.state";
+
+const sourceUser: UserNegotiationContext = {
+  id: "user-source",
+  intents: [{ id: "i1", title: "Looking for ML engineer", description: "Need ML expertise", confidence: 0.9 }],
+  profile: { name: "Alice", bio: "PM at startup", skills: ["product"] },
+  hydeDocuments: [],
+};
+
+const candidateUser: UserNegotiationContext = {
+  id: "user-candidate",
+  intents: [{ id: "i2", title: "Seeking PM", description: "ML eng seeking product co-founder", confidence: 0.85 }],
+  profile: { name: "Bob", bio: "ML engineer", skills: ["ML"] },
+  hydeDocuments: [],
+};
+
+const seed: SeedAssessment = { score: 78, reasoning: "Complementary skills", valencyRole: "Peer" };
+
+function createMockDeps(proposerAction = "propose", responderAction = "accept") {
+  let callCount = 0;
+  return {
+    conversationService: {
+      createConversation: mock(() => Promise.resolve({ id: "conv-1" })),
+      sendMessage: mock(() => Promise.resolve({ id: "msg-1", senderId: "agent", role: "agent", parts: [], createdAt: new Date() })),
+    },
+    taskService: {
+      createTask: mock(() => Promise.resolve({ id: "task-1", conversationId: "conv-1", state: "submitted" })),
+      updateState: mock(() => Promise.resolve({})),
+      createArtifact: mock(() => Promise.resolve({ id: "art-1" })),
+    },
+    proposer: {
+      invoke: mock(() => {
+        callCount++;
+        return Promise.resolve({
+          action: proposerAction,
+          assessment: { fitScore: 80, reasoning: "Good match", suggestedRoles: { ownUser: "peer", otherUser: "peer" } },
+        });
+      }),
+    },
+    responder: {
+      invoke: mock(() => {
+        return Promise.resolve({
+          action: responderAction,
+          assessment: { fitScore: 75, reasoning: "Agreed, good fit", suggestedRoles: { ownUser: "peer", otherUser: "peer" } },
+        });
+      }),
+    },
+  };
+}
+
+describe("NegotiationGraph", () => {
+  it("reaches consensus when responder accepts", async () => {
+    const deps = createMockDeps("propose", "accept");
+    const factory = new NegotiationGraphFactory(
+      deps.conversationService as any,
+      deps.taskService as any,
+      deps.proposer as any,
+      deps.responder as any,
+    );
+    const graph = factory.createGraph();
+    const result = await graph.invoke({
+      sourceUser,
+      candidateUser,
+      indexContext: { indexId: "idx-1", prompt: "AI co-founders" },
+      seedAssessment: seed,
+    });
+
+    expect(result.outcome).not.toBeNull();
+    expect(result.outcome!.consensus).toBe(true);
+    expect(result.outcome!.turnCount).toBe(2);
+    expect(deps.taskService.createArtifact).toHaveBeenCalled();
+  }, 30_000);
+
+  it("rejects when responder rejects", async () => {
+    const deps = createMockDeps("propose", "reject");
+    const factory = new NegotiationGraphFactory(
+      deps.conversationService as any,
+      deps.taskService as any,
+      deps.proposer as any,
+      deps.responder as any,
+    );
+    const graph = factory.createGraph();
+    const result = await graph.invoke({
+      sourceUser,
+      candidateUser,
+      indexContext: { indexId: "idx-1", prompt: "AI co-founders" },
+      seedAssessment: seed,
+    });
+
+    expect(result.outcome).not.toBeNull();
+    expect(result.outcome!.consensus).toBe(false);
+  }, 30_000);
+
+  it("rejects when turn cap is exceeded", async () => {
+    const deps = createMockDeps("counter", "counter");
+    const factory = new NegotiationGraphFactory(
+      deps.conversationService as any,
+      deps.taskService as any,
+      deps.proposer as any,
+      deps.responder as any,
+    );
+    const graph = factory.createGraph();
+    const result = await graph.invoke({
+      sourceUser,
+      candidateUser,
+      indexContext: { indexId: "idx-1", prompt: "AI co-founders" },
+      seedAssessment: seed,
+      maxTurns: 4,
+    });
+
+    expect(result.outcome).not.toBeNull();
+    expect(result.outcome!.consensus).toBe(false);
+    expect(result.outcome!.reason).toBe("turn_cap");
+    expect(result.turnCount).toBeLessThanOrEqual(4);
+  }, 30_000);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd protocol && bun test tests/negotiation.graph.spec.ts`
+Expected: FAIL — cannot find module `negotiation.graph`
+
+- [ ] **Step 3: Implement the negotiation graph**
+
+```typescript
+// protocol/src/lib/protocol/graphs/negotiation.graph.ts
+import { StateGraph, END } from "@langchain/langgraph";
+
+import { NegotiationGraphState, type NegotiationTurn, type NegotiationOutcome } from "../states/negotiation.state";
+import type { NegotiationProposer } from "../agents/negotiation.proposer";
+import type { NegotiationResponder } from "../agents/negotiation.responder";
+
+interface ConversationServiceLike {
+  createConversation(participants: { participantId: string; participantType: "user" | "agent" }[]): Promise<{ id: string }>;
+  sendMessage(
+    conversationId: string,
+    senderId: string,
+    role: "user" | "agent",
+    parts: unknown[],
+    opts?: { taskId?: string; metadata?: Record<string, unknown> },
+  ): Promise<{ id: string; senderId: string; role: string; parts: unknown[]; createdAt: Date }>;
+}
+
+interface TaskServiceLike {
+  createTask(conversationId: string, metadata?: Record<string, unknown>): Promise<{ id: string; conversationId: string; state: string }>;
+  updateState(taskId: string, state: string, statusMessage?: unknown): Promise<unknown>;
+  createArtifact(taskId: string, data: { name?: string; parts: unknown[]; metadata?: Record<string, unknown> }): Promise<{ id: string }>;
+}
+
+interface ProposerLike {
+  invoke(input: {
+    ownUser: typeof NegotiationGraphState.State.sourceUser;
+    otherUser: typeof NegotiationGraphState.State.candidateUser;
+    indexContext: typeof NegotiationGraphState.State.indexContext;
+    seedAssessment: typeof NegotiationGraphState.State.seedAssessment;
+    history: NegotiationTurn[];
+  }): Promise<NegotiationTurn>;
+}
+
+interface ResponderLike {
+  invoke(input: {
+    ownUser: typeof NegotiationGraphState.State.candidateUser;
+    otherUser: typeof NegotiationGraphState.State.sourceUser;
+    indexContext: typeof NegotiationGraphState.State.indexContext;
+    seedAssessment: typeof NegotiationGraphState.State.seedAssessment;
+    history: NegotiationTurn[];
+  }): Promise<NegotiationTurn>;
+}
+
+/**
+ * Factory for the bilateral negotiation LangGraph state machine.
+ * @remarks Accepts dependencies via constructor for testability.
+ */
+export class NegotiationGraphFactory {
+  constructor(
+    private conversationService: ConversationServiceLike,
+    private taskService: TaskServiceLike,
+    private proposer: ProposerLike,
+    private responder: ResponderLike,
+  ) {}
+
+  createGraph() {
+    const { conversationService, taskService, proposer, responder } = this;
+
+    const initNode = async (state: typeof NegotiationGraphState.State) => {
+      try {
+        const conversation = await conversationService.createConversation([
+          { participantId: `agent:${state.sourceUser.id}`, participantType: "agent" },
+          { participantId: `agent:${state.candidateUser.id}`, participantType: "agent" },
+        ]);
+
+        const task = await taskService.createTask(conversation.id, {
+          type: "negotiation",
+          sourceUserId: state.sourceUser.id,
+          candidateUserId: state.candidateUser.id,
+        });
+
+        return {
+          conversationId: conversation.id,
+          taskId: task.id,
+          currentSpeaker: "source" as const,
+          turnCount: 0,
+        };
+      } catch (err) {
+        return { error: `Init failed: ${err instanceof Error ? err.message : String(err)}` };
+      }
+    };
+
+    const turnNode = async (state: typeof NegotiationGraphState.State) => {
+      try {
+        const history: NegotiationTurn[] = state.messages.map((m) => {
+          const dataPart = (m.parts as Array<{ kind?: string; data?: unknown }>).find((p) => p.kind === "data");
+          return dataPart?.data as NegotiationTurn;
+        }).filter(Boolean);
+
+        const isSource = state.currentSpeaker === "source";
+        const agent = isSource ? proposer : responder;
+        const ownUser = isSource ? state.sourceUser : state.candidateUser;
+        const otherUser = isSource ? state.candidateUser : state.sourceUser;
+        const senderId = `agent:${ownUser.id}`;
+
+        const turn = await agent.invoke({
+          ownUser,
+          otherUser,
+          indexContext: state.indexContext,
+          seedAssessment: state.seedAssessment,
+          history,
+        });
+
+        // First turn must be "propose"
+        if (state.turnCount === 0 && turn.action !== "propose") {
+          turn.action = "propose";
+        }
+
+        const parts = [{ kind: "data" as const, data: turn }];
+        const message = await conversationService.sendMessage(
+          state.conversationId,
+          senderId,
+          "agent",
+          parts,
+          { taskId: state.taskId },
+        );
+
+        const taskState = state.turnCount === 0 ? "working" : "input_required";
+        await taskService.updateState(state.taskId, taskState);
+
+        return {
+          messages: [{
+            id: message.id,
+            senderId: message.senderId,
+            role: "agent" as const,
+            parts: message.parts,
+            createdAt: message.createdAt,
+          }],
+          turnCount: state.turnCount + 1,
+          currentSpeaker: (isSource ? "candidate" : "source") as "source" | "candidate",
+          lastTurn: turn,
+        };
+      } catch (err) {
+        return {
+          lastTurn: {
+            action: "reject" as const,
+            assessment: { fitScore: 0, reasoning: `Agent error: ${err instanceof Error ? err.message : String(err)}`, suggestedRoles: { ownUser: "peer" as const, otherUser: "peer" as const } },
+          },
+          turnCount: state.turnCount + 1,
+          error: `Turn failed: ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+    };
+
+    const evaluateNode = (state: typeof NegotiationGraphState.State): string => {
+      if (state.error) return "finalize";
+      if (!state.lastTurn) return "finalize";
+      if (state.lastTurn.action === "accept") return "finalize";
+      if (state.lastTurn.action === "reject") return "finalize";
+      if (state.turnCount >= state.maxTurns) return "finalize";
+      return "turn";
+    };
+
+    const finalizeNode = async (state: typeof NegotiationGraphState.State) => {
+      const history: NegotiationTurn[] = state.messages.map((m) => {
+        const dataPart = (m.parts as Array<{ kind?: string; data?: unknown }>).find((p) => p.kind === "data");
+        return dataPart?.data as NegotiationTurn;
+      }).filter(Boolean);
+
+      const lastTurn = state.lastTurn;
+      const consensus = lastTurn?.action === "accept";
+      const atCap = state.turnCount >= state.maxTurns && lastTurn?.action === "counter";
+
+      // Average fit scores from both sides for final score
+      const scores = history.map((t) => t.assessment.fitScore);
+      const avgScore = scores.length > 0 ? Math.round(scores.reduce((a, b) => a + b, 0) / scores.length) : 0;
+
+      // Derive agreed roles from the last two turns (if consensus)
+      let agreedRoles: Array<{ userId: string; role: string }> = [];
+      if (consensus && history.length >= 2) {
+        const lastTwo = history.slice(-2);
+        agreedRoles = [
+          { userId: state.sourceUser.id, role: lastTwo[0].assessment.suggestedRoles.ownUser },
+          { userId: state.candidateUser.id, role: lastTwo[1].assessment.suggestedRoles.ownUser },
+        ];
+      }
+
+      const outcome: NegotiationOutcome = {
+        consensus,
+        finalScore: consensus ? avgScore : 0,
+        agreedRoles,
+        reasoning: history.map((t) => t.assessment.reasoning).join(" | "),
+        turnCount: state.turnCount,
+        ...(atCap && { reason: "turn_cap" }),
+      };
+
+      try {
+        await taskService.updateState(state.taskId, "completed");
+        await taskService.createArtifact(state.taskId, {
+          name: "negotiation-outcome",
+          parts: [{ kind: "data", data: outcome }],
+          metadata: { consensus, turnCount: state.turnCount },
+        });
+      } catch (err) {
+        // DB failure is non-blocking — outcome is still returned via state
+      }
+
+      return { outcome };
+    };
+
+    const workflow = new StateGraph(NegotiationGraphState)
+      .addNode("init", initNode)
+      .addNode("turn", turnNode)
+      .addNode("finalize", finalizeNode)
+      .addConditionalEdges("turn", evaluateNode, {
+        turn: "turn",
+        finalize: "finalize",
+      })
+      .addEdge("__start__", "init")
+      .addEdge("init", "turn")
+      .addEdge("finalize", "__end__");
+
+    return workflow.compile();
+  }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd protocol && bun test tests/negotiation.graph.spec.ts`
+Expected: PASS (all 3 tests: consensus, rejection, turn cap)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add protocol/src/lib/protocol/graphs/negotiation.graph.ts protocol/tests/negotiation.graph.spec.ts
+git commit -m "feat(negotiation): add negotiation graph with routing tests"
+```
+
+---
+
+## Task 6: Integrate negotiateNode into Opportunity Graph
+
+**Files:**
+- Modify: `protocol/src/lib/protocol/graphs/opportunity.graph.ts`
+- Test: `protocol/tests/opportunity.negotiation.spec.ts`
+
+- [ ] **Step 1: Write the failing integration test**
+
+```typescript
+// protocol/tests/opportunity.negotiation.spec.ts
+import { config } from "dotenv";
+config({ path: ".env.development" });
+
+import { describe, it, expect, mock } from "bun:test";
+
+describe("Opportunity Graph — Negotiation Integration", () => {
+  it("negotiateNode filters candidates by negotiation consensus", async () => {
+    // This test verifies the wiring: candidates that fail negotiation are dropped
+    // We test the negotiateNode function in isolation by extracting it
+
+    // Mock negotiation graph that accepts first candidate, rejects second
+    const mockNegotiationGraph = {
+      invoke: mock((input: any) => {
+        const isFirstCandidate = input.candidateUser.id === "candidate-1";
+        return Promise.resolve({
+          outcome: {
+            consensus: isFirstCandidate,
+            finalScore: isFirstCandidate ? 82 : 0,
+            agreedRoles: isFirstCandidate
+              ? [{ userId: "source", role: "peer" }, { userId: "candidate-1", role: "peer" }]
+              : [],
+            reasoning: isFirstCandidate ? "Good match" : "No fit",
+            turnCount: 2,
+          },
+        });
+      }),
+    };
+
+    // Import the negotiate helper after mocking
+    const { negotiateCandidates } = await import("../src/lib/protocol/graphs/negotiation.graph");
+
+    const candidates = [
+      { userId: "candidate-1", score: 78, reasoning: "OK", valencyRole: "Peer" },
+      { userId: "candidate-2", score: 72, reasoning: "Weak", valencyRole: "Agent" },
+    ];
+
+    const sourceUser = {
+      id: "source",
+      intents: [{ id: "i1", title: "Test", description: "Test intent", confidence: 0.9 }],
+      profile: { name: "Alice" },
+      hydeDocuments: [],
+    };
+
+    const results = await negotiateCandidates(
+      mockNegotiationGraph as any,
+      sourceUser,
+      candidates.map((c) => ({
+        ...c,
+        candidateUser: {
+          id: c.userId,
+          intents: [{ id: "i2", title: "Test", description: "Counter intent", confidence: 0.8 }],
+          profile: { name: c.userId },
+          hydeDocuments: [],
+        },
+      })),
+      { indexId: "idx-1", prompt: "Test" },
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0].userId).toBe("candidate-1");
+    expect(results[0].negotiationScore).toBe(82);
+  }, 30_000);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd protocol && bun test tests/opportunity.negotiation.spec.ts`
+Expected: FAIL — `negotiateCandidates` not found
+
+- [ ] **Step 3: Add the `negotiateCandidates` helper to negotiation.graph.ts**
+
+Append to `protocol/src/lib/protocol/graphs/negotiation.graph.ts`:
+
+```typescript
+import type { UserNegotiationContext, SeedAssessment } from "../states/negotiation.state";
+
+interface NegotiationCandidate {
+  userId: string;
+  score: number;
+  reasoning: string;
+  valencyRole: string;
+  candidateUser: UserNegotiationContext;
+}
+
+interface NegotiationResult {
+  userId: string;
+  negotiationScore: number;
+  agreedRoles: Array<{ userId: string; role: string }>;
+  reasoning: string;
+  turnCount: number;
+}
+
+/**
+ * Runs bilateral negotiation for each candidate in parallel.
+ * Returns only candidates that achieved consensus.
+ */
+export async function negotiateCandidates(
+  negotiationGraph: { invoke: (input: any) => Promise<{ outcome: any }> },
+  sourceUser: UserNegotiationContext,
+  candidates: NegotiationCandidate[],
+  indexContext: { indexId: string; prompt: string },
+  maxTurns?: number,
+): Promise<NegotiationResult[]> {
+  const results = await Promise.all(
+    candidates.map(async (candidate) => {
+      try {
+        const result = await negotiationGraph.invoke({
+          sourceUser,
+          candidateUser: candidate.candidateUser,
+          indexContext,
+          seedAssessment: {
+            score: candidate.score,
+            reasoning: candidate.reasoning,
+            valencyRole: candidate.valencyRole,
+          },
+          ...(maxTurns !== undefined && { maxTurns }),
+        });
+
+        if (result.outcome?.consensus) {
+          return {
+            userId: candidate.userId,
+            negotiationScore: result.outcome.finalScore,
+            agreedRoles: result.outcome.agreedRoles,
+            reasoning: result.outcome.reasoning,
+            turnCount: result.outcome.turnCount,
+          };
+        }
+        return null;
+      } catch {
+        return null; // Negotiation failure = no consensus
+      }
+    }),
+  );
+
+  return results.filter((r): r is NegotiationResult => r !== null);
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd protocol && bun test tests/opportunity.negotiation.spec.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add protocol/src/lib/protocol/graphs/negotiation.graph.ts protocol/tests/opportunity.negotiation.spec.ts
+git commit -m "feat(negotiation): add negotiateCandidates helper with integration test"
+```
+
+---
+
+## Task 7: Wire negotiateNode into Opportunity Graph
+
+**Files:**
+- Modify: `protocol/src/lib/protocol/graphs/opportunity.graph.ts`
+
+This task modifies the opportunity graph to insert negotiation between evaluation and ranking. This is the most delicate change — it rewires existing graph edges.
+
+- [ ] **Step 1: Read the current opportunity graph to locate exact insertion points**
+
+Read `protocol/src/lib/protocol/graphs/opportunity.graph.ts` and identify:
+- The `OpportunityGraphFactory` constructor (to add negotiation graph dependency)
+- The `evaluationNode` output shape (what candidates look like post-evaluation)
+- The `.addEdge('evaluation', 'ranking')` line (to replace with conditional routing)
+- The `routeByMode` and `shouldContinueAfterPrep` functions (to understand skip logic)
+
+- [ ] **Step 2: Add negotiation graph as a dependency to OpportunityGraphFactory**
+
+In the constructor, add a new optional parameter:
+
+```typescript
+private negotiationGraph?: { invoke: (input: any) => Promise<{ outcome: any }> },
+```
+
+- [ ] **Step 3: Add the negotiateNode**
+
+Add after the evaluationNode definition. The node:
+1. Checks if negotiation should be skipped (continue_discovery, introduction mode, or no negotiation graph)
+2. Builds `UserNegotiationContext` for source and each candidate from existing state
+3. Calls `negotiateCandidates()` in parallel
+4. Replaces the candidates list with only consensus results
+5. Emits trace events
+
+```typescript
+// NOTE: The opportunity graph uses `evaluatedOpportunities` (multi-actor, from entity-bundle
+// evaluator), NOT the legacy `evaluatedCandidates`. Each EvaluatedOpportunity has:
+//   { actors: [{ userId, role, intentId, indexId }], score, reasoning }
+// The source user's profile is in `state.sourceProfile` which has nested structure:
+//   { identity?: { name?, bio?, location? }, attributes?: { skills?, interests? } }
+// Chat path detection uses `state.options?.conversationId` (not chatSessionId).
+
+const negotiateNode = async (state: typeof OpportunityGraphState.State) => {
+  if (!this.negotiationGraph) {
+    return {}; // Pass through — no negotiation configured
+  }
+
+  const traceEmitter = requestContext.getStore()?.traceEmitter;
+  const graphStart = Date.now();
+  traceEmitter?.({ type: "graph_start", name: "negotiation" });
+
+  try {
+    // Build source user context from state
+    const sourceUser = {
+      id: state.userId as string,
+      intents: state.indexedIntents?.map(i => ({
+        id: i.intentId as string,
+        title: i.summary ?? '',
+        description: i.payload ?? '',
+        confidence: 1, // IndexedIntent has no confidence; use default
+      })) ?? [],
+      profile: {
+        name: state.sourceProfile?.identity?.name,
+        bio: state.sourceProfile?.identity?.bio,
+        location: state.sourceProfile?.identity?.location,
+        skills: state.sourceProfile?.attributes?.skills,
+        interests: state.sourceProfile?.attributes?.interests,
+      },
+      hydeDocuments: [] as string[],
+    };
+
+    // Build candidate contexts from evaluatedOpportunities (multi-actor shape)
+    // For each opportunity, find the non-source actor(s) as the candidate
+    const negotiationCandidates = state.evaluatedOpportunities.map(opp => {
+      const candidateActor = opp.actors.find(a => a.userId !== state.userId);
+      if (!candidateActor) return null;
+
+      return {
+        userId: candidateActor.userId as string,
+        score: opp.score,
+        reasoning: opp.reasoning,
+        valencyRole: candidateActor.role ?? 'peer',
+        candidateUser: {
+          id: candidateActor.userId as string,
+          // NOTE: Candidate profile/intents need to be loaded from DB.
+          // The evaluatedOpportunities don't carry full profiles — the implementer
+          // must add a DB lookup here (similar to how opportunity.discover.ts
+          // fetches profiles for enrichment). For now, use what's available in state.
+          intents: candidateActor.intentId
+            ? [{ id: candidateActor.intentId as string, title: '', description: '', confidence: 1 }]
+            : [],
+          profile: { name: '' },
+          hydeDocuments: [] as string[],
+        },
+      };
+    }).filter(Boolean);
+
+    // Chat path uses reduced turn cap for latency; detected via options.conversationId
+    const isChatPath = !!state.options?.conversationId;
+    const maxTurns = isChatPath ? 4 : 6;
+
+    const consensusResults = await negotiateCandidates(
+      this.negotiationGraph, sourceUser, negotiationCandidates as any[],
+      { indexId: state.indexId as string ?? '', prompt: '' },
+      maxTurns,
+    );
+
+    // Filter evaluatedOpportunities to only those with consensus
+    const consensusUserIds = new Set(consensusResults.map(r => r.userId));
+    const filtered = state.evaluatedOpportunities.filter(opp => {
+      const candidateActor = opp.actors.find(a => a.userId !== state.userId);
+      return candidateActor && consensusUserIds.has(candidateActor.userId as string);
+    });
+
+    // Update scores with negotiation scores
+    for (const opp of filtered) {
+      const candidateActor = opp.actors.find(a => a.userId !== state.userId);
+      if (!candidateActor) continue;
+      const negResult = consensusResults.find(r => r.userId === (candidateActor.userId as string));
+      if (negResult) {
+        opp.score = negResult.negotiationScore;
+      }
+    }
+
+    traceEmitter?.({ type: "graph_end", name: "negotiation", durationMs: Date.now() - graphStart });
+    return { evaluatedOpportunities: filtered };
+  } catch (err) {
+    traceEmitter?.({ type: "graph_end", name: "negotiation", durationMs: Date.now() - graphStart });
+    return {}; // On error, pass through without filtering
+  }
+};
+```
+
+- [ ] **Step 4: Register the node and rewire edges**
+
+Replace the direct `evaluation → ranking` edge:
+
+```typescript
+// Before:
+.addEdge('evaluation', 'ranking')
+
+// After:
+.addNode('negotiate', negotiateNode)
+.addConditionalEdges('evaluation', (state) => {
+  // Skip negotiation for continue_discovery (paginated cached candidates)
+  // Note: create_introduction never reaches evaluation node (separate path)
+  if (state.operationMode === 'continue_discovery') return 'ranking';
+  if (!this.negotiationGraph) return 'ranking';
+  return 'negotiate';
+}, {
+  negotiate: 'negotiate',
+  ranking: 'ranking',
+})
+.addEdge('negotiate', 'ranking')
+```
+
+- [ ] **Step 5: Verify the opportunity graph still compiles**
+
+Run: `cd protocol && npx tsc --noEmit src/lib/protocol/graphs/opportunity.graph.ts`
+Expected: No errors
+
+- [ ] **Step 6: Run existing opportunity graph tests to verify no regression**
+
+Run: `cd protocol && bun test tests/maintenance-graph.spec.ts`
+Expected: PASS (existing tests unaffected since negotiation graph is optional)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add protocol/src/lib/protocol/graphs/opportunity.graph.ts
+git commit -m "feat(negotiation): wire negotiateNode into opportunity graph pipeline"
+```
+
+---
+
+## Task 8: End-to-End Smoke Test
+
+**Files:**
+- Create: `protocol/tests/negotiation.e2e.spec.ts`
+
+- [ ] **Step 1: Write the E2E test with real LLM calls**
+
+```typescript
+// protocol/tests/negotiation.e2e.spec.ts
+import { config } from "dotenv";
+config({ path: ".env.development" });
+
+import { describe, it, expect } from "bun:test";
+import { NegotiationGraphFactory } from "../src/lib/protocol/graphs/negotiation.graph";
+import { NegotiationProposer } from "../src/lib/protocol/agents/negotiation.proposer";
+import { NegotiationResponder } from "../src/lib/protocol/agents/negotiation.responder";
+import { ConversationService } from "../src/services/conversation.service";
+import { TaskService } from "../src/services/task.service";
+
+// Prerequisites: requires DATABASE_URL and OPENROUTER_API_KEY in .env.development
+// Run with: cd protocol && bun test tests/negotiation.e2e.spec.ts
+
+describe("Negotiation E2E", () => {
+  it("runs a full negotiation with real agents and A2A persistence", async () => {
+    const conversationService = new ConversationService();
+    const taskService = new TaskService();
+    const proposer = new NegotiationProposer();
+    const responder = new NegotiationResponder();
+
+    const factory = new NegotiationGraphFactory(
+      conversationService,
+      taskService,
+      proposer,
+      responder,
+    );
+    const graph = factory.createGraph();
+
+    const result = await graph.invoke({
+      sourceUser: {
+        id: "e2e-source",
+        intents: [{ id: "i1", title: "Looking for ML engineer", description: "Need ML expertise for recommendation system", confidence: 0.9 }],
+        profile: { name: "Alice", bio: "Product manager building AI startup", skills: ["product management", "AI strategy"] },
+        hydeDocuments: [],
+      },
+      candidateUser: {
+        id: "e2e-candidate",
+        intents: [{ id: "i2", title: "Seeking PM co-founder", description: "ML engineer looking for product-minded co-founder", confidence: 0.85 }],
+        profile: { name: "Bob", bio: "Senior ML engineer with 8 years experience", skills: ["machine learning", "PyTorch"] },
+        hydeDocuments: [],
+      },
+      indexContext: { indexId: "e2e-index", prompt: "AI startup co-founders" },
+      seedAssessment: { score: 78, reasoning: "Complementary skills", valencyRole: "Peer" },
+      maxTurns: 4,
+    });
+
+    // Verify outcome exists
+    expect(result.outcome).not.toBeNull();
+    expect(typeof result.outcome!.consensus).toBe("boolean");
+    expect(result.outcome!.turnCount).toBeGreaterThanOrEqual(2);
+    expect(result.outcome!.turnCount).toBeLessThanOrEqual(4);
+    expect(result.outcome!.reasoning).toBeTruthy();
+
+    // Verify A2A records were created
+    expect(result.conversationId).toBeTruthy();
+    expect(result.taskId).toBeTruthy();
+    expect(result.messages.length).toBeGreaterThanOrEqual(2);
+  }, 120_000); // 2 minute timeout for multiple LLM calls
+});
+```
+
+- [ ] **Step 2: Run the E2E test**
+
+Run: `cd protocol && bun test tests/negotiation.e2e.spec.ts`
+Expected: PASS (requires database and OpenRouter API key)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add protocol/tests/negotiation.e2e.spec.ts
+git commit -m "test(negotiation): add E2E smoke test with real LLM calls"
+```
+
+---
+
+## Summary
+
+| Task | What | Files | Depends On |
+|------|------|-------|------------|
+| 1 | State & Zod schemas | `negotiation.state.ts` | — |
+| 2 | Model config entries | `model.config.ts` | — |
+| 3 | Proposer agent | `negotiation.proposer.ts`, tests | 1, 2 |
+| 4 | Responder agent | `negotiation.responder.ts`, tests | 1, 2 |
+| 5 | Negotiation graph | `negotiation.graph.ts`, tests | 1, 3, 4 |
+| 6 | negotiateCandidates helper | `negotiation.graph.ts`, tests | 5 |
+| 7 | Wire into opportunity graph | `opportunity.graph.ts` | 5, 6 |
+| 8 | E2E smoke test | `negotiation.e2e.spec.ts` | 5, 7 |

--- a/frontend/src/app/library/page.tsx
+++ b/frontend/src/app/library/page.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
-import { useNavigate } from "react-router";
+import { useNavigate, useParams } from "react-router";
 import * as Tabs from "@radix-ui/react-tabs";
 import { Loader2, Trash2, ExternalLink } from "lucide-react";
 import { useAuthContext } from "@/contexts/AuthContext";
@@ -9,7 +9,7 @@ import { useNotifications } from "@/contexts/NotificationContext";
 import { formatDate } from "@/lib/utils";
 import { formatFileSize, getFileCategoryBadge } from "@/lib/file-validation";
 import IntentList from "@/components/IntentList";
-import NegotiationList from "@/components/NegotiationList";
+import NegotiationHistory from "@/components/NegotiationHistory";
 import ClientLayout from "@/components/ClientLayout";
 import { ContentContainer } from "@/components/layout";
 
@@ -41,14 +41,19 @@ type LinkItem = {
   lastSyncAt?: string | null;
 };
 
+const VALID_TABS = ['intents', 'negotiations', 'files', 'links'] as const;
+type TabValue = typeof VALID_TABS[number];
+
 export default function LibraryPage() {
   const navigate = useNavigate();
-  const { isAuthenticated, isLoading: authLoading } = useAuthContext();
+  const { tab } = useParams<{ tab?: string }>();
+  const { user, isAuthenticated, isLoading: authLoading } = useAuthContext();
   const { filesService, linksService, intentsService } = useAPI();
   const api = useAuthenticatedAPI();
   const { success, error } = useNotifications();
 
-  const [activeTab, setActiveTab] = useState<'intents' | 'negotiations' | 'files' | 'links'>('intents');
+  const activeTab: TabValue = VALID_TABS.includes(tab as TabValue) ? (tab as TabValue) : 'intents';
+  const setActiveTab = (v: string) => navigate(`/library/${v}`, { replace: true });
   const [isLoading, setIsLoading] = useState(true);
   const tabDescriptions = {
     intents: {
@@ -61,7 +66,7 @@ export default function LibraryPage() {
     negotiations: {
       title: "Negotiations",
       description:
-        "Your agent negotiates with other agents to coordinate discovery. They continuously align on intent, timing, trust, value, and data sharing before any connection is made.",
+        "Past negotiations between your agent and others. Expand any to see the full dialogue.",
       privacy:
         "Negotiations are private between participating agents. You see only your side."
     },
@@ -215,7 +220,7 @@ export default function LibraryPage() {
         <ContentContainer>
           <h1 className="text-2xl font-bold text-black font-ibm-plex-mono mb-6">Library</h1>
 
-          <Tabs.Root value={activeTab} onValueChange={(v) => setActiveTab(v as typeof activeTab)}>
+          <Tabs.Root value={activeTab} onValueChange={setActiveTab}>
             <Tabs.List className="flex border-b border-gray-200 mb-6">
             <Tabs.Trigger 
               value="intents" 
@@ -225,6 +230,12 @@ export default function LibraryPage() {
               {intents.length > 0 && (
                 <span className="ml-2 text-xs text-gray-500">({intents.length})</span>
               )}
+            </Tabs.Trigger>
+            <Tabs.Trigger 
+              value="negotiations" 
+              className="px-4 py-2 text-sm text-gray-600 border-b-2 border-transparent data-[state=active]:border-black data-[state=active]:text-black data-[state=active]:font-bold"
+            >
+              Negotiations
             </Tabs.Trigger>
             <Tabs.Trigger 
               value="files" 
@@ -243,12 +254,6 @@ export default function LibraryPage() {
               {links.length > 0 && (
                 <span className="ml-2 text-xs text-gray-500">({links.length})</span>
               )}
-            </Tabs.Trigger>
-            <Tabs.Trigger 
-              value="negotiations" 
-              className="px-4 py-2 text-sm text-gray-600 border-b-2 border-transparent data-[state=active]:border-black data-[state=active]:text-black data-[state=active]:font-bold"
-            >
-              Negotiations
             </Tabs.Trigger>
           </Tabs.List>
           <div className="mb-6 space-y-1">
@@ -279,7 +284,7 @@ export default function LibraryPage() {
 
           {/* Negotiations Tab */}
           <Tabs.Content value="negotiations" className="w-full">
-            <NegotiationList />
+            <NegotiationHistory userId={user?.id ?? ""} />
           </Tabs.Content>
 
           {/* Files Tab */}

--- a/frontend/src/app/u/[id]/page.tsx
+++ b/frontend/src/app/u/[id]/page.tsx
@@ -10,6 +10,7 @@ import { Link } from "react-router";
 import ClientLayout from "@/components/ClientLayout";
 import { ContentContainer } from "@/components/layout";
 import InviteMessageModal from "@/components/InviteMessageModal";
+import NegotiationHistory from "@/components/NegotiationHistory";
 
 export default function UserProfilePage() {
   const { id } = useParams();
@@ -181,6 +182,14 @@ export default function UserProfilePage() {
                   </Link>
                 ))}
               </div>
+            </div>
+          )}
+
+          {/* Past Negotiations */}
+          {id && (
+            <div>
+              <h3 className="text-base font-bold text-gray-900 font-ibm-plex-mono mb-2">Negotiations</h3>
+              <NegotiationHistory userId={id} />
             </div>
           )}
 

--- a/frontend/src/components/NegotiationHistory.tsx
+++ b/frontend/src/components/NegotiationHistory.tsx
@@ -170,9 +170,12 @@ export default function NegotiationHistory({ userId }: NegotiationHistoryProps) 
         return (
           <div key={neg.id} className="bg-[#F8F8F8] rounded-md overflow-hidden">
             {/* Summary row — clickable to expand */}
-            <button
+            <div
+              role="button"
+              tabIndex={0}
               onClick={() => setExpandedId(isExpanded ? null : neg.id)}
-              className="w-full p-4 flex items-center gap-4 text-left hover:bg-gray-100/50 transition-colors"
+              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setExpandedId(isExpanded ? null : neg.id); } }}
+              className="w-full p-4 flex items-center gap-4 text-left hover:bg-gray-100/50 transition-colors cursor-pointer"
             >
               <Link
                 to={`/u/${neg.counterparty.id}`}
@@ -229,7 +232,7 @@ export default function NegotiationHistory({ userId }: NegotiationHistoryProps) 
               <ChevronDown
                 className={`w-4 h-4 text-gray-400 shrink-0 transition-transform ${isExpanded ? "rotate-180" : ""}`}
               />
-            </button>
+            </div>
 
             {/* Expanded dialogue */}
             {isExpanded && neg.turns.length > 0 && (

--- a/frontend/src/components/NegotiationHistory.tsx
+++ b/frontend/src/components/NegotiationHistory.tsx
@@ -1,0 +1,277 @@
+import { useState, useEffect, useCallback } from "react";
+import { Link } from "react-router";
+import { Loader2, ChevronDown, Bot } from "lucide-react";
+import UserAvatar from "@/components/UserAvatar";
+import { useUsers } from "@/contexts/APIContext";
+import type { NegotiationSummary, NegotiationTurnSummary } from "@/services/users";
+
+const PAGE_SIZE = 20;
+
+type ResultFilter = '' | 'consensus' | 'no_consensus' | 'in_progress';
+
+const FILTERS: { value: ResultFilter; label: string }[] = [
+  { value: '', label: 'All' },
+  { value: 'consensus', label: 'Consensus' },
+  { value: 'no_consensus', label: 'No consensus' },
+  { value: 'in_progress', label: 'In progress' },
+];
+
+const ROLE_LABELS: Record<string, string> = {
+  agent: "Helper",
+  patient: "Seeker",
+  peer: "Peer",
+};
+
+const ACTION_LABELS: Record<string, { label: string; color: string }> = {
+  propose: { label: "Proposed", color: "text-blue-600" },
+  counter: { label: "Countered", color: "text-amber-600" },
+  accept: { label: "Accepted", color: "text-emerald-600" },
+  reject: { label: "Rejected", color: "text-red-600" },
+};
+
+function timeAgo(dateStr: string): string {
+  const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  return `${months}mo ago`;
+}
+
+function TurnMessage({ turn, isLast }: { turn: NegotiationTurnSummary; isLast: boolean }) {
+  const actionInfo = ACTION_LABELS[turn.action] ?? { label: turn.action, color: "text-gray-600" };
+
+  return (
+    <div className="flex gap-3">
+      <div className="flex flex-col items-center">
+        <UserAvatar
+          id={turn.speaker.id}
+          name={turn.speaker.name}
+          avatar={turn.speaker.avatar}
+          size={28}
+        />
+        {!isLast && <div className="w-px flex-1 bg-gray-200 mt-1" />}
+      </div>
+      <div className={`flex-1 pb-4 ${isLast ? "" : ""}`}>
+        <div className="flex items-center gap-2 mb-1">
+          <span className="text-sm font-medium text-gray-900 flex items-center gap-1">
+            {turn.speaker.name}
+            <Bot className="w-3 h-3 text-gray-400" />
+          </span>
+          <span className={`text-xs font-medium ${actionInfo.color}`}>{actionInfo.label}</span>
+          <span className="text-xs text-gray-400 ml-auto">{turn.fitScore}/100</span>
+        </div>
+        <p className="text-sm text-gray-600 leading-relaxed">{turn.reasoning}</p>
+      </div>
+    </div>
+  );
+}
+
+interface NegotiationHistoryProps {
+  userId: string;
+}
+
+export default function NegotiationHistory({ userId }: NegotiationHistoryProps) {
+  const usersService = useUsers();
+  const [negotiations, setNegotiations] = useState<NegotiationSummary[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasMore, setHasMore] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [resultFilter, setResultFilter] = useState<ResultFilter>('');
+
+  const fetchNegotiations = useCallback(async (offset: number) => {
+    const results = await usersService.getUserNegotiations(userId, {
+      limit: PAGE_SIZE,
+      offset,
+      result: resultFilter || undefined,
+    });
+    return results;
+  }, [userId, usersService, resultFilter]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    setNegotiations([]);
+    setExpandedId(null);
+    fetchNegotiations(0)
+      .then((results) => {
+        if (cancelled) return;
+        setNegotiations(results);
+        setHasMore(results.length === PAGE_SIZE);
+      })
+      .catch(() => {
+        if (!cancelled) setNegotiations([]);
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [fetchNegotiations]);
+
+  const loadMore = async () => {
+    setLoadingMore(true);
+    try {
+      const results = await fetchNegotiations(negotiations.length);
+      setNegotiations((prev) => [...prev, ...results]);
+      setHasMore(results.length === PAGE_SIZE);
+    } finally {
+      setLoadingMore(false);
+    }
+  };
+
+  const showFilters = !isLoading || resultFilter;
+
+  return (
+    <div className="space-y-2">
+      {showFilters && (
+        <div className="flex gap-1.5 mb-2">
+          {FILTERS.map((f) => (
+            <button
+              key={f.value}
+              onClick={() => setResultFilter(f.value)}
+              className={`text-xs px-2.5 py-1 rounded-full transition-colors ${
+                resultFilter === f.value
+                  ? 'bg-gray-900 text-white'
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              }`}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {isLoading && (
+        <div className="flex justify-center py-8">
+          <Loader2 className="h-5 w-5 animate-spin text-gray-400" />
+        </div>
+      )}
+
+      {!isLoading && negotiations.length === 0 && !resultFilter && (
+        <div className="text-sm text-gray-500 font-ibm-plex-mono py-12 text-center border border-dashed border-gray-200 rounded-lg">
+          <p>No negotiations yet</p>
+        </div>
+      )}
+
+      {!isLoading && negotiations.length === 0 && resultFilter && (
+        <div className="text-sm text-gray-500 py-8 text-center">
+          <p>No negotiations match this filter</p>
+        </div>
+      )}
+
+      {negotiations.map((neg) => {
+        const isExpanded = expandedId === neg.id;
+
+        return (
+          <div key={neg.id} className="bg-[#F8F8F8] rounded-md overflow-hidden">
+            {/* Summary row — clickable to expand */}
+            <button
+              onClick={() => setExpandedId(isExpanded ? null : neg.id)}
+              className="w-full p-4 flex items-center gap-4 text-left hover:bg-gray-100/50 transition-colors"
+            >
+              <Link
+                to={`/u/${neg.counterparty.id}`}
+                className="shrink-0"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <UserAvatar
+                  id={neg.counterparty.id}
+                  name={neg.counterparty.name}
+                  avatar={neg.counterparty.avatar}
+                  size={36}
+                />
+              </Link>
+
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 mb-0.5">
+                  <Link
+                    to={`/u/${neg.counterparty.id}`}
+                    className="text-sm font-bold text-gray-900 truncate hover:underline"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    {neg.counterparty.name}
+                  </Link>
+                  {neg.outcome ? (
+                    <span
+                      className={`text-xs px-1.5 py-0.5 rounded-full font-medium ${
+                        neg.outcome.consensus
+                          ? "bg-emerald-50 text-emerald-700"
+                          : "bg-gray-100 text-gray-500"
+                      }`}
+                    >
+                      {neg.outcome.consensus ? "Consensus" : "No consensus"}
+                    </span>
+                  ) : (
+                    <span className="text-xs px-1.5 py-0.5 rounded-full font-medium bg-yellow-50 text-yellow-700">
+                      In progress
+                    </span>
+                  )}
+                </div>
+                <div className="flex items-center gap-2 text-xs text-gray-500">
+                  {neg.outcome?.consensus && neg.outcome.finalScore > 0 && (
+                    <span>Score: {neg.outcome.finalScore}</span>
+                  )}
+                  {neg.outcome?.role && (
+                    <span>{ROLE_LABELS[neg.outcome.role] ?? neg.outcome.role}</span>
+                  )}
+                  {neg.outcome?.turnCount != null && neg.outcome.turnCount > 0 && (
+                    <span>{neg.outcome.turnCount} {neg.outcome.turnCount === 1 ? "turn" : "turns"}</span>
+                  )}
+                  <span className="ml-auto">{timeAgo(neg.createdAt)}</span>
+                </div>
+              </div>
+
+              <ChevronDown
+                className={`w-4 h-4 text-gray-400 shrink-0 transition-transform ${isExpanded ? "rotate-180" : ""}`}
+              />
+            </button>
+
+            {/* Expanded dialogue */}
+            {isExpanded && neg.turns.length > 0 && (
+              <div className="px-4 pb-4 pt-1 border-t border-gray-200/60">
+                <p className="text-xs text-gray-400 mt-2 mb-3 flex items-center gap-1">
+                  <Bot className="w-3 h-3" />
+                  Agents negotiated on behalf of both parties
+                </p>
+                <div>
+                  {neg.turns.map((turn, i) => (
+                    <TurnMessage
+                      key={`${neg.id}-${i}`}
+                      turn={turn}
+                      isLast={i === neg.turns.length - 1}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {isExpanded && neg.turns.length === 0 && (
+              <div className="px-4 pb-4 pt-1 border-t border-gray-200/60">
+                <p className="text-xs text-gray-400 text-center py-3">No turn data available</p>
+              </div>
+            )}
+          </div>
+        );
+      })}
+
+      {hasMore && (
+        <button
+          onClick={loadMore}
+          disabled={loadingMore}
+          className="w-full text-center py-2 text-sm text-gray-600 hover:text-black transition-colors disabled:opacity-50"
+        >
+          {loadingMore ? (
+            <Loader2 className="h-4 w-4 animate-spin mx-auto" />
+          ) : (
+            "Show more"
+          )}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/NegotiationList.tsx
+++ b/frontend/src/components/NegotiationList.tsx
@@ -1,7 +1,0 @@
-export default function NegotiationList() {
-  return (
-    <div className="text-sm text-gray-500 font-ibm-plex-mono py-12 text-center border border-dashed border-gray-200 rounded-lg">
-      <p>No negotiations yet</p>
-    </div>
-  );
-}

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -70,7 +70,7 @@ export const router = createBrowserRouter([
         lazy: () => import("@/app/l/[code]/page"),
       },
       {
-        path: "/library",
+        path: "/library/:tab?",
         lazy: () => import("@/app/library/page"),
       },
       {

--- a/frontend/src/services/users.ts
+++ b/frontend/src/services/users.ts
@@ -5,6 +5,29 @@ interface BatchUsersResponse {
   users: User[];
 }
 
+export interface NegotiationTurnSummary {
+  speaker: { id: string; name: string; avatar: string | null };
+  action: string;
+  fitScore: number;
+  reasoning: string;
+  suggestedRoles: { ownUser?: string; otherUser?: string } | null;
+  createdAt: string;
+}
+
+export interface NegotiationSummary {
+  id: string;
+  counterparty: { id: string; name: string; avatar: string | null };
+  outcome: {
+    consensus: boolean;
+    finalScore: number;
+    role: string | null;
+    turnCount: number;
+    reason?: string;
+  } | null;
+  turns: NegotiationTurnSummary[];
+  createdAt: string;
+}
+
 export const createUsersService = (api: ReturnType<typeof import('../lib/api').useAuthenticatedAPI>) => ({
   // Get user profile by ID
   getUserProfile: async (userId: string): Promise<User> => {
@@ -56,5 +79,18 @@ export const createUsersService = (api: ReturnType<typeof import('../lib/api').u
    */
   addContact: async (email: string, name?: string): Promise<void> => {
     await api.post('/users/contacts', { email, name });
+  },
+
+  /**
+   * Get past negotiations for a user. Returns mutual negotiations when viewing another user's profile.
+   */
+  getUserNegotiations: async (userId: string, opts?: { limit?: number; offset?: number; result?: string }): Promise<NegotiationSummary[]> => {
+    const params = new URLSearchParams();
+    if (opts?.limit) params.set('limit', String(opts.limit));
+    if (opts?.offset) params.set('offset', String(opts.offset));
+    if (opts?.result) params.set('result', opts.result);
+    const qs = params.toString();
+    const response = await api.get<{ negotiations: NegotiationSummary[] }>(`/users/${userId}/negotiations${qs ? `?${qs}` : ''}`);
+    return response.negotiations ?? [];
   },
 });

--- a/protocol/src/adapters/database.adapter.ts
+++ b/protocol/src/adapters/database.adapter.ts
@@ -5797,6 +5797,94 @@ export class ConversationDatabaseAdapter {
       .where(eq(schema.artifacts.taskId, taskId))
       .orderBy(schema.artifacts.createdAt);
   }
+
+  /**
+   * Retrieves messages for multiple tasks in a single query.
+   * @param taskIds - Task IDs to fetch messages for
+   * @returns Map of taskId to ordered messages
+   */
+  async getMessagesByTaskIds(taskIds: string[]): Promise<Map<string, Message[]>> {
+    if (taskIds.length === 0) return new Map();
+
+    const rows = await db
+      .select()
+      .from(schema.messages)
+      .where(inArray(schema.messages.taskId, taskIds))
+      .orderBy(asc(schema.messages.createdAt));
+
+    const map = new Map<string, Message[]>();
+    for (const row of rows) {
+      if (!row.taskId) continue;
+      const list = map.get(row.taskId) ?? [];
+      list.push(row);
+      map.set(row.taskId, list);
+    }
+    return map;
+  }
+
+  /**
+   * Retrieves negotiation tasks for a user, with their outcome artifacts.
+   * @param userId - User to find negotiations for (as source or candidate)
+   * @param opts - Optional pagination and mutual-only filtering
+   * @returns Tasks with joined outcome artifacts, ordered by most recent first
+   */
+  async getNegotiationsByUser(
+    userId: string,
+    opts?: { limit?: number; offset?: number; mutualWithUserId?: string; result?: 'consensus' | 'no_consensus' | 'in_progress' },
+  ): Promise<Array<Task & { artifact: Artifact | null }>> {
+    const limit = opts?.limit ?? 10;
+    const offset = opts?.offset ?? 0;
+
+    const userFilter = opts?.mutualWithUserId
+      ? and(
+          sql`${schema.tasks.metadata}->>'type' = 'negotiation'`,
+          or(
+            and(
+              sql`${schema.tasks.metadata}->>'sourceUserId' = ${userId}`,
+              sql`${schema.tasks.metadata}->>'candidateUserId' = ${opts.mutualWithUserId}`,
+            ),
+            and(
+              sql`${schema.tasks.metadata}->>'sourceUserId' = ${opts.mutualWithUserId}`,
+              sql`${schema.tasks.metadata}->>'candidateUserId' = ${userId}`,
+            ),
+          ),
+        )
+      : and(
+          sql`${schema.tasks.metadata}->>'type' = 'negotiation'`,
+          or(
+            sql`${schema.tasks.metadata}->>'sourceUserId' = ${userId}`,
+            sql`${schema.tasks.metadata}->>'candidateUserId' = ${userId}`,
+          ),
+        );
+
+    const resultFilter = opts?.result === 'consensus'
+      ? sql`(${schema.artifacts.parts}->0->>'kind' = 'data' AND (${schema.artifacts.parts}->0->'data'->>'consensus')::boolean = true)`
+      : opts?.result === 'no_consensus'
+        ? sql`(${schema.artifacts.parts}->0->>'kind' = 'data' AND (${schema.artifacts.parts}->0->'data'->>'consensus')::boolean = false)`
+        : opts?.result === 'in_progress'
+          ? isNull(schema.artifacts.id)
+          : undefined;
+
+    const rows = await db
+      .select({
+        task: schema.tasks,
+        artifact: schema.artifacts,
+      })
+      .from(schema.tasks)
+      .leftJoin(
+        schema.artifacts,
+        and(
+          eq(schema.artifacts.taskId, schema.tasks.id),
+          eq(schema.artifacts.name, 'negotiation-outcome'),
+        ),
+      )
+      .where(resultFilter ? and(userFilter, resultFilter) : userFilter)
+      .orderBy(desc(schema.tasks.createdAt))
+      .limit(limit)
+      .offset(offset);
+
+    return rows.map((r) => ({ ...r.task, artifact: r.artifact }));
+  }
 }
 
 /** Singleton instance of the conversation database adapter. */

--- a/protocol/src/adapters/database.adapter.ts
+++ b/protocol/src/adapters/database.adapter.ts
@@ -5862,7 +5862,7 @@ export class ConversationDatabaseAdapter {
       : opts?.result === 'no_consensus'
         ? sql`(${schema.artifacts.parts}->0->>'kind' = 'data' AND (${schema.artifacts.parts}->0->'data'->>'consensus')::boolean = false)`
         : opts?.result === 'in_progress'
-          ? isNull(schema.artifacts.id)
+          ? and(isNull(schema.artifacts.id), inArray(schema.tasks.state, ['submitted', 'working', 'input_required']))
           : undefined;
 
     const rows = await db

--- a/protocol/src/controllers/user.controller.ts
+++ b/protocol/src/controllers/user.controller.ts
@@ -5,6 +5,7 @@ import { AuthGuard } from '../guards/auth.guard';
 import type { AuthenticatedUser } from '../guards/auth.guard';
 import { userService } from '../services/user.service';
 import { contactService } from '../services/contact.service';
+import { TaskService } from '../services/task.service';
 import { log } from '../lib/log';
 
 const logger = log.controller.from('user');
@@ -18,6 +19,8 @@ const BATCH_MAX_IDS = 100;
 
 @Controller('/users')
 export class UserController {
+  constructor(private readonly taskService: TaskService = new TaskService()) {}
+
   @Get('/batch')
   @UseGuards(AuthGuard)
   async getBatch(req: Request, _user: AuthenticatedUser) {
@@ -63,6 +66,103 @@ export class UserController {
     logger.verbose('Add contact requested', { userId: user.id });
     const result = await contactService.addContact(user.id, parsed.data.email, { name: parsed.data.name });
     return Response.json({ result });
+  }
+
+  /**
+   * GET /users/:userId/negotiations — list past negotiations for a user.
+   * When the viewer differs from the profile owner, only mutual negotiations are returned.
+   * @param req - Request with optional ?limit and ?offset query params
+   * @param viewer - Authenticated user from AuthGuard
+   * @param params - Route params containing userId
+   * @returns JSON with negotiations array
+   */
+  @Get('/:userId/negotiations')
+  @UseGuards(AuthGuard)
+  async getNegotiations(req: Request, viewer: AuthenticatedUser, params: { userId: string }) {
+    const url = new URL(req.url);
+    const limit = Math.min(Math.max(parseInt(url.searchParams.get('limit') ?? '20', 10) || 20, 1), 50);
+    const offset = Math.max(parseInt(url.searchParams.get('offset') ?? '0', 10) || 0, 0);
+    const resultParam = url.searchParams.get('result');
+    const result = (['consensus', 'no_consensus', 'in_progress'] as const).includes(resultParam as never)
+      ? (resultParam as 'consensus' | 'no_consensus' | 'in_progress')
+      : undefined;
+
+    const isSelf = viewer.id === params.userId;
+    const mutualWithUserId = isSelf ? undefined : viewer.id;
+
+    try {
+      const rows = await this.taskService.getNegotiationsByUser(params.userId, { limit, offset, mutualWithUserId, result });
+
+      const taskIds = rows.map((r) => r.id);
+      const messagesMap = await this.taskService.getMessagesByTaskIds(taskIds);
+
+      const participantIds = new Set<string>();
+      for (const row of rows) {
+        const meta = row.metadata as { sourceUserId?: string; candidateUserId?: string } | null;
+        if (meta?.sourceUserId) participantIds.add(meta.sourceUserId);
+        if (meta?.candidateUserId) participantIds.add(meta.candidateUserId);
+      }
+
+      const participantUsers = participantIds.size > 0
+        ? await userService.findByIds([...participantIds])
+        : [];
+      const userMap = new Map(participantUsers.map((u) => [u.id, u]));
+
+      type TurnData = { action?: string; assessment?: { fitScore?: number; reasoning?: string; suggestedRoles?: { ownUser?: string; otherUser?: string } } };
+      type OutcomePart = { kind?: string; data?: { consensus?: boolean; finalScore?: number; agreedRoles?: Array<{ userId: string; role: string }>; turnCount?: number; reason?: string } };
+
+      const negotiations = rows.map((row) => {
+        const meta = row.metadata as { sourceUserId?: string; candidateUserId?: string } | null;
+        const counterpartyId = meta?.sourceUserId === params.userId ? meta?.candidateUserId : meta?.sourceUserId;
+        const counterparty = counterpartyId ? userMap.get(counterpartyId) : null;
+
+        const outcomePart = (row.artifact?.parts as OutcomePart[] | null)?.find((p) => p.kind === 'data');
+        const outcomeData = outcomePart?.data;
+        const viewerRole = outcomeData?.agreedRoles?.find((r) => r.userId === params.userId)?.role ?? null;
+
+        const rawMessages = messagesMap.get(row.id) ?? [];
+        const turns = rawMessages.map((msg) => {
+          const agentUserId = msg.senderId.replace(/^agent:/, '');
+          const speakerUser = userMap.get(agentUserId);
+          const dataPart = (msg.parts as Array<{ kind?: string; data?: TurnData }>).find((p) => p.kind === 'data');
+          const turn = dataPart?.data;
+
+          return {
+            speaker: speakerUser
+              ? { id: speakerUser.id, name: speakerUser.name, avatar: speakerUser.avatar }
+              : { id: agentUserId, name: 'Unknown', avatar: null },
+            action: turn?.action ?? 'unknown',
+            fitScore: turn?.assessment?.fitScore ?? 0,
+            reasoning: turn?.assessment?.reasoning ?? '',
+            suggestedRoles: turn?.assessment?.suggestedRoles ?? null,
+            createdAt: msg.createdAt.toISOString(),
+          };
+        });
+
+        return {
+          id: row.id,
+          counterparty: counterparty
+            ? { id: counterparty.id, name: counterparty.name, avatar: counterparty.avatar }
+            : { id: counterpartyId ?? 'unknown', name: 'Unknown user', avatar: null },
+          outcome: outcomeData
+            ? {
+                consensus: outcomeData.consensus ?? false,
+                finalScore: outcomeData.finalScore ?? 0,
+                role: viewerRole,
+                turnCount: outcomeData.turnCount ?? 0,
+                reason: outcomeData.reason,
+              }
+            : null,
+          turns,
+          createdAt: row.createdAt.toISOString(),
+        };
+      });
+
+      return Response.json({ negotiations });
+    } catch (err) {
+      logger.error('Failed to fetch negotiations', { userId: params.userId, error: err instanceof Error ? err.message : String(err) });
+      return Response.json({ error: 'Failed to fetch negotiations' }, { status: 500 });
+    }
   }
 
   @Get('/:userId')

--- a/protocol/src/lib/protocol/agents/model.config.ts
+++ b/protocol/src/lib/protocol/agents/model.config.ts
@@ -24,6 +24,8 @@ export const MODEL_CONFIG = {
   lensInferrer:         { model: "google/gemini-2.5-flash" },
   opportunityEvaluator: { model: "google/gemini-2.5-flash" },
   opportunityPresenter: { model: "google/gemini-2.5-flash" },
+  negotiationProposer:  { model: "google/gemini-2.5-flash" },
+  negotiationResponder: { model: "google/gemini-2.5-flash" },
   homeCategorizer:      { model: "google/gemini-2.5-flash" },
   suggestionGenerator:  { model: "google/gemini-2.5-flash", temperature: 0.4, maxTokens: 512 },
   chatTitleGenerator:   { model: "google/gemini-2.5-flash", temperature: 0.3, maxTokens: 32 },

--- a/protocol/src/lib/protocol/agents/negotiation.proposer.ts
+++ b/protocol/src/lib/protocol/agents/negotiation.proposer.ts
@@ -1,0 +1,85 @@
+import { createModel } from "./model.config";
+import { NegotiationTurnSchema, type NegotiationTurn, type UserNegotiationContext, type SeedAssessment } from "../states/negotiation.state";
+
+const SYSTEM_PROMPT = `You are a negotiation agent representing your user in an opportunity matching system.
+Your role is to PROPOSE and ARGUE FOR a potential match between your user and another user.
+
+You will receive:
+- Your user's profile, intents, and context
+- The other user's profile, intents, and context
+- An initial assessment from a pre-screening evaluator
+- Any prior negotiation history
+
+Your job:
+1. On the FIRST turn: Propose the match. Explain why this connection would benefit both parties. Set action to "propose".
+2. On SUBSEQUENT turns (after a counter from the other agent): Address their objections. Either:
+   - "counter" with updated reasoning if you still believe in the match
+   - "accept" if the other agent's counter is reasonable and you agree
+   - "reject" if their objections reveal this is genuinely not a good match
+
+Rules:
+- Be honest. Do not hallucinate fit where there is none.
+- Focus on concrete intent alignment, not vague similarities.
+- If the evaluator pre-screen score was low, acknowledge weaknesses.
+- Your fitScore should reflect YOUR honest assessment, not just echo the seed score.
+- suggestedRoles: "agent" = can help, "patient" = seeks help, "peer" = mutual benefit.`;
+
+export interface NegotiationProposerInput {
+  ownUser: UserNegotiationContext;
+  otherUser: UserNegotiationContext;
+  indexContext: { indexId: string; prompt: string };
+  seedAssessment: SeedAssessment;
+  history: NegotiationTurn[];
+}
+
+/**
+ * Negotiation agent that argues for the match.
+ * @remarks Uses structured output to produce a NegotiationTurn.
+ */
+export class NegotiationProposer {
+  private model;
+
+  constructor() {
+    this.model = createModel("negotiationProposer").withStructuredOutput(
+      NegotiationTurnSchema,
+      { name: "negotiation_proposer" },
+    );
+  }
+
+  /**
+   * Generate a proposal or counter-proposal turn.
+   * @param input - User contexts, seed assessment, and negotiation history
+   * @returns A structured NegotiationTurn
+   */
+  async invoke(input: NegotiationProposerInput): Promise<NegotiationTurn> {
+    const historyText = input.history.length > 0
+      ? `\n\nNegotiation history:\n${input.history.map((t, i) => `Turn ${i + 1}: ${t.action} — fitScore: ${t.assessment.fitScore}, reasoning: ${t.assessment.reasoning}`).join("\n")}`
+      : "";
+
+    const userMessage = `YOUR USER:
+Name: ${input.ownUser.profile.name ?? "Unknown"}
+Bio: ${input.ownUser.profile.bio ?? "N/A"}
+Skills: ${input.ownUser.profile.skills?.join(", ") ?? "N/A"}
+Intents: ${input.ownUser.intents.map((i) => `- ${i.title}: ${i.description} (confidence: ${i.confidence})`).join("\n")}
+
+OTHER USER:
+Name: ${input.otherUser.profile.name ?? "Unknown"}
+Bio: ${input.otherUser.profile.bio ?? "N/A"}
+Skills: ${input.otherUser.profile.skills?.join(", ") ?? "N/A"}
+Intents: ${input.otherUser.intents.map((i) => `- ${i.title}: ${i.description} (confidence: ${i.confidence})`).join("\n")}
+
+INDEX CONTEXT: ${input.indexContext.prompt || "General discovery"}
+
+EVALUATOR PRE-SCREEN: Score ${input.seedAssessment.score}/100 — ${input.seedAssessment.reasoning}
+Suggested role: ${input.seedAssessment.valencyRole}${historyText}
+
+${input.history.length === 0 ? "This is the opening turn. Propose the match." : "The other agent countered. Respond to their objections."}`;
+
+    const result = await this.model.invoke([
+      { role: "system", content: SYSTEM_PROMPT },
+      { role: "user", content: userMessage },
+    ]);
+
+    return result;
+  }
+}

--- a/protocol/src/lib/protocol/agents/negotiation.responder.ts
+++ b/protocol/src/lib/protocol/agents/negotiation.responder.ts
@@ -1,0 +1,89 @@
+import { createModel } from "./model.config";
+import { NegotiationTurnSchema, type NegotiationTurn, type UserNegotiationContext, type SeedAssessment } from "../states/negotiation.state";
+
+const SYSTEM_PROMPT = `You are a negotiation agent representing your user in an opportunity matching system.
+Your role is to EVALUATE proposals and PROTECT your user from poor matches.
+
+You will receive:
+- Your user's profile, intents, and context
+- The other user's profile, intents, and context
+- The proposal or counter-proposal from the other agent
+- Full negotiation history
+
+Your job:
+1. Critically evaluate whether this match genuinely serves YOUR user's intents.
+2. Respond with one of:
+   - "accept" — the match is genuinely valuable for your user. Both sides benefit.
+   - "reject" — the match does not serve your user's needs. Explain clearly why.
+   - "counter" — partially convinced but have specific objections. State what's missing or weak.
+
+Rules:
+- Be skeptical. Your job is to protect your user from noise.
+- Don't accept just because the other agent is enthusiastic.
+- Look for concrete intent alignment, not vague overlap.
+- If the other agent addressed your previous objections well, acknowledge it.
+- If their counter didn't address your concerns, reject.
+- Your fitScore should reflect YOUR independent assessment.
+- suggestedRoles: "agent" = can help, "patient" = seeks help, "peer" = mutual benefit.`;
+
+export interface NegotiationResponderInput {
+  ownUser: UserNegotiationContext;
+  otherUser: UserNegotiationContext;
+  indexContext: { indexId: string; prompt: string };
+  seedAssessment: SeedAssessment;
+  history: NegotiationTurn[];
+}
+
+/**
+ * Negotiation agent that evaluates proposals against its user's interests.
+ * @remarks Uses structured output to produce a NegotiationTurn.
+ */
+export class NegotiationResponder {
+  private model;
+
+  constructor() {
+    this.model = createModel("negotiationResponder").withStructuredOutput(
+      NegotiationTurnSchema,
+      { name: "negotiation_responder" },
+    );
+  }
+
+  /**
+   * Evaluate a proposal/counter and respond.
+   * @param input - User contexts, seed assessment, and negotiation history
+   * @returns A structured NegotiationTurn (accept/reject/counter)
+   */
+  async invoke(input: NegotiationResponderInput): Promise<NegotiationTurn> {
+    const historyText = input.history
+      .map((t, i) => `Turn ${i + 1}: ${t.action} — fitScore: ${t.assessment.fitScore}, reasoning: ${t.assessment.reasoning}`)
+      .join("\n");
+
+    const userMessage = `YOUR USER:
+Name: ${input.ownUser.profile.name ?? "Unknown"}
+Bio: ${input.ownUser.profile.bio ?? "N/A"}
+Skills: ${input.ownUser.profile.skills?.join(", ") ?? "N/A"}
+Intents: ${input.ownUser.intents.map((i) => `- ${i.title}: ${i.description} (confidence: ${i.confidence})`).join("\n")}
+
+OTHER USER (proposing the match):
+Name: ${input.otherUser.profile.name ?? "Unknown"}
+Bio: ${input.otherUser.profile.bio ?? "N/A"}
+Skills: ${input.otherUser.profile.skills?.join(", ") ?? "N/A"}
+Intents: ${input.otherUser.intents.map((i) => `- ${i.title}: ${i.description} (confidence: ${i.confidence})`).join("\n")}
+
+INDEX CONTEXT: ${input.indexContext.prompt || "General discovery"}
+
+EVALUATOR PRE-SCREEN: Score ${input.seedAssessment.score}/100 — ${input.seedAssessment.reasoning}
+
+NEGOTIATION HISTORY:
+${historyText}
+
+Evaluate the latest proposal/counter from the other agent. Does this match genuinely serve your user?`;
+
+    const result = await this.model.invoke([
+      { role: "system", content: SYSTEM_PROMPT },
+      { role: "user", content: userMessage },
+    ]);
+
+    return result;
+  }
+}

--- a/protocol/src/lib/protocol/graphs/negotiation.graph.ts
+++ b/protocol/src/lib/protocol/graphs/negotiation.graph.ts
@@ -1,7 +1,10 @@
 import { StateGraph } from "@langchain/langgraph";
 
-import { requestContext } from "../../request-context";
+import { requestContext, type TraceEmitter } from "../../request-context";
 import { NegotiationGraphState, type NegotiationTurn, type NegotiationOutcome, type UserNegotiationContext, type SeedAssessment, type NegotiationGraphLike } from "../states/negotiation.state";
+import { protocolLogger } from "../support/protocol.logger";
+
+const logger = protocolLogger("NegotiationGraph");
 
 interface ConversationServiceLike {
   createConversation(participants: { participantId: string; participantType: "user" | "agent" }[]): Promise<{ id: string }>;
@@ -20,20 +23,14 @@ interface TaskServiceLike {
   createArtifact(taskId: string, data: { name?: string; parts: unknown[]; metadata?: Record<string, unknown> }): Promise<{ id: string }>;
 }
 
-interface NegotiationAgentInput {
-  ownUser: UserNegotiationContext;
-  otherUser: UserNegotiationContext;
-  indexContext: { indexId: string; prompt: string };
-  seedAssessment: SeedAssessment;
-  history: NegotiationTurn[];
-}
-
-interface ProposerLike {
-  invoke(input: NegotiationAgentInput): Promise<NegotiationTurn>;
-}
-
-interface ResponderLike {
-  invoke(input: NegotiationAgentInput): Promise<NegotiationTurn>;
+interface NegotiationAgentLike {
+  invoke(input: {
+    ownUser: UserNegotiationContext;
+    otherUser: UserNegotiationContext;
+    indexContext: { indexId: string; prompt: string };
+    seedAssessment: SeedAssessment;
+    history: NegotiationTurn[];
+  }): Promise<NegotiationTurn>;
 }
 
 /**
@@ -44,8 +41,8 @@ export class NegotiationGraphFactory {
   constructor(
     private conversationService: ConversationServiceLike,
     private taskService: TaskServiceLike,
-    private proposer: ProposerLike,
-    private responder: ResponderLike,
+    private proposer: NegotiationAgentLike,
+    private responder: NegotiationAgentLike,
   ) {}
 
   createGraph() {
@@ -105,7 +102,7 @@ export class NegotiationGraphFactory {
 
         // First turn must be "propose"
         if (state.turnCount === 0 && turn.action !== "propose") {
-          console.warn(`[NegotiationGraph] Proposer returned "${turn.action}" on turn 0, forcing to "propose"`);
+          logger.warn("[Graph:Turn] Proposer returned unexpected action on turn 0, forcing to propose", { action: turn.action });
           turn.action = "propose";
         }
 
@@ -201,7 +198,7 @@ export class NegotiationGraphFactory {
           metadata: { consensus, turnCount: state.turnCount },
         });
       } catch (err) {
-        // DB failure is non-blocking
+        logger.error("[Graph:Finalize] Failed to persist outcome", { error: err });
       }
 
       return { outcome };
@@ -240,8 +237,6 @@ export interface NegotiationResult {
   reasoning: string;
   turnCount: number;
 }
-
-type TraceEmitter = (event: { type: "graph_start" | "graph_end" | "agent_start" | "agent_end"; name: string; durationMs?: number; summary?: string }) => void;
 
 /**
  * Runs bilateral negotiation for each candidate in parallel.
@@ -310,7 +305,7 @@ export async function negotiateCandidates(
       } catch (err) {
         const durationMs = Date.now() - start;
         traceEmitter?.({ type: "agent_end", name: "negotiation", durationMs, summary: `${candidate.userId}: error` });
-        console.error(`[negotiateCandidates] Negotiation failed for candidate ${candidate.userId}:`, err);
+        logger.error("[negotiateCandidates] Negotiation failed", { candidateUserId: candidate.userId, error: err });
         return null;
       }
     }),

--- a/protocol/src/lib/protocol/graphs/negotiation.graph.ts
+++ b/protocol/src/lib/protocol/graphs/negotiation.graph.ts
@@ -105,6 +105,7 @@ export class NegotiationGraphFactory {
 
         // First turn must be "propose"
         if (state.turnCount === 0 && turn.action !== "propose") {
+          console.warn(`[NegotiationGraph] Proposer returned "${turn.action}" on turn 0, forcing to "propose"`);
           turn.action = "propose";
         }
 
@@ -117,8 +118,7 @@ export class NegotiationGraphFactory {
           { taskId: state.taskId },
         );
 
-        const taskState = state.turnCount === 0 ? "working" : "input_required";
-        await taskService.updateState(state.taskId, taskState);
+        await taskService.updateState(state.taskId, "working");
 
         return {
           messages: [{
@@ -188,7 +188,7 @@ export class NegotiationGraphFactory {
         consensus,
         finalScore: consensus ? avgScore : 0,
         agreedRoles,
-        reasoning: history.map((t) => t.assessment.reasoning).join(" | "),
+        reasoning: lastTurn?.assessment.reasoning ?? "",
         turnCount: state.turnCount,
         ...(atCap && { reason: "turn_cap" }),
       };
@@ -215,15 +215,17 @@ export class NegotiationGraphFactory {
         turn: "turn",
         finalize: "finalize",
       })
+      .addConditionalEdges("init", (state: typeof NegotiationGraphState.State) => {
+        return state.error ? "finalize" : "turn";
+      }, { turn: "turn", finalize: "finalize" })
       .addEdge("__start__", "init")
-      .addEdge("init", "turn")
       .addEdge("finalize", "__end__");
 
     return workflow.compile();
   }
 }
 
-interface NegotiationCandidate {
+export interface NegotiationCandidate {
   userId: string;
   score: number;
   reasoning: string;
@@ -231,7 +233,7 @@ interface NegotiationCandidate {
   candidateUser: UserNegotiationContext;
 }
 
-interface NegotiationResult {
+export interface NegotiationResult {
   userId: string;
   negotiationScore: number;
   agreedRoles: NegotiationOutcome["agreedRoles"];
@@ -239,19 +241,31 @@ interface NegotiationResult {
   turnCount: number;
 }
 
+type TraceEmitter = (event: { type: "graph_start" | "graph_end" | "agent_start" | "agent_end"; name: string; durationMs?: number; summary?: string }) => void;
+
 /**
  * Runs bilateral negotiation for each candidate in parallel.
- * Returns only candidates that achieved consensus.
+ * @param negotiationGraph - Compiled negotiation graph
+ * @param sourceUser - Source user context
+ * @param candidates - Evaluated candidates to negotiate with
+ * @param indexContext - Index context for the negotiation
+ * @param opts - Optional maxTurns and traceEmitter
+ * @returns Only candidates that achieved consensus
  */
 export async function negotiateCandidates(
   negotiationGraph: NegotiationGraphLike,
   sourceUser: UserNegotiationContext,
   candidates: NegotiationCandidate[],
   indexContext: { indexId: string; prompt: string },
-  maxTurns?: number,
+  opts?: { maxTurns?: number; traceEmitter?: TraceEmitter },
 ): Promise<NegotiationResult[]> {
+  const { maxTurns, traceEmitter } = opts ?? {};
+
   const results = await Promise.all(
     candidates.map(async (candidate) => {
+      const start = Date.now();
+      traceEmitter?.({ type: "agent_start", name: "negotiation" });
+
       try {
         const result = await negotiationGraph.invoke({
           sourceUser,
@@ -265,17 +279,37 @@ export async function negotiateCandidates(
           ...(maxTurns !== undefined && { maxTurns }),
         });
 
-        if (result.outcome?.consensus) {
+        const durationMs = Date.now() - start;
+        const outcome = result.outcome;
+        const consensus = outcome?.consensus === true;
+
+        // Build inline turn flow: "propose:85 → counter:70 → accept:78"
+        const turnFlow = (result.messages ?? [])
+          .map((m) => {
+            const dataPart = (m.parts as Array<{ kind?: string; data?: Record<string, unknown> }>)?.find((p) => p.kind === "data");
+            if (!dataPart?.data) return null;
+            const turn = dataPart.data as { action?: string; assessment?: { fitScore?: number } };
+            return `${turn.action ?? "unknown"}:${turn.assessment?.fitScore ?? "?"}`;
+          })
+          .filter(Boolean)
+          .join(" → ");
+
+        const statusTag = consensus ? "✓ consensus" : "✗ rejected";
+        traceEmitter?.({ type: "agent_end", name: "negotiation", durationMs, summary: `${candidate.userId}: ${turnFlow} ${statusTag}` });
+
+        if (consensus && outcome) {
           return {
             userId: candidate.userId,
-            negotiationScore: result.outcome.finalScore,
-            agreedRoles: result.outcome.agreedRoles,
-            reasoning: result.outcome.reasoning,
-            turnCount: result.outcome.turnCount,
+            negotiationScore: outcome.finalScore,
+            agreedRoles: outcome.agreedRoles,
+            reasoning: outcome.reasoning,
+            turnCount: outcome.turnCount,
           };
         }
         return null;
       } catch (err) {
+        const durationMs = Date.now() - start;
+        traceEmitter?.({ type: "agent_end", name: "negotiation", durationMs, summary: `${candidate.userId}: error` });
         console.error(`[negotiateCandidates] Negotiation failed for candidate ${candidate.userId}:`, err);
         return null;
       }
@@ -283,24 +317,4 @@ export async function negotiateCandidates(
   );
 
   return results.filter((r): r is NegotiationResult => r !== null);
-}
-
-/**
- * Creates a default negotiation graph with real services and agents.
- * Used as the default parameter for OpportunityGraphFactory.
- */
-export function createDefaultNegotiationGraph() {
-  // Lazy imports to avoid circular dependencies
-  const { ConversationService } = require("../../../services/conversation.service");
-  const { TaskService } = require("../../../services/task.service");
-  const { NegotiationProposer } = require("../agents/negotiation.proposer");
-  const { NegotiationResponder } = require("../agents/negotiation.responder");
-
-  const factory = new NegotiationGraphFactory(
-    new ConversationService(),
-    new TaskService(),
-    new NegotiationProposer(),
-    new NegotiationResponder(),
-  );
-  return factory.createGraph();
 }

--- a/protocol/src/lib/protocol/graphs/negotiation.graph.ts
+++ b/protocol/src/lib/protocol/graphs/negotiation.graph.ts
@@ -162,7 +162,7 @@ export class NegotiationGraphFactory {
       const scores = history.map((t) => t.assessment.fitScore);
       const avgScore = scores.length > 0 ? Math.round(scores.reduce((a, b) => a + b, 0) / scores.length) : 0;
 
-      let agreedRoles: Array<{ userId: string; role: string }> = [];
+      let agreedRoles: NegotiationOutcome["agreedRoles"] = [];
       if (consensus && history.length >= 2) {
         const lastTwo = history.slice(-2);
         agreedRoles = [
@@ -269,4 +269,24 @@ export async function negotiateCandidates(
   );
 
   return results.filter((r): r is NegotiationResult => r !== null);
+}
+
+/**
+ * Creates a default negotiation graph with real services and agents.
+ * Used as the default parameter for OpportunityGraphFactory.
+ */
+export function createDefaultNegotiationGraph() {
+  // Lazy imports to avoid circular dependencies
+  const { ConversationService } = require("../../../services/conversation.service");
+  const { TaskService } = require("../../../services/task.service");
+  const { NegotiationProposer } = require("../agents/negotiation.proposer");
+  const { NegotiationResponder } = require("../agents/negotiation.responder");
+
+  const factory = new NegotiationGraphFactory(
+    new ConversationService(),
+    new TaskService(),
+    new NegotiationProposer(),
+    new NegotiationResponder(),
+  );
+  return factory.createGraph();
 }

--- a/protocol/src/lib/protocol/graphs/negotiation.graph.ts
+++ b/protocol/src/lib/protocol/graphs/negotiation.graph.ts
@@ -1,6 +1,6 @@
 import { StateGraph } from "@langchain/langgraph";
 
-import { NegotiationGraphState, type NegotiationTurn, type NegotiationOutcome } from "../states/negotiation.state";
+import { NegotiationGraphState, type NegotiationTurn, type NegotiationOutcome, type UserNegotiationContext } from "../states/negotiation.state";
 
 interface ConversationServiceLike {
   createConversation(participants: { participantId: string; participantType: "user" | "agent" }[]): Promise<{ id: string }>;
@@ -208,4 +208,65 @@ export class NegotiationGraphFactory {
 
     return workflow.compile();
   }
+}
+
+interface NegotiationCandidate {
+  userId: string;
+  score: number;
+  reasoning: string;
+  valencyRole: string;
+  candidateUser: UserNegotiationContext;
+}
+
+interface NegotiationResult {
+  userId: string;
+  negotiationScore: number;
+  agreedRoles: Array<{ userId: string; role: string }>;
+  reasoning: string;
+  turnCount: number;
+}
+
+/**
+ * Runs bilateral negotiation for each candidate in parallel.
+ * Returns only candidates that achieved consensus.
+ */
+export async function negotiateCandidates(
+  negotiationGraph: { invoke: (input: any) => Promise<{ outcome: any }> },
+  sourceUser: UserNegotiationContext,
+  candidates: NegotiationCandidate[],
+  indexContext: { indexId: string; prompt: string },
+  maxTurns?: number,
+): Promise<NegotiationResult[]> {
+  const results = await Promise.all(
+    candidates.map(async (candidate) => {
+      try {
+        const result = await negotiationGraph.invoke({
+          sourceUser,
+          candidateUser: candidate.candidateUser,
+          indexContext,
+          seedAssessment: {
+            score: candidate.score,
+            reasoning: candidate.reasoning,
+            valencyRole: candidate.valencyRole,
+          },
+          ...(maxTurns !== undefined && { maxTurns }),
+        });
+
+        if (result.outcome?.consensus) {
+          return {
+            userId: candidate.userId,
+            negotiationScore: result.outcome.finalScore,
+            agreedRoles: result.outcome.agreedRoles,
+            reasoning: result.outcome.reasoning,
+            turnCount: result.outcome.turnCount,
+          };
+        }
+        return null;
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  return results.filter((r): r is NegotiationResult => r !== null);
 }

--- a/protocol/src/lib/protocol/graphs/negotiation.graph.ts
+++ b/protocol/src/lib/protocol/graphs/negotiation.graph.ts
@@ -1,27 +1,11 @@
 import { StateGraph } from "@langchain/langgraph";
 
 import { requestContext, type TraceEmitter } from "../../request-context";
+import type { NegotiationDatabase } from "../interfaces/database.interface";
 import { NegotiationGraphState, type NegotiationTurn, type NegotiationOutcome, type UserNegotiationContext, type SeedAssessment, type NegotiationGraphLike } from "../states/negotiation.state";
 import { protocolLogger } from "../support/protocol.logger";
 
 const logger = protocolLogger("NegotiationGraph");
-
-interface ConversationServiceLike {
-  createConversation(participants: { participantId: string; participantType: "user" | "agent" }[]): Promise<{ id: string }>;
-  sendMessage(
-    conversationId: string,
-    senderId: string,
-    role: "user" | "agent",
-    parts: unknown[],
-    opts?: { taskId?: string; metadata?: Record<string, unknown> },
-  ): Promise<{ id: string; senderId: string; role: string; parts: unknown[]; createdAt: Date }>;
-}
-
-interface TaskServiceLike {
-  createTask(conversationId: string, metadata?: Record<string, unknown>): Promise<{ id: string; conversationId: string; state: string }>;
-  updateState(taskId: string, state: string, statusMessage?: unknown): Promise<unknown>;
-  createArtifact(taskId: string, data: { name?: string; parts: unknown[]; metadata?: Record<string, unknown> }): Promise<{ id: string }>;
-}
 
 interface NegotiationAgentLike {
   invoke(input: {
@@ -39,23 +23,22 @@ interface NegotiationAgentLike {
  */
 export class NegotiationGraphFactory {
   constructor(
-    private conversationService: ConversationServiceLike,
-    private taskService: TaskServiceLike,
+    private database: NegotiationDatabase,
     private proposer: NegotiationAgentLike,
     private responder: NegotiationAgentLike,
   ) {}
 
   createGraph() {
-    const { conversationService, taskService, proposer, responder } = this;
+    const { database, proposer, responder } = this;
 
     const initNode = async (state: typeof NegotiationGraphState.State) => {
       try {
-        const conversation = await conversationService.createConversation([
+        const conversation = await database.createConversation([
           { participantId: `agent:${state.sourceUser.id}`, participantType: "agent" },
           { participantId: `agent:${state.candidateUser.id}`, participantType: "agent" },
         ]);
 
-        const task = await taskService.createTask(conversation.id, {
+        const task = await database.createTask(conversation.id, {
           type: "negotiation",
           sourceUserId: state.sourceUser.id,
           candidateUserId: state.candidateUser.id,
@@ -86,7 +69,7 @@ export class NegotiationGraphFactory {
         const senderId = `agent:${ownUser.id}`;
 
         const traceEmitter = requestContext.getStore()?.traceEmitter;
-        const agentName = isSource ? "negotiation-proposer" : "negotiation-responder";
+        const agentName = isSource ? "Negotiation proposer agent" : "Negotiation responder agent";
         const agentStart = Date.now();
         traceEmitter?.({ type: "agent_start", name: agentName });
 
@@ -107,15 +90,15 @@ export class NegotiationGraphFactory {
         }
 
         const parts = [{ kind: "data" as const, data: turn }];
-        const message = await conversationService.sendMessage(
-          state.conversationId,
+        const message = await database.createMessage({
+          conversationId: state.conversationId,
           senderId,
-          "agent",
+          role: "agent",
           parts,
-          { taskId: state.taskId },
-        );
+          taskId: state.taskId,
+        });
 
-        await taskService.updateState(state.taskId, "working");
+        await database.updateTaskState(state.taskId, "working");
 
         return {
           messages: [{
@@ -191,8 +174,9 @@ export class NegotiationGraphFactory {
       };
 
       try {
-        await taskService.updateState(state.taskId, "completed");
-        await taskService.createArtifact(state.taskId, {
+        await database.updateTaskState(state.taskId, "completed");
+        await database.createArtifact({
+          taskId: state.taskId,
           name: "negotiation-outcome",
           parts: [{ kind: "data", data: outcome }],
           metadata: { consensus, turnCount: state.turnCount },
@@ -260,7 +244,7 @@ export async function negotiateCandidates(
   const results = await Promise.all(
     candidates.map(async (candidate) => {
       const start = Date.now();
-      traceEmitter?.({ type: "agent_start", name: "negotiation" });
+      traceEmitter?.({ type: "agent_start", name: "Negotiating candidate" });
 
       try {
         // Use per-candidate index context; never fall back to a different index's prompt
@@ -296,7 +280,7 @@ export async function negotiateCandidates(
           .join(" → ");
 
         const statusTag = consensus ? "✓ consensus" : "✗ rejected";
-        traceEmitter?.({ type: "agent_end", name: "negotiation", durationMs, summary: `${candidate.userId}: ${turnFlow} ${statusTag}` });
+        traceEmitter?.({ type: "agent_end", name: "Negotiating candidate", durationMs, summary: `${candidate.userId}: ${turnFlow} ${statusTag}` });
 
         if (consensus && outcome) {
           return {
@@ -310,7 +294,7 @@ export async function negotiateCandidates(
         return null;
       } catch (err) {
         const durationMs = Date.now() - start;
-        traceEmitter?.({ type: "agent_end", name: "negotiation", durationMs, summary: `${candidate.userId}: error` });
+        traceEmitter?.({ type: "agent_end", name: "Negotiating candidate", durationMs, summary: `${candidate.userId}: error` });
         logger.error("[negotiateCandidates] Negotiation failed", { candidateUserId: candidate.userId, error: err });
         return null;
       }

--- a/protocol/src/lib/protocol/graphs/negotiation.graph.ts
+++ b/protocol/src/lib/protocol/graphs/negotiation.graph.ts
@@ -263,9 +263,9 @@ export async function negotiateCandidates(
       traceEmitter?.({ type: "agent_start", name: "negotiation" });
 
       try {
-        // Use per-candidate index context if available
-        const candidateIndexContext = candidate.indexId && indexContextOverrides?.has(candidate.indexId)
-          ? { indexId: candidate.indexId, prompt: indexContextOverrides.get(candidate.indexId)! }
+        // Use per-candidate index context; never fall back to a different index's prompt
+        const candidateIndexContext = candidate.indexId
+          ? { indexId: candidate.indexId, prompt: indexContextOverrides?.get(candidate.indexId) ?? '' }
           : indexContext;
 
         const result = await negotiationGraph.invoke({

--- a/protocol/src/lib/protocol/graphs/negotiation.graph.ts
+++ b/protocol/src/lib/protocol/graphs/negotiation.graph.ts
@@ -1,0 +1,211 @@
+import { StateGraph } from "@langchain/langgraph";
+
+import { NegotiationGraphState, type NegotiationTurn, type NegotiationOutcome } from "../states/negotiation.state";
+
+interface ConversationServiceLike {
+  createConversation(participants: { participantId: string; participantType: "user" | "agent" }[]): Promise<{ id: string }>;
+  sendMessage(
+    conversationId: string,
+    senderId: string,
+    role: "user" | "agent",
+    parts: unknown[],
+    opts?: { taskId?: string; metadata?: Record<string, unknown> },
+  ): Promise<{ id: string; senderId: string; role: string; parts: unknown[]; createdAt: Date }>;
+}
+
+interface TaskServiceLike {
+  createTask(conversationId: string, metadata?: Record<string, unknown>): Promise<{ id: string; conversationId: string; state: string }>;
+  updateState(taskId: string, state: string, statusMessage?: unknown): Promise<unknown>;
+  createArtifact(taskId: string, data: { name?: string; parts: unknown[]; metadata?: Record<string, unknown> }): Promise<{ id: string }>;
+}
+
+interface ProposerLike {
+  invoke(input: {
+    ownUser: any;
+    otherUser: any;
+    indexContext: any;
+    seedAssessment: any;
+    history: NegotiationTurn[];
+  }): Promise<NegotiationTurn>;
+}
+
+interface ResponderLike {
+  invoke(input: {
+    ownUser: any;
+    otherUser: any;
+    indexContext: any;
+    seedAssessment: any;
+    history: NegotiationTurn[];
+  }): Promise<NegotiationTurn>;
+}
+
+/**
+ * Factory for the bilateral negotiation LangGraph state machine.
+ * @remarks Accepts dependencies via constructor for testability.
+ */
+export class NegotiationGraphFactory {
+  constructor(
+    private conversationService: ConversationServiceLike,
+    private taskService: TaskServiceLike,
+    private proposer: ProposerLike,
+    private responder: ResponderLike,
+  ) {}
+
+  createGraph() {
+    const { conversationService, taskService, proposer, responder } = this;
+
+    const initNode = async (state: typeof NegotiationGraphState.State) => {
+      try {
+        const conversation = await conversationService.createConversation([
+          { participantId: `agent:${state.sourceUser.id}`, participantType: "agent" },
+          { participantId: `agent:${state.candidateUser.id}`, participantType: "agent" },
+        ]);
+
+        const task = await taskService.createTask(conversation.id, {
+          type: "negotiation",
+          sourceUserId: state.sourceUser.id,
+          candidateUserId: state.candidateUser.id,
+        });
+
+        return {
+          conversationId: conversation.id,
+          taskId: task.id,
+          currentSpeaker: "source" as const,
+          turnCount: 0,
+        };
+      } catch (err) {
+        return { error: `Init failed: ${err instanceof Error ? err.message : String(err)}` };
+      }
+    };
+
+    const turnNode = async (state: typeof NegotiationGraphState.State) => {
+      try {
+        const history: NegotiationTurn[] = state.messages.map((m) => {
+          const dataPart = (m.parts as Array<{ kind?: string; data?: unknown }>).find((p) => p.kind === "data");
+          return dataPart?.data as NegotiationTurn;
+        }).filter(Boolean);
+
+        const isSource = state.currentSpeaker === "source";
+        const agent = isSource ? proposer : responder;
+        const ownUser = isSource ? state.sourceUser : state.candidateUser;
+        const otherUser = isSource ? state.candidateUser : state.sourceUser;
+        const senderId = `agent:${ownUser.id}`;
+
+        const turn = await agent.invoke({
+          ownUser,
+          otherUser,
+          indexContext: state.indexContext,
+          seedAssessment: state.seedAssessment,
+          history,
+        });
+
+        // First turn must be "propose"
+        if (state.turnCount === 0 && turn.action !== "propose") {
+          turn.action = "propose";
+        }
+
+        const parts = [{ kind: "data" as const, data: turn }];
+        const message = await conversationService.sendMessage(
+          state.conversationId,
+          senderId,
+          "agent",
+          parts,
+          { taskId: state.taskId },
+        );
+
+        const taskState = state.turnCount === 0 ? "working" : "input_required";
+        await taskService.updateState(state.taskId, taskState);
+
+        return {
+          messages: [{
+            id: message.id,
+            senderId: message.senderId,
+            role: "agent" as const,
+            parts: message.parts,
+            createdAt: message.createdAt,
+          }],
+          turnCount: state.turnCount + 1,
+          currentSpeaker: (isSource ? "candidate" : "source") as "source" | "candidate",
+          lastTurn: turn,
+        };
+      } catch (err) {
+        return {
+          lastTurn: {
+            action: "reject" as const,
+            assessment: { fitScore: 0, reasoning: `Agent error: ${err instanceof Error ? err.message : String(err)}`, suggestedRoles: { ownUser: "peer" as const, otherUser: "peer" as const } },
+          },
+          turnCount: state.turnCount + 1,
+          error: `Turn failed: ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+    };
+
+    const evaluateNode = (state: typeof NegotiationGraphState.State): string => {
+      if (state.error) return "finalize";
+      if (!state.lastTurn) return "finalize";
+      if (state.lastTurn.action === "accept") return "finalize";
+      if (state.lastTurn.action === "reject") return "finalize";
+      if (state.turnCount >= state.maxTurns) return "finalize";
+      return "turn";
+    };
+
+    const finalizeNode = async (state: typeof NegotiationGraphState.State) => {
+      const history: NegotiationTurn[] = state.messages.map((m) => {
+        const dataPart = (m.parts as Array<{ kind?: string; data?: unknown }>).find((p) => p.kind === "data");
+        return dataPart?.data as NegotiationTurn;
+      }).filter(Boolean);
+
+      const lastTurn = state.lastTurn;
+      const consensus = lastTurn?.action === "accept";
+      const atCap = state.turnCount >= state.maxTurns && lastTurn?.action === "counter";
+
+      const scores = history.map((t) => t.assessment.fitScore);
+      const avgScore = scores.length > 0 ? Math.round(scores.reduce((a, b) => a + b, 0) / scores.length) : 0;
+
+      let agreedRoles: Array<{ userId: string; role: string }> = [];
+      if (consensus && history.length >= 2) {
+        const lastTwo = history.slice(-2);
+        agreedRoles = [
+          { userId: state.sourceUser.id, role: lastTwo[0].assessment.suggestedRoles.ownUser },
+          { userId: state.candidateUser.id, role: lastTwo[1].assessment.suggestedRoles.ownUser },
+        ];
+      }
+
+      const outcome: NegotiationOutcome = {
+        consensus,
+        finalScore: consensus ? avgScore : 0,
+        agreedRoles,
+        reasoning: history.map((t) => t.assessment.reasoning).join(" | "),
+        turnCount: state.turnCount,
+        ...(atCap && { reason: "turn_cap" }),
+      };
+
+      try {
+        await taskService.updateState(state.taskId, "completed");
+        await taskService.createArtifact(state.taskId, {
+          name: "negotiation-outcome",
+          parts: [{ kind: "data", data: outcome }],
+          metadata: { consensus, turnCount: state.turnCount },
+        });
+      } catch (err) {
+        // DB failure is non-blocking
+      }
+
+      return { outcome };
+    };
+
+    const workflow = new StateGraph(NegotiationGraphState)
+      .addNode("init", initNode)
+      .addNode("turn", turnNode)
+      .addNode("finalize", finalizeNode)
+      .addConditionalEdges("turn", evaluateNode, {
+        turn: "turn",
+        finalize: "finalize",
+      })
+      .addEdge("__start__", "init")
+      .addEdge("init", "turn")
+      .addEdge("finalize", "__end__");
+
+    return workflow.compile();
+  }
+}

--- a/protocol/src/lib/protocol/graphs/negotiation.graph.ts
+++ b/protocol/src/lib/protocol/graphs/negotiation.graph.ts
@@ -227,6 +227,7 @@ export interface NegotiationCandidate {
   score: number;
   reasoning: string;
   valencyRole: string;
+  indexId?: string;
   candidateUser: UserNegotiationContext;
 }
 
@@ -252,9 +253,9 @@ export async function negotiateCandidates(
   sourceUser: UserNegotiationContext,
   candidates: NegotiationCandidate[],
   indexContext: { indexId: string; prompt: string },
-  opts?: { maxTurns?: number; traceEmitter?: TraceEmitter },
+  opts?: { maxTurns?: number; traceEmitter?: TraceEmitter; indexContextOverrides?: Map<string, string> },
 ): Promise<NegotiationResult[]> {
-  const { maxTurns, traceEmitter } = opts ?? {};
+  const { maxTurns, traceEmitter, indexContextOverrides } = opts ?? {};
 
   const results = await Promise.all(
     candidates.map(async (candidate) => {
@@ -262,10 +263,15 @@ export async function negotiateCandidates(
       traceEmitter?.({ type: "agent_start", name: "negotiation" });
 
       try {
+        // Use per-candidate index context if available
+        const candidateIndexContext = candidate.indexId && indexContextOverrides?.has(candidate.indexId)
+          ? { indexId: candidate.indexId, prompt: indexContextOverrides.get(candidate.indexId)! }
+          : indexContext;
+
         const result = await negotiationGraph.invoke({
           sourceUser,
           candidateUser: candidate.candidateUser,
-          indexContext,
+          indexContext: candidateIndexContext,
           seedAssessment: {
             score: candidate.score,
             reasoning: candidate.reasoning,

--- a/protocol/src/lib/protocol/graphs/negotiation.graph.ts
+++ b/protocol/src/lib/protocol/graphs/negotiation.graph.ts
@@ -1,6 +1,7 @@
 import { StateGraph } from "@langchain/langgraph";
 
-import { NegotiationGraphState, type NegotiationTurn, type NegotiationOutcome, type UserNegotiationContext } from "../states/negotiation.state";
+import { requestContext } from "../../request-context";
+import { NegotiationGraphState, type NegotiationTurn, type NegotiationOutcome, type UserNegotiationContext, type SeedAssessment, type NegotiationGraphLike } from "../states/negotiation.state";
 
 interface ConversationServiceLike {
   createConversation(participants: { participantId: string; participantType: "user" | "agent" }[]): Promise<{ id: string }>;
@@ -19,24 +20,20 @@ interface TaskServiceLike {
   createArtifact(taskId: string, data: { name?: string; parts: unknown[]; metadata?: Record<string, unknown> }): Promise<{ id: string }>;
 }
 
+interface NegotiationAgentInput {
+  ownUser: UserNegotiationContext;
+  otherUser: UserNegotiationContext;
+  indexContext: { indexId: string; prompt: string };
+  seedAssessment: SeedAssessment;
+  history: NegotiationTurn[];
+}
+
 interface ProposerLike {
-  invoke(input: {
-    ownUser: any;
-    otherUser: any;
-    indexContext: any;
-    seedAssessment: any;
-    history: NegotiationTurn[];
-  }): Promise<NegotiationTurn>;
+  invoke(input: NegotiationAgentInput): Promise<NegotiationTurn>;
 }
 
 interface ResponderLike {
-  invoke(input: {
-    ownUser: any;
-    otherUser: any;
-    indexContext: any;
-    seedAssessment: any;
-    history: NegotiationTurn[];
-  }): Promise<NegotiationTurn>;
+  invoke(input: NegotiationAgentInput): Promise<NegotiationTurn>;
 }
 
 /**
@@ -91,6 +88,11 @@ export class NegotiationGraphFactory {
         const otherUser = isSource ? state.candidateUser : state.sourceUser;
         const senderId = `agent:${ownUser.id}`;
 
+        const traceEmitter = requestContext.getStore()?.traceEmitter;
+        const agentName = isSource ? "negotiation-proposer" : "negotiation-responder";
+        const agentStart = Date.now();
+        traceEmitter?.({ type: "agent_start", name: agentName });
+
         const turn = await agent.invoke({
           ownUser,
           otherUser,
@@ -98,6 +100,8 @@ export class NegotiationGraphFactory {
           seedAssessment: state.seedAssessment,
           history,
         });
+
+        traceEmitter?.({ type: "agent_end", name: agentName, durationMs: Date.now() - agentStart, summary: `${turn.action}:${turn.assessment.fitScore}` });
 
         // First turn must be "propose"
         if (state.turnCount === 0 && turn.action !== "propose") {
@@ -164,10 +168,19 @@ export class NegotiationGraphFactory {
 
       let agreedRoles: NegotiationOutcome["agreedRoles"] = [];
       if (consensus && history.length >= 2) {
-        const lastTwo = history.slice(-2);
+        // The accept turn is always last; the preceding turn is from the other side.
+        // Use currentSpeaker (who would speak NEXT) to determine who spoke last.
+        const acceptTurn = history[history.length - 1];
+        const precedingTurn = history[history.length - 2];
+        // currentSpeaker flips after each turn; after the accept turn it points to who would go next.
+        // The accepter is the one who just spoke (opposite of currentSpeaker).
+        const accepterIsSource = state.currentSpeaker === "candidate";
+        const [sourceRole, candidateRole] = accepterIsSource
+          ? [acceptTurn.assessment.suggestedRoles.ownUser, precedingTurn.assessment.suggestedRoles.ownUser]
+          : [precedingTurn.assessment.suggestedRoles.ownUser, acceptTurn.assessment.suggestedRoles.ownUser];
         agreedRoles = [
-          { userId: state.sourceUser.id, role: lastTwo[0].assessment.suggestedRoles.ownUser },
-          { userId: state.candidateUser.id, role: lastTwo[1].assessment.suggestedRoles.ownUser },
+          { userId: state.sourceUser.id, role: sourceRole },
+          { userId: state.candidateUser.id, role: candidateRole },
         ];
       }
 
@@ -221,7 +234,7 @@ interface NegotiationCandidate {
 interface NegotiationResult {
   userId: string;
   negotiationScore: number;
-  agreedRoles: Array<{ userId: string; role: string }>;
+  agreedRoles: NegotiationOutcome["agreedRoles"];
   reasoning: string;
   turnCount: number;
 }
@@ -231,7 +244,7 @@ interface NegotiationResult {
  * Returns only candidates that achieved consensus.
  */
 export async function negotiateCandidates(
-  negotiationGraph: { invoke: (input: any) => Promise<{ outcome: any }> },
+  negotiationGraph: NegotiationGraphLike,
   sourceUser: UserNegotiationContext,
   candidates: NegotiationCandidate[],
   indexContext: { indexId: string; prompt: string },
@@ -262,7 +275,8 @@ export async function negotiateCandidates(
           };
         }
         return null;
-      } catch {
+      } catch (err) {
+        console.error(`[negotiateCandidates] Negotiation failed for candidate ${candidate.userId}:`, err);
         return null;
       }
     }),

--- a/protocol/src/lib/protocol/graphs/opportunity.graph.ts
+++ b/protocol/src/lib/protocol/graphs/opportunity.graph.ts
@@ -1590,14 +1590,69 @@ export class OpportunityGraphFactory {
 
         const isChatPath = !!state.options?.conversationId;
         const maxTurns = isChatPath ? 4 : 6;
+        const indexContext = { indexId: state.indexId as string ?? '', prompt: '' };
 
-        const consensusResults = await negotiateCandidates(
-          this.negotiationGraph, sourceUser, negotiationCandidates as any[],
-          { indexId: state.indexId as string ?? '', prompt: '' },
-          maxTurns,
+        // Run negotiations in parallel with per-candidate trace events
+        const negotiationResults = await Promise.all(
+          (negotiationCandidates as any[]).map(async (candidate: any) => {
+            const candidateStart = Date.now();
+            const candidateName = candidate.candidateUser?.profile?.name || candidate.userId;
+            traceEmitter?.({ type: "agent_start", name: "negotiation" });
+
+            try {
+              const result = await this.negotiationGraph.invoke({
+                sourceUser,
+                candidateUser: candidate.candidateUser,
+                indexContext,
+                seedAssessment: {
+                  score: candidate.score,
+                  reasoning: candidate.reasoning,
+                  valencyRole: candidate.valencyRole,
+                },
+                maxTurns,
+              });
+
+              const durationMs = Date.now() - candidateStart;
+              const outcome = result.outcome;
+
+              // Build inline turn flow: "propose:85 → counter:70 → accept:78"
+              const turnFlow = (result.messages ?? [])
+                .map((m: any) => {
+                  const dataPart = (m.parts as Array<{ kind?: string; data?: any }>)?.find((p: any) => p.kind === "data");
+                  if (!dataPart?.data) return null;
+                  const turn = dataPart.data;
+                  const actionShort = turn.action === 'propose' ? 'propose' : turn.action === 'accept' ? 'accept' : turn.action === 'reject' ? 'reject' : 'counter';
+                  return `${actionShort}:${turn.assessment?.fitScore ?? '?'}`;
+                })
+                .filter(Boolean)
+                .join(' → ');
+
+              const consensus = outcome?.consensus === true;
+              const statusTag = consensus ? '✓ consensus' : '✗ rejected';
+              const summary = `${candidateName}: ${turnFlow} ${statusTag}`;
+
+              traceEmitter?.({ type: "agent_end", name: "negotiation", durationMs, summary });
+
+              if (consensus) {
+                return {
+                  userId: candidate.userId,
+                  negotiationScore: outcome.finalScore,
+                  agreedRoles: outcome.agreedRoles,
+                  reasoning: outcome.reasoning,
+                  turnCount: outcome.turnCount,
+                };
+              }
+              return null;
+            } catch (err) {
+              const durationMs = Date.now() - candidateStart;
+              traceEmitter?.({ type: "agent_end", name: "negotiation", durationMs, summary: `${candidateName}: error` });
+              return null;
+            }
+          }),
         );
 
-        const consensusUserIds = new Set(consensusResults.map(r => r.userId));
+        const consensusResults = negotiationResults.filter((r: any): r is NonNullable<typeof r> => r !== null);
+        const consensusUserIds = new Set(consensusResults.map((r: any) => r.userId));
         const filtered = state.evaluatedOpportunities.filter(opp => {
           const candidateActor = opp.actors.find(a => a.userId !== state.userId);
           return candidateActor && consensusUserIds.has(candidateActor.userId as string);
@@ -1606,7 +1661,7 @@ export class OpportunityGraphFactory {
         for (const opp of filtered) {
           const candidateActor = opp.actors.find(a => a.userId !== state.userId);
           if (!candidateActor) continue;
-          const negResult = consensusResults.find(r => r.userId === (candidateActor.userId as string));
+          const negResult = consensusResults.find((r: any) => r.userId === (candidateActor.userId as string));
           if (negResult) {
             opp.score = negResult.negotiationScore;
           }

--- a/protocol/src/lib/protocol/graphs/opportunity.graph.ts
+++ b/protocol/src/lib/protocol/graphs/opportunity.graph.ts
@@ -1568,7 +1568,6 @@ export class OpportunityGraphFactory {
             skills: state.sourceProfile?.attributes?.skills,
             interests: state.sourceProfile?.attributes?.interests,
           },
-          hydeDocuments: [] as string[],
         };
 
         // Build candidates with enriched context from database
@@ -1608,7 +1607,6 @@ export class OpportunityGraphFactory {
                   skills: profile?.attributes?.skills,
                   interests: profile?.attributes?.interests,
                 },
-                hydeDocuments: [] as string[],
               },
             };
           }),
@@ -1616,7 +1614,9 @@ export class OpportunityGraphFactory {
 
         const isChatPath = !!state.options?.conversationId;
         const maxTurns = isChatPath ? 4 : 6;
-        const indexContext = { indexId: state.indexId as string ?? '', prompt: '' };
+        const indexId = state.indexId as string ?? '';
+        const memberCtx = indexId ? await this.database.getIndexMemberContext(indexId, state.userId as string).catch(() => null) : null;
+        const indexContext = { indexId, prompt: memberCtx?.indexPrompt ?? '' };
 
         const consensusResults = await negotiateCandidates(
           this.negotiationGraph, sourceUser, candidates, indexContext,
@@ -1639,7 +1639,7 @@ export class OpportunityGraphFactory {
         traceEmitter?.({ type: "graph_end", name: "negotiation", durationMs: Date.now() - graphStart });
         return { evaluatedOpportunities: updatedOpportunities };
       } catch (err) {
-        console.error("[OpportunityGraph:negotiateNode] Negotiation stage failed:", err);
+        logger.error("[Graph:Negotiate] Negotiation stage failed", { error: err });
         traceEmitter?.({ type: "graph_end", name: "negotiation", durationMs: Date.now() - graphStart });
         return {};
       }

--- a/protocol/src/lib/protocol/graphs/opportunity.graph.ts
+++ b/protocol/src/lib/protocol/graphs/opportunity.graph.ts
@@ -1550,7 +1550,7 @@ export class OpportunityGraphFactory {
 
       const traceEmitter = requestContext.getStore()?.traceEmitter;
       const graphStart = Date.now();
-      traceEmitter?.({ type: "graph_start", name: "negotiation" });
+      traceEmitter?.({ type: "graph_start", name: "Negotiation graph" });
 
       try {
         // Use the same discoveryUserId pattern as evaluationNode
@@ -1666,11 +1666,11 @@ export class OpportunityGraphFactory {
             return negResult ? { ...opp, score: negResult.negotiationScore } : opp;
           });
 
-        traceEmitter?.({ type: "graph_end", name: "negotiation", durationMs: Date.now() - graphStart });
+        traceEmitter?.({ type: "graph_end", name: "Negotiation graph", durationMs: Date.now() - graphStart });
         return { evaluatedOpportunities: updatedOpportunities };
       } catch (err) {
         logger.error("[Graph:Negotiate] Negotiation stage failed", { error: err });
-        traceEmitter?.({ type: "graph_end", name: "negotiation", durationMs: Date.now() - graphStart });
+        traceEmitter?.({ type: "graph_end", name: "Negotiation graph", durationMs: Date.now() - graphStart });
         return { evaluatedOpportunities: [] };
       }
     };

--- a/protocol/src/lib/protocol/graphs/opportunity.graph.ts
+++ b/protocol/src/lib/protocol/graphs/opportunity.graph.ts
@@ -1597,16 +1597,22 @@ export class OpportunityGraphFactory {
                 : null,
             ]);
 
-            // Prefer active intents (capped at 5, trigger intent first); fall back to single intent
-            const orderedIntents = [
-              ...activeIntents.filter(ai => ai.id === candidateActor.intentId),
-              ...activeIntents.filter(ai => ai.id !== candidateActor.intentId),
+            // Prefer active intents (capped at 5, trigger intent first); fall back to single intent.
+            // If the trigger intent was archived but we fetched it by ID, prepend it so negotiation
+            // always includes the intent that produced the opportunity match.
+            const toNegIntent = (ai: { id?: string | null; summary?: string | null; payload?: string | null }) => ({
+              id: (ai.id ?? candidateActor.intentId) as string,
+              title: ai.summary ?? '',
+              description: ai.payload ?? '',
+              confidence: 1,
+            });
+            const triggerInActive = activeIntents.some(ai => ai.id === candidateActor.intentId);
+            const triggerFallback = !triggerInActive && intent ? [toNegIntent(intent)] : [];
+            const candidateIntents = [
+              ...triggerFallback,
+              ...activeIntents.filter(ai => ai.id === candidateActor.intentId).map(toNegIntent),
+              ...activeIntents.filter(ai => ai.id !== candidateActor.intentId).map(toNegIntent),
             ].slice(0, 5);
-            const candidateIntents = orderedIntents.length > 0
-              ? orderedIntents.map(ai => ({ id: ai.id as string, title: ai.summary ?? '', description: ai.payload ?? '', confidence: 1 }))
-              : intent
-                ? [{ id: intent.id ?? (candidateActor.intentId as string), title: intent.summary ?? '', description: intent.payload ?? '', confidence: 1 }]
-                : [];
 
             return {
               userId,

--- a/protocol/src/lib/protocol/graphs/opportunity.graph.ts
+++ b/protocol/src/lib/protocol/graphs/opportunity.graph.ts
@@ -1586,13 +1586,25 @@ export class OpportunityGraphFactory {
         const candidates: NegotiationCandidate[] = await Promise.all(
           candidateEntries.map(async ({ opp, candidateActor }) => {
             const userId = candidateActor.userId as string;
-            const [profile, user, intent] = await Promise.all([
+            const [profile, user, activeIntents, intent] = await Promise.all([
               this.database.getProfile(userId).catch(() => null),
               this.database.getUser(userId).catch(() => null),
+              this.database.getActiveIntents(userId).catch(() => []),
               candidateActor.intentId
                 ? this.database.getIntent(candidateActor.intentId as string).catch(() => null)
                 : null,
             ]);
+
+            // Prefer active intents (capped at 5, trigger intent first); fall back to single intent
+            const orderedIntents = [
+              ...activeIntents.filter(ai => ai.id === candidateActor.intentId),
+              ...activeIntents.filter(ai => ai.id !== candidateActor.intentId),
+            ].slice(0, 5);
+            const candidateIntents = orderedIntents.length > 0
+              ? orderedIntents.map(ai => ({ id: ai.id as string, title: ai.summary ?? '', description: ai.payload ?? '', confidence: 1 }))
+              : intent
+                ? [{ id: intent.id ?? (candidateActor.intentId as string), title: intent.summary ?? '', description: intent.payload ?? '', confidence: 1 }]
+                : [];
 
             return {
               userId,
@@ -1602,9 +1614,7 @@ export class OpportunityGraphFactory {
               indexId: candidateActor.indexId as string,
               candidateUser: {
                 id: userId,
-                intents: intent
-                  ? [{ id: intent.id ?? (candidateActor.intentId as string), title: intent.summary ?? '', description: intent.payload ?? '', confidence: 1 }]
-                  : [],
+                intents: candidateIntents,
                 profile: {
                   name: profile?.identity?.name ?? user?.name,
                   bio: profile?.identity?.bio ?? user?.intro ?? undefined,
@@ -1626,7 +1636,10 @@ export class OpportunityGraphFactory {
         await Promise.all(
           uniqueIndexIds.map(async (indexId) => {
             const ctx = await this.database.getIndexMemberContext(indexId, discoveryUserId).catch(() => null);
-            if (ctx?.indexPrompt) indexContextMap.set(indexId, ctx.indexPrompt);
+            const prompt = [ctx?.indexPrompt, ctx?.memberPrompt]
+              .filter((v): v is string => !!v?.trim())
+              .join('\n\n');
+            if (prompt) indexContextMap.set(indexId, prompt);
           }),
         );
 

--- a/protocol/src/lib/protocol/graphs/opportunity.graph.ts
+++ b/protocol/src/lib/protocol/graphs/opportunity.graph.ts
@@ -64,7 +64,7 @@ import type {
   ActiveIntent,
 } from '../interfaces/database.interface';
 import { persistOpportunities } from '../support/opportunity.persist';
-import { negotiateCandidates } from "./negotiation.graph";
+import { negotiateCandidates, createDefaultNegotiationGraph } from "./negotiation.graph";
 import { protocolLogger, withCallLogging } from '../support/protocol.logger';
 import { timed } from '../../performance';
 import { requestContext } from "../../request-context";
@@ -147,7 +147,7 @@ export class OpportunityGraphFactory {
     },
     private optionalEvaluator?: OpportunityEvaluatorLike,
     private queueNotification?: QueueOpportunityNotificationFn,
-    private negotiationGraph?: { invoke: (input: any) => Promise<{ outcome: any }> },
+    private negotiationGraph: { invoke: (input: any) => Promise<{ outcome: any }> } = createDefaultNegotiationGraph(),
   ) {}
 
   public createGraph() {
@@ -1545,10 +1545,6 @@ export class OpportunityGraphFactory {
      * Filters out candidates that fail to reach consensus; updates scores for those that pass.
      */
     const negotiateNode = async (state: typeof OpportunityGraphState.State) => {
-      if (!this.negotiationGraph) {
-        return {};
-      }
-
       const traceEmitter = requestContext.getStore()?.traceEmitter;
       const graphStart = Date.now();
       traceEmitter?.({ type: "graph_start", name: "negotiation" });
@@ -2669,7 +2665,6 @@ export class OpportunityGraphFactory {
       .addNode('negotiate', negotiateNode)
       .addConditionalEdges('evaluation', (state) => {
         if (state.operationMode === 'continue_discovery') return 'ranking';
-        if (!this.negotiationGraph) return 'ranking';
         return 'negotiate';
       }, {
         negotiate: 'negotiate',

--- a/protocol/src/lib/protocol/graphs/opportunity.graph.ts
+++ b/protocol/src/lib/protocol/graphs/opportunity.graph.ts
@@ -1556,6 +1556,8 @@ export class OpportunityGraphFactory {
         // Use the same discoveryUserId pattern as evaluationNode
         const discoveryUserId = (state.onBehalfOfUserId ?? state.userId) as string;
 
+        const sourceAccount = await this.database.getUser(discoveryUserId).catch(() => null);
+
         const sourceUser = {
           id: discoveryUserId,
           intents: state.indexedIntents?.slice(0, 5).map(i => ({
@@ -1565,9 +1567,9 @@ export class OpportunityGraphFactory {
             confidence: 1,
           })) ?? [],
           profile: {
-            name: state.sourceProfile?.identity?.name,
-            bio: state.sourceProfile?.identity?.bio,
-            location: state.sourceProfile?.identity?.location,
+            name: state.sourceProfile?.identity?.name ?? sourceAccount?.name,
+            bio: state.sourceProfile?.identity?.bio ?? sourceAccount?.intro ?? undefined,
+            location: state.sourceProfile?.identity?.location ?? sourceAccount?.location ?? undefined,
             skills: state.sourceProfile?.attributes?.skills,
             interests: state.sourceProfile?.attributes?.interests,
           },

--- a/protocol/src/lib/protocol/graphs/opportunity.graph.ts
+++ b/protocol/src/lib/protocol/graphs/opportunity.graph.ts
@@ -64,7 +64,7 @@ import type {
   ActiveIntent,
 } from '../interfaces/database.interface';
 import { persistOpportunities } from '../support/opportunity.persist';
-import { negotiateCandidates, createDefaultNegotiationGraph } from "./negotiation.graph";
+import { negotiateCandidates, type NegotiationCandidate } from "./negotiation.graph";
 import type { NegotiationGraphLike } from "../states/negotiation.state";
 import { protocolLogger, withCallLogging } from '../support/protocol.logger';
 import { timed } from '../../performance';
@@ -148,7 +148,7 @@ export class OpportunityGraphFactory {
     },
     private optionalEvaluator?: OpportunityEvaluatorLike,
     private queueNotification?: QueueOpportunityNotificationFn,
-    private negotiationGraph: NegotiationGraphLike = createDefaultNegotiationGraph(),
+    private negotiationGraph?: NegotiationGraphLike,
   ) {}
 
   public createGraph() {
@@ -1546,6 +1546,8 @@ export class OpportunityGraphFactory {
      * Filters out candidates that fail to reach consensus; updates scores for those that pass.
      */
     const negotiateNode = async (state: typeof OpportunityGraphState.State) => {
+      if (!this.negotiationGraph) return {};
+
       const traceEmitter = requestContext.getStore()?.traceEmitter;
       const graphStart = Date.now();
       traceEmitter?.({ type: "graph_start", name: "negotiation" });
@@ -1569,107 +1571,70 @@ export class OpportunityGraphFactory {
           hydeDocuments: [] as string[],
         };
 
-        const negotiationCandidates = state.evaluatedOpportunities.map(opp => {
-          const candidateActor = opp.actors.find(a => a.userId !== state.userId);
-          if (!candidateActor) return null;
+        // Build candidates with enriched context from database
+        const candidateEntries = state.evaluatedOpportunities
+          .map(opp => {
+            const candidateActor = opp.actors.find(a => a.userId !== state.userId);
+            if (!candidateActor) return null;
+            return { opp, candidateActor };
+          })
+          .filter((e): e is NonNullable<typeof e> => e !== null);
 
-          return {
-            userId: candidateActor.userId as string,
-            score: opp.score,
-            reasoning: opp.reasoning,
-            valencyRole: candidateActor.role ?? 'peer',
-            candidateUser: {
-              id: candidateActor.userId as string,
-              intents: candidateActor.intentId
-                ? [{ id: candidateActor.intentId as string, title: '', description: '', confidence: 1 }]
-                : [],
-              profile: { name: '' },
-              hydeDocuments: [] as string[],
-            },
-          };
-        });
+        const candidates: NegotiationCandidate[] = await Promise.all(
+          candidateEntries.map(async ({ opp, candidateActor }) => {
+            const userId = candidateActor.userId as string;
+            const [profile, user, intent] = await Promise.all([
+              this.database.getProfile(userId).catch(() => null),
+              this.database.getUser(userId).catch(() => null),
+              candidateActor.intentId
+                ? this.database.getIntent(candidateActor.intentId as string).catch(() => null)
+                : null,
+            ]);
+
+            return {
+              userId,
+              score: opp.score,
+              reasoning: opp.reasoning,
+              valencyRole: candidateActor.role ?? 'peer',
+              candidateUser: {
+                id: userId,
+                intents: intent
+                  ? [{ id: intent.id ?? (candidateActor.intentId as string), title: intent.summary ?? '', description: intent.payload ?? '', confidence: 1 }]
+                  : [],
+                profile: {
+                  name: profile?.identity?.name ?? user?.name,
+                  bio: profile?.identity?.bio ?? user?.intro ?? undefined,
+                  location: profile?.identity?.location ?? user?.location ?? undefined,
+                  skills: profile?.attributes?.skills,
+                  interests: profile?.attributes?.interests,
+                },
+                hydeDocuments: [] as string[],
+              },
+            };
+          }),
+        );
 
         const isChatPath = !!state.options?.conversationId;
         const maxTurns = isChatPath ? 4 : 6;
         const indexContext = { indexId: state.indexId as string ?? '', prompt: '' };
 
-        // Run negotiations in parallel with per-candidate trace events
-        const validCandidates = negotiationCandidates.filter(
-          (c): c is NonNullable<typeof c> => c !== null,
-        );
-        const negotiationResults = await Promise.all(
-          validCandidates.map(async (candidate) => {
-            const candidateStart = Date.now();
-            const candidateName = candidate.candidateUser?.profile?.name || candidate.userId;
-            traceEmitter?.({ type: "agent_start", name: "negotiation" });
-
-            try {
-              const result = await this.negotiationGraph.invoke({
-                sourceUser,
-                candidateUser: candidate.candidateUser,
-                indexContext,
-                seedAssessment: {
-                  score: candidate.score,
-                  reasoning: candidate.reasoning,
-                  valencyRole: candidate.valencyRole,
-                },
-                maxTurns,
-              });
-
-              const durationMs = Date.now() - candidateStart;
-              const outcome = result.outcome;
-
-              // Build inline turn flow: "propose:85 → counter:70 → accept:78"
-              const turnFlow = (result.messages ?? [])
-                .map((m) => {
-                  const dataPart = (m.parts as Array<{ kind?: string; data?: Record<string, unknown> }>)?.find((p) => p.kind === "data");
-                  if (!dataPart?.data) return null;
-                  const turn = dataPart.data as { action?: string; assessment?: { fitScore?: number } };
-                  return `${turn.action ?? 'unknown'}:${turn.assessment?.fitScore ?? '?'}`;
-                })
-                .filter(Boolean)
-                .join(' → ');
-
-              const consensus = outcome?.consensus === true;
-              const statusTag = consensus ? '✓ consensus' : '✗ rejected';
-              const summary = `${candidateName}: ${turnFlow} ${statusTag}`;
-
-              traceEmitter?.({ type: "agent_end", name: "negotiation", durationMs, summary });
-
-              if (consensus) {
-                return {
-                  userId: candidate.userId,
-                  negotiationScore: outcome.finalScore,
-                  agreedRoles: outcome.agreedRoles,
-                  reasoning: outcome.reasoning,
-                  turnCount: outcome.turnCount,
-                };
-              }
-              return null;
-            } catch (err) {
-              const durationMs = Date.now() - candidateStart;
-              traceEmitter?.({ type: "agent_end", name: "negotiation", durationMs, summary: `${candidateName}: error` });
-              return null;
-            }
-          }),
+        const consensusResults = await negotiateCandidates(
+          this.negotiationGraph, sourceUser, candidates, indexContext,
+          { maxTurns, traceEmitter: traceEmitter ?? undefined },
         );
 
-        const consensusResults = negotiationResults.filter((r): r is NonNullable<typeof r> => r !== null);
-        const consensusUserIds = new Set(consensusResults.map((r) => r.userId));
-        const filtered = state.evaluatedOpportunities.filter(opp => {
-          const candidateActor = opp.actors.find(a => a.userId !== state.userId);
-          return candidateActor && consensusUserIds.has(candidateActor.userId as string);
-        });
-
-        const updatedOpportunities = filtered.map(opp => {
-          const candidateActor = opp.actors.find(a => a.userId !== state.userId);
-          if (!candidateActor) return opp;
-          const negResult = consensusResults.find((r) => r.userId === (candidateActor.userId as string));
-          if (negResult) {
-            return { ...opp, score: negResult.negotiationScore };
-          }
-          return opp;
-        });
+        // Filter opportunities to only those with consensus, update scores
+        const consensusMap = new Map(consensusResults.map(r => [r.userId, r]));
+        const updatedOpportunities = state.evaluatedOpportunities
+          .filter(opp => {
+            const candidateActor = opp.actors.find(a => a.userId !== state.userId);
+            return candidateActor && consensusMap.has(candidateActor.userId as string);
+          })
+          .map(opp => {
+            const candidateActor = opp.actors.find(a => a.userId !== state.userId);
+            const negResult = candidateActor && consensusMap.get(candidateActor.userId as string);
+            return negResult ? { ...opp, score: negResult.negotiationScore } : opp;
+          });
 
         traceEmitter?.({ type: "graph_end", name: "negotiation", durationMs: Date.now() - graphStart });
         return { evaluatedOpportunities: updatedOpportunities };

--- a/protocol/src/lib/protocol/graphs/opportunity.graph.ts
+++ b/protocol/src/lib/protocol/graphs/opportunity.graph.ts
@@ -1558,7 +1558,7 @@ export class OpportunityGraphFactory {
 
         const sourceUser = {
           id: discoveryUserId,
-          intents: state.indexedIntents?.map(i => ({
+          intents: state.indexedIntents?.slice(0, 5).map(i => ({
             id: i.intentId as string,
             title: i.summary ?? '',
             description: i.payload ?? '',

--- a/protocol/src/lib/protocol/graphs/opportunity.graph.ts
+++ b/protocol/src/lib/protocol/graphs/opportunity.graph.ts
@@ -64,6 +64,7 @@ import type {
   ActiveIntent,
 } from '../interfaces/database.interface';
 import { persistOpportunities } from '../support/opportunity.persist';
+import { negotiateCandidates } from "./negotiation.graph";
 import { protocolLogger, withCallLogging } from '../support/protocol.logger';
 import { timed } from '../../performance';
 import { requestContext } from "../../request-context";
@@ -145,7 +146,8 @@ export class OpportunityGraphFactory {
       }>;
     },
     private optionalEvaluator?: OpportunityEvaluatorLike,
-    private queueNotification?: QueueOpportunityNotificationFn
+    private queueNotification?: QueueOpportunityNotificationFn,
+    private negotiationGraph?: { invoke: (input: any) => Promise<{ outcome: any }> },
   ) {}
 
   public createGraph() {
@@ -1538,6 +1540,91 @@ export class OpportunityGraphFactory {
     };
 
     /**
+     * Node 3b: Negotiate
+     * Runs bilateral negotiation between source user and each evaluated candidate.
+     * Filters out candidates that fail to reach consensus; updates scores for those that pass.
+     */
+    const negotiateNode = async (state: typeof OpportunityGraphState.State) => {
+      if (!this.negotiationGraph) {
+        return {};
+      }
+
+      const traceEmitter = requestContext.getStore()?.traceEmitter;
+      const graphStart = Date.now();
+      traceEmitter?.({ type: "graph_start", name: "negotiation" });
+
+      try {
+        const sourceUser = {
+          id: state.userId as string,
+          intents: state.indexedIntents?.map(i => ({
+            id: i.intentId as string,
+            title: i.summary ?? '',
+            description: i.payload ?? '',
+            confidence: 1,
+          })) ?? [],
+          profile: {
+            name: state.sourceProfile?.identity?.name,
+            bio: state.sourceProfile?.identity?.bio,
+            location: state.sourceProfile?.identity?.location,
+            skills: state.sourceProfile?.attributes?.skills,
+            interests: state.sourceProfile?.attributes?.interests,
+          },
+          hydeDocuments: [] as string[],
+        };
+
+        const negotiationCandidates = state.evaluatedOpportunities.map(opp => {
+          const candidateActor = opp.actors.find(a => a.userId !== state.userId);
+          if (!candidateActor) return null;
+
+          return {
+            userId: candidateActor.userId as string,
+            score: opp.score,
+            reasoning: opp.reasoning,
+            valencyRole: candidateActor.role ?? 'peer',
+            candidateUser: {
+              id: candidateActor.userId as string,
+              intents: candidateActor.intentId
+                ? [{ id: candidateActor.intentId as string, title: '', description: '', confidence: 1 }]
+                : [],
+              profile: { name: '' },
+              hydeDocuments: [] as string[],
+            },
+          };
+        }).filter(Boolean);
+
+        const isChatPath = !!state.options?.conversationId;
+        const maxTurns = isChatPath ? 4 : 6;
+
+        const consensusResults = await negotiateCandidates(
+          this.negotiationGraph, sourceUser, negotiationCandidates as any[],
+          { indexId: state.indexId as string ?? '', prompt: '' },
+          maxTurns,
+        );
+
+        const consensusUserIds = new Set(consensusResults.map(r => r.userId));
+        const filtered = state.evaluatedOpportunities.filter(opp => {
+          const candidateActor = opp.actors.find(a => a.userId !== state.userId);
+          return candidateActor && consensusUserIds.has(candidateActor.userId as string);
+        });
+
+        for (const opp of filtered) {
+          const candidateActor = opp.actors.find(a => a.userId !== state.userId);
+          if (!candidateActor) continue;
+          const negResult = consensusResults.find(r => r.userId === (candidateActor.userId as string));
+          if (negResult) {
+            opp.score = negResult.negotiationScore;
+          }
+        }
+
+        traceEmitter?.({ type: "graph_end", name: "negotiation", durationMs: Date.now() - graphStart });
+        return { evaluatedOpportunities: filtered };
+      } catch (err) {
+        traceEmitter?.({ type: "graph_end", name: "negotiation", durationMs: Date.now() - graphStart });
+        return {};
+      }
+    };
+
+    /**
      * Node 4: Ranking
      * Sorts evaluated opportunities by score, applies limit, dedupes by actor-set hash.
      */
@@ -2578,8 +2665,17 @@ export class OpportunityGraphFactory {
         [END]: END,
       })
 
-      // Linear edges for main flow
-      .addEdge('evaluation', 'ranking')
+      // Negotiation step (optional, skipped for continue_discovery or when no negotiation graph)
+      .addNode('negotiate', negotiateNode)
+      .addConditionalEdges('evaluation', (state) => {
+        if (state.operationMode === 'continue_discovery') return 'ranking';
+        if (!this.negotiationGraph) return 'ranking';
+        return 'negotiate';
+      }, {
+        negotiate: 'negotiate',
+        ranking: 'ranking',
+      })
+      .addEdge('negotiate', 'ranking')
       .addEdge('ranking', 'persist')
       .addEdge('persist', END);
 

--- a/protocol/src/lib/protocol/graphs/opportunity.graph.ts
+++ b/protocol/src/lib/protocol/graphs/opportunity.graph.ts
@@ -65,6 +65,7 @@ import type {
 } from '../interfaces/database.interface';
 import { persistOpportunities } from '../support/opportunity.persist';
 import { negotiateCandidates, createDefaultNegotiationGraph } from "./negotiation.graph";
+import type { NegotiationGraphLike } from "../states/negotiation.state";
 import { protocolLogger, withCallLogging } from '../support/protocol.logger';
 import { timed } from '../../performance';
 import { requestContext } from "../../request-context";
@@ -147,7 +148,7 @@ export class OpportunityGraphFactory {
     },
     private optionalEvaluator?: OpportunityEvaluatorLike,
     private queueNotification?: QueueOpportunityNotificationFn,
-    private negotiationGraph: { invoke: (input: any) => Promise<{ outcome: any }> } = createDefaultNegotiationGraph(),
+    private negotiationGraph: NegotiationGraphLike = createDefaultNegotiationGraph(),
   ) {}
 
   public createGraph() {
@@ -1586,15 +1587,18 @@ export class OpportunityGraphFactory {
               hydeDocuments: [] as string[],
             },
           };
-        }).filter(Boolean);
+        });
 
         const isChatPath = !!state.options?.conversationId;
         const maxTurns = isChatPath ? 4 : 6;
         const indexContext = { indexId: state.indexId as string ?? '', prompt: '' };
 
         // Run negotiations in parallel with per-candidate trace events
+        const validCandidates = negotiationCandidates.filter(
+          (c): c is NonNullable<typeof c> => c !== null,
+        );
         const negotiationResults = await Promise.all(
-          (negotiationCandidates as any[]).map(async (candidate: any) => {
+          validCandidates.map(async (candidate) => {
             const candidateStart = Date.now();
             const candidateName = candidate.candidateUser?.profile?.name || candidate.userId;
             traceEmitter?.({ type: "agent_start", name: "negotiation" });
@@ -1617,12 +1621,11 @@ export class OpportunityGraphFactory {
 
               // Build inline turn flow: "propose:85 → counter:70 → accept:78"
               const turnFlow = (result.messages ?? [])
-                .map((m: any) => {
-                  const dataPart = (m.parts as Array<{ kind?: string; data?: any }>)?.find((p: any) => p.kind === "data");
+                .map((m) => {
+                  const dataPart = (m.parts as Array<{ kind?: string; data?: Record<string, unknown> }>)?.find((p) => p.kind === "data");
                   if (!dataPart?.data) return null;
-                  const turn = dataPart.data;
-                  const actionShort = turn.action === 'propose' ? 'propose' : turn.action === 'accept' ? 'accept' : turn.action === 'reject' ? 'reject' : 'counter';
-                  return `${actionShort}:${turn.assessment?.fitScore ?? '?'}`;
+                  const turn = dataPart.data as { action?: string; assessment?: { fitScore?: number } };
+                  return `${turn.action ?? 'unknown'}:${turn.assessment?.fitScore ?? '?'}`;
                 })
                 .filter(Boolean)
                 .join(' → ');
@@ -1651,25 +1654,27 @@ export class OpportunityGraphFactory {
           }),
         );
 
-        const consensusResults = negotiationResults.filter((r: any): r is NonNullable<typeof r> => r !== null);
-        const consensusUserIds = new Set(consensusResults.map((r: any) => r.userId));
+        const consensusResults = negotiationResults.filter((r): r is NonNullable<typeof r> => r !== null);
+        const consensusUserIds = new Set(consensusResults.map((r) => r.userId));
         const filtered = state.evaluatedOpportunities.filter(opp => {
           const candidateActor = opp.actors.find(a => a.userId !== state.userId);
           return candidateActor && consensusUserIds.has(candidateActor.userId as string);
         });
 
-        for (const opp of filtered) {
+        const updatedOpportunities = filtered.map(opp => {
           const candidateActor = opp.actors.find(a => a.userId !== state.userId);
-          if (!candidateActor) continue;
-          const negResult = consensusResults.find((r: any) => r.userId === (candidateActor.userId as string));
+          if (!candidateActor) return opp;
+          const negResult = consensusResults.find((r) => r.userId === (candidateActor.userId as string));
           if (negResult) {
-            opp.score = negResult.negotiationScore;
+            return { ...opp, score: negResult.negotiationScore };
           }
-        }
+          return opp;
+        });
 
         traceEmitter?.({ type: "graph_end", name: "negotiation", durationMs: Date.now() - graphStart });
-        return { evaluatedOpportunities: filtered };
+        return { evaluatedOpportunities: updatedOpportunities };
       } catch (err) {
+        console.error("[OpportunityGraph:negotiateNode] Negotiation stage failed:", err);
         traceEmitter?.({ type: "graph_end", name: "negotiation", durationMs: Date.now() - graphStart });
         return {};
       }

--- a/protocol/src/lib/protocol/graphs/opportunity.graph.ts
+++ b/protocol/src/lib/protocol/graphs/opportunity.graph.ts
@@ -1553,8 +1553,11 @@ export class OpportunityGraphFactory {
       traceEmitter?.({ type: "graph_start", name: "negotiation" });
 
       try {
+        // Use the same discoveryUserId pattern as evaluationNode
+        const discoveryUserId = (state.onBehalfOfUserId ?? state.userId) as string;
+
         const sourceUser = {
-          id: state.userId as string,
+          id: discoveryUserId,
           intents: state.indexedIntents?.map(i => ({
             id: i.intentId as string,
             title: i.summary ?? '',
@@ -1570,10 +1573,11 @@ export class OpportunityGraphFactory {
           },
         };
 
-        // Build candidates with enriched context from database
+        // Build candidates with enriched context from database.
+        // Each actor carries its own indexId — use it for per-candidate index context.
         const candidateEntries = state.evaluatedOpportunities
           .map(opp => {
-            const candidateActor = opp.actors.find(a => a.userId !== state.userId);
+            const candidateActor = opp.actors.find(a => a.userId !== discoveryUserId);
             if (!candidateActor) return null;
             return { opp, candidateActor };
           })
@@ -1595,6 +1599,7 @@ export class OpportunityGraphFactory {
               score: opp.score,
               reasoning: opp.reasoning,
               valencyRole: candidateActor.role ?? 'peer',
+              indexId: candidateActor.indexId as string,
               candidateUser: {
                 id: userId,
                 intents: intent
@@ -1614,24 +1619,34 @@ export class OpportunityGraphFactory {
 
         const isChatPath = !!state.options?.conversationId;
         const maxTurns = isChatPath ? 4 : 6;
-        const indexId = state.indexId as string ?? '';
-        const memberCtx = indexId ? await this.database.getIndexMemberContext(indexId, state.userId as string).catch(() => null) : null;
-        const indexContext = { indexId, prompt: memberCtx?.indexPrompt ?? '' };
 
+        // Fetch per-candidate index context (group by indexId to avoid duplicate lookups)
+        const uniqueIndexIds = [...new Set(candidates.map(c => c.indexId).filter((id): id is string => !!id))];
+        const indexContextMap = new Map<string, string>();
+        await Promise.all(
+          uniqueIndexIds.map(async (indexId) => {
+            const ctx = await this.database.getIndexMemberContext(indexId, discoveryUserId).catch(() => null);
+            if (ctx?.indexPrompt) indexContextMap.set(indexId, ctx.indexPrompt);
+          }),
+        );
+
+        // Run negotiations per candidate with their actual index context
         const consensusResults = await negotiateCandidates(
-          this.negotiationGraph, sourceUser, candidates, indexContext,
-          { maxTurns, traceEmitter: traceEmitter ?? undefined },
+          this.negotiationGraph, sourceUser, candidates,
+          { indexId: '', prompt: '' }, // base context, overridden per-candidate below
+          { maxTurns, traceEmitter: traceEmitter ?? undefined,
+            indexContextOverrides: indexContextMap },
         );
 
         // Filter opportunities to only those with consensus, update scores
         const consensusMap = new Map(consensusResults.map(r => [r.userId, r]));
         const updatedOpportunities = state.evaluatedOpportunities
           .filter(opp => {
-            const candidateActor = opp.actors.find(a => a.userId !== state.userId);
+            const candidateActor = opp.actors.find(a => a.userId !== discoveryUserId);
             return candidateActor && consensusMap.has(candidateActor.userId as string);
           })
           .map(opp => {
-            const candidateActor = opp.actors.find(a => a.userId !== state.userId);
+            const candidateActor = opp.actors.find(a => a.userId !== discoveryUserId);
             const negResult = candidateActor && consensusMap.get(candidateActor.userId as string);
             return negResult ? { ...opp, score: negResult.negotiationScore } : opp;
           });
@@ -1641,7 +1656,7 @@ export class OpportunityGraphFactory {
       } catch (err) {
         logger.error("[Graph:Negotiate] Negotiation stage failed", { error: err });
         traceEmitter?.({ type: "graph_end", name: "negotiation", durationMs: Date.now() - graphStart });
-        return {};
+        return { evaluatedOpportunities: [] };
       }
     };
 

--- a/protocol/src/lib/protocol/interfaces/database.interface.ts
+++ b/protocol/src/lib/protocol/interfaces/database.interface.ts
@@ -1651,6 +1651,26 @@ export type OpportunityGraphDatabase = Pick<
 >;
 
 /**
+ * Database interface for the negotiation graph (A2A conversation/task/artifact persistence).
+ *
+ * Access layer: ConversationDatabaseAdapter
+ */
+export interface NegotiationDatabase {
+  createConversation(participants: { participantId: string; participantType: 'user' | 'agent' }[]): Promise<{ id: string }>;
+  createMessage(data: {
+    conversationId: string;
+    senderId: string;
+    role: 'user' | 'agent';
+    parts: unknown[];
+    taskId?: string;
+    metadata?: Record<string, unknown> | null;
+  }): Promise<{ id: string; senderId: string; role: string; parts: unknown[]; createdAt: Date }>;
+  createTask(conversationId: string, metadata?: Record<string, unknown>): Promise<{ id: string; conversationId: string; state: string }>;
+  updateTaskState(taskId: string, state: string, statusMessage?: unknown): Promise<unknown>;
+  createArtifact(data: { taskId: string; name?: string; parts: unknown[]; metadata?: Record<string, unknown> | null }): Promise<{ id: string }>;
+}
+
+/**
  * Database interface for opportunity controller (API).
  *
  * Access layer: Both UserDatabase + SystemDatabase (API handles auth)

--- a/protocol/src/lib/protocol/interfaces/database.interface.ts
+++ b/protocol/src/lib/protocol/interfaces/database.interface.ts
@@ -1656,7 +1656,18 @@ export type OpportunityGraphDatabase = Pick<
  * Access layer: ConversationDatabaseAdapter
  */
 export interface NegotiationDatabase {
+  /**
+   * Creates an A2A conversation between negotiation agents.
+   * @param participants - Agent participant descriptors
+   * @returns The created conversation with its id
+   */
   createConversation(participants: { participantId: string; participantType: 'user' | 'agent' }[]): Promise<{ id: string }>;
+
+  /**
+   * Persists a negotiation turn message within a conversation.
+   * @param data - Message payload including conversation, sender, role, and structured parts
+   * @returns The persisted message record
+   */
   createMessage(data: {
     conversationId: string;
     senderId: string;
@@ -1664,9 +1675,30 @@ export interface NegotiationDatabase {
     parts: unknown[];
     taskId?: string;
     metadata?: Record<string, unknown> | null;
-  }): Promise<{ id: string; senderId: string; role: string; parts: unknown[]; createdAt: Date }>;
+  }): Promise<{ id: string; senderId: string; role: 'user' | 'agent'; parts: unknown; createdAt: Date }>;
+
+  /**
+   * Creates a task to track the negotiation lifecycle within a conversation.
+   * @param conversationId - Parent conversation id
+   * @param metadata - Task metadata (type, sourceUserId, candidateUserId)
+   * @returns The created task with id, conversationId, and initial state
+   */
   createTask(conversationId: string, metadata?: Record<string, unknown>): Promise<{ id: string; conversationId: string; state: string }>;
-  updateTaskState(taskId: string, state: string, statusMessage?: unknown): Promise<unknown>;
+
+  /**
+   * Transitions a task to a new state (e.g. working, completed, failed).
+   * @param taskId - Task to update
+   * @param state - Target state
+   * @param statusMessage - Optional status message or structured status
+   * @returns The updated task record
+   */
+  updateTaskState(taskId: string, state: string, statusMessage?: unknown): Promise<{ id: string; conversationId: string; state: string }>;
+
+  /**
+   * Persists a negotiation outcome artifact attached to a task.
+   * @param data - Artifact payload including task reference, name, structured parts, and metadata
+   * @returns The created artifact with its id
+   */
   createArtifact(data: { taskId: string; name?: string; parts: unknown[]; metadata?: Record<string, unknown> | null }): Promise<{ id: string }>;
 }
 

--- a/protocol/src/lib/protocol/states/negotiation.state.ts
+++ b/protocol/src/lib/protocol/states/negotiation.state.ts
@@ -36,7 +36,6 @@ export interface UserNegotiationContext {
   id: string;
   intents: Array<{ id: string; title: string; description: string; confidence: number }>;
   profile: { name?: string; bio?: string; location?: string; interests?: string[]; skills?: string[] };
-  hydeDocuments: string[];
 }
 
 /** Seed assessment from the evaluator pre-filter. */
@@ -71,11 +70,11 @@ export interface NegotiationMessage {
 export const NegotiationGraphState = Annotation.Root({
   sourceUser: Annotation<UserNegotiationContext>({
     reducer: (curr, next) => next ?? curr,
-    default: () => ({ id: "", intents: [], profile: {}, hydeDocuments: [] }),
+    default: () => ({ id: "", intents: [], profile: {} }),
   }),
   candidateUser: Annotation<UserNegotiationContext>({
     reducer: (curr, next) => next ?? curr,
-    default: () => ({ id: "", intents: [], profile: {}, hydeDocuments: [] }),
+    default: () => ({ id: "", intents: [], profile: {} }),
   }),
   indexContext: Annotation<{ indexId: string; prompt: string }>({
     reducer: (curr, next) => next ?? curr,

--- a/protocol/src/lib/protocol/states/negotiation.state.ts
+++ b/protocol/src/lib/protocol/states/negotiation.state.ts
@@ -47,6 +47,17 @@ export interface SeedAssessment {
   actors?: Array<{ userId: string; role: string }>;
 }
 
+/** Typed interface for a negotiation graph's invoke signature. */
+export interface NegotiationGraphLike {
+  invoke(input: {
+    sourceUser: UserNegotiationContext;
+    candidateUser: UserNegotiationContext;
+    indexContext: { indexId: string; prompt: string };
+    seedAssessment: Omit<SeedAssessment, "actors">;
+    maxTurns?: number;
+  }): Promise<{ outcome: NegotiationOutcome | null; messages?: NegotiationMessage[] }>;
+}
+
 /** A2A message record shape (matches messages table). */
 export interface NegotiationMessage {
   id: string;
@@ -60,11 +71,11 @@ export interface NegotiationMessage {
 export const NegotiationGraphState = Annotation.Root({
   sourceUser: Annotation<UserNegotiationContext>({
     reducer: (curr, next) => next ?? curr,
-    default: () => ({} as UserNegotiationContext),
+    default: () => ({ id: "", intents: [], profile: {}, hydeDocuments: [] }),
   }),
   candidateUser: Annotation<UserNegotiationContext>({
     reducer: (curr, next) => next ?? curr,
-    default: () => ({} as UserNegotiationContext),
+    default: () => ({ id: "", intents: [], profile: {}, hydeDocuments: [] }),
   }),
   indexContext: Annotation<{ indexId: string; prompt: string }>({
     reducer: (curr, next) => next ?? curr,

--- a/protocol/src/lib/protocol/states/negotiation.state.ts
+++ b/protocol/src/lib/protocol/states/negotiation.state.ts
@@ -1,0 +1,116 @@
+import { Annotation } from "@langchain/langgraph";
+import { z } from "zod";
+
+/** Zod schema for a single negotiation turn (DataPart payload in A2A message). */
+export const NegotiationTurnSchema = z.object({
+  action: z.enum(["propose", "accept", "reject", "counter"]),
+  assessment: z.object({
+    fitScore: z.number().min(0).max(100),
+    reasoning: z.string(),
+    suggestedRoles: z.object({
+      ownUser: z.enum(["agent", "patient", "peer"]),
+      otherUser: z.enum(["agent", "patient", "peer"]),
+    }),
+  }),
+});
+
+export type NegotiationTurn = z.infer<typeof NegotiationTurnSchema>;
+
+/** Zod schema for the negotiation outcome (Artifact payload on COMPLETED task). */
+export const NegotiationOutcomeSchema = z.object({
+  consensus: z.boolean(),
+  finalScore: z.number().min(0).max(100),
+  agreedRoles: z.array(z.object({
+    userId: z.string(),
+    role: z.enum(["agent", "patient", "peer"]),
+  })),
+  reasoning: z.string(),
+  turnCount: z.number(),
+  reason: z.string().optional(),
+});
+
+export type NegotiationOutcome = z.infer<typeof NegotiationOutcomeSchema>;
+
+/** Context each agent receives about its user. */
+export interface UserNegotiationContext {
+  id: string;
+  intents: Array<{ id: string; title: string; description: string; confidence: number }>;
+  profile: { name?: string; bio?: string; location?: string; interests?: string[]; skills?: string[] };
+  hydeDocuments: string[];
+}
+
+/** Seed assessment from the evaluator pre-filter. */
+export interface SeedAssessment {
+  score: number;
+  reasoning: string;
+  valencyRole: string;
+  actors?: Array<{ userId: string; role: string }>;
+}
+
+/** A2A message record shape (matches messages table). */
+export interface NegotiationMessage {
+  id: string;
+  senderId: string;
+  role: "agent";
+  parts: unknown[];
+  createdAt: Date;
+}
+
+/** LangGraph state annotation for the negotiation graph. */
+export const NegotiationGraphState = Annotation.Root({
+  sourceUser: Annotation<UserNegotiationContext>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => ({} as UserNegotiationContext),
+  }),
+  candidateUser: Annotation<UserNegotiationContext>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => ({} as UserNegotiationContext),
+  }),
+  indexContext: Annotation<{ indexId: string; prompt: string }>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => ({ indexId: "", prompt: "" }),
+  }),
+  seedAssessment: Annotation<SeedAssessment>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => ({ score: 0, reasoning: "", valencyRole: "" }),
+  }),
+
+  conversationId: Annotation<string>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => "",
+  }),
+  taskId: Annotation<string>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => "",
+  }),
+  messages: Annotation<NegotiationMessage[]>({
+    reducer: (curr, next) => [...curr, ...(next || [])],
+    default: () => [],
+  }),
+  turnCount: Annotation<number>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => 0,
+  }),
+  maxTurns: Annotation<number>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => 6,
+  }),
+
+  currentSpeaker: Annotation<"source" | "candidate">({
+    reducer: (curr, next) => next ?? curr,
+    default: () => "source" as const,
+  }),
+  lastTurn: Annotation<NegotiationTurn | null>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => null,
+  }),
+
+  outcome: Annotation<NegotiationOutcome | null>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => null,
+  }),
+  error: Annotation<string | null>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => null,
+  }),
+});

--- a/protocol/src/lib/protocol/tools/index.ts
+++ b/protocol/src/lib/protocol/tools/index.ts
@@ -11,10 +11,14 @@ import { LensInferrer } from "../agents/lens.inferrer";
 import { IndexGraphFactory } from "../graphs/index.graph";
 import { IndexMembershipGraphFactory } from "../graphs/index_membership.graph";
 import { IntentIndexGraphFactory } from "../graphs/intent_index.graph";
+import { NegotiationGraphFactory } from "../graphs/negotiation.graph";
+import { NegotiationProposer } from "../agents/negotiation.proposer";
+import { NegotiationResponder } from "../agents/negotiation.responder";
 import { RedisCacheAdapter } from "../../../adapters/cache.adapter";
 import { ComposioIntegrationAdapter } from "../../../adapters/integration.adapter";
 import {
   chatDatabaseAdapter,
+  conversationDatabaseAdapter,
   createUserDatabase,
   createSystemDatabase,
 } from "../../../adapters/database.adapter";
@@ -111,10 +115,18 @@ export async function createChatTools(
     lensInferrer,
     hydeGenerator
   ).createGraph();
+  const negotiationGraph = new NegotiationGraphFactory(
+    conversationDatabaseAdapter,
+    new NegotiationProposer(),
+    new NegotiationResponder(),
+  ).createGraph();
   const opportunityGraph = new OpportunityGraphFactory(
     database,
     embedder,
-    compiledHydeGraph
+    compiledHydeGraph,
+    undefined, // evaluator (default)
+    undefined, // queueNotification
+    negotiationGraph,
   ).createGraph();
   const indexGraph = new IndexGraphFactory(database).createGraph();
   const indexMembershipGraph = new IndexMembershipGraphFactory(database).createGraph();

--- a/protocol/src/services/task.service.ts
+++ b/protocol/src/services/task.service.ts
@@ -80,4 +80,26 @@ export class TaskService {
     }
     return this.db.getArtifacts(taskId);
   }
+
+  /**
+   * Retrieves negotiation tasks for a user, with outcome artifacts.
+   * @param userId - User to find negotiations for
+   * @param opts - Optional limit, offset, and mutual-only filter
+   * @returns Tasks with joined outcome artifacts
+   */
+  async getNegotiationsByUser(
+    userId: string,
+    opts?: { limit?: number; offset?: number; mutualWithUserId?: string; result?: 'consensus' | 'no_consensus' | 'in_progress' },
+  ) {
+    return this.db.getNegotiationsByUser(userId, opts);
+  }
+
+  /**
+   * Retrieves messages for multiple tasks in a single query.
+   * @param taskIds - Task IDs to fetch messages for
+   * @returns Map of taskId to ordered messages
+   */
+  async getMessagesByTaskIds(taskIds: string[]) {
+    return this.db.getMessagesByTaskIds(taskIds);
+  }
 }

--- a/protocol/tests/negotiation.agents.spec.ts
+++ b/protocol/tests/negotiation.agents.spec.ts
@@ -1,0 +1,75 @@
+import { config } from "dotenv";
+config({ path: ".env.development" });
+
+import { describe, it, expect } from "bun:test";
+import { NegotiationProposer } from "../src/lib/protocol/agents/negotiation.proposer";
+import { NegotiationResponder } from "../src/lib/protocol/agents/negotiation.responder";
+import type { UserNegotiationContext, SeedAssessment, NegotiationTurn } from "../src/lib/protocol/states/negotiation.state";
+
+const sourceUser: UserNegotiationContext = {
+  id: "user-source",
+  intents: [{ id: "i1", title: "Looking for ML engineer", description: "Need ML expertise for recommendation system", confidence: 0.9 }],
+  profile: { name: "Alice", bio: "Product manager at a startup", skills: ["product management", "AI strategy"] },
+  hydeDocuments: ["A product leader seeking technical ML collaboration"],
+};
+
+const candidateUser: UserNegotiationContext = {
+  id: "user-candidate",
+  intents: [{ id: "i2", title: "Seeking PM collaboration", description: "ML engineer looking for product-minded co-founder", confidence: 0.85 }],
+  profile: { name: "Bob", bio: "Senior ML engineer", skills: ["machine learning", "PyTorch", "recommendations"] },
+  hydeDocuments: ["An ML engineer seeking product leadership for a startup venture"],
+};
+
+const seedAssessment: SeedAssessment = {
+  score: 78,
+  reasoning: "Strong complementary skills between product management and ML engineering",
+  valencyRole: "Peer",
+};
+
+describe("NegotiationProposer", () => {
+  it("generates a valid proposal turn", async () => {
+    const proposer = new NegotiationProposer();
+    const result = await proposer.invoke({
+      ownUser: sourceUser,
+      otherUser: candidateUser,
+      indexContext: { indexId: "idx-1", prompt: "AI startup co-founders" },
+      seedAssessment,
+      history: [],
+    });
+
+    expect(result.action).toBe("propose");
+    expect(result.assessment.fitScore).toBeGreaterThanOrEqual(0);
+    expect(result.assessment.fitScore).toBeLessThanOrEqual(100);
+    expect(result.assessment.reasoning).toBeTruthy();
+    expect(["agent", "patient", "peer"]).toContain(result.assessment.suggestedRoles.ownUser);
+    expect(["agent", "patient", "peer"]).toContain(result.assessment.suggestedRoles.otherUser);
+  }, 30_000);
+});
+
+describe("NegotiationResponder", () => {
+  it("evaluates a proposal and responds with accept, reject, or counter", async () => {
+    const responder = new NegotiationResponder();
+
+    const proposal: NegotiationTurn = {
+      action: "propose",
+      assessment: {
+        fitScore: 78,
+        reasoning: "Strong complementary skills — Alice needs ML, Bob needs product leadership",
+        suggestedRoles: { ownUser: "peer", otherUser: "peer" },
+      },
+    };
+
+    const result = await responder.invoke({
+      ownUser: candidateUser,
+      otherUser: sourceUser,
+      indexContext: { indexId: "idx-1", prompt: "AI startup co-founders" },
+      seedAssessment,
+      history: [proposal],
+    });
+
+    expect(["accept", "reject", "counter"]).toContain(result.action);
+    expect(result.assessment.fitScore).toBeGreaterThanOrEqual(0);
+    expect(result.assessment.fitScore).toBeLessThanOrEqual(100);
+    expect(result.assessment.reasoning).toBeTruthy();
+  }, 30_000);
+});

--- a/protocol/tests/negotiation.agents.spec.ts
+++ b/protocol/tests/negotiation.agents.spec.ts
@@ -10,14 +10,12 @@ const sourceUser: UserNegotiationContext = {
   id: "user-source",
   intents: [{ id: "i1", title: "Looking for ML engineer", description: "Need ML expertise for recommendation system", confidence: 0.9 }],
   profile: { name: "Alice", bio: "Product manager at a startup", skills: ["product management", "AI strategy"] },
-  hydeDocuments: ["A product leader seeking technical ML collaboration"],
 };
 
 const candidateUser: UserNegotiationContext = {
   id: "user-candidate",
   intents: [{ id: "i2", title: "Seeking PM collaboration", description: "ML engineer looking for product-minded co-founder", confidence: 0.85 }],
   profile: { name: "Bob", bio: "Senior ML engineer", skills: ["machine learning", "PyTorch", "recommendations"] },
-  hydeDocuments: ["An ML engineer seeking product leadership for a startup venture"],
 };
 
 const seedAssessment: SeedAssessment = {

--- a/protocol/tests/negotiation.e2e.spec.ts
+++ b/protocol/tests/negotiation.e2e.spec.ts
@@ -31,13 +31,11 @@ describe("Negotiation E2E", () => {
         id: "e2e-source",
         intents: [{ id: "i1", title: "Looking for ML engineer", description: "Need ML expertise for recommendation system", confidence: 0.9 }],
         profile: { name: "Alice", bio: "Product manager building AI startup", skills: ["product management", "AI strategy"] },
-        hydeDocuments: [],
       },
       candidateUser: {
         id: "e2e-candidate",
         intents: [{ id: "i2", title: "Seeking PM co-founder", description: "ML engineer looking for product-minded co-founder", confidence: 0.85 }],
         profile: { name: "Bob", bio: "Senior ML engineer with 8 years experience", skills: ["machine learning", "PyTorch"] },
-        hydeDocuments: [],
       },
       indexContext: { indexId: "e2e-index", prompt: "AI startup co-founders" },
       seedAssessment: { score: 78, reasoning: "Complementary skills", valencyRole: "Peer" },

--- a/protocol/tests/negotiation.e2e.spec.ts
+++ b/protocol/tests/negotiation.e2e.spec.ts
@@ -1,0 +1,59 @@
+import { config } from "dotenv";
+config({ path: ".env.development" });
+
+import { describe, it, expect } from "bun:test";
+import { NegotiationGraphFactory } from "../src/lib/protocol/graphs/negotiation.graph";
+import { NegotiationProposer } from "../src/lib/protocol/agents/negotiation.proposer";
+import { NegotiationResponder } from "../src/lib/protocol/agents/negotiation.responder";
+import { ConversationService } from "../src/services/conversation.service";
+import { TaskService } from "../src/services/task.service";
+
+// Prerequisites: requires DATABASE_URL and OPENROUTER_API_KEY in .env.development
+// Run with: cd protocol && bun test tests/negotiation.e2e.spec.ts
+
+describe("Negotiation E2E", () => {
+  it("runs a full negotiation with real agents and A2A persistence", async () => {
+    const conversationService = new ConversationService();
+    const taskService = new TaskService();
+    const proposer = new NegotiationProposer();
+    const responder = new NegotiationResponder();
+
+    const factory = new NegotiationGraphFactory(
+      conversationService,
+      taskService,
+      proposer,
+      responder,
+    );
+    const graph = factory.createGraph();
+
+    const result = await graph.invoke({
+      sourceUser: {
+        id: "e2e-source",
+        intents: [{ id: "i1", title: "Looking for ML engineer", description: "Need ML expertise for recommendation system", confidence: 0.9 }],
+        profile: { name: "Alice", bio: "Product manager building AI startup", skills: ["product management", "AI strategy"] },
+        hydeDocuments: [],
+      },
+      candidateUser: {
+        id: "e2e-candidate",
+        intents: [{ id: "i2", title: "Seeking PM co-founder", description: "ML engineer looking for product-minded co-founder", confidence: 0.85 }],
+        profile: { name: "Bob", bio: "Senior ML engineer with 8 years experience", skills: ["machine learning", "PyTorch"] },
+        hydeDocuments: [],
+      },
+      indexContext: { indexId: "e2e-index", prompt: "AI startup co-founders" },
+      seedAssessment: { score: 78, reasoning: "Complementary skills", valencyRole: "Peer" },
+      maxTurns: 4,
+    });
+
+    // Verify outcome exists
+    expect(result.outcome).not.toBeNull();
+    expect(typeof result.outcome!.consensus).toBe("boolean");
+    expect(result.outcome!.turnCount).toBeGreaterThanOrEqual(2);
+    expect(result.outcome!.turnCount).toBeLessThanOrEqual(4);
+    expect(result.outcome!.reasoning).toBeTruthy();
+
+    // Verify A2A records were created
+    expect(result.conversationId).toBeTruthy();
+    expect(result.taskId).toBeTruthy();
+    expect(result.messages.length).toBeGreaterThanOrEqual(2);
+  }, 120_000);
+});

--- a/protocol/tests/negotiation.graph.spec.ts
+++ b/protocol/tests/negotiation.graph.spec.ts
@@ -25,7 +25,7 @@ function createMockDeps(proposerAction = "propose" as const, responderAction = "
     createConversation: mock(() => Promise.resolve({ id: "conv-1" })),
     createMessage: mock(() => Promise.resolve({ id: "msg-1", senderId: "agent", role: "agent", parts: [], createdAt: new Date() })),
     createTask: mock(() => Promise.resolve({ id: "task-1", conversationId: "conv-1", state: "submitted" })),
-    updateTaskState: mock(() => Promise.resolve({})),
+    updateTaskState: mock(() => Promise.resolve({ id: "task-1", conversationId: "conv-1", state: "working" })),
     createArtifact: mock(() => Promise.resolve({ id: "art-1" })),
   };
   const proposer: ConstructorParameters<typeof NegotiationGraphFactory>[1] = {

--- a/protocol/tests/negotiation.graph.spec.ts
+++ b/protocol/tests/negotiation.graph.spec.ts
@@ -9,14 +9,12 @@ const sourceUser: UserNegotiationContext = {
   id: "user-source",
   intents: [{ id: "i1", title: "Looking for ML engineer", description: "Need ML expertise", confidence: 0.9 }],
   profile: { name: "Alice", bio: "PM at startup", skills: ["product"] },
-  hydeDocuments: [],
 };
 
 const candidateUser: UserNegotiationContext = {
   id: "user-candidate",
   intents: [{ id: "i2", title: "Seeking PM", description: "ML eng seeking product co-founder", confidence: 0.85 }],
   profile: { name: "Bob", bio: "ML engineer", skills: ["ML"] },
-  hydeDocuments: [],
 };
 
 const seed: SeedAssessment = { score: 78, reasoning: "Complementary skills", valencyRole: "Peer" };

--- a/protocol/tests/negotiation.graph.spec.ts
+++ b/protocol/tests/negotiation.graph.spec.ts
@@ -3,7 +3,8 @@ config({ path: ".env.development" });
 
 import { describe, it, expect, mock } from "bun:test";
 import { NegotiationGraphFactory } from "../src/lib/protocol/graphs/negotiation.graph";
-import type { UserNegotiationContext, SeedAssessment, NegotiationMessage } from "../src/lib/protocol/states/negotiation.state";
+import type { NegotiationDatabase } from "../src/lib/protocol/interfaces/database.interface";
+import type { UserNegotiationContext, SeedAssessment } from "../src/lib/protocol/states/negotiation.state";
 
 const sourceUser: UserNegotiationContext = {
   id: "user-source",
@@ -20,36 +21,33 @@ const candidateUser: UserNegotiationContext = {
 const seed: SeedAssessment = { score: 78, reasoning: "Complementary skills", valencyRole: "Peer" };
 
 function createMockDeps(proposerAction = "propose" as const, responderAction = "accept" as const) {
-  const conversationService: ConstructorParameters<typeof NegotiationGraphFactory>[0] = {
+  const database: NegotiationDatabase = {
     createConversation: mock(() => Promise.resolve({ id: "conv-1" })),
-    sendMessage: mock(() => Promise.resolve({ id: "msg-1", senderId: "agent", role: "agent", parts: [], createdAt: new Date() })),
-  };
-  const taskService: ConstructorParameters<typeof NegotiationGraphFactory>[1] = {
+    createMessage: mock(() => Promise.resolve({ id: "msg-1", senderId: "agent", role: "agent", parts: [], createdAt: new Date() })),
     createTask: mock(() => Promise.resolve({ id: "task-1", conversationId: "conv-1", state: "submitted" })),
-    updateState: mock(() => Promise.resolve({})),
+    updateTaskState: mock(() => Promise.resolve({})),
     createArtifact: mock(() => Promise.resolve({ id: "art-1" })),
   };
-  const proposer: ConstructorParameters<typeof NegotiationGraphFactory>[2] = {
+  const proposer: ConstructorParameters<typeof NegotiationGraphFactory>[1] = {
     invoke: mock(() => Promise.resolve({
       action: proposerAction,
       assessment: { fitScore: 80, reasoning: "Good match", suggestedRoles: { ownUser: "peer" as const, otherUser: "peer" as const } },
     })),
   };
-  const responder: ConstructorParameters<typeof NegotiationGraphFactory>[3] = {
+  const responder: ConstructorParameters<typeof NegotiationGraphFactory>[2] = {
     invoke: mock(() => Promise.resolve({
       action: responderAction,
       assessment: { fitScore: 75, reasoning: "Agreed, good fit", suggestedRoles: { ownUser: "peer" as const, otherUser: "peer" as const } },
     })),
   };
-  return { conversationService, taskService, proposer, responder };
+  return { database, proposer, responder };
 }
 
 describe("NegotiationGraph", () => {
   it("reaches consensus when responder accepts", async () => {
     const deps = createMockDeps("propose", "accept");
     const factory = new NegotiationGraphFactory(
-      deps.conversationService,
-      deps.taskService,
+      deps.database,
       deps.proposer,
       deps.responder,
     );
@@ -64,14 +62,13 @@ describe("NegotiationGraph", () => {
     expect(result.outcome).not.toBeNull();
     expect(result.outcome!.consensus).toBe(true);
     expect(result.outcome!.turnCount).toBe(2);
-    expect(deps.taskService.createArtifact).toHaveBeenCalled();
+    expect(deps.database.createArtifact).toHaveBeenCalled();
   }, 30_000);
 
   it("rejects when responder rejects", async () => {
     const deps = createMockDeps("propose", "reject");
     const factory = new NegotiationGraphFactory(
-      deps.conversationService,
-      deps.taskService,
+      deps.database,
       deps.proposer,
       deps.responder,
     );
@@ -90,8 +87,7 @@ describe("NegotiationGraph", () => {
   it("rejects when turn cap is exceeded", async () => {
     const deps = createMockDeps("counter", "counter");
     const factory = new NegotiationGraphFactory(
-      deps.conversationService,
-      deps.taskService,
+      deps.database,
       deps.proposer,
       deps.responder,
     );

--- a/protocol/tests/negotiation.graph.spec.ts
+++ b/protocol/tests/negotiation.graph.spec.ts
@@ -3,7 +3,7 @@ config({ path: ".env.development" });
 
 import { describe, it, expect, mock } from "bun:test";
 import { NegotiationGraphFactory } from "../src/lib/protocol/graphs/negotiation.graph";
-import type { UserNegotiationContext, SeedAssessment } from "../src/lib/protocol/states/negotiation.state";
+import type { UserNegotiationContext, SeedAssessment, NegotiationMessage } from "../src/lib/protocol/states/negotiation.state";
 
 const sourceUser: UserNegotiationContext = {
   id: "user-source",
@@ -21,44 +21,39 @@ const candidateUser: UserNegotiationContext = {
 
 const seed: SeedAssessment = { score: 78, reasoning: "Complementary skills", valencyRole: "Peer" };
 
-function createMockDeps(proposerAction = "propose", responderAction = "accept") {
-  return {
-    conversationService: {
-      createConversation: mock(() => Promise.resolve({ id: "conv-1" })),
-      sendMessage: mock(() => Promise.resolve({ id: "msg-1", senderId: "agent", role: "agent", parts: [], createdAt: new Date() })),
-    },
-    taskService: {
-      createTask: mock(() => Promise.resolve({ id: "task-1", conversationId: "conv-1", state: "submitted" })),
-      updateState: mock(() => Promise.resolve({})),
-      createArtifact: mock(() => Promise.resolve({ id: "art-1" })),
-    },
-    proposer: {
-      invoke: mock(() => {
-        return Promise.resolve({
-          action: proposerAction,
-          assessment: { fitScore: 80, reasoning: "Good match", suggestedRoles: { ownUser: "peer", otherUser: "peer" } },
-        });
-      }),
-    },
-    responder: {
-      invoke: mock(() => {
-        return Promise.resolve({
-          action: responderAction,
-          assessment: { fitScore: 75, reasoning: "Agreed, good fit", suggestedRoles: { ownUser: "peer", otherUser: "peer" } },
-        });
-      }),
-    },
+function createMockDeps(proposerAction = "propose" as const, responderAction = "accept" as const) {
+  const conversationService: ConstructorParameters<typeof NegotiationGraphFactory>[0] = {
+    createConversation: mock(() => Promise.resolve({ id: "conv-1" })),
+    sendMessage: mock(() => Promise.resolve({ id: "msg-1", senderId: "agent", role: "agent", parts: [], createdAt: new Date() })),
   };
+  const taskService: ConstructorParameters<typeof NegotiationGraphFactory>[1] = {
+    createTask: mock(() => Promise.resolve({ id: "task-1", conversationId: "conv-1", state: "submitted" })),
+    updateState: mock(() => Promise.resolve({})),
+    createArtifact: mock(() => Promise.resolve({ id: "art-1" })),
+  };
+  const proposer: ConstructorParameters<typeof NegotiationGraphFactory>[2] = {
+    invoke: mock(() => Promise.resolve({
+      action: proposerAction,
+      assessment: { fitScore: 80, reasoning: "Good match", suggestedRoles: { ownUser: "peer" as const, otherUser: "peer" as const } },
+    })),
+  };
+  const responder: ConstructorParameters<typeof NegotiationGraphFactory>[3] = {
+    invoke: mock(() => Promise.resolve({
+      action: responderAction,
+      assessment: { fitScore: 75, reasoning: "Agreed, good fit", suggestedRoles: { ownUser: "peer" as const, otherUser: "peer" as const } },
+    })),
+  };
+  return { conversationService, taskService, proposer, responder };
 }
 
 describe("NegotiationGraph", () => {
   it("reaches consensus when responder accepts", async () => {
     const deps = createMockDeps("propose", "accept");
     const factory = new NegotiationGraphFactory(
-      deps.conversationService as any,
-      deps.taskService as any,
-      deps.proposer as any,
-      deps.responder as any,
+      deps.conversationService,
+      deps.taskService,
+      deps.proposer,
+      deps.responder,
     );
     const graph = factory.createGraph();
     const result = await graph.invoke({
@@ -77,10 +72,10 @@ describe("NegotiationGraph", () => {
   it("rejects when responder rejects", async () => {
     const deps = createMockDeps("propose", "reject");
     const factory = new NegotiationGraphFactory(
-      deps.conversationService as any,
-      deps.taskService as any,
-      deps.proposer as any,
-      deps.responder as any,
+      deps.conversationService,
+      deps.taskService,
+      deps.proposer,
+      deps.responder,
     );
     const graph = factory.createGraph();
     const result = await graph.invoke({
@@ -97,10 +92,10 @@ describe("NegotiationGraph", () => {
   it("rejects when turn cap is exceeded", async () => {
     const deps = createMockDeps("counter", "counter");
     const factory = new NegotiationGraphFactory(
-      deps.conversationService as any,
-      deps.taskService as any,
-      deps.proposer as any,
-      deps.responder as any,
+      deps.conversationService,
+      deps.taskService,
+      deps.proposer,
+      deps.responder,
     );
     const graph = factory.createGraph();
     const result = await graph.invoke({

--- a/protocol/tests/negotiation.graph.spec.ts
+++ b/protocol/tests/negotiation.graph.spec.ts
@@ -1,0 +1,119 @@
+import { config } from "dotenv";
+config({ path: ".env.development" });
+
+import { describe, it, expect, mock } from "bun:test";
+import { NegotiationGraphFactory } from "../src/lib/protocol/graphs/negotiation.graph";
+import type { UserNegotiationContext, SeedAssessment } from "../src/lib/protocol/states/negotiation.state";
+
+const sourceUser: UserNegotiationContext = {
+  id: "user-source",
+  intents: [{ id: "i1", title: "Looking for ML engineer", description: "Need ML expertise", confidence: 0.9 }],
+  profile: { name: "Alice", bio: "PM at startup", skills: ["product"] },
+  hydeDocuments: [],
+};
+
+const candidateUser: UserNegotiationContext = {
+  id: "user-candidate",
+  intents: [{ id: "i2", title: "Seeking PM", description: "ML eng seeking product co-founder", confidence: 0.85 }],
+  profile: { name: "Bob", bio: "ML engineer", skills: ["ML"] },
+  hydeDocuments: [],
+};
+
+const seed: SeedAssessment = { score: 78, reasoning: "Complementary skills", valencyRole: "Peer" };
+
+function createMockDeps(proposerAction = "propose", responderAction = "accept") {
+  return {
+    conversationService: {
+      createConversation: mock(() => Promise.resolve({ id: "conv-1" })),
+      sendMessage: mock(() => Promise.resolve({ id: "msg-1", senderId: "agent", role: "agent", parts: [], createdAt: new Date() })),
+    },
+    taskService: {
+      createTask: mock(() => Promise.resolve({ id: "task-1", conversationId: "conv-1", state: "submitted" })),
+      updateState: mock(() => Promise.resolve({})),
+      createArtifact: mock(() => Promise.resolve({ id: "art-1" })),
+    },
+    proposer: {
+      invoke: mock(() => {
+        return Promise.resolve({
+          action: proposerAction,
+          assessment: { fitScore: 80, reasoning: "Good match", suggestedRoles: { ownUser: "peer", otherUser: "peer" } },
+        });
+      }),
+    },
+    responder: {
+      invoke: mock(() => {
+        return Promise.resolve({
+          action: responderAction,
+          assessment: { fitScore: 75, reasoning: "Agreed, good fit", suggestedRoles: { ownUser: "peer", otherUser: "peer" } },
+        });
+      }),
+    },
+  };
+}
+
+describe("NegotiationGraph", () => {
+  it("reaches consensus when responder accepts", async () => {
+    const deps = createMockDeps("propose", "accept");
+    const factory = new NegotiationGraphFactory(
+      deps.conversationService as any,
+      deps.taskService as any,
+      deps.proposer as any,
+      deps.responder as any,
+    );
+    const graph = factory.createGraph();
+    const result = await graph.invoke({
+      sourceUser,
+      candidateUser,
+      indexContext: { indexId: "idx-1", prompt: "AI co-founders" },
+      seedAssessment: seed,
+    });
+
+    expect(result.outcome).not.toBeNull();
+    expect(result.outcome!.consensus).toBe(true);
+    expect(result.outcome!.turnCount).toBe(2);
+    expect(deps.taskService.createArtifact).toHaveBeenCalled();
+  }, 30_000);
+
+  it("rejects when responder rejects", async () => {
+    const deps = createMockDeps("propose", "reject");
+    const factory = new NegotiationGraphFactory(
+      deps.conversationService as any,
+      deps.taskService as any,
+      deps.proposer as any,
+      deps.responder as any,
+    );
+    const graph = factory.createGraph();
+    const result = await graph.invoke({
+      sourceUser,
+      candidateUser,
+      indexContext: { indexId: "idx-1", prompt: "AI co-founders" },
+      seedAssessment: seed,
+    });
+
+    expect(result.outcome).not.toBeNull();
+    expect(result.outcome!.consensus).toBe(false);
+  }, 30_000);
+
+  it("rejects when turn cap is exceeded", async () => {
+    const deps = createMockDeps("counter", "counter");
+    const factory = new NegotiationGraphFactory(
+      deps.conversationService as any,
+      deps.taskService as any,
+      deps.proposer as any,
+      deps.responder as any,
+    );
+    const graph = factory.createGraph();
+    const result = await graph.invoke({
+      sourceUser,
+      candidateUser,
+      indexContext: { indexId: "idx-1", prompt: "AI co-founders" },
+      seedAssessment: seed,
+      maxTurns: 4,
+    });
+
+    expect(result.outcome).not.toBeNull();
+    expect(result.outcome!.consensus).toBe(false);
+    expect(result.outcome!.reason).toBe("turn_cap");
+    expect(result.turnCount).toBeLessThanOrEqual(4);
+  }, 30_000);
+});

--- a/protocol/tests/opportunity.negotiation.spec.ts
+++ b/protocol/tests/opportunity.negotiation.spec.ts
@@ -2,18 +2,19 @@ import { config } from "dotenv";
 config({ path: ".env.development" });
 
 import { describe, it, expect, mock } from "bun:test";
+import type { NegotiationGraphLike } from "../src/lib/protocol/states/negotiation.state";
 
 describe("Opportunity Graph — Negotiation Integration", () => {
   it("negotiateNode filters candidates by negotiation consensus", async () => {
-    const mockNegotiationGraph = {
-      invoke: mock((input: any) => {
+    const mockNegotiationGraph: NegotiationGraphLike = {
+      invoke: mock((input) => {
         const isFirstCandidate = input.candidateUser.id === "candidate-1";
         return Promise.resolve({
           outcome: {
             consensus: isFirstCandidate,
             finalScore: isFirstCandidate ? 82 : 0,
             agreedRoles: isFirstCandidate
-              ? [{ userId: "source", role: "peer" }, { userId: "candidate-1", role: "peer" }]
+              ? [{ userId: "source", role: "peer" as const }, { userId: "candidate-1", role: "peer" as const }]
               : [],
             reasoning: isFirstCandidate ? "Good match" : "No fit",
             turnCount: 2,
@@ -37,7 +38,7 @@ describe("Opportunity Graph — Negotiation Integration", () => {
     };
 
     const results = await negotiateCandidates(
-      mockNegotiationGraph as any,
+      mockNegotiationGraph,
       sourceUser,
       candidates.map((c) => ({
         ...c,

--- a/protocol/tests/opportunity.negotiation.spec.ts
+++ b/protocol/tests/opportunity.negotiation.spec.ts
@@ -1,0 +1,58 @@
+import { config } from "dotenv";
+config({ path: ".env.development" });
+
+import { describe, it, expect, mock } from "bun:test";
+
+describe("Opportunity Graph — Negotiation Integration", () => {
+  it("negotiateNode filters candidates by negotiation consensus", async () => {
+    const mockNegotiationGraph = {
+      invoke: mock((input: any) => {
+        const isFirstCandidate = input.candidateUser.id === "candidate-1";
+        return Promise.resolve({
+          outcome: {
+            consensus: isFirstCandidate,
+            finalScore: isFirstCandidate ? 82 : 0,
+            agreedRoles: isFirstCandidate
+              ? [{ userId: "source", role: "peer" }, { userId: "candidate-1", role: "peer" }]
+              : [],
+            reasoning: isFirstCandidate ? "Good match" : "No fit",
+            turnCount: 2,
+          },
+        });
+      }),
+    };
+
+    const { negotiateCandidates } = await import("../src/lib/protocol/graphs/negotiation.graph");
+
+    const candidates = [
+      { userId: "candidate-1", score: 78, reasoning: "OK", valencyRole: "Peer" },
+      { userId: "candidate-2", score: 72, reasoning: "Weak", valencyRole: "Agent" },
+    ];
+
+    const sourceUser = {
+      id: "source",
+      intents: [{ id: "i1", title: "Test", description: "Test intent", confidence: 0.9 }],
+      profile: { name: "Alice" },
+      hydeDocuments: [],
+    };
+
+    const results = await negotiateCandidates(
+      mockNegotiationGraph as any,
+      sourceUser,
+      candidates.map((c) => ({
+        ...c,
+        candidateUser: {
+          id: c.userId,
+          intents: [{ id: "i2", title: "Test", description: "Counter intent", confidence: 0.8 }],
+          profile: { name: c.userId },
+          hydeDocuments: [],
+        },
+      })),
+      { indexId: "idx-1", prompt: "Test" },
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0].userId).toBe("candidate-1");
+    expect(results[0].negotiationScore).toBe(82);
+  }, 30_000);
+});

--- a/protocol/tests/opportunity.negotiation.spec.ts
+++ b/protocol/tests/opportunity.negotiation.spec.ts
@@ -34,7 +34,6 @@ describe("Opportunity Graph — Negotiation Integration", () => {
       id: "source",
       intents: [{ id: "i1", title: "Test", description: "Test intent", confidence: 0.9 }],
       profile: { name: "Alice" },
-      hydeDocuments: [],
     };
 
     const results = await negotiateCandidates(
@@ -46,8 +45,7 @@ describe("Opportunity Graph — Negotiation Integration", () => {
           id: c.userId,
           intents: [{ id: "i2", title: "Test", description: "Counter intent", confidence: 0.8 }],
           profile: { name: c.userId },
-          hydeDocuments: [],
-        },
+            },
       })),
       { indexId: "idx-1", prompt: "Test" },
     );


### PR DESCRIPTION
## Summary

- Add bilateral agent negotiation as a consensus gate between opportunity evaluation and ranking
- Two agents (proposer/responder) negotiate in structured turns using A2A conversation primitives (conversations, messages, tasks, artifacts)
- New standalone `negotiation.graph.ts` LangGraph state machine: init → turn → evaluate → finalize
- Variable turn cap (6 for background, 4 for chat path), default reject on no consensus
- Wired into opportunity graph as optional `negotiateNode` between evaluation and ranking
- Federation-ready: A2A data model is protocol-compliant, execution is synchronous for now

## New Features

- **Negotiation Graph** (`negotiation.graph.ts`): State machine with 4 nodes, conditional routing, A2A persistence
- **Proposer Agent** (`negotiation.proposer.ts`): Argues for the match with structured output
- **Responder Agent** (`negotiation.responder.ts`): Evaluates skeptically against its user's interests
- **`negotiateCandidates` helper**: Parallel negotiation across multiple candidates
- **State & schemas** (`negotiation.state.ts`): Annotation.Root state, Zod schemas for NegotiationTurn and NegotiationOutcome

## Integration

- `opportunity.graph.ts`: New `negotiateNode` between evaluation → ranking, skipped for `continue_discovery` mode and when no negotiation graph is provided
- `model.config.ts`: `negotiationProposer` and `negotiationResponder` entries

## Tests

- 3 unit tests: graph routing (consensus, rejection, turn cap)
- 1 integration test: `negotiateCandidates` parallel filtering
- 2 agent tests: proposer/responder with real LLM calls
- 1 E2E test: full negotiation with real agents + A2A DB persistence

## Test plan

- [x] Unit tests pass (6/6)
- [x] E2E smoke test passes with real LLM + DB
- [x] Existing negotiation graph tests unaffected
- [ ] Manual: trigger opportunity discovery and verify negotiation runs inline
- [ ] Manual: verify `continue_discovery` mode bypasses negotiation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds bilateral agent-to-agent multi-turn negotiation as an optional consensus stage that can adjust candidate scores and agreed roles; surfaces past negotiations in the UI with a new "Negotiations" library tab and profile section.

* **Documentation**
  * Adds a detailed implementation and rollout plan for the negotiation workflow.

* **Backend**
  * Adds negotiation engine, graph workflow, persistence interfaces, DB adapters, and service integrations for storing and aggregating outcomes.

* **API**
  * New paginated endpoint to fetch a user’s negotiations with result filtering.

* **Tests**
  * Adds unit, integration, and end-to-end tests for agents, graph behavior, utilities, and API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->