### PR TITLE
fix(opportunity): create DM + bidirectional contacts on accept, backfill historical rows

### DIFF
--- a/backend/drizzle/0058_backfill_accepted_opportunity_dms.sql
+++ b/backend/drizzle/0058_backfill_accepted_opportunity_dms.sql
@@ -1,0 +1,36 @@
+-- Backfill DM conversations for accepted opportunities that have no conversation yet.
+--
+-- Opportunities store actors as JSONB array of { "userId": "...", "role": "...", ... }.
+-- We pair every non-introducer actor combination (LEAST/GREATEST ensures the dm_pair
+-- string is sorted the same way as ConversationDatabaseAdapter.getOrCreateDM()).
+-- ON CONFLICT (dm_pair) skips pairs that already have a conversation.
+-- conversation_participants uses (conversation_id, participant_id) as primary key,
+-- so the UNION ALL insert is safe for newly-created conversations only.
+
+--> statement-breakpoint
+WITH accepted_pairs AS (
+  SELECT DISTINCT
+    LEAST(a1.actor->>'userId', a2.actor->>'userId')    AS user_a,
+    GREATEST(a1.actor->>'userId', a2.actor->>'userId') AS user_b
+  FROM opportunities o,
+       jsonb_array_elements(o.actors) WITH ORDINALITY AS a1(actor, i),
+       jsonb_array_elements(o.actors) WITH ORDINALITY AS a2(actor, j)
+  WHERE o.status = 'accepted'
+    AND a1.i < a2.j
+    AND COALESCE(a1.actor->>'role', '') <> 'introducer'
+    AND COALESCE(a2.actor->>'role', '') <> 'introducer'
+    AND a1.actor->>'userId' IS NOT NULL
+    AND a2.actor->>'userId' IS NOT NULL
+    AND a1.actor->>'userId' <> a2.actor->>'userId'
+),
+new_convs AS (
+  INSERT INTO conversations (id, dm_pair, created_at, updated_at)
+  SELECT gen_random_uuid(), user_a || ':' || user_b, now(), now()
+  FROM accepted_pairs
+  ON CONFLICT (dm_pair) DO NOTHING
+  RETURNING id, dm_pair
+)
+INSERT INTO conversation_participants (conversation_id, participant_id, participant_type)
+SELECT id, split_part(dm_pair, ':', 1), 'user' FROM new_convs
+UNION ALL
+SELECT id, split_part(dm_pair, ':', 2), 'user' FROM new_convs;

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -407,6 +407,13 @@
 			"when": 1745193600000,
 			"tag": "0057_unique_agent_permissions_global",
 			"breakpoints": true
+		},
+		{
+			"idx": 58,
+			"version": "7",
+			"when": 1745280000000,
+			"tag": "0058_backfill_accepted_opportunity_dms",
+			"breakpoints": true
 		}
 	]
 }

--- a/backend/src/services/opportunity.service.ts
+++ b/backend/src/services/opportunity.service.ts
@@ -344,9 +344,35 @@ export class OpportunityService {
       return { opportunity: updated };
     }
 
+    await this.db.getOrCreateDM(userId, counterpart.userId).catch((err) => {
+      logger.error('[OpportunityService.updateOpportunityStatus] getOrCreateDM failed (non-blocking)', {
+        opportunityId,
+        userId,
+        counterpartUserId: counterpart.userId,
+        error: err,
+      });
+    });
+
     await this.db.acceptSiblingOpportunities(userId, counterpart.userId, opportunityId);
 
