### PR TITLE
feat(debug): surface orchestrator negotiations in debug meta + TRACE panel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,6 +266,8 @@ All agents are first-class database entities backed by `agents`, `agent_transpor
 
 `requestContext` carries a `traceEmitter?` callback for real-time TRACE panel in chat UI. Tool files emit `graph_start/graph_end` around graph invocations; graph files emit `agent_start/agent_end` around agent calls. Use kebab-case agent names. See `docs/design/protocol-deep-dive.md` for full examples.
 
+Negotiation-specific events (`negotiation_session_start/end`, `negotiation_turn`, `negotiation_outcome`) carry per-candidate turn and outcome data for orchestrator-inline negotiations. They are persisted into `debugMeta.orchestratorNegotiations.opportunityIds` for later hydration by the debug endpoint. `debugMeta` also now tracks `llm.{calls,totalDurationMs,resets,hallucinations}` accumulated from `llm_start/end`, `response_reset`, and `hallucination_detected` events.
+
 ### OpenRouter Configuration
 
 Model settings centralized in `packages/protocol/src/shared/agent/model.config.ts`. Key env vars: `OPENROUTER_API_KEY` (required), `CHAT_MODEL` (override), `CHAT_REASONING_EFFORT` (`minimal|low|medium|high|xhigh`), `RUN_OPPORTUNITY_EVAL_IN_PARALLEL` (experimental). Use `configureProtocol({ apiKey, chatModel, ... })` to inject config programmatically.

--- a/backend/src/controllers/chat.controller.ts
+++ b/backend/src/controllers/chat.controller.ts
@@ -249,7 +249,7 @@ export class ChatController {
           let fullResponse = "";
           let routingDecision: Record<string, unknown> | undefined;
           let subgraphResults: Record<string, unknown> | undefined;
-          let debugMeta: { graph: string; iterations: number; tools: unknown[] } | undefined;
+          let debugMeta: { graph: string; iterations: number; tools: unknown[]; llm?: unknown; orchestratorNegotiations?: unknown } | undefined;
 
           // Use context-aware streaming to load previous messages
           // checkpointer is PostgresSaver from the local install; the package expects
@@ -292,6 +292,8 @@ export class ChatController {
                   graph: event.graph,
                   iterations: event.iterations,
                   tools: event.tools,
+                  llm: event.llm,
+                  ...(event.orchestratorNegotiations !== undefined && { orchestratorNegotiations: event.orchestratorNegotiations }),
                 };
               }
             }

--- a/backend/src/controllers/debug.controller.ts
+++ b/backend/src/controllers/debug.controller.ts
@@ -788,8 +788,8 @@ export class DebugController {
         const turnMessages = negMessages.slice(0, TURN_LIMIT);
 
         const negTurns: NegotiationTurnEntry[] = turnMessages.map((m, i) => {
-          const actor: 'source' | 'candidate' =
-            m.senderId === sourceUserId ? 'source' : 'candidate';
+          const senderBareId = m.senderId?.startsWith('agent:') ? m.senderId.slice('agent:'.length) : m.senderId;
+          const actor: 'source' | 'candidate' = senderBareId === sourceUserId ? 'source' : 'candidate';
 
           // Find the data part
           const parts = m.parts as Array<{ kind?: string; data?: Record<string, unknown> }>;

--- a/backend/src/controllers/debug.controller.ts
+++ b/backend/src/controllers/debug.controller.ts
@@ -1,4 +1,4 @@
-import { eq, and, sql, desc, asc, min, max, count, inArray } from 'drizzle-orm';
+import { eq, and, sql, desc, asc, min, max, count, inArray, gte, lte } from 'drizzle-orm';
 
 import db from '../lib/drizzle/drizzle';
 import { log } from '../lib/log';
@@ -657,8 +657,9 @@ export class DebugController {
       negotiations?: NegotiationDebugEntry[];
     }> = [];
 
-    // Track raw debugMeta per turn index for later negotiation hydration
+    // Track raw debugMeta and message createdAt per turn index for later negotiation hydration
     const rawDebugMetaByTurnIndex = new Map<number, Record<string, unknown>>();
+    const msgCreatedAtByTurnIndex = new Map<number, Date>();
 
     for (const msg of messageRows) {
       const messageIndex = chatMessages.length;
@@ -708,22 +709,50 @@ export class DebugController {
             : [],
         });
 
-        // Capture raw debugMeta for negotiation hydration
+        // Capture raw debugMeta and message timestamp for negotiation hydration
         if (source && typeof source === 'object') {
           rawDebugMetaByTurnIndex.set(turnIndex, source as Record<string, unknown>);
+        }
+        if (msg.createdAt) {
+          msgCreatedAtByTurnIndex.set(turnIndex, msg.createdAt);
         }
       }
     }
 
     // ── 5. Hydrate negotiation data for each turn ─────────────────────────
     for (const [turnIndex, rawMeta] of rawDebugMetaByTurnIndex.entries()) {
-      // Safely extract orchestratorNegotiations.opportunityIds
+      // Safely extract orchestratorNegotiations.opportunityIds (pointer path)
       const orchNeg = rawMeta.orchestratorNegotiations;
-      if (!orchNeg || typeof orchNeg !== 'object') continue;
-      const oppIds = (orchNeg as Record<string, unknown>).opportunityIds;
-      if (!Array.isArray(oppIds) || oppIds.length === 0) continue;
-      const opportunityIds = oppIds.filter((id): id is string => typeof id === 'string');
-      if (opportunityIds.length === 0) continue;
+      const oppIds = orchNeg && typeof orchNeg === 'object'
+        ? (orchNeg as Record<string, unknown>).opportunityIds
+        : undefined;
+      const pointerIds = Array.isArray(oppIds)
+        ? oppIds.filter((id): id is string => typeof id === 'string')
+        : [];
+
+      let effectiveOpportunityIds: string[] | null = pointerIds.length > 0 ? pointerIds : null;
+
+      // Fallback: if no pointer, query by time-window for legacy messages
+      if (!effectiveOpportunityIds) {
+        const msgTs = msgCreatedAtByTurnIndex.get(turnIndex);
+        if (!msgTs) continue;
+        const WINDOW_MS = 10 * 60 * 1000;
+        const fromTs = new Date(msgTs.getTime() - WINDOW_MS);
+        const toTs = new Date(msgTs.getTime() + WINDOW_MS);
+        const oppsInWindow = await db
+          .select({ id: opportunities.id })
+          .from(opportunities)
+          .where(and(
+            sql`${opportunities.actors}::jsonb @> ${JSON.stringify([{ userId: user.id }])}::jsonb`,
+            sql`${opportunities.detection}->>'source' = 'chat'`,
+            gte(opportunities.createdAt, fromTs),
+            lte(opportunities.createdAt, toTs),
+          ));
+        if (oppsInWindow.length === 0) continue;
+        effectiveOpportunityIds = oppsInWindow.map((o) => o.id);
+      }
+
+      const opportunityIds = effectiveOpportunityIds;
 
       // Fetch negotiation tasks matching any of the opportunity IDs
       const taskRows = await db

--- a/backend/src/controllers/debug.controller.ts
+++ b/backend/src/controllers/debug.controller.ts
@@ -754,7 +754,7 @@ export class DebugController {
 
       const opportunityIds = effectiveOpportunityIds;
 
-      // Fetch negotiation tasks matching any of the opportunity IDs
+      // Fetch negotiation tasks matching any of the opportunity IDs (newest first)
       const taskRows = await db
         .select({
           id: tasks.id,
@@ -770,14 +770,15 @@ export class DebugController {
             sql`${tasks.metadata}->>'type' = 'negotiation'`,
             inArray(sql`${tasks.metadata}->>'opportunityId'`, opportunityIds),
           ),
-        );
+        )
+        .orderBy(desc(tasks.createdAt));
 
-      // Build a map from opportunityId to task row (latest wins)
+      // Build a map from opportunityId to task row — first entry wins (latest due to orderBy above)
       const taskByOppId = new Map<string, typeof taskRows[0]>();
       for (const row of taskRows) {
         const meta = row.metadata as Record<string, unknown> | null;
         const oppId = meta?.opportunityId;
-        if (typeof oppId === 'string') {
+        if (typeof oppId === 'string' && !taskByOppId.has(oppId)) {
           taskByOppId.set(oppId, row);
         }
       }

--- a/backend/src/controllers/debug.controller.ts
+++ b/backend/src/controllers/debug.controller.ts
@@ -1,4 +1,4 @@
-import { eq, and, sql, desc, asc, min, max, count } from 'drizzle-orm';
+import { eq, and, sql, desc, asc, min, max, count, inArray } from 'drizzle-orm';
 
 import db from '../lib/drizzle/drizzle';
 import { log } from '../lib/log';
@@ -17,6 +17,7 @@ import {
   conversationParticipants,
   conversationMetadata,
   messages,
+  tasks,
 } from '../schemas/conversation.schema';
 import { debugService } from '../services/debug.service';
 
@@ -610,6 +611,31 @@ export class DebugController {
     const sessionMeta = meta._sessionMeta ? { metadata: meta._sessionMeta } : null;
 
     // ── 4. Build messages and turns ──────────────────────────────────────
+
+    type NegotiationTurnEntry = {
+      turnIndex: number;
+      actor: 'source' | 'candidate';
+      action: string;
+      reasoning?: string;
+      message?: string;
+      suggestedRoles?: { ownUser?: string; otherUser?: string };
+      createdAt: string;
+    };
+
+    type NegotiationDebugEntry = {
+      opportunityId: string;
+      negotiationConversationId: string;
+      taskState: string;
+      sourceUserId: string;
+      candidateUserId: string;
+      turns: NegotiationTurnEntry[];
+      outcome: { status: string; turnCount: number } | null;
+      startedAt: string | null;
+      endedAt: string | null;
+      durationMs: number | null;
+      turnsTruncated?: boolean;
+    };
+
     const chatMessages: Array<{ role: string; content: string }> = [];
     const turns: Array<{
       messageIndex: number;
@@ -628,7 +654,11 @@ export class DebugController {
           agents: Array<{ name: string; durationMs: number }>;
         }>;
       }>;
+      negotiations?: NegotiationDebugEntry[];
     }> = [];
+
+    // Track raw debugMeta per turn index for later negotiation hydration
+    const rawDebugMetaByTurnIndex = new Map<number, Record<string, unknown>>();
 
     for (const msg of messageRows) {
       const messageIndex = chatMessages.length;
@@ -660,6 +690,7 @@ export class DebugController {
           : undefined;
         const source = debugMetaFromMetadata ?? fallbackMeta;
 
+        const turnIndex = turns.length;
         turns.push({
           messageIndex,
           graph: source?.graph ?? null,
@@ -676,6 +707,141 @@ export class DebugController {
               }))
             : [],
         });
+
+        // Capture raw debugMeta for negotiation hydration
+        if (source && typeof source === 'object') {
+          rawDebugMetaByTurnIndex.set(turnIndex, source as Record<string, unknown>);
+        }
+      }
+    }
+
+    // ── 5. Hydrate negotiation data for each turn ─────────────────────────
+    for (const [turnIndex, rawMeta] of rawDebugMetaByTurnIndex.entries()) {
+      // Safely extract orchestratorNegotiations.opportunityIds
+      const orchNeg = rawMeta.orchestratorNegotiations;
+      if (!orchNeg || typeof orchNeg !== 'object') continue;
+      const oppIds = (orchNeg as Record<string, unknown>).opportunityIds;
+      if (!Array.isArray(oppIds) || oppIds.length === 0) continue;
+      const opportunityIds = oppIds.filter((id): id is string => typeof id === 'string');
+      if (opportunityIds.length === 0) continue;
+
+      // Fetch negotiation tasks matching any of the opportunity IDs
+      const taskRows = await db
+        .select({
+          id: tasks.id,
+          conversationId: tasks.conversationId,
+          state: tasks.state,
+          metadata: tasks.metadata,
+          createdAt: tasks.createdAt,
+          updatedAt: tasks.updatedAt,
+        })
+        .from(tasks)
+        .where(
+          and(
+            sql`${tasks.metadata}->>'type' = 'negotiation'`,
+            inArray(sql`${tasks.metadata}->>'opportunityId'`, opportunityIds),
+          ),
+        );
+
+      // Build a map from opportunityId to task row (latest wins)
+      const taskByOppId = new Map<string, typeof taskRows[0]>();
+      for (const row of taskRows) {
+        const meta = row.metadata as Record<string, unknown> | null;
+        const oppId = meta?.opportunityId;
+        if (typeof oppId === 'string') {
+          taskByOppId.set(oppId, row);
+        }
+      }
+
+      // Fetch opportunity status for all IDs
+      const oppRows = await db
+        .select({ id: opportunities.id, status: opportunities.status })
+        .from(opportunities)
+        .where(inArray(opportunities.id, opportunityIds));
+      const oppStatusById = new Map(oppRows.map((o) => [o.id, o.status]));
+
+      const negotiations: NegotiationDebugEntry[] = [];
+
+      for (const oppId of opportunityIds) {
+        const task = taskByOppId.get(oppId);
+        if (!task) continue;
+
+        const taskMeta = (task.metadata ?? {}) as Record<string, unknown>;
+        const sourceUserId = typeof taskMeta.sourceUserId === 'string' ? taskMeta.sourceUserId : '';
+        const candidateUserId = typeof taskMeta.candidateUserId === 'string' ? taskMeta.candidateUserId : '';
+
+        // Fetch turn messages for this negotiation conversation
+        const TURN_LIMIT = 20;
+        const negMessages = await db
+          .select({
+            id: messages.id,
+            senderId: messages.senderId,
+            parts: messages.parts,
+            createdAt: messages.createdAt,
+          })
+          .from(messages)
+          .where(eq(messages.conversationId, task.conversationId))
+          .orderBy(asc(messages.createdAt))
+          .limit(TURN_LIMIT + 1);
+
+        const turnsTruncated = negMessages.length > TURN_LIMIT;
+        const turnMessages = negMessages.slice(0, TURN_LIMIT);
+
+        const negTurns: NegotiationTurnEntry[] = turnMessages.map((m, i) => {
+          const actor: 'source' | 'candidate' =
+            m.senderId === sourceUserId ? 'source' : 'candidate';
+
+          // Find the data part
+          const parts = m.parts as Array<{ kind?: string; data?: Record<string, unknown> }>;
+          const dataPart = parts.find((p) => p.kind === 'data');
+          const data = dataPart?.data ?? {};
+
+          const action = typeof data.action === 'string' ? data.action : 'unknown';
+          const assessment = data.assessment && typeof data.assessment === 'object'
+            ? data.assessment as Record<string, unknown>
+            : {};
+          const reasoning = typeof assessment.reasoning === 'string' ? assessment.reasoning : undefined;
+          const suggestedRolesRaw = assessment.suggestedRoles;
+          const suggestedRoles = suggestedRolesRaw && typeof suggestedRolesRaw === 'object'
+            ? suggestedRolesRaw as { ownUser?: string; otherUser?: string }
+            : undefined;
+          const message = typeof data.message === 'string' ? data.message : undefined;
+
+          return {
+            turnIndex: i,
+            actor,
+            action,
+            reasoning,
+            message,
+            suggestedRoles,
+            createdAt: m.createdAt.toISOString(),
+          };
+        });
+
+        const oppStatus = oppStatusById.get(oppId) ?? null;
+        const startedAt = task.createdAt.toISOString();
+        const endedAt = task.updatedAt.toISOString();
+        const durationMs = task.updatedAt.getTime() - task.createdAt.getTime();
+
+        const entry: NegotiationDebugEntry = {
+          opportunityId: oppId,
+          negotiationConversationId: task.conversationId,
+          taskState: task.state,
+          sourceUserId,
+          candidateUserId,
+          turns: negTurns,
+          outcome: oppStatus !== null ? { status: oppStatus, turnCount: negTurns.length } : null,
+          startedAt,
+          endedAt,
+          durationMs,
+          ...(turnsTruncated ? { turnsTruncated: true } : {}),
+        };
+
+        negotiations.push(entry);
+      }
+
+      if (negotiations.length > 0) {
+        turns[turnIndex].negotiations = negotiations;
       }
     }
 

--- a/backend/tests/debug.chat.legacy.spec.ts
+++ b/backend/tests/debug.chat.legacy.spec.ts
@@ -1,0 +1,214 @@
+import '../src/startup.env';
+
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+
+import { eq } from 'drizzle-orm';
+
+import { DebugController } from '../src/controllers/debug.controller';
+import db from '../src/lib/drizzle/drizzle';
+import { opportunities, users } from '../src/schemas/database.schema';
+import {
+  conversationParticipants,
+  conversations,
+  messages,
+  tasks,
+} from '../src/schemas/conversation.schema';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRequest(method = 'GET') {
+  return new Request('http://localhost/', { method });
+}
+
+function makeUser(id: string) {
+  return { id } as never;
+}
+
+function makeParams(overrides: Record<string, string> = {}) {
+  return overrides;
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+let userId: string;
+let chatConvId: string;
+let oppId: string;
+let negConvId: string;
+
+beforeAll(async () => {
+  // 1. Seed a real user
+  const [user] = await db
+    .insert(users)
+    .values({ email: `debug-legacy-test-${randomUUID()}@example.com`, name: 'Debug Legacy Test User' })
+    .returning();
+  userId = user.id;
+
+  // 2. Seed a chat conversation for the session user
+  const [chatConv] = await db
+    .insert(conversations)
+    .values({})
+    .returning();
+  chatConvId = chatConv.id;
+
+  // Add user participant
+  await db.insert(conversationParticipants).values({
+    conversationId: chatConvId,
+    participantId: userId,
+    participantType: 'user',
+  });
+
+  // Add a user turn message
+  await db.insert(messages).values({
+    conversationId: chatConvId,
+    senderId: userId,
+    role: 'user',
+    parts: [{ kind: 'text', text: 'Find me connections' }],
+  });
+
+  // 3. Add an assistant turn message with legacy debugMeta — NO orchestratorNegotiations pointer
+  const [assistantMsg] = await db.insert(messages).values({
+    conversationId: chatConvId,
+    senderId: 'system-agent',
+    role: 'agent',
+    parts: [{ kind: 'text', text: 'Here are your matches.' }],
+    metadata: {
+      debugMeta: {
+        graph: 'agent_loop',
+        iterations: 1,
+        tools: [],
+        // intentionally omit orchestratorNegotiations
+      },
+    },
+  }).returning();
+
+  const msgCreatedAt = assistantMsg.createdAt;
+
+  // 4. Seed one opportunity where the session user appears in actors,
+  //    detection.source = 'chat' (orchestrator-triggered), and
+  //    createdAt = 2 seconds after the assistant message's createdAt
+  const oppCreatedAt = new Date(msgCreatedAt.getTime() + 2000);
+  const [opp] = await db
+    .insert(opportunities)
+    .values({
+      detection: { source: 'chat', timestamp: new Date().toISOString() },
+      actors: [{ networkId: 'net-1', userId, role: 'source' }],
+      interpretation: { category: 'test', reasoning: 'test', confidence: 0.9 },
+      context: { networkId: 'net-1' },
+      confidence: '0.9',
+      status: 'draft',
+      createdAt: oppCreatedAt,
+    })
+    .returning();
+  oppId = opp.id;
+
+  // 5. Seed a negotiation conversation + task + 1 turn message for the opportunity
+  const [negConv] = await db
+    .insert(conversations)
+    .values({})
+    .returning();
+  negConvId = negConv.id;
+
+  const candidateUserId = 'u-cand-legacy';
+
+  const [task] = await db
+    .insert(tasks)
+    .values({
+      conversationId: negConvId,
+      state: 'completed',
+      metadata: {
+        type: 'negotiation',
+        opportunityId: oppId,
+        sourceUserId: userId,
+        candidateUserId,
+      },
+    })
+    .returning();
+
+  // Seed 1 turn message in the negotiation conversation
+  await db.insert(messages).values({
+    conversationId: negConvId,
+    taskId: task.id,
+    senderId: `agent:${userId}`,
+    role: 'user',
+    parts: [
+      {
+        kind: 'data',
+        data: {
+          action: 'propose',
+          assessment: {
+            reasoning: 'Legacy path test',
+          },
+        },
+      },
+    ],
+  });
+});
+
+afterAll(async () => {
+  // Clean up in reverse dependency order
+  if (chatConvId) {
+    await db.delete(messages).where(eq(messages.conversationId, chatConvId));
+    await db.delete(conversationParticipants).where(eq(conversationParticipants.conversationId, chatConvId));
+    await db.delete(conversations).where(eq(conversations.id, chatConvId));
+  }
+  if (negConvId) {
+    await db.delete(messages).where(eq(messages.conversationId, negConvId));
+    await db.delete(tasks).where(eq(tasks.conversationId, negConvId));
+    await db.delete(conversations).where(eq(conversations.id, negConvId));
+  }
+  if (oppId) await db.delete(opportunities).where(eq(opportunities.id, oppId));
+  if (userId) await db.delete(users).where(eq(users.id, userId));
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GET /debug/chat/:id — legacy negotiation hydration (time-window fallback)', () => {
+  it('returns 200 with negotiations hydrated via time-window fallback for legacy messages', async () => {
+    const controller = new DebugController();
+
+    const res = await controller.getChatDebug(
+      makeRequest(),
+      makeUser(userId),
+      makeParams({ id: chatConvId }),
+    );
+
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as {
+      turns: Array<{
+        messageIndex: number;
+        negotiations?: Array<{
+          opportunityId: string;
+          turns: Array<unknown>;
+          outcome: { status: string; turnCount: number } | null;
+        }>;
+      }>;
+    };
+
+    // Find the assistant turn — it should have negotiations hydrated via fallback
+    const assistantTurn = body.turns.find((t) => t.negotiations !== undefined);
+    expect(assistantTurn).toBeDefined();
+
+    const negotiations = assistantTurn!.negotiations!;
+    expect(Array.isArray(negotiations)).toBe(true);
+    expect(negotiations).toHaveLength(1);
+
+    // Verify the correct opportunity ID is present
+    expect(negotiations[0].opportunityId).toBe(oppId);
+
+    // Verify turns were fetched
+    expect(Array.isArray(negotiations[0].turns)).toBe(true);
+    expect(negotiations[0].turns.length).toBeGreaterThanOrEqual(1);
+
+    // Verify outcome
+    expect(negotiations[0].outcome).not.toBeNull();
+    expect(negotiations[0].outcome?.status).toBe('draft');
+  });
+});

--- a/backend/tests/debug.chat.negotiations.spec.ts
+++ b/backend/tests/debug.chat.negotiations.spec.ts
@@ -1,0 +1,273 @@
+import '../src/startup.env';
+
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+
+import { eq } from 'drizzle-orm';
+
+import { DebugController } from '../src/controllers/debug.controller';
+import db from '../src/lib/drizzle/drizzle';
+import { opportunities, users } from '../src/schemas/database.schema';
+import {
+  conversationParticipants,
+  conversations,
+  messages,
+  tasks,
+} from '../src/schemas/conversation.schema';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRequest(method = 'GET') {
+  return new Request('http://localhost/', { method });
+}
+
+function makeUser(id: string) {
+  return { id } as never;
+}
+
+function makeParams(overrides: Record<string, string> = {}) {
+  return overrides;
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+let userId: string;
+let chatConvId: string;
+let oppId1: string;
+let oppId2: string;
+let negConvId1: string;
+let negConvId2: string;
+
+beforeAll(async () => {
+  // 1. Seed a real user
+  const [user] = await db
+    .insert(users)
+    .values({ email: `debug-neg-test-${randomUUID()}@example.com`, name: 'Debug Neg Test User' })
+    .returning();
+  userId = user.id;
+
+  // 2. Seed two opportunities linked to the user
+  const [opp1] = await db
+    .insert(opportunities)
+    .values({
+      detection: { source: 'chat', timestamp: new Date().toISOString() },
+      actors: [{ networkId: 'net-1', userId, role: 'source' }],
+      interpretation: { category: 'test', reasoning: 'test', confidence: 0.9 },
+      context: { networkId: 'net-1' },
+      confidence: '0.9',
+      status: 'draft',
+    })
+    .returning();
+  oppId1 = opp1.id;
+
+  const [opp2] = await db
+    .insert(opportunities)
+    .values({
+      detection: { source: 'chat', timestamp: new Date().toISOString() },
+      actors: [{ networkId: 'net-1', userId, role: 'source' }],
+      interpretation: { category: 'test', reasoning: 'test', confidence: 0.8 },
+      context: { networkId: 'net-1' },
+      confidence: '0.8',
+      status: 'rejected',
+    })
+    .returning();
+  oppId2 = opp2.id;
+
+  const candidateUserId = 'u-cand';
+
+  // 3. Seed negotiation conversations + tasks + messages for each opportunity
+  for (const [oppId, idx] of [[oppId1, 0], [oppId2, 1]] as [string, number][]) {
+    const [negConv] = await db
+      .insert(conversations)
+      .values({})
+      .returning();
+    const negConvId = negConv.id;
+
+    if (idx === 0) negConvId1 = negConvId;
+    else negConvId2 = negConvId;
+
+    const [task] = await db
+      .insert(tasks)
+      .values({
+        conversationId: negConvId,
+        state: 'completed',
+        metadata: {
+          type: 'negotiation',
+          opportunityId: oppId,
+          sourceUserId: userId,
+          candidateUserId,
+        },
+      })
+      .returning();
+
+    // Seed 2 turn messages in the negotiation conversation
+    await db.insert(messages).values([
+      {
+        conversationId: negConvId,
+        taskId: task.id,
+        senderId: userId, // source actor
+        role: 'user',
+        parts: [
+          {
+            kind: 'data',
+            data: {
+              action: 'propose',
+              assessment: {
+                reasoning: 'This looks promising',
+                suggestedRoles: { ownUser: 'agent', otherUser: 'patient' },
+              },
+            },
+          },
+        ],
+      },
+      {
+        conversationId: negConvId,
+        taskId: task.id,
+        senderId: candidateUserId, // candidate actor
+        role: 'agent',
+        parts: [
+          {
+            kind: 'data',
+            data: {
+              action: 'accept',
+              assessment: {
+                reasoning: 'Agreed',
+                suggestedRoles: { ownUser: 'patient', otherUser: 'agent' },
+              },
+            },
+          },
+        ],
+      },
+    ]);
+  }
+
+  // 4. Seed a chat conversation for the session user with one assistant message
+  //    whose debugMeta.orchestratorNegotiations.opportunityIds contains both opp IDs
+  const [chatConv] = await db
+    .insert(conversations)
+    .values({})
+    .returning();
+  chatConvId = chatConv.id;
+
+  // Add user participant
+  await db.insert(conversationParticipants).values({
+    conversationId: chatConvId,
+    participantId: userId,
+    participantType: 'user',
+  });
+
+  // Add a user turn message
+  await db.insert(messages).values({
+    conversationId: chatConvId,
+    senderId: userId,
+    role: 'user',
+    parts: [{ kind: 'text', text: 'Find me connections' }],
+  });
+
+  // Add an assistant turn message with debugMeta containing opportunityIds
+  await db.insert(messages).values({
+    conversationId: chatConvId,
+    senderId: 'system-agent',
+    role: 'agent',
+    parts: [{ kind: 'text', text: 'Here are your matches.' }],
+    metadata: {
+      debugMeta: {
+        graph: 'chat',
+        iterations: 1,
+        tools: [],
+        orchestratorNegotiations: {
+          opportunityIds: [oppId1, oppId2],
+        },
+      },
+    },
+  });
+});
+
+afterAll(async () => {
+  // Clean up in reverse dependency order
+  if (chatConvId) {
+    await db.delete(messages).where(eq(messages.conversationId, chatConvId));
+    await db.delete(conversationParticipants).where(eq(conversationParticipants.conversationId, chatConvId));
+    await db.delete(conversations).where(eq(conversations.id, chatConvId));
+  }
+  for (const negConvId of [negConvId1, negConvId2].filter(Boolean)) {
+    await db.delete(messages).where(eq(messages.conversationId, negConvId));
+    await db.delete(tasks).where(eq(tasks.conversationId, negConvId));
+    await db.delete(conversations).where(eq(conversations.id, negConvId));
+  }
+  if (oppId1) await db.delete(opportunities).where(eq(opportunities.id, oppId1));
+  if (oppId2) await db.delete(opportunities).where(eq(opportunities.id, oppId2));
+  if (userId) await db.delete(users).where(eq(users.id, userId));
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GET /debug/chat/:id — negotiation hydration', () => {
+  it('returns 200 with negotiations hydrated on the assistant turn', async () => {
+    const controller = new DebugController();
+
+    const res = await controller.getChatDebug(
+      makeRequest(),
+      makeUser(userId),
+      makeParams({ id: chatConvId }),
+    );
+
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as {
+      turns: Array<{
+        messageIndex: number;
+        negotiations?: Array<{
+          opportunityId: string;
+          turns: Array<unknown>;
+          outcome: { status: string; turnCount: number } | null;
+        }>;
+      }>;
+    };
+
+    // Find the assistant turn (messageIndex 1, since user msg is 0)
+    const assistantTurn = body.turns.find((t) => t.negotiations !== undefined);
+    expect(assistantTurn).toBeDefined();
+
+    const negotiations = assistantTurn!.negotiations!;
+    expect(Array.isArray(negotiations)).toBe(true);
+    expect(negotiations).toHaveLength(2);
+
+    // Each entry must have the required fields
+    for (const neg of negotiations) {
+      expect(typeof neg.opportunityId).toBe('string');
+      expect(Array.isArray(neg.turns)).toBe(true);
+      expect(neg.turns.length).toBeGreaterThanOrEqual(1);
+      expect(neg.outcome).not.toBeUndefined();
+    }
+
+    // Verify the two opportunity IDs are present
+    const returnedOppIds = negotiations.map((n) => n.opportunityId);
+    expect(returnedOppIds).toContain(oppId1);
+    expect(returnedOppIds).toContain(oppId2);
+
+    // Verify statuses are carried through
+    const neg1 = negotiations.find((n) => n.opportunityId === oppId1);
+    const neg2 = negotiations.find((n) => n.opportunityId === oppId2);
+    expect(neg1?.outcome?.status).toBe('draft');
+    expect(neg2?.outcome?.status).toBe('rejected');
+  });
+
+  it('returns 404 when session does not belong to the user', async () => {
+    const controller = new DebugController();
+
+    const res = await controller.getChatDebug(
+      makeRequest(),
+      makeUser('unknown-user-id'),
+      makeParams({ id: chatConvId }),
+    );
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/backend/tests/debug.chat.negotiations.spec.ts
+++ b/backend/tests/debug.chat.negotiations.spec.ts
@@ -109,7 +109,7 @@ beforeAll(async () => {
       {
         conversationId: negConvId,
         taskId: task.id,
-        senderId: userId, // source actor
+        senderId: `agent:${userId}`, // source actor
         role: 'user',
         parts: [
           {
@@ -127,7 +127,7 @@ beforeAll(async () => {
       {
         conversationId: negConvId,
         taskId: task.id,
-        senderId: candidateUserId, // candidate actor
+        senderId: `agent:${candidateUserId}`, // candidate actor
         role: 'agent',
         parts: [
           {
@@ -257,6 +257,11 @@ describe('GET /debug/chat/:id — negotiation hydration', () => {
     const neg2 = negotiations.find((n) => n.opportunityId === oppId2);
     expect(neg1?.outcome?.status).toBe('draft');
     expect(neg2?.outcome?.status).toBe('rejected');
+
+    // Verify actor labelling: first turn is source, second is candidate
+    const firstNeg = negotiations[0];
+    expect((firstNeg.turns[0] as { actor: string }).actor).toBe('source');
+    expect((firstNeg.turns[1] as { actor: string }).actor).toBe('candidate');
   });
 
   it('returns 404 when session does not belong to the user', async () => {

--- a/docs/design/protocol-deep-dive.md
+++ b/docs/design/protocol-deep-dive.md
@@ -737,6 +737,14 @@ Agent names in trace events use kebab-case: `intent-inferrer`, `profile-generato
 
 Each graph node accumulates `agentTimings` (array of `{ name, durationMs }`) in its return state. These timings are aggregated by the ChatStreamer and included in the `debug_meta` event at the end of the response, providing per-agent performance visibility.
 
