### PR TITLE
feat(cli): add `index negotiation` command with full-stack `--since` filter

### DIFF
--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -6361,7 +6361,7 @@ export class ConversationDatabaseAdapter {
    */
   async getNegotiationsByUser(
     userId: string,
-    opts?: { limit?: number; offset?: number; mutualWithUserId?: string; result?: 'has_opportunity' | 'no_opportunity' | 'in_progress' },
+    opts?: { limit?: number; offset?: number; mutualWithUserId?: string; result?: 'has_opportunity' | 'no_opportunity' | 'in_progress'; since?: Date },
   ): Promise<Array<Task & { artifact: Artifact | null }>> {
     const limit = opts?.limit ?? 10;
     const offset = opts?.offset ?? 0;
@@ -6396,6 +6396,13 @@ export class ConversationDatabaseAdapter {
           ? and(isNull(schema.artifacts.id), inArray(schema.tasks.state, ['submitted', 'working', 'input_required']))
           : undefined;
 
+    const sinceFilter = opts?.since
+      ? sql`${schema.tasks.createdAt} >= ${opts.since.toISOString()}`
+      : undefined;
+
+    const allFilters = [userFilter, resultFilter, sinceFilter].filter(Boolean);
+    const combinedFilter = allFilters.length > 1 ? and(...allFilters) : allFilters[0];
+
     const rows = await db
       .select({
         task: schema.tasks,
@@ -6409,7 +6416,7 @@ export class ConversationDatabaseAdapter {
           eq(schema.artifacts.name, 'negotiation-outcome'),
         ),
       )
-      .where(resultFilter ? and(userFilter, resultFilter) : userFilter)
+      .where(combinedFilter)
       .orderBy(desc(schema.tasks.createdAt))
       .limit(limit)
       .offset(offset);

--- a/backend/src/controllers/user.controller.ts
+++ b/backend/src/controllers/user.controller.ts
@@ -220,11 +220,15 @@ export class UserController {
       ? (resultParam as 'has_opportunity' | 'no_opportunity' | 'in_progress')
       : undefined;
 
+    const sinceParam = url.searchParams.get('since');
+    const since = sinceParam ? new Date(sinceParam) : undefined;
+    const validSince = since && !isNaN(since.getTime()) ? since : undefined;
+
     const isSelf = viewer.id === params.userId;
     const mutualWithUserId = isSelf ? undefined : viewer.id;
 
     try {
-      const rows = await this.taskService.getNegotiationsByUser(params.userId, { limit, offset, mutualWithUserId, result });
+      const rows = await this.taskService.getNegotiationsByUser(params.userId, { limit, offset, mutualWithUserId, result, since: validSince });
 
       const taskIds = rows.map((r) => r.id);
       const messagesMap = await this.taskService.getMessagesByTaskIds(taskIds);

--- a/backend/src/controllers/user.controller.ts
+++ b/backend/src/controllers/user.controller.ts
@@ -221,8 +221,13 @@ export class UserController {
       : undefined;
 
     const sinceParam = url.searchParams.get('since');
-    const since = sinceParam ? new Date(sinceParam) : undefined;
-    const validSince = since && !isNaN(since.getTime()) ? since : undefined;
+    if (sinceParam) {
+      const parsed = new Date(sinceParam);
+      if (isNaN(parsed.getTime())) {
+        return Response.json({ error: `Invalid since parameter: "${sinceParam}". Use an ISO 8601 date string.` }, { status: 400 });
+      }
+    }
+    const validSince = sinceParam ? new Date(sinceParam) : undefined;
 
     const isSelf = viewer.id === params.userId;
     const mutualWithUserId = isSelf ? undefined : viewer.id;

--- a/backend/src/services/task.service.ts
+++ b/backend/src/services/task.service.ts
@@ -89,7 +89,7 @@ export class TaskService {
    */
   async getNegotiationsByUser(
     userId: string,
-    opts?: { limit?: number; offset?: number; mutualWithUserId?: string; result?: 'has_opportunity' | 'no_opportunity' | 'in_progress' },
+    opts?: { limit?: number; offset?: number; mutualWithUserId?: string; result?: 'has_opportunity' | 'no_opportunity' | 'in_progress'; since?: Date },
   ) {
     return this.db.getNegotiationsByUser(userId, opts);
   }

--- a/packages/cli/npm/darwin-arm64/package.json
+++ b/packages/cli/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/cli-darwin-arm64",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "description": "Platform-specific binary for @indexnetwork/cli (macOS arm64)",
   "license": "MIT",
   "os": [

--- a/packages/cli/npm/darwin-x64/package.json
+++ b/packages/cli/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/cli-darwin-x64",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "description": "Platform-specific binary for @indexnetwork/cli (macOS x64)",
   "license": "MIT",
   "os": [

--- a/packages/cli/npm/linux-arm64/package.json
+++ b/packages/cli/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/cli-linux-arm64",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "description": "Platform-specific binary for @indexnetwork/cli (Linux arm64)",
   "license": "MIT",
   "os": [

--- a/packages/cli/npm/linux-x64/package.json
+++ b/packages/cli/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/cli-linux-x64",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "description": "Platform-specific binary for @indexnetwork/cli (Linux x64)",
   "license": "MIT",
   "os": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/cli",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "description": "Command-line interface for Index Network",
   "license": "MIT",
   "type": "module",
@@ -20,10 +20,10 @@
     "publish:all": "bun scripts/publish.ts"
   },
   "optionalDependencies": {
-    "@indexnetwork/cli-linux-x64": "0.9.5",
-    "@indexnetwork/cli-linux-arm64": "0.9.5",
-    "@indexnetwork/cli-darwin-x64": "0.9.5",
-    "@indexnetwork/cli-darwin-arm64": "0.9.5"
+    "@indexnetwork/cli-linux-x64": "0.10.0",
+    "@indexnetwork/cli-linux-arm64": "0.10.0",
+    "@indexnetwork/cli-darwin-x64": "0.10.0",
+    "@indexnetwork/cli-darwin-arm64": "0.10.0"
   },
   "devDependencies": {
     "@types/bun": "latest"

--- a/packages/cli/src/api.client.ts
+++ b/packages/cli/src/api.client.ts
@@ -21,6 +21,8 @@ import type {
   AddMemberResult,
   Conversation,
   ConversationMessage,
+  Negotiation,
+  NegotiationListOptions,
   ToolResult,
 } from "./types";
 
@@ -46,6 +48,11 @@ export type {
   Conversation,
   MessagePart,
   ConversationMessage,
+  Negotiation,
+  NegotiationListOptions,
+  NegotiationSpeaker,
+  NegotiationTurn,
+  NegotiationOutcome,
   ToolResult,
 } from "./types";
 
@@ -400,6 +407,30 @@ export class ApiClient {
     }
 
     return res;
+  }
+
+  // ── Negotiation methods ─────────────────────────────────────────
+
+  /**
+   * List negotiations for the authenticated user.
+   *
+   * @param opts - Optional filters (limit, offset).
+   * @returns Array of negotiation objects.
+   * @throws Error on auth failure or network error.
+   */
+  async listNegotiations(opts?: NegotiationListOptions): Promise<Negotiation[]> {
+    const me = await this.getMe();
+    const params = new URLSearchParams();
+    if (opts?.limit) params.set("limit", String(opts.limit));
+    if (opts?.offset) params.set("offset", String(opts.offset));
+    if (opts?.since) params.set("since", opts.since);
+    const qs = params.toString();
+    const path = qs
+      ? `/api/users/${me.id}/negotiations?${qs}`
+      : `/api/users/${me.id}/negotiations`;
+    const res = await this.get(path);
+    const body = (await res.json()) as { negotiations: Negotiation[] };
+    return body.negotiations;
   }
 
   // ── Tool methods ────────────────────────────────────────────────

--- a/packages/cli/src/args.parser.ts
+++ b/packages/cli/src/args.parser.ts
@@ -5,7 +5,7 @@
  * are populated only when relevant to the active command.
  */
 export interface ParsedCommand {
-  command: "login" | "logout" | "profile" | "intent" | "opportunity" | "network" | "conversation" | "contact" | "scrape" | "onboarding" | "sync" | "help" | "version" | "unknown";
+  command: "login" | "logout" | "profile" | "intent" | "opportunity" | "negotiation" | "network" | "conversation" | "contact" | "scrape" | "onboarding" | "sync" | "help" | "version" | "unknown";
   /** One-shot message for conversation command (H2A agent chat). */
   message?: string;
   /** Resume a specific chat session (--session flag). */
@@ -62,11 +62,15 @@ export interface ParsedCommand {
   title?: string;
   /** Details text for profile update --details. */
   details?: string;
+  /** ISO date string for --since filter (e.g. negotiation list). */
+  since?: string;
 }
 
-const KNOWN_COMMANDS = new Set(["login", "logout", "profile", "intent", "opportunity", "network", "conversation", "contact", "scrape", "onboarding", "sync", "help", "version"]);
+const KNOWN_COMMANDS = new Set(["login", "logout", "profile", "intent", "opportunity", "negotiation", "network", "conversation", "contact", "scrape", "onboarding", "sync", "help", "version"]);
 
 const OPPORTUNITY_SUBCOMMANDS = new Set(["list", "show", "accept", "reject", "discover"]);
+
+const NEGOTIATION_SUBCOMMANDS = new Set(["list", "show"]);
 
 const NETWORK_SUBCOMMANDS = new Set(["list", "create", "show", "join", "leave", "invite", "update", "delete"]);
 
@@ -92,17 +96,32 @@ export function parseArgs(args: string[]): ParsedCommand {
     return result;
   }
 
-  const first = args[0];
+  // Pre-scan: extract global flags that may appear before the command
+  let commandIndex = -1;
+  for (let j = 0; j < args.length; j++) {
+    const a = args[j];
+    if (a === "--api-url" || a === "--app-url" || a === "--token" || a === "-t") {
+      if (a === "--api-url") result.apiUrl = args[j + 1];
+      else if (a === "--app-url") result.appUrl = args[j + 1];
+      else result.token = args[j + 1];
+      j++; // skip value
+    } else if (a === "--help" || a === "-h") {
+      result.command = "help";
+      return result;
+    } else if (a === "--version" || a === "-v") {
+      result.command = "version";
+      return result;
+    } else if (!a.startsWith("--")) {
+      commandIndex = j;
+      break;
+    }
+  }
 
-  // Global flags
-  if (first === "--help" || first === "-h") {
-    result.command = "help";
+  if (commandIndex === -1) {
     return result;
   }
-  if (first === "--version" || first === "-v") {
-    result.command = "version";
-    return result;
-  }
+
+  const first = args[commandIndex];
 
   // Route to command
   if (!KNOWN_COMMANDS.has(first)) {
@@ -114,7 +133,7 @@ export function parseArgs(args: string[]): ParsedCommand {
   result.command = first as ParsedCommand["command"];
 
   // Parse remaining args for the command
-  let i = 1;
+  let i = commandIndex + 1;
   const positionals: string[] = [];
 
   while (i < args.length) {
@@ -180,6 +199,9 @@ export function parseArgs(args: string[]): ParsedCommand {
     } else if (arg === "--details") {
       result.details = args[i + 1];
       i += 2;
+    } else if (arg === "--since") {
+      result.since = args[i + 1];
+      i += 2;
     } else if (arg.startsWith("--")) {
       // Skip unknown flags
       i++;
@@ -199,6 +221,18 @@ export function parseArgs(args: string[]): ParsedCommand {
         result.positionals = positionals.slice(1);
       } else if (positionals[1]) {
         // Second positional is the target ID (for show/accept/reject)
+        result.targetId = positionals[1];
+      }
+    }
+    return result;
+  }
+
+  // Negotiation subcommand parsing
+  if (result.command === "negotiation") {
+    const sub = positionals[0];
+    if (sub && NEGOTIATION_SUBCOMMANDS.has(sub)) {
+      result.subcommand = sub as ParsedCommand["subcommand"];
+      if (positionals[1]) {
         result.targetId = positionals[1];
       }
     }

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -16,6 +16,7 @@ import { handleLogin } from "./login.command";
 import { handleProfile } from "./profile.command";
 import { handleIntent } from "./intent.command";
 import { handleOpportunity } from "./opportunity.command";
+import { handleNegotiation } from "./negotiation.command";
 import { handleNetwork } from "./network.command";
 import { handleConversation } from "./conversation.command";
 import { handleContact } from "./contact.command";
@@ -60,6 +61,10 @@ Usage:
   index intent link <id> <network-id>  Link a signal to a network
   index intent unlink <id> <network-id> Unlink a signal from a network
   index intent links <id>              Show linked networks for a signal
+  index negotiation list               List your agent's negotiations
+  index negotiation list --limit <n>   Limit results
+  index negotiation list --since <t>   Filter by time (ISO date or 1h, 2d, 1w)
+  index negotiation show <id>          Show negotiation turn-by-turn details (accepts short ID)
   index opportunity list                List your opportunities
   index opportunity list --status <s>   Filter by status (pending|accepted|rejected|expired)
   index opportunity list --limit <n>    Limit results
@@ -270,6 +275,14 @@ async function main(): Promise<void> {
         positionals: args.positionals,
         target: args.target,
         introduce: args.introduce,
+      });
+      return;
+    case "negotiation":
+      await handleNegotiation(client, args.subcommand, {
+        targetId: args.targetId,
+        limit: args.limit,
+        since: args.since,
+        json: args.json,
       });
       return;
     case "network":

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -27,7 +27,7 @@ import * as output from "./output";
 
 const DEFAULT_API_URL = "https://protocol.index.network";
 const DEFAULT_APP_URL = "https://index.network";
-const VERSION = "0.9.5";
+const VERSION = "0.10.0";
 
 const HELP_TEXT = `
 Index CLI v${VERSION}
@@ -100,6 +100,7 @@ Options:
   --archived          Include archived signals (intent list)
   --status <status>   Filter opportunities by status
   --limit <n>         Limit number of results
+  --since <date>      Filter by time (ISO date or duration like 1h, 2d, 1w)
   --json              Output raw JSON instead of formatted text
   --name <name>       Name for contact add
   --gmail             Import source flag for contact import

--- a/packages/cli/src/negotiation.command.ts
+++ b/packages/cli/src/negotiation.command.ts
@@ -66,7 +66,7 @@ export async function handleNegotiation(
  * Parse a human-friendly duration (e.g. "1h", "2d", "1w") or ISO date string
  * into an ISO date string for the API.
  */
-function resolveSince(input: string): string {
+export function resolveSince(input: string): string {
   const match = input.match(/^(\d+)([smhdw])$/);
   if (match) {
     const n = parseInt(match[1], 10);
@@ -173,8 +173,11 @@ function negotiationTable(negotiations: Negotiation[]): void {
         })
       : "-";
 
+    const outcomeStr = outcomeLabel(n.outcome);
+    const roleStr = roleLabel(n.outcome?.role);
+
     process.stdout.write(
-      `  ${CYAN}${shortId}${RESET}  ${name.padEnd(nameW)}  ${outcomeLabel(n.outcome)}${" ".repeat(Math.max(0, outcomeW - (n.outcome?.hasOpportunity ? 11 : 8)))}  ${roleLabel(n.outcome?.role)}${" ".repeat(Math.max(0, roleW - (n.outcome?.role?.length ?? 1)))}  ${turns.padEnd(turnsW)}  ${GRAY}${date}${RESET}\n`,
+      `  ${CYAN}${shortId}${RESET}  ${name.padEnd(nameW)}  ${outcomeStr}${output.padTo(outcomeW, output.stripAnsi(outcomeStr))}  ${roleStr}${output.padTo(roleW, output.stripAnsi(roleStr))}  ${turns.padEnd(turnsW)}  ${GRAY}${date}${RESET}\n`,
     );
   }
 }

--- a/packages/cli/src/negotiation.command.ts
+++ b/packages/cli/src/negotiation.command.ts
@@ -1,0 +1,228 @@
+/**
+ * Negotiation command handlers for the Index CLI.
+ *
+ * Implements: list, show subcommands.
+ * Follows the handleX(client, subcommand, options) pattern.
+ */
+
+import type { ApiClient } from "./api.client";
+import type { Negotiation } from "./types";
+import * as output from "./output";
+
+const NEGOTIATION_HELP = `
+Usage:
+  index negotiation list                        List your agent's negotiations
+  index negotiation list --limit <n>            Limit results
+  index negotiation list --since <date|duration> Filter by time (ISO date or duration like 1h, 2d, 1w)
+  index negotiation show <id>                   Show negotiation turn-by-turn details
+`;
+
+/**
+ * Route a negotiation subcommand to the appropriate handler.
+ *
+ * @param client - Authenticated API client.
+ * @param subcommand - The subcommand (list, show).
+ * @param options - Additional options (targetId, limit, json).
+ */
+export async function handleNegotiation(
+  client: ApiClient,
+  subcommand: string | undefined,
+  options: {
+    targetId?: string;
+    limit?: number;
+    since?: string;
+    json?: boolean;
+  },
+): Promise<void> {
+  if (!subcommand) {
+    if (options.json) {
+      console.log(JSON.stringify({ error: "No subcommand provided" }));
+    } else {
+      console.log(NEGOTIATION_HELP);
+    }
+    return;
+  }
+
+  switch (subcommand) {
+    case "list":
+      await negotiationList(client, options.limit, options.since, options.json);
+      return;
+
+    case "show":
+      if (!options.targetId) {
+        output.error("Missing negotiation ID. Usage: index negotiation show <id>", 1);
+        return;
+      }
+      await negotiationShow(client, options.targetId, options.json);
+      return;
+
+    default:
+      output.error(`Unknown subcommand: ${subcommand}`, 1);
+      return;
+  }
+}
+
+/**
+ * Parse a human-friendly duration (e.g. "1h", "2d", "1w") or ISO date string
+ * into an ISO date string for the API.
+ */
+function resolveSince(input: string): string {
+  const match = input.match(/^(\d+)([smhdw])$/);
+  if (match) {
+    const n = parseInt(match[1], 10);
+    const unit = match[2];
+    const ms = { s: 1000, m: 60_000, h: 3_600_000, d: 86_400_000, w: 604_800_000 }[unit]!;
+    return new Date(Date.now() - n * ms).toISOString();
+  }
+  const d = new Date(input);
+  if (isNaN(d.getTime())) throw new Error(`Invalid --since value: "${input}". Use ISO date or duration like 1h, 2d, 1w.`);
+  return d.toISOString();
+}
+
+/**
+ * List negotiations with optional limit and since filter.
+ */
+async function negotiationList(
+  client: ApiClient,
+  limit?: number,
+  since?: string,
+  json?: boolean,
+): Promise<void> {
+  const sinceIso = since ? resolveSince(since) : undefined;
+  const negotiations = await client.listNegotiations({ limit, since: sinceIso });
+  if (json) { console.log(JSON.stringify(negotiations)); return; }
+  output.heading("Negotiations");
+  negotiationTable(negotiations);
+  console.log();
+}
+
+/**
+ * Show turn-by-turn details for a single negotiation (matched by prefix).
+ */
+async function negotiationShow(
+  client: ApiClient,
+  id: string,
+  json?: boolean,
+): Promise<void> {
+  const negotiations = await client.listNegotiations({ limit: 50 });
+  const match = negotiations.find(
+    (n) => n.id === id || n.id.startsWith(id),
+  );
+
+  if (!match) {
+    output.error(`Negotiation not found: ${id}`, 1);
+    return;
+  }
+
+  if (json) { console.log(JSON.stringify(match)); return; }
+  negotiationCard(match);
+}
+
+// ── Formatters ─────────────────────────────────────────────────────
+
+const { BOLD, RESET, CYAN, GRAY, GREEN, YELLOW, BLUE, DIM } = output;
+
+function outcomeLabel(outcome?: Negotiation["outcome"]): string {
+  if (!outcome) return `${GRAY}unknown${RESET}`;
+  return outcome.hasOpportunity
+    ? `${GREEN}opportunity${RESET}`
+    : `${GRAY}no match${RESET}`;
+}
+
+function roleLabel(role?: string): string {
+  switch (role) {
+    case "agent": return `${GREEN}helper${RESET}`;
+    case "patient": return `${YELLOW}seeker${RESET}`;
+    case "peer": return `${CYAN}peer${RESET}`;
+    default: return `${GRAY}-${RESET}`;
+  }
+}
+
+/**
+ * Print a table of negotiations.
+ */
+function negotiationTable(negotiations: Negotiation[]): void {
+  if (negotiations.length === 0) {
+    output.dim("  No negotiations found.");
+    return;
+  }
+
+  const idW = 8;
+  const nameW = 22;
+  const outcomeW = 14;
+  const roleW = 8;
+  const turnsW = 6;
+  const dateW = 20;
+
+  process.stdout.write(
+    `  ${BOLD}${"ID".padEnd(idW)}  ${"Counterparty".padEnd(nameW)}  ${"Outcome".padEnd(outcomeW)}  ${"Role".padEnd(roleW)}  ${"Turns".padEnd(turnsW)}  ${"Created".padEnd(dateW)}${RESET}\n`,
+  );
+  process.stdout.write(
+    `  ${GRAY}${"-".repeat(idW)}  ${"-".repeat(nameW)}  ${"-".repeat(outcomeW)}  ${"-".repeat(roleW)}  ${"-".repeat(turnsW)}  ${"-".repeat(dateW)}${RESET}\n`,
+  );
+
+  for (const n of negotiations) {
+    const shortId = n.id.slice(0, 8);
+    const name = (n.counterparty?.name ?? "Unknown").slice(0, nameW);
+    const turns = String(n.outcome?.turnCount ?? n.turns?.length ?? "-");
+    const date = n.createdAt
+      ? new Date(n.createdAt).toLocaleDateString("en-US", {
+          year: "numeric",
+          month: "short",
+          day: "numeric",
+        })
+      : "-";
+
+    process.stdout.write(
+      `  ${CYAN}${shortId}${RESET}  ${name.padEnd(nameW)}  ${outcomeLabel(n.outcome)}${" ".repeat(Math.max(0, outcomeW - (n.outcome?.hasOpportunity ? 11 : 8)))}  ${roleLabel(n.outcome?.role)}${" ".repeat(Math.max(0, roleW - (n.outcome?.role?.length ?? 1)))}  ${turns.padEnd(turnsW)}  ${GRAY}${date}${RESET}\n`,
+    );
+  }
+}
+
+/**
+ * Print a detailed card for a single negotiation with turn-by-turn detail.
+ */
+function negotiationCard(n: Negotiation): void {
+  console.log();
+  console.log(`  ${BOLD}${CYAN}Negotiation Details${RESET}`);
+  console.log(`  ${GRAY}${"─".repeat(60)}${RESET}`);
+  console.log(`  ${BOLD}ID${RESET}             ${GRAY}${n.id}${RESET}`);
+  console.log(`  ${BOLD}Counterparty${RESET}   ${n.counterparty?.name ?? "Unknown"}`);
+  console.log(`  ${BOLD}Outcome${RESET}        ${outcomeLabel(n.outcome)}`);
+  console.log(`  ${BOLD}Your Role${RESET}      ${roleLabel(n.outcome?.role)}`);
+  console.log(`  ${BOLD}Turns${RESET}          ${n.outcome?.turnCount ?? n.turns?.length ?? "-"}`);
+  console.log(`  ${BOLD}Created${RESET}        ${GRAY}${new Date(n.createdAt).toLocaleString()}${RESET}`);
+
+  if (n.turns && n.turns.length > 0) {
+    console.log();
+    console.log(`  ${BOLD}Turn-by-Turn${RESET}`);
+    console.log(`  ${GRAY}${"─".repeat(60)}${RESET}`);
+
+    for (let i = 0; i < n.turns.length; i++) {
+      const t = n.turns[i];
+      const time = new Date(t.createdAt).toLocaleTimeString("en-US", {
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+      });
+      const actionColor = t.action === "accept" ? GREEN : t.action === "reject" ? output.RED : BLUE;
+
+      console.log(`  ${DIM}Turn ${i + 1}${RESET}  ${CYAN}${t.speaker?.name ?? "?"}${RESET}  ${actionColor}${t.action}${RESET}  ${GRAY}${time}${RESET}`);
+
+      if (t.suggestedRoles) {
+        console.log(`  ${DIM}  roles: own=${t.suggestedRoles.ownUser ?? "?"} other=${t.suggestedRoles.otherUser ?? "?"}${RESET}`);
+      }
+
+      if (t.reasoning) {
+        const lines = output.wordWrap(t.reasoning, 72);
+        for (const line of lines) {
+          console.log(`  ${DIM}  ${line}${RESET}`);
+        }
+      }
+      console.log();
+    }
+  }
+
+  console.log(`  ${GRAY}${"─".repeat(60)}${RESET}`);
+  console.log();
+}

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -220,7 +220,7 @@ export interface NegotiationTurn {
   speaker: NegotiationSpeaker;
   action: string;
   reasoning: string;
-  suggestedRoles?: { ownUser?: string; otherUser?: string };
+  suggestedRoles: { ownUser?: string; otherUser?: string } | null;
   createdAt: string;
 }
 
@@ -236,7 +236,7 @@ export interface NegotiationOutcome {
 export interface Negotiation {
   id: string;
   counterparty: NegotiationSpeaker;
-  outcome?: NegotiationOutcome;
+  outcome: NegotiationOutcome | null;
   turns: NegotiationTurn[];
   createdAt: string;
 }

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -206,6 +206,48 @@ export interface ConversationMessage {
   metadata?: Record<string, unknown>;
 }
 
+// ── Negotiation types ────────────────────────────────────────────────
+
+/** A speaker in a negotiation turn. */
+export interface NegotiationSpeaker {
+  id: string;
+  name: string;
+  avatar?: string | null;
+}
+
+/** A single turn in a negotiation. */
+export interface NegotiationTurn {
+  speaker: NegotiationSpeaker;
+  action: string;
+  reasoning: string;
+  suggestedRoles?: { ownUser?: string; otherUser?: string };
+  createdAt: string;
+}
+
+/** Outcome summary of a negotiation. */
+export interface NegotiationOutcome {
+  hasOpportunity: boolean;
+  role?: string;
+  turnCount?: number;
+  reason?: string;
+}
+
+/** A negotiation as returned by GET /api/users/:userId/negotiations. */
+export interface Negotiation {
+  id: string;
+  counterparty: NegotiationSpeaker;
+  outcome?: NegotiationOutcome;
+  turns: NegotiationTurn[];
+  createdAt: string;
+}
+
+/** Options for listing negotiations. */
+export interface NegotiationListOptions {
+  limit?: number;
+  offset?: number;
+  since?: string;
+}
+
 // ── Tool types ───────────────────────────────────────────────────────
 
 /** Generic result from POST /api/tools/:toolName. */

--- a/packages/cli/tests/negotiation.command.test.ts
+++ b/packages/cli/tests/negotiation.command.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "bun:test";
+
+import { parseArgs } from "../src/args.parser";
+import { ApiClient } from "../src/api.client";
+import { handleNegotiation, resolveSince } from "../src/negotiation.command";
+import type { Negotiation } from "../src/types";
+import { createMockServer } from "./helpers/mock-http";
+
+// ── Argument parsing tests ──────────────────────────────────────────
+
+describe("negotiation argument parsing", () => {
+  it("parses 'negotiation list' subcommand", () => {
+    const result = parseArgs(["negotiation", "list"]);
+    expect(result.command).toBe("negotiation");
+    expect(result.subcommand).toBe("list");
+  });
+
+  it("parses 'negotiation list --limit 5'", () => {
+    const result = parseArgs(["negotiation", "list", "--limit", "5"]);
+    expect(result.command).toBe("negotiation");
+    expect(result.subcommand).toBe("list");
+    expect(result.limit).toBe(5);
+  });
+
+  it("parses 'negotiation list --since 1d'", () => {
+    const result = parseArgs(["negotiation", "list", "--since", "1d"]);
+    expect(result.command).toBe("negotiation");
+    expect(result.subcommand).toBe("list");
+    expect(result.since).toBe("1d");
+  });
+
+  it("parses 'negotiation list --limit 10 --since 2h'", () => {
+    const result = parseArgs(["negotiation", "list", "--limit", "10", "--since", "2h"]);
+    expect(result.command).toBe("negotiation");
+    expect(result.subcommand).toBe("list");
+    expect(result.limit).toBe(10);
+    expect(result.since).toBe("2h");
+  });
+
+  it("parses 'negotiation show abc-123'", () => {
+    const result = parseArgs(["negotiation", "show", "abc-123"]);
+    expect(result.command).toBe("negotiation");
+    expect(result.subcommand).toBe("show");
+    expect(result.targetId).toBe("abc-123");
+  });
+
+  it("parses bare 'negotiation' with no subcommand", () => {
+    const result = parseArgs(["negotiation"]);
+    expect(result.command).toBe("negotiation");
+    expect(result.subcommand).toBeUndefined();
+  });
+
+  it("parses 'negotiation show' without id", () => {
+    const result = parseArgs(["negotiation", "show"]);
+    expect(result.command).toBe("negotiation");
+    expect(result.subcommand).toBe("show");
+    expect(result.targetId).toBeUndefined();
+  });
+
+  it("parses 'negotiation list --json'", () => {
+    const result = parseArgs(["negotiation", "list", "--json"]);
+    expect(result.command).toBe("negotiation");
+    expect(result.subcommand).toBe("list");
+    expect(result.json).toBe(true);
+  });
+
+  it("parses '--api-url http://x negotiation list' with pre-scan global flag", () => {
+    const result = parseArgs(["--api-url", "http://x", "negotiation", "list"]);
+    expect(result.command).toBe("negotiation");
+    expect(result.subcommand).toBe("list");
+    expect(result.apiUrl).toBe("http://x");
+  });
+});
+
+// ── resolveSince tests ──────────────────────────────────────────────
+
+describe("resolveSince", () => {
+  it("resolves '1h' to an ISO date ~1 hour ago", () => {
+    const result = resolveSince("1h");
+    const parsed = Date.parse(result);
+    expect(isNaN(parsed)).toBe(false);
+    const diff = Date.now() - parsed;
+    // Should be within 1 hour + 5 seconds
+    expect(diff).toBeGreaterThan(3_600_000 - 5_000);
+    expect(diff).toBeLessThan(3_600_000 + 5_000);
+  });
+
+  it("resolves '2d' to an ISO date ~2 days ago", () => {
+    const result = resolveSince("2d");
+    const parsed = Date.parse(result);
+    expect(isNaN(parsed)).toBe(false);
+    const diff = Date.now() - parsed;
+    expect(diff).toBeGreaterThan(2 * 86_400_000 - 5_000);
+    expect(diff).toBeLessThan(2 * 86_400_000 + 5_000);
+  });
+
+  it("resolves '1w' to an ISO date ~7 days ago", () => {
+    const result = resolveSince("1w");
+    const parsed = Date.parse(result);
+    expect(isNaN(parsed)).toBe(false);
+    const diff = Date.now() - parsed;
+    expect(diff).toBeGreaterThan(7 * 86_400_000 - 5_000);
+    expect(diff).toBeLessThan(7 * 86_400_000 + 5_000);
+  });
+
+  it("resolves '30m' to an ISO date ~30 minutes ago", () => {
+    const result = resolveSince("30m");
+    const parsed = Date.parse(result);
+    expect(isNaN(parsed)).toBe(false);
+    const diff = Date.now() - parsed;
+    expect(diff).toBeGreaterThan(30 * 60_000 - 5_000);
+    expect(diff).toBeLessThan(30 * 60_000 + 5_000);
+  });
+
+  it("resolves '10s' to an ISO date ~10 seconds ago", () => {
+    const result = resolveSince("10s");
+    const parsed = Date.parse(result);
+    expect(isNaN(parsed)).toBe(false);
+    const diff = Date.now() - parsed;
+    expect(diff).toBeGreaterThan(10_000 - 5_000);
+    expect(diff).toBeLessThan(10_000 + 5_000);
+  });
+
+  it("returns ISO date string as-is", () => {
+    const iso = "2026-01-01T00:00:00Z";
+    const result = resolveSince(iso);
+    expect(result).toBe(new Date(iso).toISOString());
+  });
+
+  it("throws on invalid input 'foobar'", () => {
+    expect(() => resolveSince("foobar")).toThrow("Invalid --since");
+  });
+
+  it("throws on non-date non-duration 'abc123'", () => {
+    expect(() => resolveSince("abc123")).toThrow("Invalid --since");
+  });
+});
+
+// ── API client tests ────────────────────────────────────────────────
+
+describe("negotiation API client", () => {
+  let mock: ReturnType<typeof createMockServer>;
+  let client: ApiClient;
+
+  beforeAll(() => {
+    mock = createMockServer();
+    client = new ApiClient(mock.url, "test-token");
+  });
+
+  afterAll(() => {
+    mock.stop();
+  });
+
+  describe("listNegotiations", () => {
+    it("returns negotiations from the API", async () => {
+      mock.on("GET", "/api/auth/me", () =>
+        Response.json({ user: { id: "user-1", name: "Test", email: "test@test.com" } }),
+      );
+      mock.on("GET", "/api/users/user-1/negotiations", () =>
+        Response.json({
+          negotiations: [
+            {
+              id: "neg-1",
+              counterparty: { id: "u2", name: "Alice", avatar: null },
+              outcome: { hasOpportunity: true, role: "agent", turnCount: 2, reason: "Good match" },
+              turns: [],
+              createdAt: "2026-04-20T10:00:00Z",
+            },
+            {
+              id: "neg-2",
+              counterparty: { id: "u3", name: "Bob", avatar: null },
+              outcome: null,
+              turns: [],
+              createdAt: "2026-04-21T12:00:00Z",
+            },
+          ],
+        }),
+      );
+
+      const result = await client.listNegotiations();
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe("neg-1");
+      expect(result[1].id).toBe("neg-2");
+    });
+
+    it("passes query params (limit, since)", async () => {
+      let receivedUrl = "";
+      mock.on("GET", "/api/auth/me", () =>
+        Response.json({ user: { id: "user-1", name: "Test", email: "test@test.com" } }),
+      );
+      mock.on("GET", "/api/users/user-1/negotiations", (req) => {
+        receivedUrl = req.url;
+        return Response.json({ negotiations: [] });
+      });
+
+      await client.listNegotiations({ limit: 5, since: "2026-01-01T00:00:00Z" });
+      expect(receivedUrl).toContain("limit=5");
+      expect(receivedUrl).toContain("since=");
+    });
+  });
+});
+
+// ── Output renderer tests ───────────────────────────────────────────
+
+describe("negotiation output renderers", () => {
+  let captured: string;
+  let origWrite: typeof process.stdout.write;
+  let origLog: typeof console.log;
+
+  const mockNegotiations: Negotiation[] = [
+    {
+      id: "neg-111-222-333-444",
+      counterparty: { id: "u2", name: "Alice", avatar: null },
+      outcome: { hasOpportunity: true, role: "agent", turnCount: 3, reason: "Good match" },
+      turns: [
+        {
+          speaker: { id: "u1", name: "Bot", avatar: null },
+          action: "propose",
+          reasoning: "Found overlap in AI interests",
+          suggestedRoles: { ownUser: "agent", otherUser: "patient" },
+          createdAt: "2026-04-20T10:00:00Z",
+        },
+      ],
+      createdAt: "2026-04-20T09:00:00Z",
+    },
+    {
+      id: "neg-555-666-777-888",
+      counterparty: { id: "u3", name: "Bob", avatar: null },
+      outcome: null,
+      turns: [],
+      createdAt: "2026-04-21T12:00:00Z",
+    },
+  ];
+
+  beforeEach(() => {
+    captured = "";
+    origWrite = process.stdout.write;
+    origLog = console.log;
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      captured += typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
+      return true;
+    }) as typeof process.stdout.write;
+    console.log = (...args: unknown[]) => {
+      captured += args.map(String).join(" ") + "\n";
+    };
+  });
+
+  afterAll(() => {
+    process.stdout.write = origWrite;
+    console.log = origLog;
+  });
+
+  it("renders counterparty and outcome in table", async () => {
+    const mockClient = {
+      async getMe() { return { id: "user-1", name: "Test", email: "test@test.com" }; },
+      async listNegotiations() { return mockNegotiations; },
+    } as unknown as ApiClient;
+
+    await handleNegotiation(mockClient, "list", {});
+    expect(captured).toContain("Alice");
+    expect(captured).toContain("Bob");
+    // "opportunity" is the outcome label when hasOpportunity is true
+    expect(captured).toContain("opportunity");
+    // "unknown" is the outcome label when outcome is null
+    expect(captured).toContain("unknown");
+  });
+
+  it("shows empty message when no negotiations", async () => {
+    const mockClient = {
+      async getMe() { return { id: "user-1", name: "Test", email: "test@test.com" }; },
+      async listNegotiations() { return []; },
+    } as unknown as ApiClient;
+
+    await handleNegotiation(mockClient, "list", {});
+    expect(captured).toContain("No negotiations found");
+  });
+
+  it("outputs valid JSON with --json flag", async () => {
+    const mockClient = {
+      async getMe() { return { id: "user-1", name: "Test", email: "test@test.com" }; },
+      async listNegotiations() { return mockNegotiations; },
+    } as unknown as ApiClient;
+
+    await handleNegotiation(mockClient, "list", { json: true });
+    expect(() => JSON.parse(captured.trim())).not.toThrow();
+    const parsed = JSON.parse(captured.trim());
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0].id).toBe("neg-111-222-333-444");
+  });
+});

--- a/packages/protocol/src/negotiation/negotiation.tools.ts
+++ b/packages/protocol/src/negotiation/negotiation.tools.ts
@@ -42,6 +42,8 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
     querySchema: z.object({
       status: z.enum(['active', 'waiting_for_agent', 'completed', 'all']).optional()
         .describe('Filter by negotiation status. Omit or use "all" to return all negotiations.'),
+      since: z.string().datetime().optional()
+        .describe('ISO 8601 date-time. Only return negotiations created at or after this timestamp.'),
       limit: z.number().int().min(1).max(100).optional()
         .describe('Maximum negotiations to return per page (1-100). Omit to return all.'),
       page: z.number().int().min(1).optional()
@@ -100,7 +102,12 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
           };
         }));
 
-        const filtered = negotiations.filter(Boolean);
+        let filtered = negotiations.filter(Boolean);
+
+        if (query.since) {
+          const sinceMs = new Date(query.since).getTime();
+          filtered = filtered.filter(n => new Date(n!.createdAt).getTime() >= sinceMs);
+        }
 
         const shouldPaginate = query.limit !== undefined;
         if (shouldPaginate) {


### PR DESCRIPTION
## Summary

- Adds `index negotiation list` and `index negotiation show <id>` commands to the CLI, exposing agent negotiation data (counterparty, outcome, role, turns) that was previously only accessible via the raw API
- Full-stack `--since` filter: CLI accepts human-friendly durations (`1h`, `2d`, `1w`) or ISO dates, passed through to a new `since` query param on `GET /api/users/:id/negotiations`, filtered at the database level via `createdAt >= since`
- Fixes the args parser to allow global flags (`--api-url`, `--app-url`, `--token`) before the command name

## Test plan

- [ ] `bun src/main.ts negotiation list` — lists negotiations with table output
- [ ] `bun src/main.ts negotiation list --limit 5` — respects limit
- [ ] `bun src/main.ts negotiation list --since 1d` — filters by duration
- [ ] `bun src/main.ts negotiation list --since 2026-04-22` — filters by ISO date
- [ ] `bun src/main.ts negotiation show <short-id>` — shows turn-by-turn details
- [ ] `bun src/main.ts --api-url http://localhost:3001 negotiation list` — global flags before command work
- [ ] `bun src/main.ts negotiation list --json` — raw JSON output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a top-level `negotiation` CLI command to list and view negotiations.
  * Introduced `--since` filter (duration or ISO date) to limit results by creation date; server and API now honor this filter.
  * Added `--limit` pagination and `--json` output.
  * `negotiation show` presents detailed negotiation cards with counterparty, outcome, turns, timestamps, and per-turn reasoning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->