### PR TITLE
fix(mcp): sanitize raw DB errors from tool catch blocks

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "0.20.4",
+  "version": "0.20.5",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/agent/agent.tools.ts
+++ b/packages/protocol/src/agent/agent.tools.ts
@@ -2,6 +2,9 @@ import { z } from 'zod';
 
 import type { DefineTool, ToolDeps } from '../shared/agent/tool.helpers.js';
 import { error, success } from '../shared/agent/tool.helpers.js';
+import { protocolLogger } from '../shared/observability/protocol.logger.js';
+
+const logger = protocolLogger('AgentTools');
 
 const AGENT_ACTIONS = [
   'manage:profile',
@@ -121,7 +124,8 @@ export function createAgentTools(defineTool: DefineTool, deps: ToolDeps) {
           agent: sanitizeAgentForOutput(fullAgent ?? ({ ...agent, transports: [], permissions: [] })),
         });
       } catch (err) {
-        return error(`Failed to register agent: ${err instanceof Error ? err.message : String(err)}`);
+        logger.error('Failed to register agent', { err });
+        return error('Failed to register agent. Please try again.');
       }
     },
   });
@@ -141,7 +145,8 @@ export function createAgentTools(defineTool: DefineTool, deps: ToolDeps) {
           count: filteredAgents.length,
         });
       } catch (err) {
-        return error(`Failed to list agents: ${err instanceof Error ? err.message : String(err)}`);
+        logger.error('Failed to list agents', { err });
+        return error('Failed to list agents. Please try again.');
       }
     },
   });
@@ -201,7 +206,8 @@ export function createAgentTools(defineTool: DefineTool, deps: ToolDeps) {
           agent: sanitizeAgentForOutput(fullAgent ?? ({ ...updated, transports: [], permissions: [] })),
         });
       } catch (err) {
-        return error(`Failed to update agent: ${err instanceof Error ? err.message : String(err)}`);
+        logger.error('Failed to update agent', { err });
+        return error('Failed to update agent. Please try again.');
       }
     },
   });
@@ -230,7 +236,8 @@ export function createAgentTools(defineTool: DefineTool, deps: ToolDeps) {
         await agentDb.deleteAgent(query.agent_id);
         return success({ message: `Agent "${agent.name}" deleted.` });
       } catch (err) {
-        return error(`Failed to delete agent: ${err instanceof Error ? err.message : String(err)}`);
+        logger.error('Failed to delete agent', { err });
+        return error('Failed to delete agent. Please try again.');
       }
     },
   });
@@ -282,7 +289,8 @@ export function createAgentTools(defineTool: DefineTool, deps: ToolDeps) {
 
         return success({ message: 'Permission granted.', permission });
       } catch (err) {
-        return error(`Failed to grant permission: ${err instanceof Error ? err.message : String(err)}`);
+        logger.error('Failed to grant permission', { err });
+        return error('Failed to grant permission. Please try again.');
       }
     },
   });
@@ -314,7 +322,8 @@ export function createAgentTools(defineTool: DefineTool, deps: ToolDeps) {
         await agentDb.revokePermission(query.permission_id);
         return success({ message: 'Permission revoked.' });
       } catch (err) {
-        return error(`Failed to revoke permission: ${err instanceof Error ? err.message : String(err)}`);
+        logger.error('Failed to revoke permission', { err });
+        return error('Failed to revoke permission. Please try again.');
       }
     },
   });

--- a/packages/protocol/src/contact/contact.tools.ts
+++ b/packages/protocol/src/contact/contact.tools.ts
@@ -1,6 +1,9 @@
 import { z } from 'zod';
 import type { DefineTool, ToolDeps } from '../shared/agent/tool.helpers.js';
 import { success, error } from '../shared/agent/tool.helpers.js';
