### PR TITLE
feat(openclaw-plugin): skip opportunity batch subagent when set is unchanged

### DIFF
--- a/docs/superpowers/specs/2026-04-22-openclaw-opportunity-batch-skip-design.md
+++ b/docs/superpowers/specs/2026-04-22-openclaw-opportunity-batch-skip-design.md
@@ -1,0 +1,45 @@
+# Design: Skip Opportunity Batch LLM When Set Is Unchanged
+
+**Date:** 2026-04-22
+**Scope:** `packages/openclaw-plugin/src/index.ts`
+
+## Problem
+
+The `handleOpportunityBatch` handler fires every 5 minutes and unconditionally spawns an LLM subagent to evaluate pending opportunities — even when the opportunity set is identical to the previous poll. This wastes LLM calls when nothing has changed.
+
+## Solution
+
+Track the last-seen opportunity batch hash in memory. Skip the LLM subagent call when the hash matches the previous run.
+
+## Design
+
+### State
+
+Add a module-level variable alongside the existing `inflight` set:
+
+```ts
+let lastOpportunityBatchHash: string | null = null;
+```
+
+### Logic in `handleOpportunityBatch`
+
+After fetching opportunities and computing `hashOpportunityBatch(ids)`:
+
+1. If `hash === lastOpportunityBatchHash` → log skip, return early (no subagent spawned)
+2. Otherwise → set `lastOpportunityBatchHash = hash`, proceed with subagent call as today
+
+The empty-list case (`ids = []`) produces a stable hash, so repeated empty polls also skip after the first.
+
+### Test Reset
+
+`_resetForTesting()` resets `lastOpportunityBatchHash = null` alongside existing state resets.
+
+## Trade-offs
+
+- **Restart behavior:** `lastOpportunityBatchHash` initializes to `null` on process start, so the first poll after a restart always runs the LLM — one extra call per restart, acceptable.
+- **No persistent storage needed:** Backend maintains opportunity state; the plugin only needs to deduplicate within a session.
+- **Hash stability:** `hashOpportunityBatch` sorts IDs before hashing, so LLM-determined ordering from the API does not affect change detection.
+
+## Files Changed
+
+- `packages/openclaw-plugin/src/index.ts` — add `lastOpportunityBatchHash` variable, early-return guard in `handleOpportunityBatch`, reset in `_resetForTesting`

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -419,8 +419,6 @@ export async function handleOpportunityBatch(
     return false;
   }
 
-  lastOpportunityBatchHash = batchHash;
-
   const dateStr = new Date().toISOString().slice(0, 10);
   const model = await readModel(api);
 
@@ -440,6 +438,7 @@ export async function handleOpportunityBatch(
       deliver: true,
       model,
     });
