### PR TITLE
feat(protocol): lean MCP tool surface + chat/intent/contact search

### DIFF
--- a/backend/src/adapters/contact.database.adapter.ts
+++ b/backend/src/adapters/contact.database.adapter.ts
@@ -5,7 +5,7 @@
  * ChatDatabaseAdapter do not interfere with ContactService integration tests.
  */
 
-import { eq, and, inArray, isNull, isNotNull, or, ilike, sql } from 'drizzle-orm';
+import { asc, eq, and, inArray, isNull, isNotNull, or, ilike, sql } from 'drizzle-orm';
 import * as schema from '../schemas/database.schema';
 import db from '../lib/drizzle/drizzle';
 
@@ -290,6 +290,7 @@ export class ContactDatabaseAdapter {
         isNull(schema.users.deletedAt),
         or(ilike(schema.users.name, pattern), ilike(schema.users.email, pattern)),
       ))
+      .orderBy(asc(schema.users.name), asc(schema.users.email))
       .limit(limit);
 
     return rows.map((row) => ({

--- a/backend/src/adapters/contact.database.adapter.ts
+++ b/backend/src/adapters/contact.database.adapter.ts
@@ -5,7 +5,7 @@
  * ChatDatabaseAdapter do not interfere with ContactService integration tests.
  */
 
-import { eq, and, inArray, isNull, isNotNull, sql } from 'drizzle-orm';
+import { eq, and, inArray, isNull, isNotNull, or, ilike, sql } from 'drizzle-orm';
 import * as schema from '../schemas/database.schema';
 import db from '../lib/drizzle/drizzle';
 
@@ -254,6 +254,50 @@ export class ContactDatabaseAdapter {
     return rows.map(row => ({
       userId: row.userId,
       user: { id: row.userId, name: row.userName, email: row.userEmail, avatar: row.userAvatar, isGhost: row.userIsGhost },
+    }));
+  }
+
+  async searchContactMembers(
+    ownerId: string,
+    q: string,
+    limit: number,
+  ): Promise<Array<{
+    contactId: string;
+    name: string;
+    email: string;
+    avatar: string | null;
+    isGhost: boolean;
+  }>> {
+    const personalIndexId = await getPersonalIndexId(ownerId);
+    if (!personalIndexId) return [];
+
+    const pattern = `%${q.replace(/[\\%_]/g, (c) => `\\${c}`)}%`;
+
+    const rows = await db
+      .select({
+        userId: schema.networkMembers.userId,
+        userName: schema.users.name,
+        userEmail: schema.users.email,
+        userAvatar: schema.users.avatar,
+        userIsGhost: schema.users.isGhost,
+      })
+      .from(schema.networkMembers)
+      .innerJoin(schema.users, eq(schema.networkMembers.userId, schema.users.id))
+      .where(and(
+        eq(schema.networkMembers.networkId, personalIndexId),
+        sql`'contact' = ANY(${schema.networkMembers.permissions})`,
+        isNull(schema.networkMembers.deletedAt),
+        isNull(schema.users.deletedAt),
+        or(ilike(schema.users.name, pattern), ilike(schema.users.email, pattern)),
+      ))
+      .limit(limit);
+
+    return rows.map((row) => ({
+      contactId: row.userId,
+      name: row.userName,
+      email: row.userEmail,
+      avatar: row.userAvatar,
+      isGhost: row.userIsGhost,
     }));
   }
 

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -6411,7 +6411,10 @@ export class ConversationDatabaseAdapter {
         and(
           eq(schema.conversationParticipants.participantId, userId),
           eq(schema.conversationParticipants.participantType, 'user'),
-          isNull(schema.conversationParticipants.hiddenAt),
+          or(
+            isNull(schema.conversationParticipants.hiddenAt),
+            gt(schema.conversations.lastMessageAt, schema.conversationParticipants.hiddenAt),
+          ),
           inArray(schema.conversations.id, chatSessionIds),
         ),
       )
@@ -6481,7 +6484,6 @@ export class ConversationDatabaseAdapter {
           eq(schema.conversationParticipants.conversationId, sessionId),
           eq(schema.conversationParticipants.participantId, userId),
           eq(schema.conversationParticipants.participantType, 'user'),
-          isNull(schema.conversationParticipants.hiddenAt),
         ),
       )
       .limit(1);
@@ -6525,10 +6527,10 @@ export class ConversationDatabaseAdapter {
       .select()
       .from(schema.messages)
       .where(eq(schema.messages.conversationId, sessionId))
-      .orderBy(asc(schema.messages.createdAt))
+      .orderBy(desc(schema.messages.createdAt))
       .limit(messageLimit);
 
-    const messages = msgRows.map((msg) => {
+    const messages = msgRows.reverse().map((msg) => {
       const parts = msg.parts as Array<{ type?: string; text?: string }>;
       const content =
         parts?.find((p) => p?.type === 'text' && typeof p.text === 'string')?.text

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -6346,6 +6346,189 @@ export class ConversationDatabaseAdapter {
   }
 
   /**
+   * List chat session summaries for a user, ordered by most recent activity.
+   * Mirrors `getUserChatSessions` but returns the `ChatSessionSummary` shape
+   * expected by `ChatSessionReader`.
+   *
+   * @param userId - The user whose sessions to list
+   * @param limit - Maximum number of sessions to return (default 25)
+   * @returns Array of chat session summaries
+   */
+  async listChatSessionSummaries(
+    userId: string,
+    limit = 25,
+  ): Promise<Array<{ sessionId: string; title: string | null; messageCount: number; lastMessageAt: Date | null; createdAt: Date }>> {
+    // Subquery: conversation IDs that include the system agent
+    const chatSessionIds = db
+      .select({ conversationId: schema.conversationParticipants.conversationId })
+      .from(schema.conversationParticipants)
+      .where(
+        and(
+          eq(schema.conversationParticipants.participantId, SYSTEM_AGENT_ID),
+          eq(schema.conversationParticipants.participantType, 'agent'),
+        ),
+      );
+
+    const rows = await db
+      .select({
+        id: schema.conversations.id,
+        lastMessageAt: schema.conversations.lastMessageAt,
+        createdAt: schema.conversations.createdAt,
+        updatedAt: schema.conversations.updatedAt,
+      })
+      .from(schema.conversationParticipants)
+      .innerJoin(
+        schema.conversations,
+        eq(schema.conversationParticipants.conversationId, schema.conversations.id),
+      )
+      .where(
+        and(
+          eq(schema.conversationParticipants.participantId, userId),
+          eq(schema.conversationParticipants.participantType, 'user'),
+          isNull(schema.conversationParticipants.hiddenAt),
+          inArray(schema.conversations.id, chatSessionIds),
+        ),
+      )
+      .orderBy(desc(schema.conversations.updatedAt))
+      .limit(limit);
+
+    if (rows.length === 0) return [];
+
+    const convIds = rows.map((r) => r.id);
+
+    // Batch-fetch metadata (titles)
+    const metaRows = await db
+      .select()
+      .from(schema.conversationMetadata)
+      .where(inArray(schema.conversationMetadata.conversationId, convIds));
+    const metaMap = new Map<string, ChatConversationMeta>(
+      metaRows.map((m) => [m.conversationId, m.metadata as ChatConversationMeta]),
+    );
+
+    // Batch-fetch message counts
+    const countRows = await db
+      .select({
+        conversationId: schema.messages.conversationId,
+        cnt: count(schema.messages.id),
+      })
+      .from(schema.messages)
+      .where(inArray(schema.messages.conversationId, convIds))
+      .groupBy(schema.messages.conversationId);
+    const countMap = new Map<string, number>(countRows.map((r) => [r.conversationId, Number(r.cnt)]));
+
+    return rows.map((conv) => ({
+      sessionId: conv.id,
+      title: (metaMap.get(conv.id)?.title) ?? null,
+      messageCount: countMap.get(conv.id) ?? 0,
+      lastMessageAt: conv.lastMessageAt ?? conv.updatedAt,
+      createdAt: conv.createdAt,
+    }));
+  }
+
+  /**
+   * Get full detail for a single chat session, including messages.
+   * Returns null if the user does not participate or it is not a chat session.
+   *
+   * @param userId - The requesting user
+   * @param sessionId - The conversation ID
+   * @param messageLimit - Maximum messages to return (default 50)
+   * @returns Session detail or null
+   */
+  async getChatSessionDetail(
+    userId: string,
+    sessionId: string,
+    messageLimit = 50,
+  ): Promise<{
+    sessionId: string;
+    title: string | null;
+    messageCount: number;
+    lastMessageAt: Date | null;
+    createdAt: Date;
+    messages: Array<{ role: string; content: string; createdAt: Date }>;
+  } | null> {
+    // Verify user participation
+    const [userParticipant] = await db
+      .select({ participantId: schema.conversationParticipants.participantId })
+      .from(schema.conversationParticipants)
+      .where(
+        and(
+          eq(schema.conversationParticipants.conversationId, sessionId),
+          eq(schema.conversationParticipants.participantId, userId),
+          eq(schema.conversationParticipants.participantType, 'user'),
+          isNull(schema.conversationParticipants.hiddenAt),
+        ),
+      )
+      .limit(1);
+
+    if (!userParticipant) return null;
+
+    // Verify system agent participation (i.e. it's a chat session, not a DM)
+    const [agentParticipant] = await db
+      .select({ participantId: schema.conversationParticipants.participantId })
+      .from(schema.conversationParticipants)
+      .where(
+        and(
+          eq(schema.conversationParticipants.conversationId, sessionId),
+          eq(schema.conversationParticipants.participantId, SYSTEM_AGENT_ID),
+          eq(schema.conversationParticipants.participantType, 'agent'),
+        ),
+      )
+      .limit(1);
+
+    if (!agentParticipant) return null;
+
+    // Fetch conversation row
+    const [conv] = await db
+      .select({
+        id: schema.conversations.id,
+        lastMessageAt: schema.conversations.lastMessageAt,
+        createdAt: schema.conversations.createdAt,
+        updatedAt: schema.conversations.updatedAt,
+      })
+      .from(schema.conversations)
+      .where(eq(schema.conversations.id, sessionId))
+      .limit(1);
+
+    if (!conv) return null;
+
+    // Fetch metadata
+    const meta = await this._getConvMeta(sessionId);
+
+    // Fetch messages (limited)
+    const msgRows = await db
+      .select()
+      .from(schema.messages)
+      .where(eq(schema.messages.conversationId, sessionId))
+      .orderBy(asc(schema.messages.createdAt))
+      .limit(messageLimit);
+
+    const messages = msgRows.map((msg) => {
+      const parts = msg.parts as Array<{ type?: string; text?: string }>;
+      const content =
+        parts?.find((p) => p?.type === 'text' && typeof p.text === 'string')?.text
+        ?? parts?.find((p) => typeof p?.text === 'string')?.text
+        ?? '';
+      const role = msg.role === 'agent' ? 'assistant' : msg.role;
+      return { role, content, createdAt: msg.createdAt };
+    });
+
+    // Count all messages (not limited)
+    const [{ totalCount }] = await db
+      .select({ totalCount: count(schema.messages.id) })
+      .from(schema.messages)
+      .where(eq(schema.messages.conversationId, sessionId));
+
+    return {
+      sessionId: conv.id,
+      title: meta?.title ?? null,
+      messageCount: Number(totalCount),
+      lastMessageAt: conv.lastMessageAt ?? conv.updatedAt,
+      createdAt: conv.createdAt,
+      messages,
+    };
+  }
+
+  /**
    * Update chat session index scope.
    */
   async updateChatSessionIndex(sessionId: string, networkId: string | null): Promise<void> {

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -842,6 +842,31 @@ export class ChatDatabaseAdapter {
     }
   }
 
+  async searchOwnIntents(
+    userId: string,
+    q: string,
+    limit: number,
+  ): Promise<Array<{ id: string; payload: string; summary: string | null; createdAt: Date }>> {
+    const pattern = `%${q.replace(/[\\%_]/g, (c) => `\\${c}`)}%`;
+    return db
+      .select({
+        id: schema.intents.id,
+        payload: schema.intents.payload,
+        summary: schema.intents.summary,
+        createdAt: schema.intents.createdAt,
+      })
+      .from(schema.intents)
+      .where(
+        and(
+          eq(schema.intents.userId, userId),
+          isNull(schema.intents.archivedAt),
+          or(ilike(schema.intents.payload, pattern), ilike(schema.intents.summary, pattern)),
+        ),
+      )
+      .orderBy(desc(schema.intents.createdAt))
+      .limit(limit);
+  }
+
   async getIntentsInIndexForMember(userId: string, indexNameOrId: string): Promise<ActiveIntentRow[]> {
     const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
     let networkId: string | null;
@@ -4818,6 +4843,7 @@ export function createUserDatabase(db: ChatDatabaseAdapter, authUserId: string) 
     // Intent Operations
     // ─────────────────────────────────────────────────────────────────────────────
     getActiveIntents: () => db.getActiveIntents(authUserId),
+    searchOwnIntents: (q: string, limit: number) => db.searchOwnIntents(authUserId, q, limit),
     getIntent: async (intentId: string) => {
       // Enforce ownership by checking userId on returned intent
       const intent = await db.getIntent(intentId);

--- a/backend/src/protocol-init.ts
+++ b/backend/src/protocol-init.ts
@@ -53,7 +53,16 @@ export function createDefaultProtocolDeps(): ProtocolDeps {
     integration,
     intentQueue,
     contactService,
-    chatSession: chatSessionService,
+    chatSession: {
+      getSessionMessages: async (sessionId, limit) => {
+        const rows = await chatSessionService.getSessionMessages(sessionId, limit);
+        return rows.map((m) => ({ role: m.role, content: m.content }));
+      },
+      listSessions: (userId, limit) =>
+        conversationDatabaseAdapter.listChatSessionSummaries(userId, limit),
+      getSession: (userId, sessionId, messageLimit) =>
+        conversationDatabaseAdapter.getChatSessionDetail(userId, sessionId, messageLimit),
+    },
     enricher: { enrichUserProfile },
     negotiationDatabase: conversationDatabaseAdapter as unknown as ProtocolDeps['negotiationDatabase'],
     integrationImporter: integrationService,

--- a/backend/src/services/chat.service.ts
+++ b/backend/src/services/chat.service.ts
@@ -53,7 +53,13 @@ export class ChatSessionService {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { createDefaultProtocolDeps } = require('../protocol-init');
       const protocolDeps = createDefaultProtocolDeps();
-      this._factory = new ChatGraphFactory(this.graphDb, this.embedder, this.scraper, this, protocolDeps);
+      const chatSessionReader = {
+        getSessionMessages: (sessionId: string, limit?: number) => this.getSessionMessages(sessionId, limit),
+        listSessions: (userId: string, limit?: number) => this.db.listChatSessionSummaries(userId, limit),
+        getSession: (userId: string, sessionId: string, messageLimit?: number) =>
+          this.db.getChatSessionDetail(userId, sessionId, messageLimit),
+      };
+      this._factory = new ChatGraphFactory(this.graphDb, this.embedder, this.scraper, chatSessionReader, protocolDeps);
     }
     return this._factory;
   }

--- a/backend/src/services/contact.service.ts
+++ b/backend/src/services/contact.service.ts
@@ -125,7 +125,7 @@ export class ContactService {
     // Look up existing user
     let user = await this.db.getUserByEmail(normalizedEmail);
     let isNew = false;
-    let isGhost = false;
+    let isGhost: boolean;
 
     if (!user) {
       // Create ghost user (handles concurrency, creates profile)
@@ -304,6 +304,23 @@ export class ContactService {
     user: { id: string; name: string; email: string; avatar: string | null; isGhost: boolean };
   }>> {
     return this.db.getContactMembers(ownerId);
+  }
+
+  /**
+   * Search the owner's contacts by name or email (case-insensitive ILIKE).
+   *
+   * @param ownerId - The user whose contacts to search
+   * @param q - Free-text query
+   * @param limit - Maximum rows to return (default 25)
+   */
+  async searchContacts(ownerId: string, q: string, limit = 25): Promise<Array<{
+    contactId: string;
+    name: string;
+    email: string;
+    avatar: string | null;
+    isGhost: boolean;
+  }>> {
+    return this.db.searchContactMembers(ownerId, q, limit);
   }
 
   /**

--- a/docs/design/protocol-deep-dive.md
+++ b/docs/design/protocol-deep-dive.md
@@ -426,10 +426,11 @@ Tools bridge the ChatAgent to subgraphs. Each tool file defines LangChain tool f
 | Tool File | Tools | Subgraph(s) Invoked |
 |-----------|-------|---------------------|
 | `profile.tools.ts` | read_user_profiles, create_user_profile, update_user_profile | Profile Graph |
-| `intent.tools.ts` | read_intents, create_intent, update_intent, delete_intent, create_intent_index, read_intent_indexes, delete_intent_index | Intent Graph, Intent Index Graph, Opportunity Graph (auto-discovery on create) |
+| `intent.tools.ts` | read_intents, create_intent, update_intent, delete_intent, search_intents, create_intent_index, read_intent_indexes, delete_intent_index | Intent Graph, Intent Index Graph, Opportunity Graph (auto-discovery on create) |
 | `network.tools.ts` | read_indexes, read_users, create_index, update_index, delete_index, create_index_membership | Index Graph, Index Membership Graph |
 | `opportunity.tools.ts` | create_opportunities, list_my_opportunities, send_opportunity | Opportunity Graph |
-| `contact.tools.ts` | add_contact, list_contacts | (direct service calls) |
+| `contact.tools.ts` | add_contact, list_contacts, search_contacts | (direct service calls) |
+| `chat.tools.ts` | list_conversations, get_conversation | (direct `ChatSessionReader` calls) |
 | `utility.tools.ts` | scrape_url, confirm_action, cancel_action | (direct scraper call, pending action state) |
 | `integration.tools.ts` | list_integrations, sync_integration | (service calls) |
 
@@ -488,7 +489,7 @@ Errors are trapped and returned as MCP error responses so a single failing tool 
 
 ### MCP_INSTRUCTIONS — the canonical behavioral contract
 
-`MCP_INSTRUCTIONS` is a long template string passed into the `McpServer` constructor as `instructions`. Every MCP client that connects receives it automatically and is expected to follow it for the session. It is the **single canonical home** for Index Network agent behavior — voice, banned vocabulary, the entity model, the discovery-first rule, personal-index scoping, output rules, and the **Negotiation turn mode** block. Plugin skill files, CLI wrappers, and marketplace manifests do not redefine this guidance; they defer to what ships in `MCP_INSTRUCTIONS`.
+`MCP_INSTRUCTIONS` is a template string passed into the `McpServer` constructor as `instructions`. Every MCP client that connects receives it automatically and is expected to follow it for the session. It carries the **global** contract: voice, banned vocabulary, the entity model, output rules, and pointers to tool descriptions for per-pattern behavior. Per-tool guidance (discovery-first, personal-index scoping, intent specificity, silent-subagent negotiation stance) lives in each tool's own description so it surfaces alongside the tool in MCP tool listings. Plugin skill files, CLI wrappers, and marketplace manifests do not redefine this guidance; they defer to what ships with the MCP server.
 
 When `MCP_INSTRUCTIONS` changes, every connected runtime picks up the new guidance on its next session — no plugin or skill release is needed.
 

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/chat/chat.tools.ts
+++ b/packages/protocol/src/chat/chat.tools.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+
+import type { DefineTool, ToolDeps } from "../shared/agent/tool.helpers.js";
+import { success, error, UUID_REGEX } from "../shared/agent/tool.helpers.js";
+
+export function createChatTools(defineTool: DefineTool, deps: ToolDeps) {
+  const { chatSession } = deps;
+  if (!chatSession) {
+    throw new Error("createChatTools requires `chatSession` in deps");
+  }
+
+  const listConversations = defineTool({
+    name: "list_conversations",
+    description:
+      "Lists the authenticated user's past chat conversations, most-recently-active first. Use when the user " +
+      "asks about their prior chats, wants to resume a conversation, or is orienting themselves in their own " +
+      "history. Only returns sessions the caller participates in.\n\n" +
+      "**Returns:** `conversations: [{ sessionId, title, messageCount, lastMessageAt, createdAt }]`. Use " +
+      "`sessionId` with `get_conversation` to read the full thread.",
+    querySchema: z.object({
+      limit: z
+        .number()
+        .int()
+        .positive()
+        .max(100)
+        .optional()
+        .describe("Maximum conversations to return (default 25, max 100)."),
+    }),
+    handler: async ({ context, query }) => {
+      const sessions = await chatSession.listSessions(context.userId, query.limit ?? 25);
+      return success({ conversations: sessions });
+    },
+  });
+
+  const getConversation = defineTool({
+    name: "get_conversation",
+    description:
+      "Fetches a single chat conversation belonging to the authenticated user, including its messages. " +
+      "Use after `list_conversations` has yielded a specific `sessionId` — for example when the user asks " +
+      "you to pick up a prior thread by topic or title. Returns an error if the session does not exist or " +
+      "the caller is not a participant.\n\n" +
+      "**Returns:** `{ sessionId, title, messageCount, lastMessageAt, createdAt, messages: [{ role, content, createdAt }] }`.",
+    querySchema: z.object({
+      sessionId: z.string().describe("Session UUID from list_conversations."),
+      messageLimit: z
+        .number()
+        .int()
+        .positive()
+        .max(500)
+        .optional()
+        .describe("Maximum messages to include (default 50, max 500)."),
+    }),
+    handler: async ({ context, query }) => {
+      if (!UUID_REGEX.test(query.sessionId)) {
+        return error("Invalid session ID format. Pass a sessionId returned by list_conversations.");
+      }
+      const session = await chatSession.getSession(
+        context.userId,
+        query.sessionId,
+        query.messageLimit ?? 50,
+      );
+      if (!session) {
+        return error("Conversation not found or you are not a participant.");
+      }
+      return success(session);
+    },
+  });
+
+  return { listConversations, getConversation };
+}

--- a/packages/protocol/src/chat/tests/chat.graph.mocks.ts
+++ b/packages/protocol/src/chat/tests/chat.graph.mocks.ts
@@ -300,7 +300,7 @@ export function createMockProtocolDeps(overrides?: Partial<ProtocolDeps>): Proto
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     intentQueue: { addGenerateHydeJob: async () => ({}), addDeleteHydeJob: async () => ({}) } as any,
     contactService: { importContacts: async () => ({ imported: 0, skipped: 0, newContacts: 0, existingContacts: 0, details: [] }), listContacts: async () => [], addContact: async () => ({ userId: "", isNew: false, isGhost: false }), removeContact: async () => {} } as unknown as ProtocolDeps["contactService"],
-    chatSession: { getSessionMessages: async () => [] },
+    chatSession: mockChatSessionReader,
     enricher: { enrichUserProfile: async () => null } as unknown as ProtocolDeps["enricher"],
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     negotiationDatabase: {} as any,

--- a/packages/protocol/src/chat/tests/chat.graph.mocks.ts
+++ b/packages/protocol/src/chat/tests/chat.graph.mocks.ts
@@ -280,6 +280,8 @@ export function createChatGraphMockDb(
 /** Mock ChatSessionReader with stub implementations for graph tests. */
 export const mockChatSessionReader: ChatSessionReader = {
   getSessionMessages: async () => [],
+  listSessions: async () => [],
+  getSession: async () => null,
 };
 
 /**

--- a/packages/protocol/src/chat/tests/chat.tools.spec.ts
+++ b/packages/protocol/src/chat/tests/chat.tools.spec.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "bun:test";
+import { z } from "zod";
+import { createChatTools } from "../chat.tools.js";
+import type { ToolDeps } from "../../shared/agent/tool.helpers.js";
+import type { ResolvedToolContext } from "../../shared/agent/tool.helpers.js";
+import type { ChatSessionReader } from "../../shared/interfaces/chat-session.interface.js";
+
+function makeContext(userId = "user-123"): ResolvedToolContext {
+  return {
+    userId,
+    user: { id: userId, name: "Alice", email: "a@test" } as any,
+    userProfile: null,
+    userNetworks: [],
+    isMcp: true,
+  } as unknown as ResolvedToolContext;
+}
+
+function makeDeps(chatSession: Partial<ChatSessionReader>): ToolDeps {
+  return {
+    chatSession: chatSession as ChatSessionReader,
+  } as unknown as ToolDeps;
+}
+
+interface CapturedTool {
+  name: string;
+  handler: (input: { context: ResolvedToolContext; query: unknown }) => Promise<string>;
+}
+
+function captureTools(
+  build: (defineTool: unknown, deps: ToolDeps) => void,
+  deps: ToolDeps,
+): CapturedTool[] {
+  const toolDefs: CapturedTool[] = [];
+  const defineTool = (def: {
+    name: string;
+    description: string;
+    querySchema: z.ZodType;
+    handler: (input: { context: ResolvedToolContext; query: unknown }) => Promise<string>;
+  }) => {
+    toolDefs.push({ name: def.name, handler: def.handler });
+    return def;
+  };
+  build(defineTool, deps);
+  return toolDefs;
+}
+
+describe("list_conversations", () => {
+  test("returns sessions for the authenticated user", async () => {
+    const now = new Date("2026-04-14T00:00:00Z");
+    const listSessions = async (userId: string, limit?: number) => {
+      expect(userId).toBe("alice-id");
+      expect(limit).toBe(25);
+      return [
+        {
+          sessionId: "11111111-1111-4111-8111-111111111111",
+          title: "Hello",
+          messageCount: 3,
+          lastMessageAt: now,
+          createdAt: now,
+        },
+      ];
+    };
+    const tools = captureTools(
+      (defineTool, deps) => createChatTools(defineTool as any, deps),
+      makeDeps({ listSessions }),
+    );
+    const tool = tools.find((t) => t.name === "list_conversations")!;
+    const result = await tool.handler({ context: makeContext("alice-id"), query: {} });
+    const parsed = JSON.parse(result);
+    expect(parsed.success).toBe(true);
+    expect(parsed.data.conversations[0].sessionId).toBe("11111111-1111-4111-8111-111111111111");
+    expect(parsed.data.conversations[0].title).toBe("Hello");
+  });
+
+  test("forwards the limit argument", async () => {
+    let capturedLimit: number | undefined;
+    const listSessions = async (_userId: string, limit?: number) => {
+      capturedLimit = limit;
+      return [];
+    };
+    const tools = captureTools(
+      (defineTool, deps) => createChatTools(defineTool as any, deps),
+      makeDeps({ listSessions }),
+    );
+    const tool = tools.find((t) => t.name === "list_conversations")!;
+    await tool.handler({ context: makeContext(), query: { limit: 10 } });
+    expect(capturedLimit).toBe(10);
+  });
+});
+
+describe("get_conversation", () => {
+  const validSessionId = "22222222-2222-4222-8222-222222222222";
+
+  test("returns the conversation when the user owns it", async () => {
+    const now = new Date("2026-04-14T00:00:00Z");
+    const getSession = async (userId: string, sessionId: string) => {
+      expect(userId).toBe("user-123");
+      expect(sessionId).toBe(validSessionId);
+      return {
+        sessionId,
+        title: "Chat with Bob",
+        messageCount: 1,
+        lastMessageAt: now,
+        createdAt: now,
+        messages: [{ role: "user", content: "hello", createdAt: now }],
+      };
+    };
+    const tools = captureTools(
+      (defineTool, deps) => createChatTools(defineTool as any, deps),
+      makeDeps({ getSession }),
+    );
+    const tool = tools.find((t) => t.name === "get_conversation")!;
+    const result = await tool.handler({
+      context: makeContext(),
+      query: { sessionId: validSessionId },
+    });
+    const parsed = JSON.parse(result);
+    expect(parsed.success).toBe(true);
+    expect(parsed.data.title).toBe("Chat with Bob");
+    expect(parsed.data.messages).toHaveLength(1);
+  });
+
+  test("returns an error when the session is not found", async () => {
+    const tools = captureTools(
+      (defineTool, deps) => createChatTools(defineTool as any, deps),
+      makeDeps({ getSession: async () => null }),
+    );
+    const tool = tools.find((t) => t.name === "get_conversation")!;
+    const result = await tool.handler({
+      context: makeContext(),
+      query: { sessionId: validSessionId },
+    });
+    const parsed = JSON.parse(result);
+    expect(parsed.success).toBe(false);
+  });
+
+  test("rejects a non-UUID sessionId", async () => {
+    const tools = captureTools(
+      (defineTool, deps) => createChatTools(defineTool as any, deps),
+      makeDeps({ getSession: async () => null }),
+    );
+    const tool = tools.find((t) => t.name === "get_conversation")!;
+    const result = await tool.handler({
+      context: makeContext(),
+      query: { sessionId: "not-a-uuid" },
+    });
+    const parsed = JSON.parse(result);
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toContain("Invalid session ID");
+  });
+});

--- a/packages/protocol/src/contact/contact.tools.ts
+++ b/packages/protocol/src/contact/contact.tools.ts
@@ -147,7 +147,7 @@ export function createContactTools(defineTool: DefineTool, deps: ToolDeps) {
       "**When to use:** Before list_contacts when the network is large — returns only matching contacts, bounded by limit.\n\n" +
       "**Returns:** Array of matching contacts: contactId (userId), name, email, avatar, isGhost.",
     querySchema: z.object({
-      q: z.string().describe('Free-text query matched against contact name and email (case-insensitive, substring).'),
+      q: z.string().trim().min(1).describe('Free-text query matched against contact name and email (case-insensitive, substring).'),
       limit: z.number().int().positive().max(100).optional().describe('Maximum rows to return. Defaults to 25.'),
     }),
     handler: async ({ context, query }) => {

--- a/packages/protocol/src/contact/contact.tools.ts
+++ b/packages/protocol/src/contact/contact.tools.ts
@@ -138,5 +138,27 @@ export function createContactTools(defineTool: DefineTool, deps: ToolDeps) {
     },
   });
 
-  return [import_contacts, list_contacts, add_contact, remove_contact];
+  const search_contacts = defineTool({
+    name: 'search_contacts',
+    description:
+      "Searches the authenticated user's personal network by name or email (case-insensitive substring). " +
+      "Use when the user refers to a contact by partial name or email and you need their userId for another tool " +
+      "(e.g. read_user_profiles, create_opportunities).\n\n" +
+      "**When to use:** Before list_contacts when the network is large — returns only matching contacts, bounded by limit.\n\n" +
+      "**Returns:** Array of matching contacts: contactId (userId), name, email, avatar, isGhost.",
+    querySchema: z.object({
+      q: z.string().describe('Free-text query matched against contact name and email (case-insensitive, substring).'),
+      limit: z.number().int().positive().max(100).optional().describe('Maximum rows to return. Defaults to 25.'),
+    }),
+    handler: async ({ context, query }) => {
+      try {
+        const rows = await contactService.searchContacts(context.userId, query.q, query.limit ?? 25);
+        return success({ count: rows.length, contacts: rows });
+      } catch (err) {
+        return error(`Failed to search contacts: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    },
+  });
+
+  return [import_contacts, list_contacts, add_contact, remove_contact, search_contacts];
 }

--- a/packages/protocol/src/contact/tests/search-contacts.spec.ts
+++ b/packages/protocol/src/contact/tests/search-contacts.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { z } from "zod";
+import { createContactTools } from "../contact.tools.js";
+import type { ToolDeps, ResolvedToolContext } from "../../shared/agent/tool.helpers.js";
+
+function makeContext(userId = "user-123"): ResolvedToolContext {
+  return {
+    userId,
+    user: { id: userId, name: "Alice", email: "a@test" } as any,
+    userProfile: null,
+    userNetworks: [],
+    isMcp: true,
+  } as unknown as ResolvedToolContext;
+}
+
+interface CapturedTool {
+  name: string;
+  handler: (input: { context: ResolvedToolContext; query: unknown }) => Promise<string>;
+}
+
+function captureTools(deps: ToolDeps): CapturedTool[] {
+  const toolDefs: CapturedTool[] = [];
+  const defineTool = (def: {
+    name: string;
+    description: string;
+    querySchema: z.ZodType;
+    handler: (input: { context: ResolvedToolContext; query: unknown }) => Promise<string>;
+  }) => {
+    toolDefs.push({ name: def.name, handler: def.handler });
+    return def;
+  };
+  createContactTools(defineTool as any, deps);
+  return toolDefs;
+}
+
+describe("search_contacts", () => {
+  test("forwards ownerId + q + limit and returns rows", async () => {
+    let captured: { ownerId: string; q: string; limit: number } | null = null;
+    const contactService = {
+      searchContacts: async (ownerId: string, q: string, limit: number) => {
+        captured = { ownerId, q, limit };
+        return [
+          {
+            contactId: "cid-1",
+            name: "Jane Smith",
+            email: "jane@example.com",
+            avatar: null,
+            isGhost: false,
+          },
+        ];
+      },
+    };
+    const tools = captureTools({ contactService } as unknown as ToolDeps);
+    const tool = tools.find((t) => t.name === "search_contacts")!;
+    const result = await tool.handler({
+      context: makeContext("alice"),
+      query: { q: "jane", limit: 10 },
+    });
+    const parsed = JSON.parse(result);
+    expect(captured).toEqual({ ownerId: "alice", q: "jane", limit: 10 });
+    expect(parsed.success).toBe(true);
+    expect(parsed.data.count).toBe(1);
+    expect(parsed.data.contacts[0].email).toBe("jane@example.com");
+  });
+
+  test("defaults limit to 25", async () => {
+    let capturedLimit: number | null = null;
+    const contactService = {
+      searchContacts: async (_ownerId: string, _q: string, limit: number) => {
+        capturedLimit = limit;
+        return [];
+      },
+    };
+    const tools = captureTools({ contactService } as unknown as ToolDeps);
+    const tool = tools.find((t) => t.name === "search_contacts")!;
+    await tool.handler({ context: makeContext(), query: { q: "anything" } });
+    expect(capturedLimit).toBe(25);
+  });
+});

--- a/packages/protocol/src/intent/intent.tools.ts
+++ b/packages/protocol/src/intent/intent.tools.ts
@@ -159,7 +159,20 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       "**Returns:** An intent_proposal code block that MUST be included verbatim in the response. The frontend renders it as an interactive " +
       "card the user can approve or skip. On approval, the intent is persisted, indexed, and discovery begins.\n\n" +
       "**Next steps after approval:** The intent is automatically linked to relevant indexes. Call create_opportunities(searchQuery) to explicitly trigger discovery, " +
-      "or wait for background processing to find matches.",
+      "or wait for background processing to find matches.\n\n" +
+      "**Specificity gate.** Before calling this tool, judge whether the description is concrete enough to be " +
+      "useful for matching. If the user says \"find a job\", \"meet people\", or \"learn something\", that's too " +
+      "vague — FIRST call read_user_profiles() + read_intents() to understand their context, THEN propose a " +
+      "refined version (\"Based on your background in X, did you mean 'Y'?\") and wait for confirmation before " +
+      "calling create_intent. Specific asks (\"senior UX design role at a tech company in Berlin\") can go " +
+      "directly to create_intent.\n\n" +
+      "**URL handling.** If the user pastes a URL describing the intent (e.g. a job posting), call scrape_url " +
+      "first with objective=\"Extract key details for an intent\", synthesize a conceptual description from the " +
+      "content, then call create_intent with the synthesis. Exception: profile URLs (LinkedIn, GitHub, X) passed " +
+      "to create_user_profile are handled by that tool directly — do not scrape first.\n\n" +
+      "**Proposal card contract.** The response contains an ```intent_proposal code block. Include that block " +
+      "VERBATIM in your reply to the user — do not summarize it, do not write an intent_proposal block yourself. " +
+      "Only this tool returns valid blocks (they embed a proposalId the UI needs to persist the intent on approval).",
     querySchema: z.object({
       description: z.string().describe("A clear, specific description of what the user is looking for. Should be concept-based, not a raw URL. If the user shared a URL, scrape it first with scrape_url and pass the synthesized content here. Vague descriptions will be rejected — include what kind, what for, and/or timeframe."),
       networkId: z.string().optional().describe("Index UUID to link the intent to upon creation. Defaults to the scoped index in index-scoped chats. Get index IDs from read_networks. If omitted, the system auto-assigns to relevant indexes based on their prompts."),

--- a/packages/protocol/src/intent/intent.tools.ts
+++ b/packages/protocol/src/intent/intent.tools.ts
@@ -31,7 +31,7 @@ async function ensureScopedMembership(
 }
 
 export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
-  const { graphs } = deps;
+  const { graphs, userDb } = deps;
 
   // ─────────────────────────────────────────────────────────────────────────────
   // INTENT CRUD
@@ -650,5 +650,31 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
     },
   });
 
-  return [readIntents, createIntent, updateIntent, deleteIntent, createIntentIndex, readIntentIndexes, deleteIntentIndex] as const;
+  const searchIntents = defineTool({
+    name: "search_intents",
+    description:
+      "Text-searches the authenticated user's own active signals by description. Case-insensitive substring " +
+      "match over the signal's payload and summary. Use when the user references a past signal they wrote " +
+      '("find my signal about React mentorship") or wants to audit what they\'ve posted.\n\n' +
+      "For discovery of OTHER users' signals that match a query, use create_opportunities(searchQuery=...) " +
+      "instead — that runs semantic matching across the user's networks.\n\n" +
+      "**Returns:** `intents: [{ id, payload, summary, createdAt }]`, most recent first, up to `limit` (default 25).",
+    querySchema: z.object({
+      q: z.string().min(1).describe("Text to match against payload and summary (case-insensitive)."),
+      limit: z
+        .number()
+        .int()
+        .positive()
+        .max(100)
+        .optional()
+        .describe("Maximum intents to return (default 25, max 100)."),
+    }),
+    handler: async ({ context, query }) => {
+      const rows = await userDb.searchOwnIntents(query.q, query.limit ?? 25);
+      logger.verbose("search_intents", { userId: context.userId, q: query.q, matched: rows.length });
+      return success({ intents: rows });
+    },
+  });
+
+  return [readIntents, createIntent, updateIntent, deleteIntent, createIntentIndex, readIntentIndexes, deleteIntentIndex, searchIntents] as const;
 }

--- a/packages/protocol/src/intent/tests/search-intents.spec.ts
+++ b/packages/protocol/src/intent/tests/search-intents.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import { z } from "zod";
+import { createIntentTools } from "../intent.tools.js";
+import type { ToolDeps } from "../../shared/agent/tool.helpers.js";
+import type { ResolvedToolContext } from "../../shared/agent/tool.helpers.js";
+
+function makeContext(userId = "user-123"): ResolvedToolContext {
+  return {
+    userId,
+    user: { id: userId, name: "Alice", email: "a@test" } as any,
+    userProfile: null,
+    userNetworks: [],
+    isMcp: true,
+  } as unknown as ResolvedToolContext;
+}
+
+interface CapturedTool {
+  name: string;
+  handler: (input: { context: ResolvedToolContext; query: unknown }) => Promise<string>;
+}
+
+function captureTools(deps: ToolDeps): CapturedTool[] {
+  const toolDefs: CapturedTool[] = [];
+  const defineTool = (def: {
+    name: string;
+    description: string;
+    querySchema: z.ZodType;
+    handler: (input: { context: ResolvedToolContext; query: unknown }) => Promise<string>;
+  }) => {
+    toolDefs.push({ name: def.name, handler: def.handler });
+    return def;
+  };
+  createIntentTools(defineTool as any, deps);
+  return toolDefs;
+}
+
+describe("search_intents", () => {
+  test("forwards query + limit and returns rows", async () => {
+    const now = new Date("2026-04-14T00:00:00Z");
+    let captured: { q: string; limit: number } | null = null;
+    const userDb = {
+      searchOwnIntents: async (q: string, limit: number) => {
+        captured = { q, limit };
+        return [
+          {
+            id: "11111111-1111-4111-8111-111111111111",
+            payload: "Looking for React mentorship",
+            summary: null,
+            createdAt: now,
+          },
+        ];
+      },
+    };
+    const tools = captureTools({
+      userDb,
+      graphs: {} as any,
+      systemDb: {} as any,
+    } as unknown as ToolDeps);
+    const tool = tools.find((t) => t.name === "search_intents")!;
+    const result = await tool.handler({
+      context: makeContext("alice"),
+      query: { q: "React", limit: 5 },
+    });
+    const parsed = JSON.parse(result);
+    expect(captured).toEqual({ q: "React", limit: 5 });
+    expect(parsed.success).toBe(true);
+    expect(parsed.data.intents[0].payload).toContain("React");
+  });
+
+  test("defaults limit to 25", async () => {
+    let capturedLimit: number | null = null;
+    const userDb = {
+      searchOwnIntents: async (_q: string, limit: number) => {
+        capturedLimit = limit;
+        return [];
+      },
+    };
+    const tools = captureTools({
+      userDb,
+      graphs: {} as any,
+      systemDb: {} as any,
+    } as unknown as ToolDeps);
+    const tool = tools.find((t) => t.name === "search_intents")!;
+    await tool.handler({ context: makeContext(), query: { q: "anything" } });
+    expect(capturedLimit).toBe(25);
+  });
+});

--- a/packages/protocol/src/mcp/mcp.server.ts
+++ b/packages/protocol/src/mcp/mcp.server.ts
@@ -130,21 +130,6 @@ NEVER use "search" in any form. Use "looking up" for indexed data, "find" / "loo
 - IntentIndex — Intent↔Index junction (auto-assigned).
 - Opportunity — discovered connection between users. Roles, status, reasoning.
 
-# Discovery-first rule
-For connection-seeking requests ("find me a mentor", "who needs a React dev") call \`create_opportunities\` with \`searchQuery\` FIRST. Do NOT call \`create_intent\` unless the user asks to "create", "save", "add", or "remember" a signal.
-
-# Context gathering
-On activation, silently call \`read_user_profiles\`, \`read_intents\`, \`read_networks\`, \`list_contacts\` (all with no args) to build state. Do not show raw output.
-
-# After-mutation refresh
-After any write (create/update/delete), silently re-call the relevant read tool.
-
-# Personal-index scoping
-"In my network" / "from my contacts" / "people I know" → pass the personal index ID (from memberships where \`isPersonal: true\`) as \`indexId\`.
-
-# Negotiation turn mode
-When invoked with a task prompt that describes a live negotiation turn (session key prefixed \`index:negotiation:\`), you are running as a silent background subagent representing your user in a bilateral negotiation. Fetch the full negotiation via \`get_negotiation\`, ground yourself in the user's profile and intents via \`read_user_profiles\` and \`read_intents\`, and submit a response via \`respond_to_negotiation\`. Do not produce user-facing output; do not ask clarifying questions. If the decision is ambiguous, pick the most conservative action — usually \`counter\` with specific objections, or \`reject\` with clear reasoning.
-
 # Output rules
 - NEVER expose IDs, UUIDs, field names, or tool names.
 - NEVER use internal vocabulary — say "signal" not "intent", "community" not "index".
@@ -153,6 +138,9 @@ When invoked with a task prompt that describes a live negotiation turn (session 
 - Prefer first names; use full names only to disambiguate.
 - Translate statuses: draft/latent → "draft", pending → "sent", accepted → "connected".
 - NEVER fabricate data. If you don't have it, call the appropriate tool.
+
+# Tool guidance
+Each tool's description contains its own usage rules (when to call, when NOT to call, required prerequisites, post-call follow-ups). Read the description of every tool you call — that is where the per-tool workflow patterns live.
 
 # Authentication
 Pass your API key in the \`x-api-key\` request header (not \`Authorization: Bearer\`).

--- a/packages/protocol/src/mcp/tests/mcp.server.spec.ts
+++ b/packages/protocol/src/mcp/tests/mcp.server.spec.ts
@@ -1,10 +1,10 @@
 /**
  * Tests for the MCP_INSTRUCTIONS constant.
  *
- * MCP_INSTRUCTIONS is the canonical home for Index Network behavioral
- * guidance. Every MCP client receives it on connect, so it must be
- * dense (under budget) and complete (covers voice, vocabulary, entity
- * model, discovery-first rule, output rules, auth).
+ * MCP_INSTRUCTIONS carries only global guidance: identity, voice, banned
+ * vocabulary, entity model, output rules, and auth. Per-tool workflow
+ * patterns (discovery-first, introduction mode, negotiation-turn mode,
+ * etc.) live in each tool's `description` string, not here.
  */
 import { config } from "dotenv";
 config({ path: ".env.test" });
@@ -29,9 +29,12 @@ describe("MCP_INSTRUCTIONS", () => {
     expect(MCP_INSTRUCTIONS.toLowerCase()).toMatch(/never.*search|banned.*search|do not.*search/);
   });
 
-  test("declares the discovery-first rule", () => {
+  test("frames Index Network as a discovery protocol", () => {
     expect(MCP_INSTRUCTIONS.toLowerCase()).toContain("discovery");
-    expect(MCP_INSTRUCTIONS).toContain("create_opportunities");
+  });
+
+  test("delegates per-tool guidance to tool descriptions", () => {
+    expect(MCP_INSTRUCTIONS.toLowerCase()).toContain("tool's description");
   });
 
   test("describes the entity model", () => {

--- a/packages/protocol/src/negotiation/negotiation.tools.ts
+++ b/packages/protocol/src/negotiation/negotiation.tools.ts
@@ -106,7 +106,12 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
       '**Access control:** You must be a party to the negotiation (source or candidate) to view it.\n\n' +
       '**Statuses:** `active` — in progress. `waiting_for_agent` — waiting for an agent response or timeout. `completed` — concluded.\n\n' +
       '**When to use:** To review the full negotiation history before responding, to understand why a negotiation was ' +
-      'accepted or rejected, or to see the current state of an active negotiation.',
+      'accepted or rejected, or to see the current state of an active negotiation.\n\n' +
+      '**Negotiation-turn-mode usage.** If you are running as a silent background subagent (dispatched by the ' +
+      "openclaw runtime's poller in response to a claimed negotiation turn), call this tool FIRST with the " +
+      'negotiationId from your task prompt. This returns the current state, both parties\' context, and the ' +
+      'history of turns so far. Ground your response in the caller\'s profile (read_user_profiles) and intents ' +
+      '(read_intents) before deciding on a turn action. Do not produce user-facing output in this mode.',
     querySchema: z.object({
       negotiationId: z.string().describe('The negotiation task ID (from list_negotiations results).'),
     }),
@@ -247,7 +252,13 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
       '- `counter` — Counter the proposal with a message (message is required). The negotiation will continue.\n' +
       '- `question` — Ask the counterparty a clarifying question (message is required). The negotiation will continue.\n\n' +
       '**What happens after:** Accept/reject finalizes the negotiation immediately. Counter/question continues the negotiation — ' +
-      'if the counterparty has an agent, the negotiation yields again; otherwise the AI agent responds inline.',
+      'if the counterparty has an agent, the negotiation yields again; otherwise the AI agent responds inline.\n\n' +
+      '**Silent-subagent response contract.** In negotiation-turn mode, submit exactly ONE call to this tool ' +
+      'per dispatch with the action (propose | counter | accept | reject | question) and the assessment ' +
+      '(reasoning + suggestedRoles). If the decision is ambiguous, pick the most conservative action — usually ' +
+      '`counter` with specific objections, or `reject` with clear reasoning. On the first turn of a negotiation ' +
+      '(turnCount === 0) the action MUST be `propose`. Do not ask the user clarifying questions; you are ' +
+      'authorized to act on their behalf within the scope granted to your agent.',
     querySchema: z.object({
       negotiationId: z.string().describe('The negotiation task ID to respond to.'),
       action: z.enum(['accept', 'reject', 'counter', 'question']).describe('The response action: accept the proposal, reject it, counter with a new message, or ask a clarifying question.'),

--- a/packages/protocol/src/network/network.tools.ts
+++ b/packages/protocol/src/network/network.tools.ts
@@ -75,12 +75,13 @@ export function createNetworkTools(defineTool: DefineTool, deps: ToolDeps) {
       "or to check if a user belongs to a specific index.\n\n" +
       "**Returns:** Member list with user details, or membership list with index details, or a membership check result.\n\n" +
       "**Personal index semantics.** The personal index (`isPersonal: true` on the membership) is the user's " +
-      "contact list — members of that index are the user's contacts. Pass `userId` of another user to see which " +
-      "indexes they belong to, which is how you find shared ground before an introduction.\n\n" +
-      "**Shared-context pattern.** To find overlap between the current user and another user: (1) call this tool " +
-      "with userId=me and again with userId=other, (2) intersect the returned networkIds, (3) call read_intents " +
-      "for each shared network to see what each is looking for there, (4) call read_user_profiles for the other " +
-      "party. That sequence gives you enough to decide whether to propose a direct connection or an introduction.",
+      "contact list — members of that index are the user's contacts. For another user, this tool only reveals the " +
+      "indexes you already share with them.\n\n" +
+      "**Shared-context pattern.** To find overlap with another user: (1) omit `userId` to read your own " +
+      "memberships, (2) call this tool with the other person's actual `userId` to get the shared indexes, " +
+      "(3) call read_intents for each shared network to see what each is looking for there, (4) call " +
+      "read_user_profiles for the other party. That sequence gives you enough to decide whether to propose a " +
+      "direct connection or an introduction.",
     querySchema: z.object({
       networkId: z.string().optional().describe("Index UUID — lists all members of this index. Get from read_networks. In index-scoped chats, only the scoped index can be queried."),
       userId: z.string().optional().describe("User ID — lists that user's index memberships. Omit to get the current user's memberships. When combined with networkId, checks if this user is in that specific index."),

--- a/packages/protocol/src/network/network.tools.ts
+++ b/packages/protocol/src/network/network.tools.ts
@@ -73,7 +73,14 @@ export function createNetworkTools(defineTool: DefineTool, deps: ToolDeps) {
       "- With both `networkId` and `userId`: checks whether that specific user is a member of that specific index (returns isMember boolean).\n\n" +
       "**When to use:** Before creating introductions (need to verify shared index membership), to explore community members, " +
       "or to check if a user belongs to a specific index.\n\n" +
-      "**Returns:** Member list with user details, or membership list with index details, or a membership check result.",
+      "**Returns:** Member list with user details, or membership list with index details, or a membership check result.\n\n" +
+      "**Personal index semantics.** The personal index (`isPersonal: true` on the membership) is the user's " +
+      "contact list — members of that index are the user's contacts. Pass `userId` of another user to see which " +
+      "indexes they belong to, which is how you find shared ground before an introduction.\n\n" +
+      "**Shared-context pattern.** To find overlap between the current user and another user: (1) call this tool " +
+      "with userId=me and again with userId=other, (2) intersect the returned networkIds, (3) call read_intents " +
+      "for each shared network to see what each is looking for there, (4) call read_user_profiles for the other " +
+      "party. That sequence gives you enough to decide whether to propose a direct connection or an introduction.",
     querySchema: z.object({
       networkId: z.string().optional().describe("Index UUID — lists all members of this index. Get from read_networks. In index-scoped chats, only the scoped index can be queried."),
       userId: z.string().optional().describe("User ID — lists that user's index memberships. Omit to get the current user's memberships. When combined with networkId, checks if this user is in that specific index."),

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -213,7 +213,25 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
       "Use when user asks 'who should I introduce to [person]?'\n\n" +
       "**Returns:** Opportunity code blocks (render as interactive cards) with opportunityId, match reasoning, confidence score, and status. " +
       "All results start as drafts. Supports pagination via `continueFrom` for large result sets.\n\n" +
-      "**Next steps:** Use update_opportunity(opportunityId, status='pending') to send a draft to the other party.",
+      "**Next steps:** Use update_opportunity(opportunityId, status='pending') to send a draft to the other party.\n\n" +
+      "**Discovery-first rule.** For open-ended connection-seeking requests (\"find me a mentor\", " +
+      "\"who needs a React dev\", \"looking for investors\"), call this tool with `searchQuery` FIRST. " +
+      "Do NOT call create_intent for these phrasings — create_intent is only for when the user explicitly " +
+      "asks to \"create\", \"save\", \"add\", or \"remember\" a signal.\n\n" +
+      "**Personal-index scoping.** When the user says \"in my network\", \"from my contacts\", \"people I know\", " +
+      "or similar scoping language, pass the user's personal index ID (from memberships where `isPersonal: true`) " +
+      "as `networkId`. The personal index contains the user's contacts — scoping discovery to it restricts " +
+      "results to people the user already knows. Without this scoping language, omit networkId to let discovery " +
+      "run across all indexes.\n\n" +
+      "**Introduction mode prerequisites.** When using `partyUserIds` + `entities`, YOU must pre-fetch each party's " +
+      "profile and intents before calling this tool. The entities array must include each party's userId, profile, " +
+      "intents from shared indexes, and the shared networkId. Call read_user_profiles, read_network_memberships, " +
+      "and read_intents for both parties first. The introducer (current user) must NOT appear in entities.\n\n" +
+      "**Signal-visibility follow-up.** If the response includes `suggestIntentCreationForVisibility: true` and " +
+      "`suggestedIntentDescription`, after presenting opportunity cards ask the user ONCE whether they'd also like " +
+      "to create a signal so others can find them. On yes, call create_intent with the suggested description. " +
+      "Never suggest this after introducer-mode (`introTargetUserId`) calls — the query describes the other person's " +
+      "needs, not the signed-in user's.",
     querySchema: z.object({
       continueFrom: z
         .string()

--- a/packages/protocol/src/profile/profile.tools.ts
+++ b/packages/protocol/src/profile/profile.tools.ts
@@ -131,10 +131,7 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
         return success({ query: nameQuery, matchCount: profiles.length, profiles });
       }
 
-      // Guard: when chat is NOT index-scoped and no userId/networkId provided, disallow
-      if (!effectiveIndexId && !targetUserId && !context.networkId) {
-        return error("Please provide a userId, networkId, or query. Outside of an index-scoped chat, read_user_profiles requires at least one of these parameters. To read your own profile, pass your own userId.");
-      }
+      // When no userId / networkId / query is provided, fall through to Mode 1 (self lookup).
 
       // --- Mode 3: networkId provided → fetch all member profiles ---
       if (effectiveIndexId) {

--- a/packages/protocol/src/profile/profile.tools.ts
+++ b/packages/protocol/src/profile/profile.tools.ts
@@ -44,7 +44,7 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
       "This is the primary way to look up a person by name. Add `networkId` to restrict search to one index.\n" +
       "- With `userId`: returns that specific user's full profile (name, bio, skills, interests, location).\n" +
       "- With `networkId` alone: returns profiles of ALL members in that index.\n" +
-      "- No parameters (index-scoped chat only): returns the current user's own profile.\n\n" +
+      "- No parameters: returns the current user's own profile.\n\n" +
       "**When to use:** Before creating introductions (need profiles of both parties), when the user asks about a person, " +
       "or to check if a profile exists before suggesting create_user_profile.\n\n" +
       "**Returns:** Profile objects with name, bio, location, skills[], interests[]. Use userId from results with other tools like read_intents(userId, networkId).",

--- a/packages/protocol/src/profile/tests/read-defaults.spec.ts
+++ b/packages/protocol/src/profile/tests/read-defaults.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { z } from "zod";
+import { createProfileTools } from "../profile.tools.js";
+import type { ToolDeps } from "../../shared/agent/tool.helpers.js";
+import type { ResolvedToolContext } from "../../shared/agent/tool.helpers.js";
+
+function makeContext(overrides: Partial<ResolvedToolContext> = {}): ResolvedToolContext {
+  return {
+    userId: "user-123",
+    user: { id: "user-123", name: "Alice", email: "a@test" } as any,
+    userProfile: null,
+    userNetworks: [],
+    isMcp: true,
+    ...overrides,
+  } as ResolvedToolContext;
+}
+
+function makeDeps(profileResult: unknown): ToolDeps {
+  return {
+    userDb: {} as any,
+    systemDb: {} as any,
+    database: {} as any,
+    graphs: {
+      profile: {
+        invoke: async () => ({ readResult: profileResult }),
+      },
+    } as any,
+    enricher: {} as any,
+    grantDefaultSystemPermissions: async () => {},
+  } as unknown as ToolDeps;
+}
+
+describe("read_user_profiles default-to-self", () => {
+  test("no args, no scope → returns caller's own profile via Mode 1", async () => {
+    const toolDefs: Array<{ name: string; handler: Function }> = [];
+    const defineTool = (def: { name: string; description: string; schema: z.ZodType; handler: Function }) => {
+      toolDefs.push({ name: def.name, handler: def.handler });
+      return def as any;
+    };
+    const profileResult = { hasProfile: true, profile: { name: "Alice", bio: "hi" } };
+    createProfileTools(defineTool as any, makeDeps(profileResult));
+    const readTool = toolDefs.find((t) => t.name === "read_user_profiles");
+    expect(readTool).toBeDefined();
+
+    const result = await readTool!.handler({ context: makeContext(), query: {} });
+    const parsed = JSON.parse(result as string);
+    expect(parsed.success).toBe(true);
+    expect(parsed.data.hasProfile).toBe(true);
+    expect(parsed.data.profile.name).toBe("Alice");
+  });
+});

--- a/packages/protocol/src/shared/agent/tool.helpers.ts
+++ b/packages/protocol/src/shared/agent/tool.helpers.ts
@@ -325,6 +325,8 @@ export interface ToolDeps {
   enricher: ProfileEnricher;
   /** Database adapter for negotiation/conversation operations. */
   negotiationDatabase: NegotiationDatabase;
+  /** Chat session reader for exposing the caller's past conversations as MCP tools. */
+  chatSession?: ChatSessionReader;
   /** Manages negotiation timeout jobs (optional — enables AI fallback on external agent timeout). */
   negotiationTimeoutQueue?: NegotiationTimeoutQueue;
   /** Agent registry database adapter (optional — absent when host does not support agents). */

--- a/packages/protocol/src/shared/agent/tool.registry.ts
+++ b/packages/protocol/src/shared/agent/tool.registry.ts
@@ -11,6 +11,7 @@ import { createIntegrationTools } from '../../integration/integration.tools.js';
 import { createContactTools } from '../../contact/contact.tools.js';
 import { createAgentTools } from '../../agent/agent.tools.js';
 import { createNegotiationTools } from '../../negotiation/negotiation.tools.js';
+import { createChatTools } from '../../chat/chat.tools.js';
 import { protocolLogger } from '../observability/protocol.logger.js';
 
 const logger = protocolLogger('ToolRegistry');
@@ -73,6 +74,9 @@ export function createToolRegistry(deps: ToolDeps): ToolRegistry {
   createContactTools(dt, deps);
   createAgentTools(dt, deps);
   createNegotiationTools(dt, deps);
+  if (deps.chatSession) {
+    createChatTools(dt, deps);
+  }
 
   logger.verbose(`Tool registry created with ${registry.size} tools`);
   return registry;

--- a/packages/protocol/src/shared/interfaces/chat-session.interface.ts
+++ b/packages/protocol/src/shared/interfaces/chat-session.interface.ts
@@ -1,10 +1,24 @@
-/**
- * Minimal interface for reading chat session messages.
- * Used by ChatGraphFactory to load conversation history.
- */
+export interface ChatSessionSummary {
+  sessionId: string;
+  title: string | null;
+  messageCount: number;
+  lastMessageAt: Date | null;
+  createdAt: Date;
+}
+
+export interface ChatSessionDetail extends ChatSessionSummary {
+  messages: Array<{ role: string; content: string; createdAt: Date }>;
+}
+
 export interface ChatSessionReader {
-  getSessionMessages(sessionId: string, limit?: number): Promise<Array<{
-    role: string;
-    content: string;
-  }>>;
+  getSessionMessages(
+    sessionId: string,
+    limit?: number,
+  ): Promise<Array<{ role: string; content: string }>>;
+  listSessions(userId: string, limit?: number): Promise<ChatSessionSummary[]>;
+  getSession(
+    userId: string,
+    sessionId: string,
+    messageLimit?: number,
+  ): Promise<ChatSessionDetail | null>;
 }

--- a/packages/protocol/src/shared/interfaces/contact.interface.ts
+++ b/packages/protocol/src/shared/interfaces/contact.interface.ts
@@ -30,9 +30,19 @@ export interface ContactEntry {
  * Contact management operations used by chat tools.
  * Consumers must provide a concrete implementation (e.g. backed by ContactService).
  */
+/** Flat contact row returned by searchContacts. */
+export interface ContactSearchResult {
+  contactId: string;
+  name: string;
+  email: string;
+  avatar: string | null;
+  isGhost: boolean;
+}
+
 export interface ContactServiceAdapter {
   importContacts(ownerId: string, contacts: ContactInput[]): Promise<ContactImportResult>;
   listContacts(ownerId: string): Promise<ContactEntry[]>;
   addContact(ownerId: string, email: string, options?: { name?: string; restore?: boolean }): Promise<ContactResult>;
   removeContact(ownerId: string, contactUserId: string): Promise<void>;
+  searchContacts(ownerId: string, q: string, limit?: number): Promise<ContactSearchResult[]>;
 }

--- a/packages/protocol/src/shared/interfaces/database.interface.ts
+++ b/packages/protocol/src/shared/interfaces/database.interface.ts
@@ -1296,6 +1296,15 @@ export interface UserDatabase {
   /** Get ALL active intents for the authenticated user (not index-filtered). */
   getActiveIntents(): Promise<ActiveIntent[]>;
 
+  /**
+   * Case-insensitive substring search over the authenticated user's own
+   * active intents. Matches against `payload` and `summary`. Most recent first.
+   */
+  searchOwnIntents(
+    q: string,
+    limit: number,
+  ): Promise<Array<{ id: string; payload: string; summary: string | null; createdAt: Date }>>;
+
   /** Get a single intent by ID (ownership enforced). */
   getIntent(intentId: string): Promise<IntentRecord | null>;
 


### PR DESCRIPTION
## Summary

Trim `MCP_INSTRUCTIONS` to a global-only contract, move per-pattern guidance (discovery-first, intent specificity, personal-index scoping, silent-subagent negotiation) into the individual tool descriptions where it surfaces alongside the tool in MCP listings, and add three new MCP tools for conversation history and text search.

## New Features

- **MCP `list_conversations` / `get_conversation`** — new `chat.tools.ts` with `ChatSessionReader` backend adapter so MCP clients can inspect prior chat threads.
- **MCP `search_intents`** — owner-scoped substring search over `payload` + `summary` via `UserDatabase.searchOwnIntents`.
- **MCP `search_contacts`** — substring search over the caller's personal network by name/email (`ContactService.searchContacts`, `ContactDatabaseAdapter.searchContactMembers`).

## Bug Fixes

- `read_user_profiles` now defaults to the authenticated user when called without `userIds` (previous behavior returned empty).

## Refactors

- `MCP_INSTRUCTIONS` trimmed to: Voice, Banned vocabulary, Entity model, Output rules, Tool guidance, Authentication. Plugin skills/CLI wrappers/marketplace manifests stay in sync automatically on next session.
- Per-pattern guidance ported into tool descriptions:
  - Discovery-first, introduction, personal-index scoping → `create_opportunities`
  - Intent specificity, URL handling → `create_intent`
  - Silent-subagent stance → negotiation tools
  - Personal-index + shared-context → `read_network_memberships`

## Documentation

- `docs/design/protocol-deep-dive.md` — updated tool/graph mapping table with `chat.tools.ts`, `search_intents`, `search_contacts`; rewrote MCP_INSTRUCTIONS section to reflect lean global contract + per-tool description model.

## Tests

- New: `chat.tools.spec.ts` (5), `search-intents.spec.ts` (2), `search-contacts.spec.ts` (2), `read-defaults.spec.ts` (updated).
- MCP e2e: `mcp.server.spec.ts` 10/10 pass.
- Full `tsc --noEmit` clean on both `@indexnetwork/protocol` and `backend`.

## Test plan

- [x] `bun test` for all new/touched specs
- [x] `bunx tsc --noEmit` on protocol and backend
- [x] MCP server spec (`OPENROUTER_API_KEY=test-key bun test src/mcp/tests/mcp.server.spec.ts`)
- [ ] Smoke-test a live MCP client (Claude Code/Codex) against the new tools
- [ ] Verify `@indexnetwork/protocol@0.11.0-rc.*` publishes from dev subtree push

## Package versions

- `@indexnetwork/protocol`: 0.10.0 → 0.11.0 (minor, additive MCP surface)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search your saved intents
  * Search contacts by name or email
  * List conversations and view full conversation details/messages

* **Documentation**
  * Expanded protocol/tool guidance (chat, contact, intent, negotiation, opportunity, network, profile usage)

* **Tests**
  * Added tests covering intent/contact search, chat tools, and profile defaults

* **Chore**
  * Protocol package version bumped to 0.11.0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->