### PR TITLE
feat(opportunity): accept via MCP creates DM conversation (Start Chat)

### DIFF
--- a/packages/protocol/src/mcp/mcp.server.ts
+++ b/packages/protocol/src/mcp/mcp.server.ts
@@ -176,6 +176,16 @@ Each tool's description contains its own usage rules (when to call, when NOT to 
 
 # Authentication
 Pass your API key in the \`x-api-key\` request header (not \`Authorization: Bearer\`).
+
+# Opportunity lifecycle
+Opportunities move through: draft → pending → accepted (or rejected).
+
+- **draft** (you created it, not yet sent): offer to send it; confirm before calling update_opportunity with pending.
+- **pending, you sent it**: waiting for the other side — nothing to do.
+- **pending, you received it**: the other person is waiting for your response. Surface it to the user and ask if they want to start a chat. Only call update_opportunity with accepted after explicit user confirmation.
+- **accepted**: both sides are connected — a direct conversation exists. Surface the conversationId to the user if available.
+
+Never accept a received opportunity without explicit user approval in the current conversation.
 `.trim();
 
 export function createMcpServer(

--- a/packages/protocol/src/mcp/mcp.server.ts
+++ b/packages/protocol/src/mcp/mcp.server.ts
@@ -163,7 +163,7 @@ NEVER use "search" in any form. Use "looking up" for indexed data, "find" / "loo
 - Opportunity — discovered connection between users. Roles, status, reasoning.
 
 # Output rules
-- NEVER expose IDs, UUIDs, field names, or tool names.
+- NEVER expose internal IDs, UUIDs, field names, or tool names — EXCEPT when an ID is actionable for the user (e.g. a \`conversationId\` they need to open a chat). Surface such IDs verbatim when the tool returns them.
 - NEVER use internal vocabulary — say "signal" not "intent", "community" not "index".
 - NEVER dump raw JSON. Synthesize in natural language.
 - Surface top 1–3 relevant points unless asked for the full list.

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -2753,6 +2753,17 @@ export class OpportunityGraphFactory {
             return { mutationResult: { success: false, error: 'You are not part of this opportunity.' } };
           }
 
+          let conversationId: string | undefined;
+          if (state.newStatus === 'accepted') {
+            const counterpart = opp.actors.find(
+              (a: OpportunityActor) => a.userId !== state.userId && a.role !== 'introducer'
+            );
+            if (counterpart) {
+              const dm = await this.database.getOrCreateDM(state.userId, counterpart.userId);
+              conversationId = dm.id;
+            }
+          }
+
           await this.database.updateOpportunityStatus(
             state.opportunityId,
             state.newStatus as 'accepted' | 'rejected' | 'expired'
@@ -2763,6 +2774,7 @@ export class OpportunityGraphFactory {
               success: true,
               opportunityId: state.opportunityId,
               message: `Opportunity status updated to ${state.newStatus}.`,
+              ...(conversationId && { conversationId }),
             },
           };
         } catch (err) {

--- a/packages/protocol/src/opportunity/opportunity.state.ts
+++ b/packages/protocol/src/opportunity/opportunity.state.ts
@@ -440,6 +440,7 @@ export const OpportunityGraphState = Annotation.Root({
     message?: string;
     opportunityId?: string;
     notified?: string[];
+    conversationId?: string;
     error?: string;
   } | undefined>({
     reducer: (curr, next) => next,

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -1056,7 +1056,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
       "**Status transitions:**\n" +
       "- `pending`: Sends a draft opportunity to the other party. They'll be notified and can accept or reject. " +
       "This is the primary action after create_opportunities returns a draft.\n" +
-      "- `accepted`: Accept a received opportunity — signals interest in connecting. Both parties can now communicate.\n" +
+      "- `accepted`: Accept a received opportunity — opens a direct conversation between both parties. Returns a conversationId to surface to the user.\n" +
       "- `rejected`: Decline a received opportunity.\n" +
       "- `expired`: Mark as expired (typically done by the system after timeout).\n\n" +
       "**When to use:** After create_opportunities or list_opportunities returns opportunity cards. " +
@@ -1128,6 +1128,9 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
             status: query.status,
             message: result.mutationResult.message,
             ...(result.mutationResult.notified && { notified: result.mutationResult.notified }),
+            ...(result.mutationResult.conversationId && {
+              conversationId: result.mutationResult.conversationId,
+            }),
             _graphTimings: [{ name: 'opportunity', durationMs: _updateGraphMs, agents: result.agentTimings ?? [] }],
           });
         }

--- a/packages/protocol/src/opportunity/tests/opportunity.graph.update.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.graph.update.spec.ts
@@ -134,4 +134,30 @@ describe('opportunity graph — update node (accepted)', () => {
     expect(result.mutationResult?.conversationId).toBeUndefined();
     expect(dmCalled).toBe(false);
   });
+
+  test('does NOT flip status when getOrCreateDM throws', async () => {
+    let statusUpdateCalled = false;
+
+    const db = buildDb({
+      getOpportunity: async () => mockOpportunity,
+      getOrCreateDM: async () => {
+        throw new Error('DM creation failed');
+      },
+      updateOpportunityStatus: async () => {
+        statusUpdateCalled = true;
+        return null;
+      },
+    });
+
+    const graph = new OpportunityGraphFactory(db, dummyEmbedder, dummyHyde, mockEvaluator, async () => undefined).createGraph();
+    const result = await graph.invoke({
+      userId: USER_ID,
+      operationMode: 'update' as const,
+      opportunityId: OPP_ID,
+      newStatus: 'accepted',
+    });
+
+    expect(result.mutationResult?.success).toBe(false);
+    expect(statusUpdateCalled).toBe(false);
+  });
 });

--- a/packages/protocol/src/opportunity/tests/opportunity.graph.update.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.graph.update.spec.ts
@@ -1,0 +1,137 @@
+import { config } from 'dotenv';
+config({ path: '.env.test' });
+
+import { describe, test, expect } from 'bun:test';
+import { OpportunityGraphFactory } from '../opportunity.graph.js';
+import type { Id } from '../../types/common.types.js';
+import type {
+  OpportunityGraphDatabase,
+  Opportunity,
+} from '../../shared/interfaces/database.interface.js';
+import type { Embedder } from '../../shared/interfaces/embedder.interface.js';
+import type { OpportunityEvaluatorLike } from '../opportunity.graph.js';
+
+const mockEvaluator: OpportunityEvaluatorLike = {
+  invokeEntityBundle: async () => [],
+};
+
+const dummyEmbedder = {
+  generate: async () => [],
+  search: async () => [],
+  searchWithHydeEmbeddings: async () => [],
+  searchWithProfileEmbedding: async () => [],
+} as unknown as Embedder;
+
+const dummyHyde = {
+  invoke: async () => ({ hydeEmbeddings: { mirror: [], reciprocal: [] } }),
+};
+
+function buildDb(overrides: Partial<OpportunityGraphDatabase>): OpportunityGraphDatabase {
+  const base: OpportunityGraphDatabase = {
+    getProfile: async () => null,
+    createOpportunity: async (data) => ({
+      ...data,
+      id: 'opp-1',
+      status: 'pending' as const,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      expiresAt: null,
+    }),
+    opportunityExistsBetweenActors: async () => false,
+    getAcceptedOpportunitiesBetweenActors: async () => [],
+    getOpportunityBetweenActors: async () => null,
+    findOverlappingOpportunities: async () => [],
+    getUserIndexIds: async () => [] as Id<'networks'>[],
+    getNetworkMemberships: async () => [],
+    getActiveIntents: async () => [],
+    getNetworkIdsForIntent: async () => [],
+    getNetwork: async () => null,
+    getNetworkMemberCount: async () => 0,
+    getIntentIndexScores: async () => [],
+    getNetworkMemberContext: async () => null,
+    getOpportunity: async () => null,
+    getOpportunitiesForUser: async () => [],
+    updateOpportunityStatus: async () => null,
+    updateOpportunityActorApproval: async () => null,
+    isNetworkMember: async () => true,
+    isIndexOwner: async () => false,
+    getUser: async (id) => ({ id, name: 'Test', email: 'test@example.com' }),
+    getOrCreateDM: async () => ({ id: 'conv-default' }),
+    getIntent: async () => null,
+  };
+  return { ...base, ...overrides };
+}
+
+const USER_ID = 'u0000000-0000-4000-8000-000000000001' as Id<'users'>;
+const COUNTERPART_ID = 'u0000000-0000-4000-8000-000000000002' as Id<'users'>;
+const OPP_ID = 'op000000-0000-4000-8000-000000000001';
+const CONV_ID = 'conv0000-0000-4000-8000-000000000001';
+const NET_ID = 'net00000-0000-4000-8000-000000000001' as Id<'networks'>;
+
+const mockOpportunity = {
+  id: OPP_ID,
+  status: 'pending',
+  actors: [
+    { userId: USER_ID, role: 'party', networkId: NET_ID },
+    { userId: COUNTERPART_ID, role: 'party', networkId: NET_ID },
+  ],
+  detection: { source: 'manual' },
+  interpretation: { reasoning: '', confidence: 1 },
+  context: {},
+  confidence: 1,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  expiresAt: null,
+} as unknown as Opportunity;
+
+describe('opportunity graph — update node (accepted)', () => {
+  test('calls getOrCreateDM with userId and counterpart, returns conversationId', async () => {
+    let dmCalledWith: [string, string] | null = null;
+
+    const db = buildDb({
+      getOpportunity: async () => mockOpportunity,
+      updateOpportunityStatus: async () => null,
+      getOrCreateDM: async (a, b) => {
+        dmCalledWith = [a, b];
+        return { id: CONV_ID };
+      },
+    });
+
+    const graph = new OpportunityGraphFactory(db, dummyEmbedder, dummyHyde, mockEvaluator, async () => undefined).createGraph();
+    const result = await graph.invoke({
+      userId: USER_ID,
+      operationMode: 'update' as const,
+      opportunityId: OPP_ID,
+      newStatus: 'accepted',
+    });
+
+    expect(result.mutationResult?.success).toBe(true);
+    expect(result.mutationResult?.conversationId).toBe(CONV_ID);
+    expect(dmCalledWith).toEqual([USER_ID, COUNTERPART_ID]);
+  });
+
+  test('does NOT call getOrCreateDM when newStatus is rejected', async () => {
+    let dmCalled = false;
+
+    const db = buildDb({
+      getOpportunity: async () => mockOpportunity,
+      updateOpportunityStatus: async () => null,
+      getOrCreateDM: async () => {
+        dmCalled = true;
+        return { id: CONV_ID };
+      },
+    });
+
+    const graph = new OpportunityGraphFactory(db, dummyEmbedder, dummyHyde, mockEvaluator, async () => undefined).createGraph();
+    const result = await graph.invoke({
+      userId: USER_ID,
+      operationMode: 'update' as const,
+      opportunityId: OPP_ID,
+      newStatus: 'rejected',
+    });
+
+    expect(result.mutationResult?.success).toBe(true);
+    expect(result.mutationResult?.conversationId).toBeUndefined();
+    expect(dmCalled).toBe(false);
+  });
+});

--- a/packages/protocol/src/shared/interfaces/database.interface.ts
+++ b/packages/protocol/src/shared/interfaces/database.interface.ts
@@ -1674,6 +1674,7 @@ export type ChatGraphCompositeDatabase = Pick<
   | 'getOpportunitiesForUser'
   | 'updateOpportunityStatus'
   | 'updateOpportunityActorApproval'
+  | 'getOrCreateDM'
   // HyDE graph (used by OpportunityGraph)
   | 'getHydeDocument'
   | 'getHydeDocumentsForSource'
@@ -1745,6 +1746,7 @@ export type OpportunityGraphDatabase = Pick<
   | 'isNetworkMember'
   | 'isIndexOwner'
   | 'getUser'
+  | 'getOrCreateDM'
   // Load candidate intent payload/summary for evaluator
   | 'getIntent'
 >;


### PR DESCRIPTION
## Summary

- `update_opportunity` with `accepted` now calls `getOrCreateDM` in the opportunity graph's update node, creating the DM conversation between both parties — matching the behavior of the frontend "Start Chat" button
- `conversationId` is returned in the tool's success response so the agent can surface it to the user
- `MCP_INSTRUCTIONS` gains a `# Opportunity lifecycle` section that instructs the agent to ask for explicit user approval before accepting received pending opportunities

## Bug Fixed

When the OpenClaw plugin reported a pending received opportunity, the agent had no way to accept it and open a conversation. `update_opportunity` with `accepted` only updated the status — it did not create the DM. This brings the MCP path to parity with the frontend.

## Changes

- `opportunity.state.ts` — added `conversationId?: string` to `mutationResult` annotation
- `database.interface.ts` — added `'getOrCreateDM'` to `OpportunityGraphDatabase` (and `ChatGraphCompositeDatabase`, `OpportunityControllerDatabase` for type consistency)
- `opportunity.graph.ts` — `updateNode` calls `getOrCreateDM(userId, counterpartId)` before `updateOpportunityStatus` when `newStatus === 'accepted'`
- `opportunity.tools.ts` — `conversationId` threaded through success response; `accepted` description updated
- `mcp.server.ts` — `# Opportunity lifecycle` section added to `MCP_INSTRUCTIONS`
- `opportunity.graph.update.spec.ts` — new test file covering the accepted/rejected paths

## Test Plan

- [ ] `bun test ../packages/protocol/src/opportunity/tests/opportunity.graph.update.spec.ts` from `backend/` — 2 pass
- [ ] `bun test ../packages/protocol/src/opportunity/tests/introducer-gating-lifecycle.spec.ts` from `backend/` — 1 pass
- [ ] Call `update_opportunity` with `accepted` via MCP in the OpenClaw plugin — verify a conversation is created and `conversationId` is returned
- [ ] Verify the agent now asks for confirmation before accepting a received pending opportunity