+import { protocolLogger } from '../shared/observability/protocol.logger.js';
+
+const logger = protocolLogger('ContactTools');
 
 /**
  * Creates contact management tools for the chat agent.
@@ -41,7 +44,8 @@ export function createContactTools(defineTool: DefineTool, deps: ToolDeps) {
           existingContacts: result.existingContacts,
         });
       } catch (err) {
-        return error(`Failed to import contacts: ${err instanceof Error ? err.message : String(err)}`);
+        logger.error('Failed to import contacts', { err });
+        return error('Failed to import contacts. Please try again.');
       }
     },
   });
@@ -78,7 +82,8 @@ export function createContactTools(defineTool: DefineTool, deps: ToolDeps) {
           })),
         });
       } catch (err) {
-        return error(`Failed to list contacts: ${err instanceof Error ? err.message : String(err)}`);
+        logger.error('Failed to list contacts', { err });
+        return error('Failed to list contacts. Please try again.');
       }
     },
   });
@@ -111,7 +116,8 @@ export function createContactTools(defineTool: DefineTool, deps: ToolDeps) {
           isNewGhost: result.isNew,
         });
       } catch (err) {
-        return error(`Failed to add contact: ${err instanceof Error ? err.message : String(err)}`);
+        logger.error('Failed to add contact', { err });
+        return error('Failed to add contact. Please try again.');
       }
     },
   });
@@ -133,7 +139,8 @@ export function createContactTools(defineTool: DefineTool, deps: ToolDeps) {
         await contactService.removeContact(context.userId, query.contactUserId);
         return success({ removed: true, message: 'Contact removed from your network.' });
       } catch (err) {
-        return error(`Failed to remove contact: ${err instanceof Error ? err.message : String(err)}`);
+        logger.error('Failed to remove contact', { err });
+        return error('Failed to remove contact. Please try again.');
       }
     },
   });
@@ -164,7 +171,8 @@ export function createContactTools(defineTool: DefineTool, deps: ToolDeps) {
           })),
         });
       } catch (err) {
-        return error(`Failed to search contacts: ${err instanceof Error ? err.message : String(err)}`);
+        logger.error('Failed to search contacts', { err });
+        return error('Failed to search contacts. Please try again.');
       }
     },
   });

--- a/packages/protocol/src/integration/integration.tools.ts
+++ b/packages/protocol/src/integration/integration.tools.ts
@@ -2,9 +2,9 @@ import { z } from 'zod';
 import type { DefineTool, ToolDeps } from '../shared/agent/tool.helpers.js';
 import { success, error } from '../shared/agent/tool.helpers.js';
 import { requestContext } from "../shared/observability/request-context.js";
-import { log } from '../shared/observability/log.js';
+import { protocolLogger } from '../shared/observability/protocol.logger.js';
 
-const logger = log.lib.from('integration.tools');
+const logger = protocolLogger('IntegrationTools');
 
 /**
  * Creates integration tools for the chat agent.
@@ -78,7 +78,7 @@ export function createIntegrationTools(defineTool: DefineTool, deps: ToolDeps) {
       } catch (err) {
         logger.error('import_gmail_contacts failed', {
           userId: context.userId,
-          error: err instanceof Error ? err.message : String(err),
+          err,
         });
         return error('Failed to import Gmail contacts. Please try again.');
       }

--- a/packages/protocol/src/integration/integration.tools.ts
+++ b/packages/protocol/src/integration/integration.tools.ts
@@ -80,7 +80,7 @@ export function createIntegrationTools(defineTool: DefineTool, deps: ToolDeps) {
           userId: context.userId,
           error: err instanceof Error ? err.message : String(err),
         });
-        return error(`Failed to import Gmail contacts: ${err instanceof Error ? err.message : String(err)}`);
+        return error('Failed to import Gmail contacts. Please try again.');
       }
     },
   });

--- a/packages/protocol/src/negotiation/negotiation.tools.ts
+++ b/packages/protocol/src/negotiation/negotiation.tools.ts
@@ -123,7 +123,8 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
           negotiations: filtered,
         });
       } catch (err) {
-        return error(`Failed to list negotiations: ${err instanceof Error ? err.message : String(err)}`);
+        logger.error('Failed to list negotiations', { err });
+        return error('Failed to list negotiations. Please try again.');
       }
     },
   });
@@ -267,7 +268,8 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
           updatedAt: task.updatedAt,
         });
       } catch (err) {
-        return error(`Failed to get negotiation: ${err instanceof Error ? err.message : String(err)}`);
+        logger.error('Failed to get negotiation', { err });
+        return error('Failed to get negotiation. Please try again.');
       }
     },
   });
@@ -687,7 +689,8 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
           counterpartyResponse: { action: aiTurn.action, reasoning: aiTurn.assessment.reasoning, message: aiTurn.message ?? null },
         });
       } catch (err) {
-        return error(`Failed to respond to negotiation: ${err instanceof Error ? err.message : String(err)}`);
+        logger.error('Failed to respond to negotiation', { err });
+        return error('Failed to respond to negotiation. Please try again.');
       }
     },
   });

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -919,7 +919,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
 
       const cardDataList: Array<ReturnType<typeof buildMinimalOpportunityCard>> = [];
       const seenOpportunityIds = new Set<string>();
-      const skippedCards: Array<{ opportunityId: string; error: string }> = [];
+      const skippedIds: string[] = [];
 
       for (const opp of opportunities) {
         if (seenOpportunityIds.has(opp.id)) continue;
@@ -990,31 +990,30 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
 
           cardDataList.push(cardData);
         } catch (err) {
-          const errMsg = err instanceof Error ? err.message : String(err);
           logger.warn("Skipping opportunity that failed to build minimal card", {
             opportunityId: opp.id,
-            error: errMsg,
+            err,
           });
-          skippedCards.push({ opportunityId: opp.id, error: errMsg });
+          skippedIds.push(opp.id);
           continue;
         }
       }
 
       const listDebugSteps: Array<{ step: string; detail?: string; data?: Record<string, unknown> }> = [];
-      if (skippedCards.length > 0) {
+      if (skippedIds.length > 0) {
         listDebugSteps.push({
           step: "card_build_errors",
-          detail: `${skippedCards.length} opportunity card(s) failed to build`,
+          detail: `${skippedIds.length} opportunity card(s) failed to build`,
           data: {
-            skippedCount: skippedCards.length,
+            skippedCount: skippedIds.length,
             totalOpportunities: opportunities.length,
-            errors: skippedCards,
+            skippedOpportunityIds: skippedIds,
           },
         });
       }
 
       if (cardDataList.length === 0) {
-        if (skippedCards.length > 0) {
+        if (skippedIds.length > 0) {
           return success({
             found: false,
             count: 0,

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -1168,7 +1168,8 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         });
         return success({ status: result });
       } catch (err) {
-        return error(err instanceof Error ? err.message : String(err));
+        logger.error('Failed to confirm opportunity delivery', { err });
+        return error('Failed to confirm opportunity delivery. Please try again.');
       }
     },
   });


### PR DESCRIPTION
## Summary
- Raw PostgreSQL query strings, table/column names, and parameter values were being forwarded directly to MCP clients via `err.message` in tool catch blocks — confirmed during MCP validation testing via `grant_agent_permission`
- Replaced all 10 bare `err.message` forwards in `agent.tools`, `contact.tools`, `negotiation.tools`, and `opportunity.tools` with generic user-facing messages
- Real errors are now logged server-side via `protocolLogger` (also adds the logger to `agent.tools` and `contact.tools`, which previously had no server-side error logging)

## Note
The `grant_agent_permission` failure on the dev server is a separate issue: migration `0057_unique_agent_permissions_global` needs to be applied to the deployed dev DB (`bun run db:migrate`) — the migration file exists and is correct, the DB just hasn't been migrated yet.

## Test Plan
- [ ] `grant_agent_permission` (and other tools) on error now returns a generic message without exposing SQL
- [ ] Actual errors visible in server logs under `AgentTools`, `ContactTools`, `NegotiationTools`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated protocol package version to 0.20.5.

* **Bug Fixes**
  * Standardized error responses across agent, contact, negotiation, and opportunity tools with consistent user-facing messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->