+**Negotiation events** (added 2026-04-17):
+
+- `negotiation_session_start` / `negotiation_session_end` — emitted by `negotiateCandidates` in `negotiation.graph.ts`, wrapping each per-candidate run. Carries `opportunityId`, `negotiationConversationId`, source/candidate user ids, `trigger` (`'orchestrator' | 'ambient'`), `startedAt`, and `durationMs` (on end).
+- `negotiation_turn` — emitted by the negotiation graph's `turnNode` after each successful turn. Carries `opportunityId`, `turnIndex`, `actor` (`'source' | 'candidate'`), `action` (`propose | accept | reject | counter | question`), `reasoning`, `message`, `suggestedRoles`, `durationMs`.
+- `negotiation_outcome` — emitted from `finalizeNode` on every terminal path (`accepted`, `rejected_stalled`, `waiting_for_agent`, `timed_out`, `turn_cap`). Carries `opportunityId`, `outcome`, `turnCount`, `reasoning`, `agreedRoles`.
+
+Consumers: the live TRACE panel uses these to render per-candidate negotiation nodes. `/debug/chat/:id` uses `debugMeta.orchestratorNegotiations.opportunityIds` (persisted from `negotiation_session_start` during the turn) to hydrate full negotiation history from `tasks` + `messages` + `opportunities`. Existing `agent_start/end` emissions in `negotiation.graph.ts` are retained for backward compatibility with the rolled-up `debugMeta.tools[].graphs[].agents[]` render path.
+
 ## 11. Model Configuration
 
 All LLM model settings are centralized in `packages/protocol/src/agents/model.config.ts`.