-    await this.db.upsertContactMembership(userId, counterpart.userId, { restore: true });
+    // Accepter explicitly acted — restore if previously removed.
+    // Counterpart: add them to the accepter but honour any prior opt-out on their side.
+    await this.db.upsertContactMembership(userId, counterpart.userId, { restore: true }).catch((err) => {
+      logger.error('[OpportunityService.updateOpportunityStatus] upsertContactMembership failed (non-blocking)', {
+        opportunityId,
+        userId,
+        counterpartUserId: counterpart.userId,
+        error: err,
+      });
+    });
+    await this.db.upsertContactMembership(counterpart.userId, userId, { restore: false }).catch((err) => {
+      logger.error('[OpportunityService.updateOpportunityStatus] upsertContactMembership (counterpart) failed (non-blocking)', {
+        opportunityId,
+        userId,
+        counterpartUserId: counterpart.userId,
+        error: err,
+      });
+    });
 
     return {
       opportunity: updated,

--- a/backend/src/services/opportunity.service.ts
+++ b/backend/src/services/opportunity.service.ts
@@ -328,62 +328,67 @@ export class OpportunityService {
       return { error: 'Not authorized to update this opportunity', status: 403 };
     }
 
+    const counterpart = status === 'accepted'
+      ? (opp.actors.find((actor) => actor.role !== 'introducer' && actor.userId !== userId)
+          ?? opp.actors.find((actor) => actor.userId !== userId))
+      : undefined;
+
+    if (counterpart) {
+      try {
+        await this.db.getOrCreateDM(userId, counterpart.userId);
+      } catch (err) {
+        logger.error('[OpportunityService.updateOpportunityStatus] getOrCreateDM failed; status left untouched', {
+          opportunityId,
+          userId,
+          counterpartUserId: counterpart.userId,
+          error: err,
+        });
+        return { error: 'Failed to create conversation for this opportunity', status: 500 };
+      }
+    }
+
     const updated = await this.db.updateOpportunityStatus(opportunityId, status);
     if (!updated) {
       return { error: 'Opportunity not found', status: 404 };
     }
 
-    if (status !== 'accepted') {
-      return { opportunity: updated };
-    }
-
-    const counterpart = opp.actors.find((actor) => actor.role !== 'introducer' && actor.userId !== userId)
-      ?? opp.actors.find((actor) => actor.userId !== userId);
-
     if (!counterpart) {
       return { opportunity: updated };
     }
 
-    await this.db.getOrCreateDM(userId, counterpart.userId).catch((err) => {
-      logger.error('[OpportunityService.updateOpportunityStatus] getOrCreateDM failed (non-blocking)', {
-        opportunityId,
-        userId,
-        counterpartUserId: counterpart.userId,
-        error: err,
-      });
-    });
+    const counterpartUserId = counterpart.userId;
 
-    await this.db.acceptSiblingOpportunities(userId, counterpart.userId, opportunityId).catch((err) => {
+    await this.db.acceptSiblingOpportunities(userId, counterpartUserId, opportunityId).catch((err) => {
       logger.error('[OpportunityService.updateOpportunityStatus] acceptSiblingOpportunities failed (non-blocking)', {
         opportunityId,
         userId,
-        counterpartUserId: counterpart.userId,
+        counterpartUserId,
         error: err,
       });
     });
 
     // Accepter explicitly acted — restore if previously removed.
     // Counterpart: add them to the accepter but honour any prior opt-out on their side.
-    await this.db.upsertContactMembership(userId, counterpart.userId, { restore: true }).catch((err) => {
+    await this.db.upsertContactMembership(userId, counterpartUserId, { restore: true }).catch((err) => {
       logger.error('[OpportunityService.updateOpportunityStatus] upsertContactMembership failed (non-blocking)', {
         opportunityId,
         userId,
-        counterpartUserId: counterpart.userId,
+        counterpartUserId,
         error: err,
       });
     });
-    await this.db.upsertContactMembership(counterpart.userId, userId, { restore: false }).catch((err) => {
+    await this.db.upsertContactMembership(counterpartUserId, userId, { restore: false }).catch((err) => {
       logger.error('[OpportunityService.updateOpportunityStatus] upsertContactMembership (counterpart) failed (non-blocking)', {
         opportunityId,
         userId,
-        counterpartUserId: counterpart.userId,
+        counterpartUserId,
         error: err,
       });
     });
 
     return {
       opportunity: updated,
-      counterpartUserId: counterpart.userId,
+      counterpartUserId,
     };
   }
 

--- a/backend/src/services/opportunity.service.ts
+++ b/backend/src/services/opportunity.service.ts
@@ -353,7 +353,14 @@ export class OpportunityService {
       });
     });
 
-    await this.db.acceptSiblingOpportunities(userId, counterpart.userId, opportunityId);
+    await this.db.acceptSiblingOpportunities(userId, counterpart.userId, opportunityId).catch((err) => {
+      logger.error('[OpportunityService.updateOpportunityStatus] acceptSiblingOpportunities failed (non-blocking)', {
+        opportunityId,
+        userId,
+        counterpartUserId: counterpart.userId,
+        error: err,
+      });
+    });
 
     // Accepter explicitly acted — restore if previously removed.
     // Counterpart: add them to the accepter but honour any prior opt-out on their side.

--- a/backend/src/services/opportunity.service.ts
+++ b/backend/src/services/opportunity.service.ts
@@ -482,6 +482,14 @@ export class OpportunityService {
         error: err,
       });
     });
