### PR TITLE
fix: ghost enrichment — defer enqueue until after dedup, soft-delete nameless ghosts

### DIFF
--- a/backend/src/adapters/contact.database.adapter.ts
+++ b/backend/src/adapters/contact.database.adapter.ts
@@ -127,7 +127,7 @@ export class ContactDatabaseAdapter {
 
     if (actuallyCreatedIds.size > 0) {
       const profilesToInsert = usersToInsert.filter(u => actuallyCreatedIds.has(u.id)).map(u => ({ userId: u.id }));
-      await db.insert(schema.userProfiles).values(profilesToInsert);
+      await db.insert(schema.userProfiles).values(profilesToInsert).onConflictDoNothing();
     }
 
     return usersToInsert

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -1245,7 +1245,7 @@ export class ChatDatabaseAdapter {
         const [memberCount] = await db
           .select({ count: count() })
           .from(schema.networkMembers)
-          .where(eq(schema.networkMembers.networkId, row.id));
+          .where(and(eq(schema.networkMembers.networkId, row.id), isNull(schema.networkMembers.deletedAt)));
         return {
           id: row.id,
           title: row.title,
@@ -1302,7 +1302,7 @@ export class ChatDatabaseAdapter {
         memberCount: count(schema.networkMembers.networkId),
       })
       .from(schema.networks)
-      .innerJoin(schema.networkMembers, eq(schema.networks.id, schema.networkMembers.networkId))
+      .innerJoin(schema.networkMembers, and(eq(schema.networks.id, schema.networkMembers.networkId), isNull(schema.networkMembers.deletedAt)))
       .where(
         and(
           isNull(schema.networks.deletedAt),
@@ -1377,7 +1377,7 @@ export class ChatDatabaseAdapter {
       const [countResult] = await db
         .select({ count: count() })
         .from(schema.networkMembers)
-        .where(eq(schema.networkMembers.networkId, row.id));
+        .where(and(eq(schema.networkMembers.networkId, row.id), isNull(schema.networkMembers.deletedAt)));
 
       result.push({
         id: row.id,
@@ -1626,7 +1626,7 @@ export class ChatDatabaseAdapter {
     const result = await Promise.all(
       ownerRows.map(async (row) => {
         const [memberCountResult, intentCountResult] = await Promise.all([
-          db.select({ count: count() }).from(networkMembers).where(eq(networkMembers.networkId, row.networkId)),
+          db.select({ count: count() }).from(networkMembers).where(and(eq(networkMembers.networkId, row.networkId), isNull(networkMembers.deletedAt))),
           db.select({ count: count() }).from(intentNetworks).where(eq(intentNetworks.networkId, row.networkId)),
         ]);
         const perms = row.permissions as { joinPolicy: string; invitationLink: { code: string } | null; allowGuestVibeCheck: boolean } | null;
@@ -1672,7 +1672,7 @@ export class ChatDatabaseAdapter {
       })
       .from(networkMembers)
       .innerJoin(users, eq(networkMembers.userId, users.id))
-      .where(eq(networkMembers.networkId, networkId));
+      .where(and(eq(networkMembers.networkId, networkId), isNull(networkMembers.deletedAt), isNull(users.deletedAt)));
 
     const [requestingUserEmailRow] = await db
       .select({ email: users.email })
@@ -1740,7 +1740,7 @@ export class ChatDatabaseAdapter {
       })
       .from(networkMembers)
       .innerJoin(users, eq(networkMembers.userId, users.id))
-      .where(eq(networkMembers.networkId, networkId));
+      .where(and(eq(networkMembers.networkId, networkId), isNull(networkMembers.deletedAt), isNull(users.deletedAt)));
 
     const memberUserIds = members.map((m) => m.userId);
     const intentCountRows = memberUserIds.length > 0
@@ -1795,6 +1795,7 @@ export class ChatDatabaseAdapter {
           inArray(networkMembers.networkId, myIndexIds),
           isNull(networks.deletedAt),
           isNull(users.deletedAt),
+          isNull(networkMembers.deletedAt),
         )
       );
 
@@ -1985,7 +1986,7 @@ export class ChatDatabaseAdapter {
       throw new Error('Index not found after update');
     }
     const [memberCountResult, intentCountResult] = await Promise.all([
-      db.select({ count: count() }).from(networkMembers).where(eq(networkMembers.networkId, networkId)),
+      db.select({ count: count() }).from(networkMembers).where(and(eq(networkMembers.networkId, networkId), isNull(networkMembers.deletedAt))),
       db.select({ count: count() }).from(intentNetworks).where(eq(intentNetworks.networkId, networkId)),
     ]);
     const perms = (updatedRow.permissions as { joinPolicy: string; invitationLink: { code: string } | null; allowGuestVibeCheck: boolean }) ?? {};
@@ -2119,7 +2120,7 @@ export class ChatDatabaseAdapter {
   }
 
   async getNetworkMemberCount(networkId: string): Promise<number> {
-    const [r] = await db.select({ count: count() }).from(networkMembers).where(eq(networkMembers.networkId, networkId));
+    const [r] = await db.select({ count: count() }).from(networkMembers).where(and(eq(networkMembers.networkId, networkId), isNull(networkMembers.deletedAt)));
     return Number(r?.count ?? 0);
   }
 

--- a/backend/src/services/contact.service.ts
+++ b/backend/src/services/contact.service.ts
@@ -159,8 +159,9 @@ export class ContactService {
 
   /**
    * Resolve contacts to user IDs without creating any memberships.
-   * Normalizes, filters non-human, deduplicates, looks up existing users,
-   * creates ghost users for unknowns, and enqueues enrichment for new ghosts.
+   * Normalizes, filters non-human, deduplicates by email, looks up existing users,
+   * and creates ghost users for unknowns. Does NOT enqueue enrichment — callers
+   * that apply further filtering (e.g. name-based dedup) should enqueue after filtering.
    *
    * @param ownerId - The requesting user (excluded from results)
    * @param contacts - Raw contact data (name, email)
@@ -223,13 +224,7 @@ export class ContactService {
       }
     }
 
-    const newGhostIdsArray = [...newGhostIds];
-    if (newGhostIdsArray.length > 0) {
-      await profileQueue.addEnrichUserJobBulk(newGhostIdsArray.map(id => ({ userId: id })));
-      logger.info('[ContactService] Enrichment jobs enqueued for new ghosts', { count: newGhostIdsArray.length });
-    }
-
-    return { userIds, newGhostIds: newGhostIdsArray, skipped, details };
+    return { userIds, newGhostIds: [...newGhostIds], skipped, details };
   }
 
   /**
@@ -272,6 +267,15 @@ export class ContactService {
 
     await this.db.upsertContactMembershipBulk(ownerId, dedupedUserIds);
     await this.db.clearReverseOptOutBulk(ownerId, dedupedUserIds);
+
+    // Enqueue enrichment only for kept new ghosts (after dedup)
+    const newGhostIdsToEnrich = dedupResult.kept
+      .filter(d => d.isNew && resolved.newGhostIds.includes(d.userId))
+      .map(d => d.userId);
+    if (newGhostIdsToEnrich.length > 0) {
+      await profileQueue.addEnrichUserJobBulk(newGhostIdsToEnrich.map(id => ({ userId: id })));
+      logger.info('[ContactService] Enrichment jobs enqueued for new ghosts', { count: newGhostIdsToEnrich.length });
+    }
 
     const newCount = dedupResult.kept.filter(d => d.isNew).length;
     const result: ImportResult = {

--- a/backend/src/services/integration.service.ts
+++ b/backend/src/services/integration.service.ts
@@ -4,6 +4,7 @@ import { ChatDatabaseAdapter, userDatabaseAdapter } from '../adapters/database.a
 import { getRedisClient } from '../adapters/cache.adapter';
 
 import { deduplicateContacts, getPreset } from '../lib/dedup/dedup';
+import { profileQueue } from '../queues/profile.queue';
 import type { ContactImporter, ImportResult } from '../types/integrations.types';
 import type { TelegramPrefs } from '../schemas/database.schema';
 import type { IntegrationConnection } from '../adapters/integration.adapter';
@@ -134,6 +135,15 @@ export class IntegrationService {
     }
 
     await this.db.addMembersBulkToIndex(networkId, dedupedUserIds);
+
+    // Enqueue enrichment only for kept new ghosts (after dedup)
+    const newGhostIdsToEnrich = dedupResult.kept
+      .filter(d => d.isNew && resolved.newGhostIds.includes(d.userId))
+      .map(d => d.userId);
+    if (newGhostIdsToEnrich.length > 0) {
+      await profileQueue.addEnrichUserJobBulk(newGhostIdsToEnrich.map(id => ({ userId: id })));
+      logger.info('[IntegrationService] Enrichment jobs enqueued for new ghosts', { count: newGhostIdsToEnrich.length });
+    }
 
     const newCount = dedupResult.kept.filter(d => d.isNew).length;
     return {

--- a/packages/protocol/src/profile/profile.enricher.ts
+++ b/packages/protocol/src/profile/profile.enricher.ts
@@ -9,6 +9,17 @@
  * @param enrichedName - `enrichment.identity.name` from Parallel (may be untrimmed)
  * @returns True if `users.name` should be updated to the enriched full name
  */
+/**
+ * Returns true when the enriched name is meaningfully better than the email local-part.
+ * A name that is empty, contains '@', or case-insensitively matches the prefix is NOT meaningful.
+ */
+export function isEnrichedNameMeaningful(email: string, enrichedName: string): boolean {
+  const trimmed = enrichedName.trim();
+  if (!trimmed || trimmed.includes('@')) return false;
+  const localPart = email.split('@')[0].toLowerCase();
+  return trimmed.toLowerCase() !== localPart;
+}
+
 export function shouldEnrichGhostDisplayNameFromParallel(
   user: { name: string; email: string; isGhost?: boolean | null },
   enrichedName: string,
@@ -17,8 +28,8 @@ export function shouldEnrichGhostDisplayNameFromParallel(
   const trimmed = enrichedName.trim();
   if (!trimmed || trimmed.includes("@")) return false;
 
-  const current = user.name.trim();
-  if (current === trimmed.toLowerCase()) return false;
+  // Skip only if exactly the same (case-sensitive)
+  if (user.name.trim() === trimmed) return false;
 
   return true;
 }

--- a/packages/protocol/src/profile/profile.graph.ts
+++ b/packages/protocol/src/profile/profile.graph.ts
@@ -6,7 +6,7 @@ import { ProfileGraphDatabase } from "../shared/interfaces/database.interface.js
 import { Embedder } from "../shared/interfaces/embedder.interface.js";
 import { Scraper } from "../shared/interfaces/scraper.interface.js";
 import type { ProfileEnricher } from "../shared/interfaces/enrichment.interface.js";
-import { shouldEnrichGhostDisplayNameFromParallel } from "./profile.enricher.js";
+import { shouldEnrichGhostDisplayNameFromParallel, isEnrichedNameMeaningful } from "./profile.enricher.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { timed } from "../shared/observability/performance.js";
 import { requestContext } from "../shared/observability/request-context.js";
@@ -430,6 +430,12 @@ export class ProfileGraphFactory {
               );
 
             if (hasMeaningfulEnrichment) {
+              if (user.isGhost && !isEnrichedNameMeaningful(user.email || '', enrichment!.identity.name || '')) {
+                logger.info("Enrichment has content but no real name for ghost, soft-deleting", { userId: state.userId });
+                await this.database.softDeleteGhost(state.userId);
+                return { error: "No real name found for ghost user" };
+              }
+
               logger.verbose("Chat API enrichment succeeded", {
                 userId: state.userId,
                 skillsCount: enrichment!.attributes.skills.length,
@@ -921,12 +927,17 @@ export class ProfileGraphFactory {
             logger.verbose("Enrichment succeeded — using pre-populated profile");
             return "use_prepopulated_profile";
           }
-          logger.verbose("Enrichment failed — falling back to LLM profile generation");
-          return "generate_profile";
+          if (state.input) {
+            logger.verbose("Enrichment fell back — using basic info for LLM generation");
+            return "generate_profile";
+          }
+          logger.verbose("Enrichment ended without data (ghost soft-deleted or error) — done");
+          return END;
         },
         {
           use_prepopulated_profile: "use_prepopulated_profile",
           generate_profile: "generate_profile",
+          [END]: END,
         }
       )
 


### PR DESCRIPTION
## Summary

- **Defer enrichment enqueue**: Moved ghost enrichment from `resolveContactsToUserIds` to `importContacts` and `IntegrationService.importContactsToNetwork`, so only ghosts that survive name-based dedup get enriched — prevents wasting enrichment credits on duplicates
- **Soft-delete nameless ghosts**: After enrichment, if the enriched name is not meaningful (empty, contains @, or matches the email local-part), the ghost is soft-deleted instead of kept with a useless profile
- **Fix member counts**: All network member count queries now filter out soft-deleted members (`isNull(networkMembers.deletedAt)`)
- **Prevent duplicate profile crash**: Added `.onConflictDoNothing()` on `userProfiles` insert during ghost creation

## Test plan
- [ ] Import contacts with duplicates — verify only deduped ghosts get enrichment jobs
- [ ] Enrich a ghost whose email yields no real name — verify it gets soft-deleted
- [ ] Check network member counts exclude soft-deleted members
- [ ] Verify existing enrichment flow still works for ghosts with valid names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of duplicate profiles during bulk contact imports.
  * Soft-deleted members are now properly excluded from network member lists and counts.
  * Enrichment logic is now more selective, filtering out contacts with incomplete or meaningless information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->