--- a/docs/superpowers/plans/2026-04-17-negotiation-debug-visibility.md
+++ b/docs/superpowers/plans/2026-04-17-negotiation-debug-visibility.md
@@ -1,0 +1,1876 @@
+# Negotiation Debug Visibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface orchestrator-inline negotiations in `/debug/chat/:id` JSON and in the live TRACE panel; persist previously-ephemeral chat trace events (`iteration_start`, `llm_start/end`, `response_reset`, `hallucination_detected`) into `debugMeta`.
+
+**Architecture:** Negotiations stay in `tasks` + `messages` + `opportunities`; the chat message's `debugMeta` records only a small `orchestratorNegotiations.opportunityIds` pointer, and `/debug/chat/:id` hydrates through that pointer. Protocol emits four new typed stream events (`negotiation_session_start/end`, `negotiation_turn`, `negotiation_outcome`) so the live TRACE panel can render per-candidate negotiation nodes. Legacy messages without pointers fall through a bounded time-window query.
+
+**Tech Stack:** TypeScript, Bun, Drizzle ORM (Postgres), LangGraph, React 19, Vite, Tailwind. Tests via `bun:test` in the protocol and backend workspaces; Vitest/RTL-compatible runners in frontend.
+
+**Spec:** `docs/superpowers/specs/2026-04-17-negotiation-debug-visibility-design.md`
+
+---
+
+## File structure
+
+Files created or modified, grouped by responsibility:
+
+**Protocol — stream event contract + emission (`packages/protocol/src/`):**
+- `chat/chat-streaming.types.ts` — extend `ChatStreamEventType`, add four new event interfaces, append to `ChatStreamEvent` union, add creator helpers.
+- `chat/chat.agent.ts` — extend inline `AgentStreamEvent` union (lines 59–73) with the four new types; extend `streamRun` return type + `debugMeta` shape; accumulate `llm` counters and `orchestratorNegotiations.opportunityIds`.
+- `chat/chat.state.ts` — update the LangGraph `debugMeta` Annotation to match new shape.
+- `chat/chat.streamer.ts` — update pass-through of `debugMeta` to include new fields.
+- `negotiation/negotiation.graph.ts` — emit `negotiation_turn` in `turnNode`; emit `negotiation_outcome` from `finalizeNode` on every terminal path; emit `negotiation_session_start/end` in `negotiateCandidates` (replaces nothing — coexists with the existing `agent_start/end` for backward compat).
+- `opportunity/opportunity.graph.ts` — pass `trigger` (`'orchestrator' | 'ambient'`) through to `negotiateCandidates` via its `opts`.
+
+**Protocol — tests:**
+- `negotiation/tests/negotiation.graph.spec.ts` — new spec file or extend existing negotiation test: assert turn/outcome events emitted on each terminal path.
+- `chat/tests/chat.agent.spec.ts` — extend: assert `debugMeta.llm.*` populated from a scripted iteration.
+
+**Backend — accumulator + debug endpoint (`backend/src/`):**
+- `controllers/chat.controller.ts` — the stream-consumer loop (lines 252–356) persists the expanded debugMeta unchanged (pass-through). Minor: extend type annotation on the local `debugMeta` binding.
+- `controllers/debug.controller.ts#getChatDebug` (lines 519–691) — for each turn, read `orchestratorNegotiations.opportunityIds`; pointer-path or fallback-path join; embed `turn.negotiations[]`.
+
+**Backend — tests:**
+- `backend/tests/debug.chat.negotiations.spec.ts` (new) — integration: seed an orchestrator session with accepted + rejected candidates; assert `/debug/chat/:id` returns populated `turn.negotiations`.
+- `backend/tests/debug.chat.legacy.spec.ts` (new) — integration: seed a session without pointer; assert fallback path still returns negotiations.
+
+**Frontend — types + parser + render (`frontend/src/`):**
+- `contexts/AIChatContext.tsx` — extend `TraceEventType` and `TraceEvent`; extend SSE handler to map new events; extend `mergeDebugMetaIntoTraceEvents` stub (no-op — debug meta for negotiations lives at `/debug/chat/:id`, not on the message).
+- `components/chat/ToolCallsDisplay.tsx` — extend `ToolNode` with `negotiations: NegotiationNode[]`; add parser branches; new `NegotiationTree` subcomponent.
+- `components/chat/tests/ToolCallsDisplay.test.tsx` (new if no tests dir) — snapshot test of negotiation rendering.
+
+**Docs:**
+- `docs/design/protocol-deep-dive.md` — update Trace Event Instrumentation with the four new event types and emission contract.
+- `CLAUDE.md` — append one paragraph under Trace Event Instrumentation pointing to negotiation events.
+
+---
+
+## Task 0: Setup — create worktree
+
+**Files:**
+- Create: `.worktrees/feat-negotiation-debug-visibility/` (worktree root)
+
+- [ ] **Step 1: Create worktree from dev and symlink envs**
+
+```bash
+cd /home/yanek/Projects/index
+git worktree add .worktrees/feat-negotiation-debug-visibility -b feat/negotiation-debug-visibility dev
+bun run worktree:setup feat-negotiation-debug-visibility
+```
+
+Expected: worktree created, `.env` symlinks in `backend/` and `frontend/` under the worktree, node_modules installed.
+
+- [ ] **Step 2: Verify worktree is clean**
+
+```bash
+cd .worktrees/feat-negotiation-debug-visibility && git status
+```
+
+Expected: `On branch feat/negotiation-debug-visibility. nothing to commit, working tree clean`.
+
+All subsequent tasks run from this worktree path.
+
+---
+
+## Task 1: Add new stream event types to protocol
+
+**Files:**
+- Modify: `packages/protocol/src/chat/chat-streaming.types.ts`
+- Modify: `packages/protocol/src/chat/chat.agent.ts:59-73`
+
+- [ ] **Step 1: Extend `ChatStreamEventType` union**
+
+In `packages/protocol/src/chat/chat-streaming.types.ts` lines 9–37, append the four new discriminators to the `ChatStreamEventType` union:
+
+```ts
+export type ChatStreamEventType =
+  | "status"
+  | "routing"
+  | "thinking"
+  | "subgraph_start"
+  | "subgraph_result"
+  | "token"
+  | "done"
+  | "error"
+  | "tool_start"
+  | "tool_end"
+  | "agent_thinking"
+  | "tool_activity"
+  | "iteration_start"
+  | "llm_start"
+  | "llm_end"
+  | "response_complete"
+  | "response_reset"
+  | "debug_meta"
+  | "graph_start"
+  | "graph_end"
+  | "agent_start"
+  | "agent_end"
+  | "hallucination_detected"
+  // Orchestrator-inline negotiation trace events
+  | "negotiation_session_start"
+  | "negotiation_session_end"
+  | "negotiation_turn"
+  | "negotiation_outcome";
+```
+
+- [ ] **Step 2: Add the four new event interfaces**
+
+After `AgentEndEvent` (line 403), before the `ChatStreamEvent` union declaration, append:
+
+```ts
+/** Orchestrator per-candidate negotiation wrapper — emitted from `negotiateCandidates`. */
+export interface NegotiationSessionStartEvent extends ChatStreamEventBase {
+  type: "negotiation_session_start";
+  opportunityId: string;
+  negotiationConversationId: string;
+  sourceUserId: string;
+  candidateUserId: string;
+  candidateName?: string;
+  trigger: "orchestrator" | "ambient";
+  startedAt: number;
+}
+
+export interface NegotiationSessionEndEvent extends ChatStreamEventBase {
+  type: "negotiation_session_end";
+  opportunityId: string;
+  negotiationConversationId: string;
+  durationMs: number;
+}
+
+/** One turn inside a bilateral negotiation. Emitted by the negotiation graph's turn node. */
+export interface NegotiationTurnEvent extends ChatStreamEventBase {
+  type: "negotiation_turn";
+  opportunityId: string;
+  negotiationConversationId: string;
+  turnIndex: number;
+  actor: "source" | "candidate";
+  action: "propose" | "accept" | "reject" | "counter" | "question";
+  reasoning?: string;
+  message?: string;
+  suggestedRoles?: { ownUser?: string; otherUser?: string };
+  durationMs: number;
+}
+
+export interface NegotiationOutcomeEvent extends ChatStreamEventBase {
+  type: "negotiation_outcome";
+  opportunityId: string;
+  outcome:
+    | "accepted"
+    | "rejected_stalled"
+    | "waiting_for_agent"
+    | "timed_out"
+    | "turn_cap";
+  turnCount: number;
+  reasoning?: string;
+  agreedRoles?: { ownUser?: string; otherUser?: string };
+}
+```
+
+- [ ] **Step 3: Append the interfaces to the `ChatStreamEvent` union**
+
+In the union declaration (lines 408–437), append:
+
+```ts
+  | NegotiationSessionStartEvent
+  | NegotiationSessionEndEvent
+  | NegotiationTurnEvent
+  | NegotiationOutcomeEvent;
+```
+
+- [ ] **Step 4: Add creator helpers**
+
+After the last creator helper in the file (`createAgentEndEvent`, line 815), append:
+
+```ts
+export function createNegotiationSessionStartEvent(
+  sessionId: string,
+  payload: Omit<NegotiationSessionStartEvent, "type" | "sessionId" | "timestamp">,
+): NegotiationSessionStartEvent {
+  return createStreamEvent<NegotiationSessionStartEvent>(
+    "negotiation_session_start",
+    sessionId,
+    payload,
+  );
+}
+
+export function createNegotiationSessionEndEvent(
+  sessionId: string,
+  payload: Omit<NegotiationSessionEndEvent, "type" | "sessionId" | "timestamp">,
+): NegotiationSessionEndEvent {
+  return createStreamEvent<NegotiationSessionEndEvent>(
+    "negotiation_session_end",
+    sessionId,
+    payload,
+  );
+}
+
+export function createNegotiationTurnEvent(
+  sessionId: string,
+  payload: Omit<NegotiationTurnEvent, "type" | "sessionId" | "timestamp">,
+): NegotiationTurnEvent {
+  return createStreamEvent<NegotiationTurnEvent>("negotiation_turn", sessionId, payload);
+}
+
+export function createNegotiationOutcomeEvent(
+  sessionId: string,
+  payload: Omit<NegotiationOutcomeEvent, "type" | "sessionId" | "timestamp">,
+): NegotiationOutcomeEvent {
+  return createStreamEvent<NegotiationOutcomeEvent>(
+    "negotiation_outcome",
+    sessionId,
+    payload,
+  );
+}
+```
+
+- [ ] **Step 5: Extend the inline `AgentStreamEvent` union in `chat.agent.ts`**
+
+In `packages/protocol/src/chat/chat.agent.ts` lines 54–75, the inline discriminated union `AgentStreamEvent` does NOT carry `sessionId`/`timestamp` (those are added by the streamer). Append:
+
+```ts
+  | {
+      type: "negotiation_session_start";
+      opportunityId: string;
+      negotiationConversationId: string;
+      sourceUserId: string;
+      candidateUserId: string;
+      candidateName?: string;
+      trigger: "orchestrator" | "ambient";
+      startedAt: number;
+    }
+  | {
+      type: "negotiation_session_end";
+      opportunityId: string;
+      negotiationConversationId: string;
+      durationMs: number;
+    }
+  | {
+      type: "negotiation_turn";
+      opportunityId: string;
+      negotiationConversationId: string;
+      turnIndex: number;
+      actor: "source" | "candidate";
+      action: "propose" | "accept" | "reject" | "counter" | "question";
+      reasoning?: string;
+      message?: string;
+      suggestedRoles?: { ownUser?: string; otherUser?: string };
+      durationMs: number;
+    }
+  | {
+      type: "negotiation_outcome";
+      opportunityId: string;
+      outcome:
+        | "accepted"
+        | "rejected_stalled"
+        | "waiting_for_agent"
+        | "timed_out"
+        | "turn_cap";
+      turnCount: number;
+      reasoning?: string;
+      agreedRoles?: { ownUser?: string; otherUser?: string };
+    };
+```
+
+- [ ] **Step 6: Typecheck**
+
+```bash
+cd backend && bun run lint 2>&1 | head -40
+cd ../packages/protocol && npx tsc --noEmit 2>&1 | head -40
+```
+
+Expected: no new errors about the added types; existing code untouched.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/protocol/src/chat/chat-streaming.types.ts packages/protocol/src/chat/chat.agent.ts
+git -c commit.gpgsign=false commit -m "feat(chat-stream): add negotiation session/turn/outcome event types"
+```
+
+---
+
+## Task 2: Emit `negotiation_turn` from `turnNode`
+
+**Files:**
+- Modify: `packages/protocol/src/negotiation/negotiation.graph.ts` (turnNode, lines 80–199)
+- Test: `packages/protocol/src/negotiation/tests/negotiation.graph.spec.ts` (may already exist; extend it)
+
+- [ ] **Step 1: Write the failing test**
+
+Create or extend `packages/protocol/src/negotiation/tests/negotiation.graph.spec.ts`:
+
+```ts
+import { describe, it, expect } from "bun:test";
+import { NegotiationGraphFactory } from "../negotiation.graph.js";
+import type { NegotiationGraphState } from "../negotiation.state.js";
+
+// Helpers: minimal stubs for database / dispatcher / timeoutQueue.
+function mkStubs() {
+  const messages: Array<{ id: string; senderId: string; parts: unknown[]; createdAt: Date }> = [];
+  const database = {
+    createConversation: async () => ({ id: "conv-1" }),
+    createTask: async () => ({ id: "task-1" }),
+    updateOpportunityStatus: async () => {},
+    createMessage: async (p: { conversationId: string; senderId: string; parts: unknown[] }) => {
+      const msg = { id: `msg-${messages.length}`, senderId: p.senderId, parts: p.parts, createdAt: new Date() };
+      messages.push(msg);
+      return msg;
+    },
+    updateTaskState: async () => {},
+    createArtifact: async () => {},
+    setTaskTurnContext: async () => {},
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[0];
+
+  const dispatcher = {
+    hasPersonalAgent: async () => false,
+    dispatch: async () => ({ handled: false, reason: "no-agent" }),
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[1];
+
+  return { database, dispatcher, messages };
+}
+
+describe("negotiation graph — negotiation_turn emission", () => {
+  it("emits negotiation_turn with correct payload after each turn", async () => {
+    const { database, dispatcher } = mkStubs();
+    const factory = new NegotiationGraphFactory(database, dispatcher);
+    const graph = factory.createGraph();
+
+    const events: Array<Record<string, unknown>> = [];
+    const traceEmitter = (e: Record<string, unknown>) => events.push(e);
+
+    const { requestContext } = await import("../../shared/observability/request-context.js");
+    await requestContext.run({ traceEmitter }, async () => {
+      await graph.invoke({
+        sourceUser: { id: "u-src", name: "Alice" },
+        candidateUser: { id: "u-cand", name: "Bob" },
+        indexContext: { networkId: "net-1", prompt: "" },
+        seedAssessment: { reasoning: "x", valencyRole: "peer" },
+        opportunityId: "opp-1",
+        maxTurns: 2,
+      } as Partial<typeof NegotiationGraphState.State>);
+    });
+
+    const turnEvents = events.filter((e) => e.type === "negotiation_turn");
+    expect(turnEvents.length).toBeGreaterThanOrEqual(1);
+    const first = turnEvents[0];
+    expect(first.opportunityId).toBe("opp-1");
+    expect(first.negotiationConversationId).toBe("conv-1");
+    expect(first.turnIndex).toBe(0);
+    expect(first.actor).toBe("source");
+    expect(typeof first.action).toBe("string");
+    expect(typeof first.durationMs).toBe("number");
+  }, 30000);
+});
+```
+
+- [ ] **Step 2: Run and watch it fail**
+
+```bash
+cd packages/protocol && bun test src/negotiation/tests/negotiation.graph.spec.ts -t "negotiation_turn emission" 2>&1 | tail -30
+```
+
+Expected: test fails (`turnEvents.length` is 0 because we don't emit the event yet).
+
+- [ ] **Step 3: Emit `negotiation_turn` after each successful turn**
+
+In `negotiation.graph.ts` turnNode, after the message is persisted and task state is updated (currently line 172 `await database.updateTaskState(state.taskId, "working");`), and before the return block (line 174), insert:
+
+```ts
+        traceEmitter?.({
+          type: "negotiation_turn",
+          opportunityId: state.opportunityId ?? "",
+          negotiationConversationId: state.conversationId,
+          turnIndex: state.turnCount,
+          actor: isSource ? "source" : "candidate",
+          action: turn.action,
+          ...(turn.assessment?.reasoning && { reasoning: turn.assessment.reasoning }),
+          ...(turn.message && { message: turn.message }),
+          ...(turn.assessment?.suggestedRoles && { suggestedRoles: turn.assessment.suggestedRoles }),
+          durationMs: Date.now() - agentStart,
+        });
+```
+
+Do not remove the existing `agent_end` emission on line 155 — it stays for backward-compat consumers of the rolled-up `debugMeta.tools[].graphs[].agents[]` path.
+
+- [ ] **Step 4: Run and watch it pass**
+
+```bash
+cd packages/protocol && bun test src/negotiation/tests/negotiation.graph.spec.ts -t "negotiation_turn emission" 2>&1 | tail -20
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/protocol/src/negotiation/negotiation.graph.ts packages/protocol/src/negotiation/tests/negotiation.graph.spec.ts
+git -c commit.gpgsign=false commit -m "feat(negotiation): emit negotiation_turn per turn with action + reasoning"
+```
+
+---
+
+## Task 3: Emit `negotiation_outcome` from every terminal path
+
+**Files:**
+- Modify: `packages/protocol/src/negotiation/negotiation.graph.ts` (finalizeNode lines 212–272; turnNode `waiting_for_agent` branch lines 121–140)
+- Test: extend `packages/protocol/src/negotiation/tests/negotiation.graph.spec.ts`
+
+- [ ] **Step 1: Write failing tests for accept / reject / turn_cap / waiting_for_agent**
+
+Append to the same spec file:
+
+```ts
+describe("negotiation graph — negotiation_outcome emission", () => {
+  it("emits negotiation_outcome with outcome='accepted' when finalize runs after an accept turn", async () => {
+    // Scripted dispatcher: first turn 'propose', second turn 'accept'
+    let call = 0;
+    const scripted = [
+      { action: "propose", assessment: { reasoning: "r1", suggestedRoles: { ownUser: "agent", otherUser: "patient" } } },
+      { action: "accept",  assessment: { reasoning: "r2", suggestedRoles: { ownUser: "agent", otherUser: "patient" } } },
+    ];
+    const { database } = mkStubs();
+    const dispatcher = {
+      hasPersonalAgent: async () => false,
+      dispatch: async () => {
+        // Force the system-agent path to return our scripted turn
+        return { handled: false, reason: "no-agent" } as const;
+      },
+    } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[1];
+    // Swap the system agent via a partial spy on IndexNegotiator.invoke
+    const { IndexNegotiator } = await import("../negotiation.agent.js");
+    const origInvoke = IndexNegotiator.prototype.invoke;
+    IndexNegotiator.prototype.invoke = async function () {
+      return scripted[Math.min(call++, scripted.length - 1)] as never;
+    };
+
+    try {
+      const factory = new NegotiationGraphFactory(database, dispatcher);
+      const graph = factory.createGraph();
+      const events: Array<Record<string, unknown>> = [];
+      const { requestContext } = await import("../../shared/observability/request-context.js");
+      await requestContext.run({ traceEmitter: (e) => events.push(e) }, async () => {
+        await graph.invoke({
+          sourceUser: { id: "u-src" },
+          candidateUser: { id: "u-cand" },
+          indexContext: { networkId: "net-1", prompt: "" },
+          seedAssessment: { reasoning: "x", valencyRole: "peer" },
+          opportunityId: "opp-2",
+          maxTurns: 4,
+        } as Partial<typeof NegotiationGraphState.State>);
+      });
+
+      const outcome = events.find((e) => e.type === "negotiation_outcome");
+      expect(outcome).toBeTruthy();
+      expect(outcome!.opportunityId).toBe("opp-2");
+      expect(outcome!.outcome).toBe("accepted");
+      expect(outcome!.turnCount).toBe(2);
+    } finally {
+      IndexNegotiator.prototype.invoke = origInvoke;
+    }
+  }, 30000);
+
+  it("emits outcome='turn_cap' when maxTurns is reached without accept/reject", async () => {
+    const { database } = mkStubs();
+    const dispatcher = { hasPersonalAgent: async () => false, dispatch: async () => ({ handled: false, reason: "no-agent" }) } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[1];
+    const { IndexNegotiator } = await import("../negotiation.agent.js");
+    const orig = IndexNegotiator.prototype.invoke;
+    IndexNegotiator.prototype.invoke = async () => ({ action: "counter", assessment: { reasoning: "r", suggestedRoles: { ownUser: "peer", otherUser: "peer" } } } as never);
+    try {
+      const graph = new NegotiationGraphFactory(database, dispatcher).createGraph();
+      const events: Array<Record<string, unknown>> = [];
+      const { requestContext } = await import("../../shared/observability/request-context.js");
+      await requestContext.run({ traceEmitter: (e) => events.push(e) }, async () => {
+        await graph.invoke({
+          sourceUser: { id: "u-src" }, candidateUser: { id: "u-cand" },
+          indexContext: { networkId: "net-1", prompt: "" },
+          seedAssessment: { reasoning: "x", valencyRole: "peer" },
+          opportunityId: "opp-3", maxTurns: 2,
+        } as Partial<typeof NegotiationGraphState.State>);
+      });
+      const outcome = events.find((e) => e.type === "negotiation_outcome");
+      expect(outcome?.outcome).toBe("turn_cap");
+      expect(outcome?.turnCount).toBe(2);
+    } finally {
+      IndexNegotiator.prototype.invoke = orig;
+    }
+  }, 30000);
+
+  it("emits outcome='waiting_for_agent' when dispatcher parks the turn", async () => {
+    const { database } = mkStubs();
+    const dispatcher = { hasPersonalAgent: async () => true, dispatch: async () => ({ handled: false, reason: "waiting" as const }) } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[1];
+    const graph = new NegotiationGraphFactory(database, dispatcher).createGraph();
+    const events: Array<Record<string, unknown>> = [];
+    const { requestContext } = await import("../../shared/observability/request-context.js");
+    await requestContext.run({ traceEmitter: (e) => events.push(e) }, async () => {
+      await graph.invoke({
+        sourceUser: { id: "u-src" }, candidateUser: { id: "u-cand" },
+        indexContext: { networkId: "net-1", prompt: "" },
+        seedAssessment: { reasoning: "x", valencyRole: "peer" },
+        opportunityId: "opp-4", maxTurns: 4,
+      } as Partial<typeof NegotiationGraphState.State>);
+    });
+    const outcome = events.find((e) => e.type === "negotiation_outcome");
+    expect(outcome?.outcome).toBe("waiting_for_agent");
+  }, 30000);
+});
+```
+
+- [ ] **Step 2: Run and watch all three fail**
+
+```bash
+cd packages/protocol && bun test src/negotiation/tests/negotiation.graph.spec.ts -t "negotiation_outcome emission" 2>&1 | tail -40
+```
+
+Expected: all three new tests fail (no `negotiation_outcome` events emitted).
+
+- [ ] **Step 3: Emit `negotiation_outcome` in `finalizeNode`**
+
+In `negotiation.graph.ts` finalizeNode, modify the `status === 'waiting_for_agent'` early-return (line 212–215) to emit first:
+
+```ts
+    const finalizeNode = async (state: typeof NegotiationGraphState.State) => {
+      const traceEmitter = requestContext.getStore()?.traceEmitter;
+
+      if (state.status === 'waiting_for_agent') {
+        traceEmitter?.({
+          type: "negotiation_outcome",
+          opportunityId: state.opportunityId ?? "",
+          outcome: "waiting_for_agent",
+          turnCount: state.turnCount,
+        });
+        return {};
+      }
+      // ... existing body unchanged until `return { outcome, status: 'completed' as const };`
+```
+
+Then, just before the final `return { outcome, status: 'completed' as const };` at line 271, insert:
+
+```ts
+      const emittedOutcome: "accepted" | "rejected_stalled" | "turn_cap" | "timed_out" =
+        hasOpportunity
+          ? "accepted"
+          : atCap
+          ? "turn_cap"
+          : lastTurn?.action === "reject"
+          ? "rejected_stalled"
+          : state.error && /timeout/i.test(state.error)
+          ? "timed_out"
+          : "rejected_stalled";
+
+      traceEmitter?.({
+        type: "negotiation_outcome",
+        opportunityId: state.opportunityId ?? "",
+        outcome: emittedOutcome,
+        turnCount: state.turnCount,
+        ...(outcome.reasoning && { reasoning: outcome.reasoning }),
+        ...(hasOpportunity && agreedRoles.length >= 2 && {
+          agreedRoles: {
+            ownUser: agreedRoles[0]?.role,
+            otherUser: agreedRoles[1]?.role,
+          },
+        }),
+      });
+```
+
+- [ ] **Step 4: Run and watch them pass**
+
+```bash
+cd packages/protocol && bun test src/negotiation/tests/negotiation.graph.spec.ts -t "negotiation_outcome emission" 2>&1 | tail -20
+```
+
+Expected: all three new tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/protocol/src/negotiation/negotiation.graph.ts packages/protocol/src/negotiation/tests/negotiation.graph.spec.ts
+git -c commit.gpgsign=false commit -m "feat(negotiation): emit negotiation_outcome on all terminal paths"
+```
+
+---
+
+## Task 4: Emit `negotiation_session_start/end` in `negotiateCandidates` + thread `trigger`
+
+**Files:**
+- Modify: `packages/protocol/src/negotiation/negotiation.graph.ts` (`negotiateCandidates` signature + body, lines 331–428; `OnNegotiationResolved` may receive the conversation id — check it)
+- Modify: `packages/protocol/src/opportunity/opportunity.graph.ts` (the call site inside `negotiateNode`)
+- Test: extend `packages/protocol/src/negotiation/tests/negotiation.graph.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the spec file:
+
+```ts
+describe("negotiateCandidates — session wrapper events", () => {
+  it("emits negotiation_session_start and _end per candidate with trigger + ids", async () => {
+    const { database, dispatcher } = mkStubs();
+    // Pre-stamp graph invoke so we can assert order without going through full turn loop
+    const fakeGraph = {
+      invoke: async (input: { opportunityId?: string }) => ({
+        conversationId: `conv-for-${input.opportunityId}`,
+        messages: [],
+        outcome: { hasOpportunity: false, agreedRoles: [], reasoning: "", turnCount: 0 },
+      }),
+    };
+    const events: Array<Record<string, unknown>> = [];
+    const { negotiateCandidates } = await import("../negotiation.graph.js");
+    const { requestContext } = await import("../../shared/observability/request-context.js");
+    await requestContext.run({ traceEmitter: (e) => events.push(e) }, async () => {
+      await negotiateCandidates(
+        fakeGraph as never,
+        { id: "u-src", name: "Alice" } as never,
+        [
+          {
+            userId: "u-1",
+            reasoning: "r", valencyRole: "peer",
+            candidateUser: { id: "u-1", name: "Bob" } as never,
+            opportunityId: "opp-10",
+          },
+        ],
+        { networkId: "net-1", prompt: "" },
+        {
+          traceEmitter: (e) => events.push(e),
+          trigger: "orchestrator",
+        },
+      );
+    });
+
+    const starts = events.filter((e) => e.type === "negotiation_session_start");
+    const ends = events.filter((e) => e.type === "negotiation_session_end");
+    expect(starts).toHaveLength(1);
+    expect(ends).toHaveLength(1);
+    expect(starts[0].opportunityId).toBe("opp-10");
+    expect(starts[0].trigger).toBe("orchestrator");
+    expect(starts[0].sourceUserId).toBe("u-src");
+    expect(starts[0].candidateUserId).toBe("u-1");
+    expect(ends[0].opportunityId).toBe("opp-10");
+    expect(typeof ends[0].durationMs).toBe("number");
+  }, 30000);
+});
+```
+
+- [ ] **Step 2: Run and watch it fail**
+
+```bash
+cd packages/protocol && bun test src/negotiation/tests/negotiation.graph.spec.ts -t "session wrapper events" 2>&1 | tail -20
+```
+
+Expected: FAIL (no session events emitted; also likely a type error on `trigger` opt — that's fine, implementation step adds it).
+
+- [ ] **Step 3: Add `trigger` to the opts and emit session events**
+
+In `negotiation.graph.ts`, extend the `opts` type on `negotiateCandidates` (around lines 336–342):
+
+```ts
+  opts?: {
+    maxTurns?: number;
+    traceEmitter?: TraceEmitter;
+    indexContextOverrides?: Map<string, string>;
+    timeoutMs?: number;
+    onCandidateResolved?: OnNegotiationResolved;
+    trigger?: "orchestrator" | "ambient";
+  },
+```
+
+Destructure `trigger` at line 344:
+
+```ts
+  const { maxTurns, traceEmitter, indexContextOverrides, timeoutMs, onCandidateResolved, trigger } = opts ?? {};
+```
+
+Replace the per-candidate `agent_start`/`agent_end` emissions at lines 349 and 385/413 by *wrapping* them with session events (the existing `agent_start/end` stay). The updated block inside `candidates.map(async (candidate) => { ... })`:
+
+```ts
+      const start = Date.now();
+      const startedAt = start;
+      traceEmitter?.({ type: "agent_start", name: "Negotiating candidate" });
+
+      // Session start — emitted before graph.invoke so the UI node is
+      // created even if the graph throws. We don't know the negotiation
+      // conversationId until the graph's init node runs; emit empty and
+      // fill in via a late session_end if needed (or via graph init).
+      traceEmitter?.({
+        type: "negotiation_session_start",
+        opportunityId: candidate.opportunityId ?? "",
+        negotiationConversationId: "", // filled by session_end
+        sourceUserId: sourceUser.id,
+        candidateUserId: candidate.userId,
+        ...(candidate.candidateUser?.name && { candidateName: candidate.candidateUser.name }),
+        trigger: trigger ?? "ambient",
+        startedAt,
+      });
+
+      try {
+        // ... existing body unchanged ...
+
+        const durationMs = Date.now() - start;
+        // Existing:
+        traceEmitter?.({ type: "agent_end", name: "Negotiating candidate", durationMs, summary: `${candidate.userId}: ${turnFlow} ${statusTag}` });
+
+        // New: session end carries the conversation id now known from graph result.
+        traceEmitter?.({
+          type: "negotiation_session_end",
+          opportunityId: candidate.opportunityId ?? "",
+          negotiationConversationId: (result as { conversationId?: string }).conversationId ?? "",
+          durationMs,
+        });
+
+        // ... rest unchanged (accepted, onCandidateResolved, return) ...
+      } catch (err) {
+        const durationMs = Date.now() - start;
+        traceEmitter?.({ type: "agent_end", name: "Negotiating candidate", durationMs, summary: `${candidate.userId}: error` });
+        traceEmitter?.({
+          type: "negotiation_session_end",
+          opportunityId: candidate.opportunityId ?? "",
+          negotiationConversationId: "",
+          durationMs,
+        });
+        // ... rest unchanged ...
+      }
+```
+
+- [ ] **Step 4: Pass `trigger` from `opportunity.graph.ts`**
+
+Open `packages/protocol/src/opportunity/opportunity.graph.ts`. Find the `negotiateCandidates(...)` call inside `negotiateNode`. It currently passes `{ maxTurns, traceEmitter, timeoutMs, onCandidateResolved }`. Add:
+
+```ts
+  trigger: state.trigger === "orchestrator" ? "orchestrator" : "ambient",
+```
+
+(The opportunity graph state already carries `trigger`; confirm the field name with a quick grep. If it is `state.trigger`, use it directly; if it is differently named, use the actual field.)
+
+- [ ] **Step 5: Run and watch tests pass**
+
+```bash
+cd packages/protocol && bun test src/negotiation/tests/negotiation.graph.spec.ts 2>&1 | tail -30
+```
+
+Expected: all new tests PASS; existing tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/protocol/src/negotiation/negotiation.graph.ts packages/protocol/src/opportunity/opportunity.graph.ts packages/protocol/src/negotiation/tests/negotiation.graph.spec.ts
+git -c commit.gpgsign=false commit -m "feat(negotiation): wrap per-candidate runs with session_start/end events"
+```
+
+---
+
+## Task 5: Extend `debugMeta` shape with `llm` + `orchestratorNegotiations`
+
+**Files:**
+- Modify: `packages/protocol/src/chat/chat-streaming.types.ts` (`DebugMetaEvent` interface lines 370–375; introduce supporting types)
+- Modify: `packages/protocol/src/chat/chat.agent.ts` (`streamRun` lines 707–1176)
+- Modify: `packages/protocol/src/chat/chat.state.ts` (line 150 `debugMeta` Annotation)
+- Modify: `packages/protocol/src/chat/chat.streamer.ts` (lines 282–294)
+- Modify: `backend/src/controllers/chat.controller.ts` (lines 252–356 local `debugMeta` typing)
+- Test: extend `packages/protocol/src/chat/tests/chat.agent.spec.ts`
+
+- [ ] **Step 1: Extend the types**
+
+In `chat-streaming.types.ts`, insert before `DebugMetaEvent` (around line 370):
+
+```ts
+export interface DebugMetaLlm {
+  calls: number;
+  totalDurationMs: number;
+  resets: Array<{ reason: string; at: number }>;
+  hallucinations: Array<{ blockType: string; tool: string; at: number }>;
+}
+
+export interface DebugMetaOrchestratorNegotiations {
+  opportunityIds: string[];
+}
+```
+
+Modify `DebugMetaEvent`:
+
+```ts
+export interface DebugMetaEvent extends ChatStreamEventBase {
+  type: "debug_meta";
+  graph: string;
+  iterations: number;
+  tools: DebugMetaToolCall[];
+  llm: DebugMetaLlm;
+  orchestratorNegotiations?: DebugMetaOrchestratorNegotiations;
+}
+```
+
+Modify the `createDebugMetaEvent` helper (lines 774–785):
+
+```ts
+export function createDebugMetaEvent(
+  sessionId: string,
+  graph: string,
+  iterations: number,
+  tools: DebugMetaToolCall[],
+  llm: DebugMetaLlm,
+  orchestratorNegotiations?: DebugMetaOrchestratorNegotiations,
+): DebugMetaEvent {
+  return createStreamEvent<DebugMetaEvent>("debug_meta", sessionId, {
+    graph,
+    iterations,
+    tools,
+    llm,
+    ...(orchestratorNegotiations && { orchestratorNegotiations }),
+  });
+}
+```
+
+- [ ] **Step 2: Update `chat.state.ts` Annotation**
+
+In `packages/protocol/src/chat/chat.state.ts` line 150:
+
+```ts
+  debugMeta: Annotation<{
+    graph: string;
+    iterations: number;
+    tools: DebugMetaToolCall[];
+    llm: DebugMetaLlm;
+    orchestratorNegotiations?: DebugMetaOrchestratorNegotiations;
+  } | undefined>({
+```
+
+Add the imports at the top of that file if they are not already imported from `chat-streaming.types.ts`:
+
+```ts
+import type { DebugMetaToolCall, DebugMetaLlm, DebugMetaOrchestratorNegotiations } from "./chat-streaming.types.js";
+```
+
+- [ ] **Step 3: Write failing test for the accumulator**
+
+In `packages/protocol/src/chat/tests/chat.agent.spec.ts`, add a new test (pattern matches existing specs in that file):
+
+```ts
+describe("ChatAgent streamRun — debugMeta accumulator", () => {
+  it("populates debugMeta.llm.calls, totalDurationMs, resets, and hallucinations", async () => {
+    // Arrange: a test ChatAgent whose model emits a response_reset (code-fence stripping)
+    // and a hallucination_detected event. Reuse the existing test harness that scripts
+    // an LLM response; add an `opportunity` code block to trigger hallucination_detected.
+    const { agent, runWithAbort } = await buildHallucinatingAgent({
+      responseText: "hello ```opportunity\n{}\n``` world",
+    });
+    const events: Array<Record<string, unknown>> = [];
+    const result = await agent.streamRun([new HumanMessage("hi")], (e) => events.push(e));
+
+    expect(result.debugMeta.llm.calls).toBeGreaterThanOrEqual(1);
+    expect(result.debugMeta.llm.totalDurationMs).toBeGreaterThanOrEqual(0);
+    expect(result.debugMeta.llm.hallucinations.length).toBeGreaterThanOrEqual(1);
+    // hallucination also triggers a response_reset
+    expect(result.debugMeta.llm.resets.length).toBeGreaterThanOrEqual(1);
+  }, 30000);
+});
+```
+
+> **Note:** `buildHallucinatingAgent` is a helper that should match the existing test harness in `chat.agent.spec.ts`. Reuse the pattern from the existing tests at lines 150–400 of that spec file (`response_reset` assertions already use scripted model responses). If the helper does not exist, inline the model-stub setup from the first existing test in the file.
+
+- [ ] **Step 4: Run and watch it fail**
+
+```bash
+cd packages/protocol && bun test src/chat/tests/chat.agent.spec.ts -t "debugMeta accumulator" 2>&1 | tail -30
+```
+
+Expected: FAIL (`result.debugMeta.llm` is `undefined`).
+
+- [ ] **Step 5: Implement the accumulator**
+
+In `chat.agent.ts`, modify `streamRun`:
+
+At the top of the method (just after `const toolsDebug: DebugMetaToolCall[] = [];` at line 727), add:
+
+```ts
+    const llm: { calls: number; totalDurationMs: number; resets: Array<{ reason: string; at: number }>; hallucinations: Array<{ blockType: string; tool: string; at: number }> } = {
+      calls: 0,
+      totalDurationMs: 0,
+      resets: [],
+      hallucinations: [],
+    };
+    const orchestratorNegotiationIds = new Set<string>();
+    let lastLlmStart = 0;
+```
+
+Replace the `emit` wrapper at line 717 so it also accumulates the observed events:
+
+```ts
+    const emit = (event: AgentStreamEvent) => {
+      // Accumulate for persisted debugMeta
+      if (event.type === "llm_start") {
+        llm.calls += 1;
+        lastLlmStart = Date.now();
+      } else if (event.type === "llm_end") {
+        llm.totalDurationMs += Date.now() - lastLlmStart;
+      } else if (event.type === "response_reset") {
+        llm.resets.push({ reason: event.reason, at: Date.now() });
+      } else if (event.type === "hallucination_detected") {
+        llm.hallucinations.push({ blockType: event.blockType, tool: event.tool, at: Date.now() });
+      } else if (event.type === "negotiation_session_start") {
+        if (event.opportunityId) orchestratorNegotiationIds.add(event.opportunityId);
+      }
+      try {
+        writer?.(event);
+      } catch {
+        /* swallow if writer is gone */
+      }
+    };
+```
+
+Update the three `return { ... debugMeta: { graph, iterations, tools } }` sites (lines 1126, 1136, 1168) to include the new fields:
+
+```ts
+      return {
+        responseText: sanitizedText,
+        messages,
+        iterationCount,
+        debugMeta: {
+          graph: "agent_loop",
+          iterations: iterationCount,
+          tools: toolsDebug,
+          llm,
+          ...(orchestratorNegotiationIds.size > 0 && {
+            orchestratorNegotiations: { opportunityIds: [...orchestratorNegotiationIds] },
+          }),
+        },
+      };
+```
+
+Do this in all three return blocks (normal, aborted, hard-limit forced).
+
+Update the return type of `streamRun` at line 711:
+
+```ts
+  ): Promise<{
+    responseText: string;
+    messages: BaseMessage[];
+    iterationCount: number;
+    debugMeta: {
+      graph: string;
+      iterations: number;
+      tools: DebugMetaToolCall[];
+      llm: DebugMetaLlm;
+      orchestratorNegotiations?: DebugMetaOrchestratorNegotiations;
+    };
+  }> {
+```
+
+Add imports at top of `chat.agent.ts`:
+
+```ts
+import type { DebugMetaLlm, DebugMetaOrchestratorNegotiations } from "./chat-streaming.types.js";
+```
+
+- [ ] **Step 6: Pass the new fields through `chat.streamer.ts`**
+
+In `packages/protocol/src/chat/chat.streamer.ts`, find the debug_meta emit site (lines 282–294). Replace it:
+
+```ts
+          const debugMeta = agentOutput?.debugMeta as
+            | { graph?: string; iterations?: number; tools?: DebugMetaToolCall[]; llm?: DebugMetaLlm; orchestratorNegotiations?: DebugMetaOrchestratorNegotiations }
+            | undefined;
+          if (
+            debugMeta?.graph != null &&
+            typeof debugMeta.iterations === "number"
+          ) {
+            const debugEvent = createDebugMetaEvent(
+              sessionId,
+              debugMeta.graph,
+              debugMeta.iterations,
+              Array.isArray(debugMeta.tools) ? debugMeta.tools : [],
+              debugMeta.llm ?? { calls: 0, totalDurationMs: 0, resets: [], hallucinations: [] },
+              debugMeta.orchestratorNegotiations,
+            );
+            write(formatSSEEvent(debugEvent));
+          }
+```
+
+Import `DebugMetaLlm`, `DebugMetaOrchestratorNegotiations`, and `DebugMetaToolCall` at the top of the file if not already imported.
+
+- [ ] **Step 7: Update `backend/src/controllers/chat.controller.ts` local type**
+
+At line 252, extend the local `debugMeta` declaration:
+
+```ts
+          let debugMeta: {
+            graph: string;
+            iterations: number;
+            tools: unknown[];
+            llm?: unknown;
+            orchestratorNegotiations?: unknown;
+          } | undefined;
+```
+
+At line 291, update the assignment to capture the extra fields from the event:
+
+```ts
+                debugMeta = {
+                  graph: event.graph,
+                  iterations: event.iterations,
+                  tools: event.tools,
+                  ...(event.llm != null && { llm: event.llm }),
+                  ...(event.orchestratorNegotiations != null && { orchestratorNegotiations: event.orchestratorNegotiations }),
+                };
+```
+
+No changes are needed in `chat.service.ts` — `debugMeta` is stored as `unknown` in `upsertMessageMetadata`.
+
+- [ ] **Step 8: Run and watch tests pass**
+
+```bash
+cd packages/protocol && bun test src/chat/tests/chat.agent.spec.ts -t "debugMeta accumulator" 2>&1 | tail -30
+cd packages/protocol && bun test src/chat/tests/chat.agent.spec.ts 2>&1 | tail -10
+cd ../../backend && bun run lint 2>&1 | tail -10
+```
+
+Expected: new test PASS; existing tests PASS; lint clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/protocol/src/chat/chat-streaming.types.ts \
+        packages/protocol/src/chat/chat.agent.ts \
+        packages/protocol/src/chat/chat.state.ts \
+        packages/protocol/src/chat/chat.streamer.ts \
+        packages/protocol/src/chat/tests/chat.agent.spec.ts \
+        backend/src/controllers/chat.controller.ts
+git -c commit.gpgsign=false commit -m "feat(chat): persist llm + orchestratorNegotiations fields in debugMeta"
+```
+
+---
+
+## Task 6: `/debug/chat/:id` — pointer-path negotiation hydration
+
+**Files:**
+- Modify: `backend/src/controllers/debug.controller.ts` (`getChatDebug` lines 519–691)
+- Test: `backend/tests/debug.chat.negotiations.spec.ts` (new)
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `backend/tests/debug.chat.negotiations.spec.ts`:
+
+```ts
+import "./setup.env";
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { db } from "../src/lib/drizzle/drizzle";
+import { conversations, conversationParticipants, messages, tasks, opportunities, conversationMetadata } from "../src/schemas/database.schema";
+import { buildTestApp, getRequest, createTestUser, cleanupTestUser } from "./helpers"; // adapt to local helpers
+
+describe("/debug/chat/:id — orchestrator negotiations (pointer path)", () => {
+  let app: Awaited<ReturnType<typeof buildTestApp>>;
+  let userId: string;
+  let sessionId: string;
+  let oppIdAccepted: string;
+  let oppIdRejected: string;
+
+  beforeAll(async () => {
+    app = await buildTestApp();
+    userId = await createTestUser();
+
+    // ── seed chat session + assistant message with orchestratorNegotiations pointer ──
+    const [conv] = await db.insert(conversations).values({ kind: "chat" }).returning();
+    sessionId = conv.id;
+    await db.insert(conversationParticipants).values({
+      conversationId: sessionId, participantId: userId, participantType: "user",
+    });
+    await db.insert(conversationMetadata).values({
+      conversationId: sessionId, metadata: { title: "test", networkId: null },
+    });
+
+    // ── seed two opportunities (one accepted, one rejected) ──
+    [{ id: oppIdAccepted }] = await db.insert(opportunities).values({
+      userId, status: "draft", trigger: "orchestrator", metadata: {},
+    }).returning();
+    [{ id: oppIdRejected }] = await db.insert(opportunities).values({
+      userId, status: "rejected", trigger: "orchestrator", metadata: {},
+    }).returning();
+
+    // ── seed assistant message with pointer ──
+    await db.insert(messages).values({
+      conversationId: sessionId, role: "agent",
+      parts: [{ type: "text", text: "ok" }],
+      metadata: {
+        debugMeta: {
+          graph: "agent_loop",
+          iterations: 1,
+          tools: [],
+          llm: { calls: 1, totalDurationMs: 10, resets: [], hallucinations: [] },
+          orchestratorNegotiations: { opportunityIds: [oppIdAccepted, oppIdRejected] },
+        },
+      },
+    });
+
+    // ── seed 1 negotiation per opportunity (task + conversation + 2 turn messages) ──
+    for (const [oppId, accept] of [[oppIdAccepted, true], [oppIdRejected, false]] as const) {
+      const [negConv] = await db.insert(conversations).values({ kind: "negotiation" }).returning();
+      const [task] = await db.insert(tasks).values({
+        conversationId: negConv.id,
+        state: "completed",
+        metadata: { type: "negotiation", opportunityId: oppId, sourceUserId: userId, candidateUserId: "u-cand", maxTurns: 4 },
+      }).returning();
+      await db.insert(messages).values([
+        {
+          conversationId: negConv.id, role: "agent", taskId: task.id, senderId: `agent:${userId}`,
+          parts: [{ kind: "data", data: { action: "propose", assessment: { reasoning: "r1", suggestedRoles: { ownUser: "agent", otherUser: "patient" } }, message: "hi" } }],
+        },
+        {
+          conversationId: negConv.id, role: "agent", taskId: task.id, senderId: `agent:u-cand`,
+          parts: [{ kind: "data", data: { action: accept ? "accept" : "reject", assessment: { reasoning: "r2", suggestedRoles: { ownUser: "patient", otherUser: "agent" } } } }],
+        },
+      ]);
+    }
+  });
+
+  afterAll(async () => { await cleanupTestUser(userId); });
+
+  it("returns populated turn.negotiations[] with both candidates", async () => {
+    const res = await getRequest(app, `/debug/chat/${sessionId}`, userId);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { turns: Array<{ negotiations?: unknown[] }> };
+    const negotiations = body.turns.flatMap((t) => t.negotiations ?? []) as Array<{ opportunityId: string; turns: unknown[]; outcome: { status: string } | null }>;
+    expect(negotiations).toHaveLength(2);
+    const accepted = negotiations.find((n) => n.opportunityId === oppIdAccepted);
+    const rejected = negotiations.find((n) => n.opportunityId === oppIdRejected);
+    expect(accepted?.turns).toHaveLength(2);
+    expect(accepted?.outcome?.status).toBe("draft");
+    expect(rejected?.outcome?.status).toBe("rejected");
+  });
+});
+```
+
+> **Note:** The helper names `buildTestApp`, `getRequest`, `createTestUser`, `cleanupTestUser` should match what the existing backend tests use. If the conventions differ, open any file under `backend/tests/` and mirror its setup.
+
+- [ ] **Step 2: Run and watch it fail**
+
+```bash
+cd backend && bun test tests/debug.chat.negotiations.spec.ts 2>&1 | tail -30
+```
+
+Expected: FAIL — `body.turns[i].negotiations` is undefined (the endpoint does not hydrate yet).
+
+- [ ] **Step 3: Implement the hydration**
+
+In `debug.controller.ts`, add imports at the top if not already present:
+
+```ts
+import { tasks, opportunities } from '../schemas/database.schema';
+import { inArray, sql } from 'drizzle-orm';
+```
+
+Then modify `getChatDebug`. After the existing `turns.push({ messageIndex, graph, iterations, tools })` block (around line 678), but before `return Response.json({ ... })`, insert a post-processing loop:
+
+```ts
+    // ── 5. Hydrate negotiations for each turn that has orchestratorNegotiations pointers ──
+    const turnNegotiations: Array<Array<{
+      opportunityId: string;
+      negotiationConversationId: string;
+      taskState: string;
+      sourceUserId: string;
+      candidateUserId: string;
+      candidateName: string;
+      turns: Array<{
+        turnIndex: number;
+        actor: 'source' | 'candidate';
+        action: string;
+        reasoning?: string;
+        message?: string;
+        suggestedRoles?: { ownUser?: string; otherUser?: string };
+        createdAt: Date;
+      }>;
+      outcome: { status: string; turnCount: number; agreedRoles?: unknown; reasoning?: string } | null;
+      startedAt: Date | null;
+      endedAt: Date | null;
+      durationMs: number | null;
+      turnsTruncated?: boolean;
+    }>> = turns.map(() => []);
+
+    for (let i = 0; i < turns.length; i++) {
+      const turn = turns[i];
+      const msgRow = messageRows[turn.messageIndex];
+      if (!msgRow || msgRow.role !== 'assistant') continue;
+      const pointerIds = (msgRow.debugMeta as { orchestratorNegotiations?: { opportunityIds?: string[] } } | null)?.orchestratorNegotiations?.opportunityIds;
+      if (!pointerIds || pointerIds.length === 0) continue;
+
+      // Fetch tasks whose metadata.opportunityId is in pointerIds.
+      const taskRows = await db
+        .select({
+          id: tasks.id,
+          conversationId: tasks.conversationId,
+          state: tasks.state,
+          metadata: tasks.metadata,
+          createdAt: tasks.createdAt,
+          updatedAt: tasks.updatedAt,
+        })
+        .from(tasks)
+        .where(and(
+          sql`${tasks.metadata}->>'opportunityId' = ANY(${pointerIds})`,
+          sql`${tasks.metadata}->>'type' = 'negotiation'`,
+        ));
+
+      for (const t of taskRows) {
+        const tmeta = (t.metadata ?? {}) as { opportunityId?: string; sourceUserId?: string; candidateUserId?: string };
+        const oppId = tmeta.opportunityId;
+        if (!oppId) continue;
+
+        // Load negotiation turn messages
+        const turnMessages = await db
+          .select({ parts: messages.parts, createdAt: messages.createdAt, senderId: messages.senderId })
+          .from(messages)
+          .where(eq(messages.conversationId, t.conversationId))
+          .orderBy(asc(messages.createdAt))
+          .limit(20);
+
+        const MAX_TURNS = 20;
+        const truncated = turnMessages.length >= MAX_TURNS;
+
+        const [opp] = await db.select({ status: opportunities.status }).from(opportunities).where(eq(opportunities.id, oppId)).limit(1);
+
+        const parsedTurns = turnMessages.map((m, idx) => {
+          const dataPart = (m.parts as Array<{ kind?: string; data?: Record<string, unknown> }>)?.find((p) => p.kind === 'data');
+          const d = (dataPart?.data ?? {}) as {
+            action?: string;
+            assessment?: { reasoning?: string; suggestedRoles?: { ownUser?: string; otherUser?: string } };
+            message?: string;
+          };
+          const isSource = m.senderId === `agent:${tmeta.sourceUserId ?? ''}`;
+          return {
+            turnIndex: idx,
+            actor: (isSource ? 'source' : 'candidate') as 'source' | 'candidate',
+            action: d.action ?? 'unknown',
+            reasoning: d.assessment?.reasoning,
+            message: d.message,
+            suggestedRoles: d.assessment?.suggestedRoles,
+            createdAt: m.createdAt,
+          };
+        });
+
+        turnNegotiations[i].push({
+          opportunityId: oppId,
+          negotiationConversationId: t.conversationId,
+          taskState: t.state,
+          sourceUserId: tmeta.sourceUserId ?? '',
+          candidateUserId: tmeta.candidateUserId ?? '',
+          candidateName: '',
+          turns: parsedTurns,
+          outcome: opp ? { status: opp.status, turnCount: parsedTurns.length } : null,
+          startedAt: t.createdAt,
+          endedAt: t.state === 'completed' ? t.updatedAt : null,
+          durationMs: t.state === 'completed' && t.createdAt && t.updatedAt
+            ? new Date(t.updatedAt).getTime() - new Date(t.createdAt).getTime()
+            : null,
+          ...(truncated && { turnsTruncated: true }),
+        });
+      }
+    }
+
+    // Attach to each turn before the response assembly.
+    const turnsWithNegotiations = turns.map((t, i) => ({ ...t, negotiations: turnNegotiations[i] }));
+```
+
+Replace `turns` with `turnsWithNegotiations` in the final `Response.json(...)` payload at line 688.
+
+- [ ] **Step 4: Run and watch it pass**
+
+```bash
+cd backend && bun test tests/debug.chat.negotiations.spec.ts 2>&1 | tail -30
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/controllers/debug.controller.ts backend/tests/debug.chat.negotiations.spec.ts
+git -c commit.gpgsign=false commit -m "feat(debug): hydrate orchestrator negotiations via pointer in /debug/chat"
+```
+
+---
+
+## Task 7: `/debug/chat/:id` — fallback time-window hydration for legacy messages
+
+**Files:**
+- Modify: `backend/src/controllers/debug.controller.ts`
+- Test: `backend/tests/debug.chat.legacy.spec.ts` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/debug.chat.legacy.spec.ts`:
+
+```ts
+import "./setup.env";
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { db } from "../src/lib/drizzle/drizzle";
+import { conversations, conversationParticipants, messages, tasks, opportunities, conversationMetadata } from "../src/schemas/database.schema";
+import { buildTestApp, getRequest, createTestUser, cleanupTestUser } from "./helpers";
+
+describe("/debug/chat/:id — fallback path for legacy messages", () => {
+  let app: Awaited<ReturnType<typeof buildTestApp>>;
+  let userId: string;
+  let sessionId: string;
+  let oppId: string;
+  const msgCreatedAt = new Date();
+
+  beforeAll(async () => {
+    app = await buildTestApp();
+    userId = await createTestUser();
+
+    const [conv] = await db.insert(conversations).values({ kind: "chat" }).returning();
+    sessionId = conv.id;
+    await db.insert(conversationParticipants).values({
+      conversationId: sessionId, participantId: userId, participantType: "user",
+    });
+    await db.insert(conversationMetadata).values({
+      conversationId: sessionId, metadata: {},
+    });
+
+    // Assistant message WITHOUT orchestratorNegotiations pointer (legacy).
+    await db.insert(messages).values({
+      conversationId: sessionId, role: "agent",
+      parts: [{ type: "text", text: "ok" }],
+      metadata: { debugMeta: { graph: "agent_loop", iterations: 1, tools: [] } },
+      createdAt: msgCreatedAt,
+    });
+
+    // Opportunity authored by this user via orchestrator, inside the fallback window.
+    [{ id: oppId }] = await db.insert(opportunities).values({
+      userId, status: "draft", trigger: "orchestrator", metadata: {},
+      createdAt: new Date(msgCreatedAt.getTime() + 2_000),
+    }).returning();
+
+    const [negConv] = await db.insert(conversations).values({ kind: "negotiation" }).returning();
+    const [task] = await db.insert(tasks).values({
+      conversationId: negConv.id, state: "completed",
+      metadata: { type: "negotiation", opportunityId: oppId, sourceUserId: userId, candidateUserId: "u-cand" },
+    }).returning();
+    await db.insert(messages).values({
+      conversationId: negConv.id, role: "agent", taskId: task.id, senderId: `agent:${userId}`,
+      parts: [{ kind: "data", data: { action: "accept", assessment: { reasoning: "r" } } }],
+    });
+  });
+
+  afterAll(async () => { await cleanupTestUser(userId); });
+
+  it("hydrates negotiations via time-window join when no pointer present", async () => {
+    const res = await getRequest(app, `/debug/chat/${sessionId}`, userId);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { turns: Array<{ negotiations?: Array<{ opportunityId: string }> }> };
+    const ids = body.turns.flatMap((t) => t.negotiations ?? []).map((n) => n.opportunityId);
+    expect(ids).toContain(oppId);
+  });
+});
+```
+
+- [ ] **Step 2: Run and watch it fail**
+
+```bash
+cd backend && bun test tests/debug.chat.legacy.spec.ts 2>&1 | tail -30
+```
+
+Expected: FAIL — no negotiations returned because no pointer and no fallback implemented.
+
+- [ ] **Step 3: Add fallback branch**
+
+In `debug.controller.ts`, inside the same hydration loop from Task 6, after the `if (!pointerIds || pointerIds.length === 0) continue;` line, replace it with a fallback branch:
+
+```ts
+      let effectivePointerIds = pointerIds ?? null;
+
+      if (!effectivePointerIds) {
+        const msgTs = new Date(msgRow.createdAt).getTime();
+        const WINDOW_MS = 10 * 60 * 1000; // ±10 min
+        const fromTs = new Date(msgTs - WINDOW_MS);
+        const toTs = new Date(msgTs + WINDOW_MS);
+        const oppsInWindow = await db
+          .select({ id: opportunities.id })
+          .from(opportunities)
+          .where(and(
+            eq(opportunities.userId, user.id),
+            eq(opportunities.trigger, 'orchestrator'),
+            sql`${opportunities.createdAt} >= ${fromTs}`,
+            sql`${opportunities.createdAt} <= ${toTs}`,
+          ));
+        if (oppsInWindow.length === 0) continue;
+        effectivePointerIds = oppsInWindow.map((o) => o.id);
+      }
+
+      // … reuse `effectivePointerIds` below (rename `pointerIds` uses to `effectivePointerIds`).
+```
+
+- [ ] **Step 4: Run and watch it pass**
+
+```bash
+cd backend && bun test tests/debug.chat.legacy.spec.ts 2>&1 | tail -20
+cd backend && bun test tests/debug.chat.negotiations.spec.ts 2>&1 | tail -20
+```
+
+Expected: new legacy test PASS; prior Task 6 test still PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/controllers/debug.controller.ts backend/tests/debug.chat.legacy.spec.ts
+git -c commit.gpgsign=false commit -m "feat(debug): fallback time-window hydration for legacy chat messages"
+```
+
+---
+
+## Task 8: Frontend — extend `TraceEvent` type and SSE mapping
+
+**Files:**
+- Modify: `frontend/src/contexts/AIChatContext.tsx`
+
+- [ ] **Step 1: Extend `TraceEventType` and `TraceEvent`**
+
+In `AIChatContext.tsx` lines 59–82, append to `TraceEventType`:
+
+```ts
+export type TraceEventType =
+  | "iteration_start"
+  | "llm_start"
+  | "llm_end"
+  | "hallucination_detected"
+  | "tool_start"
+  | "tool_end"
+  | "graph_start"
+  | "graph_end"
+  | "agent_start"
+  | "agent_end"
+  | "negotiation_session_start"
+  | "negotiation_session_end"
+  | "negotiation_turn"
+  | "negotiation_outcome";
+```
+
+Extend `TraceEvent`:
+
+```ts
+export interface TraceEvent {
+  type: TraceEventType;
+  timestamp: number;
+  iteration?: number;
+  name?: string;
+  status?: "running" | "success" | "error";
+  summary?: string;
+  durationMs?: number;
+  steps?: ToolCallStep[];
+  hasToolCalls?: boolean;
+  toolNames?: string[];
+  // Negotiation-event fields
+  opportunityId?: string;
+  negotiationConversationId?: string;
+  sourceUserId?: string;
+  candidateUserId?: string;
+  candidateName?: string;
+  trigger?: "orchestrator" | "ambient";
+  startedAt?: number;
+  turnIndex?: number;
+  actor?: "source" | "candidate";
+  action?: "propose" | "accept" | "reject" | "counter" | "question";
+  reasoning?: string;
+  message?: string;
+  suggestedRoles?: { ownUser?: string; otherUser?: string };
+  outcome?:
+    | "accepted"
+    | "rejected_stalled"
+    | "waiting_for_agent"
+    | "timed_out"
+    | "turn_cap";
+  turnCount?: number;
+  agreedRoles?: { ownUser?: string; otherUser?: string };
+}
+```
+
+- [ ] **Step 2: Map incoming SSE events to `TraceEvent` objects**
+
+Find the SSE handler (the file already handles events like `graph_start` around line 455). Add matching cases for the four new types. Pattern:
+
+```tsx
+                case "negotiation_session_start": {
+                  const te: TraceEvent = {
+                    type: "negotiation_session_start",
+                    timestamp: performance.now(),
+                    opportunityId: event.opportunityId,
+                    negotiationConversationId: event.negotiationConversationId,
+                    sourceUserId: event.sourceUserId,
+                    candidateUserId: event.candidateUserId,
+                    candidateName: event.candidateName,
+                    trigger: event.trigger,
+                    startedAt: event.startedAt,
+                  };
+                  appendTraceEvent(te);
+                  break;
+                }
+                case "negotiation_session_end": {
+                  appendTraceEvent({
+                    type: "negotiation_session_end",
+                    timestamp: performance.now(),
+                    opportunityId: event.opportunityId,
+                    negotiationConversationId: event.negotiationConversationId,
+                    durationMs: event.durationMs,
+                  });
+                  break;
+                }
+                case "negotiation_turn": {
+                  appendTraceEvent({
+                    type: "negotiation_turn",
+                    timestamp: performance.now(),
+                    opportunityId: event.opportunityId,
+                    negotiationConversationId: event.negotiationConversationId,
+                    turnIndex: event.turnIndex,
+                    actor: event.actor,
+                    action: event.action,
+                    reasoning: event.reasoning,
+                    message: event.message,
+                    suggestedRoles: event.suggestedRoles,
+                    durationMs: event.durationMs,
+                  });
+                  break;
+                }
+                case "negotiation_outcome": {
+                  appendTraceEvent({
+                    type: "negotiation_outcome",
+                    timestamp: performance.now(),
+                    opportunityId: event.opportunityId,
+                    outcome: event.outcome,
+                    turnCount: event.turnCount,
+                    reasoning: event.reasoning,
+                    agreedRoles: event.agreedRoles,
+                  });
+                  break;
+                }
+```
+
+Use whatever `appendTraceEvent` / inline append the file already uses (match the existing `graph_start` case as a template).
+
+- [ ] **Step 3: Typecheck**
+
+```bash
+cd frontend && bun run lint 2>&1 | tail -20
+```
+
+Expected: lint clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/contexts/AIChatContext.tsx
+git -c commit.gpgsign=false commit -m "feat(frontend): map negotiation stream events to TraceEvent"
+```
+
+---
+
+## Task 9: Frontend — parser branches in `ToolCallsDisplay`
+
+**Files:**
+- Modify: `frontend/src/components/chat/ToolCallsDisplay.tsx`
+
+- [ ] **Step 1: Add negotiation types to the node model**
+
+Near the other node types (around lines 385–410), add:
+
+```ts
+export interface NegotiationTurnRow {
+  turnIndex: number;
+  actor: "source" | "candidate";
+  action: "propose" | "accept" | "reject" | "counter" | "question";
+  reasoning?: string;
+  message?: string;
+  suggestedRoles?: { ownUser?: string; otherUser?: string };
+  durationMs: number;
+}
+
+export interface NegotiationNode {
+  opportunityId: string;
+  negotiationConversationId: string;
+  candidateUserId: string;
+  candidateName?: string;
+  trigger: "orchestrator" | "ambient";
+  startTimestamp: number;
+  durationMs?: number;
+  turns: NegotiationTurnRow[];
+  outcome?:
+    | "accepted"
+    | "rejected_stalled"
+    | "waiting_for_agent"
+    | "timed_out"
+    | "turn_cap";
+  turnCount?: number;
+  outcomeReasoning?: string;
+  isRunning: boolean;
+}
+```
+
+Extend `ToolNode`:
+
+```ts
+interface ToolNode {
+  name: string;
+  startTimestamp: number;
+  isRunning: boolean;
+  activities: TraceEvent[];
+  steps?: ToolCallStep[];
+  summary?: string;
+  durationMs?: number;
+  status?: "success" | "error";
+  graphs: GraphNode[];
+  negotiations: NegotiationNode[]; // NEW
+}
+```
+
+Ensure each `ToolNode` literal in the parser (there is one at line 452–459) initializes `negotiations: []`.
+
+- [ ] **Step 2: Add parser branches**
+
+Inside `parseTraceEvents` (line 418) switch, append cases after `agent_end` (line 557):
+
+```ts
+      case "negotiation_session_start": {
+        const target = currentTool ?? (tools.length > 0 ? tools[tools.length - 1] : null);
+        if (!target) break;
+        const node: NegotiationNode = {
+          opportunityId: event.opportunityId ?? "",
+          negotiationConversationId: event.negotiationConversationId ?? "",
+          candidateUserId: event.candidateUserId ?? "",
+          candidateName: event.candidateName,
+          trigger: event.trigger ?? "ambient",
+          startTimestamp: event.timestamp,
+          turns: [],
+          isRunning: true,
+        };
+        target.negotiations.push(node);
+        break;
+      }
+
+      case "negotiation_turn": {
+        const all = tools.flatMap((t) => t.negotiations);
+        const node = [...all].reverse().find(
+          (n) => n.opportunityId === (event.opportunityId ?? "") && n.isRunning,
+        );
+        if (!node) break;
+        node.turns.push({
+          turnIndex: event.turnIndex ?? node.turns.length,
+          actor: (event.actor ?? "source") as "source" | "candidate",
+          action: (event.action ?? "propose") as NegotiationTurnRow["action"],
+          reasoning: event.reasoning,
+          message: event.message,
+          suggestedRoles: event.suggestedRoles,
+          durationMs: event.durationMs ?? 0,
+        });
+        break;
+      }
+
+      case "negotiation_outcome": {
+        const all = tools.flatMap((t) => t.negotiations);
+        const node = [...all].reverse().find(
+          (n) => n.opportunityId === (event.opportunityId ?? "") && n.isRunning,
+        );
+        if (!node) break;
+        node.outcome = event.outcome;
+        node.turnCount = event.turnCount;
+        node.outcomeReasoning = event.reasoning;
+        break;
+      }
+
+      case "negotiation_session_end": {
+        const all = tools.flatMap((t) => t.negotiations);
+        const node = [...all].reverse().find(
+          (n) => n.opportunityId === (event.opportunityId ?? "") && n.isRunning,
+        );
+        if (!node) break;
+        node.isRunning = false;
+        node.durationMs = event.durationMs;
+        break;
+      }
+```
+
+- [ ] **Step 3: Typecheck**
+
+```bash
+cd frontend && bun run lint 2>&1 | tail -20
+```
+
+Expected: lint clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/chat/ToolCallsDisplay.tsx
+git -c commit.gpgsign=false commit -m "feat(frontend): parse negotiation events into NegotiationNode model"
+```
+
+---
+
+## Task 10: Frontend — `NegotiationTree` subcomponent + rendering
+
+**Files:**
+- Modify: `frontend/src/components/chat/ToolCallsDisplay.tsx`
+
+- [ ] **Step 1: Add the `NegotiationTree` subcomponent**
+
+Near the other subcomponents (search for `function ToolCallsDisplay` in the file — the subcomponent goes just above it):
+
+```tsx
+function outcomeIcon(o: NegotiationNode["outcome"]): string {
+  if (o === "accepted") return "🟢";
+  if (o === "waiting_for_agent") return "⏳";
+  return "🔴";
+}
+
+function NegotiationTree({ negotiations }: { negotiations: NegotiationNode[] }) {
+  const [openIdxs, setOpenIdxs] = useState<Set<number>>(new Set());
+
+  if (negotiations.length === 0) return null;
+
+  return (
+    <div className="mt-2 pl-3 border-l border-gray-200">
+      <div className="text-xs text-gray-500 mb-1">Negotiations ({negotiations.length})</div>
+      {negotiations.map((n, i) => {
+        const isOpen = openIdxs.has(i);
+        const toggle = () => {
+          const next = new Set(openIdxs);
+          if (isOpen) next.delete(i); else next.add(i);
+          setOpenIdxs(next);
+        };
+        return (
+          <div key={`${n.opportunityId}-${i}`} className="mb-1">
+            <button
+              type="button"
+              onClick={toggle}
+              className="flex items-center gap-1 text-xs text-gray-700 hover:text-gray-900"
+              title={n.outcomeReasoning ?? ""}
+            >
+              <span>{isOpen ? "▾" : "▸"}</span>
+              <span>{outcomeIcon(n.outcome)}</span>
+              <span className="font-medium">{n.candidateName ?? n.candidateUserId}</span>
+              <span className="text-gray-500">
+                — {n.outcome ?? (n.isRunning ? "running" : "unknown")} ({n.turns.length} turn{n.turns.length === 1 ? "" : "s"}{n.durationMs != null ? `, ${n.durationMs}ms` : ""})
+              </span>
+            </button>
+            {isOpen && (
+              <ol className="ml-5 mt-1 space-y-0.5 text-xs text-gray-700">
+                {n.turns.map((t) => (
+                  <li key={t.turnIndex}>
+                    <span className="text-gray-500">{t.turnIndex + 1}.</span>{" "}
+                    <span className="font-mono text-[10px] text-gray-500">[{t.actor}]</span>{" "}
+                    <span className="font-medium">{t.action}</span>
+                    {t.message && <span> — {t.message}</span>}
+                    {t.reasoning && (
+                      <div className="ml-5 text-gray-500">{t.reasoning}</div>
+                    )}
+                  </li>
+                ))}
+              </ol>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Render `NegotiationTree` inside each tool card**
+
+Find the section that renders `tool.graphs` inside an expanded tool block. Below the graphs render, insert:
+
+```tsx
+{tool.negotiations.length > 0 && <NegotiationTree negotiations={tool.negotiations} />}
+```
+
+- [ ] **Step 3: Manual verification**
+
+Start both dev servers and trigger an orchestrator flow:
+
+```bash
+# terminal 1
+cd /home/yanek/Projects/index/.worktrees/feat-negotiation-debug-visibility && bun run worktree:dev feat-negotiation-debug-visibility
+```
+
+Open the frontend, start a new chat in an index with at least two members, trigger an opportunity via an intent, click Start Chat. Confirm the TRACE panel now shows a "Negotiations (N)" section with a row per candidate, expandable to show turns. Note: report explicitly if manual verification could not be run (e.g. no seeded data).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/chat/ToolCallsDisplay.tsx
+git -c commit.gpgsign=false commit -m "feat(frontend): render per-candidate negotiations in TRACE panel"
+```
+
+---
+
+## Task 11: Docs
+
+**Files:**
+- Modify: `docs/design/protocol-deep-dive.md`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Update `docs/design/protocol-deep-dive.md`**
+
+Find the Trace Event Instrumentation section. Append under the existing event list:
+
+```markdown
+**Negotiation events** (added 2026-04-17):
+
+- `negotiation_session_start` / `negotiation_session_end` — emitted by `negotiateCandidates` in `negotiation.graph.ts`, wrapping each per-candidate run. Carries `opportunityId`, `negotiationConversationId`, source/candidate user ids, `trigger` (`'orchestrator' | 'ambient'`), `startedAt`, and `durationMs` (on end).
+- `negotiation_turn` — emitted by the negotiation graph's `turnNode` after each successful turn. Carries `opportunityId`, `turnIndex`, `actor` (`'source' | 'candidate'`), `action` (`propose | accept | reject | counter | question`), `reasoning`, `message`, `suggestedRoles`, `durationMs`.
+- `negotiation_outcome` — emitted from `finalizeNode` on every terminal path (`accepted`, `rejected_stalled`, `waiting_for_agent`, `timed_out`, `turn_cap`). Carries `opportunityId`, `outcome`, `turnCount`, `reasoning`, `agreedRoles`.
+
+Consumers: the live TRACE panel uses these to render per-candidate negotiation nodes. `/debug/chat/:id` uses `debugMeta.orchestratorNegotiations.opportunityIds` (persisted from `negotiation_session_start` during the turn) to hydrate full negotiation history from `tasks` + `messages` + `opportunities`. Existing `agent_start/end` emissions in `negotiation.graph.ts` are retained for backward compatibility with the rolled-up `debugMeta.tools[].graphs[].agents[]` render path.
+```
+
+- [ ] **Step 2: Update `CLAUDE.md`**
+
+Under the Trace Event Instrumentation subsection, append one paragraph:
+
+```markdown
+Negotiation-specific events (`negotiation_session_start/end`, `negotiation_turn`, `negotiation_outcome`) carry per-candidate turn and outcome data for orchestrator-inline negotiations. They are persisted into `debugMeta.orchestratorNegotiations.opportunityIds` for later hydration by the debug endpoint.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/design/protocol-deep-dive.md CLAUDE.md
+git -c commit.gpgsign=false commit -m "docs: document negotiation trace events + debugMeta hydration"
+```
+
+---
+
+## Task 12: Full regression + final verification
+
+- [ ] **Step 1: Run affected test suites**
+
+```bash
+cd packages/protocol && bun test src/negotiation/tests src/chat/tests 2>&1 | tail -20
+cd ../../backend && bun test tests/debug.chat.negotiations.spec.ts tests/debug.chat.legacy.spec.ts 2>&1 | tail -10
+cd ../frontend && bun run lint 2>&1 | tail -10
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Smoke test `/debug/chat/:id` response shape**
+
+Start backend:
+
+```bash
+cd backend && bun run dev
+```
+
+In another terminal, authenticate, seed an orchestrator session (or reuse an existing one), then:
+
+```bash
+curl -s -H "Cookie: <session cookie>" http://localhost:3001/debug/chat/<sessionId> | jq '.turns[] | .negotiations'
+```
+
+Expected: each turn has `negotiations` array; orchestrator-origin turns populated; non-orchestrator turns empty.
+
+- [ ] **Step 3: Leave branch ready for review**
+
+Do not merge or rebase. Surface: current branch state, any tests skipped, any manual verification that could not be run. Follow `feedback_finishing_branch.md` — do not auto-merge to dev.
+
+---
+
+## Open considerations during execution (not blockers)
+
+- **Opportunity schema — `trigger` field:** The plan assumes `opportunities.trigger` and `state.trigger` exist with values `'orchestrator' | 'ambient'`. Confirm field names at Task 4 step 4 before committing; if the actual field name differs (e.g. `originTrigger`), update references accordingly.
+- **`candidateName` source:** Task 6's hydration sets `candidateName: ''`. If readily available via an existing `userProfiles`/`contacts` join in the surrounding code, populate it; otherwise leave empty and track as a polish item.
+- **Seed assessment in turn history:** Task 2's `turnIndex` uses `state.turnCount`; the seed assessment is not a persisted turn. Confirm this matches expectations when reviewing the first PR.
+- **Payload cap per session:** The plan caps negotiation turn messages at 20 per opportunity (`turnsTruncated`). If real sessions regularly exceed this, raise the cap or add per-opportunity truncation to the final response shape in a follow-up.

--- a/docs/superpowers/specs/2026-04-17-negotiation-debug-visibility-design.md
+++ b/docs/superpowers/specs/2026-04-17-negotiation-debug-visibility-design.md
@@ -1,0 +1,232 @@
+# Negotiation Debug Visibility
+
+**Date:** 2026-04-17
+**Status:** Approved for planning
+**Scope:** Surface orchestrator-inline negotiations in both the persistent debug meta (`/debug/chat/:id` JSON export) and the live TRACE panel. Bundle previously-ephemeral chat trace events into persisted debug meta.
+
+## Problem
+
+Recent PRs introduced an orchestrator-inline negotiation flow: when a user clicks Start Chat on an opportunity, the orchestrator runs a short-window negotiation directly (no personal-agent park) and streams drafts back. The flow works, but its diagnostic surfaces are blind:
+
+- `/debug/chat/:id` returns per-turn `debugMeta` (tools, graphs, agents) but nothing about the negotiations that ran. Negotiation conversations live in separate `tasks` + `messages` rows joined by `opportunityId`, and the debug endpoint never joins to them.
+- The live TRACE panel (`ToolCallsDisplay.tsx`) renders `graph_start/end` and nested `agent_start/end`, but negotiation turns emitted by `negotiation.graph.ts` appear orphaned — its turn-level `agent_*` events are not graph-wrapped at the orchestrator layer, and the parser has no first-class rendering for negotiation turns or outcomes.
+- Pre-existing gap bundled into this spec: `iteration_start`, `llm_start/end`, `response_reset`, and `hallucination_detected` events stream live but are never persisted into `debugMeta`, so they vanish on reload.
+
+## Non-goals
+
+- Persisting the live TRACE panel across reload (separate, tracked gap — same class as the streamingDrafts persistence gap).
+- Instrumentation of subsystems that do not currently emit trace events during an orchestrator chat turn: `contact/`, `integration/`, `agent/`, `maintenance/`, `mcp/`. These do not run on a chat turn or do not have hooks; they are out of scope.
+- Opportunity evaluator per-candidate scoring promotion (predates this regression — tracked separately).
+- A dedicated `/debug/opportunities/:id` endpoint.
+
+## Approach
+
+**Hydrate at read time, capture minimal pointers at write time.**
+
+- Negotiations are first-class persistent entities (`tasks` + `messages` + `opportunities`). Do not duplicate them into `debugMeta`.
+- The chat message's `debugMeta` records only the `opportunityIds` negotiated during that turn as a pointer.
+- `/debug/chat/:id` joins those pointers → negotiation conversation rows → turn messages + task state + opportunity outcome, and embeds the result per turn.
+- For older messages lacking pointers, a bounded time-window fallback query keeps the endpoint retroactively useful.
+- Live TRACE consumes new typed stream events (`negotiation_session_start/end`, `negotiation_turn`, `negotiation_outcome`) emitted by the negotiation graph and wrapped by `opportunity.graph.ts#negotiateNode`.
+
+Alternatives considered:
+
+- *Capture at emit time into debugMeta* — duplicates data already modeled in tables, ships nothing retroactive, couples chat metadata shape to negotiation shape.
+- *Trace-stream-as-truth (persist the raw event log)* — full fidelity but large refactor of the existing rolled-up `debugMeta` shape and the UI parser; not justified by the recent regression.
+
+## Design
+
+### Protocol: new stream events
+
+Added to the `AgentStreamEvent` discriminated union in `packages/protocol/src/chat/chat-streaming.types.ts`:
+
+```ts
+type NegotiationSessionEvent = {
+  type: 'negotiation_session_start' | 'negotiation_session_end';
+  opportunityId: string;
+  negotiationConversationId: string;
+  sourceUserId: string;
+  candidateUserId: string;
+  candidateName?: string;
+  trigger: 'orchestrator' | 'ambient';
+  startedAt: number;    // only on _start
+  durationMs?: number;  // only on _end
+};
+
+type NegotiationTurnEvent = {
+  type: 'negotiation_turn';
+  opportunityId: string;
+  negotiationConversationId: string;
+  turnIndex: number;
+  actor: 'source' | 'candidate';
+  action: 'propose' | 'accept' | 'reject' | 'counter' | 'question';
+  reasoning?: string;
+  message?: string;
+  suggestedRoles?: { ownUser?: string; otherUser?: string };
+  durationMs: number;
+};
+
+type NegotiationOutcomeEvent = {
+  type: 'negotiation_outcome';
+  opportunityId: string;
+  outcome: 'accepted' | 'rejected_stalled' | 'waiting_for_agent' | 'timed_out' | 'turn_cap';
+  turnCount: number;
+  reasoning?: string;
+  agreedRoles?: { ownUser?: string; otherUser?: string };
+};
+```
+
+**Emission sites:**
+
+- `packages/protocol/src/negotiation/negotiation.graph.ts` turn node — emit `negotiation_turn` after each assessment+action resolves.
+- `packages/protocol/src/negotiation/negotiation.graph.ts` terminal nodes — emit `negotiation_outcome` on every exit (accept, reject, turn cap, waiting_for_agent, timeout).
+- `packages/protocol/src/opportunity/opportunity.graph.ts#negotiateNode` — wrap each per-candidate run with `negotiation_session_start` / `negotiation_session_end`, carrying trigger + user identities so the UI has a stable candidate-level grouping independent of graph topology.
+
+Existing `agent_start/end` emissions in `negotiation.graph.ts` remain untouched for backward compatibility with the legacy `debugMeta.tools[].graphs[].agents[]` render path.
+
+### Backend: `debugMeta` accumulator extension
+
+Location: wherever the chat stream consumer builds per-turn `debugMeta` today (`backend/src/controllers/chat.controller.ts` or `backend/src/services/chat.service.ts` — identify precisely in plan phase).
+
+The rolled-up shape is preserved. Add two fields:
+
+```ts
+debugMeta: {
+  graph, iterations, tools,                  // existing
+  llm: {                                      // NEW
+    calls: number;
+    totalDurationMs: number;
+    resets: Array<{ reason: string; at: number }>;
+    hallucinations: Array<{ claim: string; correction?: string; at: number }>;
+  };
+  orchestratorNegotiations?: {                // NEW
+    opportunityIds: string[];
+  };
+};
+```
+
+Accumulation lives in the same loop as the existing `tools[]` builder. Mapping:
+
+- `iteration_start` → count iterations (already tracked; formalize).
+- `llm_start` / `llm_end` → increment `llm.calls`, accumulate `llm.totalDurationMs`.
+- `response_reset` → append to `llm.resets`.
+- `hallucination_detected` → append to `llm.hallucinations`.
+- `negotiation_session_start` → push `opportunityId` into `orchestratorNegotiations.opportunityIds` (dedup).
+
+### Backend: `/debug/chat/:id` hydration
+
+Extend `getChatDebug` in `backend/src/controllers/debug.controller.ts`. After the existing per-turn build, for each turn:
+
+1. Read `turn.debugMeta.orchestratorNegotiations?.opportunityIds`. If non-empty, use the **pointer path**; otherwise use the **fallback path**.
+2. **Pointer path:** query `tasks` where `metadata->>opportunityId` ∈ those ids and `metadata->>type = 'negotiation'`.
+3. **Fallback path (legacy messages):** query `opportunities` authored by the session user with `trigger='orchestrator'` created within a bounded window relative to the turn's `createdAt` (window size decided in plan phase; candidate: message timestamp ± 10 min). Then follow into `tasks` the same way.
+4. For each matched task: fetch its `conversationId`, load `messages` ordered by `createdAt` with role='agent' and `parts` filtered to NegotiationTurn data parts.
+5. Fetch the linked `opportunities` row for final `status`, `agreedRoles`, source/candidate user ids and names.
+6. Embed as:
+
+```ts
+turn.negotiations: Array<{
+  opportunityId: string;
+  negotiationConversationId: string;
+  taskState: 'working' | 'waiting_for_agent' | 'completed' | 'failed' | 'cancelled';
+  sourceUserId: string;
+  candidateUserId: string;
+  candidateName: string;
+  turns: Array<{
+    turnIndex: number;
+    actor: 'source' | 'candidate';
+    action: 'propose' | 'accept' | 'reject' | 'counter' | 'question';
+    reasoning?: string;
+    message?: string;
+    suggestedRoles?: { ownUser?: string; otherUser?: string };
+    createdAt: string;
+  }>;
+  outcome: {
+    status: string;
+    turnCount: number;
+    agreedRoles?: { ownUser?: string; otherUser?: string };
+    reasoning?: string;
+  } | null;
+  startedAt: string;
+  endedAt?: string;
+  durationMs?: number;
+}>;
+```
+
+Guards: keep the existing `DebugGuard + AuthGuard`. Cap negotiation turns loaded per opportunity at 20 to bound response size. If the cap is hit, include `{ turnsTruncated: true }` on the negotiation.
+
+### Frontend: TRACE panel
+
+Changes to `frontend/src/components/chat/ToolCallsDisplay.tsx` and the stream-event types file (which mirrors the protocol union).
+
+**Parser updates (`parseTraceEvents`):** walk the stream, maintain a `negotiationsByOpportunityId` map scoped to the current tool call, and dispatch:
+
+- `negotiation_session_start` → create node, attach to current tool call's `negotiations[]`.
+- `negotiation_turn` → append to matching node's `turns[]`.
+- `negotiation_outcome` → set matching node's `outcome`.
+- `negotiation_session_end` → close node, record `durationMs`.
+
+**Rendering (`NegotiationTree` subcomponent):** sibling to the existing graphs/agents tree inside an expanded tool block.
+
+```
+▾ create_opportunities (1.2s)
+  ▸ Graphs
+  ▾ Negotiations (3)
+    ▾ 🟢 Alice Chen — accepted (4 turns, 820ms)
+      1. [source] propose — "Overlap on pgvector tuning"
+      2. [candidate] question — "Scope of the consulting engagement?"
+      3. [source] counter — "Scoped to migration only"
+      4. [candidate] accept — roles: agent/patient
+    ▾ 🔴 Bob Lee — rejected_stalled (2 turns)
+    ▾ ⏳ Carol Park — waiting_for_agent (1 turn, parked)
+```
+
+Icons: 🟢 accepted, 🔴 rejected_stalled / timed_out / turn_cap, ⏳ waiting_for_agent. Each turn row is compact with click-to-expand for full `reasoning` + `message`. Outcome summary on hover exposes `reasoning` tooltip.
+
+**Persistent view:** the TRACE panel is live-only today. On reload, nothing renders. Out of scope for this spec; the persistent artifact is the `/debug/chat/:id` JSON export (which now includes `turn.negotiations` end-to-end).
+
+## Testing
+
+- `packages/protocol/src/negotiation/tests/negotiation.graph.spec.ts` — assert `negotiation_turn` emitted per turn with correct payload; `negotiation_outcome` emitted on every terminal path (accept, reject_stalled, turn_cap, waiting_for_agent, timed_out).
+- `packages/protocol/src/opportunity/tests/opportunity.graph.spec.ts` — assert `negotiation_session_start/end` wrap each per-candidate run; `trigger` and ids propagate.
+- `backend/tests/debug.chat.spec.ts` (new) — integration: orchestrator session with 2 candidates (1 accepted, 1 rejected). Call `/debug/chat/:id`. Assert `turns[i].negotiations` includes both with correct `taskState`, turn history, and outcome. Assert `llm.calls` and `iterations` are populated.
+- `backend/tests/debug.chat.legacy.spec.ts` — legacy message (no `orchestratorNegotiations` pointer): fallback time-window hydration finds the same negotiations.
+- `frontend` — snapshot test of `ToolCallsDisplay` rendering for a mixed trace stream with negotiation events across multiple candidates and outcomes.
+
+## Files touched
+
+Protocol:
+
+- `packages/protocol/src/chat/chat-streaming.types.ts` — new event types added to the union.
+- `packages/protocol/src/negotiation/negotiation.graph.ts` — emit turn + outcome.
+- `packages/protocol/src/opportunity/opportunity.graph.ts` — emit session start/end around each per-candidate negotiation.
+
+Backend:
+
+- `backend/src/controllers/chat.controller.ts` (or `backend/src/services/chat.service.ts`) — `llm` accumulator + `orchestratorNegotiations.opportunityIds`.
+- `backend/src/controllers/debug.controller.ts` — negotiation hydration in `getChatDebug`.
+
+Frontend:
+
+- `frontend/src/components/chat/ToolCallsDisplay.tsx` — parser branches + `NegotiationTree` subcomponent.
+- frontend stream-event types file mirroring the protocol union.
+
+Docs:
+
+- `docs/design/protocol-deep-dive.md` — update Trace Event Instrumentation section with the four new event types and their emission contract.
+- `CLAUDE.md` — brief note under Trace Event Instrumentation referencing negotiation events.
+
+## Open items for plan phase
+
+- Exact turn-index and `actor` semantics: confirm whether the `source` is always `turnIndex=0` in `negotiation.graph.ts` or whether the seed assessment occupies that slot.
+- Retroactive fallback time window: propose ±10 min around the turn `createdAt`; validate against representative sessions before committing.
+- Per-session payload cap: N candidates included in debug response (propose 25; surface `negotiationsTruncated: true` if exceeded).
+- Precise location of the chat stream consumer that builds `debugMeta` today (`chat.controller.ts` vs `chat.service.ts`) — confirm during plan phase, do not guess.
+
+## Acceptance
+
+- `/debug/chat/:id` returns `turn.negotiations` populated end-to-end for a fresh orchestrator-triggered session with at least one accepted and one rejected candidate.
+- `/debug/chat/:id` retroactively returns `turn.negotiations` (via fallback path) for an orchestrator session that predates the pointer write.
+- `debugMeta.llm.{calls,totalDurationMs,resets,hallucinations}` populated on turns where those events fired.
+- Live TRACE panel renders per-candidate negotiation nodes with turn children and outcome indicators during an active orchestrator run.
+- All new tests pass; no regression in existing trace/graph/agent rendering.

--- a/frontend/src/components/chat/ToolCallsDisplay.tsx
+++ b/frontend/src/components/chat/ToolCallsDisplay.tsx
@@ -441,6 +441,22 @@ interface ParsedTrace {
  * agent_start opens an AgentNode inside the current graph.
  * The corresponding *_end events close and annotate their nodes.
  */
+function findRunningNegotiationNode(
+  tools: ToolNode[],
+  event: Pick<TraceEvent, "opportunityId" | "negotiationConversationId">,
+): NegotiationNode | undefined {
+  const convId = event.negotiationConversationId ?? "";
+  const oppId = event.opportunityId ?? "";
+  return [...tools.flatMap((t) => t.negotiations)].reverse().find((n) => {
+    if (!n.isRunning) return false;
+    // Prefer matching by conversation ID once the node has one populated
+    if (convId !== "" && n.negotiationConversationId !== "") {
+      return n.negotiationConversationId === convId;
+    }
+    return oppId !== "" && n.opportunityId === oppId;
+  });
+}
+
 function parseTraceEvents(events: TraceEvent[]): ParsedTrace {
   const timeline: TimelineEntry[] = [];
   const tools: ToolNode[] = [];
@@ -600,11 +616,12 @@ function parseTraceEvents(events: TraceEvent[]): ParsedTrace {
       }
 
       case "negotiation_turn": {
-        const allNegNodes = tools.flatMap((t) => t.negotiations);
-        const negNode = [...allNegNodes].reverse().find(
-          (n) => n.opportunityId === (event.opportunityId ?? "") && n.isRunning,
-        );
+        const negNode = findRunningNegotiationNode(tools, event);
         if (!negNode) break;
+        // Back-fill conversation ID once the graph has created the conversation
+        if (negNode.negotiationConversationId === "" && event.negotiationConversationId) {
+          negNode.negotiationConversationId = event.negotiationConversationId;
+        }
         negNode.turns.push({
           turnIndex: event.turnIndex ?? negNode.turns.length,
           actor: (event.actor ?? "source") as "source" | "candidate",
@@ -618,10 +635,7 @@ function parseTraceEvents(events: TraceEvent[]): ParsedTrace {
       }
 
       case "negotiation_outcome": {
-        const allNegNodes = tools.flatMap((t) => t.negotiations);
-        const negNode = [...allNegNodes].reverse().find(
-          (n) => n.opportunityId === (event.opportunityId ?? "") && n.isRunning,
-        );
+        const negNode = findRunningNegotiationNode(tools, event);
         if (!negNode) break;
         negNode.outcome = event.outcome;
         negNode.turnCount = event.turnCount;
@@ -630,10 +644,7 @@ function parseTraceEvents(events: TraceEvent[]): ParsedTrace {
       }
 
       case "negotiation_session_end": {
-        const allNegNodes = tools.flatMap((t) => t.negotiations);
-        const negNode = [...allNegNodes].reverse().find(
-          (n) => n.opportunityId === (event.opportunityId ?? "") && n.isRunning,
-        );
+        const negNode = findRunningNegotiationNode(tools, event);
         if (!negNode) break;
         negNode.isRunning = false;
         negNode.durationMs = event.durationMs;
@@ -1106,6 +1117,7 @@ function GraphRow({ graph, wasStoppedByUser, stoppedAt }: GraphRowProps) {
 }
 
 function outcomeIcon(o: NegotiationNode["outcome"]): string {
+  if (!o) return "⚪";
   if (o === "accepted") return "🟢";
   if (o === "waiting_for_agent") return "⏳";
   return "🔴";

--- a/frontend/src/components/chat/ToolCallsDisplay.tsx
+++ b/frontend/src/components/chat/ToolCallsDisplay.tsx
@@ -1105,6 +1105,67 @@ function GraphRow({ graph, wasStoppedByUser, stoppedAt }: GraphRowProps) {
   );
 }
 
+function outcomeIcon(o: NegotiationNode["outcome"]): string {
+  if (o === "accepted") return "🟢";
+  if (o === "waiting_for_agent") return "⏳";
+  return "🔴";
+}
+
+function NegotiationTree({ negotiations }: { negotiations: NegotiationNode[] }) {
+  const [openIdxs, setOpenIdxs] = useState<Set<number>>(new Set());
+
+  if (negotiations.length === 0) return null;
+
+  return (
+    <div className="mt-2 pl-3 border-l border-gray-200">
+      <div className="text-xs text-gray-500 mb-1">Negotiations ({negotiations.length})</div>
+      {negotiations.map((n, i) => {
+        const isOpen = openIdxs.has(i);
+        const toggle = () => {
+          const next = new Set(openIdxs);
+          if (isOpen) next.delete(i); else next.add(i);
+          setOpenIdxs(next);
+        };
+        return (
+          <div key={`${n.opportunityId}-${i}`} className="mb-1">
+            <button
+              type="button"
+              onClick={toggle}
+              className="flex items-center gap-1 text-xs text-gray-700 hover:text-gray-900"
+              title={n.outcomeReasoning ?? ""}
+            >
+              <span>{isOpen ? "▾" : "▸"}</span>
+              <span>{outcomeIcon(n.outcome)}</span>
+              <span className="font-medium">{n.candidateName ?? n.candidateUserId}</span>
+              <span className="text-gray-500">
+                {" — "}{n.outcome ?? (n.isRunning ? "running" : "unknown")}
+                {" ("}{n.turns.length} turn{n.turns.length === 1 ? "" : "s"}
+                {n.durationMs != null ? `, ${n.durationMs}ms` : ""}
+                {")"}
+              </span>
+            </button>
+            {isOpen && (
+              <ol className="ml-5 mt-1 space-y-0.5 text-xs text-gray-700">
+                {n.turns.map((t) => (
+                  <li key={t.turnIndex}>
+                    <span className="text-gray-500">{t.turnIndex + 1}.</span>{" "}
+                    <span className="font-mono text-[10px] text-gray-500">[{t.actor}]</span>{" "}
+                    <span className="font-medium">{t.action}</span>
+                    {t.message && <span> — {t.message}</span>}
+                    {t.reasoning && (
+                      <div className="ml-5 text-gray-400 italic">{t.reasoning}</div>
+                    )}
+                  </li>
+                ))}
+              </ol>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 interface ToolRowProps {
   tool: ToolNode;
   toolIdx: number;
@@ -1202,6 +1263,11 @@ function ToolRow({
           stoppedAt={stoppedAt}
         />
       ))}
+
+      {/* Negotiations nested under this tool */}
+      {tool.negotiations.length > 0 && (
+        <NegotiationTree negotiations={tool.negotiations} />
+      )}
 
       {/* Expandable steps detail */}
       {hasSteps && isToolExpanded && (

--- a/frontend/src/components/chat/ToolCallsDisplay.tsx
+++ b/frontend/src/components/chat/ToolCallsDisplay.tsx
@@ -379,6 +379,31 @@ interface GraphNode {
   agents: AgentNode[];
 }
 
+export interface NegotiationTurnRow {
+  turnIndex: number;
+  actor: "source" | "candidate";
+  action: "propose" | "accept" | "reject" | "counter" | "question";
+  reasoning?: string;
+  message?: string;
+  suggestedRoles?: { ownUser?: string; otherUser?: string };
+  durationMs: number;
+}
+
+export interface NegotiationNode {
+  opportunityId: string;
+  negotiationConversationId: string;
+  candidateUserId: string;
+  candidateName?: string;
+  trigger: "orchestrator" | "ambient";
+  startTimestamp: number;
+  durationMs?: number;
+  turns: NegotiationTurnRow[];
+  outcome?: "accepted" | "rejected_stalled" | "waiting_for_agent" | "timed_out" | "turn_cap";
+  turnCount?: number;
+  outcomeReasoning?: string;
+  isRunning: boolean;
+}
+
 interface ToolNode {
   name: string;
   startTimestamp?: number;
@@ -389,6 +414,7 @@ interface ToolNode {
   status?: "success" | "error";
   summary?: string;
   graphs: GraphNode[];
+  negotiations: NegotiationNode[];
 }
 
 /** Ordered list of items to render in the non-tool sections (llm / iteration events). */
@@ -456,6 +482,7 @@ function parseTraceEvents(events: TraceEvent[]): ParsedTrace {
           isRunning: true,
           activities: [],
           graphs: [],
+          negotiations: [],
         };
         const toolIdx = tools.length;
         tools.push(node);
@@ -553,6 +580,63 @@ function parseTraceEvents(events: TraceEvent[]): ParsedTrace {
           agentNode.isRunning = false;
           agentNode.summary = event.summary;
         }
+        break;
+      }
+
+      case "negotiation_session_start": {
+        const target = currentTool ?? (tools.length > 0 ? tools[tools.length - 1] : null);
+        if (!target) break;
+        target.negotiations.push({
+          opportunityId: event.opportunityId ?? "",
+          negotiationConversationId: event.negotiationConversationId ?? "",
+          candidateUserId: event.candidateUserId ?? "",
+          candidateName: event.candidateName,
+          trigger: event.trigger ?? "ambient",
+          startTimestamp: event.timestamp,
+          turns: [],
+          isRunning: true,
+        });
+        break;
+      }
+
+      case "negotiation_turn": {
+        const allNegNodes = tools.flatMap((t) => t.negotiations);
+        const negNode = [...allNegNodes].reverse().find(
+          (n) => n.opportunityId === (event.opportunityId ?? "") && n.isRunning,
+        );
+        if (!negNode) break;
+        negNode.turns.push({
+          turnIndex: event.turnIndex ?? negNode.turns.length,
+          actor: (event.actor ?? "source") as "source" | "candidate",
+          action: (event.action ?? "propose") as NegotiationTurnRow["action"],
+          reasoning: event.reasoning,
+          message: event.message,
+          suggestedRoles: event.suggestedRoles,
+          durationMs: event.durationMs ?? 0,
+        });
+        break;
+      }
+
+      case "negotiation_outcome": {
+        const allNegNodes = tools.flatMap((t) => t.negotiations);
+        const negNode = [...allNegNodes].reverse().find(
+          (n) => n.opportunityId === (event.opportunityId ?? "") && n.isRunning,
+        );
+        if (!negNode) break;
+        negNode.outcome = event.outcome;
+        negNode.turnCount = event.turnCount;
+        negNode.outcomeReasoning = event.reasoning;
+        break;
+      }
+
+      case "negotiation_session_end": {
+        const allNegNodes = tools.flatMap((t) => t.negotiations);
+        const negNode = [...allNegNodes].reverse().find(
+          (n) => n.opportunityId === (event.opportunityId ?? "") && n.isRunning,
+        );
+        if (!negNode) break;
+        negNode.isRunning = false;
+        negNode.durationMs = event.durationMs;
         break;
       }
     }

--- a/frontend/src/contexts/AIChatContext.tsx
+++ b/frontend/src/contexts/AIChatContext.tsx
@@ -66,7 +66,11 @@ export type TraceEventType =
   | "graph_start"
   | "graph_end"
   | "agent_start"
-  | "agent_end";
+  | "agent_end"
+  | "negotiation_session_start"
+  | "negotiation_session_end"
+  | "negotiation_turn"
+  | "negotiation_outcome";
 
 export interface TraceEvent {
   type: TraceEventType;
@@ -79,6 +83,23 @@ export interface TraceEvent {
   steps?: ToolCallStep[];
   hasToolCalls?: boolean;
   toolNames?: string[];
+  // Negotiation event fields
+  opportunityId?: string;
+  negotiationConversationId?: string;
+  sourceUserId?: string;
+  candidateUserId?: string;
+  candidateName?: string;
+  trigger?: "orchestrator" | "ambient";
+  startedAt?: number;
+  turnIndex?: number;
+  actor?: "source" | "candidate";
+  action?: "propose" | "accept" | "reject" | "counter" | "question";
+  reasoning?: string;
+  message?: string;
+  suggestedRoles?: { ownUser?: string; otherUser?: string };
+  outcome?: "accepted" | "rejected_stalled" | "waiting_for_agent" | "timed_out" | "turn_cap";
+  turnCount?: number;
+  agreedRoles?: { ownUser?: string; otherUser?: string };
 }
 
 interface ChatMessage {
@@ -514,6 +535,91 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
                       prev.map((msg) => {
                         if (msg.id !== assistantMessageId) return msg;
                         const traceEvents = [...(msg.traceEvents || []), agentEndEvent];
+                        return { ...msg, traceEvents };
+                      }),
+                    );
+                    break;
+                  }
+                  case "negotiation_session_start": {
+                    const negSessionStartEvent: TraceEvent = {
+                      type: "negotiation_session_start",
+                      timestamp: Date.now(),
+                      opportunityId: event.opportunityId,
+                      negotiationConversationId: event.negotiationConversationId,
+                      sourceUserId: event.sourceUserId,
+                      candidateUserId: event.candidateUserId,
+                      candidateName: event.candidateName,
+                      trigger: event.trigger,
+                      startedAt: event.startedAt,
+                    };
+                    streamTraceEvents.push(negSessionStartEvent);
+                    setMessages((prev) =>
+                      prev.map((msg) => {
+                        if (msg.id !== assistantMessageId) return msg;
+                        const traceEvents = [...(msg.traceEvents || []), negSessionStartEvent];
+                        return { ...msg, traceEvents };
+                      }),
+                    );
+                    break;
+                  }
+                  case "negotiation_turn": {
+                    const negTurnEvent: TraceEvent = {
+                      type: "negotiation_turn",
+                      timestamp: Date.now(),
+                      opportunityId: event.opportunityId,
+                      negotiationConversationId: event.negotiationConversationId,
+                      turnIndex: event.turnIndex,
+                      actor: event.actor,
+                      action: event.action,
+                      reasoning: event.reasoning,
+                      message: event.message,
+                      suggestedRoles: event.suggestedRoles,
+                      durationMs: event.durationMs,
+                    };
+                    streamTraceEvents.push(negTurnEvent);
+                    setMessages((prev) =>
+                      prev.map((msg) => {
+                        if (msg.id !== assistantMessageId) return msg;
+                        const traceEvents = [...(msg.traceEvents || []), negTurnEvent];
+                        return { ...msg, traceEvents };
+                      }),
+                    );
+                    break;
+                  }
+                  case "negotiation_outcome": {
+                    const negOutcomeEvent: TraceEvent = {
+                      type: "negotiation_outcome",
+                      timestamp: Date.now(),
+                      opportunityId: event.opportunityId,
+                      negotiationConversationId: event.negotiationConversationId,
+                      outcome: event.outcome,
+                      turnCount: event.turnCount,
+                      reasoning: event.reasoning,
+                      agreedRoles: event.agreedRoles,
+                    };
+                    streamTraceEvents.push(negOutcomeEvent);
+                    setMessages((prev) =>
+                      prev.map((msg) => {
+                        if (msg.id !== assistantMessageId) return msg;
+                        const traceEvents = [...(msg.traceEvents || []), negOutcomeEvent];
+                        return { ...msg, traceEvents };
+                      }),
+                    );
+                    break;
+                  }
+                  case "negotiation_session_end": {
+                    const negSessionEndEvent: TraceEvent = {
+                      type: "negotiation_session_end",
+                      timestamp: Date.now(),
+                      opportunityId: event.opportunityId,
+                      negotiationConversationId: event.negotiationConversationId,
+                      durationMs: event.durationMs,
+                    };
+                    streamTraceEvents.push(negSessionEndEvent);
+                    setMessages((prev) =>
+                      prev.map((msg) => {
+                        if (msg.id !== assistantMessageId) return msg;
+                        const traceEvents = [...(msg.traceEvents || []), negSessionEndEvent];
                         return { ...msg, traceEvents };
                       }),
                     );

--- a/packages/protocol/src/chat/chat-streaming.types.ts
+++ b/packages/protocol/src/chat/chat-streaming.types.ts
@@ -34,7 +34,12 @@ export type ChatStreamEventType =
   | "graph_end"
   | "agent_start"
   | "agent_end"
-  | "hallucination_detected";
+  | "hallucination_detected"
+  // Orchestrator-inline negotiation trace events
+  | "negotiation_session_start"
+  | "negotiation_session_end"
+  | "negotiation_turn"
+  | "negotiation_outcome";
 
 /**
  * Base interface for all chat stream events.
@@ -402,6 +407,53 @@ export interface AgentEndEvent extends ChatStreamEventBase {
   summary: string;
 }
 
+/** Orchestrator per-candidate negotiation wrapper — emitted from `negotiateCandidates`. */
+export interface NegotiationSessionStartEvent extends ChatStreamEventBase {
+  type: "negotiation_session_start";
+  opportunityId: string;
+  negotiationConversationId: string;
+  sourceUserId: string;
+  candidateUserId: string;
+  candidateName?: string;
+  trigger: "orchestrator" | "ambient";
+  startedAt: number;
+}
+
+export interface NegotiationSessionEndEvent extends ChatStreamEventBase {
+  type: "negotiation_session_end";
+  opportunityId: string;
+  negotiationConversationId: string;
+  durationMs: number;
+}
+
+/** One turn inside a bilateral negotiation. Emitted by the negotiation graph's turn node. */
+export interface NegotiationTurnEvent extends ChatStreamEventBase {
+  type: "negotiation_turn";
+  opportunityId: string;
+  negotiationConversationId: string;
+  turnIndex: number;
+  actor: "source" | "candidate";
+  action: "propose" | "accept" | "reject" | "counter" | "question";
+  reasoning?: string;
+  message?: string;
+  suggestedRoles?: { ownUser?: string; otherUser?: string };
+  durationMs: number;
+}
+
+export interface NegotiationOutcomeEvent extends ChatStreamEventBase {
+  type: "negotiation_outcome";
+  opportunityId: string;
+  outcome:
+    | "accepted"
+    | "rejected_stalled"
+    | "waiting_for_agent"
+    | "timed_out"
+    | "turn_cap";
+  turnCount: number;
+  reasoning?: string;
+  agreedRoles?: { ownUser?: string; otherUser?: string };
+}
+
 /**
  * Union type of all chat stream events.
  */
@@ -434,7 +486,11 @@ export type ChatStreamEvent =
   | GraphStartEvent
   | GraphEndEvent
   | AgentStartEvent
-  | AgentEndEvent;
+  | AgentEndEvent
+  | NegotiationSessionStartEvent
+  | NegotiationSessionEndEvent
+  | NegotiationTurnEvent
+  | NegotiationOutcomeEvent;
 
 /**
  * Formats a chat stream event as an SSE message. If JSON.stringify throws (e.g. circular ref,
@@ -819,4 +875,44 @@ export function createAgentEndEvent(
   summary: string,
 ): AgentEndEvent {
   return createStreamEvent<AgentEndEvent>("agent_end", sessionId, { agentName, durationMs, summary });
+}
+
+export function createNegotiationSessionStartEvent(
+  sessionId: string,
+  payload: Omit<NegotiationSessionStartEvent, "type" | "sessionId" | "timestamp">,
+): NegotiationSessionStartEvent {
+  return createStreamEvent<NegotiationSessionStartEvent>(
+    "negotiation_session_start",
+    sessionId,
+    payload,
+  );
+}
+
+export function createNegotiationSessionEndEvent(
+  sessionId: string,
+  payload: Omit<NegotiationSessionEndEvent, "type" | "sessionId" | "timestamp">,
+): NegotiationSessionEndEvent {
+  return createStreamEvent<NegotiationSessionEndEvent>(
+    "negotiation_session_end",
+    sessionId,
+    payload,
+  );
+}
+
+export function createNegotiationTurnEvent(
+  sessionId: string,
+  payload: Omit<NegotiationTurnEvent, "type" | "sessionId" | "timestamp">,
+): NegotiationTurnEvent {
+  return createStreamEvent<NegotiationTurnEvent>("negotiation_turn", sessionId, payload);
+}
+
+export function createNegotiationOutcomeEvent(
+  sessionId: string,
+  payload: Omit<NegotiationOutcomeEvent, "type" | "sessionId" | "timestamp">,
+): NegotiationOutcomeEvent {
+  return createStreamEvent<NegotiationOutcomeEvent>(
+    "negotiation_outcome",
+    sessionId,
+    payload,
+  );
 }

--- a/packages/protocol/src/chat/chat-streaming.types.ts
+++ b/packages/protocol/src/chat/chat-streaming.types.ts
@@ -370,6 +370,28 @@ export interface DebugMetaToolCall {
 }
 
 /**
+ * LLM call statistics accumulated during a single agent turn.
+ */
+export interface DebugMetaLlm {
+  /** Total number of LLM calls made in this turn. */
+  calls: number;
+  /** Cumulative wall-clock time spent waiting for the LLM across all calls. */
+  totalDurationMs: number;
+  /** Entries recorded each time a response_reset event was emitted. */
+  resets: Array<{ reason: string; at: number }>;
+  /** Entries recorded each time a hallucination_detected event was emitted. */
+  hallucinations: Array<{ blockType: string; tool: string; at: number }>;
+}
+
+/**
+ * Negotiation sessions initiated by the orchestrator during this turn.
+ */
+export interface DebugMetaOrchestratorNegotiations {
+  /** Opportunity IDs for which a negotiation_session_start was emitted. */
+  opportunityIds: string[];
+}
+
+/**
  * Debug meta event - per-turn graph and tool usage for copy debug.
  */
 export interface DebugMetaEvent extends ChatStreamEventBase {
@@ -377,6 +399,8 @@ export interface DebugMetaEvent extends ChatStreamEventBase {
   graph: string;
   iterations: number;
   tools: DebugMetaToolCall[];
+  llm: DebugMetaLlm;
+  orchestratorNegotiations?: DebugMetaOrchestratorNegotiations;
 }
 
 /** Graph start event — emitted when a LangGraph sub-graph begins inside a tool. */
@@ -832,11 +856,15 @@ export function createDebugMetaEvent(
   graph: string,
   iterations: number,
   tools: DebugMetaToolCall[],
+  llm: DebugMetaLlm,
+  orchestratorNegotiations?: DebugMetaOrchestratorNegotiations,
 ): DebugMetaEvent {
   return createStreamEvent<DebugMetaEvent>("debug_meta", sessionId, {
     graph,
     iterations,
     tools,
+    llm,
+    ...(orchestratorNegotiations !== undefined && { orchestratorNegotiations }),
   });
 }
 

--- a/packages/protocol/src/chat/chat.agent.ts
+++ b/packages/protocol/src/chat/chat.agent.ts
@@ -764,15 +764,16 @@ export class ChatAgent {
         llm.calls += 1;
         lastLlmStart = Date.now();
       } else if (event.type === "llm_end") {
-        llm.totalDurationMs += Date.now() - lastLlmStart;
+        if (lastLlmStart > 0) {
+          llm.totalDurationMs += Date.now() - lastLlmStart;
+          lastLlmStart = 0;
+        }
       } else if (event.type === "response_reset") {
-        llm.resets.push({ reason: (event as unknown as { reason: string }).reason, at: Date.now() });
+        llm.resets.push({ reason: event.reason, at: Date.now() });
       } else if (event.type === "hallucination_detected") {
-        const e = event as unknown as { blockType: string; tool: string };
-        llm.hallucinations.push({ blockType: e.blockType, tool: e.tool, at: Date.now() });
+        llm.hallucinations.push({ blockType: event.blockType, tool: event.tool, at: Date.now() });
       } else if (event.type === "negotiation_session_start") {
-        const e = event as unknown as { opportunityId?: string };
-        if (e.opportunityId) orchestratorNegotiationIds.add(e.opportunityId);
+        orchestratorNegotiationIds.add(event.opportunityId);
       }
       try {
         writer?.(event);

--- a/packages/protocol/src/chat/chat.agent.ts
+++ b/packages/protocol/src/chat/chat.agent.ts
@@ -88,6 +88,47 @@ export type AgentStreamEvent =
         userId: string;
         name?: string;
       };
+    }
+  | {
+      type: "negotiation_session_start";
+      opportunityId: string;
+      negotiationConversationId: string;
+      sourceUserId: string;
+      candidateUserId: string;
+      candidateName?: string;
+      trigger: "orchestrator" | "ambient";
+      startedAt: number;
+    }
+  | {
+      type: "negotiation_session_end";
+      opportunityId: string;
+      negotiationConversationId: string;
+      durationMs: number;
+    }
+  | {
+      type: "negotiation_turn";
+      opportunityId: string;
+      negotiationConversationId: string;
+      turnIndex: number;
+      actor: "source" | "candidate";
+      action: "propose" | "accept" | "reject" | "counter" | "question";
+      reasoning?: string;
+      message?: string;
+      suggestedRoles?: { ownUser?: string; otherUser?: string };
+      durationMs: number;
+    }
+  | {
+      type: "negotiation_outcome";
+      opportunityId: string;
+      outcome:
+        | "accepted"
+        | "rejected_stalled"
+        | "waiting_for_agent"
+        | "timed_out"
+        | "turn_cap";
+      turnCount: number;
+      reasoning?: string;
+      agreedRoles?: { ownUser?: string; otherUser?: string };
     };
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/packages/protocol/src/chat/chat.agent.ts
+++ b/packages/protocol/src/chat/chat.agent.ts
@@ -20,7 +20,7 @@ import {
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { createModel } from "../shared/agent/model.config.js";
 import { sanitizeForDebugMeta } from "../shared/observability/debug-meta.sanitizer.js";
-import type { DebugMetaToolCall } from "./chat-streaming.types.js";
+import type { DebugMetaToolCall, DebugMetaLlm, DebugMetaOrchestratorNegotiations } from "./chat-streaming.types.js";
 import type { Opportunity } from "../shared/interfaces/database.interface.js";
 import { Timed } from "../shared/observability/performance.js";
 import { requestContext } from "../shared/observability/request-context.js";
@@ -753,9 +753,27 @@ export class ChatAgent {
     responseText: string;
     messages: BaseMessage[];
     iterationCount: number;
-    debugMeta: { graph: string; iterations: number; tools: DebugMetaToolCall[] };
+    debugMeta: { graph: string; iterations: number; tools: DebugMetaToolCall[]; llm: DebugMetaLlm; orchestratorNegotiations?: DebugMetaOrchestratorNegotiations };
   }> {
+    const llm: DebugMetaLlm = { calls: 0, totalDurationMs: 0, resets: [], hallucinations: [] };
+    const orchestratorNegotiationIds = new Set<string>();
+    let lastLlmStart = 0;
+
     const emit = (event: AgentStreamEvent) => {
+      if (event.type === "llm_start") {
+        llm.calls += 1;
+        lastLlmStart = Date.now();
+      } else if (event.type === "llm_end") {
+        llm.totalDurationMs += Date.now() - lastLlmStart;
+      } else if (event.type === "response_reset") {
+        llm.resets.push({ reason: (event as unknown as { reason: string }).reason, at: Date.now() });
+      } else if (event.type === "hallucination_detected") {
+        const e = event as unknown as { blockType: string; tool: string };
+        llm.hallucinations.push({ blockType: e.blockType, tool: e.tool, at: Date.now() });
+      } else if (event.type === "negotiation_session_start") {
+        const e = event as unknown as { opportunityId?: string };
+        if (e.opportunityId) orchestratorNegotiationIds.add(e.opportunityId);
+      }
       try {
         writer?.(event);
       } catch {
@@ -1168,7 +1186,15 @@ export class ChatAgent {
         responseText: sanitizedText,
         messages,
         iterationCount,
-        debugMeta: { graph: "agent_loop", iterations: iterationCount, tools: toolsDebug },
+        debugMeta: {
+          graph: "agent_loop",
+          iterations: iterationCount,
+          tools: toolsDebug,
+          llm,
+          ...(orchestratorNegotiationIds.size > 0 && {
+            orchestratorNegotiations: { opportunityIds: [...orchestratorNegotiationIds] },
+          }),
+        },
       };
     }
 
@@ -1178,7 +1204,15 @@ export class ChatAgent {
         responseText: "",
         messages,
         iterationCount,
-        debugMeta: { graph: "agent_loop", iterations: iterationCount, tools: toolsDebug },
+        debugMeta: {
+          graph: "agent_loop",
+          iterations: iterationCount,
+          tools: toolsDebug,
+          llm,
+          ...(orchestratorNegotiationIds.size > 0 && {
+            orchestratorNegotiations: { opportunityIds: [...orchestratorNegotiationIds] },
+          }),
+        },
       };
     }
 
@@ -1213,7 +1247,15 @@ export class ChatAgent {
         ...(forcedAccumulated ? [forcedAccumulated] : []),
       ],
       iterationCount,
-      debugMeta: { graph: "agent_loop", iterations: iterationCount, tools: toolsDebug },
+      debugMeta: {
+        graph: "agent_loop",
+        iterations: iterationCount,
+        tools: toolsDebug,
+        llm,
+        ...(orchestratorNegotiationIds.size > 0 && {
+          orchestratorNegotiations: { opportunityIds: [...orchestratorNegotiationIds] },
+        }),
+      },
     };
   }
 }

--- a/packages/protocol/src/chat/chat.state.ts
+++ b/packages/protocol/src/chat/chat.state.ts
@@ -1,7 +1,7 @@
 import { Annotation, messagesStateReducer } from "@langchain/langgraph";
 import type { BaseMessage } from "@langchain/core/messages";
 
-import type { DebugMetaToolCall } from "./chat-streaming.types.js";
+import type { DebugMetaToolCall, DebugMetaLlm, DebugMetaOrchestratorNegotiations } from "./chat-streaming.types.js";
 
 // ══════════════════════════════════════════════════════════════════════════════
 // TYPES (used by legacy subgraph nodes; agent-loop graph does not set these)
@@ -147,7 +147,7 @@ export const ChatGraphState = Annotation.Root({
    * Per-turn debug meta (graph, iterations, tool calls) for copy-debug.
    * Not persisted; only used so the streamer receives it in the updates chunk.
    */
-  debugMeta: Annotation<{ graph: string; iterations: number; tools: DebugMetaToolCall[] } | undefined>({
+  debugMeta: Annotation<{ graph: string; iterations: number; tools: DebugMetaToolCall[]; llm: DebugMetaLlm; orchestratorNegotiations?: DebugMetaOrchestratorNegotiations } | undefined>({
     reducer: (curr, next) => next,
     default: () => undefined,
   }),

--- a/packages/protocol/src/chat/chat.streamer.ts
+++ b/packages/protocol/src/chat/chat.streamer.ts
@@ -4,6 +4,8 @@ import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import type {
   ChatStreamEvent,
   DebugMetaToolCall,
+  DebugMetaLlm,
+  DebugMetaOrchestratorNegotiations,
 } from "./chat-streaming.types.js";
 import {
   createAgentEndEvent,
@@ -280,17 +282,20 @@ export class ChatStreamer {
           yield createResponseCompleteEvent(sessionId, responseText);
 
           const debugMeta = agentOutput?.debugMeta as
-            | { graph: string; iterations: number; tools?: DebugMetaToolCall[] }
+            | { graph: string; iterations: number; tools?: DebugMetaToolCall[]; llm?: DebugMetaLlm; orchestratorNegotiations?: DebugMetaOrchestratorNegotiations }
             | undefined;
           if (
             debugMeta?.graph != null &&
             typeof debugMeta.iterations === "number"
           ) {
+            const llmFallback: DebugMetaLlm = { calls: 0, totalDurationMs: 0, resets: [], hallucinations: [] };
             yield createDebugMetaEvent(
               sessionId,
               debugMeta.graph,
               debugMeta.iterations,
               Array.isArray(debugMeta.tools) ? debugMeta.tools : [],
+              debugMeta.llm ?? llmFallback,
+              debugMeta.orchestratorNegotiations,
             );
           }
 

--- a/packages/protocol/src/chat/tests/chat.agent.spec.ts
+++ b/packages/protocol/src/chat/tests/chat.agent.spec.ts
@@ -92,6 +92,7 @@ import { ChatAgent, type AgentStreamEvent } from "../chat.agent.js";
 
 function makeTextStream(text: string): AsyncIterable<AIMessageChunk> {
   return (async function* () {
+    await new Promise<void>((resolve) => setTimeout(resolve, 1)); // ensure measurable elapsed time for llm timing
     yield new AIMessageChunk({ content: text });
   })();
 }
@@ -436,8 +437,8 @@ describe("ChatAgent streamRun — debugMeta.llm accumulator", () => {
       writer,
     );
 
-    expect(result.debugMeta.llm.calls).toBeGreaterThanOrEqual(1);
-    expect(result.debugMeta.llm.totalDurationMs).toBeGreaterThanOrEqual(0);
+    expect(result.debugMeta.llm.calls).toBe(1);
+    expect(result.debugMeta.llm.totalDurationMs).toBeGreaterThan(0);
     expect(Array.isArray(result.debugMeta.llm.resets)).toBe(true);
     expect(Array.isArray(result.debugMeta.llm.hallucinations)).toBe(true);
   }, 15000);

--- a/packages/protocol/src/chat/tests/chat.agent.spec.ts
+++ b/packages/protocol/src/chat/tests/chat.agent.spec.ts
@@ -31,7 +31,7 @@ const makeMockModel = () => {
   return inst;
 };
 
-mock.module("../model.config", () => ({
+mock.module("../../shared/agent/model.config", () => ({
   createModel: (agent: string) => {
     const inst = makeMockModel();
     if (agent === "chat") {
@@ -78,7 +78,7 @@ function createMockTools() {
   return capturedTools;
 }
 
-mock.module("../../tools", () => ({
+mock.module("../../shared/agent/tool.factory", () => ({
   createChatTools: async () => createMockTools(),
 }));
 
@@ -393,6 +393,53 @@ I've created an intent for you!`;
         (e as { reason: string }).reason.includes("Hallucinated"),
     );
     expect(hallucinationResets.length).toBe(0);
+  }, 15000);
+});
+
+describe("ChatAgent streamRun — debugMeta.llm accumulator", () => {
+  it("increments llm.calls on each llm_start", async () => {
+    // Create agent first — this sets mockModelInstance via the mock.module factory
+    const agent = await ChatAgent.create({
+      database: {
+        getUser: async () => ({ id: "test-user", name: "Test User", email: "test@example.com", location: null, socials: {} }),
+        getProfile: async () => null,
+        getNetworkMemberships: async () => [],
+      } as any,
+      embedder: {} as any,
+      scraper: {} as any,
+      userId: "test-user",
+      sessionId: "test-session",
+      cache: {} as any,
+      hydeCache: {} as any,
+      integration: {} as any,
+      intentQueue: {} as any,
+      contactService: {} as any,
+      chatSession: {} as any,
+      enricher: {} as any,
+      negotiationDatabase: {} as any,
+      integrationImporter: {} as any,
+      createUserDatabase: () => ({}) as any,
+      createSystemDatabase: () => ({}) as any,
+    });
+
+    // mockModelInstance is now set — override stream to return a plain response
+    if (!mockModelInstance) {
+      throw new Error("mockModelInstance not set after ChatAgent.create()");
+    }
+    mockModelInstance.stream = mock(() =>
+      makeTextStream("Here is a plain response with no tool calls."),
+    );
+
+    const { writer } = createEventCollector();
+    const result = await agent.streamRun(
+      [new HumanMessage("Hello, what can you do?")],
+      writer,
+    );
+
+    expect(result.debugMeta.llm.calls).toBeGreaterThanOrEqual(1);
+    expect(result.debugMeta.llm.totalDurationMs).toBeGreaterThanOrEqual(0);
+    expect(Array.isArray(result.debugMeta.llm.resets)).toBe(true);
+    expect(Array.isArray(result.debugMeta.llm.hallucinations)).toBe(true);
   }, 15000);
 });
 

--- a/packages/protocol/src/negotiation/negotiation.graph.ts
+++ b/packages/protocol/src/negotiation/negotiation.graph.ts
@@ -79,6 +79,11 @@ export class NegotiationGraphFactory {
 
     const turnNode = async (state: typeof NegotiationGraphState.State) => {
       const traceEmitter = requestContext.getStore()?.traceEmitter;
+      // Local helper to emit events whose shape is wider than the declared
+      // `TraceEmitter` union. The chat agent already casts at its relay sink;
+      // here we localize the cast at the callsite so the rest of the body stays typed.
+      const emitWide = (event: Record<string, unknown>) =>
+        (traceEmitter as ((e: Record<string, unknown>) => void) | undefined)?.(event);
       const agentName = "Index negotiator";
       const agentStart = Date.now();
       traceEmitter?.({ type: "agent_start", name: agentName });
@@ -171,18 +176,20 @@ export class NegotiationGraphFactory {
 
         await database.updateTaskState(state.taskId, "working");
 
-        (traceEmitter as ((e: Record<string, unknown>) => void) | undefined)?.({
-          type: "negotiation_turn",
-          opportunityId: state.opportunityId ?? "",
-          negotiationConversationId: state.conversationId,
-          turnIndex: state.turnCount,
-          actor: isSource ? "source" : "candidate",
-          action: turn.action,
-          ...(turn.assessment?.reasoning && { reasoning: turn.assessment.reasoning }),
-          ...(turn.message && { message: turn.message }),
-          ...(turn.assessment?.suggestedRoles && { suggestedRoles: turn.assessment.suggestedRoles }),
-          durationMs: Date.now() - agentStart,
-        });
+        if (state.opportunityId) {
+          emitWide({
+            type: "negotiation_turn",
+            opportunityId: state.opportunityId,
+            negotiationConversationId: state.conversationId,
+            turnIndex: state.turnCount,
+            actor: isSource ? "source" : "candidate",
+            action: turn.action,
+            ...(turn.assessment?.reasoning && { reasoning: turn.assessment.reasoning }),
+            ...(turn.message && { message: turn.message }),
+            ...(turn.assessment?.suggestedRoles && { suggestedRoles: turn.assessment.suggestedRoles }),
+            durationMs: Date.now() - agentStart,
+          });
+        }
 
         return {
           messages: [{

--- a/packages/protocol/src/negotiation/negotiation.graph.ts
+++ b/packages/protocol/src/negotiation/negotiation.graph.ts
@@ -398,13 +398,39 @@ export async function negotiateCandidates(
     indexContextOverrides?: Map<string, string>;
     timeoutMs?: number;
     onCandidateResolved?: OnNegotiationResolved;
+    trigger?: "orchestrator" | "ambient";
   },
 ): Promise<NegotiationResult[]> {
-  const { maxTurns, traceEmitter, indexContextOverrides, timeoutMs, onCandidateResolved } = opts ?? {};
+  const { maxTurns, traceEmitter, indexContextOverrides, timeoutMs, onCandidateResolved, trigger } = opts ?? {};
+
+  // Local helper to emit events whose shape is wider than the declared
+  // `TraceEmitter` union (mirrors the cast used in chat.agent at the relay sink
+  // and inside turn/finalize nodes above).
+  const emitWide = (event: Record<string, unknown>) =>
+    (traceEmitter as ((e: Record<string, unknown>) => void) | undefined)?.(event);
 
   const results = await Promise.all(
     candidates.map(async (candidate) => {
       const start = Date.now();
+      const sessionStart = start;
+      if (candidate.opportunityId) {
+        // The candidateUser type canonically carries a `.profile.name`, but some
+        // call-sites pass a flatter shape with a top-level `.name`. Probe both
+        // so the debug panel gets a human-readable label when either is set.
+        const candidateName =
+          candidate.candidateUser?.profile?.name
+          ?? (candidate.candidateUser as unknown as { name?: string } | undefined)?.name;
+        emitWide({
+          type: "negotiation_session_start",
+          opportunityId: candidate.opportunityId,
+          negotiationConversationId: "", // filled in on session_end
+          sourceUserId: sourceUser.id,
+          candidateUserId: candidate.userId,
+          ...(candidateName && { candidateName }),
+          trigger: trigger ?? "ambient",
+          startedAt: sessionStart,
+        });
+      }
       traceEmitter?.({ type: "agent_start", name: "Negotiating candidate" });
 
       try {
@@ -443,6 +469,15 @@ export async function negotiateCandidates(
         const statusTag = hasOpportunity ? "✓ opportunity" : "✗ rejected";
         traceEmitter?.({ type: "agent_end", name: "Negotiating candidate", durationMs, summary: `${candidate.userId}: ${turnFlow} ${statusTag}` });
 
+        if (candidate.opportunityId) {
+          emitWide({
+            type: "negotiation_session_end",
+            opportunityId: candidate.opportunityId,
+            negotiationConversationId: (result as { conversationId?: string }).conversationId ?? "",
+            durationMs: Date.now() - sessionStart,
+          });
+        }
+
         const accepted: NegotiationResult | null = hasOpportunity && outcome
           ? {
               userId: candidate.userId,
@@ -470,6 +505,14 @@ export async function negotiateCandidates(
       } catch (err) {
         const durationMs = Date.now() - start;
         traceEmitter?.({ type: "agent_end", name: "Negotiating candidate", durationMs, summary: `${candidate.userId}: error` });
+        if (candidate.opportunityId) {
+          emitWide({
+            type: "negotiation_session_end",
+            opportunityId: candidate.opportunityId,
+            negotiationConversationId: "",
+            durationMs: Date.now() - sessionStart,
+          });
+        }
         logger.error("[negotiateCandidates] Negotiation failed", { candidateUserId: candidate.userId, error: err });
         if (onCandidateResolved) {
           try {

--- a/packages/protocol/src/negotiation/negotiation.graph.ts
+++ b/packages/protocol/src/negotiation/negotiation.graph.ts
@@ -306,10 +306,10 @@ export class NegotiationGraphFactory {
             ? "accepted"
             : atCap
             ? "turn_cap"
-            : lastTurn?.action === "reject"
-            ? "rejected_stalled"
             : state.error && /timeout/i.test(state.error)
             ? "timed_out"
+            : lastTurn?.action === "reject"
+            ? "rejected_stalled"
             : "rejected_stalled";
 
         emitWide({

--- a/packages/protocol/src/negotiation/negotiation.graph.ts
+++ b/packages/protocol/src/negotiation/negotiation.graph.ts
@@ -171,6 +171,19 @@ export class NegotiationGraphFactory {
 
         await database.updateTaskState(state.taskId, "working");
 
+        (traceEmitter as ((e: Record<string, unknown>) => void) | undefined)?.({
+          type: "negotiation_turn",
+          opportunityId: state.opportunityId ?? "",
+          negotiationConversationId: state.conversationId,
+          turnIndex: state.turnCount,
+          actor: isSource ? "source" : "candidate",
+          action: turn.action,
+          ...(turn.assessment?.reasoning && { reasoning: turn.assessment.reasoning }),
+          ...(turn.message && { message: turn.message }),
+          ...(turn.assessment?.suggestedRoles && { suggestedRoles: turn.assessment.suggestedRoles }),
+          durationMs: Date.now() - agentStart,
+        });
+
         return {
           messages: [{
             id: message.id,

--- a/packages/protocol/src/negotiation/negotiation.graph.ts
+++ b/packages/protocol/src/negotiation/negotiation.graph.ts
@@ -412,14 +412,8 @@ export async function negotiateCandidates(
   const results = await Promise.all(
     candidates.map(async (candidate) => {
       const start = Date.now();
-      const sessionStart = start;
       if (candidate.opportunityId) {
-        // The candidateUser type canonically carries a `.profile.name`, but some
-        // call-sites pass a flatter shape with a top-level `.name`. Probe both
-        // so the debug panel gets a human-readable label when either is set.
-        const candidateName =
-          candidate.candidateUser?.profile?.name
-          ?? (candidate.candidateUser as unknown as { name?: string } | undefined)?.name;
+        const candidateName = candidate.candidateUser?.profile?.name;
         emitWide({
           type: "negotiation_session_start",
           opportunityId: candidate.opportunityId,
@@ -428,7 +422,7 @@ export async function negotiateCandidates(
           candidateUserId: candidate.userId,
           ...(candidateName && { candidateName }),
           trigger: trigger ?? "ambient",
-          startedAt: sessionStart,
+          startedAt: start,
         });
       }
       traceEmitter?.({ type: "agent_start", name: "Negotiating candidate" });
@@ -474,7 +468,7 @@ export async function negotiateCandidates(
             type: "negotiation_session_end",
             opportunityId: candidate.opportunityId,
             negotiationConversationId: (result as { conversationId?: string }).conversationId ?? "",
-            durationMs: Date.now() - sessionStart,
+            durationMs: Date.now() - start,
           });
         }
 
@@ -510,7 +504,7 @@ export async function negotiateCandidates(
             type: "negotiation_session_end",
             opportunityId: candidate.opportunityId,
             negotiationConversationId: "",
-            durationMs: Date.now() - sessionStart,
+            durationMs: Date.now() - start,
           });
         }
         logger.error("[negotiateCandidates] Negotiation failed", { candidateUserId: candidate.userId, error: err });

--- a/packages/protocol/src/negotiation/negotiation.graph.ts
+++ b/packages/protocol/src/negotiation/negotiation.graph.ts
@@ -230,7 +230,19 @@ export class NegotiationGraphFactory {
     };
 
     const finalizeNode = async (state: typeof NegotiationGraphState.State) => {
+      const traceEmitter = requestContext.getStore()?.traceEmitter;
+      const emitWide = (event: Record<string, unknown>) =>
+        (traceEmitter as ((e: Record<string, unknown>) => void) | undefined)?.(event);
+
       if (state.status === 'waiting_for_agent') {
+        if (state.opportunityId) {
+          emitWide({
+            type: "negotiation_outcome",
+            opportunityId: state.opportunityId,
+            outcome: "waiting_for_agent",
+            turnCount: state.turnCount,
+          });
+        }
         return {};
       }
 
@@ -286,6 +298,33 @@ export class NegotiationGraphFactory {
         }
       } catch (err) {
         logger.error("[Graph:Finalize] Failed to persist outcome", { error: err });
+      }
+
+      if (state.opportunityId) {
+        const emittedOutcome: "accepted" | "rejected_stalled" | "turn_cap" | "timed_out" =
+          hasOpportunity
+            ? "accepted"
+            : atCap
+            ? "turn_cap"
+            : lastTurn?.action === "reject"
+            ? "rejected_stalled"
+            : state.error && /timeout/i.test(state.error)
+            ? "timed_out"
+            : "rejected_stalled";
+
+        emitWide({
+          type: "negotiation_outcome",
+          opportunityId: state.opportunityId,
+          outcome: emittedOutcome,
+          turnCount: state.turnCount,
+          ...(outcome.reasoning && { reasoning: outcome.reasoning }),
+          ...(hasOpportunity && agreedRoles.length >= 2 && {
+            agreedRoles: {
+              ownUser: agreedRoles[0]?.role,
+              otherUser: agreedRoles[1]?.role,
+            },
+          }),
+        });
       }
 
       return { outcome, status: 'completed' as const };

--- a/packages/protocol/src/negotiation/tests/negotiation.graph.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.graph.spec.ts
@@ -180,3 +180,80 @@ describe("negotiation graph — negotiation_outcome emission", () => {
     expect(outcome?.outcome).toBe("waiting_for_agent");
   }, 30000);
 });
+
+describe("negotiateCandidates — session wrapper events", () => {
+  it("emits negotiation_session_start and _end per candidate with trigger + ids", async () => {
+    const fakeGraph = {
+      invoke: async (input: { opportunityId?: string }) => ({
+        conversationId: `conv-for-${input.opportunityId}`,
+        messages: [],
+        outcome: { hasOpportunity: false, agreedRoles: [], reasoning: "", turnCount: 0 },
+      }),
+    };
+    const events: Array<Record<string, unknown>> = [];
+    const { negotiateCandidates } = await import("../negotiation.graph.js");
+    const { requestContext } = await import("../../shared/observability/request-context.js");
+    await requestContext.run(
+      { traceEmitter: (e: Record<string, unknown>) => events.push(e) },
+      async () => {
+        await negotiateCandidates(
+          fakeGraph as never,
+          { id: "u-src", name: "Alice" } as never,
+          [
+            {
+              userId: "u-1",
+              reasoning: "r",
+              valencyRole: "peer",
+              candidateUser: { id: "u-1", name: "Bob" } as never,
+              opportunityId: "opp-10",
+            },
+          ],
+          { networkId: "net-1", prompt: "" },
+          {
+            traceEmitter: (e: Record<string, unknown>) => events.push(e),
+            trigger: "orchestrator",
+          },
+        );
+      },
+    );
+
+    const starts = events.filter((e) => e.type === "negotiation_session_start");
+    const ends = events.filter((e) => e.type === "negotiation_session_end");
+    expect(starts).toHaveLength(1);
+    expect(ends).toHaveLength(1);
+    expect(starts[0].opportunityId).toBe("opp-10");
+    expect(starts[0].trigger).toBe("orchestrator");
+    expect(starts[0].sourceUserId).toBe("u-src");
+    expect(starts[0].candidateUserId).toBe("u-1");
+    expect(starts[0].candidateName).toBe("Bob");
+    expect(ends[0].opportunityId).toBe("opp-10");
+    expect(typeof ends[0].durationMs).toBe("number");
+  }, 30000);
+
+  it("does not emit session events when opportunityId is missing", async () => {
+    const fakeGraph = {
+      invoke: async () => ({
+        conversationId: "conv-x",
+        messages: [],
+        outcome: { hasOpportunity: false, agreedRoles: [], reasoning: "", turnCount: 0 },
+      }),
+    };
+    const events: Array<Record<string, unknown>> = [];
+    const { negotiateCandidates } = await import("../negotiation.graph.js");
+    const { requestContext } = await import("../../shared/observability/request-context.js");
+    await requestContext.run(
+      { traceEmitter: (e: Record<string, unknown>) => events.push(e) },
+      async () => {
+        await negotiateCandidates(
+          fakeGraph as never,
+          { id: "u-src" } as never,
+          [{ userId: "u-2", reasoning: "r", valencyRole: "peer", candidateUser: { id: "u-2" } as never }],
+          { networkId: "net-1", prompt: "" },
+          { traceEmitter: (e: Record<string, unknown>) => events.push(e), trigger: "ambient" },
+        );
+      },
+    );
+    expect(events.filter((e) => e.type === "negotiation_session_start")).toHaveLength(0);
+    expect(events.filter((e) => e.type === "negotiation_session_end")).toHaveLength(0);
+  }, 30000);
+});

--- a/packages/protocol/src/negotiation/tests/negotiation.graph.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.graph.spec.ts
@@ -79,3 +79,94 @@ describe("negotiation graph — negotiation_turn emission", () => {
     }
   }, 30000);
 });
+
+describe("negotiation graph — negotiation_outcome emission", () => {
+  it("emits outcome='accepted' when finalize runs after an accept turn", async () => {
+    // Scripted: first turn propose, second turn accept
+    const scripted = [
+      { action: "propose", assessment: { reasoning: "r1", suggestedRoles: { ownUser: "agent", otherUser: "patient" } }, message: "hi" },
+      { action: "accept",  assessment: { reasoning: "r2", suggestedRoles: { ownUser: "agent", otherUser: "patient" } } },
+    ];
+    let call = 0;
+    const { database, dispatcher } = mkStubs();
+    const { IndexNegotiator } = await import("../negotiation.agent.js");
+    const orig = IndexNegotiator.prototype.invoke;
+    IndexNegotiator.prototype.invoke = async function () { return scripted[Math.min(call++, scripted.length - 1)] as never; };
+
+    try {
+      const graph = new NegotiationGraphFactory(database, dispatcher).createGraph();
+      const events: Array<Record<string, unknown>> = [];
+      const { requestContext } = await import("../../shared/observability/request-context.js");
+      await requestContext.run({ traceEmitter: (e: Record<string, unknown>) => events.push(e) }, async () => {
+        await graph.invoke({
+          sourceUser: { id: "u-src" },
+          candidateUser: { id: "u-cand" },
+          indexContext: { networkId: "net-1", prompt: "" },
+          seedAssessment: { reasoning: "x", valencyRole: "peer" },
+          opportunityId: "opp-accept",
+          maxTurns: 4,
+        } as Partial<typeof NegotiationGraphState.State>);
+      });
+
+      const outcome = events.find((e) => e.type === "negotiation_outcome");
+      expect(outcome).toBeTruthy();
+      expect(outcome!.opportunityId).toBe("opp-accept");
+      expect(outcome!.outcome).toBe("accepted");
+      expect(outcome!.turnCount).toBe(2);
+    } finally {
+      IndexNegotiator.prototype.invoke = orig;
+    }
+  }, 30000);
+
+  it("emits outcome='turn_cap' when maxTurns is reached without accept/reject", async () => {
+    const { database, dispatcher } = mkStubs();
+    const { IndexNegotiator } = await import("../negotiation.agent.js");
+    const orig = IndexNegotiator.prototype.invoke;
+    // First turn must be "propose" (graph forces it), subsequent turns counter — so we hit turn_cap at maxTurns.
+    let call = 0;
+    IndexNegotiator.prototype.invoke = async function () {
+      call++;
+      if (call === 1) return { action: "propose", assessment: { reasoning: "r", suggestedRoles: { ownUser: "peer", otherUser: "peer" } } } as never;
+      return { action: "counter", assessment: { reasoning: "r", suggestedRoles: { ownUser: "peer", otherUser: "peer" } } } as never;
+    };
+    try {
+      const graph = new NegotiationGraphFactory(database, dispatcher).createGraph();
+      const events: Array<Record<string, unknown>> = [];
+      const { requestContext } = await import("../../shared/observability/request-context.js");
+      await requestContext.run({ traceEmitter: (e: Record<string, unknown>) => events.push(e) }, async () => {
+        await graph.invoke({
+          sourceUser: { id: "u-src" }, candidateUser: { id: "u-cand" },
+          indexContext: { networkId: "net-1", prompt: "" },
+          seedAssessment: { reasoning: "x", valencyRole: "peer" },
+          opportunityId: "opp-cap", maxTurns: 2,
+        } as Partial<typeof NegotiationGraphState.State>);
+      });
+      const outcome = events.find((e) => e.type === "negotiation_outcome");
+      expect(outcome?.outcome).toBe("turn_cap");
+      expect(outcome?.turnCount).toBe(2);
+    } finally {
+      IndexNegotiator.prototype.invoke = orig;
+    }
+  }, 30000);
+
+  it("emits outcome='waiting_for_agent' when dispatcher parks the turn", async () => {
+    const { database } = mkStubs();
+    const dispatcher = {
+      hasPersonalAgent: async () => true,
+      dispatch: async () => ({ handled: false, reason: "waiting" as const }),
+    } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[1];
+    const graph = new NegotiationGraphFactory(database, dispatcher).createGraph();
+    const events: Array<Record<string, unknown>> = [];
+    const { requestContext } = await import("../../shared/observability/request-context.js");
+    await requestContext.run({ traceEmitter: (e: Record<string, unknown>) => events.push(e) }, async () => {
+      await graph.invoke({
+        sourceUser: { id: "u-src" }, candidateUser: { id: "u-cand" },
+        indexContext: { networkId: "net-1", prompt: "" },
+        seedAssessment: { reasoning: "x", valencyRole: "peer" },
+        opportunityId: "opp-park", maxTurns: 4,
+      } as Partial<typeof NegotiationGraphState.State>);
+    });
+    const outcome = events.find((e) => e.type === "negotiation_outcome");
+    expect(outcome?.outcome).toBe("waiting_for_agent");
+  }, 30000);
+});

--- a/packages/protocol/src/negotiation/tests/negotiation.graph.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.graph.spec.ts
@@ -71,6 +71,9 @@ describe("negotiation graph — negotiation_turn emission", () => {
       expect(first.actor).toBe("source");
       expect(typeof first.action).toBe("string");
       expect(typeof first.durationMs).toBe("number");
+      expect(first.reasoning).toBe("stub reasoning");
+      expect(first.message).toBe("hi");
+      expect(first.suggestedRoles).toEqual({ ownUser: "agent", otherUser: "patient" });
     } finally {
       IndexNegotiator.prototype.invoke = origInvoke;
     }

--- a/packages/protocol/src/negotiation/tests/negotiation.graph.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.graph.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "bun:test";
+import { NegotiationGraphFactory } from "../negotiation.graph.js";
+import { NegotiationGraphState } from "../negotiation.state.js";
+
+function mkStubs() {
+  const messages: Array<{ id: string; senderId: string; parts: unknown[]; createdAt: Date }> = [];
+  const database = {
+    createConversation: async () => ({ id: "conv-1" }),
+    createTask: async () => ({ id: "task-1" }),
+    updateOpportunityStatus: async () => {},
+    createMessage: async (p: { conversationId: string; senderId: string; parts: unknown[] }) => {
+      const msg = { id: `msg-${messages.length}`, senderId: p.senderId, parts: p.parts, createdAt: new Date() };
+      messages.push(msg);
+      return msg;
+    },
+    updateTaskState: async () => {},
+    createArtifact: async () => {},
+    setTaskTurnContext: async () => {},
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[0];
+
+  const dispatcher = {
+    hasPersonalAgent: async () => false,
+    dispatch: async () => ({ handled: false, reason: "no-agent" }),
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[1];
+
+  return { database, dispatcher, messages };
+}
+
+describe("negotiation graph — negotiation_turn emission", () => {
+  it("emits negotiation_turn with correct payload after each turn", async () => {
+    // Stub IndexNegotiator.invoke so the test is fully hermetic — no LLM calls.
+    const { IndexNegotiator } = await import("../negotiation.agent.js");
+    const origInvoke = IndexNegotiator.prototype.invoke;
+    IndexNegotiator.prototype.invoke = async function () {
+      return {
+        action: "propose" as const,
+        assessment: {
+          reasoning: "stub reasoning",
+          suggestedRoles: { ownUser: "agent" as const, otherUser: "patient" as const },
+        },
+        message: "hi",
+      };
+    };
+
+    try {
+      const { database, dispatcher } = mkStubs();
+      const factory = new NegotiationGraphFactory(database, dispatcher);
+      const graph = factory.createGraph();
+
+      const events: Array<Record<string, unknown>> = [];
+      const traceEmitter = (e: Record<string, unknown>) => events.push(e);
+
+      const { requestContext } = await import("../../shared/observability/request-context.js");
+      await requestContext.run({ traceEmitter: traceEmitter as never }, async () => {
+        await graph.invoke({
+          sourceUser: { id: "u-src", intents: [], profile: { name: "Alice" } },
+          candidateUser: { id: "u-cand", intents: [], profile: { name: "Bob" } },
+          indexContext: { networkId: "net-1", prompt: "" },
+          seedAssessment: { reasoning: "x", valencyRole: "peer" },
+          opportunityId: "opp-1",
+          maxTurns: 2,
+        } as Partial<typeof NegotiationGraphState.State>);
+      });
+
+      const turnEvents = events.filter((e) => e.type === "negotiation_turn");
+      expect(turnEvents.length).toBeGreaterThanOrEqual(1);
+      const first = turnEvents[0];
+      expect(first.opportunityId).toBe("opp-1");
+      expect(first.negotiationConversationId).toBe("conv-1");
+      expect(first.turnIndex).toBe(0);
+      expect(first.actor).toBe("source");
+      expect(typeof first.action).toBe("string");
+      expect(typeof first.durationMs).toBe("number");
+    } finally {
+      IndexNegotiator.prototype.invoke = origInvoke;
+    }
+  }, 30000);
+});

--- a/packages/protocol/src/negotiation/tests/negotiation.graph.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.graph.spec.ts
@@ -108,11 +108,16 @@ describe("negotiation graph — negotiation_outcome emission", () => {
         } as Partial<typeof NegotiationGraphState.State>);
       });
 
-      const outcome = events.find((e) => e.type === "negotiation_outcome");
+      const outcomes = events.filter((e) => e.type === "negotiation_outcome");
+      expect(outcomes).toHaveLength(1);
+      const outcome = outcomes[0];
       expect(outcome).toBeTruthy();
       expect(outcome!.opportunityId).toBe("opp-accept");
       expect(outcome!.outcome).toBe("accepted");
       expect(outcome!.turnCount).toBe(2);
+      expect(outcome!.agreedRoles).toBeDefined();
+      expect(outcome!.agreedRoles?.ownUser).toBeTruthy();
+      expect(outcome!.agreedRoles?.otherUser).toBeTruthy();
     } finally {
       IndexNegotiator.prototype.invoke = orig;
     }
@@ -141,7 +146,9 @@ describe("negotiation graph — negotiation_outcome emission", () => {
           opportunityId: "opp-cap", maxTurns: 2,
         } as Partial<typeof NegotiationGraphState.State>);
       });
-      const outcome = events.find((e) => e.type === "negotiation_outcome");
+      const outcomes = events.filter((e) => e.type === "negotiation_outcome");
+      expect(outcomes).toHaveLength(1);
+      const outcome = outcomes[0];
       expect(outcome?.outcome).toBe("turn_cap");
       expect(outcome?.turnCount).toBe(2);
     } finally {
@@ -166,7 +173,9 @@ describe("negotiation graph — negotiation_outcome emission", () => {
         opportunityId: "opp-park", maxTurns: 4,
       } as Partial<typeof NegotiationGraphState.State>);
     });
-    const outcome = events.find((e) => e.type === "negotiation_outcome");
+    const outcomes = events.filter((e) => e.type === "negotiation_outcome");
+    expect(outcomes).toHaveLength(1);
+    const outcome = outcomes[0];
     expect(outcome?.outcome).toBe("waiting_for_agent");
   }, 30000);
 });

--- a/packages/protocol/src/negotiation/tests/negotiation.graph.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.graph.spec.ts
@@ -115,9 +115,10 @@ describe("negotiation graph — negotiation_outcome emission", () => {
       expect(outcome!.opportunityId).toBe("opp-accept");
       expect(outcome!.outcome).toBe("accepted");
       expect(outcome!.turnCount).toBe(2);
-      expect(outcome!.agreedRoles).toBeDefined();
-      expect(outcome!.agreedRoles?.ownUser).toBeTruthy();
-      expect(outcome!.agreedRoles?.otherUser).toBeTruthy();
+      const agreedRoles = outcome!.agreedRoles as { ownUser?: string; otherUser?: string } | undefined;
+      expect(agreedRoles).toBeDefined();
+      expect(agreedRoles?.ownUser).toBeTruthy();
+      expect(agreedRoles?.otherUser).toBeTruthy();
     } finally {
       IndexNegotiator.prototype.invoke = orig;
     }

--- a/packages/protocol/src/negotiation/tests/negotiation.graph.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.graph.spec.ts
@@ -204,7 +204,7 @@ describe("negotiateCandidates — session wrapper events", () => {
               userId: "u-1",
               reasoning: "r",
               valencyRole: "peer",
-              candidateUser: { id: "u-1", name: "Bob" } as never,
+              candidateUser: { id: "u-1", intents: [], profile: { name: "Bob" } } as never,
               opportunityId: "opp-10",
             },
           ],

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -1844,6 +1844,7 @@ export class OpportunityGraphFactory {
           { maxTurns, traceEmitter: traceEmitter ?? undefined,
             indexContextOverrides: indexContextMap,
             timeoutMs,
+            trigger: state.trigger === 'orchestrator' ? 'orchestrator' : 'ambient',
             ...(onCandidateResolved && { onCandidateResolved }) },
         );
 


### PR DESCRIPTION
## Summary

- **Protocol**: 4 new trace events (`negotiation_session_start/end`, `negotiation_turn`, `negotiation_outcome`) emitted by `negotiation.graph.ts` and `negotiateCandidates`; `debugMeta` extended with `llm` accumulator (calls, totalDurationMs, resets, hallucinations) and `orchestratorNegotiations.opportunityIds` pointer
- **Backend**: `/debug/chat/:id` now hydrates `turn.negotiations[]` via pointer path (new messages) and ±10-min time-window fallback (legacy messages without pointer); two new integration tests
- **Frontend**: TRACE panel renders a collapsible "Negotiations (N)" tree inside tool cards with per-candidate outcome icons, turn list, and reasoning

## New stream events

| Event | Emitted by | Carries |
|---|---|---|
| `negotiation_session_start` | `negotiateCandidates` | opportunityId, sourceUserId, candidateUserId, trigger |
| `negotiation_session_end` | `negotiateCandidates` | opportunityId, durationMs |
| `negotiation_turn` | `negotiation.graph.ts` turnNode | turnIndex, actor, action, reasoning, message, suggestedRoles |
| `negotiation_outcome` | `negotiation.graph.ts` finalizeNode | outcome (accepted/rejected_stalled/turn_cap/waiting_for_agent/timed_out), turnCount, agreedRoles |

## Test Plan

- [ ] `packages/protocol`: `bun test src/negotiation/tests/negotiation.graph.spec.ts src/chat/tests/chat.agent.spec.ts` — 11 tests pass
- [ ] `backend`: `bun test tests/debug.chat.negotiations.spec.ts tests/debug.chat.legacy.spec.ts` — 3 tests pass
- [ ] `frontend`: `bun run lint` — no new errors in changed files
- [ ] Smoke: trigger an orchestrator chat session, open `/debug/chat/:id`, verify `turns[i].negotiations` populated
- [ ] Smoke: observe live TRACE panel during active orchestrator run for "Negotiations (N)" section

## Notes

- Existing `agent_start/end` emissions in `negotiation.graph.ts` retained for backward compat with rolled-up `debugMeta.tools[].graphs[].agents[]`
- `negotiationConversationId` is `""` on error-path `session_end` (conversation ID not available if `graph.invoke` throws) — cosmetic only, UI matching uses `opportunityId`
- Legacy hydration uses `actors @> [{"userId": ...}]` + `detection->>'source' = 'chat'` (no `trigger` column on `opportunities` table)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Negotiation debug visibility: view per-candidate negotiation sessions with turn-level actions, reasoning, durations, and outcomes in trace panels and chat debug exports.
  * `/debug/chat/:id` now includes hydrated negotiation histories attached to assistant turns (with truncation signals when long).

* **Documentation**
  * Added protocol and design docs describing negotiation trace events and rollout/visibility plan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->