### PR TITLE
fix(protocol): make presenter actually use negotiation transcripts

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/opportunity/opportunity.presenter.ts
+++ b/packages/protocol/src/opportunity/opportunity.presenter.ts
@@ -367,7 +367,14 @@ Produce headline, personalizedSummary (2-3 sentences in "you" language), and sug
       ? `\nINTRODUCTION CONTEXT: This opportunity was created by an explicit introduction from ${input.introducerName ?? "someone in the community"}. It was NOT discovered automatically — a real person made this connection.\n`
       : "";
     const negotiationBlock = buildNegotiationPromptBlock(input.negotiationContext);
+    // When negotiation context exists, lead with it — these cards exist
+    // *because* the negotiation happened. Trailing the block lets weaker
+    // models lean on surface signals and ignore the transcript entirely.
+    const negotiationDirective = negotiationBlock
+      ? `\nIMPORTANT: This opportunity surfaced because the agents negotiated and converged. Your personalizedSummary MUST reference at least one specific signal from the NEGOTIATION CONTEXT block below — what concern was raised, what was confirmed, what the agents agreed on. Do not produce a generic skill-complementarity summary; that's what every card looked like before this negotiation happened. Use the transcript to explain *why this specific match* surfaced now.\n`
+      : "";
     const humanContent = `
+${negotiationBlock}${negotiationDirective}
 VIEWER (the person seeing this opportunity):
 ${input.viewerContext}
 
@@ -380,7 +387,7 @@ MATCH CONTEXT:
 - Why we matched: ${input.matchReasoning}
 - Signals: ${input.signalsSummary}
 - ${mutualHint}
-${introContext}${negotiationBlock}
+${introContext}
 COMMUNITY: ${input.indexName}
 Viewer's role in this opportunity: ${input.viewerRole}
 Opportunity status: ${input.opportunityStatus ?? "pending"}


### PR DESCRIPTION
## Summary

Follow-up to #661. Smoke test on Gemini 2.5 Flash showed the negotiation block was reaching the LLM but being ignored — both with-context and without-context cards produced the same generic skill-complementarity summary.

## Changes

- Lift the `NEGOTIATION CONTEXT` block to the top of `humanContent` so the model sees the transcript before the surface signals it can fall back to.
- Add a hard directive — "personalizedSummary MUST reference at least one specific signal from the NEGOTIATION CONTEXT block" — so weaker models can't satisfy the prompt with a generic summary.

## Smoke test result

**Before (baseline, no context):**
> Bob is a frontend lead with strong React and TypeScript experience, recently shipping an AI code review product. He's open to co-founder conversations in the dev tools/AI infrastructure space, which perfectly aligns with your search for a frontend co-founder for your developer tools startup.

**Before (with context, pre-fix):** essentially identical — generic skill-complementarity summary.

**After (with context, this PR):**
> Bob Park is a frontend lead with **direct experience shipping React surfaces integrating with AI agents in production, specifically leading frontend for an AI code review product**. Your need for a co-founder with deep React + TypeScript expertise aligns perfectly with his background. While he's based in NYC and you're in SF, **he's open to remote-first collaboration, addressing any geographic concerns**.

The bolded phrases come straight from the transcript (turn 3 + the question→counter→accept arc).

## Version

`@indexnetwork/protocol`: `0.14.0` → `0.14.1` (patch).

## Test plan

- [x] All 30 existing presenter + loader unit tests still pass — block content is unchanged, only its position and the surrounding directive moved.
- [x] Smoke comparison (with vs without context) on real LLM shows transcript-grounded output.
- [x] `tsc --noEmit` clean on `packages/protocol`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced negotiation context handling to provide more targeted and signal-specific guidance in home card generation

* **Chores**
  * Bumped protocol package version to 0.14.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->