+    await this.db.upsertContactMembership(counterpart.userId, userId, { restore: false }).catch((err) => {
+      logger.error('[OpportunityService.startChat] upsertContactMembership (counterpart) failed (non-blocking)', {
+        opportunityId,
+        userId,
+        counterpartUserId: counterpart.userId,
+        error: err,
+      });
+    });
 
     return {
       conversationId: conversation.id,

--- a/backend/src/services/tests/opportunity.service.startChat.spec.ts
+++ b/backend/src/services/tests/opportunity.service.startChat.spec.ts
@@ -184,7 +184,7 @@ describe('OpportunityService.startChat', () => {
 
     it('still returns the conversation when upsertContactMembership throws (best-effort)', async () => {
       const opp = makeOpportunity({ status: 'pending' });
-      const { service } = makeServiceWithDb(opp, {
+      const { service, db } = makeServiceWithDb(opp, {
         upsertContactMembership: mock(async () => {
           throw new Error('contacts index locked');
         }),
@@ -195,6 +195,8 @@ describe('OpportunityService.startChat', () => {
       expect('error' in result).toBe(false);
       if ('error' in result) return;
       expect(result.conversationId).toBe(CONV_ID);
+      // Both directions attempted even when first throws
+      expect(db.upsertContactMembership).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/backend/src/services/tests/opportunity.service.startChat.spec.ts
+++ b/backend/src/services/tests/opportunity.service.startChat.spec.ts
@@ -71,6 +71,11 @@ describe('OpportunityService.startChat', () => {
     expect(result.counterpartUserId).toBe(PEER_ID);
     expect(db.updateOpportunityStatus).toHaveBeenCalledWith(OPP_ID, 'accepted');
     expect(db.getOrCreateDM).toHaveBeenCalledWith(VIEWER_ID, PEER_ID);
+
+    // Both-way contact membership: accepter (restore:true) + counterpart (restore:false)
+    expect(db.upsertContactMembership).toHaveBeenCalledTimes(2);
+    expect(db.upsertContactMembership).toHaveBeenCalledWith(VIEWER_ID, PEER_ID, { restore: true });
+    expect(db.upsertContactMembership).toHaveBeenCalledWith(PEER_ID, VIEWER_ID, { restore: false });
   });
 
   it('flips draft → accepted for the orchestrator path', async () => {

--- a/backend/src/services/tests/opportunity.service.updateStatus.spec.ts
+++ b/backend/src/services/tests/opportunity.service.updateStatus.spec.ts
@@ -143,6 +143,25 @@ describe("OpportunityService.updateOpportunityStatus", () => {
     expect(db.upsertContactMembership).not.toHaveBeenCalled();
   });
 
+  it("returns 500 and does not flip status when getOrCreateDM throws", async () => {
+    const db = {
+      getOpportunity: mock(() => Promise.resolve(twoActorOpportunity)),
+      updateOpportunityStatus: mock(() =>
+        Promise.resolve({ ...twoActorOpportunity, status: "accepted" })
+      ),
+      acceptSiblingOpportunities: mock(() => Promise.resolve()),
+      upsertContactMembership: mock(() => Promise.resolve()),
+      getOrCreateDM: mock(() => Promise.reject(new Error("pg: connection error"))),
+    } as unknown as OpportunityControllerDatabase;
+    const service = new OpportunityService(db);
+
+    const result = await service.updateOpportunityStatus(OPP_ID, "accepted", USER_A);
+
+    expect(result).toHaveProperty("error");
+    expect((result as { status: number }).status).toBe(500);
+    expect(db.updateOpportunityStatus).not.toHaveBeenCalled();
+  });
+
   it("returns 403 when user is not an actor", async () => {
     const db = createMockDb(twoActorOpportunity);
     const service = new OpportunityService(db);

--- a/backend/src/services/tests/opportunity.service.updateStatus.spec.ts
+++ b/backend/src/services/tests/opportunity.service.updateStatus.spec.ts
@@ -111,6 +111,15 @@ describe("OpportunityService.updateOpportunityStatus", () => {
     expect(db.upsertContactMembership).not.toHaveBeenCalled();
   });
 
+  it("does NOT call getOrCreateDM when rejecting", async () => {
+    const db = createMockDb(twoActorOpportunity);
+    const service = new OpportunityService(db);
+
+    await service.updateOpportunityStatus(OPP_ID, "rejected", USER_A);
+
+    expect(db.getOrCreateDM).not.toHaveBeenCalled();
+  });
+
   it("accepts 'stalled' status and does NOT create a contact membership", async () => {
     const db = createMockDb(twoActorOpportunity);
     const service = new OpportunityService(db);

--- a/backend/src/services/tests/opportunity.service.updateStatus.spec.ts
+++ b/backend/src/services/tests/opportunity.service.updateStatus.spec.ts
@@ -2,7 +2,7 @@
 import { config } from "dotenv";
 config({ path: ".env.test", override: true });
 
-import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { describe, it, expect, mock } from "bun:test";
 
 import type { Opportunity, OpportunityControllerDatabase } from '@indexnetwork/protocol';
 import { OpportunityService } from "../opportunity.service";
@@ -59,6 +59,7 @@ function createMockDb(opportunity: Opportunity | null) {
     ),
     acceptSiblingOpportunities: mock(() => Promise.resolve()),
     upsertContactMembership: mock(() => Promise.resolve()),
+    getOrCreateDM: mock(() => Promise.resolve({ id: "conv-backfill-001" })),
   } as unknown as OpportunityControllerDatabase;
 }
 
@@ -67,7 +68,7 @@ function createMockDb(opportunity: Opportunity | null) {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("OpportunityService.updateOpportunityStatus", () => {
-  it("calls upsertContactMembership with counterpart when accepting a 2-actor opportunity", async () => {
+  it("creates DM and adds contacts both ways when accepting a 2-actor opportunity", async () => {
     const db = createMockDb(twoActorOpportunity);
     const service = new OpportunityService(db);
 
@@ -75,11 +76,18 @@ describe("OpportunityService.updateOpportunityStatus", () => {
 
     expect(result).not.toHaveProperty("error");
     expect((result as { counterpartUserId?: string }).counterpartUserId).toBe(USER_B);
-    expect(db.upsertContactMembership).toHaveBeenCalledTimes(1);
+
+    // DM created between the pair
+    expect(db.getOrCreateDM).toHaveBeenCalledWith(USER_A, USER_B);
+
+    // Contact added both ways: accepter gets counterpart (restore:true),
+    // counterpart gets accepter (restore:false — honours prior opt-out)
+    expect(db.upsertContactMembership).toHaveBeenCalledTimes(2);
     expect(db.upsertContactMembership).toHaveBeenCalledWith(USER_A, USER_B, { restore: true });
+    expect(db.upsertContactMembership).toHaveBeenCalledWith(USER_B, USER_A, { restore: false });
   });
 
-  it("calls upsertContactMembership with non-introducer counterpart in 3-actor opportunity", async () => {
+  it("creates DM and adds contacts both ways with non-introducer counterpart in 3-actor opportunity", async () => {
     const db = createMockDb(threeActorOpportunity);
     const service = new OpportunityService(db);
 
@@ -87,8 +95,11 @@ describe("OpportunityService.updateOpportunityStatus", () => {
 
     expect(result).not.toHaveProperty("error");
     expect((result as { counterpartUserId?: string }).counterpartUserId).toBe(USER_B);
-    expect(db.upsertContactMembership).toHaveBeenCalledTimes(1);
+
+    expect(db.getOrCreateDM).toHaveBeenCalledWith(USER_A, USER_B);
+    expect(db.upsertContactMembership).toHaveBeenCalledTimes(2);
     expect(db.upsertContactMembership).toHaveBeenCalledWith(USER_A, USER_B, { restore: true });
+    expect(db.upsertContactMembership).toHaveBeenCalledWith(USER_B, USER_A, { restore: false });
   });
 
   it("does NOT call upsertContactMembership when rejecting", async () => {

--- a/frontend/src/components/ChatContent.tsx
+++ b/frontend/src/components/ChatContent.tsx
@@ -43,6 +43,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { useNetworkFilter } from "@/contexts/IndexFilterContext";
 import { useNetworksState } from "@/contexts/IndexesContext";
+import { useConversation } from "@/contexts/ConversationContext";
 import { apiClient } from "@/lib/api";
 import { useSuggestions } from "@/hooks/useSuggestions";
 
@@ -361,6 +362,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
   } = useAIChat();
   const uploadServiceV2 = useUploadServiceV2();
   const { error: showError, success: showSuccess, addNotification } = useNotifications();
+  const { refreshConversations } = useConversation();
   const [input, setInput] = useState("");
   const [selectedFiles, setSelectedFiles] = useState<PendingFile[]>([]);
   const [isUploadingFiles, setIsUploadingFiles] = useState(false);
@@ -791,6 +793,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
       try {
         const result = await opportunitiesService.startChat(opportunityId);
         setOpportunityStatusMap((prev) => ({ ...prev, [opportunityId]: "accepted" }));
+        refreshConversations();
         if (result.conversationId) {
           navigate(`/chat/${result.conversationId}`);
         } else {
@@ -802,7 +805,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
         setOpportunityActionLoading((prev) => ({ ...prev, [opportunityId]: false }));
       }
     },
-    [opportunitiesService, navigate, showError],
+    [opportunitiesService, navigate, showError, refreshConversations],
   );
 
   const archiveProposalIntent = useCallback(

--- a/frontend/src/components/ChatSidebar.tsx
+++ b/frontend/src/components/ChatSidebar.tsx
@@ -102,7 +102,7 @@ export default function ChatSidebar() {
         lastMessage: preview,
         lastMessageIsInternal: !messageText && !!reasoningText,
         negotiationStatus,
-        sortTimestamp: conv.lastMessageAt ? new Date(conv.lastMessageAt).getTime() : 0,
+        sortTimestamp: new Date(conv.lastMessageAt ?? conv.createdAt).getTime(),
       };
     }
     const peer = (conv.participants ?? []).find((p) => p.participantId !== user?.id && p.participantType === 'user');
@@ -115,7 +115,7 @@ export default function ChatSidebar() {
       lastMessage: lastText,
       lastMessageIsInternal: false,
       negotiationStatus: null,
-      sortTimestamp: conv.lastMessageAt ? new Date(conv.lastMessageAt).getTime() : 0,
+      sortTimestamp: new Date(conv.lastMessageAt ?? conv.createdAt).getTime(),
     };
   }).sort((a, b) => b.sortTimestamp - a.sortTimestamp);
 

--- a/frontend/src/services/conversation.ts
+++ b/frontend/src/services/conversation.ts
@@ -8,6 +8,7 @@ export interface ConversationSummary {
   lastMessage: { parts: unknown[]; senderId: string; createdAt: string } | null;
   metadata: { title?: string; shareToken?: string } | null;
   lastMessageAt: string | null;
+  createdAt: string;
 }
 
 export interface ConversationMessage {


### PR DESCRIPTION
## Summary

- **`updateOpportunityStatus` (PATCH path)**: on `status=accepted`, now calls `getOrCreateDM` and adds each user to the other's contacts (`restore:true` for accepter, `restore:false` for counterpart). Previously only added one-directional contact with no DM.
- **`startChat`**: adds the missing reverse `upsertContactMembership(counterpart → accepter, restore:false)` to match the PATCH path.
- **Migration `0058_backfill_accepted_opportunity_dms`**: SQL backfill that creates DM conversations for all historically accepted opportunities missing a `dm_pair` row. Runs automatically on deploy via `preDeployCommand`. Idempotent via `ON CONFLICT (dm_pair) DO NOTHING`.
- **Bonus fix**: `acceptSiblingOpportunities` in `updateOpportunityStatus` was an unguarded `await` — wrapped with `.catch` so a failure no longer skips the contact-membership writes below it.

## Test Plan

- [ ] All 16 unit tests pass (`opportunity.service.updateStatus.spec.ts` × 7, `opportunity.service.startChat.spec.ts` × 9)
- [ ] Deploy to staging — confirm `bun run db:migrate` applies migration `0058` cleanly
- [ ] Accept a new opportunity via the UI "Start Chat" button — verify conversation appears in `/chat` sidebar
- [ ] Accept an opportunity via `PATCH /opportunities/:id` with `{status:"accepted"}` — verify conversation created and both users see each other in contacts
- [ ] Verify pre-existing accepted opportunities (historical) now appear in the `/chat` sidebar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Direct message conversations are now automatically created when accepting an opportunity, enabling seamless communication between participants.
  * Bidirectional messaging relationships are now established between all relevant parties in accepted opportunities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->