### PR TITLE
fix: delete contact from personal network in networks panel

### DIFF
--- a/backend/src/controllers/user.controller.ts
+++ b/backend/src/controllers/user.controller.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { Controller, Get, Post, Put, UseGuards } from '../lib/router/router.decorators';
+import { Controller, Delete, Get, Post, Put, UseGuards } from '../lib/router/router.decorators';
 import { AuthGuard } from '../guards/auth.guard';
 import type { AuthenticatedUser } from '../guards/auth.guard';
 import { userService } from '../services/user.service';
@@ -73,6 +73,28 @@ export class UserController {
     logger.verbose('Add contact requested', { userId: user.id });
     const result = await contactService.addContact(user.id, parsed.data.email, { name: parsed.data.name });
     return Response.json({ result });
+  }
+
+  /**
+   * DELETE /users/contacts/:contactId — remove a contact from the authenticated user's personal network.
+   * @param _req - Request (unused)
+   * @param user - Authenticated user from AuthGuard
+   * @param params - Route params containing contactId (the contact's userId)
+   * @returns JSON `{ success: true }` or 404 if not found
+   */
+  @Delete('/contacts/:contactId')
+  @UseGuards(AuthGuard)
+  async removeContact(_req: Request, user: AuthenticatedUser, params: Record<string, string>) {
+    try {
+      await contactService.removeContact(user.id, params.contactId);
+      return Response.json({ success: true });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes('not found') || msg.includes('Not found')) {
+        return Response.json({ error: 'Contact not found' }, { status: 404 });
+      }
+      throw err;
+    }
   }
 
   /**

--- a/frontend/src/components/NetworkSettingsPanel.tsx
+++ b/frontend/src/components/NetworkSettingsPanel.tsx
@@ -285,7 +285,11 @@ export default function NetworkSettingsPanel({ index, onDeleted, activeTab }: Ne
 
   const handleRemoveMember = async (memberId: string) => {
     try {
-      await indexesService.removeMember(index.id, memberId);
+      if (index.isPersonal) {
+        await usersService.removeContact(memberId);
+      } else {
+        await indexesService.removeMember(index.id, memberId);
+      }
       setMembers(prev => prev.filter(m => m.id !== memberId));
     } catch (err) {
       console.error('Error removing member:', err);

--- a/frontend/src/services/users.ts
+++ b/frontend/src/services/users.ts
@@ -92,6 +92,13 @@ export const createUsersService = (api: ReturnType<typeof import('../lib/api').u
   },
 
   /**
+   * Remove a contact from the authenticated user's personal network.
+   */
+  removeContact: async (contactUserId: string): Promise<void> => {
+    await api.delete(`/users/contacts/${contactUserId}`);
+  },
+
+  /**
    * Get negotiation dashboard data: LLM-generated summary + structured stats. Self-only.
    */
   getNegotiationInsights: async (userId: string): Promise<NegotiationInsights | null> => {


### PR DESCRIPTION
Contacts live as network_members on the personal index, but the existing DELETE /networks/:id/members/:memberId path was blocked by assertNotPersonal(). Added DELETE /users/contacts/:contactId endpoint backed by ContactService.removeContact() and updated the frontend to call it when removing from a personal network.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now remove contacts from their personal network with a new delete option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->