+    lastOpportunityBatchHash = batchHash;
   } catch (err) {
     // Subagent dispatch failed — swallow so the poll loop doesn't escalate backoff
     // on a runtime-side issue. The same batch will retry on the next tick.

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -38,6 +38,9 @@ const POLL_PATH = '/index-network/poll';
 /** Tracks in-flight turns so we don't re-launch subagents for already-claimed work. */
 const inflight = new Set<string>();
 
+/** Hash of the last opportunity batch dispatched to the evaluator subagent. Used to skip unchanged batches. */
+let lastOpportunityBatchHash: string | null = null;
+
 /** Prevents double-registration when OpenClaw calls register() more than once. */
 let registered = false;
 
@@ -410,6 +413,14 @@ export async function handleOpportunityBatch(
   }
 
   const batchHash = hashOpportunityBatch(body.opportunities.map((o) => o.opportunityId));
+
+  if (batchHash === lastOpportunityBatchHash) {
+    api.logger.debug('Opportunity batch unchanged since last poll — skipping subagent.');
+    return false;
+  }
+
+  lastOpportunityBatchHash = batchHash;
+
   const dateStr = new Date().toISOString().slice(0, 10);
   const model = await readModel(api);
 
@@ -661,6 +672,7 @@ export function _resetForTesting(): void {
   registered = false;
   backoffMultiplier = 1;
   inflight.clear();
+  lastOpportunityBatchHash = null;
   if (pollTimer) {
     clearTimeout(pollTimer);
     pollTimer = null;

--- a/packages/openclaw-plugin/src/tests/opportunity-batch.spec.ts
+++ b/packages/openclaw-plugin/src/tests/opportunity-batch.spec.ts
@@ -253,4 +253,51 @@ describe('handleOpportunityBatch', () => {
     expect(fetchCalls[0].url).toContain(`/agents/${AGENT_ID}/opportunities/pending`);
     expect(fetchCalls[0].init?.method).toBe('GET');
   });
+
+  test('does not launch subagent on second call with identical opportunity set', async () => {
+    global.fetch = mock(async () =>
+      new Response(JSON.stringify({ opportunities: [SAMPLE_CANDIDATE] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ) as unknown as typeof fetch;
+
+    const fake = buildFakeApi();
+    const first = await handleOpportunityBatch(fake.api, BASE_URL, AGENT_ID, API_KEY);
+    const second = await handleOpportunityBatch(fake.api, BASE_URL, AGENT_ID, API_KEY);
+
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+    expect(fake.subagentCalls).toHaveLength(1);
+  });
+
+  test('launches subagent again when opportunity set changes between calls', async () => {
+    const SECOND_CANDIDATE = {
+      opportunityId: 'opp-xyz',
+      rendered: {
+        headline: 'Another match',
+        personalizedSummary: 'Bob is looking for a designer.',
+        suggestedAction: 'Connect with Bob.',
+        narratorRemark: 'Solid fit.',
+      },
+    };
+
+    let callCount = 0;
+    global.fetch = mock(async () => {
+      callCount++;
+      const opportunities = callCount === 1
+        ? [SAMPLE_CANDIDATE]
+        : [SAMPLE_CANDIDATE, SECOND_CANDIDATE];
+      return new Response(JSON.stringify({ opportunities }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+
+    const fake = buildFakeApi();
+    await handleOpportunityBatch(fake.api, BASE_URL, AGENT_ID, API_KEY);
+    await handleOpportunityBatch(fake.api, BASE_URL, AGENT_ID, API_KEY);
+
+    expect(fake.subagentCalls).toHaveLength(2);
+  });
 });

--- a/packages/openclaw-plugin/src/tests/opportunity-batch.spec.ts
+++ b/packages/openclaw-plugin/src/tests/opportunity-batch.spec.ts
@@ -295,9 +295,11 @@ describe('handleOpportunityBatch', () => {
     }) as unknown as typeof fetch;
 
     const fake = buildFakeApi();
-    await handleOpportunityBatch(fake.api, BASE_URL, AGENT_ID, API_KEY);
-    await handleOpportunityBatch(fake.api, BASE_URL, AGENT_ID, API_KEY);
+    const first = await handleOpportunityBatch(fake.api, BASE_URL, AGENT_ID, API_KEY);
+    const second = await handleOpportunityBatch(fake.api, BASE_URL, AGENT_ID, API_KEY);
 
+    expect(first).toBe(true);
+    expect(second).toBe(true);
     expect(fake.subagentCalls).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary

- Added `lastOpportunityBatchHash` module-level variable to cache the hash of the last dispatched opportunity batch
- Added early-return guard in `handleOpportunityBatch` that skips the LLM subagent when the opportunity set (by IDs) hasn't changed since the last poll
- Reset `lastOpportunityBatchHash` in `_resetForTesting()` for test isolation

## Test Plan

- [ ] `does not launch subagent on second call with identical opportunity set` — second call returns `false`, subagent called only once
- [ ] `launches subagent again when opportunity set changes between calls` — subagent called twice when IDs differ
- [ ] All 71 existing tests continue to pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Opportunity batch processing now skips redundant evaluations when opportunity data remains unchanged.

* **Tests**
  * Added comprehensive test coverage for batch processing deduplication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->