### PR TITLE
feat(protocol): post-enrichment ghost user deduplication

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -1020,6 +1020,13 @@ export class ChatDatabaseAdapter {
     return profileAdapter.findDuplicateUser(userId, socials);
   }
 
+  /**
+   * Merge a ghost user (source) into a target user.
+   * Re-points all data from source to target, cleans up ghost-only records, and soft-deletes source.
+   * Delegates to ProfileDatabaseAdapter.
+   * @param sourceId - The ghost user to merge away (must be an active ghost)
+   * @param targetId - The user to merge into
+   */
   async mergeGhostUser(sourceId: string, targetId: string): Promise<void> {
     const profileAdapter = new ProfileDatabaseAdapter();
     return profileAdapter.mergeGhostUser(sourceId, targetId);
@@ -3633,6 +3640,16 @@ export class ProfileDatabaseAdapter {
    */
   async mergeGhostUser(sourceId: string, targetId: string): Promise<void> {
     await db.transaction(async (tx) => {
+      // Guard: only active ghost users may be merged away
+      const [source] = await tx
+        .select({ isGhost: schema.users.isGhost })
+        .from(schema.users)
+        .where(and(eq(schema.users.id, sourceId), isNull(schema.users.deletedAt)))
+        .limit(1);
+      if (!source?.isGhost) {
+        throw new Error(`mergeGhostUser: sourceId ${sourceId} is not an active ghost user`);
+      }
+
       // ── 1. Delete ghost-only records (unique constraints prevent re-pointing) ──
 
       await tx.delete(schema.userProfiles).where(eq(schema.userProfiles.userId, sourceId));
@@ -3673,7 +3690,7 @@ export class ProfileDatabaseAdapter {
 
       const targetMemberships = await tx.select({ networkId: schema.networkMembers.networkId })
         .from(schema.networkMembers)
-        .where(eq(schema.networkMembers.userId, targetId));
+        .where(and(eq(schema.networkMembers.userId, targetId), isNull(schema.networkMembers.deletedAt)));
       const targetNetworkIds = new Set(targetMemberships.map(m => m.networkId));
 
       for (const gm of ghostMemberships) {

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -3,7 +3,7 @@
  * Postgres implementations; no dependency on lib/protocol.
  */
 
-import { eq, and, or, isNull, isNotNull, sql, count, desc, gt, lt, lte, ne, inArray, ilike, notInArray, asc } from 'drizzle-orm';
+import { eq, and, or, isNull, isNotNull, sql, count, desc, gt, lt, lte, ne, inArray, ilike, notInArray, asc, not } from 'drizzle-orm';
 
 import * as schema from '../schemas/database.schema';
 import db from '../lib/drizzle/drizzle';
@@ -1003,6 +1003,21 @@ export class ChatDatabaseAdapter {
   async softDeleteGhost(userId: string): Promise<boolean> {
     const profileAdapter = new ProfileDatabaseAdapter();
     return profileAdapter.softDeleteGhost(userId);
+  }
+
+  /**
+   * Find an existing user that shares any of the given social handles with the specified ghost.
+   * Delegates to ProfileDatabaseAdapter.
+   * @param userId - The ghost user ID to exclude from results
+   * @param socials - Social handles to match against
+   * @returns The matching user's ID, or null if no match found
+   */
+  async findDuplicateUser(
+    userId: string,
+    socials: { x?: string; linkedin?: string; github?: string; websites?: string[] },
+  ): Promise<{ id: string } | null> {
+    const profileAdapter = new ProfileDatabaseAdapter();
+    return profileAdapter.findDuplicateUser(userId, socials);
   }
 
   async createIntent(data: CreateIntentInput): Promise<CreatedIntentRow> {
@@ -3562,6 +3577,46 @@ export class ProfileDatabaseAdapter {
       .where(eq(schema.users.id, userId));
 
     return true;
+  }
+
+  /**
+   * Find an existing user that shares any of the given social handles with the specified ghost.
+   * Case-insensitive exact match on linkedin, github, and x handles.
+   * Excludes the ghost itself and soft-deleted users.
+   * Prefers real users over ghosts; among ghosts, picks the oldest by created_at.
+   * @param userId - The ghost user ID to exclude from results
+   * @param socials - Social handles to match against
+   * @returns The matching user's ID, or null if no match found
+   */
+  async findDuplicateUser(
+    userId: string,
+    socials: { x?: string; linkedin?: string; github?: string; websites?: string[] },
+  ): Promise<{ id: string } | null> {
+    const handles: { field: string; value: string }[] = [];
+    if (socials.linkedin) handles.push({ field: 'linkedin', value: socials.linkedin.toLowerCase() });
+    if (socials.github) handles.push({ field: 'github', value: socials.github.toLowerCase() });
+    if (socials.x) handles.push({ field: 'x', value: socials.x.toLowerCase() });
+
+    if (handles.length === 0) return null;
+
+    const conditions = handles.map(
+      (h) => sql`LOWER(${schema.users.socials}->>'${sql.raw(h.field)}') = ${h.value}`,
+    );
+
+    const results = await db
+      .select({ id: schema.users.id, isGhost: schema.users.isGhost, createdAt: schema.users.createdAt })
+      .from(schema.users)
+      .where(
+        and(
+          sql`(${sql.join(conditions, sql` OR `)})`,
+          not(eq(schema.users.id, userId)),
+          isNull(schema.users.deletedAt),
+        ),
+      )
+      .orderBy(asc(schema.users.isGhost), asc(schema.users.createdAt))
+      .limit(1);
+
+    return results[0] ? { id: results[0].id } : null;
   }
 }
 

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -1020,6 +1020,11 @@ export class ChatDatabaseAdapter {
     return profileAdapter.findDuplicateUser(userId, socials);
   }
 
+  async mergeGhostUser(sourceId: string, targetId: string): Promise<void> {
+    const profileAdapter = new ProfileDatabaseAdapter();
+    return profileAdapter.mergeGhostUser(sourceId, targetId);
+  }
+
   async createIntent(data: CreateIntentInput): Promise<CreatedIntentRow> {
     try {
       const [created] = await db.insert(schema.intents)
@@ -3617,6 +3622,176 @@ export class ProfileDatabaseAdapter {
       .limit(1);
 
     return results[0] ? { id: results[0].id } : null;
+  }
+
+  /**
+   * Merge a ghost user (source) into a target user.
+   * Re-points all FK references, deletes ghost-only records, and soft-deletes the source.
+   * Runs entirely within a single database transaction.
+   * @param sourceId - The ghost user to merge away
+   * @param targetId - The target user to absorb the ghost's data
+   */
+  async mergeGhostUser(sourceId: string, targetId: string): Promise<void> {
+    await db.transaction(async (tx) => {
+      // ── 1. Delete ghost-only records (unique constraints prevent re-pointing) ──
+
+      await tx.delete(schema.userProfiles).where(eq(schema.userProfiles.userId, sourceId));
+      await tx.delete(schema.userNotificationSettings).where(eq(schema.userNotificationSettings.userId, sourceId));
+      await tx.delete(schema.sessions).where(eq(schema.sessions.userId, sourceId));
+      await tx.delete(schema.accounts).where(eq(schema.accounts.userId, sourceId));
+      await tx.delete(schema.apikeys).where(eq(schema.apikeys.userId, sourceId));
+      await tx.delete(schema.agentPermissions).where(eq(schema.agentPermissions.userId, sourceId));
+      await tx.delete(schema.agents).where(eq(schema.agents.ownerId, sourceId));
+
+      // Delete ghost's HyDE profile documents
+      await tx.delete(schema.hydeDocuments).where(
+        and(
+          eq(schema.hydeDocuments.sourceType, 'profile'),
+          eq(schema.hydeDocuments.sourceId, sourceId),
+        ),
+      );
+
+      // ── 2. Re-point simple FK references ──
+
+      await tx.update(schema.intents)
+        .set({ userId: targetId })
+        .where(eq(schema.intents.userId, sourceId));
+
+      await tx.update(schema.files)
+        .set({ userId: targetId })
+        .where(eq(schema.files.userId, sourceId));
+
+      await tx.update(schema.links)
+        .set({ userId: targetId })
+        .where(eq(schema.links.userId, sourceId));
+
+      // ── 3. Re-point network_members (composite PK: skip if target already member) ──
+
+      const ghostMemberships = await tx.select({ networkId: schema.networkMembers.networkId })
+        .from(schema.networkMembers)
+        .where(and(eq(schema.networkMembers.userId, sourceId), isNull(schema.networkMembers.deletedAt)));
+
+      const targetMemberships = await tx.select({ networkId: schema.networkMembers.networkId })
+        .from(schema.networkMembers)
+        .where(eq(schema.networkMembers.userId, targetId));
+      const targetNetworkIds = new Set(targetMemberships.map(m => m.networkId));
+
+      for (const gm of ghostMemberships) {
+        if (targetNetworkIds.has(gm.networkId)) {
+          // Target already in this network — soft-delete ghost's membership
+          await tx.update(schema.networkMembers)
+            .set({ deletedAt: new Date() })
+            .where(and(
+              eq(schema.networkMembers.networkId, gm.networkId),
+              eq(schema.networkMembers.userId, sourceId),
+            ));
+        } else {
+          // Re-point ghost's membership to target
+          await tx.update(schema.networkMembers)
+            .set({ userId: targetId })
+            .where(and(
+              eq(schema.networkMembers.networkId, gm.networkId),
+              eq(schema.networkMembers.userId, sourceId),
+            ));
+        }
+      }
+
+      // ── 4. Re-point opportunity_deliveries (conditional unique: skip conflicts) ──
+
+      const ghostDeliveries = await tx.select({
+        id: schema.opportunityDeliveries.id,
+        opportunityId: schema.opportunityDeliveries.opportunityId,
+        channel: schema.opportunityDeliveries.channel,
+        deliveredAtStatus: schema.opportunityDeliveries.deliveredAtStatus,
+        deliveredAt: schema.opportunityDeliveries.deliveredAt,
+      })
+        .from(schema.opportunityDeliveries)
+        .where(eq(schema.opportunityDeliveries.userId, sourceId));
+
+      const targetDeliveries = await tx.select({
+        opportunityId: schema.opportunityDeliveries.opportunityId,
+        channel: schema.opportunityDeliveries.channel,
+        deliveredAtStatus: schema.opportunityDeliveries.deliveredAtStatus,
+      })
+        .from(schema.opportunityDeliveries)
+        .where(and(
+          eq(schema.opportunityDeliveries.userId, targetId),
+          sql`${schema.opportunityDeliveries.deliveredAt} IS NOT NULL`,
+        ));
+
+      const targetDeliveryKeys = new Set(
+        targetDeliveries.map(d => `${d.opportunityId}:${d.channel}:${d.deliveredAtStatus}`),
+      );
+
+      for (const gd of ghostDeliveries) {
+        const wouldConflict = gd.deliveredAt !== null &&
+          targetDeliveryKeys.has(`${gd.opportunityId}:${gd.channel}:${gd.deliveredAtStatus}`);
+        if (wouldConflict) {
+          await tx.delete(schema.opportunityDeliveries).where(eq(schema.opportunityDeliveries.id, gd.id));
+        } else {
+          await tx.update(schema.opportunityDeliveries)
+            .set({ userId: targetId })
+            .where(eq(schema.opportunityDeliveries.id, gd.id));
+        }
+      }
+
+      // ── 5. Re-point conversation_participants (composite PK: skip if target already in conversation) ──
+
+      await tx.execute(sql`
+        UPDATE conversation_participants
+        SET participant_id = ${targetId}
+        WHERE participant_id = ${sourceId}
+          AND participant_type = 'user'
+          AND conversation_id NOT IN (
+            SELECT conversation_id FROM conversation_participants WHERE participant_id = ${targetId}
+          )
+      `);
+      // Delete remaining ghost participants (where target already in conversation)
+      await tx.execute(sql`
+        DELETE FROM conversation_participants
+        WHERE participant_id = ${sourceId} AND participant_type = 'user'
+      `);
+
+      // ── 6. Re-point messages ──
+
+      await tx.execute(sql`
+        UPDATE messages SET sender_id = ${targetId}
+        WHERE sender_id = ${sourceId} AND role = 'user'
+      `);
+
+      // ── 7. Re-point opportunity actors JSONB ──
+
+      const affectedOpps = await tx.execute(sql`
+        SELECT id, actors, detection FROM opportunities
+        WHERE actors::text LIKE ${'%' + sourceId + '%'}
+           OR detection::text LIKE ${'%' + sourceId + '%'}
+      `) as unknown as { id: string; actors: unknown; detection: unknown }[];
+
+      for (const row of affectedOpps) {
+        const actors = (Array.isArray(row.actors) ? row.actors : []) as { userId: string; [k: string]: unknown }[];
+        const updatedActors = actors.map(a =>
+          a.userId === sourceId ? { ...a, userId: targetId } : a,
+        );
+
+        const detection = (row.detection ?? {}) as { createdBy?: string; [k: string]: unknown };
+        const updatedDetection = detection.createdBy === sourceId
+          ? { ...detection, createdBy: targetId }
+          : detection;
+
+        await tx.execute(sql`
+          UPDATE opportunities
+          SET actors = ${JSON.stringify(updatedActors)}::jsonb,
+              detection = ${JSON.stringify(updatedDetection)}::jsonb
+          WHERE id = ${row.id}
+        `);
+      }
+
+      // ── 8. Soft-delete the ghost user ──
+
+      await tx.update(schema.users)
+        .set({ deletedAt: new Date() })
+        .where(eq(schema.users.id, sourceId));
+    });
   }
 }
 

--- a/backend/src/adapters/tests/ghost-dedup.spec.ts
+++ b/backend/src/adapters/tests/ghost-dedup.spec.ts
@@ -1,0 +1,144 @@
+/** Config */
+import { config } from "dotenv";
+config({ path: '.env.test' });
+
+import { describe, expect, it, beforeAll, afterAll } from 'bun:test';
+import { eq, inArray } from 'drizzle-orm';
+import { v4 as uuidv4 } from 'uuid';
+import db from '../../lib/drizzle/drizzle';
+import {
+  users,
+  userProfiles,
+} from '../../schemas/database.schema';
+import { ProfileDatabaseAdapter } from '../database.adapter';
+
+const TEST_PREFIX = 'ghost_dedup_spec_' + Date.now() + '_';
+const adapter = new ProfileDatabaseAdapter();
+
+interface TestIds {
+  realUserId: string;
+  ghostAId: string;
+  ghostBId: string;
+  ghostNoSocialsId: string;
+  differentPersonId: string;
+}
+let ids: TestIds;
+
+beforeAll(async () => {
+  ids = {
+    realUserId: uuidv4(),
+    ghostAId: uuidv4(),
+    ghostBId: uuidv4(),
+    ghostNoSocialsId: uuidv4(),
+    differentPersonId: uuidv4(),
+  };
+
+  await db.insert(users).values([
+    {
+      id: ids.realUserId,
+      email: TEST_PREFIX + 'real@index.network',
+      name: 'Seref Yarar',
+      isGhost: false,
+      socials: { linkedin: 'serefyarar', github: 'serefyarar', x: 'hyperseref' },
+    },
+    {
+      id: ids.ghostAId,
+      email: TEST_PREFIX + 'ghost-a@index.as',
+      name: 'Seref Yarar',
+      isGhost: true,
+      socials: { linkedin: 'serefyarar' },
+    },
+    {
+      id: ids.ghostBId,
+      email: TEST_PREFIX + 'ghost-b@gowit.dev',
+      name: 'Serafettin Yarar',
+      isGhost: true,
+      socials: { github: 'serefyarar' },
+    },
+    {
+      id: ids.ghostNoSocialsId,
+      email: TEST_PREFIX + 'ghost-nosocials@test.com',
+      name: 'Seref Yarar',
+      isGhost: true,
+      socials: null,
+    },
+    {
+      id: ids.differentPersonId,
+      email: TEST_PREFIX + 'different@nato.int',
+      name: 'Seref Ozu',
+      isGhost: true,
+      socials: { linkedin: 'serefozu-b5b87322a' },
+    },
+  ]);
+});
+
+afterAll(async () => {
+  const allIds = Object.values(ids);
+  await db.delete(userProfiles).where(inArray(userProfiles.userId, allIds));
+  await db.delete(users).where(inArray(users.id, allIds));
+});
+
+describe('ProfileDatabaseAdapter.findDuplicateUser', () => {
+  it('matches by LinkedIn handle and prefers real user over ghost', async () => {
+    const result = await adapter.findDuplicateUser(ids.ghostAId, { linkedin: 'serefyarar' });
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe(ids.realUserId);
+  });
+
+  it('matches by GitHub handle', async () => {
+    const result = await adapter.findDuplicateUser(ids.ghostBId, { github: 'serefyarar' });
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe(ids.realUserId);
+  });
+
+  it('matches by X handle', async () => {
+    const newGhostId = uuidv4();
+    await db.insert(users).values({
+      id: newGhostId,
+      email: TEST_PREFIX + 'ghost-x@test.com',
+      name: 'Seref X',
+      isGhost: true,
+    });
+    try {
+      const result = await adapter.findDuplicateUser(newGhostId, { x: 'hyperseref' });
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe(ids.realUserId);
+    } finally {
+      await db.delete(users).where(eq(users.id, newGhostId));
+    }
+  });
+
+  it('is case-insensitive', async () => {
+    const result = await adapter.findDuplicateUser(ids.ghostAId, { linkedin: 'SerefYarar' });
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe(ids.realUserId);
+  });
+
+  it('does not match different social handles', async () => {
+    const result = await adapter.findDuplicateUser(ids.differentPersonId, { linkedin: 'serefozu-b5b87322a' });
+    expect(result).toBeNull();
+  });
+
+  it('returns null when no socials provided', async () => {
+    const result = await adapter.findDuplicateUser(ids.ghostNoSocialsId, {});
+    expect(result).toBeNull();
+  });
+
+  it('excludes soft-deleted users from matching', async () => {
+    const deletedId = uuidv4();
+    await db.insert(users).values({
+      id: deletedId,
+      email: TEST_PREFIX + 'deleted@test.com',
+      name: 'Deleted User',
+      isGhost: true,
+      socials: { linkedin: 'deleted-handle-unique' },
+      deletedAt: new Date(),
+    });
+    try {
+      const result = await adapter.findDuplicateUser(ids.ghostAId, { linkedin: 'deleted-handle-unique' });
+      expect(result).toBeNull();
+    } finally {
+      await db.delete(users).where(eq(users.id, deletedId));
+    }
+  });
+});

--- a/backend/src/adapters/tests/ghost-dedup.spec.ts
+++ b/backend/src/adapters/tests/ghost-dedup.spec.ts
@@ -3,12 +3,16 @@ import { config } from "dotenv";
 config({ path: '.env.test' });
 
 import { describe, expect, it, beforeAll, afterAll } from 'bun:test';
-import { eq, inArray } from 'drizzle-orm';
+import { eq, and, inArray } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
 import db from '../../lib/drizzle/drizzle';
 import {
   users,
   userProfiles,
+  networks,
+  networkMembers,
+  intents,
+  opportunities,
 } from '../../schemas/database.schema';
 import { ProfileDatabaseAdapter } from '../database.adapter';
 
@@ -21,6 +25,9 @@ interface TestIds {
   ghostBId: string;
   ghostNoSocialsId: string;
   differentPersonId: string;
+  mergeNetworkId: string;
+  mergeGhostId: string;
+  mergeTargetId: string;
 }
 let ids: TestIds;
 
@@ -31,6 +38,9 @@ beforeAll(async () => {
     ghostBId: uuidv4(),
     ghostNoSocialsId: uuidv4(),
     differentPersonId: uuidv4(),
+    mergeNetworkId: uuidv4(),
+    mergeGhostId: uuidv4(),
+    mergeTargetId: uuidv4(),
   };
 
   await db.insert(users).values([
@@ -69,11 +79,54 @@ beforeAll(async () => {
       isGhost: true,
       socials: { linkedin: 'serefozu-b5b87322a' },
     },
+    {
+      id: ids.mergeTargetId,
+      email: TEST_PREFIX + 'merge-target@index.network',
+      name: 'Target User',
+      isGhost: false,
+    },
+    {
+      id: ids.mergeGhostId,
+      email: TEST_PREFIX + 'merge-ghost@other.com',
+      name: 'Ghost To Merge',
+      isGhost: true,
+    },
   ]);
+
+  await db.insert(userProfiles).values([
+    {
+      userId: ids.mergeTargetId,
+      identity: { name: 'Target User', bio: 'target bio', location: 'NYC' },
+      narrative: { context: 'target context' },
+      attributes: { skills: ['a'], interests: ['b'] },
+    },
+    {
+      userId: ids.mergeGhostId,
+      identity: { name: 'Ghost', bio: 'ghost bio', location: 'LA' },
+      narrative: { context: 'ghost context' },
+      attributes: { skills: ['c'], interests: ['d'] },
+    },
+  ]);
+
+  await db.insert(networks).values({
+    id: ids.mergeNetworkId,
+    title: TEST_PREFIX + 'Merge Test Network',
+  });
+
+  await db.insert(networkMembers).values({
+    networkId: ids.mergeNetworkId,
+    userId: ids.mergeGhostId,
+    permissions: ['contact'],
+  });
 });
 
 afterAll(async () => {
-  const allIds = Object.values(ids);
+  const allIds = Object.values(ids).filter(Boolean);
+  // Clean up in FK order
+  await db.delete(networkMembers).where(
+    eq(networkMembers.networkId, ids.mergeNetworkId),
+  );
+  await db.delete(networks).where(eq(networks.id, ids.mergeNetworkId));
   await db.delete(userProfiles).where(inArray(userProfiles.userId, allIds));
   await db.delete(users).where(inArray(users.id, allIds));
 });
@@ -139,6 +192,169 @@ describe('ProfileDatabaseAdapter.findDuplicateUser', () => {
       expect(result).toBeNull();
     } finally {
       await db.delete(users).where(eq(users.id, deletedId));
+    }
+  });
+});
+
+describe('ProfileDatabaseAdapter.mergeGhostUser', () => {
+  it('re-points network memberships and soft-deletes ghost', async () => {
+    const ghostId = ids.mergeGhostId;
+    const targetId = ids.mergeTargetId;
+    const networkId = ids.mergeNetworkId;
+
+    await adapter.mergeGhostUser(ghostId, targetId);
+
+    // Ghost should be soft-deleted
+    const [ghost] = await db.select({ deletedAt: users.deletedAt })
+      .from(users).where(eq(users.id, ghostId));
+    expect(ghost.deletedAt).not.toBeNull();
+
+    // Ghost's profile should be deleted
+    const ghostProfile = await db.select()
+      .from(userProfiles).where(eq(userProfiles.userId, ghostId));
+    expect(ghostProfile).toHaveLength(0);
+
+    // Target's profile should still exist
+    const targetProfile = await db.select()
+      .from(userProfiles).where(eq(userProfiles.userId, targetId));
+    expect(targetProfile).toHaveLength(1);
+
+    // Membership should be re-pointed to target
+    const membership = await db.select()
+      .from(networkMembers)
+      .where(and(
+        eq(networkMembers.networkId, networkId),
+        eq(networkMembers.userId, targetId),
+      ));
+    expect(membership).toHaveLength(1);
+  });
+
+  it('skips memberships where target already belongs to the network', async () => {
+    const ghostId = uuidv4();
+    const targetId = uuidv4();
+    const netId = uuidv4();
+
+    await db.insert(users).values([
+      { id: ghostId, email: TEST_PREFIX + 'skip-ghost@test.com', name: 'G', isGhost: true },
+      { id: targetId, email: TEST_PREFIX + 'skip-target@test.com', name: 'T', isGhost: false },
+    ]);
+    await db.insert(userProfiles).values({
+      userId: ghostId,
+      identity: { name: 'G', bio: '', location: '' },
+      narrative: { context: '' },
+      attributes: { skills: [], interests: [] },
+    });
+    await db.insert(networks).values({ id: netId, title: TEST_PREFIX + 'skip-net' });
+    await db.insert(networkMembers).values([
+      { networkId: netId, userId: ghostId, permissions: ['contact'] },
+      { networkId: netId, userId: targetId, permissions: ['owner'] },
+    ]);
+
+    try {
+      await adapter.mergeGhostUser(ghostId, targetId);
+
+      // Ghost's membership should be soft-deleted (not re-pointed, since target already in network)
+      const ghostMembership = await db.select()
+        .from(networkMembers)
+        .where(and(eq(networkMembers.networkId, netId), eq(networkMembers.userId, ghostId)));
+      expect(ghostMembership).toHaveLength(1);
+      expect(ghostMembership[0].deletedAt).not.toBeNull();
+
+      // Target's membership should be unchanged
+      const targetMembership = await db.select()
+        .from(networkMembers)
+        .where(and(eq(networkMembers.networkId, netId), eq(networkMembers.userId, targetId)));
+      expect(targetMembership).toHaveLength(1);
+      expect(targetMembership[0].permissions).toContain('owner');
+    } finally {
+      await db.delete(networkMembers).where(eq(networkMembers.networkId, netId));
+      await db.delete(networks).where(eq(networks.id, netId));
+      await db.delete(userProfiles).where(inArray(userProfiles.userId, [ghostId, targetId]));
+      await db.delete(users).where(inArray(users.id, [ghostId, targetId]));
+    }
+  });
+
+  it('re-points intents from ghost to target', async () => {
+    const ghostId = uuidv4();
+    const targetId = uuidv4();
+    const intentId = uuidv4();
+
+    await db.insert(users).values([
+      { id: ghostId, email: TEST_PREFIX + 'intent-ghost@test.com', name: 'G', isGhost: true },
+      { id: targetId, email: TEST_PREFIX + 'intent-target@test.com', name: 'T', isGhost: false },
+    ]);
+    await db.insert(userProfiles).values({
+      userId: ghostId,
+      identity: { name: 'G', bio: '', location: '' },
+      narrative: { context: '' },
+      attributes: { skills: [], interests: [] },
+    });
+    await db.insert(intents).values({
+      id: intentId,
+      userId: ghostId,
+      payload: TEST_PREFIX + 'test intent',
+    });
+
+    try {
+      await adapter.mergeGhostUser(ghostId, targetId);
+
+      const [intent] = await db.select({ userId: intents.userId })
+        .from(intents).where(eq(intents.id, intentId));
+      expect(intent.userId).toBe(targetId);
+    } finally {
+      await db.delete(intents).where(eq(intents.id, intentId));
+      await db.delete(userProfiles).where(inArray(userProfiles.userId, [ghostId, targetId]));
+      await db.delete(users).where(inArray(users.id, [ghostId, targetId]));
+    }
+  });
+
+  it('re-points opportunity actors JSONB from ghost to target', async () => {
+    const ghostId = uuidv4();
+    const targetId = uuidv4();
+    const netId = uuidv4();
+    const oppId = uuidv4();
+
+    await db.insert(users).values([
+      { id: ghostId, email: TEST_PREFIX + 'opp-ghost@test.com', name: 'G', isGhost: true },
+      { id: targetId, email: TEST_PREFIX + 'opp-target@test.com', name: 'T', isGhost: false },
+    ]);
+    await db.insert(userProfiles).values({
+      userId: ghostId,
+      identity: { name: 'G', bio: '', location: '' },
+      narrative: { context: '' },
+      attributes: { skills: [], interests: [] },
+    });
+    await db.insert(networks).values({ id: netId, title: TEST_PREFIX + 'opp-net' });
+    await db.insert(opportunities).values({
+      id: oppId,
+      actors: [
+        { userId: ghostId, networkId: netId, role: 'seeker' },
+        { userId: targetId, networkId: netId, role: 'provider' },
+      ],
+      detection: { source: 'enrichment', timestamp: new Date().toISOString(), createdBy: ghostId },
+      interpretation: { category: 'test', reasoning: 'test', confidence: 0.9 },
+      context: { networkId: netId },
+      confidence: '0.9',
+    });
+
+    try {
+      await adapter.mergeGhostUser(ghostId, targetId);
+
+      const [opp] = await db.select({ actors: opportunities.actors, detection: opportunities.detection })
+        .from(opportunities).where(eq(opportunities.id, oppId));
+      const actors = opp.actors as { userId: string }[];
+      const ghostActors = actors.filter(a => a.userId === ghostId);
+      expect(ghostActors).toHaveLength(0);
+      const targetActors = actors.filter(a => a.userId === targetId);
+      expect(targetActors.length).toBeGreaterThanOrEqual(1);
+
+      const detection = opp.detection as { createdBy?: string };
+      expect(detection.createdBy).toBe(targetId);
+    } finally {
+      await db.delete(opportunities).where(eq(opportunities.id, oppId));
+      await db.delete(networks).where(eq(networks.id, netId));
+      await db.delete(userProfiles).where(inArray(userProfiles.userId, [ghostId, targetId]));
+      await db.delete(users).where(inArray(users.id, [ghostId, targetId]));
     }
   });
 });

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "0.21.3",
+  "version": "0.22.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/profile/profile.graph.ts
+++ b/packages/protocol/src/profile/profile.graph.ts
@@ -473,6 +473,25 @@ export class ProfileGraphFactory {
                 await this.database.updateUser(state.userId, updatePayload);
               }
 
+              // Post-enrichment dedup: check if this ghost matches an existing user
+              if (user.isGhost) {
+                const enrichedSocials: { x?: string; linkedin?: string; github?: string; websites?: string[] } = {};
+                if (enrichment!.socials.twitter) enrichedSocials.x = enrichment!.socials.twitter;
+                if (enrichment!.socials.linkedin) enrichedSocials.linkedin = enrichment!.socials.linkedin;
+                if (enrichment!.socials.github) enrichedSocials.github = enrichment!.socials.github;
+                if (enrichment!.socials.websites?.length) enrichedSocials.websites = enrichment!.socials.websites;
+
+                const duplicate = await this.database.findDuplicateUser(state.userId, enrichedSocials);
+                if (duplicate) {
+                  logger.info("Post-enrichment dedup: merging ghost into existing user", {
+                    ghostId: state.userId,
+                    targetId: duplicate.id,
+                  });
+                  await this.database.mergeGhostUser(state.userId, duplicate.id);
+                  return { error: `Merged as duplicate of user ${duplicate.id}` };
+                }
+              }
+
               return {
                 prePopulatedProfile: {
                   identity: enrichment!.identity,

--- a/packages/protocol/src/profile/profile.graph.ts
+++ b/packages/protocol/src/profile/profile.graph.ts
@@ -475,13 +475,7 @@ export class ProfileGraphFactory {
 
               // Post-enrichment dedup: check if this ghost matches an existing user
               if (user.isGhost) {
-                const enrichedSocials: { x?: string; linkedin?: string; github?: string; websites?: string[] } = {};
-                if (enrichment!.socials.twitter) enrichedSocials.x = enrichment!.socials.twitter;
-                if (enrichment!.socials.linkedin) enrichedSocials.linkedin = enrichment!.socials.linkedin;
-                if (enrichment!.socials.github) enrichedSocials.github = enrichment!.socials.github;
-                if (enrichment!.socials.websites?.length) enrichedSocials.websites = enrichment!.socials.websites;
-
-                const duplicate = await this.database.findDuplicateUser(state.userId, enrichedSocials);
+                const duplicate = await this.database.findDuplicateUser(state.userId, socials);
                 if (duplicate) {
                   logger.info("Post-enrichment dedup: merging ghost into existing user", {
                     ghostId: state.userId,

--- a/packages/protocol/src/shared/interfaces/database.interface.ts
+++ b/packages/protocol/src/shared/interfaces/database.interface.ts
@@ -479,6 +479,27 @@ export interface Database {
    */
   softDeleteGhost(userId: string): Promise<boolean>;
 
+  /**
+   * Find an existing user that matches the given social handles.
+   * Checks LinkedIn, GitHub, and Twitter/X handles (case-insensitive, exact match).
+   * Excludes the given userId and soft-deleted users.
+   * Prefers real users over ghosts; among ghosts, returns the oldest.
+   * @param userId - The ghost user being enriched (excluded from results)
+   * @param socials - Enriched social handles to match against
+   * @returns The matching user's id, or null if no match
+   */
+  findDuplicateUser(userId: string, socials: UserSocials): Promise<{ id: string } | null>;
+
+  /**
+   * Merge a ghost user (source) into a target user.
+   * Re-points all data (intents, opportunities, memberships, etc.) from source to target,
+   * deletes ghost-only records (profile, sessions, etc.), and soft-deletes the source user.
+   * Runs in a single transaction.
+   * @param sourceId - The ghost user to merge away
+   * @param targetId - The user to merge into
+   */
+  mergeGhostUser(sourceId: string, targetId: string): Promise<void>;
+
   // ─────────────────────────────────────────────────────────────────────────────
   // Pre-Graph Operations (State Population)
   // ─────────────────────────────────────────────────────────────────────────────
@@ -1648,7 +1669,7 @@ export interface SystemDatabase {
  */
 export type ProfileGraphDatabase = Pick<
   Database,
-  'getProfile' | 'getUser' | 'updateUser' | 'saveProfile' | 'getProfileByUserId' | 'getHydeDocument' | 'saveHydeDocument' | 'softDeleteGhost'
+  'getProfile' | 'getUser' | 'updateUser' | 'saveProfile' | 'getProfileByUserId' | 'getHydeDocument' | 'saveHydeDocument' | 'softDeleteGhost' | 'findDuplicateUser' | 'mergeGhostUser'
 >;
 
 /**

--- a/packages/protocol/src/shared/interfaces/database.interface.ts
+++ b/packages/protocol/src/shared/interfaces/database.interface.ts
@@ -1745,6 +1745,9 @@ export type ChatGraphCompositeDatabase = Pick<
   | 'getNetworkMemberCount'
   | 'addMemberToNetwork'
   | 'removeMemberFromIndex'
+  // ProfileGraph post-enrichment ghost deduplication
+  | 'findDuplicateUser'
+  | 'mergeGhostUser'
 >;
 
 /**


### PR DESCRIPTION
## Summary

- Add post-enrichment ghost user deduplication that runs after the Parallel Chat API enriches a ghost contact
- Match duplicates by social handles (LinkedIn, GitHub, Twitter/X) — case-insensitive, exact match, globally scoped
- Merge duplicate ghosts into existing users (prefer real users over ghosts, oldest ghost as tiebreaker)
- Full transactional merge re-points all FK references: intents, opportunities (JSONB actors), opportunity deliveries, network memberships, conversation participants, messages, files, links
- Handles all unique/composite key constraints: skips conflicting memberships, deliveries, and conversation participants
- Deletes ghost-only records (profile, sessions, accounts, apikeys, agents, HyDE docs) before soft-deleting the ghost

## Test plan

- [x] 7 tests for `findDuplicateUser` — LinkedIn/GitHub/X matching, case-insensitivity, self-exclusion, soft-deleted exclusion, empty socials
- [x] 4 tests for `mergeGhostUser` — membership re-pointing, conflict skipping, intent re-pointing, opportunity JSONB re-pointing
- [x] Existing database adapter tests pass (72/72)
- [x] Existing auth adapter tests pass (10/10)