### PR TITLE
fix: reduce ambient discovery message spam

### DIFF
--- a/docs/superpowers/plans/2026-04-22-ambient-discovery-spam-fix.md
+++ b/docs/superpowers/plans/2026-04-22-ambient-discovery-spam-fix.md
@@ -42,7 +42,6 @@ sequenceDiagram
 - Config: [`openclaw.plugin.json`](../../packages/openclaw-plugin/openclaw.plugin.json) -- plugin config schema
 - Delivery dispatcher: [`delivery.dispatcher.ts`](../../packages/openclaw-plugin/src/lib/delivery/delivery.dispatcher.ts) -- builds session key, dispatches pre-rendered cards via `deliver: true`
 - Delivery prompt: [`delivery.prompt.ts`](../../packages/openclaw-plugin/src/lib/delivery/delivery.prompt.ts) -- simple relay prompt: "deliver faithfully, don't add commentary"
-- Digest scheduler: [`daily-digest.scheduler.ts`](../../packages/openclaw-plugin/src/polling/daily-digest/daily-digest.scheduler.ts) -- `msUntilNextDigest()`, daily timer
 
 **Deduplication layers**:
 1. Backend: `opportunity_deliveries` table prevents re-delivering the same opportunity at the same status
@@ -67,102 +66,70 @@ Root causes:
 
 4. **The LLM ignores the "no output" instruction**: The prompt says "produce absolutely no output" for rejections, but the model narrates its reasoning. With `deliver: true`, all of it goes to Telegram.
 
-## Proposed architecture: agent-driven notification with separate delivery
+## Proposed architecture
 
 ```mermaid
 flowchart TD
-    Sched["Scheduler (5 min)"] --> DigestCheck
-    DigestCheck{"Within digest quiet window?"} -->|"yes"| Skip["Skip -- digest is imminent"]
-    DigestCheck -->|"no"| Poll
+    Sched["Scheduler (5 min)"] --> Poll
     Poll["Poller: fetch pending opps"] --> Diff
     Diff{"new IDs not in seenSet?"} -->|"none"| NoOp["No-op (no LLM cost)"]
     Diff -->|"1+ new"| Cap
-    Cap{"Hard daily cap exceeded?"} -->|"yes"| MarkSeen["Mark seen, digest handles rest"]
+    Cap{"Daily cap exceeded?"} -->|"yes"| MarkSeen["Mark seen, digest handles rest"]
     Cap -->|"no"| Evaluate
-    Evaluate["Evaluator subagent (deliver: false)"] --> Confirmed
-    Confirmed["Re-fetch pending, diff to find confirmed IDs"] --> Any
-    Any{"any confirmed?"} -->|"no"| Done["Mark all seen, no delivery"]
-    Any -->|"yes"| Deliver["dispatchDelivery per confirmed opp (deliver: true, pre-rendered)"]
+    Evaluate["Evaluator subagent (deliver: false)"] --> Deliver
+    Deliver["Aggregate all new opps into one message"] --> Dispatch["dispatchDelivery (deliver: true, pre-rendered)"]
+    Dispatch --> Mark["Mark all as seen, persist to file"]
 ```
