### PR TITLE
feat: wire ConnectorSection on profile page, remove mock data

### DIFF
--- a/frontend/src/app/u/[id]/page.tsx
+++ b/frontend/src/app/u/[id]/page.tsx
@@ -11,6 +11,7 @@ import ClientLayout from "@/components/ClientLayout";
 import { ContentContainer } from "@/components/layout";
 import InviteMessageModal from "@/components/InviteMessageModal";
 import NegotiationHistory from "@/components/NegotiationHistory";
+import ConnectorSection from "@/components/ConnectorSection";
 
 export default function UserProfilePage() {
   const { id } = useParams();
@@ -213,64 +214,16 @@ export default function UserProfilePage() {
             </div>
           )}
 
-          {/* You're the connector — only shown when viewing someone else's profile */}
-          {false && user?.id !== id && (
-            <div>
-              <h3 className="text-base font-bold text-gray-900 font-ibm-plex-mono mb-0.5">You&apos;re the connector</h3>
-              <p className="text-xs text-gray-400 mb-3">Intros you could make with {profileData?.name.split(' ')[0]}</p>
-              <div className="space-y-2">
-                {[
-                  {
-                    id: 'match-1',
-                    name: 'Riley Park',
-                    userId: 'mock-riley',
-                    avatar: null,
-                    reason: `Both ${profileData?.name.split(' ')[0]} and Riley are deep in agent infrastructure from different angles — they'd have a lot to stress-test together.`,
-                  },
-                  {
-                    id: 'match-2',
-                    name: 'Mia Chen',
-                    userId: 'mock-mia',
-                    avatar: null,
-                    reason: `Mia just relocated to the same city and is looking to plug into the local builder scene. ${profileData?.name.split(' ')[0]} would be a perfect first connection.`,
-                  },
-                ].map((match) => (
-                  <div key={match.id} className="bg-[#F8F8F8] rounded-md p-4">
-                    {/* Header: A <> B */}
-                    <div className="flex items-center justify-between gap-2 mb-3">
-                      <div className="flex items-center gap-2 min-w-0">
-                        <div className="flex items-center gap-2 shrink-0">
-                          <div className="flex items-center gap-1.5">
-                            <UserAvatar id={profileData?.id ?? ''} name={profileData?.name ?? ''} avatar={profileData?.avatar ?? null} size={24} />
-                            <span className="text-sm font-bold text-gray-900">{profileData?.name.split(' ')[0]}</span>
-                          </div>
-                          <span className="text-gray-400 text-xs">&lt;&gt;</span>
-                          <div className="flex items-center gap-1.5">
-                            <UserAvatar id={match.userId} name={match.name} avatar={match.avatar} size={24} />
-                            <span className="text-sm font-bold text-gray-900">{match.name}</span>
-                          </div>
-                        </div>
-                      </div>
-                      <div className="flex gap-1.5 shrink-0">
-                        <button className="bg-[#041729] text-white px-3 py-1.5 rounded-sm text-xs font-medium leading-none hover:bg-[#0a2d4a] transition-colors">
-                          Good match
-                        </button>
-                        <button className="bg-transparent border border-gray-400 text-[#3D3D3D] px-3 py-1.5 rounded-sm text-xs font-medium leading-none hover:bg-gray-200 transition-colors">
-                          Pass
-                        </button>
-                      </div>
-                    </div>
-                    {/* Reason */}
-                    <p className="text-[14px] text-[#3D3D3D] leading-relaxed">{match.reason}</p>
-                  </div>
-                ))}
-              </div>
-            </div>
+          {/* You're the connector — only when viewing someone else's profile */}
+          {isOtherUser && (
+            <ConnectorSection
+              profileUserId={id!}
+              profileFirstName={profileData.name.split(" ")[0]}
+            />
           )}
 
-
-          {/* Affiliations */}
-          {false && <div>
+          {/* TODO: Affiliations section — hidden until backend data is available
+          <div>
             <h3 className="text-base font-bold text-gray-900 font-ibm-plex-mono mb-3">Affiliations</h3>
             <div className="space-y-3">
               {[
@@ -290,7 +243,8 @@ export default function UserProfilePage() {
                 </div>
               ))}
             </div>
-          </div>}
+          </div>
+          */}
 
         </ContentContainer>
       </div>

--- a/frontend/src/components/ConnectorSection.tsx
+++ b/frontend/src/components/ConnectorSection.tsx
@@ -1,0 +1,141 @@
+import { useState, useEffect, useCallback } from "react";
+import { useOpportunities } from "@/contexts/APIContext";
+import { useNotifications } from "@/contexts/NotificationContext";
+import OpportunityCard, {
+  OpportunitySkeleton,
+  type OpportunityCardData,
+} from "@/components/chat/OpportunityCardInChat";
+import type { HomeViewCardItem } from "@/services/opportunities";
+
+interface ConnectorSectionProps {
+  profileUserId: string;
+  profileFirstName: string;
+}
+
+export default function ConnectorSection({
+  profileUserId,
+  profileFirstName,
+}: ConnectorSectionProps) {
+  const opportunitiesService = useOpportunities();
+  const { error: showError, success: showSuccess } = useNotifications();
+  const [connectorCards, setConnectorCards] = useState<HomeViewCardItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [actionLoading, setActionLoading] = useState<Record<string, boolean>>({});
+  const [actionStatus, setActionStatus] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    let cancelled = false;
+    const fetchConnectorOpportunities = async () => {
+      try {
+        setIsLoading(true);
+        const data = await opportunitiesService.getHomeView();
+        if (cancelled) return;
+        const introducerCards = data.sections
+          .flatMap((s) => s.items)
+          .filter(
+            (item) =>
+              item.viewerRole === "introducer" &&
+              (item.userId === profileUserId ||
+                item.secondParty?.userId === profileUserId)
+          );
+        setConnectorCards(introducerCards);
+      } catch {
+        if (!cancelled) setConnectorCards([]);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+    fetchConnectorOpportunities();
+    return () => {
+      cancelled = true;
+    };
+  }, [opportunitiesService, profileUserId]);
+
+  const handleAction = useCallback(
+    async (
+      opportunityId: string,
+      action: "accepted" | "rejected",
+      _userId?: string,
+      viewerRole?: string,
+      counterpartName?: string,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      _isGhost?: boolean,
+    ) => {
+      const isIntroducer = viewerRole === "introducer";
+      setActionLoading((prev) => ({ ...prev, [opportunityId]: true }));
+      try {
+        const effectiveStatus =
+          isIntroducer && action === "accepted" ? "pending" : action;
+        await opportunitiesService.updateStatus(opportunityId, effectiveStatus);
+        setActionStatus((prev) => ({
+          ...prev,
+          [opportunityId]: effectiveStatus,
+        }));
+
+        if (action === "accepted" && isIntroducer) {
+          showSuccess(
+            "Introduction sent",
+            `${counterpartName || "They"} will be notified and can accept to start the conversation.`,
+          );
+        }
+
+        setConnectorCards((prev) =>
+          prev.filter((c) => c.opportunityId !== opportunityId)
+        );
+      } catch (error) {
+        showError(
+          error instanceof Error ? error.message : "Failed to update opportunity"
+        );
+      } finally {
+        setActionLoading((prev) => ({ ...prev, [opportunityId]: false }));
+      }
+    },
+    [opportunitiesService, showError, showSuccess]
+  );
+
+  if (isLoading) {
+    return (
+      <div>
+        <h3 className="text-base font-bold text-gray-900 font-ibm-plex-mono mb-0.5">
+          You&apos;re the connector
+        </h3>
+        <p className="text-xs text-gray-400 mb-3">
+          Intros you could make with {profileFirstName}
+        </p>
+        <div className="space-y-2">
+          <OpportunitySkeleton />
+          <OpportunitySkeleton />
+        </div>
+      </div>
+    );
+  }
+
+  if (connectorCards.length === 0) {
+    return null;
+  }
+
+  return (
+    <div>
+      <h3 className="text-base font-bold text-gray-900 font-ibm-plex-mono mb-0.5">
+        You&apos;re the connector
+      </h3>
+      <p className="text-xs text-gray-400 mb-3">
+        Intros you could make with {profileFirstName}
+      </p>
+      <div className="space-y-2">
+        {connectorCards.map((card) => (
+          <OpportunityCard
+            key={card.opportunityId}
+            card={card as OpportunityCardData}
+            onPrimaryAction={handleAction}
+            onSecondaryAction={handleAction}
+            isLoading={actionLoading[card.opportunityId]}
+            currentStatus={
+              actionStatus[card.opportunityId] ?? card.status
+            }
+          />
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Created `ConnectorSection.tsx` component that fetches home view data, filters for introducer opportunities involving the profile user, and renders them using the existing `OpportunityCard` component
- Replaced the `{false && ...}` mock "You're the connector" block on the user profile page (`u/[id]/page.tsx`) with real data from `GET /opportunities/home`
- Connector section shows loading skeletons → connector cards with arrow layout → hidden when empty

## Changes
- **New:** `frontend/src/components/ConnectorSection.tsx` — fetches, filters (`viewerRole === 'introducer'` + profile user is a party), and renders connector opportunities
- **Modified:** `frontend/src/app/u/[id]/page.tsx` — removed mock data block, wired `ConnectorSection` with real API data
- "Make the intro" action uses `updateStatus(id, 'pending')` (introducer confirms, parties yet to accept)
- "Skip" action uses `updateStatus(id, 'rejected')`, removes card from local state
- Success toast on intro sent, error toast on failure
- Loading state with `OpportunitySkeleton`, empty state hides section, fetch error hides section gracefully

Closes IND-208

## Test Plan
- [ ] Navigate to another user's profile page
- [ ] Verify connector section shows skeletons while loading
- [ ] If connector opportunities exist, verify they render with arrow layout (NameA → NameB)
- [ ] Click "Make the intro" → verify toast "Introduction sent" appears and card is removed
- [ ] Click "Skip" → verify card is removed
- [ ] If no connector opportunities, verify section is hidden
- [ ] Verify no new lint errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new "Connector" section on user profiles that displays introduction opportunities associated with that user.
  * Users can now accept or manage introductions directly from a profile page, with real-time status updates and success notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->