### PR TITLE
fix: wire ghost invite emails into DM flow and add production email mode

### DIFF
--- a/protocol/.env.example
+++ b/protocol/.env.example
@@ -91,7 +91,9 @@ S3_SECRET_ACCESS_KEY=your-secret-access-key
 
 # If not set, emails are skipped.
 # RESEND_API_KEY=
-# ENABLE_EMAIL_TESTING=true
+# EMAIL_PRODUCTION_MODE=true sends to real recipients.
+# When false/absent, emails redirect to TESTING_EMAIL_ADDRESS (or skip if unset).
+# EMAIL_PRODUCTION_MODE=
 # TESTING_EMAIL_ADDRESS=
 
 

--- a/protocol/src/adapters/database.adapter.ts
+++ b/protocol/src/adapters/database.adapter.ts
@@ -5912,6 +5912,56 @@ export class ConversationDatabaseAdapter {
   }
 
   // ─────────────────────────────────────────────────────────────────────────
+  // Users (for ghost invite emails)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Looks up a user by ID.
+   * @param userId - User ID
+   * @returns Core user fields, or null if not found
+   */
+  async getUser(userId: string): Promise<{ id: string; name: string | null; email: string | null; isGhost: boolean; deletedAt: Date | null } | null> {
+    const [row] = await db
+      .select({
+        id: schema.users.id,
+        name: schema.users.name,
+        email: schema.users.email,
+        isGhost: schema.users.isGhost,
+        deletedAt: schema.users.deletedAt,
+      })
+      .from(schema.users)
+      .where(eq(schema.users.id, userId))
+      .limit(1);
+    return row ?? null;
+  }
+
+  /**
+   * Returns notification settings for a user, creating a default row if none exists.
+   * @param userId - The user's ID
+   * @returns The notification settings row (includes unsubscribeToken)
+   */
+  async getOrCreateNotificationSettings(userId: string): Promise<{ id: string; userId: string; unsubscribeToken: string }> {
+    const projection = {
+      id: schema.userNotificationSettings.id,
+      userId: schema.userNotificationSettings.userId,
+      unsubscribeToken: schema.userNotificationSettings.unsubscribeToken,
+    };
+
+    await db.insert(schema.userNotificationSettings)
+      .values({ userId })
+      .onConflictDoNothing({ target: schema.userNotificationSettings.userId });
+
+    const [row] = await db.select(projection)
+      .from(schema.userNotificationSettings)
+      .where(eq(schema.userNotificationSettings.userId, userId))
+      .limit(1);
+    if (!row) {
+      throw new Error(`Failed to get or create notification settings for user ${userId}`);
+    }
+    return row;
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
   // Tasks
   // ─────────────────────────────────────────────────────────────────────────
 

--- a/protocol/src/adapters/database.adapter.ts
+++ b/protocol/src/adapters/database.adapter.ts
@@ -1323,6 +1323,17 @@ export class ChatDatabaseAdapter {
       });
   }
 