+
+Two subagent runs per cycle, each with a distinct job:
+
+1. **Evaluator** (`deliver: false`): runs silently, calls `confirm_opportunity_delivery` for worthy opportunities (ledger cleanup -- confirmed ones won't appear in future polls or digest). Verbose LLM text is discarded.
+2. **Delivery** (`deliver: true`): relays all new opportunities as one aggregated, pre-rendered message. Uses the existing `dispatchDelivery` with the simple "relay faithfully" prompt. No LLM evaluation, no narration risk.
 
 ### Layer 1 -- Poller (cheap, no LLM)
 
-Replace batch hash with a **`seenOpportunityIds` set**, persisted to a file so it survives restarts.
+Replace batch hash with a **`seenOpportunityIds` set**, persisted to a JSON file so it survives restarts.
 
 - Maintain `Set<string>` of all IDs the poller has fetched (reset daily)
 - `newOpps = fetched.filter(id => !seenSet.has(id))`
 - If empty: no-op, no LLM cost
-- If non-empty: pass to agent with context
-- After agent runs (or cap blocks): add all IDs to seen set and persist to file
+- If non-empty: evaluate + deliver
+- After processing: add all IDs to seen set and persist to file
 - On startup: load seen set from file (if same date)
 
-### Layer 2 -- Agent evaluates silently (deliver: false)
+### Layer 2 -- Evaluator (deliver: false, ledger only)
 
-The evaluator subagent runs with **`deliver: false`**. Its verbose text output (reasoning, rejections, etc.) never reaches the user.
+The evaluator subagent runs silently. Its text output never reaches the user.
 
-The agent's job:
-1. Call `read_intents` and `read_user_profiles` to ground itself
-2. Evaluate each new opportunity against the user's profile and intents
-3. For each opportunity worth surfacing: call `confirm_opportunity_delivery`
-4. For everything else: do nothing
-
-The agent also receives **decision context** so it can make timing decisions:
+The agent receives **decision context** to make informed calls:
 - **Deliveries so far today**: how many notifications already sent today
 - **Time since last notification**: minutes since the last ambient delivery
 - **Time of day**: so it can avoid notifying at odd hours
 - **Total pending count**: how many opportunities are waiting
 
-The prompt tells the agent:
+The agent's job:
+1. Call `read_intents` and `read_user_profiles` to ground itself
+2. Evaluate each new opportunity against the user's profile and intents
+3. For each opportunity worth surfacing: call `confirm_opportunity_delivery` (this removes it from the pending list, so the digest won't re-surface it)
+4. For everything else: do nothing (stays pending, digest will show it)
 
-> You are the user's notification gatekeeper. You run silently -- your text output is NOT delivered to the user.
->
-> You decide:
-> 1. **Whether** any of these new opportunities are worth notifying the user right now
-> 2. For each one you approve: call `confirm_opportunity_delivery` with its opportunityId
->
-> Consider:
-> - Is this genuinely valuable, or noise?
-> - Have you already notified recently? Is this urgent enough to interrupt again?
-> - Would this be better left for the daily digest?
-> - Is it a reasonable time to notify?
->
-> Call `confirm_opportunity_delivery` ONLY for opportunities worth an immediate notification.
-> Everything else will appear in the user's daily digest.
+The evaluator curates the **ledger** -- it decides what disappears from pending (handled by ambient) vs. what stays for the daily digest to highlight.
 
-### Layer 3 -- Aggregated delivery (one message per evaluation cycle)
+### Layer 3 -- Aggregated delivery (deliver: true, pre-rendered)
 
-After the evaluator subagent completes (`await subagent.run()` resolves):
+After the evaluator completes, the poller delivers **all new opportunities** as one aggregated message via `dispatchDelivery()`. No re-fetch needed.
 
-1. Re-fetch `/api/agents/{id}/opportunities/pending`
-2. Compare: IDs that were in `newOpps` but are no longer pending = confirmed by the evaluator
-3. Aggregate all confirmed opportunities into a **single delivery message** and dispatch once via `dispatchDelivery()`
+The pre-rendered cards come from the Index Network backend (headline, personalizedSummary, suggestedAction). They're already curated -- only opportunities that passed backend-level filtering (status, actor match, visibility) appear in the pending list.
 
-If the evaluator confirms 3 opportunities, the user gets **one** Telegram message containing all 3 -- not 3 separate notifications.
-
-`dispatchDelivery` already exists in `delivery.dispatcher.ts`. It uses `deliveryPrompt` ("Relay faithfully, don't add commentary") with `deliver: true`. The delivery subagent gets pre-authored content, not open-ended evaluation -- so there's no risk of verbose narration.
-
-**Why this is safe**: Even if the evaluator LLM goes rogue and produces paragraphs of text, that text never reaches the user because `deliver: false`. Only the pre-rendered cards from the Index Network backend reach the user.
-
-**Why the re-fetch is needed**: `SubagentRunResult` only returns `{ runId }` -- no output text, no list of confirmed IDs. The only way to detect the evaluator's decisions is by checking what `confirm_opportunity_delivery` removed from the pending list. This is a single lightweight GET to the backend. A future improvement could add a dedicated endpoint (e.g., `GET /opportunities/recently-confirmed`) to avoid the full pending re-fetch.
+One evaluation cycle = one Telegram message, regardless of how many new opportunities appeared.
 
 ### Layer 4 -- System safety net (hard cap only)
 
 The only system-level gate is a **hard daily cap** (configurable, default **5**).
 
 - Tracked in the poller, persisted alongside seen IDs
-- If cap exceeded: mark IDs as seen, skip agent entirely, digest handles them
-- No cooldown timer, no system-level throttling -- timing is the agent's job
-
-### Daily digest -- independent, with quiet window
-
-The daily digest is a **separate, independent evaluation** of the day's overall important opportunities. It does NOT depend on what ambient already delivered.
-
-- The digest evaluates ALL pending opportunities, not just undelivered ones
-- It presents the day's highlights as an overview summary
-- Ambient discovery pauses during a **quiet window** around digest time (configurable, e.g., 30 min before and after)
-- This prevents the user getting an ambient notification right before/after a digest
-
-The ambient scheduler checks if the current time falls within the quiet window. If so, it skips the poll entirely.
+- If cap exceeded: mark IDs as seen, skip both evaluator and delivery, digest handles them
+- No cooldown timer, no system-level throttling
 
 ## Implementation
 
@@ -203,49 +170,38 @@ if (deliveriesToday >= maxDaily) {
 
 Store `{ date, seenIds, deliveriesToday, lastDeliveryTimestamp }` in a JSON file. Load on startup. Implementation detail (file location, write strategy) left to implementer.
 
-### 3. Two-step evaluate + aggregated deliver
+### 3. Evaluate silently + deliver all new opps
 
 ```typescript
-// Step 1: Evaluator runs silently
+// Step 1: Evaluator runs silently -- curates the ledger
 await api.runtime.subagent.run({
   sessionKey,
   idempotencyKey: `index:eval:opportunity-batch:${config.agentId}:${dateStr}:${evalHash}`,
   message: opportunityEvaluatorPrompt(newOpps, decisionContext),
-  deliver: false,  // <-- verbose text never reaches user
+  deliver: false,
   model,
 });
 
-// Step 2: Re-fetch to find what the evaluator confirmed
-const afterRes = await fetch(pendingUrl, { headers, signal });
-const afterBody = await afterRes.json();
-const stillPendingIds = new Set(afterBody.opportunities.map(o => o.opportunityId));
-const confirmedOpps = newOpps.filter(o => !stillPendingIds.has(o.opportunityId));
+// Step 2: Deliver all new opportunities as one aggregated message
+const aggregatedBody = newOpps
+  .map(o => `**${o.headline}**\n${o.personalizedSummary}\n→ ${o.suggestedAction}`)
+  .join('\n\n');
 
-// Step 3: Aggregate confirmed into a single delivery message
-if (confirmedOpps.length > 0) {
-  const aggregatedBody = confirmedOpps
-    .map(o => `**${o.headline}**\n${o.personalizedSummary}\n→ ${o.suggestedAction}`)
-    .join('\n\n');
+await dispatchDelivery(api, {
+  rendered: {
+    headline: newOpps.length === 1
+      ? newOpps[0].headline
+      : `${newOpps.length} new connections`,
+    body: aggregatedBody,
+  },
+  idempotencyKey: `index:delivery:ambient:${config.agentId}:${dateStr}:${evalHash}`,
+});
 
-  await dispatchDelivery(api, {
-    rendered: {
-      headline: confirmedOpps.length === 1
-        ? confirmedOpps[0].headline
-        : `${confirmedOpps.length} new connections`,
-      body: aggregatedBody,
-    },
-    idempotencyKey: `index:delivery:ambient:${config.agentId}:${dateStr}:${evalHash}`,
-  });
-
-  deliveriesToday++;
-  lastDeliveryTimestamp = Date.now();
-}
-
-// Mark all as seen regardless of confirmation outcome
+// Update state
 for (const id of allIds) seenOpportunityIds.add(id);
+deliveriesToday++;
+lastDeliveryTimestamp = Date.now();
 ```
-
-Note: the re-fetch (step 2) is needed because `SubagentRunResult` only returns `{ runId }` -- there's no way to read the evaluator's output or get a list of confirmed IDs. The re-fetch is a single lightweight GET. A future optimization could add a backend endpoint like `GET /opportunities/recently-confirmed?since=<timestamp>` to avoid the full pending re-fetch.
 
 ### 4. Decision context for the evaluator prompt
 
@@ -264,10 +220,10 @@ opportunityEvaluatorPrompt(newOpps, {
 
 In `opportunity-evaluator.prompt.ts`:
 
-- Agent role: "You are the user's notification gatekeeper. You run silently."
+- Agent role: "You run silently. Your text output is discarded."
 - Provide decision context (deliveries today, time since last, time of day, etc.)
-- Agent calls `confirm_opportunity_delivery` for winners -- that's the only signal
-- No output formatting needed (deliver: false means text is discarded)
+- Agent calls `confirm_opportunity_delivery` for worthy opportunities -- this is ledger management, not delivery gating
+- Opportunities the agent confirms are removed from the pending list (handled). Unconfirmed ones stay pending for the daily digest.
 
 ### 6. Change `handle()` return type
 
@@ -278,40 +234,14 @@ Return `'no_new' | 'dispatched' | 'error'` instead of boolean.
 - `'error'` -> `increaseBackoff`
 - `'dispatched'` or `'no_new'` -> leave interval as-is (no reset to 5 min)
 
-### 8. Digest quiet window
-
-In the ambient scheduler or poller, skip the poll if current time is within `digestQuietMinutes` (default 30) of the configured `digestTime`:
-
-```typescript
-function isInDigestQuietWindow(digestTime: string, quietMinutes: number): boolean {
-  const now = new Date();
-  const [h, m] = digestTime.split(':').map(Number);
-  const digestMinuteOfDay = h * 60 + m;
-  const nowMinuteOfDay = now.getHours() * 60 + now.getMinutes();
-  const diff = Math.abs(nowMinuteOfDay - digestMinuteOfDay);
-  return Math.min(diff, 1440 - diff) <= quietMinutes;
-}
-```
-
-### 9. Make daily digest independent
-
-In `daily-digest.poller.ts` / `digest-evaluator.prompt.ts`:
-
-- The digest should show the day's overall important stuff regardless of what ambient already delivered
-- Prompt the digest agent to produce a summary of the day's highlights, including opportunities that were already notified via ambient
-- This means the digest does NOT filter by `opportunity_deliveries` -- it re-evaluates all pending opportunities from scratch
-
-### 10. Add config to `openclaw.plugin.json`
+### 8. Add config to `openclaw.plugin.json`
 
 - `ambientMaxDaily` (default `"5"`) -- hard daily cap, safety net only
 
 ## Files to change
 
 - `packages/openclaw-plugin/src/polling/ambient-discovery/ambient-discovery.poller.ts` -- seen-IDs set (persisted), daily cap, two-step evaluate+deliver, new return type
-- `packages/openclaw-plugin/src/polling/ambient-discovery/opportunity-evaluator.prompt.ts` -- full redesign: silent gatekeeper with decision context
-- `packages/openclaw-plugin/src/index.ts` -- fix backoff for new return type, pass digest config to ambient scheduler
-- `packages/openclaw-plugin/src/polling/ambient-discovery/ambient-discovery.scheduler.ts` -- add digest quiet window check
-- `packages/openclaw-plugin/src/polling/daily-digest/daily-digest.poller.ts` -- make digest independent of delivery ledger
-- `packages/openclaw-plugin/src/polling/daily-digest/digest-evaluator.prompt.ts` -- redesign as day's highlights summary
+- `packages/openclaw-plugin/src/polling/ambient-discovery/opportunity-evaluator.prompt.ts` -- redesign: silent ledger curator with decision context
+- `packages/openclaw-plugin/src/index.ts` -- fix backoff for new return type
 - `packages/openclaw-plugin/openclaw.plugin.json` -- add `ambientMaxDaily`
 - `packages/openclaw-plugin/src/tests/opportunity-batch.spec.ts` -- update tests for new behavior

--- a/docs/superpowers/plans/2026-04-22-ambient-discovery-spam-fix.md
+++ b/docs/superpowers/plans/2026-04-22-ambient-discovery-spam-fix.md
@@ -5,135 +5,133 @@
 ```mermaid
 sequenceDiagram
     participant Sched as Scheduler Timer
-    participant Route as HTTP Route Handler
     participant Poller as ambient-discovery.poller
     participant Backend as Index Network Backend
     participant Subagent as OpenClaw Subagent
     participant Telegram as Telegram Chat
 
     Note over Sched: Plugin boot -> first trigger at 5s
-    Sched->>Route: POST /poll/ambient-discovery (every 5m * backoff)
-    Route->>Poller: handle(api, config)
+    Sched->>Poller: POST /poll/ambient-discovery (every 5m * backoff)
     Poller->>Backend: GET /api/agents/{id}/opportunities/pending (max 20)
     Backend-->>Poller: { opportunities: [...] }
 
-    alt No opportunities / no delivery config / batch hash unchanged
-        Poller-->>Route: return false
-        Route->>Sched: increaseBackoff() 5m->10m->20m->40m->80m
-    else New batch of candidates
+    alt No opportunities / batch hash unchanged
+        Poller->>Sched: increaseBackoff() 5m->10m->...->80m
+    else Batch changed
         Poller->>Subagent: subagent.run({deliver:true, message:evaluatorPrompt})
-        Subagent->>Subagent: LLM calls read_intents + read_user_profiles
-        Subagent->>Subagent: LLM evaluates each candidate
-        Subagent->>Backend: confirm_opportunity_delivery(id) per surfaced opp
-        Subagent->>Telegram: ALL output text delivered to user
-        Poller-->>Route: return true
-        Route->>Sched: resetBackoff() -> back to 5 min
+        Subagent->>Subagent: LLM evaluates all 20 candidates
+        Subagent->>Telegram: ALL text output delivered (including rejection reasoning)
+        Poller->>Sched: resetBackoff() -> back to 5 min
     end
 ```
 
-**Timing**: Base interval 5 min. Backoff doubles on `false` return (5m->10m->...->80m max). Resets to 5 min after successful dispatch.
+**Problem**: 6 messages in 10 minutes. Most are the LLM narrating its rejection reasoning. Batch hash dedup is too coarse (one new opp re-evaluates all 20). Backoff resets to 5 min after sending. No daily cap.
 
 **Key files**:
-- Scheduler: [`ambient-discovery.scheduler.ts`](../../packages/openclaw-plugin/src/polling/ambient-discovery/ambient-discovery.scheduler.ts) -- timer loop, backoff logic
-- Poller: [`ambient-discovery.poller.ts`](../../packages/openclaw-plugin/src/polling/ambient-discovery/ambient-discovery.poller.ts) -- fetches pending opps, dedup via batch hash, launches subagent
-- Prompt: [`opportunity-evaluator.prompt.ts`](../../packages/openclaw-plugin/src/polling/ambient-discovery/opportunity-evaluator.prompt.ts) -- LLM instructions for evaluating candidates
-- Route registration: [`index.ts`](../../packages/openclaw-plugin/src/index.ts) (lines 175-201) -- wires scheduler result to backoff/reset
-- Backend filter: [`opportunity-delivery.service.ts`](../../backend/src/services/opportunity-delivery.service.ts) (lines 290-353) -- SQL query for pending candidates, LIMIT 20, dedup via `opportunity_deliveries` ledger
-- Config: [`openclaw.plugin.json`](../../packages/openclaw-plugin/openclaw.plugin.json) -- plugin config schema
-- Delivery dispatcher: [`delivery.dispatcher.ts`](../../packages/openclaw-plugin/src/lib/delivery/delivery.dispatcher.ts) -- builds session key, dispatches pre-rendered cards via `deliver: true`
-- Delivery prompt: [`delivery.prompt.ts`](../../packages/openclaw-plugin/src/lib/delivery/delivery.prompt.ts) -- simple relay prompt: "deliver faithfully, don't add commentary"
+- [`ambient-discovery.scheduler.ts`](../../packages/openclaw-plugin/src/polling/ambient-discovery/ambient-discovery.scheduler.ts) -- timer, backoff
+- [`ambient-discovery.poller.ts`](../../packages/openclaw-plugin/src/polling/ambient-discovery/ambient-discovery.poller.ts) -- fetch, dedup, launch subagent
+- [`opportunity-evaluator.prompt.ts`](../../packages/openclaw-plugin/src/polling/ambient-discovery/opportunity-evaluator.prompt.ts) -- LLM instructions
+- [`index.ts`](../../packages/openclaw-plugin/src/index.ts) (lines 175-201) -- route handler, backoff wiring
+- [`delivery.dispatcher.ts`](../../packages/openclaw-plugin/src/lib/delivery/delivery.dispatcher.ts) -- dispatches pre-rendered cards
+- [`openclaw.plugin.json`](../../packages/openclaw-plugin/openclaw.plugin.json) -- plugin config schema
 
-**Deduplication layers**:
-1. Backend: `opportunity_deliveries` table prevents re-delivering the same opportunity at the same status
-2. Poller: `lastOpportunityBatchHash` skips subagent if the set of opportunity IDs hasn't changed
-3. Subagent: `idempotencyKey` per `agentId:date:batchHash` prevents duplicate subagent runs
-
-**What the LLM is told**: Evaluate candidates against user's intents/profile. Call `confirm_opportunity_delivery` for winners. Format as bold headline + summary for Telegram. "If no opportunity passes the bar: produce absolutely no output and call no tools."
-
-**What actually happens**: The LLM narrates its entire evaluation process (which candidates it rejected and why), and `deliver: true` sends all of that text straight to Telegram. After a successful dispatch, backoff resets to 5 min, so the next poll fires quickly, finds a slightly changed batch, and the cycle repeats.
-
-## Problem diagnosis
-
-The plugin sent **6 messages in ~10 minutes** (18:16-18:24). Most of them are the LLM "thinking out loud" about why candidates were rejected.
-
-Root causes:
-
-1. **Agent runs on every poll, not just new opportunities**: The batch hash dedup only catches "exact same set of IDs." If one new opp appears, the entire batch (up to 20) is re-evaluated from scratch, re-triggering LLM reasoning about already-seen candidates.
-
-2. **No separation between evaluation and delivery**: The subagent both evaluates AND delivers in one step with `deliver: true`. There's no system gate between the agent's decision and the user's notification.
-
-3. **Backoff logic is inverted**: Successful dispatch resets to 5 min (aggressive). Benign no-ops increase backoff (relaxed). Exactly backwards.
-
-4. **The LLM ignores the "no output" instruction**: The prompt says "produce absolutely no output" for rejections, but the model narrates its reasoning. With `deliver: true`, all of it goes to Telegram.
-
-## Proposed architecture
+## Proposed flow
 
 ```mermaid
 flowchart TD
-    Sched["Scheduler (5 min)"] --> Poll
-    Poll["Poller: fetch pending opps"] --> Diff
-    Diff{"new IDs not in seenSet?"} -->|"none"| NoOp["No-op (no LLM cost)"]
+    Sched["Scheduler fires every 5 min"] --> Poll
+    Poll["Fetch pending opps from backend"] --> Load
+    Load["Load seen IDs from file"] --> Diff
+    Diff{"New IDs not in seenSet?"} -->|"none"| NoOp["No-op, no LLM cost"]
     Diff -->|"1+ new"| Cap
-    Cap{"Daily cap exceeded?"} -->|"yes"| MarkSeen["Mark seen, digest handles rest"]
+    Cap{"Hit daily cap of 3?"} -->|"yes"| Wait["Skip — digest handles rest"]
     Cap -->|"no"| Evaluate
-    Evaluate["Evaluator subagent (deliver: false)"] --> Deliver
-    Deliver["Aggregate all new opps into one message"] --> Dispatch["dispatchDelivery (deliver: true, pre-rendered)"]
-    Dispatch --> Mark["Mark all as seen, persist to file"]
+    Evaluate["Evaluator subagent runs silently\n(deliver: false)\nThinks about new opps\nCalls confirm_opportunity_delivery\nfor the ones worth notifying"] --> Refetch
+    Refetch["Re-fetch pending from backend\nCompare: which IDs left the list?"] --> Any
+    Any{"Any confirmed?"} -->|"no"| Done["Nothing worth notifying\nSkipped opps stay unseen\nRe-evaluated next cycle"]
+    Any -->|"yes"| Deliver
+    Deliver["Aggregate confirmed opps\ninto one formatted message"] --> Send
+    Send["Delivery subagent\n(deliver: true)\nRelays the message to Telegram"] --> Persist
+    Persist["Add confirmed IDs to seenSet\nIncrement delivery count\nSave state to file"]
 ```
 
-Two subagent runs per cycle, each with a distinct job:
+### Step by step
 
-1. **Evaluator** (`deliver: false`): runs silently, calls `confirm_opportunity_delivery` for worthy opportunities (ledger cleanup -- confirmed ones won't appear in future polls or digest). Verbose LLM text is discarded.
-2. **Delivery** (`deliver: true`): relays all new opportunities as one aggregated, pre-rendered message. Uses the existing `dispatchDelivery` with the simple "relay faithfully" prompt. No LLM evaluation, no narration risk.
+**1. Scheduler fires every 5 minutes.**
 
-### Layer 1 -- Poller (cheap, no LLM)
+Same as today. On plugin startup, first trigger after 5 seconds.
 
-Replace batch hash with a **`seenOpportunityIds` set**, persisted to a JSON file so it survives restarts.
+**2. Fetch pending opportunities from the backend.**
 
-- Maintain `Set<string>` of all IDs the poller has fetched (reset daily)
-- `newOpps = fetched.filter(id => !seenSet.has(id))`
-- If empty: no-op, no LLM cost
-- If non-empty: evaluate + deliver
-- After processing: add all IDs to seen set and persist to file
-- On startup: load seen set from file (if same date)
+`GET /api/agents/{id}/opportunities/pending` with `x-api-key`. Returns up to 20 opportunities with pre-rendered card data (headline, personalizedSummary, suggestedAction).
 
-### Layer 2 -- Evaluator (deliver: false, ledger only)
+**3. Load seen IDs from file.**
 
-The evaluator subagent runs silently. Its text output never reaches the user.
+Read a persisted JSON file containing the set of opportunity IDs already processed. If the stored date doesn't match today, reset to empty (fresh day). This survives gateway restarts.
 
-The agent receives **decision context** to make informed calls:
-- **Deliveries so far today**: how many notifications already sent today
-- **Time since last notification**: minutes since the last ambient delivery
-- **Time of day**: so it can avoid notifying at odd hours
-- **Total pending count**: how many opportunities are waiting
+**4. Diff: find new opportunities.**
 
-The agent's job:
-1. Call `read_intents` and `read_user_profiles` to ground itself
-2. Evaluate each new opportunity against the user's profile and intents
-3. For each opportunity worth surfacing: call `confirm_opportunity_delivery` (this removes it from the pending list, so the digest won't re-surface it)
-4. For everything else: do nothing (stays pending, digest will show it)
+`newOpps = fetched.filter(id => !seenSet.has(id))`. If everything was already seen, do nothing -- no LLM call, zero cost.
 
-The evaluator curates the **ledger** -- it decides what disappears from pending (handled by ambient) vs. what stays for the daily digest to highlight.
+**5. Check daily cap.**
 
-### Layer 3 -- Aggregated delivery (deliver: true, pre-rendered)
+If 3 evaluator dispatches have already happened today, skip. The new opportunities stay unseen (they'll be picked up by the daily digest or re-evaluated tomorrow).
 
-After the evaluator completes, the poller delivers **all new opportunities** as one aggregated message via `dispatchDelivery()`. No re-fetch needed.
+**6. Evaluator subagent runs silently (`deliver: false`).**
 
-The pre-rendered cards come from the Index Network backend (headline, personalizedSummary, suggestedAction). They're already curated -- only opportunities that passed backend-level filtering (status, actor match, visibility) appear in the pending list.
+The evaluator's text output is discarded -- it never reaches the user. The LLM can think as verbosely as it wants.
 
-One evaluation cycle = one Telegram message, regardless of how many new opportunities appeared.
+The evaluator receives:
+- The new opportunities (only the ones not in the seen set)
+- Decision context: deliveries today, minutes since last delivery, current time, total pending count
 
-### Layer 4 -- System safety net (hard cap only)
+The evaluator's job:
+- Call `read_intents` and `read_user_profiles` to understand the user
+- Think about each new opportunity: is it genuinely valuable? Is this a good time to notify?
+- For each opportunity worth notifying about: call `confirm_opportunity_delivery` with its ID
+- For everything else: do nothing (they stay unseen and get re-evaluated next cycle)
 
-The only system-level gate is a **hard daily cap** (configurable, default **5**).
+**7. Re-fetch pending to detect the evaluator's decisions.**
 
-- Tracked in the poller, persisted alongside seen IDs
-- If cap exceeded: mark IDs as seen, skip both evaluator and delivery, digest handles them
-- No cooldown timer, no system-level throttling
+After the evaluator completes, fetch `/opportunities/pending` again. Compare against the new opportunities: any IDs that were in `newOpps` but are no longer in the pending list were confirmed by the evaluator. This is how the poller discovers which opportunities the agent approved.
+
+**8. If any were confirmed: aggregate into one message.**
+
+Take the confirmed opportunities and format them into a single message using the pre-rendered card data from step 2 (headline, personalizedSummary, suggestedAction). Example:
+
+> **Darlin Alberto — Brooklyn, AI & product** is a local technologist specializing in applied AI and B2B SaaS, based right in Brooklyn.
+> → Connect with Darlin on Index Network.
+>
+> **Zoe Weinberg — Agentic tech investor at ex/ante** is a VC focused on agentic technology and human agency in digital systems.
+> → Connect with Zoe to discuss agentic tech.
+
+**9. Delivery subagent sends to Telegram (`deliver: true`).**
+
+The aggregated message is dispatched via `dispatchDelivery()`, which wraps it in the "relay faithfully, don't add commentary" prompt and sends it through a delivery subagent. The user receives exactly one Telegram notification for this batch.
+
+**10. Persist state to file.**
+
+- Add confirmed IDs to `seenOpportunityIds` (they won't be re-evaluated)
+- Skipped IDs are NOT added to the seen set (they get another chance next cycle)
+- Increment `deliveriesToday`
+- Update `lastDeliveryTimestamp`
+- Write everything to the JSON file
+
+### What happens to skipped opportunities
+
+When the evaluator decides an opportunity isn't worth notifying about right now, it simply doesn't call `confirm_opportunity_delivery` for it. That opportunity:
+- Stays in the backend's pending list
+- Stays outside the `seenOpportunityIds` set
+- Gets re-evaluated next cycle with fresh context (different time of day, different delivery count)
+- Eventually shows up in the daily digest if it's never confirmed
+
+This means the agent can defer an opportunity because of timing ("I already notified twice today, this can wait") and reconsider it later when conditions change.
 
 ## Implementation
 
-### 1. Replace batch hash with seen-IDs set in `ambient-discovery.poller.ts`
+### 1. Seen-IDs set with file persistence
+
+In `ambient-discovery.poller.ts`:
 
 ```typescript
 let seenOpportunityIds = new Set<string>();
@@ -141,89 +139,83 @@ let seenDateStr: string | null = null;
 let deliveriesToday = 0;
 let lastDeliveryTimestamp: number | null = null;
 
-// In handle():
 const today = new Date().toISOString().slice(0, 10);
 if (seenDateStr !== today) {
   seenOpportunityIds = new Set();
   deliveriesToday = 0;
+  lastDeliveryTimestamp = null;
   seenDateStr = today;
 }
 
-const allIds = body.opportunities.map(o => o.opportunityId);
 const newOpps = body.opportunities.filter(o => !seenOpportunityIds.has(o.opportunityId));
+if (newOpps.length === 0) return 'no_new';
 
-if (newOpps.length === 0) {
-  for (const id of allIds) seenOpportunityIds.add(id);
-  return 'no_new';
-}
-
-// Hard daily cap -- safety net only
-const maxDaily = parseInt(readConfig(api, 'ambientMaxDaily') || '5', 10);
-if (deliveriesToday >= maxDaily) {
-  for (const id of allIds) seenOpportunityIds.add(id);
-  api.logger.info('Ambient discovery: daily cap reached, deferring to digest');
-  return 'no_new';
-}
+const maxDaily = parseInt(readConfig(api, 'ambientMaxDaily') || '3', 10);
+if (deliveriesToday >= maxDaily) return 'no_new';
 ```
 
-### 2. Persist seen-IDs to file
+File persistence: store `{ date, seenIds, deliveriesToday, lastDeliveryTimestamp }` in a JSON file. Load on startup. File location left to implementer.
 
-Store `{ date, seenIds, deliveriesToday, lastDeliveryTimestamp }` in a JSON file. Load on startup. Implementation detail (file location, write strategy) left to implementer.
-
-### 3. Evaluate silently + deliver all new opps
+### 2. Silent evaluator subagent
 
 ```typescript
-// Step 1: Evaluator runs silently -- curates the ledger
 await api.runtime.subagent.run({
   sessionKey,
-  idempotencyKey: `index:eval:opportunity-batch:${config.agentId}:${dateStr}:${evalHash}`,
-  message: opportunityEvaluatorPrompt(newOpps, decisionContext),
+  idempotencyKey: `index:eval:ambient:${config.agentId}:${dateStr}:${evalHash}`,
+  message: opportunityEvaluatorPrompt(newOpps, {
+    deliveriesToday,
+    minutesSinceLastDelivery: lastDeliveryTimestamp
+      ? Math.round((Date.now() - lastDeliveryTimestamp) / 60_000)
+      : null,
+    totalPendingCount: body.opportunities.length,
+    currentTime: new Date().toLocaleTimeString(),
+  }),
   deliver: false,
   model,
 });
-
-// Step 2: Deliver all new opportunities as one aggregated message
-const aggregatedBody = newOpps
-  .map(o => `**${o.headline}**\n${o.personalizedSummary}\n→ ${o.suggestedAction}`)
-  .join('\n\n');
-
-await dispatchDelivery(api, {
-  rendered: {
-    headline: newOpps.length === 1
-      ? newOpps[0].headline
-      : `${newOpps.length} new connections`,
-    body: aggregatedBody,
-  },
-  idempotencyKey: `index:delivery:ambient:${config.agentId}:${dateStr}:${evalHash}`,
-});
-
-// Update state
-for (const id of allIds) seenOpportunityIds.add(id);
-deliveriesToday++;
-lastDeliveryTimestamp = Date.now();
 ```
 
-### 4. Decision context for the evaluator prompt
+### 3. Re-fetch and diff
 
 ```typescript
-opportunityEvaluatorPrompt(newOpps, {
-  deliveriesToday,
-  minutesSinceLastDelivery: lastDeliveryTimestamp
-    ? Math.round((Date.now() - lastDeliveryTimestamp) / 60_000)
-    : null,
-  totalPendingCount: body.opportunities.length,
-  currentTime: new Date().toLocaleTimeString(),
-});
+const afterRes = await fetch(pendingUrl, { headers, signal });
+const afterBody = await afterRes.json();
+const stillPendingIds = new Set(afterBody.opportunities.map(o => o.opportunityId));
+const confirmedOpps = newOpps.filter(o => !stillPendingIds.has(o.opportunityId));
+```
+
+### 4. Aggregated delivery
+
+```typescript
+if (confirmedOpps.length > 0) {
+  const aggregatedBody = confirmedOpps
+    .map(o => `**${o.headline}**\n${o.personalizedSummary}\n→ ${o.suggestedAction}`)
+    .join('\n\n');
+
+  await dispatchDelivery(api, {
+    rendered: {
+      headline: confirmedOpps.length === 1
+        ? confirmedOpps[0].headline
+        : `${confirmedOpps.length} new connections`,
+      body: aggregatedBody,
+    },
+    idempotencyKey: `index:delivery:ambient:${config.agentId}:${dateStr}:${evalHash}`,
+  });
+
+  for (const opp of confirmedOpps) seenOpportunityIds.add(opp.opportunityId);
+  deliveriesToday++;
+  lastDeliveryTimestamp = Date.now();
+  // persist to file
+}
 ```
 
 ### 5. Redesign the evaluator prompt
 
-In `opportunity-evaluator.prompt.ts`:
-
-- Agent role: "You run silently. Your text output is discarded."
-- Provide decision context (deliveries today, time since last, time of day, etc.)
-- Agent calls `confirm_opportunity_delivery` for worthy opportunities -- this is ledger management, not delivery gating
-- Opportunities the agent confirms are removed from the pending list (handled). Unconfirmed ones stay pending for the daily digest.
+The evaluator runs silently. Its prompt should:
+- Explain its role: "You evaluate opportunities silently. Your text output is discarded."
+- Provide decision context (deliveries today, time since last, time of day, total pending)
+- Instruct: "Call `confirm_opportunity_delivery` for each opportunity worth an immediate notification. Everything you don't confirm stays pending and will be re-evaluated later or included in the daily digest."
+- List allowed opportunity IDs (injection hardening)
 
 ### 6. Change `handle()` return type
 
@@ -231,17 +223,20 @@ Return `'no_new' | 'dispatched' | 'error'` instead of boolean.
 
 ### 7. Fix backoff in route handler
 
-- `'error'` -> `increaseBackoff`
-- `'dispatched'` or `'no_new'` -> leave interval as-is (no reset to 5 min)
+In `index.ts`:
+- `'error'` → `increaseBackoff`
+- `'dispatched'` or `'no_new'` → leave interval as-is (don't reset to 5 min)
 
 ### 8. Add config to `openclaw.plugin.json`
 
-- `ambientMaxDaily` (default `"5"`) -- hard daily cap, safety net only
+- `ambientMaxDaily` (default `"3"`) -- hard daily cap
 
 ## Files to change
 
-- `packages/openclaw-plugin/src/polling/ambient-discovery/ambient-discovery.poller.ts` -- seen-IDs set (persisted), daily cap, two-step evaluate+deliver, new return type
-- `packages/openclaw-plugin/src/polling/ambient-discovery/opportunity-evaluator.prompt.ts` -- redesign: silent ledger curator with decision context
-- `packages/openclaw-plugin/src/index.ts` -- fix backoff for new return type
-- `packages/openclaw-plugin/openclaw.plugin.json` -- add `ambientMaxDaily`
-- `packages/openclaw-plugin/src/tests/opportunity-batch.spec.ts` -- update tests for new behavior
+| File | What changes |
+|------|-------------|
+| `packages/openclaw-plugin/src/polling/ambient-discovery/ambient-discovery.poller.ts` | Seen-IDs set (persisted), daily cap, two-step evaluate+deliver, re-fetch diff, new return type |
+| `packages/openclaw-plugin/src/polling/ambient-discovery/opportunity-evaluator.prompt.ts` | Redesign: silent evaluator with decision context |
+| `packages/openclaw-plugin/src/index.ts` | Fix backoff for new return type |
+| `packages/openclaw-plugin/openclaw.plugin.json` | Add `ambientMaxDaily` |
+| `packages/openclaw-plugin/src/tests/opportunity-batch.spec.ts` | Update tests |

--- a/docs/superpowers/plans/2026-04-22-ambient-discovery-spam-fix.md
+++ b/docs/superpowers/plans/2026-04-22-ambient-discovery-spam-fix.md
@@ -40,6 +40,9 @@ sequenceDiagram
 - Route registration: [`index.ts`](../../packages/openclaw-plugin/src/index.ts) (lines 175-201) -- wires scheduler result to backoff/reset
 - Backend filter: [`opportunity-delivery.service.ts`](../../backend/src/services/opportunity-delivery.service.ts) (lines 290-353) -- SQL query for pending candidates, LIMIT 20, dedup via `opportunity_deliveries` ledger
 - Config: [`openclaw.plugin.json`](../../packages/openclaw-plugin/openclaw.plugin.json) -- plugin config schema
+- Delivery dispatcher: [`delivery.dispatcher.ts`](../../packages/openclaw-plugin/src/lib/delivery/delivery.dispatcher.ts) -- builds session key, dispatches pre-rendered cards via `deliver: true`
+- Delivery prompt: [`delivery.prompt.ts`](../../packages/openclaw-plugin/src/lib/delivery/delivery.prompt.ts) -- simple relay prompt: "deliver faithfully, don't add commentary"
+- Digest scheduler: [`daily-digest.scheduler.ts`](../../packages/openclaw-plugin/src/polling/daily-digest/daily-digest.scheduler.ts) -- `msUntilNextDigest()`, daily timer
 
 **Deduplication layers**:
 1. Backend: `opportunity_deliveries` table prevents re-delivering the same opportunity at the same status
@@ -64,71 +67,98 @@ Root causes:
 
 4. **The LLM ignores the "no output" instruction**: The prompt says "produce absolutely no output" for rejections, but the model narrates its reasoning. With `deliver: true`, all of it goes to Telegram.
 
-## Proposed architecture: agent-driven notification
+## Proposed architecture: agent-driven notification with separate delivery
 
 ```mermaid
 flowchart TD
-    Sched["Scheduler (5 min)"] --> Poll
+    Sched["Scheduler (5 min)"] --> DigestCheck
+    DigestCheck{"Within digest quiet window?"} -->|"yes"| Skip["Skip -- digest is imminent"]
+    DigestCheck -->|"no"| Poll
     Poll["Poller: fetch pending opps"] --> Diff
     Diff{"new IDs not in seenSet?"} -->|"none"| NoOp["No-op (no LLM cost)"]
     Diff -->|"1+ new"| Cap
-    Cap{"Hard daily cap exceeded?"} -->|"yes"| Block["Skip -- digest handles rest"]
-    Cap -->|"no"| Agent
-    Agent["Agent gets: new opps + context"] --> Decision
-    Decision{"agent decision"} -->|"notify now"| Deliver["Output delivered to Telegram"]
-    Decision -->|"skip / not worth it"| Silent["No output, no notification"]
+    Cap{"Hard daily cap exceeded?"} -->|"yes"| MarkSeen["Mark seen, digest handles rest"]
+    Cap -->|"no"| Evaluate
+    Evaluate["Evaluator subagent (deliver: false)"] --> Confirmed
+    Confirmed["Re-fetch pending, diff to find confirmed IDs"] --> Any
+    Any{"any confirmed?"} -->|"no"| Done["Mark all seen, no delivery"]
+    Any -->|"yes"| Deliver["dispatchDelivery per confirmed opp (deliver: true, pre-rendered)"]
 ```
 
 ### Layer 1 -- Poller (cheap, no LLM)
 
-Replace batch hash with a **`seenOpportunityIds` set**. Each opportunity is seen by the agent exactly once.
+Replace batch hash with a **`seenOpportunityIds` set**, persisted to a file so it survives restarts.
 
 - Maintain `Set<string>` of all IDs the poller has fetched (reset daily)
 - `newOpps = fetched.filter(id => !seenSet.has(id))`
 - If empty: no-op, no LLM cost
 - If non-empty: pass to agent with context
-- After agent runs (or cap blocks): add all IDs to seen set
+- After agent runs (or cap blocks): add all IDs to seen set and persist to file
+- On startup: load seen set from file (if same date)
 
-### Layer 2 -- Agent (full decision authority)
+### Layer 2 -- Agent evaluates silently (deliver: false)
 
-The agent receives not just the new opportunities, but **decision context** so it can make an informed call:
+The evaluator subagent runs with **`deliver: false`**. Its verbose text output (reasoning, rejections, etc.) never reaches the user.
 
-- **New opportunities** to evaluate (only the unseen ones)
+The agent's job:
+1. Call `read_intents` and `read_user_profiles` to ground itself
+2. Evaluate each new opportunity against the user's profile and intents
+3. For each opportunity worth surfacing: call `confirm_opportunity_delivery`
+4. For everything else: do nothing
+
+The agent also receives **decision context** so it can make timing decisions:
 - **Deliveries so far today**: how many notifications already sent today
 - **Time since last notification**: minutes since the last ambient delivery
 - **Time of day**: so it can avoid notifying at odd hours
-- **Total pending count**: how many opportunities are waiting (gives a sense of volume)
+- **Total pending count**: how many opportunities are waiting
 
 The prompt tells the agent:
 
-> You are the user's notification gatekeeper. Your output goes directly to their messaging app.
+> You are the user's notification gatekeeper. You run silently -- your text output is NOT delivered to the user.
 >
 > You decide:
-> 1. **Whether** any of these new opportunities are worth a notification right now
-> 2. **How** to present them (concise, Telegram-friendly)
+> 1. **Whether** any of these new opportunities are worth notifying the user right now
+> 2. For each one you approve: call `confirm_opportunity_delivery` with its opportunityId
 >
 > Consider:
 > - Is this genuinely valuable, or noise?
-> - Have you already notified recently? If so, is this urgent enough to interrupt again?
-> - Would this be better batched into the daily digest?
+> - Have you already notified recently? Is this urgent enough to interrupt again?
+> - Would this be better left for the daily digest?
 > - Is it a reasonable time to notify?
 >
-> If you decide to notify: call `confirm_opportunity_delivery` for each surfaced opportunity, then output the message.
-> If you decide NOT to notify: produce exactly zero tokens of output. No explanation, no reasoning, nothing.
+> Call `confirm_opportunity_delivery` ONLY for opportunities worth an immediate notification.
+> Everything else will appear in the user's daily digest.
 
-This means the agent can:
-- Surface a perfect match immediately even if one was sent 10 minutes ago
-- Hold back a "decent but not urgent" match because the user was already notified recently
-- Batch 3 new opportunities into one message instead of sending 3 separate notifications
-- Decide "it's 2am, this can wait" based on the time context
+### Layer 3 -- Separate delivery (deliver: true, pre-rendered)
 
-### Layer 3 -- System safety net (hard cap only)
+After the evaluator subagent completes (`await subagent.run()` resolves):
 
-The only system-level gate is a **hard daily cap** (configurable, default 10). This is a safety net, not a policy -- it only fires if the agent is being unreasonably chatty.
+1. Re-fetch `/api/agents/{id}/opportunities/pending`
+2. Compare: IDs that were in `newOpps` but are no longer pending = confirmed by the evaluator
+3. For each confirmed opportunity, dispatch via `dispatchDelivery()` using the **pre-rendered card data** already in memory from the initial fetch
 
-- Tracked in the poller: `deliveriesToday` counter, resets when the date changes
-- If cap exceeded: skip the agent entirely, add IDs to seen set (digest will handle them)
-- No cooldown timer, no system-level throttling -- that's the agent's job
+`dispatchDelivery` already exists in `delivery.dispatcher.ts`. It uses `deliveryPrompt` ("Relay faithfully, don't add commentary") with `deliver: true`. The delivery subagent gets pre-authored content, not open-ended evaluation -- so there's no risk of verbose narration.
+
+**Why this is safe**: Even if the evaluator LLM goes rogue and produces paragraphs of text, that text never reaches the user because `deliver: false`. Only the pre-rendered cards from the Index Network backend reach the user.
+
+### Layer 4 -- System safety net (hard cap only)
+
+The only system-level gate is a **hard daily cap** (configurable, default **5**).
+
+- Tracked in the poller, persisted alongside seen IDs
+- If cap exceeded: mark IDs as seen, skip agent entirely, digest handles them
+- No cooldown timer, no system-level throttling -- timing is the agent's job
+
+### Daily digest -- independent, with quiet window
+
+The daily digest is a **separate, independent evaluation** of the day's overall important opportunities. It does NOT depend on what ambient already delivered.
+
+- The digest evaluates ALL pending opportunities, not just undelivered ones
+- It presents the day's highlights as an overview summary
+- Ambient discovery pauses during a **quiet window** around digest time (configurable, e.g., 30 min before and after)
+- This prevents the user getting an ambient notification right before/after a digest
+
+The ambient scheduler checks if the current time falls within the quiet window. If so, it skips the poll entirely.
 
 ## Implementation
 
@@ -157,7 +187,7 @@ if (newOpps.length === 0) {
 }
 
 // Hard daily cap -- safety net only
-const maxDaily = parseInt(readConfig(api, 'ambientMaxDaily') || '10', 10);
+const maxDaily = parseInt(readConfig(api, 'ambientMaxDaily') || '5', 10);
 if (deliveriesToday >= maxDaily) {
   for (const id of allIds) seenOpportunityIds.add(id);
   api.logger.info('Ambient discovery: daily cap reached, deferring to digest');
@@ -165,9 +195,45 @@ if (deliveriesToday >= maxDaily) {
 }
 ```
 
-### 2. Pass decision context to the agent
+### 2. Persist seen-IDs to file
 
-Build the evaluator prompt with context the agent needs to make timing decisions:
+Store `{ date, seenIds, deliveriesToday, lastDeliveryTimestamp }` in a JSON file. Load on startup. Implementation detail (file location, write strategy) left to implementer.
+
+### 3. Two-step evaluate + deliver
+
+```typescript
+// Step 1: Evaluator runs silently
+await api.runtime.subagent.run({
+  sessionKey,
+  idempotencyKey: `index:eval:opportunity-batch:${config.agentId}:${dateStr}:${evalHash}`,
+  message: opportunityEvaluatorPrompt(newOpps, decisionContext),
+  deliver: false,  // <-- verbose text never reaches user
+  model,
+});
+
+// Step 2: Re-fetch to find what the evaluator confirmed
+const afterRes = await fetch(pendingUrl, { headers, signal });
+const afterBody = await afterRes.json();
+const stillPendingIds = new Set(afterBody.opportunities.map(o => o.opportunityId));
+const confirmedOpps = newOpps.filter(o => !stillPendingIds.has(o.opportunityId));
+
+// Step 3: Deliver confirmed ones using pre-rendered cards
+for (const opp of confirmedOpps) {
+  await dispatchDelivery(api, {
+    rendered: { headline: opp.headline, body: opp.personalizedSummary },
+    idempotencyKey: `index:delivery:ambient:${opp.opportunityId}`,
+  });
+}
+
+// Update state
+for (const id of allIds) seenOpportunityIds.add(id);
+if (confirmedOpps.length > 0) {
+  deliveriesToday += confirmedOpps.length;
+  lastDeliveryTimestamp = Date.now();
+}
+```
+
+### 4. Decision context for the evaluator prompt
 
 ```typescript
 opportunityEvaluatorPrompt(newOpps, {
@@ -180,36 +246,58 @@ opportunityEvaluatorPrompt(newOpps, {
 });
 ```
 
-After successful dispatch: `deliveriesToday++`, `lastDeliveryTimestamp = Date.now()`.
-
-### 3. Redesign the evaluator prompt
+### 5. Redesign the evaluator prompt
 
 In `opportunity-evaluator.prompt.ts`:
 
-- Give the agent its role: "You are the user's notification gatekeeper"
-- Provide decision context (deliveries today, time since last, etc.)
-- Let it decide whether to notify, not just what to notify
-- Keep the hard rule: "If you decide not to notify: produce exactly zero tokens"
-- Keep the `confirm_opportunity_delivery` call requirement for winners
+- Agent role: "You are the user's notification gatekeeper. You run silently."
+- Provide decision context (deliveries today, time since last, time of day, etc.)
+- Agent calls `confirm_opportunity_delivery` for winners -- that's the only signal
+- No output formatting needed (deliver: false means text is discarded)
 
-### 4. Change `handle()` return type
+### 6. Change `handle()` return type
 
 Return `'no_new' | 'dispatched' | 'error'` instead of boolean.
 
-### 5. Fix backoff in route handler
+### 7. Fix backoff in route handler
 
 - `'error'` -> `increaseBackoff`
 - `'dispatched'` or `'no_new'` -> leave interval as-is (no reset to 5 min)
 
-### 6. Add config to `openclaw.plugin.json`
+### 8. Digest quiet window
 
-- `ambientMaxDaily` (default `"10"`) -- hard daily cap, safety net only
+In the ambient scheduler or poller, skip the poll if current time is within `digestQuietMinutes` (default 30) of the configured `digestTime`:
+
+```typescript
+function isInDigestQuietWindow(digestTime: string, quietMinutes: number): boolean {
+  const now = new Date();
+  const [h, m] = digestTime.split(':').map(Number);
+  const digestMinuteOfDay = h * 60 + m;
+  const nowMinuteOfDay = now.getHours() * 60 + now.getMinutes();
+  const diff = Math.abs(nowMinuteOfDay - digestMinuteOfDay);
+  return Math.min(diff, 1440 - diff) <= quietMinutes;
+}
+```
+
+### 9. Make daily digest independent
+
+In `daily-digest.poller.ts` / `digest-evaluator.prompt.ts`:
+
+- The digest should show the day's overall important stuff regardless of what ambient already delivered
+- Prompt the digest agent to produce a summary of the day's highlights, including opportunities that were already notified via ambient
+- This means the digest does NOT filter by `opportunity_deliveries` -- it re-evaluates all pending opportunities from scratch
+
+### 10. Add config to `openclaw.plugin.json`
+
+- `ambientMaxDaily` (default `"5"`) -- hard daily cap, safety net only
 
 ## Files to change
 
-- `packages/openclaw-plugin/src/polling/ambient-discovery/ambient-discovery.poller.ts` -- seen-IDs set, daily cap, context passing, new return type
-- `packages/openclaw-plugin/src/polling/ambient-discovery/opportunity-evaluator.prompt.ts` -- full redesign: agent as gatekeeper with decision context
-- `packages/openclaw-plugin/src/index.ts` -- fix backoff for new return type
-- `packages/openclaw-plugin/src/polling/ambient-discovery/ambient-discovery.scheduler.ts` -- minor: remove `resetBackoff` export if unused
+- `packages/openclaw-plugin/src/polling/ambient-discovery/ambient-discovery.poller.ts` -- seen-IDs set (persisted), daily cap, two-step evaluate+deliver, new return type
+- `packages/openclaw-plugin/src/polling/ambient-discovery/opportunity-evaluator.prompt.ts` -- full redesign: silent gatekeeper with decision context
+- `packages/openclaw-plugin/src/index.ts` -- fix backoff for new return type, pass digest config to ambient scheduler
+- `packages/openclaw-plugin/src/polling/ambient-discovery/ambient-discovery.scheduler.ts` -- add digest quiet window check
+- `packages/openclaw-plugin/src/polling/daily-digest/daily-digest.poller.ts` -- make digest independent of delivery ledger
+- `packages/openclaw-plugin/src/polling/daily-digest/digest-evaluator.prompt.ts` -- redesign as day's highlights summary
 - `packages/openclaw-plugin/openclaw.plugin.json` -- add `ambientMaxDaily`
 - `packages/openclaw-plugin/src/tests/opportunity-batch.spec.ts` -- update tests for new behavior

--- a/docs/superpowers/plans/2026-04-22-ambient-discovery-spam-fix.md
+++ b/docs/superpowers/plans/2026-04-22-ambient-discovery-spam-fix.md
@@ -1,0 +1,215 @@
+# Reduce Ambient Discovery Message Spam
+
+## Current status (how it works today)
+
+```mermaid
+sequenceDiagram
+    participant Sched as Scheduler Timer
+    participant Route as HTTP Route Handler
+    participant Poller as ambient-discovery.poller
+    participant Backend as Index Network Backend
+    participant Subagent as OpenClaw Subagent
+    participant Telegram as Telegram Chat
+
+    Note over Sched: Plugin boot -> first trigger at 5s
+    Sched->>Route: POST /poll/ambient-discovery (every 5m * backoff)
+    Route->>Poller: handle(api, config)
+    Poller->>Backend: GET /api/agents/{id}/opportunities/pending (max 20)
+    Backend-->>Poller: { opportunities: [...] }
+
+    alt No opportunities / no delivery config / batch hash unchanged
+        Poller-->>Route: return false
+        Route->>Sched: increaseBackoff() 5m->10m->20m->40m->80m
+    else New batch of candidates
+        Poller->>Subagent: subagent.run({deliver:true, message:evaluatorPrompt})
+        Subagent->>Subagent: LLM calls read_intents + read_user_profiles
+        Subagent->>Subagent: LLM evaluates each candidate
+        Subagent->>Backend: confirm_opportunity_delivery(id) per surfaced opp
+        Subagent->>Telegram: ALL output text delivered to user
+        Poller-->>Route: return true
+        Route->>Sched: resetBackoff() -> back to 5 min
+    end
+```
+
+**Timing**: Base interval 5 min. Backoff doubles on `false` return (5m->10m->...->80m max). Resets to 5 min after successful dispatch.
+
+**Key files**:
+- Scheduler: [`ambient-discovery.scheduler.ts`](../../packages/openclaw-plugin/src/polling/ambient-discovery/ambient-discovery.scheduler.ts) -- timer loop, backoff logic
+- Poller: [`ambient-discovery.poller.ts`](../../packages/openclaw-plugin/src/polling/ambient-discovery/ambient-discovery.poller.ts) -- fetches pending opps, dedup via batch hash, launches subagent
+- Prompt: [`opportunity-evaluator.prompt.ts`](../../packages/openclaw-plugin/src/polling/ambient-discovery/opportunity-evaluator.prompt.ts) -- LLM instructions for evaluating candidates
+- Route registration: [`index.ts`](../../packages/openclaw-plugin/src/index.ts) (lines 175-201) -- wires scheduler result to backoff/reset
+- Backend filter: [`opportunity-delivery.service.ts`](../../backend/src/services/opportunity-delivery.service.ts) (lines 290-353) -- SQL query for pending candidates, LIMIT 20, dedup via `opportunity_deliveries` ledger
+- Config: [`openclaw.plugin.json`](../../packages/openclaw-plugin/openclaw.plugin.json) -- plugin config schema
+
+**Deduplication layers**:
+1. Backend: `opportunity_deliveries` table prevents re-delivering the same opportunity at the same status
+2. Poller: `lastOpportunityBatchHash` skips subagent if the set of opportunity IDs hasn't changed
+3. Subagent: `idempotencyKey` per `agentId:date:batchHash` prevents duplicate subagent runs
+
+**What the LLM is told**: Evaluate candidates against user's intents/profile. Call `confirm_opportunity_delivery` for winners. Format as bold headline + summary for Telegram. "If no opportunity passes the bar: produce absolutely no output and call no tools."
+
+**What actually happens**: The LLM narrates its entire evaluation process (which candidates it rejected and why), and `deliver: true` sends all of that text straight to Telegram. After a successful dispatch, backoff resets to 5 min, so the next poll fires quickly, finds a slightly changed batch, and the cycle repeats.
+
+## Problem diagnosis
+
+The plugin sent **6 messages in ~10 minutes** (18:16-18:24). Most of them are the LLM "thinking out loud" about why candidates were rejected.
+
+Root causes:
+
+1. **Agent runs on every poll, not just new opportunities**: The batch hash dedup only catches "exact same set of IDs." If one new opp appears, the entire batch (up to 20) is re-evaluated from scratch, re-triggering LLM reasoning about already-seen candidates.
+
+2. **No separation between evaluation and delivery**: The subagent both evaluates AND delivers in one step with `deliver: true`. There's no system gate between the agent's decision and the user's notification.
+
+3. **Backoff logic is inverted**: Successful dispatch resets to 5 min (aggressive). Benign no-ops increase backoff (relaxed). Exactly backwards.
+
+4. **The LLM ignores the "no output" instruction**: The prompt says "produce absolutely no output" for rejections, but the model narrates its reasoning. With `deliver: true`, all of it goes to Telegram.
+
+## Proposed architecture: agent-driven notification
+
+```mermaid
+flowchart TD
+    Sched["Scheduler (5 min)"] --> Poll
+    Poll["Poller: fetch pending opps"] --> Diff
+    Diff{"new IDs not in seenSet?"} -->|"none"| NoOp["No-op (no LLM cost)"]
+    Diff -->|"1+ new"| Cap
+    Cap{"Hard daily cap exceeded?"} -->|"yes"| Block["Skip -- digest handles rest"]
+    Cap -->|"no"| Agent
+    Agent["Agent gets: new opps + context"] --> Decision
+    Decision{"agent decision"} -->|"notify now"| Deliver["Output delivered to Telegram"]
+    Decision -->|"skip / not worth it"| Silent["No output, no notification"]
+```
+
+### Layer 1 -- Poller (cheap, no LLM)
+
+Replace batch hash with a **`seenOpportunityIds` set**. Each opportunity is seen by the agent exactly once.
+
+- Maintain `Set<string>` of all IDs the poller has fetched (reset daily)
+- `newOpps = fetched.filter(id => !seenSet.has(id))`
+- If empty: no-op, no LLM cost
+- If non-empty: pass to agent with context
+- After agent runs (or cap blocks): add all IDs to seen set
+
+### Layer 2 -- Agent (full decision authority)
+
+The agent receives not just the new opportunities, but **decision context** so it can make an informed call:
+
+- **New opportunities** to evaluate (only the unseen ones)
+- **Deliveries so far today**: how many notifications already sent today
+- **Time since last notification**: minutes since the last ambient delivery
+- **Time of day**: so it can avoid notifying at odd hours
+- **Total pending count**: how many opportunities are waiting (gives a sense of volume)
+
+The prompt tells the agent:
+
+> You are the user's notification gatekeeper. Your output goes directly to their messaging app.
+>
+> You decide:
+> 1. **Whether** any of these new opportunities are worth a notification right now
+> 2. **How** to present them (concise, Telegram-friendly)
+>
+> Consider:
+> - Is this genuinely valuable, or noise?
+> - Have you already notified recently? If so, is this urgent enough to interrupt again?
+> - Would this be better batched into the daily digest?
+> - Is it a reasonable time to notify?
+>
+> If you decide to notify: call `confirm_opportunity_delivery` for each surfaced opportunity, then output the message.
+> If you decide NOT to notify: produce exactly zero tokens of output. No explanation, no reasoning, nothing.
+
+This means the agent can:
+- Surface a perfect match immediately even if one was sent 10 minutes ago
+- Hold back a "decent but not urgent" match because the user was already notified recently
+- Batch 3 new opportunities into one message instead of sending 3 separate notifications
+- Decide "it's 2am, this can wait" based on the time context
+
+### Layer 3 -- System safety net (hard cap only)
+
+The only system-level gate is a **hard daily cap** (configurable, default 10). This is a safety net, not a policy -- it only fires if the agent is being unreasonably chatty.
+
+- Tracked in the poller: `deliveriesToday` counter, resets when the date changes
+- If cap exceeded: skip the agent entirely, add IDs to seen set (digest will handle them)
+- No cooldown timer, no system-level throttling -- that's the agent's job
+
+## Implementation
+
+### 1. Replace batch hash with seen-IDs set in `ambient-discovery.poller.ts`
+
+```typescript
+let seenOpportunityIds = new Set<string>();
+let seenDateStr: string | null = null;
+let deliveriesToday = 0;
+let lastDeliveryTimestamp: number | null = null;
+
+// In handle():
+const today = new Date().toISOString().slice(0, 10);
+if (seenDateStr !== today) {
+  seenOpportunityIds = new Set();
+  deliveriesToday = 0;
+  seenDateStr = today;
+}
+
+const allIds = body.opportunities.map(o => o.opportunityId);
+const newOpps = body.opportunities.filter(o => !seenOpportunityIds.has(o.opportunityId));
+
+if (newOpps.length === 0) {
+  for (const id of allIds) seenOpportunityIds.add(id);
+  return 'no_new';
+}
+
+// Hard daily cap -- safety net only
+const maxDaily = parseInt(readConfig(api, 'ambientMaxDaily') || '10', 10);
+if (deliveriesToday >= maxDaily) {
+  for (const id of allIds) seenOpportunityIds.add(id);
+  api.logger.info('Ambient discovery: daily cap reached, deferring to digest');
+  return 'no_new';
+}
+```
+
+### 2. Pass decision context to the agent
+
+Build the evaluator prompt with context the agent needs to make timing decisions:
+
+```typescript
+opportunityEvaluatorPrompt(newOpps, {
+  deliveriesToday,
+  minutesSinceLastDelivery: lastDeliveryTimestamp
+    ? Math.round((Date.now() - lastDeliveryTimestamp) / 60_000)
+    : null,
+  totalPendingCount: body.opportunities.length,
+  currentTime: new Date().toLocaleTimeString(),
+});
+```
+
+After successful dispatch: `deliveriesToday++`, `lastDeliveryTimestamp = Date.now()`.
+
+### 3. Redesign the evaluator prompt
+
+In `opportunity-evaluator.prompt.ts`:
+
+- Give the agent its role: "You are the user's notification gatekeeper"
+- Provide decision context (deliveries today, time since last, etc.)
+- Let it decide whether to notify, not just what to notify
+- Keep the hard rule: "If you decide not to notify: produce exactly zero tokens"
+- Keep the `confirm_opportunity_delivery` call requirement for winners
+
+### 4. Change `handle()` return type
+
+Return `'no_new' | 'dispatched' | 'error'` instead of boolean.
+
+### 5. Fix backoff in route handler
+
+- `'error'` -> `increaseBackoff`
+- `'dispatched'` or `'no_new'` -> leave interval as-is (no reset to 5 min)
+
+### 6. Add config to `openclaw.plugin.json`
+
+- `ambientMaxDaily` (default `"10"`) -- hard daily cap, safety net only
+
+## Files to change
+
+- `packages/openclaw-plugin/src/polling/ambient-discovery/ambient-discovery.poller.ts` -- seen-IDs set, daily cap, context passing, new return type
+- `packages/openclaw-plugin/src/polling/ambient-discovery/opportunity-evaluator.prompt.ts` -- full redesign: agent as gatekeeper with decision context
+- `packages/openclaw-plugin/src/index.ts` -- fix backoff for new return type
+- `packages/openclaw-plugin/src/polling/ambient-discovery/ambient-discovery.scheduler.ts` -- minor: remove `resetBackoff` export if unused
+- `packages/openclaw-plugin/openclaw.plugin.json` -- add `ambientMaxDaily`
+- `packages/openclaw-plugin/src/tests/opportunity-batch.spec.ts` -- update tests for new behavior

--- a/docs/superpowers/plans/2026-04-22-ambient-discovery-spam-fix.md
+++ b/docs/superpowers/plans/2026-04-22-ambient-discovery-spam-fix.md
@@ -129,17 +129,21 @@ The prompt tells the agent:
 > Call `confirm_opportunity_delivery` ONLY for opportunities worth an immediate notification.
 > Everything else will appear in the user's daily digest.
 
-### Layer 3 -- Separate delivery (deliver: true, pre-rendered)
+### Layer 3 -- Aggregated delivery (one message per evaluation cycle)
 
 After the evaluator subagent completes (`await subagent.run()` resolves):
 
 1. Re-fetch `/api/agents/{id}/opportunities/pending`
 2. Compare: IDs that were in `newOpps` but are no longer pending = confirmed by the evaluator
-3. For each confirmed opportunity, dispatch via `dispatchDelivery()` using the **pre-rendered card data** already in memory from the initial fetch
+3. Aggregate all confirmed opportunities into a **single delivery message** and dispatch once via `dispatchDelivery()`
+
+If the evaluator confirms 3 opportunities, the user gets **one** Telegram message containing all 3 -- not 3 separate notifications.
 
 `dispatchDelivery` already exists in `delivery.dispatcher.ts`. It uses `deliveryPrompt` ("Relay faithfully, don't add commentary") with `deliver: true`. The delivery subagent gets pre-authored content, not open-ended evaluation -- so there's no risk of verbose narration.
 
 **Why this is safe**: Even if the evaluator LLM goes rogue and produces paragraphs of text, that text never reaches the user because `deliver: false`. Only the pre-rendered cards from the Index Network backend reach the user.
+
+**Why the re-fetch is needed**: `SubagentRunResult` only returns `{ runId }` -- no output text, no list of confirmed IDs. The only way to detect the evaluator's decisions is by checking what `confirm_opportunity_delivery` removed from the pending list. This is a single lightweight GET to the backend. A future improvement could add a dedicated endpoint (e.g., `GET /opportunities/recently-confirmed`) to avoid the full pending re-fetch.
 
 ### Layer 4 -- System safety net (hard cap only)
 
@@ -199,7 +203,7 @@ if (deliveriesToday >= maxDaily) {
 
 Store `{ date, seenIds, deliveriesToday, lastDeliveryTimestamp }` in a JSON file. Load on startup. Implementation detail (file location, write strategy) left to implementer.
 
-### 3. Two-step evaluate + deliver
+### 3. Two-step evaluate + aggregated deliver
 
 ```typescript
 // Step 1: Evaluator runs silently
@@ -217,21 +221,31 @@ const afterBody = await afterRes.json();
 const stillPendingIds = new Set(afterBody.opportunities.map(o => o.opportunityId));
 const confirmedOpps = newOpps.filter(o => !stillPendingIds.has(o.opportunityId));
 
-// Step 3: Deliver confirmed ones using pre-rendered cards
-for (const opp of confirmedOpps) {
-  await dispatchDelivery(api, {
-    rendered: { headline: opp.headline, body: opp.personalizedSummary },
-    idempotencyKey: `index:delivery:ambient:${opp.opportunityId}`,
-  });
-}
-
-// Update state
-for (const id of allIds) seenOpportunityIds.add(id);
+// Step 3: Aggregate confirmed into a single delivery message
 if (confirmedOpps.length > 0) {
-  deliveriesToday += confirmedOpps.length;
+  const aggregatedBody = confirmedOpps
+    .map(o => `**${o.headline}**\n${o.personalizedSummary}\n→ ${o.suggestedAction}`)
+    .join('\n\n');
+
+  await dispatchDelivery(api, {
+    rendered: {
+      headline: confirmedOpps.length === 1
+        ? confirmedOpps[0].headline
+        : `${confirmedOpps.length} new connections`,
+      body: aggregatedBody,
+    },
+    idempotencyKey: `index:delivery:ambient:${config.agentId}:${dateStr}:${evalHash}`,
+  });
+
+  deliveriesToday++;
   lastDeliveryTimestamp = Date.now();
 }
+
+// Mark all as seen regardless of confirmation outcome
+for (const id of allIds) seenOpportunityIds.add(id);
 ```
+
+Note: the re-fetch (step 2) is needed because `SubagentRunResult` only returns `{ runId }` -- there's no way to read the evaluator's output or get a list of confirmed IDs. The re-fetch is a single lightweight GET. A future optimization could add a backend endpoint like `GET /opportunities/recently-confirmed?since=<timestamp>` to avoid the full pending re-fetch.
 
 ### 4. Decision context for the evaluator prompt
 


### PR DESCRIPTION
## Problem

Ambient discovery spams Telegram -- 6 messages in 10 minutes, most of which are the LLM narrating its rejection reasoning. Root causes: `deliver: true` sends ALL text to user, batch hash dedup re-evaluates 20 candidates when 1 changes, backoff resets to 5 min after sending, no daily cap.

## Proposed flow

```mermaid
flowchart TD
    Sched["Scheduler fires every 5 min"] --> Poll
    Poll["Fetch pending opps from backend"] --> Load
    Load["Load seen IDs from file"] --> Diff
    Diff{"New IDs not in seenSet?"} -->|"none"| NoOp["No-op, no LLM cost"]
    Diff -->|"1+ new"| Cap
    Cap{"Hit daily cap of 3?"} -->|"yes"| Wait["Skip — digest handles rest"]
    Cap -->|"no"| Evaluate
    Evaluate["Evaluator subagent runs silently\n(deliver: false)\nThinks about new opps\nCalls confirm_opportunity_delivery\nfor the ones worth notifying"] --> Refetch
    Refetch["Re-fetch pending from backend\nCompare: which IDs left the list?"] --> Any
    Any{"Any confirmed?"} -->|"no"| Done["Nothing worth notifying\nSkipped opps stay unseen\nRe-evaluated next cycle"]
    Any -->|"yes"| Deliver
    Deliver["Aggregate confirmed opps\ninto one formatted message"] --> Send
    Send["Delivery subagent\n(deliver: true)\nRelays the message to Telegram"] --> Persist
    Persist["Add confirmed IDs to seenSet\nIncrement delivery count\nSave state to file"]
```

**Two subagents per cycle:**
1. **Evaluator** (`deliver: false`): thinks silently about new opportunities. Gets decision context (deliveries today, time since last, time of day). Calls `confirm_opportunity_delivery` for opps worth notifying. Verbose text is discarded.
2. **Delivery** (`deliver: true`): relays confirmed opps as one aggregated message via `dispatchDelivery`. Pre-rendered content, no narration risk.

**Key behaviors:**
- Each opportunity enters the pipeline only when it's genuinely new (seen-IDs set, persisted to file)
- Agent decides what's worth notifying -- if it skips an opportunity, it stays unseen and gets re-evaluated next cycle with fresh context
- One Telegram notification per cycle, aggregating all confirmed opps
- Hard daily cap of 3
- Backoff only on errors, not on successful dispatch

Full plan: [`docs/superpowers/plans/2026-04-22-ambient-discovery-spam-fix.md`](docs/superpowers/plans/2026-04-22-ambient-discovery-spam-fix.md)

## Files to change

| File | What changes |
|------|-------------|
| `ambient-discovery.poller.ts` | Seen-IDs (persisted), daily cap, two-step evaluate+deliver, re-fetch diff, new return type |
| `opportunity-evaluator.prompt.ts` | Silent evaluator with decision context |
| `index.ts` | Fix backoff for new return type |
| `openclaw.plugin.json` | Add `ambientMaxDaily` |
| `opportunity-batch.spec.ts` | Update tests |

## For @yanekyuk

Yours to implement however you see fit. The plan doc has step-by-step flow, code snippets, and rationale. Hard constraints:

1. Seen-IDs tracking, **persisted to file**
2. Evaluator with **`deliver: false`** -- agent thinks silently, signals via `confirm_opportunity_delivery`
3. Re-fetch to detect decisions, then **aggregated delivery** via `dispatchDelivery`
4. **Skipped opps stay unseen** for re-evaluation next cycle
5. Daily cap of **3**
6. Fix backoff: only increase on errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added plan documentation for reducing ambient discovery message spam, including implementation of daily message limits and improved opportunity filtering to minimize repeated notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->