### PR TITLE
feat: intent sharing via unique URLs

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "frontend",

--- a/frontend/src/app/i/[token]/page.tsx
+++ b/frontend/src/app/i/[token]/page.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router";
-import { Loader2, MessageCircle, Share2, Check, ArrowRight } from "lucide-react";
+import { Loader2, UserCheck, Users, Check, Copy, ArrowRight } from "lucide-react";
 
 import { useAuthContext } from "@/contexts/AuthContext";
 import UserAvatar from "@/components/UserAvatar";
@@ -19,6 +19,7 @@ export default function SharedIntentPage() {
   const [data, setData] = useState<SharedIntentData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [showShareLink, setShowShareLink] = useState(false);
   const [copied, setCopied] = useState(false);
   const [connectStep, setConnectStep] = useState<ConnectStep>("idle");
   const connectInitiated = useRef(false);
@@ -60,7 +61,19 @@ export default function SharedIntentPage() {
     navigate("/onboarding");
   };
 
-  const handleCopyLink = async () => {
+  const handleIKnowSomeone = async () => {
+    if (!data) return;
+
+    if (isAuthenticated) {
+      const prefill = `Who in my network can help ${data.owner.name} with "${data.intent.summary?.trim() || data.intent.payload}"?`;
+      navigate("/", { state: { prefill } });
+      return;
+    }
+
+    setShowShareLink(true);
+  };
+
+  const handleCopyShareLink = async () => {
     await navigator.clipboard.writeText(window.location.href);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
@@ -149,27 +162,53 @@ export default function SharedIntentPage() {
 
           {/* Actions */}
           {connectStep !== "needs-onboarding" && (
-            <div className="flex items-center gap-2">
-              <button
-                onClick={handleConnect}
-                disabled={connectStep === "awaiting-auth"}
-                className="flex-1 flex items-center justify-center gap-2 bg-[#041729] text-white px-6 py-3 rounded-sm text-sm font-medium hover:bg-[#0a2d4a] transition-colors disabled:opacity-60"
-              >
-                {connectStep === "awaiting-auth" ? (
-                  <Loader2 className="w-4 h-4 animate-spin" />
-                ) : (
-                  <MessageCircle className="w-4 h-4" />
-                )}
-                {connectStep === "awaiting-auth" ? "Waiting..." : "Connect"}
-              </button>
-              <button
-                onClick={handleCopyLink}
-                className="flex items-center gap-2 px-4 py-3 border border-gray-200 rounded-sm text-sm text-gray-600 hover:border-gray-400 hover:text-gray-900 transition-colors"
-              >
-                {copied ? <Check className="w-4 h-4" /> : <Share2 className="w-4 h-4" />}
-                {copied ? "Copied" : "Share"}
-              </button>
-            </div>
+            showShareLink ? (
+              <div className="bg-white rounded-lg border border-gray-200 px-5 py-4 space-y-3">
+                <p className="text-sm font-medium text-black">Share this link</p>
+                <p className="text-xs text-gray-500">
+                  Send it to someone who might match {data.owner.name}'s intent — they can connect directly from this page.
+                </p>
+                <div className="flex items-center gap-2 bg-gray-50 rounded-sm border border-gray-200 px-3 py-2">
+                  <span className="flex-1 text-xs text-gray-500 truncate">
+                    {window.location.href}
+                  </span>
+                  <button
+                    onClick={handleCopyShareLink}
+                    className="shrink-0 text-gray-400 hover:text-black transition-colors"
+                  >
+                    {copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
+                  </button>
+                </div>
+                <button
+                  onClick={() => setShowShareLink(false)}
+                  className="w-full flex items-center justify-center py-2.5 border border-gray-200 rounded-sm text-sm font-medium text-gray-600 hover:border-gray-400 hover:text-black transition-colors"
+                >
+                  Done
+                </button>
+              </div>
+            ) : (
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={handleConnect}
+                  disabled={connectStep === "awaiting-auth"}
+                  className="flex-1 flex items-center justify-center gap-2 bg-[#041729] text-white px-6 py-3 rounded-sm text-sm font-medium hover:bg-[#0a2d4a] transition-colors disabled:opacity-60"
+                >
+                  {connectStep === "awaiting-auth" ? (
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                  ) : (
+                    <UserCheck className="w-4 h-4" />
+                  )}
+                  {connectStep === "awaiting-auth" ? "Waiting..." : "That's me"}
+                </button>
+                <button
+                  onClick={handleIKnowSomeone}
+                  className="flex-1 flex items-center justify-center gap-2 bg-white text-black px-6 py-3 border border-gray-200 rounded-sm text-sm font-medium hover:border-gray-400 transition-colors"
+                >
+                  <Users className="w-4 h-4" />
+                  I know someone
+                </button>
+              </div>
+            )
           )}
         </ContentContainer>
       </div>

--- a/frontend/src/app/i/[token]/page.tsx
+++ b/frontend/src/app/i/[token]/page.tsx
@@ -1,21 +1,27 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router";
-import { Loader2, MessageCircle, Share2, Check } from "lucide-react";
+import { Loader2, MessageCircle, Share2, Check, ArrowRight } from "lucide-react";
 
 import { useAuthContext } from "@/contexts/AuthContext";
 import UserAvatar from "@/components/UserAvatar";
 import { ContentContainer } from "@/components/layout";
 import { getSharedIntent, type SharedIntentData } from "@/services/intents";
 
+const PENDING_CHAT_KEY = "pendingChatUserId";
+
+type ConnectStep = "idle" | "awaiting-auth" | "needs-onboarding";
+
 export default function SharedIntentPage() {
   const { token } = useParams();
   const navigate = useNavigate();
-  const { isAuthenticated, isLoading: authLoading } = useAuthContext();
+  const { isAuthenticated, isLoading: authLoading, user, openLoginModal } = useAuthContext();
 
   const [data, setData] = useState<SharedIntentData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const [connectStep, setConnectStep] = useState<ConnectStep>("idle");
+  const connectInitiated = useRef(false);
 
   useEffect(() => {
     if (!token) return;
@@ -26,14 +32,32 @@ export default function SharedIntentPage() {
       .finally(() => setIsLoading(false));
   }, [token]);
 
+  // After login resolves, route based on onboarding status
+  useEffect(() => {
+    if (!isAuthenticated || authLoading || !user || connectStep !== "awaiting-auth") return;
+    connectInitiated.current = false;
+
+    if (user.onboarding?.completedAt) {
+      localStorage.removeItem(PENDING_CHAT_KEY);
+      navigate(`/u/${data?.owner.id}/chat`);
+    } else {
+      setConnectStep("needs-onboarding");
+    }
+  }, [isAuthenticated, authLoading, user, connectStep, data, navigate]);
+
   const handleConnect = () => {
     if (!data) return;
     if (isAuthenticated) {
       navigate(`/u/${data.owner.id}/chat`);
-    } else {
-      const returnTo = `/u/${data.owner.id}/chat`;
-      navigate(`/onboarding?returnTo=${encodeURIComponent(returnTo)}`);
+      return;
     }
+    localStorage.setItem(PENDING_CHAT_KEY, data.owner.id);
+    setConnectStep("awaiting-auth");
+    openLoginModal();
+  };
+
+  const handleStartOnboarding = () => {
+    navigate("/onboarding");
   };
 
   const handleCopyLink = async () => {
@@ -75,52 +99,78 @@ export default function SharedIntentPage() {
   });
 
   return (
-    <div className="min-h-screen bg-gray-50/50">
-      <div className="px-6 lg:px-8 py-12 pb-20">
-        <ContentContainer className="max-w-xl mx-auto space-y-8">
-          {/* Intent Card */}
-          <div className="bg-white rounded-lg border border-gray-200 p-8 shadow-sm">
-            <p className="text-lg text-gray-900 leading-relaxed font-medium mb-4">
-              {displayText}
-            </p>
-            <p className="text-xs text-gray-400 font-ibm-plex-mono">{createdAt}</p>
-          </div>
+    <div className="min-h-screen bg-[#FAFAFA]">
+      <div className="px-6 py-12">
+        <ContentContainer className="max-w-md mx-auto space-y-3">
+          {/* Unified card: owner + intent */}
+          <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
+            {/* Owner strip */}
+            <div className="flex items-center gap-3 px-5 py-4 border-b border-gray-100">
+              <UserAvatar
+                id={data.owner.id}
+                name={data.owner.name}
+                avatar={data.owner.avatar}
+                size={36}
+              />
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-bold text-black font-ibm-plex-mono leading-none mb-0.5">
+                  {data.owner.name}
+                </p>
+                {data.owner.intro && (
+                  <p className="text-xs text-gray-500 truncate">{data.owner.intro}</p>
+                )}
+              </div>
+            </div>
 
-          {/* Owner */}
-          <div className="flex items-center gap-3">
-            <UserAvatar
-              id={data.owner.id}
-              name={data.owner.name}
-              avatar={data.owner.avatar}
-              size={40}
-            />
-            <div className="flex-1 min-w-0">
-              <p className="text-sm font-bold text-gray-900 font-ibm-plex-mono truncate">
-                {data.owner.name}
+            {/* Intent body */}
+            <div className="px-5 py-5">
+              <p className="text-base text-black leading-relaxed font-medium mb-3">
+                {displayText}
               </p>
-              {data.owner.intro && (
-                <p className="text-xs text-gray-500 truncate">{data.owner.intro}</p>
-              )}
+              <p className="text-xs text-gray-400 font-ibm-plex-mono">{createdAt}</p>
             </div>
           </div>
 
+          {/* Onboarding nudge — shown after login if not yet onboarded */}
+          {connectStep === "needs-onboarding" && (
+            <div className="bg-white rounded-lg border border-gray-200 px-5 py-4">
+              <p className="text-sm font-medium text-black mb-1">One step before connecting</p>
+              <p className="text-xs text-gray-500 mb-4">
+                We need to set up your profile so {data.owner.name} knows who's reaching out. It only takes a minute.
+              </p>
+              <button
+                onClick={handleStartOnboarding}
+                className="flex items-center gap-2 text-sm font-medium text-black hover:opacity-70 transition-opacity"
+              >
+                Set up my profile <ArrowRight className="w-3.5 h-3.5" />
+              </button>
+            </div>
+          )}
+
           {/* Actions */}
-          <div className="flex items-center gap-3">
-            <button
-              onClick={handleConnect}
-              className="flex-1 flex items-center justify-center gap-2 bg-[#041729] text-white px-6 py-3 rounded-sm text-sm font-medium hover:bg-[#0a2d4a] transition-colors"
-            >
-              <MessageCircle className="w-4 h-4" />
-              Connect
-            </button>
-            <button
-              onClick={handleCopyLink}
-              className="flex items-center gap-2 px-4 py-3 border border-gray-200 rounded-sm text-sm text-gray-600 hover:border-gray-400 hover:text-gray-900 transition-colors"
-            >
-              {copied ? <Check className="w-4 h-4" /> : <Share2 className="w-4 h-4" />}
-              {copied ? "Copied" : "Share"}
-            </button>
-          </div>
+          {connectStep !== "needs-onboarding" && (
+            <div className="flex items-center gap-2">
+              <button
+                onClick={handleConnect}
+                disabled={connectStep === "awaiting-auth"}
+                className="flex-1 flex items-center justify-center gap-2 bg-[#041729] text-white px-6 py-3 rounded-sm text-sm font-medium hover:bg-[#0a2d4a] transition-colors disabled:opacity-60"
+              >
+                {connectStep === "awaiting-auth" ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <MessageCircle className="w-4 h-4" />
+                )}
+                {connectStep === "awaiting-auth" ? "Waiting..." : "Connect"}
+              </button>
+              <button
+                onClick={handleCopyLink}
+                className="flex items-center gap-2 px-4 py-3 border border-gray-200 rounded-sm text-sm text-gray-600 hover:border-gray-400 hover:text-gray-900 transition-colors"
+              >
+                {copied ? <Check className="w-4 h-4" /> : <Share2 className="w-4 h-4" />}
+                {copied ? "Copied" : "Share"}
+              </button>
+            </div>
+          )}
         </ContentContainer>
       </div>
     </div>

--- a/frontend/src/app/i/[token]/page.tsx
+++ b/frontend/src/app/i/[token]/page.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router";
+import { Loader2, MessageCircle, Share2, Check } from "lucide-react";
+
+import { useAuthContext } from "@/contexts/AuthContext";
+import UserAvatar from "@/components/UserAvatar";
+import { ContentContainer } from "@/components/layout";
+import { getSharedIntent, type SharedIntentData } from "@/services/intents";
+
+export default function SharedIntentPage() {
+  const { token } = useParams();
+  const navigate = useNavigate();
+  const { isAuthenticated, isLoading: authLoading } = useAuthContext();
+
+  const [data, setData] = useState<SharedIntentData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!token) return;
+    setIsLoading(true);
+    getSharedIntent(token)
+      .then(setData)
+      .catch(() => setError("Intent not found"))
+      .finally(() => setIsLoading(false));
+  }, [token]);
+
+  const handleConnect = () => {
+    if (!data) return;
+    if (isAuthenticated) {
+      navigate(`/u/${data.owner.id}/chat`);
+    } else {
+      const returnTo = `/u/${data.owner.id}/chat`;
+      navigate(`/onboarding?returnTo=${encodeURIComponent(returnTo)}`);
+    }
+  };
+
+  const handleCopyLink = async () => {
+    await navigator.clipboard.writeText(window.location.href);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  if (isLoading || authLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-gray-400" />
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <h2 className="text-xl font-bold text-gray-900 mb-2 font-ibm-plex-mono">Not Found</h2>
+          <p className="text-gray-500 font-ibm-plex-mono mb-4">This intent link is invalid or has been removed.</p>
+          <button
+            onClick={() => navigate("/")}
+            className="px-4 py-2 bg-[#041729] text-white rounded-sm text-sm font-medium hover:bg-[#0a2d4a] transition-colors"
+          >
+            Go Home
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const displayText = data.intent.summary?.trim() || data.intent.payload;
+  const createdAt = new Date(data.intent.createdAt).toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+
+  return (
+    <div className="min-h-screen bg-gray-50/50">
+      <div className="px-6 lg:px-8 py-12 pb-20">
+        <ContentContainer className="max-w-xl mx-auto space-y-8">
+          {/* Intent Card */}
+          <div className="bg-white rounded-lg border border-gray-200 p-8 shadow-sm">
+            <p className="text-lg text-gray-900 leading-relaxed font-medium mb-4">
+              {displayText}
+            </p>
+            <p className="text-xs text-gray-400 font-ibm-plex-mono">{createdAt}</p>
+          </div>
+
+          {/* Owner */}
+          <div className="flex items-center gap-3">
+            <UserAvatar
+              id={data.owner.id}
+              name={data.owner.name}
+              avatar={data.owner.avatar}
+              size={40}
+            />
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-bold text-gray-900 font-ibm-plex-mono truncate">
+                {data.owner.name}
+              </p>
+              {data.owner.intro && (
+                <p className="text-xs text-gray-500 truncate">{data.owner.intro}</p>
+              )}
+            </div>
+          </div>
+
+          {/* Actions */}
+          <div className="flex items-center gap-3">
+            <button
+              onClick={handleConnect}
+              className="flex-1 flex items-center justify-center gap-2 bg-[#041729] text-white px-6 py-3 rounded-sm text-sm font-medium hover:bg-[#0a2d4a] transition-colors"
+            >
+              <MessageCircle className="w-4 h-4" />
+              Connect
+            </button>
+            <button
+              onClick={handleCopyLink}
+              className="flex items-center gap-2 px-4 py-3 border border-gray-200 rounded-sm text-sm text-gray-600 hover:border-gray-400 hover:text-gray-900 transition-colors"
+            >
+              {copied ? <Check className="w-4 h-4" /> : <Share2 className="w-4 h-4" />}
+              {copied ? "Copied" : "Share"}
+            </button>
+          </div>
+        </ContentContainer>
+      </div>
+    </div>
+  );
+}
+
+export const Component = SharedIntentPage;

--- a/frontend/src/app/i/[token]/page.tsx
+++ b/frontend/src/app/i/[token]/page.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { useNavigate, useParams } from "react-router";
+import { useNavigate, useParams, Link } from "react-router";
 import { Loader2, UserCheck, Users, Check, Copy, ArrowRight } from "lucide-react";
 
 import { useAuthContext } from "@/contexts/AuthContext";
@@ -112,8 +112,27 @@ export default function SharedIntentPage() {
   });
 
   return (
-    <div className="min-h-screen bg-[#FAFAFA]">
-      <div className="px-6 py-12">
+    <div className="min-h-screen bg-[#FDFDFD]">
+      <header className="px-4 py-6 flex items-center justify-between">
+        <Link to="/" className="cursor-pointer">
+          <img
+            src="/logos/logo-black-full.svg"
+            alt="Index Network"
+            width={160}
+            height={28}
+            className="object-contain"
+          />
+        </Link>
+        {!isAuthenticated && (
+          <button
+            onClick={openLoginModal}
+            className="bg-[#041729] text-white rounded-sm px-4 py-2 text-sm font-medium hover:bg-[#0a2d4a] transition-colors"
+          >
+            Login
+          </button>
+        )}
+      </header>
+      <div className="px-6 py-8">
         <ContentContainer className="max-w-md mx-auto space-y-3">
           {/* Unified card: owner + intent */}
           <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">

--- a/frontend/src/app/library/page.tsx
+++ b/frontend/src/app/library/page.tsx
@@ -162,6 +162,18 @@ export default function LibraryPage() {
     loadAll();
   }, [isAuthenticated, authLoading, loadIntents, loadFiles, loadLinks]);
 
+  // Share intent handler
+  const handleShareIntent = useCallback(async (intent: LibrarySourceIntent) => {
+    try {
+      const shareToken = await intentsService.shareIntent(intent.id);
+      const shareUrl = `${window.location.origin}/i/${shareToken}`;
+      await navigator.clipboard.writeText(shareUrl);
+      success('Link copied to clipboard');
+    } catch {
+      error('Failed to share intent');
+    }
+  }, [intentsService, success, error]);
+
   // Archive intent handler
   const handleArchiveIntent = useCallback(async (intent: LibrarySourceIntent) => {
     setIntents(prev => prev.filter(i => i.id !== intent.id));
@@ -272,6 +284,7 @@ export default function LibraryPage() {
                 isLoading={loadingIntents}
                 emptyMessage="No intents yet"
                 onArchiveIntent={handleArchiveIntent}
+                onShareIntent={handleShareIntent}
                 className="w-full"
               />
             )}

--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -422,7 +422,14 @@ export default function OnboardingPage() {
     }
 
     setIsTransitioning(true);
-    const target = sessionId ? `/d/${sessionId}` : "/";
+    const pendingChatUserId = localStorage.getItem('pendingChatUserId');
+    let target: string;
+    if (pendingChatUserId) {
+      localStorage.removeItem('pendingChatUserId');
+      target = `/u/${pendingChatUserId}/chat`;
+    } else {
+      target = sessionId ? `/d/${sessionId}` : "/";
+    }
     const timer = setTimeout(() => navigate(target, { replace: true }), 700);
     return () => clearTimeout(timer);
   }, [user?.onboarding?.completedAt, sessionId, navigate, indexesService, refreshIndexes, showError]);

--- a/frontend/src/components/ChatContent.tsx
+++ b/frontend/src/components/ChatContent.tsx
@@ -212,6 +212,7 @@ function AssistantMessageContent({
   onIntentProposalApprove,
   onIntentProposalReject,
   onIntentProposalUndo,
+  onIntentProposalShare,
   intentProposalStatusMap,
   OAuthLink,
   onNetworkJoin,
@@ -239,6 +240,7 @@ function AssistantMessageContent({
   onIntentProposalApprove?: (proposalId: string, description: string, indexId?: string) => void;
   onIntentProposalReject?: (proposalId: string) => void;
   onIntentProposalUndo?: (proposalId: string) => void;
+  onIntentProposalShare?: (proposalId: string) => void;
   intentProposalStatusMap?: Record<string, "pending" | "created" | "rejected">;
   OAuthLink?: React.ComponentType<React.ComponentPropsWithoutRef<"a">>;
   onNetworkJoin?: (networkId: string, networkTitle: string) => void;
@@ -310,6 +312,7 @@ function AssistantMessageContent({
                 onApprove={onIntentProposalApprove}
                 onReject={onIntentProposalReject}
                 onUndo={onIntentProposalUndo}
+                onShare={onIntentProposalShare}
                 currentStatus={intentProposalStatusMap?.[segment.data.proposalId]}
               />
             </div>
@@ -823,6 +826,21 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
       await archiveProposalIntent(proposalId, intentId);
     },
     [proposalIntentMap, archiveProposalIntent],
+  );
+
+  const handleIntentProposalShare = useCallback(
+    async (proposalId: string) => {
+      const intentId = proposalIntentMap[proposalId];
+      if (!intentId) return;
+      try {
+        const { shareToken } = await apiClient.post<{ shareToken: string }>(`/intents/${intentId}/share`, {});
+        const shareUrl = `${window.location.origin}/i/${shareToken}`;
+        await navigator.clipboard.writeText(shareUrl);
+      } catch {
+        // silently fail
+      }
+    },
+    [proposalIntentMap],
   );
 
   const canSend = input.trim() || selectedFiles.length > 0;
@@ -1664,6 +1682,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
                             onIntentProposalApprove={handleIntentProposalApprove}
                             onIntentProposalReject={handleIntentProposalReject}
                             onIntentProposalUndo={handleIntentProposalUndo}
+                            onIntentProposalShare={handleIntentProposalShare}
                             intentProposalStatusMap={intentProposalStatusMap}
                             OAuthLink={OAuthLink}
                             onNetworkJoin={handleNetworkJoin}

--- a/frontend/src/components/ChatContent.tsx
+++ b/frontend/src/components/ChatContent.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useGmailConnect } from "@/hooks/useGmailConnect";
-import { useNavigate } from "react-router";
+import { useNavigate, useLocation } from "react-router";
 import {
   ArrowUp,
   Pencil,
@@ -364,7 +364,11 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
   } = useAIChat();
   const uploadServiceV2 = useUploadServiceV2();
   const { error: showError, success: showSuccess, addNotification } = useNotifications();
-  const [input, setInput] = useState("");
+  const location = useLocation();
+  const [input, setInput] = useState(() => {
+    const state = location.state as { prefill?: string } | null;
+    return state?.prefill ?? "";
+  });
   const [selectedFiles, setSelectedFiles] = useState<PendingFile[]>([]);
   const [isUploadingFiles, setIsUploadingFiles] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);

--- a/frontend/src/components/ClientWrapper.tsx
+++ b/frontend/src/components/ClientWrapper.tsx
@@ -14,7 +14,7 @@ export default function ClientWrapper({ children }: PropsWithChildren) {
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   const { isAuthenticated } = useAuthContext();
 
-  const appRoutes = ['/', '/d', '/i', '/u', '/library', '/networks', '/mynetwork', '/chat', '/profile'];
+  const appRoutes = ['/', '/d', '/u', '/library', '/networks', '/mynetwork', '/chat', '/profile'];
   const publicRoutes = ['/l', '/index', '/blog', '/about'];
   const bareRoutes = ['/onboarding', '/oauth/callback'];
 
@@ -150,8 +150,9 @@ export default function ClientWrapper({ children }: PropsWithChildren) {
                           </header>
                         }
                       >
-                        <Header 
-                          showHeaderButtons={!pathname?.startsWith('/l/') && !pathname?.startsWith('/index/')}
+                        <Header
+                          showHeaderButtons={!pathname?.startsWith('/l/') && !pathname?.startsWith('/index/') && !pathname?.startsWith('/i/')}
+                          loginOnly={pathname?.startsWith('/i/')}
                           forcePublicView={isLandingOrBlog}
                         />
                       </Suspense>

--- a/frontend/src/components/ClientWrapper.tsx
+++ b/frontend/src/components/ClientWrapper.tsx
@@ -38,7 +38,7 @@ export default function ClientWrapper({ children }: PropsWithChildren) {
   }, [pathname]);
 
   const showSidebar = isAppRoute && !isPublicRoute && !isBareRoute;
-  const showHeader = !showSidebar && !isBareRoute;
+  const showHeader = !showSidebar && !isBareRoute && !pathname?.startsWith('/i/');
 
   const isLandingOrBlog = useMemo(() =>
     (pathname === '/' && !isAuthenticated) ||

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -5,10 +5,11 @@ import { useEffect, useState, useRef } from 'react';
 
 interface HeaderProps {
   showHeaderButtons?: boolean;
+  loginOnly?: boolean;
   forcePublicView?: boolean;
 }
 
-export default function Header({ showHeaderButtons = true, forcePublicView = false }: HeaderProps) {
+export default function Header({ showHeaderButtons = true, loginOnly = false, forcePublicView = false }: HeaderProps) {
   const { pathname } = useLocation();
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
@@ -110,6 +111,15 @@ export default function Header({ showHeaderButtons = true, forcePublicView = fal
             className="object-contain w-[140px] sm:w-[180px] md:w-[200px]"
           />
         </Link>
+
+        {loginOnly && !isAuthenticated && (
+          <button
+            onClick={handleLogin}
+            className="bg-[#041729] text-white rounded-[2px] px-4 py-2 font-semibold text-sm transition-all hover:bg-[#0a2d4a] uppercase tracking-wider cursor-pointer"
+          >
+            Login
+          </button>
+        )}
 
         {showHeaderButtons && (
           <div className="flex items-center gap-3 sm:gap-8 md:gap-12">

--- a/frontend/src/components/IntentList.tsx
+++ b/frontend/src/components/IntentList.tsx
@@ -1,5 +1,5 @@
-import { useMemo } from 'react';
-import { Calendar, Trash2, ExternalLink, FileText, Link as LinkIcon, Slack, MessageSquare } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { Calendar, Trash2, ExternalLink, FileText, Link as LinkIcon, Slack, MessageSquare, Share2, Check } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import { DebugCopyButton } from './DebugCopyButton';
@@ -23,6 +23,7 @@ interface IntentListProps<T extends BaseIntent> {
   onArchiveIntent?: (intent: T) => void;
   onRemoveIntent?: (intent: T) => void;
   onOpenIntentSource?: (intent: T) => void;
+  onShareIntent?: (intent: T) => Promise<void>;
   newIntentIds?: Set<string>;
   selectedIntentIds?: Set<string>;
   removingIntentIds?: Set<string>;
@@ -36,6 +37,7 @@ export default function IntentList<T extends BaseIntent>({
   onArchiveIntent,
   onRemoveIntent,
   onOpenIntentSource,
+  onShareIntent,
   newIntentIds = new Set(),
   selectedIntentIds = new Set(),
   removingIntentIds = new Set(),
@@ -73,6 +75,17 @@ export default function IntentList<T extends BaseIntent>({
     );
   }
 
+  const [sharedIntentId, setSharedIntentId] = useState<string | null>(null);
+
+  const handleShare = async (e: React.MouseEvent, intent: T) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!onShareIntent) return;
+    await onShareIntent(intent);
+    setSharedIntentId(intent.id);
+    setTimeout(() => setSharedIntentId(null), 2000);
+  };
+
   return (
     <div className={cn("space-y-3", className)}>
       {sortedIntents.map((intent) => {
@@ -86,6 +99,7 @@ export default function IntentList<T extends BaseIntent>({
         const isSelectedSource = selectedIntentIds.has(intent.id);
         const canOpenSource = intent.sourceType === 'link' && intent.sourceValue && /^https?:/i.test(intent.sourceValue);
         const isRemoving = removingIntentIds.has(intent.id);
+        const justShared = sharedIntentId === intent.id;
         
         return (
           <div 
@@ -134,6 +148,15 @@ export default function IntentList<T extends BaseIntent>({
               {/* Actions */}
               <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
                 <DebugCopyButton fetchPath={`/debug/intents/${intent.id}`} />
+                {onShareIntent && (
+                  <button
+                    onClick={(e) => handleShare(e, intent)}
+                    className="p-1.5 rounded-md text-gray-400 hover:text-black hover:bg-gray-100 transition-colors"
+                    title={justShared ? "Copied!" : "Share"}
+                  >
+                    {justShared ? <Check className="w-4 h-4 text-green-600" /> : <Share2 className="w-4 h-4" />}
+                  </button>
+                )}
                 {onOpenIntentSource && canOpenSource && (
                   <button
                     onClick={(e) => {

--- a/frontend/src/components/NetworkOverviewPanel.tsx
+++ b/frontend/src/components/NetworkOverviewPanel.tsx
@@ -7,7 +7,7 @@ import IntentList from '@/components/IntentList';
 import { useIndexesState } from '@/contexts/IndexesContext';
 import { useNotifications } from '@/contexts/NotificationContext';
 import { useAuthenticatedAPI } from '@/lib/api';
-import { useIndexes } from '@/contexts/APIContext';
+import { useIndexes, useIntents } from '@/contexts/APIContext';
 
 interface NetworkOverviewPanelProps {
   index: Index;
@@ -22,6 +22,7 @@ export default function NetworkOverviewPanel({ index, isOwner, onLeft, onLeaveRe
   const { success, error } = useNotifications();
   const api = useAuthenticatedAPI();
   const indexesService = useIndexes();
+  const intentsService = useIntents();
 
   const [showLeaveConfirmation, setShowLeaveConfirmation] = useState(false);
   const [isLeaving, setIsLeaving] = useState(false);
@@ -51,6 +52,17 @@ export default function NetworkOverviewPanel({ index, isOwner, onLeft, onLeaveRe
     };
     loadIntents();
   }, [index.id, indexesService]);
+
+  const handleShareIntent = async (intent: { id: string }) => {
+    try {
+      const shareToken = await intentsService.shareIntent(intent.id);
+      const shareUrl = `${window.location.origin}/i/${shareToken}`;
+      await navigator.clipboard.writeText(shareUrl);
+      success('Link copied to clipboard');
+    } catch {
+      error('Failed to share intent');
+    }
+  };
 
   const handleLeaveNetwork = async () => {
     try {
@@ -88,6 +100,7 @@ export default function NetworkOverviewPanel({ index, isOwner, onLeft, onLeaveRe
             intents={intents}
             isLoading={intentsLoading}
             emptyMessage="You haven't shared any intents in this network yet"
+            onShareIntent={handleShareIntent}
           />
         </div>
 

--- a/frontend/src/components/chat/IntentProposalCard.tsx
+++ b/frontend/src/components/chat/IntentProposalCard.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Check, RotateCcw, X } from "lucide-react";
+import { Check, RotateCcw, Share2, X } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
@@ -17,6 +17,7 @@ interface IntentProposalCardProps {
   onApprove?: (proposalId: string, description: string, indexId?: string) => void | Promise<void>;
   onReject?: (proposalId: string) => void | Promise<void>;
   onUndo?: (proposalId: string) => void | Promise<void>;
+  onShare?: (proposalId: string) => void | Promise<void>;
   currentStatus?: "pending" | "created" | "rejected";
 }
 
@@ -46,6 +47,7 @@ export default function IntentProposalCard({
   onApprove,
   onReject,
   onUndo,
+  onShare,
   currentStatus,
 }: IntentProposalCardProps) {
   const [actionTaken, setActionTaken] = useState<"created" | "rejected" | null>(null);
@@ -55,6 +57,7 @@ export default function IntentProposalCard({
   const [isUndoing, setIsUndoing] = useState(false);
   const [actionError, setActionError] = useState(false);
   const [failedAction, setFailedAction] = useState<"approve" | "reject" | "undo" | null>(null);
+  const [shareCopied, setShareCopied] = useState(false);
   const countdownStarted = useRef(false);
   const autoSaveTriggered = useRef(false);
 
@@ -155,6 +158,13 @@ export default function IntentProposalCard({
     }
   }, [onUndo, card.proposalId, isUndoing]);
 
+  const handleShare = useCallback(async () => {
+    if (!onShare) return;
+    await onShare(card.proposalId);
+    setShareCopied(true);
+    setTimeout(() => setShareCopied(false), 2000);
+  }, [onShare, card.proposalId]);
+
   if (actionError) {
     const errorLabel =
       failedAction === "reject" ? "Failed: Skip intent" :
@@ -215,6 +225,16 @@ export default function IntentProposalCard({
               <span className="text-xs text-gray-400">Saving…</span>
             ) : (
               <>
+                {onShare && (
+                  <button
+                    type="button"
+                    onClick={handleShare}
+                    className="text-xs text-gray-400 hover:text-gray-500 flex items-center gap-1"
+                  >
+                    <Share2 className="w-3 h-3" />
+                    {shareCopied ? "Copied!" : "Share"}
+                  </button>
+                )}
                 {onUndo && (
                   <button
                     type="button"

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -111,8 +111,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     const isHomePage = pathname === '/';
     const isOnboardingPage = pathname === '/onboarding';
-    const isPublicPage = pathname.startsWith('/simulation') || pathname.startsWith('/l') || pathname.startsWith('/index/') || pathname.startsWith('/blog') || pathname.startsWith('/pages') || pathname.startsWith('/about') || pathname.startsWith('/login') || pathname.startsWith('/s/') || pathname.startsWith('/oauth/');
-    const isProtectedPage = pathname.startsWith('/i/');
+    const isPublicPage = pathname.startsWith('/simulation') || pathname.startsWith('/l') || pathname.startsWith('/index/') || pathname.startsWith('/blog') || pathname.startsWith('/pages') || pathname.startsWith('/about') || pathname.startsWith('/login') || pathname.startsWith('/s/') || pathname.startsWith('/oauth/') || pathname.startsWith('/i/');
+    const isProtectedPage = false;
 
     const shouldRedirectToHome = !authenticated && (isProtectedPage || (!isHomePage && !isPublicPage));
 

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -62,6 +62,10 @@ export const router = createBrowserRouter([
         lazy: () => import("@/app/d/[id]/page"),
       },
       {
+        path: "/i/:token",
+        lazy: () => import("@/app/i/[token]/page"),
+      },
+      {
         path: "/index/:indexId",
         lazy: () => import("@/app/index/[indexId]/page"),
       },

--- a/frontend/src/services/intents.ts
+++ b/frontend/src/services/intents.ts
@@ -3,6 +3,31 @@ import {
   PaginatedResponse,
   APIResponse,
 } from '../types';
+import { apiUrl } from '../lib/api';
+
+export interface SharedIntentData {
+  intent: {
+    id: string;
+    payload: string;
+    summary: string | null;
+    createdAt: string;
+  };
+  owner: {
+    id: string;
+    name: string;
+    avatar: string | null;
+    intro: string | null;
+  };
+}
+
+/**
+ * Fetches a shared intent by token (public, no auth required).
+ */
+export async function getSharedIntent(token: string): Promise<SharedIntentData> {
+  const res = await fetch(apiUrl(`/api/intents/shared/${token}`));
+  if (!res.ok) throw new Error('Shared intent not found');
+  return res.json();
+}
 
 // Service functions factory that takes an authenticated API instance
 export const createIntentsService = (api: ReturnType<typeof import('../lib/api').useAuthenticatedAPI>) => ({
@@ -69,5 +94,11 @@ export const createIntentsService = (api: ReturnType<typeof import('../lib/api')
       maxSuggestions
     });
     return response;
-  }
+  },
+
+  // Generate a share token for an intent
+  shareIntent: async (intentId: string): Promise<string> => {
+    const response = await api.post<{ shareToken: string }>(`/intents/${intentId}/share`, {});
+    return response.shareToken;
+  },
 }); 

--- a/protocol/drizzle/0028_add_intents_share_token.sql
+++ b/protocol/drizzle/0028_add_intents_share_token.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "intents" ADD COLUMN "share_token" text;--> statement-breakpoint
+CREATE UNIQUE INDEX "intents_share_token_idx" ON "intents" USING btree ("share_token");

--- a/protocol/drizzle/meta/0028_snapshot.json
+++ b/protocol/drizzle/meta/0028_snapshot.json
@@ -1,0 +1,2272 @@
+{
+  "id": "7cd0a804-c12f-43cf-a946-7e0208b8ae6b",
+  "prevId": "05ba9707-a115-466a-8419-a131a3ff2cd2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "files_user_id_users_id_fk": {
+          "name": "files_user_id_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hyde_documents": {
+      "name": "hyde_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_text": {
+          "name": "source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_corpus": {
+          "name": "target_corpus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hyde_text": {
+          "name": "hyde_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hyde_embedding": {
+          "name": "hyde_embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "hyde_source_idx": {
+          "name": "hyde_source_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_strategy_idx": {
+          "name": "hyde_strategy_idx",
+          "columns": [
+            {
+              "expression": "strategy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_embedding_idx": {
+          "name": "hyde_embedding_idx",
+          "columns": [
+            {
+              "expression": "hyde_embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "hyde_expires_idx": {
+          "name": "hyde_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_source_strategy_unique": {
+          "name": "hyde_source_strategy_unique",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "strategy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_corpus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.index_integrations": {
+      "name": "index_integrations",
+      "schema": "",
+      "columns": {
+        "index_id": {
+          "name": "index_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolkit": {
+          "name": "toolkit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "index_integrations_index_id_indexes_id_fk": {
+          "name": "index_integrations_index_id_indexes_id_fk",
+          "tableFrom": "index_integrations",
+          "tableTo": "indexes",
+          "columnsFrom": [
+            "index_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "index_integrations_index_id_toolkit_pk": {
+          "name": "index_integrations_index_id_toolkit_pk",
+          "columns": [
+            "index_id",
+            "toolkit"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.links": {
+      "name": "links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "links_user_id_users_id_fk": {
+          "name": "links_user_id_users_id_fk",
+          "tableFrom": "links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.index_members": {
+      "name": "index_members",
+      "schema": "",
+      "columns": {
+        "index_id": {
+          "name": "index_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_assign": {
+          "name": "auto_assign",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "index_members_index_id_indexes_id_fk": {
+          "name": "index_members_index_id_indexes_id_fk",
+          "tableFrom": "index_members",
+          "tableTo": "indexes",
+          "columnsFrom": [
+            "index_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "index_members_user_id_users_id_fk": {
+          "name": "index_members_user_id_users_id_fk",
+          "tableFrom": "index_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "index_members_index_id_user_id_pk": {
+          "name": "index_members_index_id_user_id_pk",
+          "columns": [
+            "index_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.indexes": {
+      "name": "indexes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"joinPolicy\":\"invite_only\",\"invitationLink\":null,\"allowGuestVibeCheck\":false}'::json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.intent_indexes": {
+      "name": "intent_indexes",
+      "schema": "",
+      "columns": {
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index_id": {
+          "name": "index_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relevancy_score": {
+          "name": "relevancy_score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "intent_indexes_index_id_idx": {
+          "name": "intent_indexes_index_id_idx",
+          "columns": [
+            {
+              "expression": "index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intent_indexes_intent_id_intents_id_fk": {
+          "name": "intent_indexes_intent_id_intents_id_fk",
+          "tableFrom": "intent_indexes",
+          "tableTo": "intents",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "intent_indexes_index_id_indexes_id_fk": {
+          "name": "intent_indexes_index_id_indexes_id_fk",
+          "tableFrom": "intent_indexes",
+          "tableTo": "indexes",
+          "columnsFrom": [
+            "index_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "intent_indexes_intent_id_index_id_pk": {
+          "name": "intent_indexes_intent_id_index_id_pk",
+          "columns": [
+            "intent_id",
+            "index_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.intents": {
+      "name": "intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_incognito": {
+          "name": "is_incognito",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "semantic_entropy": {
+          "name": "semantic_entropy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "referential_anchor": {
+          "name": "referential_anchor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intent_mode": {
+          "name": "intent_mode",
+          "type": "intent_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ATTRIBUTIVE'"
+        },
+        "speech_act_type": {
+          "name": "speech_act_type",
+          "type": "speech_act_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "felicity_authority": {
+          "name": "felicity_authority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "felicity_sincerity": {
+          "name": "felicity_sincerity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "intent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ACTIVE'"
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "embeddingIndex": {
+          "name": "embeddingIndex",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "intents_share_token_idx": {
+          "name": "intents_share_token_idx",
+          "columns": [
+            {
+              "expression": "share_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intents_user_id_users_id_fk": {
+          "name": "intents_user_id_users_id_fk",
+          "tableFrom": "intents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunities": {
+      "name": "opportunities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "detection": {
+          "name": "detection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actors": {
+          "name": "actors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interpretation": {
+          "name": "interpretation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "opportunity_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "opportunities_status_idx": {
+          "name": "opportunities_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_indexes": {
+      "name": "personal_indexes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index_id": {
+          "name": "index_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "personal_indexes_index_id_unique": {
+          "name": "personal_indexes_index_id_unique",
+          "columns": [
+            {
+              "expression": "index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_indexes_user_id_users_id_fk": {
+          "name": "personal_indexes_user_id_users_id_fk",
+          "tableFrom": "personal_indexes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "personal_indexes_index_id_indexes_id_fk": {
+          "name": "personal_indexes_index_id_indexes_id_fk",
+          "tableFrom": "personal_indexes",
+          "tableTo": "indexes",
+          "columnsFrom": [
+            "index_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "personal_indexes_user_id_pk": {
+          "name": "personal_indexes_user_id_pk",
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_settings": {
+      "name": "user_notification_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"connectionUpdates\":true,\"weeklyNewsletter\":true}'::json"
+        },
+        "unsubscribe_token": {
+          "name": "unsubscribe_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_settings_user_id_users_id_fk": {
+          "name": "user_notification_settings_user_id_users_id_fk",
+          "tableFrom": "user_notification_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_notification_settings_unsubscribe_token_unique": {
+          "name": "user_notification_settings_unsubscribe_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "unsubscribe_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity": {
+          "name": "identity",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "narrative": {
+          "name": "narrative",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "implicit_intents": {
+          "name": "implicit_intents",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_profiles_embedding_idx": {
+          "name": "user_profiles_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_profiles_user_id_unique": {
+          "name": "user_profiles_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro": {
+          "name": "intro",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "socials": {
+          "name": "socials",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding": {
+          "name": "onboarding",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::json"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UTC'"
+        },
+        "last_weekly_email_sent_at": {
+          "name": "last_weekly_email_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_ghost": {
+          "name": "is_ghost",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artifacts": {
+      "name": "artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "artifacts_task_id_idx": {
+          "name": "artifacts_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifacts_task_id_tasks_id_fk": {
+          "name": "artifacts_task_id_tasks_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_metadata": {
+      "name": "conversation_metadata",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_metadata_conversation_id_conversations_id_fk": {
+          "name": "conversation_metadata_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_metadata",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_participants": {
+      "name": "conversation_participants",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_type": {
+          "name": "participant_type",
+          "type": "participant_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "hidden_at": {
+          "name": "hidden_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversation_participants_participant_id_idx": {
+          "name": "conversation_participants_participant_id_idx",
+          "columns": [
+            {
+              "expression": "participant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_participants_conversation_id_idx": {
+          "name": "conversation_participants_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_participants_conversation_id_conversations_id_fk": {
+          "name": "conversation_participants_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_participants",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_participants_conversation_id_participant_id_pk": {
+          "name": "conversation_participants_conversation_id_participant_id_pk",
+          "columns": [
+            "conversation_id",
+            "participant_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dm_pair": {
+          "name": "dm_pair",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversations_dm_pair_idx": {
+          "name": "conversations_dm_pair_idx",
+          "columns": [
+            {
+              "expression": "dm_pair",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "message_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_task_ids": {
+          "name": "reference_task_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_conversation_id_created_at_idx": {
+          "name": "messages_conversation_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_sender_id_idx": {
+          "name": "messages_sender_id_idx",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_task_id_idx": {
+          "name": "messages_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_task_id_tasks_id_fk": {
+          "name": "messages_task_id_tasks_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "task_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "status_message": {
+          "name": "status_message",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_timestamp": {
+          "name": "status_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tasks_conversation_id_idx": {
+          "name": "tasks_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_state_idx": {
+          "name": "tasks_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_conversation_id_conversations_id_fk": {
+          "name": "tasks_conversation_id_conversations_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.intent_mode": {
+      "name": "intent_mode",
+      "schema": "public",
+      "values": [
+        "REFERENTIAL",
+        "ATTRIBUTIVE"
+      ]
+    },
+    "public.intent_status": {
+      "name": "intent_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "PAUSED",
+        "FULFILLED",
+        "EXPIRED"
+      ]
+    },
+    "public.opportunity_status": {
+      "name": "opportunity_status",
+      "schema": "public",
+      "values": [
+        "latent",
+        "draft",
+        "pending",
+        "viewed",
+        "accepted",
+        "rejected",
+        "expired"
+      ]
+    },
+    "public.source_type": {
+      "name": "source_type",
+      "schema": "public",
+      "values": [
+        "file",
+        "integration",
+        "link",
+        "discovery_form",
+        "enrichment"
+      ]
+    },
+    "public.speech_act_type": {
+      "name": "speech_act_type",
+      "schema": "public",
+      "values": [
+        "COMMISSIVE",
+        "DIRECTIVE"
+      ]
+    },
+    "public.message_role": {
+      "name": "message_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "agent"
+      ]
+    },
+    "public.participant_type": {
+      "name": "participant_type",
+      "schema": "public",
+      "values": [
+        "user",
+        "agent"
+      ]
+    },
+    "public.task_state": {
+      "name": "task_state",
+      "schema": "public",
+      "values": [
+        "submitted",
+        "working",
+        "input_required",
+        "completed",
+        "failed",
+        "canceled",
+        "rejected",
+        "auth_required"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/protocol/drizzle/meta/_journal.json
+++ b/protocol/drizzle/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1774873300000,
       "tag": "0027_create_index_integrations",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1774416194976,
+      "tag": "0028_add_intents_share_token",
+      "breakpoints": true
     }
   ]
 }

--- a/protocol/src/adapters/database.adapter.ts
+++ b/protocol/src/adapters/database.adapter.ts
@@ -643,6 +643,81 @@ export class IntentDatabaseAdapter {
       createdAt: r.createdAt,
     }));
   }
+
+  /**
+   * Sets or updates the share token for an intent.
+   * @param intentId - The intent ID
+   * @param token - The share token to set
+   */
+  async setIntentShareToken(intentId: string, token: string): Promise<void> {
+    await db.update(schema.intents)
+      .set({ shareToken: token, updatedAt: new Date() })
+      .where(eq(schema.intents.id, intentId));
+  }
+
+  /**
+   * Retrieves an intent by its share token, joined with owner profile data.
+   * @param token - The share token
+   * @returns Intent + owner info, or null if not found/archived
+   */
+  async getIntentByShareToken(token: string): Promise<{
+    id: string;
+    payload: string;
+    summary: string | null;
+    createdAt: Date;
+    userId: string;
+    ownerName: string;
+    ownerAvatar: string | null;
+    ownerIntro: string | null;
+  } | null> {
+    const rows = await db
+      .select({
+        id: schema.intents.id,
+        payload: schema.intents.payload,
+        summary: schema.intents.summary,
+        createdAt: schema.intents.createdAt,
+        userId: schema.intents.userId,
+        ownerName: schema.users.name,
+        ownerAvatar: schema.users.avatar,
+        ownerIntro: schema.users.intro,
+      })
+      .from(schema.intents)
+      .innerJoin(schema.users, eq(schema.intents.userId, schema.users.id))
+      .where(
+        and(
+          eq(schema.intents.shareToken, token),
+          isNull(schema.intents.archivedAt),
+        )
+      )
+      .limit(1);
+
+    const row = rows[0];
+    if (!row) return null;
+    return {
+      id: row.id,
+      payload: row.payload,
+      summary: row.summary,
+      createdAt: row.createdAt,
+      userId: row.userId,
+      ownerName: row.ownerName ?? 'Unknown',
+      ownerAvatar: row.ownerAvatar ?? null,
+      ownerIntro: row.ownerIntro ?? null,
+    };
+  }
+
+  /**
+   * Gets the existing share token for an intent, if any.
+   * @param intentId - The intent ID
+   * @returns The share token or null
+   */
+  async getIntentShareToken(intentId: string): Promise<string | null> {
+    const rows = await db
+      .select({ shareToken: schema.intents.shareToken })
+      .from(schema.intents)
+      .where(eq(schema.intents.id, intentId))
+      .limit(1);
+    return rows[0]?.shareToken ?? null;
+  }
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/protocol/src/controllers/intent.controller.ts
+++ b/protocol/src/controllers/intent.controller.ts
@@ -141,6 +141,49 @@ export class IntentController {
   }
 
   /**
+   * Get a shared intent by share token (public, no auth).
+   * @param params - URL params with share token
+   * @returns Intent data with owner profile
+   */
+  @Get('/shared/:token')
+  async getSharedIntent(_req: Request, _user: unknown, params: { token: string }) {
+    const data = await intentService.getSharedIntent(params.token);
+    if (!data) {
+      return Response.json({ error: 'Shared intent not found' }, { status: 404 });
+    }
+    return Response.json({
+      intent: {
+        id: data.id,
+        payload: data.payload,
+        summary: data.summary,
+        createdAt: data.createdAt.toISOString(),
+      },
+      owner: {
+        id: data.userId,
+        name: data.ownerName,
+        avatar: data.ownerAvatar,
+        intro: data.ownerIntro,
+      },
+    });
+  }
+
+  /**
+   * Generate a share token for an intent.
+   * @param params - URL params with intent ID
+   * @param user - Authenticated user from AuthGuard
+   * @returns The share token
+   */
+  @Post('/:id/share')
+  @UseGuards(AuthGuard)
+  async shareIntent(_req: Request, user: AuthenticatedUser, params: { id: string }) {
+    const shareToken = await intentService.shareIntent(params.id, user.id);
+    if (!shareToken) {
+      return Response.json({ error: 'Intent not found' }, { status: 404 });
+    }
+    return Response.json({ shareToken });
+  }
+
+  /**
    * Get a single intent by ID.
    */
   @Get('/:id')

--- a/protocol/src/schemas/database.schema.ts
+++ b/protocol/src/schemas/database.schema.ts
@@ -225,8 +225,10 @@ export const intents = pgTable('intents', {
   felicityAuthority: integer('felicity_authority'),
   felicitySincerity: integer('felicity_sincerity'),
   status: intentStatusEnum('status').default('ACTIVE'),
+  shareToken: text('share_token'),
 }, (table) => [
   index('embeddingIndex').using('hnsw', table.embedding.op('vector_cosine_ops')),
+  uniqueIndex('intents_share_token_idx').on(table.shareToken),
 ]);
 
 export const indexes = pgTable('indexes', {

--- a/protocol/src/services/intent.service.ts
+++ b/protocol/src/services/intent.service.ts
@@ -294,6 +294,37 @@ export class IntentService {
 
     return result;
   }
+
+  /**
+   * Generates a share token for an intent (idempotent).
+   * Returns the existing token if one already exists.
+   *
+   * @param intentId - The intent ID
+   * @param userId - The user ID (for ownership verification)
+   * @returns The share token, or null if intent not found / unauthorized
+   */
+  async shareIntent(intentId: string, userId: string): Promise<string | null> {
+    const owned = await this.adapter.isOwnedByUser(intentId, userId);
+    if (!owned) return null;
+
+    const existing = await this.adapter.getIntentShareToken(intentId);
+    if (existing) return existing;
+
+    const token = crypto.randomUUID();
+    await this.adapter.setIntentShareToken(intentId, token);
+    logger.verbose('[IntentService] Intent shared', { intentId });
+    return token;
+  }
+
+  /**
+   * Retrieves a shared intent by its share token (public, no auth).
+   *
+   * @param shareToken - The share token from the URL
+   * @returns Intent data with owner profile, or null if not found
+   */
+  async getSharedIntent(shareToken: string) {
+    return this.adapter.getIntentByShareToken(shareToken);
+  }
 }
 
 export const intentService = new IntentService();


### PR DESCRIPTION
## Summary

- **Token-gated shareable URLs for intents** — owners generate a share token (UUID), visitors view intent at `/i/:token` without authentication
- **Backend**: `share_token` column on intents, `POST /intents/:id/share` (auth, idempotent), `GET /intents/shared/:token` (public, returns intent + owner profile)
- **Frontend**: shared intent page (`/i/:token`) with intent card, owner info, and "Connect" CTA that routes to login then chat; share buttons on IntentList (library + network panel) and confirmed chat proposals

## Test plan

- [ ] Run `bun test` in protocol — verify no regressions
- [ ] Run `bun run db:migrate` — migration 0028 applies cleanly
- [ ] From Library, hover an intent → share icon appears → click copies `/i/:token` URL to clipboard
- [ ] Open the `/i/:token` URL in incognito → shared intent page renders with intent text, owner avatar/name, and "Connect" button
- [ ] Click "Connect" while unauthenticated → redirected to onboarding/login → then to `/u/:ownerId/chat`
- [ ] Click "Connect" while authenticated → navigated directly to `/u/:ownerId/chat`
- [ ] Share the same intent again → returns the same token (idempotent)
- [ ] Archive an intent → its shared URL returns 404
- [ ] Confirm an intent proposal in chat → "Share" button appears on the confirmed card → copies link to clipboard


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Intent Sharing: generate shareable links for intents, copy-to-clipboard with “Copied!” feedback
  * Shared Intent Viewing: public /i/<token> pages show intent + owner info and actions (Connect, I know someone, Share)

* **UX Improvements**
  * Onboarding-aware flow: post-login/onboarding redirects continue to a pending chat when applicable
  * Header/login tweaks: simplified header for shared-link pages with a prominent Login action
<!-- end of auto-generated comment: release notes by coderabbit.ai -->