### PR TITLE
fix: inject enricher in profile queue to prevent ghost deletion and null crash

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,13 +27,11 @@ jobs:
           bun-version: "1.2.20"
 
       - name: Install dependencies
-        run: |
-          bun install
-          cd protocol && bun install
+        run: bun install
 
       - name: Check architectural boundaries
         run: |
-          cd protocol
+          cd packages/protocol
           bunx eslint src/ --format json 2>/dev/null | bun -e '
             const results = JSON.parse(await Bun.stdin.text());
             const violations = results

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Check architectural boundaries
         run: |
-          cd packages/protocol
+          cd backend
           bunx eslint src/ --format json 2>/dev/null | bun -e '
             const results = JSON.parse(await Bun.stdin.text());
             const violations = results

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,9 @@ jobs:
           bun-version: "1.2.20"
 
       - name: Install dependencies
-        run: bun install
+        run: |
+          bun install
+          cd backend && bun install
 
       - name: Check architectural boundaries
         run: |

--- a/backend/src/queues/profile.queue.ts
+++ b/backend/src/queues/profile.queue.ts
@@ -5,6 +5,7 @@ import { ProfileDatabaseAdapter } from '../adapters/database.adapter';
 import { EmbedderAdapter } from '../adapters/embedder.adapter';
 import { ScraperAdapter } from '../adapters/scraper.adapter';
 import { ProfileGraphFactory } from '@indexnetwork/protocol';
+import { enrichUserProfile } from '../lib/parallel/parallel';
 
 /** BullMQ queue name for profile HyDE (ensure profile + HyDE) jobs. */
 export const QUEUE_NAME = 'profile-hyde-queue';
@@ -207,7 +208,7 @@ export class ProfileQueue {
     const database = new ProfileDatabaseAdapter();
     const embedder = new EmbedderAdapter();
     const scraper = new ScraperAdapter();
-    const factory = new ProfileGraphFactory(database, embedder, scraper);
+    const factory = new ProfileGraphFactory(database, embedder, scraper, { enrichUserProfile });
     const graph = factory.createGraph();
     return graph.invoke({ userId, operationMode });
   }

--- a/packages/protocol/src/graphs/profile.graph.ts
+++ b/packages/protocol/src/graphs/profile.graph.ts
@@ -140,11 +140,11 @@ export class ProfileGraphFactory {
                     hasProfile: true,
                     profile: {
                       id: profileWithId?.id,
-                      name: profile.identity.name,
-                      bio: profile.identity.bio,
-                      location: profile.identity.location,
-                      skills: profile.attributes.skills,
-                      interests: profile.attributes.interests,
+                      name: profile.identity?.name,
+                      bio: profile.identity?.bio,
+                      location: profile.identity?.location,
+                      skills: profile.attributes?.skills,
+                      interests: profile.attributes?.interests,
                     },
                   }
                 : {
@@ -401,10 +401,18 @@ export class ProfileGraphFactory {
             return parts || "No information available";
           };
 
+          if (!this.enricher) {
+            logger.warn("No enricher configured — falling back to basic info", { userId: state.userId });
+            return {
+              input: buildBasicInfo(),
+              needsUserInfo: false,
+              needsProfileGeneration: true,
+              operationsPerformed: { scraped: true },
+            };
+          }
+
           try {
-            const enrichment = this.enricher
-              ? await this.enricher.enrichUserProfile(request)
-              : null;
+            const enrichment = await this.enricher.enrichUserProfile(request);
 
             if (enrichment && !enrichment.isHuman) {
               logger.info("Enrichment detected non-human entity, soft-deleting ghost", { userId: state.userId });
@@ -620,14 +628,14 @@ export class ProfileGraphFactory {
           const profile = { ...state.profile };
           const textToEmbed = [
             '# Identity',
-            '## Name', profile.identity.name,
-            '## Bio', profile.identity.bio,
-            '## Location', profile.identity.location,
+            '## Name', profile.identity?.name ?? '',
+            '## Bio', profile.identity?.bio ?? '',
+            '## Location', profile.identity?.location ?? '',
             '# Narrative',
-            '## Context', profile.narrative.context,
+            '## Context', profile.narrative?.context ?? '',
             '# Attributes',
-            '## Interests', profile.attributes.interests.join(', '),
-            '## Skills', profile.attributes.skills.join(', ')
+            '## Interests', (profile.attributes?.interests ?? []).join(', '),
+            '## Skills', (profile.attributes?.skills ?? []).join(', ')
           ].join('\n');
 
           logger.verbose("Generating embedding...", {
@@ -677,7 +685,7 @@ export class ProfileGraphFactory {
 
         logger.verbose("Starting HyDE generation...", {
           userId: state.userId,
-          profileName: state.profile.identity.name
+          profileName: state.profile.identity?.name
         });
 
         const agentTimingsAccum: DebugMetaAgent[] = [];


### PR DESCRIPTION
## Summary

- **Inject enricher** into `ProfileQueue.invokeProfileGraph()` — it was the only call site creating `ProfileGraphFactory` without the enricher, causing `generate` mode to silently fail for all contact adds and Gmail imports
- **Guard missing enricher** in `autoGenerateNode` — falls back to basic info instead of treating a missing enricher as "low-confidence enrichment" and soft-deleting the ghost user
- **Add null safety** with optional chaining on `profile.identity?.name` etc. in `checkStateNode`, `embedSaveProfileNode`, and `generateHydeNode` to prevent crashes when the graph continues past errors

## Context

When adding a contact or importing Gmail contacts, new ghost users are created and enrichment jobs are enqueued. Without the enricher injected, the profile graph in `generate` mode would:
1. Get `null` from the enricher (since it wasn't configured)
2. Treat it as failed enrichment and **soft-delete the ghost user** that was just added
3. Crash on `profile.identity.name` because the empty profile row has `identity: null`

## Test plan

- [ ] Add a contact via `index contact add <email> --name "<name>"` — verify enrichment completes without error
- [ ] Import Gmail contacts — verify new ghosts are enriched, not deleted
- [ ] Check Railway logs for absence of `null is not an object` errors after deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile generation stability by safely handling missing or incomplete identity, narrative, attributes, skills, and interests.
  * Added a clear fallback path when profile enrichment is unavailable to avoid failures and ensure continued profile processing.
  * Safer embedding and logging when profile data is partial, reducing runtime errors and improving reliability.

* **Refactor**
  * Reworked profile enrichment integration to accept injected enrichment implementations for more predictable invocation.

* **Chores**
  * Simplified CI install step and adjusted lint checks to run in the backend workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->