### PR TITLE
fix(cli): align versioning and stabilize tests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,11 +29,11 @@ jobs:
       - name: Install dependencies
         run: |
           bun install
-          cd protocol && bun install
+          cd backend && bun install
 
       - name: Check architectural boundaries
         run: |
-          cd protocol
+          cd backend
           bunx eslint src/ --format json 2>/dev/null | bun -e '
             const results = JSON.parse(await Bun.stdin.text());
             const violations = results

--- a/packages/cli/npm/darwin-arm64/package.json
+++ b/packages/cli/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/cli-darwin-arm64",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Platform-specific binary for @indexnetwork/cli (macOS arm64)",
   "license": "MIT",
   "os": [

--- a/packages/cli/npm/darwin-arm64/package.json
+++ b/packages/cli/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/cli-darwin-arm64",
-  "version": "0.9.2",
+  "version": "0.9.4",
   "description": "Platform-specific binary for @indexnetwork/cli (macOS arm64)",
   "license": "MIT",
   "os": [

--- a/packages/cli/npm/darwin-x64/package.json
+++ b/packages/cli/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/cli-darwin-x64",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Platform-specific binary for @indexnetwork/cli (macOS x64)",
   "license": "MIT",
   "os": [

--- a/packages/cli/npm/darwin-x64/package.json
+++ b/packages/cli/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/cli-darwin-x64",
-  "version": "0.9.2",
+  "version": "0.9.4",
   "description": "Platform-specific binary for @indexnetwork/cli (macOS x64)",
   "license": "MIT",
   "os": [

--- a/packages/cli/npm/linux-arm64/package.json
+++ b/packages/cli/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/cli-linux-arm64",
-  "version": "0.9.2",
+  "version": "0.9.4",
   "description": "Platform-specific binary for @indexnetwork/cli (Linux arm64)",
   "license": "MIT",
   "os": [

--- a/packages/cli/npm/linux-arm64/package.json
+++ b/packages/cli/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/cli-linux-arm64",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Platform-specific binary for @indexnetwork/cli (Linux arm64)",
   "license": "MIT",
   "os": [

--- a/packages/cli/npm/linux-x64/package.json
+++ b/packages/cli/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/cli-linux-x64",
-  "version": "0.9.2",
+  "version": "0.9.4",
   "description": "Platform-specific binary for @indexnetwork/cli (Linux x64)",
   "license": "MIT",
   "os": [

--- a/packages/cli/npm/linux-x64/package.json
+++ b/packages/cli/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/cli-linux-x64",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Platform-specific binary for @indexnetwork/cli (Linux x64)",
   "license": "MIT",
   "os": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/cli",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Command-line interface for Index Network",
   "license": "MIT",
   "type": "module",
@@ -20,10 +20,10 @@
     "publish:all": "bun scripts/publish.ts"
   },
   "optionalDependencies": {
-    "@indexnetwork/cli-linux-x64": "0.9.4",
-    "@indexnetwork/cli-linux-arm64": "0.9.4",
-    "@indexnetwork/cli-darwin-x64": "0.9.4",
-    "@indexnetwork/cli-darwin-arm64": "0.9.4"
+    "@indexnetwork/cli-linux-x64": "0.9.5",
+    "@indexnetwork/cli-linux-arm64": "0.9.5",
+    "@indexnetwork/cli-darwin-x64": "0.9.5",
+    "@indexnetwork/cli-darwin-arm64": "0.9.5"
   },
   "devDependencies": {
     "@types/bun": "latest"

--- a/packages/cli/src/login.command.ts
+++ b/packages/cli/src/login.command.ts
@@ -14,6 +14,17 @@ export interface LoginOptions {
   signal?: AbortSignal;
   /** Timeout in milliseconds for the callback server. Defaults to 120_000 (2 min). */
   timeoutMs?: number;
+  /** Override the callback server factory for tests. */
+  serverFactory?: (handler: (req: IncomingMessage, res: ServerResponse) => void | Promise<void>) => CallbackServer;
+  /** Host to bind the callback server to. Defaults to 127.0.0.1. */
+  callbackHost?: string;
+}
+
+interface CallbackServer {
+  listen(port: number, host: string, callback: () => void): void;
+  address(): ReturnType<Server["address"]>;
+  close(callback: (err?: Error | null) => void): void;
+  closeAllConnections(): void;
 }
 
 /** Return value from handleLogin — gives the caller the auth URL and a promise. */
@@ -31,7 +42,7 @@ export interface LoginHandle {
  *
  * @param server - The HTTP server to close.
  */
-function closeServer(server: Server): Promise<void> {
+function closeServer(server: CallbackServer): Promise<void> {
   return new Promise<void>((resolve) => {
     server.close(() => resolve());
     // Force-close any lingering keep-alive connections
@@ -63,6 +74,7 @@ export async function handleLogin(
   const timeoutMs = options.timeoutMs ?? 120_000;
   const baseUrl = apiUrl.replace(/\/$/, "");
   const baseAppUrl = appUrl.replace(/\/$/, "");
+  const callbackHost = options.callbackHost ?? "127.0.0.1";
 
   let resolveCallback: (result: LoginResult) => void;
   const callbackPromise = new Promise<LoginResult>((resolve) => {
@@ -70,7 +82,7 @@ export async function handleLogin(
   });
 
   // Start local callback server on ephemeral port using node:http
-  const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+  const server = (options.serverFactory ?? createServer)(async (req: IncomingMessage, res: ServerResponse) => {
     const url = new URL(req.url ?? "/", `http://localhost`);
 
     if (url.pathname === "/callback") {
@@ -101,12 +113,12 @@ export async function handleLogin(
 
   // Listen on port 0 for ephemeral port assignment
   await new Promise<void>((resolve) => {
-    server.listen(0, () => resolve());
+    server.listen(0, callbackHost, () => resolve());
   });
 
   const addr = server.address();
   const port = typeof addr === "object" && addr ? addr.port : 0;
-  const callbackUrl = `http://localhost:${port}/callback`;
+  const callbackUrl = `http://${callbackHost}:${port}/callback`;
 
   // Construct the auth URL
   // Default: session exchange page that converts existing browser session to CLI token

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -26,7 +26,7 @@ import * as output from "./output";
 
 const DEFAULT_API_URL = "https://protocol.index.network";
 const DEFAULT_APP_URL = "https://index.network";
-const VERSION = "0.9.4";
+const VERSION = "0.9.5";
 
 const HELP_TEXT = `
 Index CLI v${VERSION}

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -26,7 +26,7 @@ import * as output from "./output";
 
 const DEFAULT_API_URL = "https://protocol.index.network";
 const DEFAULT_APP_URL = "https://index.network";
-const VERSION = "0.9.2";
+const VERSION = "0.9.4";
 
 const HELP_TEXT = `
 Index CLI v${VERSION}

--- a/packages/cli/src/opportunity.command.ts
+++ b/packages/cli/src/opportunity.command.ts
@@ -181,7 +181,7 @@ async function discoverIntroduction(
   hint?: string,
   json?: boolean,
 ): Promise<void> {
-  output.info("Gathering data for introduction...");
+  if (!json) output.info("Gathering data for introduction...");
 
   // Step 1: Find shared indexes between the two users
   const [membershipsA, membershipsB] = await Promise.all([
@@ -209,7 +209,7 @@ async function discoverIntroduction(
   }
 
   const sharedNetworkId = shared[0].networkId;
-  output.dim(`  Found shared network: ${sharedNetworkId}`);
+  if (!json) output.dim(`  Found shared network: ${sharedNetworkId}`);
 
   // Step 2: Gather profiles and intents in parallel
   const [profileA, profileB, intentsA, intentsB] = await Promise.all([
@@ -218,6 +218,19 @@ async function discoverIntroduction(
     client.callTool("read_intents", { userId: userA, networkId: sharedNetworkId }),
     client.callTool("read_intents", { userId: userB, networkId: sharedNetworkId }),
   ]);
+
+  const gatherError =
+    profileA.error ??
+    profileB.error ??
+    intentsA.error ??
+    intentsB.error;
+
+  if (!profileA.success || !profileB.success || !intentsA.success || !intentsB.success) {
+    const err = gatherError ?? "Failed to gather profiles and intents for introduction.";
+    if (json) { console.log(JSON.stringify({ success: false, error: err })); return; }
+    output.error(err, 1);
+    return;
+  }
 
   const extractProfile = (result: { success: boolean; data?: Record<string, unknown> }) => {
     if (!result.success || !result.data) return undefined;
@@ -241,7 +254,7 @@ async function discoverIntroduction(
     { userId: userB, profile: extractProfile(profileB), intents: extractIntents(intentsB), networkId: sharedNetworkId },
   ];
 
-  output.dim("  Profiles and intents gathered. Creating introduction...");
+  if (!json) output.dim("  Profiles and intents gathered. Creating introduction...");
 
   // Step 3: Call create_opportunities with full entity data
   const result = await client.callTool("create_opportunities", {

--- a/packages/cli/src/output/base.ts
+++ b/packages/cli/src/output/base.ts
@@ -159,7 +159,8 @@ export function wordWrap(text: string, maxWidth: number): string[] {
 
 /** Render a confidence percentage as a small bar. */
 export function confidenceBar(confidence: number): string {
-  const pct = Math.round(confidence);
+  const normalized = confidence <= 1 ? confidence * 100 : confidence;
+  const pct = Math.round(normalized);
   const filled = Math.round(pct / 10);
   const empty = 10 - filled;
   return `${GREEN}${"#".repeat(filled)}${GRAY}${"-".repeat(empty)}${RESET} ${GRAY}${pct}%`;

--- a/packages/cli/src/scrape.command.ts
+++ b/packages/cli/src/scrape.command.ts
@@ -20,7 +20,7 @@ export async function handleScrape(
 ): Promise<void> {
   const url = positionals[0];
   if (!url) { output.error("Usage: index scrape <url> [--objective <text>]", 1); return; }
-  output.info(`Scraping ${url}...`);
+  if (!options.json) output.info(`Scraping ${url}...`);
   const result = await client.callTool("scrape_url", { url, objective: options.objective });
   if (options.json) { console.log(JSON.stringify(result)); return; }
   if (!result.success) { output.error(result.error ?? "Scrape failed", 1); return; }

--- a/packages/cli/tests/api.client.test.ts
+++ b/packages/cli/tests/api.client.test.ts
@@ -1,45 +1,19 @@
 import { describe, it, expect, beforeAll, afterAll } from "bun:test";
 
 import { ApiClient } from "../src/api.client";
-
-/** Minimal mock server for API client tests. */
-function createMockServer() {
-  const handlers: Record<string, (req: Request) => Response | Promise<Response>> = {};
-
-  const server = Bun.serve({
-    port: 0,
-    fetch(req) {
-      const url = new URL(req.url);
-      const key = `${req.method} ${url.pathname}`;
-      const handler = handlers[key];
-      if (handler) return handler(req);
-      return new Response("Not Found", { status: 404 });
-    },
-  });
-
-  return {
-    server,
-    url: `http://localhost:${server.port}`,
-    on(method: string, path: string, handler: (req: Request) => Response | Promise<Response>) {
-      handlers[`${method} ${path}`] = handler;
-    },
-    stop() {
-      server.stop(true);
-    },
-  };
-}
+import { createMockServer } from "./helpers/mock-http";
 
 describe("ApiClient", () => {
   let mock: ReturnType<typeof createMockServer>;
   let client: ApiClient;
 
-  beforeAll(() => {
-    mock = createMockServer();
+  beforeAll(async () => {
+    mock = await createMockServer();
     client = new ApiClient(mock.url, "test-token-123");
   });
 
-  afterAll(() => {
-    mock.stop();
+  afterAll(async () => {
+    await mock.stop();
   });
 
   describe("listSessions", () => {

--- a/packages/cli/tests/conversation.command.test.ts
+++ b/packages/cli/tests/conversation.command.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeAll, afterAll } from "bun:test";
 import { parseArgs } from "../src/args.parser";
 import { ApiClient } from "../src/api.client";
 import { handleConversation, renderSSEStream } from "../src/conversation.command";
+import { createMockServer, createMockSSEServer } from "./helpers/mock-http";
 
 // ── Argument parsing tests ────────────────────────────────────────
 
@@ -62,47 +63,19 @@ describe("parseArgs — conversation command", () => {
   });
 });
 
-// ── Mock server helper ────────────────────────────────────────────
-
-function createMockServer() {
-  const handlers: Record<string, (req: Request) => Response | Promise<Response>> = {};
-
-  const server = Bun.serve({
-    port: 0,
-    fetch(req) {
-      const url = new URL(req.url);
-      const key = `${req.method} ${url.pathname}`;
-      const handler = handlers[key];
-      if (handler) return handler(req);
-      return new Response("Not Found", { status: 404 });
-    },
-  });
-
-  return {
-    server,
-    url: `http://localhost:${server.port}`,
-    on(method: string, path: string, handler: (req: Request) => Response | Promise<Response>) {
-      handlers[`${method} ${path}`] = handler;
-    },
-    stop() {
-      server.stop(true);
-    },
-  };
-}
-
 // ── API client conversation methods ───────────────────────────────
 
 describe("ApiClient — conversation methods", () => {
   let mock: ReturnType<typeof createMockServer>;
   let client: ApiClient;
 
-  beforeAll(() => {
-    mock = createMockServer();
+  beforeAll(async () => {
+    mock = await createMockServer();
     client = new ApiClient(mock.url, "test-token");
   });
 
-  afterAll(() => {
-    mock.stop();
+  afterAll(async () => {
+    await mock.stop();
   });
 
   it("listConversations returns conversations array", async () => {
@@ -181,13 +154,13 @@ describe("handleConversation", () => {
   let mock: ReturnType<typeof createMockServer>;
   let client: ApiClient;
 
-  beforeAll(() => {
-    mock = createMockServer();
+  beforeAll(async () => {
+    mock = await createMockServer();
     client = new ApiClient(mock.url, "test-token");
   });
 
-  afterAll(() => {
-    mock.stop();
+  afterAll(async () => {
+    await mock.stop();
   });
 
   it("lists conversations", async () => {
@@ -258,40 +231,6 @@ describe("handleConversation", () => {
 
 // ── renderSSEStream tests ────────────────────────────────────────
 
-/**
- * Creates a mock SSE server that emits the given raw SSE event strings.
- * The server format matches the protocol's formatSSEEvent: `data: {JSON}\n\n`.
- */
-function createMockSSEServer(events: string[]) {
-  const server = Bun.serve({
-    port: 0,
-    async fetch(req) {
-      const url = new URL(req.url);
-      if (req.method === "POST" && url.pathname === "/api/chat/stream") {
-        const encoder = new TextEncoder();
-        const stream = new ReadableStream({
-          start(controller) {
-            for (const event of events) {
-              controller.enqueue(encoder.encode(event));
-            }
-            controller.close();
-          },
-        });
-
-        return new Response(stream, {
-          headers: {
-            "Content-Type": "text/event-stream",
-            "X-Session-Id": "test-session-id",
-          },
-        });
-      }
-      return new Response("Not Found", { status: 404 });
-    },
-  });
-
-  return server;
-}
-
 /** Helper to build a `data: {JSON}\n\n` SSE event string. */
 function sseEvent(payload: Record<string, unknown>): string {
   return `data: ${JSON.stringify(payload)}\n\n`;
@@ -306,9 +245,9 @@ describe("renderSSEStream", () => {
       sseEvent({ type: "done", sessionId: "s1", timestamp: "t", response: "Hello world!", title: "Test" }),
     ];
 
-    const server = createMockSSEServer(events);
+    const server = await createMockSSEServer(events);
     try {
-      const response = await fetch(`http://localhost:${server.port}/api/chat/stream`, {
+      const response = await fetch(`${server.url}/api/chat/stream`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ message: "hi" }),
@@ -321,7 +260,7 @@ describe("renderSSEStream", () => {
       expect(result.sessionId).toBe("s1");
       expect(result.title).toBe("Test");
     } finally {
-      server.stop(true);
+      await server.stop();
     }
   });
 
@@ -330,9 +269,9 @@ describe("renderSSEStream", () => {
       sseEvent({ type: "done", sessionId: "abc-123", timestamp: "t", response: "Hi", title: "Chat" }),
     ];
 
-    const server = createMockSSEServer(events);
+    const server = await createMockSSEServer(events);
     try {
-      const response = await fetch(`http://localhost:${server.port}/api/chat/stream`, {
+      const response = await fetch(`${server.url}/api/chat/stream`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ message: "hi" }),
@@ -341,7 +280,7 @@ describe("renderSSEStream", () => {
       const result = await renderSSEStream(response, { onToken: () => {} });
       expect(result.sessionId).toBe("abc-123");
     } finally {
-      server.stop(true);
+      await server.stop();
     }
   });
 
@@ -350,9 +289,9 @@ describe("renderSSEStream", () => {
       sseEvent({ type: "error", sessionId: "s1", timestamp: "t", message: "Something went wrong", code: "STREAM_ERROR" }),
     ];
 
-    const server = createMockSSEServer(events);
+    const server = await createMockSSEServer(events);
     try {
-      const response = await fetch(`http://localhost:${server.port}/api/chat/stream`, {
+      const response = await fetch(`${server.url}/api/chat/stream`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ message: "hi" }),
@@ -361,7 +300,7 @@ describe("renderSSEStream", () => {
       const result = await renderSSEStream(response, { onToken: () => {} });
       expect(result.error).toBe("Something went wrong");
     } finally {
-      server.stop(true);
+      await server.stop();
     }
   });
 
@@ -373,9 +312,9 @@ describe("renderSSEStream", () => {
       sseEvent({ type: "done", sessionId: "s1", timestamp: "t", response: "result" }),
     ];
 
-    const server = createMockSSEServer(events);
+    const server = await createMockSSEServer(events);
     try {
-      const response = await fetch(`http://localhost:${server.port}/api/chat/stream`, {
+      const response = await fetch(`${server.url}/api/chat/stream`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ message: "hi" }),
@@ -395,7 +334,7 @@ describe("renderSSEStream", () => {
       expect(statuses.length).toBeGreaterThan(0);
       expect(statuses.some((s) => s.includes("Searching"))).toBe(true);
     } finally {
-      server.stop(true);
+      await server.stop();
     }
   });
 
@@ -407,9 +346,9 @@ describe("renderSSEStream", () => {
       sseEvent({ type: "done", sessionId: "s1", timestamp: "t", response: "correct answer" }),
     ];
 
-    const server = createMockSSEServer(events);
+    const server = await createMockSSEServer(events);
     try {
-      const response = await fetch(`http://localhost:${server.port}/api/chat/stream`, {
+      const response = await fetch(`${server.url}/api/chat/stream`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ message: "hi" }),
@@ -418,7 +357,7 @@ describe("renderSSEStream", () => {
       const result = await renderSSEStream(response, { onToken: () => {} });
       expect(result.response).toBe("correct answer");
     } finally {
-      server.stop(true);
+      await server.stop();
     }
   });
 });

--- a/packages/cli/tests/helpers/mock-http.ts
+++ b/packages/cli/tests/helpers/mock-http.ts
@@ -1,0 +1,57 @@
+import { spyOn } from "bun:test";
+
+export type MockHandler = (req: Request) => Response | Promise<Response>;
+export type PatternHandler = (req: Request, match: RegExpMatchArray) => Response | Promise<Response>;
+
+export function createMockServer() {
+  const handlers: Record<string, MockHandler> = {};
+  const patterns: Array<{ method: string; pattern: RegExp; handler: PatternHandler }> = [];
+
+  const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+    const req = input instanceof Request ? input : new Request(input, init);
+    const url = new URL(req.url);
+    const key = `${req.method} ${url.pathname}`;
+
+    const exact = handlers[key];
+    if (exact) {
+      return await exact(req);
+    }
+
+    for (const route of patterns) {
+      if (route.method !== req.method) continue;
+      const match = url.pathname.match(route.pattern);
+      if (match) {
+        return await route.handler(req, match);
+      }
+    }
+
+    return new Response("Not Found", { status: 404 });
+  });
+
+  return {
+    url: "http://mock.local",
+    on(method: string, path: string, handler: MockHandler) {
+      handlers[`${method} ${path}`] = handler;
+    },
+    onPattern(method: string, pattern: RegExp, handler: PatternHandler) {
+      patterns.push({ method, pattern, handler });
+    },
+    stop() {
+      fetchSpy.mockRestore();
+    },
+  };
+}
+
+export function createMockSSEServer(events: string[]) {
+  const server = createMockServer();
+  server.on("POST", "/api/chat/stream", () =>
+    new Response(events.join(""), {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "X-Session-Id": "test-session-id",
+      },
+    }),
+  );
+
+  return server;
+}

--- a/packages/cli/tests/login.command.test.ts
+++ b/packages/cli/tests/login.command.test.ts
@@ -2,9 +2,50 @@ import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { EventEmitter } from "node:events";
+import type { IncomingMessage, ServerResponse } from "node:http";
 
 import { CredentialStore } from "../src/auth.store";
 import { handleLogin } from "../src/login.command";
+
+function createFakeLoginServer() {
+  let handler: ((req: IncomingMessage, res: ServerResponse) => void | Promise<void>) | undefined;
+  let port = 43123;
+
+  return {
+    factory(nextHandler: (req: IncomingMessage, res: ServerResponse) => void | Promise<void>) {
+      handler = nextHandler;
+
+      return {
+        listen(_listenPort: number, _host: string, callback: () => void) {
+          callback();
+        },
+        address() {
+          return { port, family: "IPv4", address: "127.0.0.1" };
+        },
+        close(callback: (err?: Error | null) => void) {
+          callback(null);
+        },
+        closeAllConnections() {},
+      };
+    },
+    async dispatch(path: string) {
+      if (!handler) throw new Error("Handler not initialized");
+
+      const req = new EventEmitter() as IncomingMessage;
+      req.url = path;
+      req.method = "GET";
+      req.headers = {};
+
+      const res = {
+        writeHead() {},
+        end() {},
+      } as unknown as ServerResponse;
+
+      await handler(req, res);
+    },
+  };
+}
 
 describe("handleLogin", () => {
   let tempDir: string;
@@ -22,9 +63,11 @@ describe("handleLogin", () => {
   it("starts a local callback server and returns the auth URL", async () => {
     const apiUrl = "http://localhost:3001";
     const controller = new AbortController();
+    const fakeServer = createFakeLoginServer();
 
     const { authUrl, port, callbackPromise } = await handleLogin(apiUrl, apiUrl, store, {
       signal: controller.signal,
+      serverFactory: fakeServer.factory,
     });
 
     expect(authUrl).toContain(apiUrl);
@@ -41,15 +84,14 @@ describe("handleLogin", () => {
   it("saves tokens when callback is received", async () => {
     const apiUrl = "http://localhost:3001";
     const controller = new AbortController();
+    const fakeServer = createFakeLoginServer();
 
     const { port, callbackPromise } = await handleLogin(apiUrl, apiUrl, store, {
       signal: controller.signal,
+      serverFactory: fakeServer.factory,
     });
 
-    // Simulate the OAuth callback with a mock token exchange
-    // The callback server expects a GET with a session token
-    const callbackUrl = `http://localhost:${port}/callback?session_token=mock-jwt-token`;
-    await fetch(callbackUrl);
+    await fakeServer.dispatch(`/callback?session_token=mock-jwt-token`);
 
     // Wait a moment for the handler to complete
     const result = await callbackPromise;
@@ -64,10 +106,12 @@ describe("handleLogin", () => {
   it("times out if no callback is received", async () => {
     const apiUrl = "http://localhost:3001";
     const controller = new AbortController();
+    const fakeServer = createFakeLoginServer();
 
     const { callbackPromise } = await handleLogin(apiUrl, apiUrl, store, {
       signal: controller.signal,
       timeoutMs: 200, // Short timeout for test
+      serverFactory: fakeServer.factory,
     });
 
     const result = await callbackPromise;

--- a/packages/cli/tests/network.command.test.ts
+++ b/packages/cli/tests/network.command.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeAll, afterAll } from "bun:test";
 import { parseArgs } from "../src/args.parser";
 import { ApiClient } from "../src/api.client";
 import { handleNetwork } from "../src/network.command";
+import { createMockServer } from "./helpers/mock-http";
 
 describe("parseArgs — network command", () => {
   it("parses 'network' with no subcommand as network-help", () => {
@@ -70,44 +71,17 @@ describe("parseArgs — network command", () => {
 
 // ── handleNetwork integration tests ────────────────────────────────
 
-/** Minimal mock server for network command tests. */
-function createMockServer() {
-  const handlers: Record<string, (req: Request) => Response | Promise<Response>> = {};
-
-  const server = Bun.serve({
-    port: 0,
-    fetch(req) {
-      const url = new URL(req.url);
-      const key = `${req.method} ${url.pathname}`;
-      const handler = handlers[key];
-      if (handler) return handler(req);
-      return new Response("Not Found", { status: 404 });
-    },
-  });
-
-  return {
-    server,
-    url: `http://localhost:${server.port}`,
-    on(method: string, path: string, handler: (req: Request) => Response | Promise<Response>) {
-      handlers[`${method} ${path}`] = handler;
-    },
-    stop() {
-      server.stop(true);
-    },
-  };
-}
-
 describe("handleNetwork", () => {
   let mock: ReturnType<typeof createMockServer>;
   let client: ApiClient;
 
-  beforeAll(() => {
-    mock = createMockServer();
+  beforeAll(async () => {
+    mock = await createMockServer();
     client = new ApiClient(mock.url, "test-token");
   });
 
-  afterAll(() => {
-    mock.stop();
+  afterAll(async () => {
+    await mock.stop();
   });
 
   it("lists networks, filtering out personal indexes", async () => {

--- a/packages/cli/tests/npm-packages.test.ts
+++ b/packages/cli/tests/npm-packages.test.ts
@@ -105,4 +105,14 @@ describe("main package.json", () => {
     expect(files).toContain("bin/");
     expect(files).toContain("dist/");
   });
+
+  it("keeps the CLI runtime version in sync with package.json", async () => {
+    const pkgPath = join(CLI_ROOT, "package.json");
+    const mainTsPath = join(CLI_ROOT, "src", "main.ts");
+    const raw = await readFile(pkgPath, "utf-8");
+    const mainTs = await readFile(mainTsPath, "utf-8");
+    const pkg = JSON.parse(raw) as { version: string };
+
+    expect(mainTs).toContain(`const VERSION = "${pkg.version}"`);
+  });
 });

--- a/packages/cli/tests/opportunity.command.test.ts
+++ b/packages/cli/tests/opportunity.command.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from "bun:test"
 
 import { parseArgs } from "../src/args.parser";
 import { ApiClient } from "../src/api.client";
+import { handleOpportunity } from "../src/opportunity.command";
 import * as output from "../src/output";
 import type { Opportunity } from "../src/api.client";
+import { createMockServer } from "./helpers/mock-http";
 
 describe("opportunity argument parsing", () => {
   it("parses 'opportunity list' subcommand", () => {
@@ -78,45 +80,17 @@ describe("opportunity argument parsing", () => {
 
 // ── API client tests ──────────────────────────────────────────────
 
-/** Minimal mock server for opportunity API tests. */
-function createMockServer() {
-  const handlers: Record<string, (req: Request) => Response | Promise<Response>> = {};
-
-  const server = Bun.serve({
-    port: 0,
-    fetch(req) {
-      const url = new URL(req.url);
-      // Match method + pathname (strip query params for matching)
-      const key = `${req.method} ${url.pathname}`;
-      const handler = handlers[key];
-      if (handler) return handler(req);
-      return new Response("Not Found", { status: 404 });
-    },
-  });
-
-  return {
-    server,
-    url: `http://localhost:${server.port}`,
-    on(method: string, path: string, handler: (req: Request) => Response | Promise<Response>) {
-      handlers[`${method} ${path}`] = handler;
-    },
-    stop() {
-      server.stop(true);
-    },
-  };
-}
-
 describe("opportunity API client", () => {
   let mock: ReturnType<typeof createMockServer>;
   let client: ApiClient;
 
-  beforeAll(() => {
-    mock = createMockServer();
+  beforeAll(async () => {
+    mock = await createMockServer();
     client = new ApiClient(mock.url, "test-token");
   });
 
-  afterAll(() => {
-    mock.stop();
+  afterAll(async () => {
+    await mock.stop();
   });
 
   describe("listOpportunities", () => {
@@ -252,5 +226,152 @@ describe("opportunity output renderers", () => {
       output.opportunityCard(opportunity);
       expect(captured).toContain("Peer");
     });
+  });
+});
+
+describe("opportunity command behavior", () => {
+  it("fails fast when introduction profile or intent gathering fails", async () => {
+    const calls: string[] = [];
+    const client = {
+      async callTool(toolName: string) {
+        calls.push(toolName);
+
+        if (toolName === "read_index_memberships") {
+          return {
+            success: true,
+            data: { memberships: [{ networkId: "shared-network" }] },
+          };
+        }
+
+        if (toolName === "read_user_profiles") {
+          return {
+            success: false,
+            error: "profile lookup failed",
+          };
+        }
+
+        if (toolName === "read_intents") {
+          return {
+            success: true,
+            data: { intents: [] },
+          };
+        }
+
+        if (toolName === "create_opportunities") {
+          return {
+            success: true,
+            data: {},
+          };
+        }
+
+        return {
+          success: false,
+          error: `unexpected tool ${toolName}`,
+        };
+      },
+    } as unknown as ApiClient;
+
+    const logs: string[] = [];
+    const log = console.log;
+    console.log = (...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    };
+
+    try {
+      await handleOpportunity(client, "discover", {
+        introduce: "user-a",
+        positionals: ["user-b"],
+        json: true,
+      });
+    } finally {
+      console.log = log;
+    }
+
+    expect(calls).not.toContain("create_opportunities");
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toContain("\"success\":false");
+    expect(logs[0]).toContain("profile lookup failed");
+  });
+
+  it("keeps --json output clean during introduction discovery", async () => {
+    const client = {
+      async callTool(toolName: string) {
+        if (toolName === "read_index_memberships") {
+          return {
+            success: true,
+            data: { memberships: [{ networkId: "shared-network" }] },
+          };
+        }
+
+        if (toolName === "read_user_profiles") {
+          return {
+            success: true,
+            data: { profile: { bio: "test" } },
+          };
+        }
+
+        if (toolName === "read_intents") {
+          return {
+            success: true,
+            data: { intents: [] },
+          };
+        }
+
+        return {
+          success: true,
+          data: { created: true },
+        };
+      },
+    } as unknown as ApiClient;
+
+    const logs: string[] = [];
+    const log = console.log;
+    console.log = (...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    };
+
+    try {
+      await handleOpportunity(client, "discover", {
+        introduce: "user-a",
+        positionals: ["user-b"],
+        json: true,
+      });
+    } finally {
+      console.log = log;
+    }
+
+    expect(logs).toHaveLength(1);
+    expect(() => JSON.parse(logs[0])).not.toThrow();
+  });
+
+  it("keeps --json output clean for scrape", async () => {
+    const { handleScrape } = await import("../src/scrape.command");
+    const client = {
+      async callTool() {
+        return {
+          success: true,
+          data: {
+            url: "https://example.com",
+            contentLength: 4,
+            content: "test",
+          },
+        };
+      },
+    } as unknown as ApiClient;
+
+    const logs: string[] = [];
+    const log = console.log;
+    console.log = (...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    };
+
+    try {
+      await handleScrape(client, ["https://example.com"], { json: true });
+    } finally {
+      console.log = log;
+    }
+
+    expect(logs).toHaveLength(1);
+    expect(() => JSON.parse(logs[0])).not.toThrow();
   });
 });

--- a/packages/cli/tests/output.formatters.test.ts
+++ b/packages/cli/tests/output.formatters.test.ts
@@ -170,6 +170,24 @@ describe("intentCard", () => {
     expect(output).toContain("Startup Network");
     expect(output).toContain("0.92");
   });
+
+  it("normalizes 0-1 confidence values to percentages", () => {
+    const output = captureLogs(() => {
+      intentCard({
+        id: "i2",
+        payload: "Find design partners",
+        summary: "Partner search",
+        status: "ACTIVE",
+        confidence: 0.72,
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-02T00:00:00Z",
+        archivedAt: null,
+      } as Intent);
+    });
+
+    expect(output).toContain("72%");
+    expect(output).not.toContain("1%");
+  });
 });
 
 // ── opportunityTable ────────────────────────────────────────────────
@@ -266,6 +284,25 @@ describe("opportunityCard", () => {
     expect(output).toContain("Bob");
     expect(output).toContain("Both are looking for cofounders");
     expect(output).toContain("You and Bob should connect!");
+  });
+
+  it("normalizes 0-1 confidence values to percentages", () => {
+    const output = captureLogs(() => {
+      opportunityCard({
+        id: "o2",
+        status: "pending",
+        counterpartName: "Bob",
+        interpretation: {
+          category: "collaboration",
+          confidence: 0.72,
+          reasoning: "Strong overlap",
+        },
+        createdAt: "2026-01-01T00:00:00Z",
+      } as Opportunity);
+    });
+
+    expect(output).toContain("72%");
+    expect(output).not.toContain("1%");
   });
 });
 

--- a/packages/cli/tests/profile.command.test.ts
+++ b/packages/cli/tests/profile.command.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeAll, afterAll } from "bun:test";
 import { parseArgs } from "../src/args.parser";
 import { ApiClient } from "../src/api.client";
 import { profileCard } from "../src/output";
+import { createMockServer } from "./helpers/mock-http";
 
 describe("parseArgs — profile command", () => {
   it("parses 'profile' with no args as view-own", () => {
@@ -48,43 +49,17 @@ describe("parseArgs — profile command", () => {
 
 // ── API client — profile methods ────────────────────────────────────
 
-function createMockServer() {
-  const handlers: Record<string, (req: Request) => Response | Promise<Response>> = {};
-
-  const server = Bun.serve({
-    port: 0,
-    fetch(req) {
-      const url = new URL(req.url);
-      const key = `${req.method} ${url.pathname}`;
-      const handler = handlers[key];
-      if (handler) return handler(req);
-      return new Response("Not Found", { status: 404 });
-    },
-  });
-
-  return {
-    server,
-    url: `http://localhost:${server.port}`,
-    on(method: string, path: string, handler: (req: Request) => Response | Promise<Response>) {
-      handlers[`${method} ${path}`] = handler;
-    },
-    stop() {
-      server.stop(true);
-    },
-  };
-}
-
 describe("ApiClient — profile methods", () => {
   let mock: ReturnType<typeof createMockServer>;
   let client: ApiClient;
 
-  beforeAll(() => {
-    mock = createMockServer();
+  beforeAll(async () => {
+    mock = await createMockServer();
     client = new ApiClient(mock.url, "test-token-123");
   });
 
-  afterAll(() => {
-    mock.stop();
+  afterAll(async () => {
+    await mock.stop();
   });
 
   describe("getUser", () => {

--- a/packages/cli/tests/tool-calls.test.ts
+++ b/packages/cli/tests/tool-calls.test.ts
@@ -18,6 +18,7 @@ import { handleNetwork } from "../src/network.command";
 import { handleContact } from "../src/contact.command";
 import { handleScrape } from "../src/scrape.command";
 import { handleSync } from "../src/sync.command";
+import { createMockServer as createBaseMockServer } from "./helpers/mock-http";
 
 // ── Mock server ──────────────────────────────────────────────────────
 
@@ -30,34 +31,16 @@ function createMockServer() {
   const toolCalls: ToolCall[] = [];
   const toolResponses: Record<string, Record<string, unknown>> = {};
   const restHandlers: Record<string, (req: Request) => Response | Promise<Response>> = {};
-
-  const server = Bun.serve({
-    port: 0,
-    async fetch(req) {
-      const url = new URL(req.url);
-
-      // Tool HTTP API
-      const toolMatch = url.pathname.match(/^\/api\/tools\/(.+)$/);
-      if (toolMatch && req.method === "POST") {
-        const toolName = toolMatch[1];
-        const body = (await req.json()) as { query?: Record<string, unknown> };
-        toolCalls.push({ toolName, query: body.query ?? {} });
-        const response = toolResponses[toolName] ?? { success: true, data: {} };
-        return Response.json(response);
-      }
-
-      // REST endpoints
-      const key = `${req.method} ${url.pathname}`;
-      const handler = restHandlers[key];
-      if (handler) return handler(req);
-
-      return Response.json({ error: "Not Found" }, { status: 404 });
-    },
+  const server = createBaseMockServer();
+  server.onPattern("POST", /^\/api\/tools\/(.+)$/, async (req, match) => {
+    const toolName = match[1];
+    const parsedBody = (await req.json()) as { query?: Record<string, unknown> };
+    toolCalls.push({ toolName, query: parsedBody.query ?? {} });
+    return Response.json(toolResponses[toolName] ?? { success: true, data: {} });
   });
 
   return {
-    server,
-    url: `http://localhost:${server.port}`,
+    url: server.url,
     toolCalls,
     /** Set a canned response for a tool name. */
     setToolResponse(toolName: string, response: Record<string, unknown>) {
@@ -66,12 +49,13 @@ function createMockServer() {
     /** Register a REST handler for non-tool endpoints. */
     onRest(method: string, path: string, handler: (req: Request) => Response | Promise<Response>) {
       restHandlers[`${method} ${path}`] = handler;
+      server.on(method, path, handler);
     },
     reset() {
       toolCalls.length = 0;
     },
     stop() {
-      server.stop(true);
+      server.stop();
     },
   };
 }
@@ -223,7 +207,7 @@ describe("CLI tool call contracts", () => {
       });
     });
 
-    it("link calls create_intent_index with intentId and indexId", async () => {
+    it("link calls create_intent_index with intentId and networkId", async () => {
       mock.setToolResponse("create_intent_index", { success: true, data: {} });
 
       await handleIntent(client, "link", {
@@ -236,11 +220,11 @@ describe("CLI tool call contracts", () => {
       expect(mock.toolCalls[0].toolName).toBe("create_intent_index");
       expect(mock.toolCalls[0].query).toEqual({
         intentId: "intent-123",
-        indexId: "index-456",
+        networkId: "index-456",
       });
     });
 
-    it("unlink calls delete_intent_index with intentId and indexId", async () => {
+    it("unlink calls delete_intent_index with intentId and networkId", async () => {
       mock.setToolResponse("delete_intent_index", { success: true, data: {} });
 
       await handleIntent(client, "unlink", {
@@ -253,7 +237,7 @@ describe("CLI tool call contracts", () => {
       expect(mock.toolCalls[0].toolName).toBe("delete_intent_index");
       expect(mock.toolCalls[0].query).toEqual({
         intentId: "intent-123",
-        indexId: "index-456",
+        networkId: "index-456",
       });
     });
 
@@ -330,7 +314,7 @@ describe("CLI tool call contracts", () => {
       mock.setToolResponse("read_index_memberships", {
         success: true,
         data: {
-          memberships: [{ indexId: "shared-index-1", indexTitle: "AI Network" }],
+          memberships: [{ networkId: "shared-index-1", indexTitle: "AI Network" }],
         },
       });
       mock.setToolResponse("read_user_profiles", {
@@ -366,20 +350,20 @@ describe("CLI tool call contracts", () => {
       expect(createCall.query.entities).toBeArray();
       expect(createCall.query.hint).toBe("both working on privacy ML");
 
-      const entities = createCall.query.entities as Array<{ userId: string; indexId: string; profile?: unknown; intents?: unknown }>;
+      const entities = createCall.query.entities as Array<{ userId: string; networkId: string; profile?: unknown; intents?: unknown }>;
       expect(entities).toHaveLength(2);
       expect(entities[0].userId).toBe("user-a");
-      expect(entities[0].indexId).toBe("shared-index-1");
+      expect(entities[0].networkId).toBe("shared-index-1");
       expect(entities[0].profile).toBeDefined();
       expect(entities[0].intents).toBeArray();
       expect(entities[1].userId).toBe("user-b");
-      expect(entities[1].indexId).toBe("shared-index-1");
+      expect(entities[1].networkId).toBe("shared-index-1");
     });
 
     it("discover --introduce without hint omits hint field", async () => {
       mock.setToolResponse("read_index_memberships", {
         success: true,
-        data: { memberships: [{ indexId: "idx-1" }] },
+        data: { memberships: [{ networkId: "idx-1" }] },
       });
       mock.setToolResponse("read_user_profiles", { success: true, data: { profile: { name: "X" } } });
       mock.setToolResponse("read_intents", { success: true, data: { intents: [] } });
@@ -457,7 +441,7 @@ describe("CLI tool call contracts", () => {
   // ── Network ──────────────────────────────────────────────────────
 
   describe("network", () => {
-    it("update calls update_index with indexId and settings", async () => {
+    it("update calls update_index with networkId and settings", async () => {
       mock.setToolResponse("update_index", { success: true, data: {} });
 
       await handleNetwork(client, "update", ["index-123"], {
@@ -468,19 +452,19 @@ describe("CLI tool call contracts", () => {
       expect(mock.toolCalls).toHaveLength(1);
       expect(mock.toolCalls[0].toolName).toBe("update_index");
       expect(mock.toolCalls[0].query).toEqual({
-        indexId: "index-123",
+        networkId: "index-123",
         settings: { title: "New Name", prompt: "Updated description" },
       });
     });
 
-    it("delete calls delete_index with indexId", async () => {
+    it("delete calls delete_index with networkId", async () => {
       mock.setToolResponse("delete_index", { success: true, data: {} });
 
       await handleNetwork(client, "delete", ["index-456"], {});
 
       expect(mock.toolCalls).toHaveLength(1);
       expect(mock.toolCalls[0].toolName).toBe("delete_index");
-      expect(mock.toolCalls[0].query).toEqual({ indexId: "index-456" });
+      expect(mock.toolCalls[0].query).toEqual({ networkId: "index-456" });
     });
   });
 


### PR DESCRIPTION
## Summary
- align CLI/package metadata at 0.9.5 and keep the runtime version checked against package.json
- keep JSON output machine-readable and fail fast when introduction data gathering fails
- stabilize CLI tests by replacing port-binding mocks and covering normalized confidence rendering

## Test Plan
- bun test packages/cli/tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CLI version to 0.9.5 across all platform-specific packages.

* **Bug Fixes**
  * Fixed confidence percentage calculations to properly normalize decimal values (0–1 range) to percentage display.
  * Improved error handling during opportunity discovery; operations now exit gracefully with error details if profile or intent data retrieval fails.
  * Suppressed unnecessary progress messages when using `--json` output mode for cleaner JSON responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->