### PR TITLE
feat(opportunity): rewrite home feed visibility rules for pending + introducer.approved gating

### DIFF
--- a/backend/src/controllers/debug.controller.ts
+++ b/backend/src/controllers/debug.controller.ts
@@ -179,7 +179,7 @@ export class DebugController {
 
     // Check if all opportunities are filtered from home (using role-aware helpers)
     const actionableCount = opportunityRows.filter((o) => {
-      const actors = o.actors as Array<{ userId: string; role: string }>;
+      const actors = o.actors as Array<{ userId: string; role: string; approved?: boolean }>;
       return (
         canUserSeeOpportunity(actors, o.status, user.id) &&
         isActionableForViewer(actors, o.status, user.id)
@@ -350,7 +350,7 @@ export class DebugController {
     let cardsReturned = 0;
 
     for (const opp of opportunityRows) {
-      const actors = opp.actors as Array<{ userId: string; role: string }>;
+      const actors = opp.actors as Array<{ userId: string; role: string; approved?: boolean }>;
 
       if (!canUserSeeOpportunity(actors, opp.status, user.id)) {
         notVisible++;

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/docs/Latent Opportunity Lifecycle.md
+++ b/packages/protocol/src/docs/Latent Opportunity Lifecycle.md
@@ -28,29 +28,32 @@ Who can see an opportunity is determined by **actor role** and **status**. There
 - **Tier 1** (`pending`): Sees after someone sent; can accept/reject
 - **Tier 2** (`accepted`, `rejected`, `expired`): Terminal; all actors can see
 
-### Role–Visibility Matrix
+### Role–Visibility Matrix (Home / Actionable)
 
-| Role        | No introducer     | With introducer   |
-|------------|--------------------|--------------------|
-| `introducer` | n/a                | Tier 0 (always)   |
-| `patient`    | Tier 0 (always)    | Tier 1 (pending+) |
-| `agent`      | Tier 1 (pending+)  | Tier 2 (accepted+) |
-| `peer`       | Tier 0 (always)    | Tier 0 (always)   |
-| `party`      | same as patient    | same as patient   |
+Whether an opportunity shows up on the viewer's **home feed** (the "act on this now" surface). The broader read-level ACL is covered by `canUserSeeOpportunity` and is unchanged here.
 
-- **Introducer**: Curator who created the match (e.g. "I think Alice and Bob should meet"). Sees the opportunity from latent and can send it to the patient.
-- **Patient**: The one who **needs** something (seeker, requester). Sees early and decides whether to reach out.
-- **Agent**: The one who **can offer** something (helper, provider). Sees last when there is an introducer (only after patient has committed); sees at pending when there is no introducer.
-- **Peer**: Symmetric collaboration. Both see from latent; either can send.
-- **Party**: Generic (e.g. manual creation). Treated like patient for visibility.
+The `introducer` actor carries an `approved: boolean` field on its `actors` JSONB entry. Default `false` at creation; flipped to `true` by `updateOpportunityActorApproval` when the introducer approves the match. Status remains `latent` across the flip — the change is actor-level, not status-level. After approval, a background negotiation runs; on accept the status moves to `pending`; on reject to `rejected`.
 
-### Compact Visibility Rule
+| Status | No introducer | Has introducer, `approved=false` | Has introducer, `approved=true` |
+|---|---|---|---|
+| `latent` | all actors | **introducer only** | all non-introducer actors |
+| `pending` | all non-introducer actors | all non-introducer actors | all non-introducer actors |
+| `accepted` / `rejected` / `expired` / `stalled` / `draft` / `negotiating` | not on home | not on home | not on home |
 
-A user can see an opportunity if and only if:
+Rules, expressed compactly:
 
-- They are an **introducer** or **peer**, or
-- They are **patient** or **party** and (status is not latent, or there is no introducer), or
-- They are **agent** and (status is accepted/rejected/expired, or (status is not latent and there is no introducer)).
+- **Introducer**: actionable iff `status === 'latent'` **and** `approved !== true`.
+- **Patient / party / agent / peer**: actionable iff
+  - `status === 'pending'`, **or**
+  - `status === 'latent'` **and** (no introducer **or** introducer is approved).
+
+> **Terminal statuses (`accepted`, `rejected`, `expired`)** never appear on home. `accepted` opportunities surface only in the conversations sidebar because the counterparty is now a contact.
+
+> **`stalled`** is not in `DEFAULT_HOME_STATUSES`; the home graph never loads it in the default path.
+
+> **`draft`** is the chat-orchestrator equivalent of `pending` and is internal to that flow; it never reaches the home feed.
+
+> **Future work — peer + introducer interaction:** the current rule treats `peer` like `patient` / `agent` under introducer gating (hidden while `approved=false`). If we add a scenario where peer opportunities can exist alongside an introducer (currently they don't in the model), revisit this row.
 
 ## Three Scenarios
 
@@ -113,14 +116,19 @@ sequenceDiagram
     Note over Sys: accepted; both see it
 ```
 
-## Status Transitions and Who Triggers Them
+## Status Transitions
 
-| Transition     | Who can trigger                          |
-|----------------|------------------------------------------|
-| latent → pending | Introducer, patient (no introducer), peer, party (no introducer) |
-| pending → accepted | Recipient accepts (e.g. Start Chat)  |
-| pending → rejected | Recipient declines (e.g. Skip)     |
-| latent/pending → expired | TTL or user dismisses              |
+| Transition                      | Trigger                                                                 |
+|---------------------------------|-------------------------------------------------------------------------|
+| create → `latent`               | Discovery graph (introducer-gated branches) or chat orchestrator.       |
+| create → `pending`              | Ambient discovery graph (no introducer).                                |
+| `latent` + introducer approves  | `updateOpportunityActorApproval` sets `actor.approved=true`; status unchanged; negotiation enqueued. |
+| `latent` / `pending` → `negotiating` | Negotiation graph starts a turn cycle.                              |
+| `negotiating` → `pending`       | Negotiation graph finalize, `lastTurn.action === 'accept'`.             |
+| `negotiating` → `rejected`      | Negotiation graph finalize, `lastTurn.action === 'reject'`.             |
+| `negotiating` → `stalled`       | Negotiation graph finalize, other/no terminal action.                   |
+| `pending` → `accepted`          | User action (e.g. Start Chat / `update_opportunity`).                   |
+| any → `expired`                 | Expiry job.                                                             |
 
 ## Notification Targeting (Send Node)
 

--- a/packages/protocol/src/docs/Latent Opportunity Lifecycle.md
+++ b/packages/protocol/src/docs/Latent Opportunity Lifecycle.md
@@ -20,13 +20,10 @@ When user sends, the system notifies the appropriate next person based on roles.
 
 ## Role-Based Visibility Model
 
-Who can see an opportunity is determined by **actor role** and **status**. There is no separate "sender" or "receiver" at creation time. The presence of an **introducer** pushes the patient and agent one tier later in the reveal cascade.
+Who can see an opportunity is determined by **actor role** and **status**. Two distinct predicates govern this:
 
-### Status Tiers
-
-- **Tier 0** (`latent`): First to see — can send to next tier
-- **Tier 1** (`pending`): Sees after someone sent; can accept/reject
-- **Tier 2** (`accepted`, `rejected`, `expired`): Terminal; all actors can see
+- **`canUserSeeOpportunity`** — read-level ACL for fetching opportunity details. Broadly: introducer and peer always see; patient/party/agent see when the opportunity has cleared the introducer gate or has no introducer. Details in `opportunity.utils.ts`.
+- **`isActionableForViewer`** — home feed visibility ("act on this now"). Governed by the introducer's `approved` flag, not a tier/send sequence. See the Role–Visibility Matrix below.
 
 ### Role–Visibility Matrix (Home / Actionable)
 
@@ -48,11 +45,11 @@ Rules, expressed compactly:
   - `status === 'latent'` **and** (no introducer **or** introducer is approved).
 
 > **Terminal statuses (`accepted`, `rejected`, `expired`)** never appear on home. `accepted` opportunities surface only in the conversations sidebar because the counterparty is now a contact.
-
+>
 > **`stalled`** is not in `DEFAULT_HOME_STATUSES`; the home graph never loads it in the default path.
-
+>
 > **`draft`** is the chat-orchestrator equivalent of `pending` and is internal to that flow; it never reaches the home feed.
-
+>
 > **Future work — peer + introducer interaction:** the current rule treats `peer` like `patient` / `agent` under introducer gating (hidden while `approved=false`). If we add a scenario where peer opportunities can exist alongside an introducer (currently they don't in the model), revisit this row.
 
 ## Three Scenarios
@@ -130,13 +127,14 @@ sequenceDiagram
 | `pending` → `accepted`          | User action (e.g. Start Chat / `update_opportunity`).                   |
 | any → `expired`                 | Expiry job.                                                             |
 
-## Notification Targeting (Send Node)
+## Notification Targeting
 
-When an opportunity is promoted from latent to pending, **only the role that becomes visible at the next tier** is notified:
+When an opportunity transitions to `pending`, **only the role that becomes newly visible** is notified:
 
-- **Sender is introducer** → notify **patient** (and party if present).
-- **Sender is patient or party** (no introducer) → notify **agent**.
-- **Sender is peer** → notify the **other peer(s)**.
+- **Introducer path** (`negotiating → pending` after approval): notify **patient** (and party if present); agent is notified later on `pending → accepted`.
+- **No introducer — patient/party initiates**: notify **agent**.
+- **No introducer — ambient** (`create → pending`): notify the non-discovering actor(s) based on the roles assigned by the evaluator.
+- **Peer** sends: notify the **other peer(s)**.
 
 No schema changes are required; targeting is derived from `actors[].role`.
 
@@ -152,11 +150,15 @@ No schema changes are required; targeting is derived from `actors[].role`.
 
 ```mermaid
 stateDiagram-v2
-    [*] --> latent: Agent creates
-    latent --> pending: User with Tier0 role sends
+    [*] --> latent: Agent creates (introducer-gated)
+    [*] --> pending: Agent creates (ambient / no introducer)
+    latent --> negotiating: Introducer approves → negotiation enqueued
     latent --> expired: User dismisses / TTL
-    pending --> accepted: Recipient accepts
-    pending --> rejected: Recipient declines
+    negotiating --> pending: Negotiation accepts
+    negotiating --> rejected: Negotiation rejects
+    negotiating --> stalled: No terminal action
+    pending --> accepted: User accepts (Start Chat)
+    pending --> rejected: User declines
     pending --> expired: TTL
 ```
 
@@ -191,8 +193,8 @@ graph LR
 ### Send Node (CRUD Path)
 
 - Validates opportunity is latent and caller is an actor.
-- **Authorization**: Only actors who can see at latent (introducer, peer, patient without introducer, party without introducer) can send.
-- Updates status to `pending` and queues notifications only to the role that becomes visible at the next tier (see Notification Targeting above).
+- **Authorization**: Only non-introducer actors who can see at latent (peer, patient without introducer, party without introducer) can send. The introducer's action is `updateOpportunityActorApproval` (actor-level flip), which enqueues a background negotiation rather than directly promoting status.
+- Updates status to `pending` and queues notifications only to the role that becomes visible (see Notification Targeting above).
 
 ## How LLM Agents Use Role Information
 

--- a/packages/protocol/src/opportunity/feed/feed.graph.ts
+++ b/packages/protocol/src/opportunity/feed/feed.graph.ts
@@ -54,7 +54,7 @@ export type HomeGraphInvokeResult = {
 };
 
 /** Default home-feed statuses: the lifecycle stages a viewer can act on today. */
-export const DEFAULT_HOME_STATUSES: OpportunityStatus[] = ['latent', 'stalled', 'pending'];
+export const DEFAULT_HOME_STATUSES: OpportunityStatus[] = ['latent', 'pending'];
 
 // Exhaustive registry — keys must cover every OpportunityStatus union member.
 // Adding a new status to OpportunityStatus without adding a key here is a TS error,

--- a/packages/protocol/src/opportunity/opportunity.utils.ts
+++ b/packages/protocol/src/opportunity/opportunity.utils.ts
@@ -66,11 +66,15 @@ export function validateOpportunityActors(actors: Array<{ userId?: string; role:
  * Read-level ACL: whether a user is an actor on the opportunity and may fetch
  * its details. Intentionally broader than `isActionableForViewer` — a user can
  * read an opportunity they are not currently expected to act on (e.g. an agent
- * viewing an accepted opportunity). The two predicates diverge for `agent with
- * introducer at pending`: `canUserSeeOpportunity` returns false (hasIntroducer
- * blocks it), while `isActionableForViewer` returns true (Rule 4 shows pending
- * to all non-introducer actors). This is intentional — the agent is not granted
- * read access via this path until the introducer path completes.
+ * viewing an accepted opportunity).
+ *
+ * The feed graph and debug controller chain both predicates: an opportunity only
+ * reaches the home feed if it passes `canUserSeeOpportunity` first, then
+ * `isActionableForViewer`. For `agent with introducer at pending`,
+ * `canUserSeeOpportunity` returns false (read gate blocks it), so the opportunity
+ * never surfaces even though `isActionableForViewer` Rule 4 would return true in
+ * isolation. This is by design — the agent is not granted read access through the
+ * home path until the introducer path completes (negotiation → accepted).
  *
  * Compact Visibility Rule (from lifecycle doc):
  * - Introducer or peer: always see.

--- a/packages/protocol/src/opportunity/opportunity.utils.ts
+++ b/packages/protocol/src/opportunity/opportunity.utils.ts
@@ -63,8 +63,14 @@ export function validateOpportunityActors(actors: Array<{ userId?: string; role:
 }
 
 /**
- * Role-based visibility (Latent Opportunity Lifecycle).
- * A user can see an opportunity iff they are an actor and the rule below allows it.
+ * Read-level ACL: whether a user is an actor on the opportunity and may fetch
+ * its details. Intentionally broader than `isActionableForViewer` — a user can
+ * read an opportunity they are not currently expected to act on (e.g. an agent
+ * viewing an accepted opportunity). The two predicates diverge for `agent with
+ * introducer at pending`: `canUserSeeOpportunity` returns false (hasIntroducer
+ * blocks it), while `isActionableForViewer` returns true (Rule 4 shows pending
+ * to all non-introducer actors). This is intentional — the agent is not granted
+ * read access via this path until the introducer path completes.
  *
  * Compact Visibility Rule (from lifecycle doc):
  * - Introducer or peer: always see.

--- a/packages/protocol/src/opportunity/opportunity.utils.ts
+++ b/packages/protocol/src/opportunity/opportunity.utils.ts
@@ -95,37 +95,53 @@ export function canUserSeeOpportunity(
 }
 
 /**
- * Whether an opportunity should appear on the Home feed for the viewer (actionable = has a pending action).
- * Encodes the role-visibility matrix from the Latent Opportunity Lifecycle.
+ * Whether an opportunity should appear on the viewer's home feed (actionable =
+ * has a pending action for this user).
+ *
+ * Rules (see `docs/Latent Opportunity Lifecycle.md` — Role-Visibility Matrix):
+ *
+ *   (1) `latent`, no introducer                   → all actors actionable
+ *   (2) `latent`, introducer `approved !== true`  → introducer only
+ *   (3) `latent`, introducer `approved === true`  → all non-introducer actors
+ *   (4) `pending` (any introducer config)         → all non-introducer actors
+ *   (5) `accepted`/`rejected`/`expired`/`stalled`/`draft`/`negotiating`
+ *                                                 → never actionable
+ *
+ * The introducer approval signal is stored on the `introducer`-roled actor's
+ * `approved: boolean` field within the opportunity's `actors` JSONB. It flips
+ * from `false` to `true` when the introducer approves; status stays `latent`
+ * across the flip while a background negotiation runs.
  */
 export function isActionableForViewer(
-  actors: Array<{ userId: string; role: string }>,
+  actors: Array<{ userId: string; role: string; approved?: boolean }>,
   status: string,
   viewerId: string
 ): boolean {
   const viewerActors = actors.filter((a) => a.userId === viewerId);
   if (viewerActors.length === 0) return false;
 
-  const hasIntroducer = actors.some((a) => a.role === 'introducer');
+  const introducer = actors.find((a) => a.role === 'introducer');
+  const hasIntroducer = !!introducer;
+  const introducerApproved = introducer?.approved === true;
 
   return viewerActors.some(({ role }) => {
-    switch (role) {
-      case 'introducer':
-        return status === 'latent';
-      case 'patient':
-      case 'party':
-        return hasIntroducer
-          ? status === 'pending'
-          : status === 'latent';
-      case 'agent':
-        return hasIntroducer
-          ? status === 'accepted'
-          : status === 'pending';
-      case 'peer':
-        return status === 'latent' || status === 'pending';
-      default:
-        return false;
+    if (role === 'introducer') {
+      // Rule 2: introducer sees own latent opp only while not yet approved.
+      return status === 'latent' && !introducerApproved;
     }
+
+    // Non-introducer actors: patient / party / agent / peer.
+    if (status === 'latent') {
+      // Rule 1: no introducer → visible.
+      // Rule 3: introducer approved → visible.
+      return !hasIntroducer || introducerApproved;
+    }
+    if (status === 'pending') {
+      // Rule 4: visible to all non-introducer actors.
+      return true;
+    }
+    // Rule 5: never actionable at terminal or internal statuses.
+    return false;
   });
 }
 

--- a/packages/protocol/src/opportunity/tests/feed.graph.status-filter.spec.ts
+++ b/packages/protocol/src/opportunity/tests/feed.graph.status-filter.spec.ts
@@ -41,8 +41,8 @@ function createMockDb(captured: { statuses?: OpportunityStatus[] }): HomeGraphDa
 }
 
 describe('home graph status filter', () => {
-  test('DEFAULT_HOME_STATUSES is exactly latent, stalled, pending', () => {
-    expect(DEFAULT_HOME_STATUSES).toEqual(['latent', 'stalled', 'pending']);
+  test('DEFAULT_HOME_STATUSES is exactly latent, pending', () => {
+    expect(DEFAULT_HOME_STATUSES).toEqual(['latent', 'pending']);
   });
 
   test('ALL_OPPORTUNITY_STATUSES includes accepted/rejected/expired', () => {

--- a/packages/protocol/src/opportunity/tests/opportunity.utils.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.utils.spec.ts
@@ -174,122 +174,130 @@ describe('opportunity.utils', () => {
   });
 
   // ─── isActionableForViewer ───────────────────────────────────────────────
-  // Tests the Home feed actionability matrix: which status × role combos
-  // have a pending action (Send, Accept/Reject, Go to chat).
+  // Rules:
+  //   (1) latent, no introducer            → all actors actionable
+  //   (2) latent, introducer !approved     → introducer only
+  //   (3) latent, introducer approved      → all non-introducer actors
+  //   (4) pending, any introducer config   → all non-introducer actors
+  //   (5) terminal / stalled / draft / negotiating → never actionable
 
   describe('isActionableForViewer', () => {
     const VIEWER = 'user-viewer';
+    const OTHER = 'user-other';
+    const INTRO = 'user-intro';
 
-    test('returns false when user is not an actor', () => {
+    const NON_ACTIONABLE_STATUSES = [
+      'draft',
+      'negotiating',
+      'stalled',
+      'accepted',
+      'rejected',
+      'expired',
+    ] as const;
+
+    /**
+     * Build an actors array where `viewerRole` is the viewer's role. If
+     * `introducerApproved` is undefined, no introducer is present.
+     */
+    const actors = (
+      viewerRole: 'introducer' | 'patient' | 'party' | 'agent' | 'peer',
+      introducerApproved: boolean | undefined,
+    ) => {
+      const list: Array<{ userId: string; role: string; approved?: boolean }> = [];
+      if (viewerRole === 'introducer') {
+        list.push({ userId: VIEWER, role: 'introducer', approved: introducerApproved ?? false });
+        list.push({ userId: OTHER, role: 'patient' });
+      } else {
+        list.push({ userId: VIEWER, role: viewerRole });
+        list.push({ userId: OTHER, role: viewerRole === 'patient' ? 'agent' : 'patient' });
+        if (introducerApproved !== undefined) {
+          list.push({ userId: INTRO, role: 'introducer', approved: introducerApproved });
+        }
+      }
+      return list;
+    };
+
+    test('returns false when viewer is not an actor', () => {
       const a = [{ userId: 'someone-else', role: 'patient' }];
       expect(isActionableForViewer(a, 'latent', VIEWER)).toBe(false);
+      expect(isActionableForViewer(a, 'pending', VIEWER)).toBe(false);
     });
 
-    // Introducer: actionable only at latent (can Send)
     describe('introducer', () => {
-      test('actionable at latent', () => {
-        const a = [
-          { userId: VIEWER, role: 'introducer' },
-          { userId: 'b', role: 'patient' },
-        ];
-        expect(isActionableForViewer(a, 'latent', VIEWER)).toBe(true);
+      it('is actionable only when latent and not yet approved', () => {
+        expect(isActionableForViewer(actors('introducer', false), 'latent', VIEWER)).toBe(true);
       });
-      for (const status of ['draft', 'pending', 'accepted', 'rejected', 'expired'] as const) {
-        test(`not actionable at ${status}`, () => {
-          const a = [
-            { userId: VIEWER, role: 'introducer' },
-            { userId: 'b', role: 'patient' },
-          ];
-          expect(isActionableForViewer(a, status, VIEWER)).toBe(false);
+
+      it('stops being actionable once approved=true (status stays latent)', () => {
+        expect(isActionableForViewer(actors('introducer', true), 'latent', VIEWER)).toBe(false);
+      });
+
+      it('is not actionable at pending or any terminal status', () => {
+        expect(isActionableForViewer(actors('introducer', false), 'pending', VIEWER)).toBe(false);
+        expect(isActionableForViewer(actors('introducer', true), 'pending', VIEWER)).toBe(false);
+        for (const status of NON_ACTIONABLE_STATUSES) {
+          expect(isActionableForViewer(actors('introducer', false), status, VIEWER)).toBe(false);
+          expect(isActionableForViewer(actors('introducer', true), status, VIEWER)).toBe(false);
+        }
+      });
+    });
+
+    describe('non-introducer actor, no introducer', () => {
+      for (const role of ['patient', 'party', 'agent', 'peer'] as const) {
+        describe(role, () => {
+          it('is actionable at latent', () => {
+            expect(isActionableForViewer(actors(role, undefined), 'latent', VIEWER)).toBe(true);
+          });
+
+          it('is actionable at pending', () => {
+            expect(isActionableForViewer(actors(role, undefined), 'pending', VIEWER)).toBe(true);
+          });
+
+          it('is not actionable at terminal or internal statuses', () => {
+            for (const status of NON_ACTIONABLE_STATUSES) {
+              expect(isActionableForViewer(actors(role, undefined), status, VIEWER)).toBe(false);
+            }
+          });
         });
       }
     });
 
-    // Patient/party with introducer: actionable at pending (Accept/Reject)
-    describe('patient with introducer', () => {
-      const makeActors = () => [
-        { userId: VIEWER, role: 'patient' },
-        { userId: 'intro', role: 'introducer' },
-        { userId: 'agent-user', role: 'agent' },
-      ];
-      test('not actionable at latent', () => {
-        expect(isActionableForViewer(makeActors(), 'latent', VIEWER)).toBe(false);
-      });
-      test('actionable at pending', () => {
-        expect(isActionableForViewer(makeActors(), 'pending', VIEWER)).toBe(true);
-      });
-      for (const status of ['draft', 'accepted', 'rejected', 'expired'] as const) {
-        test(`not actionable at ${status}`, () => {
-          expect(isActionableForViewer(makeActors(), status, VIEWER)).toBe(false);
+    describe('non-introducer actor, with introducer NOT approved', () => {
+      for (const role of ['patient', 'party', 'agent', 'peer'] as const) {
+        describe(role, () => {
+          it('is NOT actionable at latent (only introducer sees it)', () => {
+            expect(isActionableForViewer(actors(role, false), 'latent', VIEWER)).toBe(false);
+          });
+
+          it('is actionable at pending', () => {
+            expect(isActionableForViewer(actors(role, false), 'pending', VIEWER)).toBe(true);
+          });
+
+          it('is not actionable at terminal or internal statuses', () => {
+            for (const status of NON_ACTIONABLE_STATUSES) {
+              expect(isActionableForViewer(actors(role, false), status, VIEWER)).toBe(false);
+            }
+          });
         });
       }
     });
 
-    // Patient/party without introducer: actionable at latent only (can Send)
-    describe('patient without introducer', () => {
-      const makeActors = () => [
-        { userId: VIEWER, role: 'patient' },
-        { userId: 'agent-user', role: 'agent' },
-      ];
-      test('actionable at latent', () => {
-        expect(isActionableForViewer(makeActors(), 'latent', VIEWER)).toBe(true);
-      });
-      for (const status of ['draft', 'pending', 'accepted', 'rejected', 'expired'] as const) {
-        test(`not actionable at ${status}`, () => {
-          expect(isActionableForViewer(makeActors(), status, VIEWER)).toBe(false);
-        });
-      }
-    });
+    describe('non-introducer actor, with introducer approved', () => {
+      for (const role of ['patient', 'party', 'agent', 'peer'] as const) {
+        describe(role, () => {
+          it('is actionable at latent', () => {
+            expect(isActionableForViewer(actors(role, true), 'latent', VIEWER)).toBe(true);
+          });
 
-    // Agent with introducer: actionable at accepted only (Go to chat)
-    describe('agent with introducer', () => {
-      const makeActors = () => [
-        { userId: VIEWER, role: 'agent' },
-        { userId: 'intro', role: 'introducer' },
-        { userId: 'patient-user', role: 'patient' },
-      ];
-      test('actionable at accepted', () => {
-        expect(isActionableForViewer(makeActors(), 'accepted', VIEWER)).toBe(true);
-      });
-      for (const status of ['latent', 'draft', 'pending', 'rejected', 'expired'] as const) {
-        test(`not actionable at ${status}`, () => {
-          expect(isActionableForViewer(makeActors(), status, VIEWER)).toBe(false);
-        });
-      }
-    });
+          it('is actionable at pending', () => {
+            expect(isActionableForViewer(actors(role, true), 'pending', VIEWER)).toBe(true);
+          });
 
-    // Agent without introducer: actionable at pending (Accept/Reject)
-    describe('agent without introducer', () => {
-      const makeActors = () => [
-        { userId: VIEWER, role: 'agent' },
-        { userId: 'patient-user', role: 'patient' },
-      ];
-      for (const status of ['pending'] as const) {
-        test(`actionable at ${status}`, () => {
-          expect(isActionableForViewer(makeActors(), status, VIEWER)).toBe(true);
-        });
-      }
-      for (const status of ['latent', 'draft', 'accepted', 'rejected', 'expired'] as const) {
-        test(`not actionable at ${status}`, () => {
-          expect(isActionableForViewer(makeActors(), status, VIEWER)).toBe(false);
-        });
-      }
-    });
-
-    // Peer: actionable at latent, pending
-    describe('peer', () => {
-      const makeActors = () => [
-        { userId: VIEWER, role: 'peer' },
-        { userId: 'other-peer', role: 'peer' },
-      ];
-      for (const status of ['latent', 'pending'] as const) {
-        test(`actionable at ${status}`, () => {
-          expect(isActionableForViewer(makeActors(), status, VIEWER)).toBe(true);
-        });
-      }
-      for (const status of ['draft', 'accepted', 'rejected', 'expired'] as const) {
-        test(`not actionable at ${status}`, () => {
-          expect(isActionableForViewer(makeActors(), status, VIEWER)).toBe(false);
+          it('is not actionable at terminal or internal statuses', () => {
+            for (const status of NON_ACTIONABLE_STATUSES) {
+              expect(isActionableForViewer(actors(role, true), status, VIEWER)).toBe(false);
+            }
+          });
         });
       }
     });


### PR DESCRIPTION
## New Features

- **`isActionableForViewer` rewrite**: Home feed now shows `pending` opportunities to all non-introducer actors (previously only shown at `latent`). Introduces four explicit rules:
  1. `latent`, no introducer → all actors actionable
  2. `latent`, has introducer, `approved=false` → introducer only
  3. `latent`, has introducer, `approved=true` → all non-introducer actors
  4. `pending` (any config) → all non-introducer actors

- **`DEFAULT_HOME_STATUSES` narrowed**: Dropped `'stalled'` — now `['latent', 'pending']` only. `stalled` was never actionable under any role; removing it prevents spurious DB fetches.

## Bug Fixes

- Post-ambient-negotiation opportunities (status=`pending`, role=`patient`, no introducer) now surface on the home feed. Previously they were invisible because the old matrix only showed `pending` to `patient` when a `hasIntroducer` condition was met — which was never true in the ambient path.

## Tests

- Rewrote `isActionableForViewer` describe block in `opportunity.utils.spec.ts` — 104 tests, all passing
- Updated `feed.graph.status-filter.spec.ts` for new `DEFAULT_HOME_STATUSES`

## Documentation

- Rewrote Role–Visibility Matrix table in `Latent Opportunity Lifecycle.md` with the new 3-column × 3-row format
- Documented `actor.approved: boolean` field on introducer actors
- Added future-work note for peer + introducer interaction

## Test plan

- [ ] Confirm Yankı's pending opportunity (`b3fd1596`, status=`pending`, role=`patient`) appears on home feed at `dev.index.network` after deploy
- [ ] Confirm introducers only see latent opportunities while `approved=false`
- [ ] Confirm `stalled` opportunities do not appear on home feed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated opportunity lifecycle documentation with new visibility rules based on introducer approval status.
  * Stalled opportunities no longer appear in the home feed by default.
  * Revised actionability rules for opportunities based on status and introducer approval state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->