+  /**
+   * Soft-delete a ghost user and all their contact memberships.
+   * Delegates to ProfileDatabaseAdapter.
+   * @param userId - The ghost user to soft-delete
+   * @returns true if the user was soft-deleted
+   */
+  async softDeleteGhost(userId: string): Promise<boolean> {
+    const profileAdapter = new ProfileDatabaseAdapter();
+    return profileAdapter.softDeleteGhost(userId);
+  }
+
   async createIntent(data: CreateIntentInput): Promise<CreatedIntentRow> {
     try {
       const [created] = await db.insert(schema.intents)

--- a/protocol/src/controllers/chat.controller.ts
+++ b/protocol/src/controllers/chat.controller.ts
@@ -29,8 +29,6 @@ const streamBodySchema = z.object({
   useCheckpointer: z.boolean().optional(),
   fileIds: z.array(z.string()).optional(),
   indexId: z.string().nullish(),
-  /** The recipient user ID for DM-style chats (used for ghost invite emails). */
-  recipientUserId: z.string().nullish(),
   prefillMessages: z.array(z.object({
     role: z.enum(["assistant", "user"]),
     content: z.string().max(10000),
@@ -305,19 +303,10 @@ export class ChatController {
           }
 
           // Persist user message and assistant response
-          let recipientUserId: string | undefined =
-            typeof body.recipientUserId === "string" && body.recipientUserId.trim()
-              ? body.recipientUserId.trim()
-              : undefined;
-          if (recipientUserId && recipientUserId === user.id) {
-            recipientUserId = undefined; // Can't be your own recipient
-          }
           await chatSessionService.addMessage({
             sessionId,
             role: "user",
             content: messageContent,
-            recipientUserId,
-            senderUserId: user.id,
           });
           let assistantMessageId: string | undefined;
           if (fullResponse) {

--- a/protocol/src/lib/email/transport.helper.ts
+++ b/protocol/src/lib/email/transport.helper.ts
@@ -14,70 +14,58 @@ export const executeSendEmail = async (options: {
   text: string;
   headers?: Record<string, string>;
 }) => {
-  // SAFETY: Override recipient for testing
-  const isTestMode = process.env.ENABLE_EMAIL_TESTING === 'true';
-  const recipient = isTestMode ? process.env.TESTING_EMAIL_ADDRESS : options.to;
-
-  if (isTestMode && !recipient) {
-    logger.warn('[EmailTransport] TESTING_EMAIL_ADDRESS not set - skipping email');
-    return { data: null, skipped: true, reason: 'testing_email_not_set' };
-  }
-
-  if (isTestMode) {
-    const { appendFile } = await import('fs/promises');
-    const { resolve } = await import('path');
-    const debugPath = resolve(process.cwd(), 'email-debug.md');
-    const separator = '='.repeat(80);
-    const timestamp = new Date().toISOString();
-
-    // Format headers for display
-    const headersStr = options.headers
-      ? Object.entries(options.headers).map(([k, v]) => `${k}: ${v}`).join('\n      ')
-      : '(none)';
-
-    const content = `
-      ${separator}
-      [${timestamp}] Email Sent
-      ${separator}
-      To: ${Array.isArray(recipient) ? recipient.join(', ') : recipient}
-      Subject: ${options.subject}
-      Headers:
-      ${headersStr}
-
-      --- TEXT CONTENT ---
-      ${options.text}
-
-      --- HTML CONTENT ---
-      ${options.html}
-    `;
-    try {
-      await appendFile(debugPath, content);
-      logger.debug(`Email logged to ${debugPath}`);
-    } catch (err) {
-      logger.error('Failed to log email to file', { error: err instanceof Error ? err.message : String(err) });
-    }
-  }
-
   if (!process.env.RESEND_API_KEY || !resend || process.env.RESEND_API_KEY === 'DISABLED') {
     logger.warn('[EmailTransport] RESEND_API_KEY not configured or disabled - email not sent');
     return { data: null, skipped: true, reason: 'resend_not_configured' };
   }
 
-  if (!isTestMode) {
-    logger.debug('[EmailTransport] Email sending disabled (ENABLE_EMAIL_TESTING is not true)');
-    return { data: null, skipped: true, reason: 'email_testing_disabled' };
-  }
+  const isProduction = process.env.EMAIL_PRODUCTION_MODE === 'true';
+  let recipient: string | string[] = options.to;
 
-  if (!recipient) {
-    if (isTestMode) {
-      logger.warn('[EmailTransport] TESTING_EMAIL_ADDRESS not set - skipping email');
-      return { data: null, skipped: true, reason: 'testing_email_not_set' };
+  if (!isProduction) {
+    const testAddress = process.env.TESTING_EMAIL_ADDRESS;
+    if (!testAddress) {
+      logger.debug('[EmailTransport] Non-production and no TESTING_EMAIL_ADDRESS - skipping');
+      return { data: null, skipped: true, reason: 'no_test_recipient' };
     }
-    logger.error('[EmailTransport] No recipient defined for email');
-    return { data: null, skipped: true, reason: 'no_recipient' };
+    recipient = testAddress;
+
+    // Log to debug file in non-production mode
+    try {
+      const { appendFile } = await import('fs/promises');
+      const { resolve } = await import('path');
+      const debugPath = resolve(process.cwd(), 'email-debug.md');
+      const separator = '='.repeat(80);
+      const timestamp = new Date().toISOString();
+      const headersStr = options.headers
+        ? Object.entries(options.headers).map(([k, v]) => `${k}: ${v}`).join('\n      ')
+        : '(none)';
+
+      await appendFile(debugPath, `
+${separator}
+[${timestamp}] Email Sent (redirected to test address)
+${separator}
+Original To: ${Array.isArray(options.to) ? options.to.join(', ') : options.to}
+Actual To: ${testAddress}
+Subject: ${options.subject}
+Headers: ${headersStr}
+
+--- TEXT ---
+${options.text}
+
+--- HTML ---
+${options.html}
+`);
+    } catch (err) {
+      logger.error('Failed to log email to debug file', { error: err instanceof Error ? err.message : String(err) });
+    }
   }
 
-  logger.verbose(`[EmailTransport] Sending email to test recipient`, { recipient: String(recipient), originalTo: String(options.to) });
+  logger.verbose('[EmailTransport] Sending email', {
+    recipient: String(recipient),
+    originalTo: String(options.to),
+    production: isProduction,
+  });
 
   try {
     const result = await resend!.emails.send({

--- a/protocol/src/services/chat.service.ts
+++ b/protocol/src/services/chat.service.ts
@@ -163,10 +163,6 @@ export class ChatSessionService {
     routingDecision?: Record<string, unknown>;
     subgraphResults?: Record<string, unknown>;
     tokenCount?: number;
-    /** When set, triggers a ghost invite email if the recipient is a ghost user. */
-    recipientUserId?: string;
-    /** The sender's user ID (needed for ghost invite email context). */
-    senderUserId?: string;
   }): Promise<string> {
     logger.verbose('Adding message', {
       sessionId: params.sessionId,
@@ -188,71 +184,6 @@ export class ChatSessionService {
 
     // Update session timestamp
     await this.db.updateSessionTimestamp(params.sessionId);
-
-    // Ghost invite email: on first user message to a ghost, send email notification
-    if (params.role === 'user' && params.recipientUserId) {
-      try {
-        const recipient = await this.db.getUser(params.recipientUserId);
-        if (recipient?.isGhost && !recipient.deletedAt) {
-          // Check if we already sent a ghost invite for this session
-          const sessionMeta = await this.db.getSessionMetadata(params.sessionId);
-          const metadataObj = sessionMeta?.metadata as Record<string, unknown> | null;
-          const alreadySent = metadataObj?.ghostInviteSent === true;
-
-          if (!alreadySent) {
-            const sender = params.senderUserId
-              ? await this.db.getUser(params.senderUserId)
-              : null;
-
-            if (sender && recipient.email) {
-              const { ghostInviteTemplate } = await import('../lib/email/templates');
-              const appUrl = process.env.APP_URL || 'https://index.network';
-              const replyUrl = `${appUrl}/onboarding?ref=invite`;
-              // Use unsubscribe token instead of raw user ID
-              const notifSettings = await this.db.getOrCreateNotificationSettings(recipient.id);
-              const unsubscribeUrl = `${appUrl}/api/unsubscribe/${notifSettings.unsubscribeToken}`;
-
-              const email = ghostInviteTemplate(
-                recipient.name ?? 'there',
-                sender.name ?? 'Someone',
-                params.content,
-                replyUrl,
-                unsubscribeUrl,
-              );
-
-              const { emailQueue } = await import('../queues/email.queue');
-              await emailQueue.addJob({
-                to: recipient.email,
-                subject: email.subject,
-                html: email.html,
-                text: email.text,
-              });
-
-              // Mark as sent so we don't send again for this session
-              const metaId = generateSnowflakeId();
-              await this.db.upsertSessionMetadata({
-                id: metaId,
-                sessionId: params.sessionId,
-                metadata: {
-                  ...(metadataObj ?? {}),
-                  ghostInviteSent: true,
-                },
-              });
-
-              logger.verbose('Ghost invite email queued', {
-                sessionId: params.sessionId,
-              });
-            }
-          }
-        }
-      } catch (err) {
-        // Log but don't fail the message creation
-        logger.error('Failed to send ghost invite email', {
-          error: err,
-          sessionId: params.sessionId,
-        });
-      }
-    }
 
     return id;
   }

--- a/protocol/src/services/conversation.service.ts
+++ b/protocol/src/services/conversation.service.ts
@@ -88,9 +88,10 @@ export class ConversationService {
       metadata: opts?.metadata,
     });
 
+    const participants = await this.db.getParticipants(conversationId);
+
     // Publish to all participants' SSE channels (best-effort)
     try {
-      const participants = await this.db.getParticipants(conversationId);
       const event = JSON.stringify({
         type: 'message',
         conversationId,
@@ -106,6 +107,18 @@ export class ConversationService {
         conversationId,
         error: err instanceof Error ? err.message : String(err),
       });
+    }
+
+    // Ghost invite email: on first user message to a ghost, send an invite
+    if (role === 'user') {
+      try {
+        await this.sendGhostInviteIfNeeded(conversationId, senderId, parts, participants);
+      } catch (err) {
+        logger.error('[sendMessage] Ghost invite email failed', {
+          conversationId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
     }
 
     return msg;
@@ -146,6 +159,72 @@ export class ConversationService {
   async updateMetadata(conversationId: string, metadata: Record<string, unknown>, userId: string) {
     await this.verifyParticipant(userId, conversationId);
     return this.db.upsertMetadata(conversationId, metadata);
+  }
+
+  /**
+   * Sends a ghost invite email if any non-sender participant is a ghost user
+   * and no invite has been sent yet for this conversation.
+   */
+  private async sendGhostInviteIfNeeded(
+    conversationId: string,
+    senderId: string,
+    parts: unknown[],
+    participants: { participantId: string; participantType: string }[],
+  ): Promise<void> {
+    const otherUsers = participants.filter(
+      (p) => p.participantId !== senderId && p.participantType === 'user',
+    );
+    if (otherUsers.length === 0) return;
+
+    const metadata = await this.db.getMetadata(conversationId);
+    if (metadata?.ghostInviteSent) return;
+
+    for (const p of otherUsers) {
+      const recipient = await this.db.getUser(p.participantId);
+      if (!recipient || !recipient.isGhost || recipient.deletedAt || !recipient.email) continue;
+
+      const sender = await this.db.getUser(senderId);
+      if (!sender) continue;
+
+      const messageText = parts
+        .map((part) => (typeof part === 'object' && part !== null && 'text' in part ? (part as { text: string }).text : ''))
+        .filter(Boolean)
+        .join('\n') || '(attachment)';
+
+      const { ghostInviteTemplate } = await import('../lib/email/templates');
+      const { emailQueue } = await import('../queues/email.queue');
+
+      const appUrl = process.env.APP_URL || 'https://index.network';
+      const replyUrl = `${appUrl}/onboarding?ref=invite`;
+      const notifSettings = await this.db.getOrCreateNotificationSettings(recipient.id);
+      const unsubscribeUrl = `${appUrl}/api/unsubscribe/${notifSettings.unsubscribeToken}`;
+
+      const email = ghostInviteTemplate(
+        recipient.name ?? 'there',
+        sender.name ?? 'Someone',
+        messageText,
+        replyUrl,
+        unsubscribeUrl,
+      );
+
+      await emailQueue.addJob({
+        to: recipient.email,
+        subject: email.subject,
+        html: email.html,
+        text: email.text,
+      });
+
+      await this.db.upsertMetadata(conversationId, {
+        ...(metadata ?? {}),
+        ghostInviteSent: true,
+      });
+
+      logger.info('[sendMessage] Ghost invite email queued', {
+        conversationId,
+        recipientId: recipient.id,
+      });
+      break;
+    }
   }
 
   /**

--- a/protocol/src/startup.env.ts
+++ b/protocol/src/startup.env.ts
@@ -65,7 +65,7 @@ const envSchema = z.object({
 
   // 7. Email (Resend)
   RESEND_API_KEY: z.string().optional(),
-  ENABLE_EMAIL_TESTING: z.string().optional(),
+  EMAIL_PRODUCTION_MODE: z.string().optional(),
   TESTING_EMAIL_ADDRESS: z.string().email().optional(),
 
   // 8. Integrations


### PR DESCRIPTION
## Summary

- **Ghost invite emails now work**: Moved the logic from `ChatSessionService` (AI chat, never triggered) to `ConversationService.sendMessage()` (actual DM flow). When a user sends the first message to a ghost user, an invite email is queued.
- **Production email support**: Replaced `ENABLE_EMAIL_TESTING` with `EMAIL_PRODUCTION_MODE` flag. When `true`, emails go to real recipients. When absent/false, emails redirect to `TESTING_EMAIL_ADDRESS` or are skipped entirely.
- **Dead code removed**: Removed unused `recipientUserId`/`senderUserId` params and ghost invite block from `ChatSessionService.addMessage()` and `chat.controller.ts`.

## Changes

| File | What |
|---|---|
| `adapters/database.adapter.ts` | Added `getUser()` and `getOrCreateNotificationSettings()` to `ConversationDatabaseAdapter` |
| `services/conversation.service.ts` | Added `sendGhostInviteIfNeeded()` called from `sendMessage()` |
| `lib/email/transport.helper.ts` | Rewrote guard logic with `EMAIL_PRODUCTION_MODE` flag |
| `services/chat.service.ts` | Removed dead ghost invite code block |
| `controllers/chat.controller.ts` | Removed `recipientUserId` from schema and usage |
| `startup.env.ts` | Replaced `ENABLE_EMAIL_TESTING` with `EMAIL_PRODUCTION_MODE` in env validation |
| `.env.example` | Updated documentation for new flag |

## Environment Variables

| `EMAIL_PRODUCTION_MODE` | `TESTING_EMAIL_ADDRESS` | Behavior |
|---|---|---|
| `true` | (ignored) | Send to real recipient |
| absent/false | set | Redirect to test address |
| absent/false | not set | Skip — no email sent |

## Test plan

- [ ] Send a DM to a ghost user → verify invite email is queued and received
- [ ] Send a second message in the same conversation → verify no duplicate email
- [ ] Verify non-ghost DMs don't trigger any email
- [ ] Verify `EMAIL_PRODUCTION_MODE=true` sends to real recipient
- [ ] Verify without the flag, emails redirect to `TESTING_EMAIL_ADDRESS`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ghost-invite emails are now sent from the conversation send flow, queued reliably, and respect user notification settings and unsubscribe links.

* **Bug Fixes**
  * Email configuration updated: new EMAIL_PRODUCTION_MODE controls real vs. redirected sends; non-production redirects to TESTING_EMAIL_ADDRESS (or skips if unset).
  * Chat streaming no longer requires a recipient ID in the request.

* **Chores**
  * Improved backend handling for user and notification settings used by email flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->