### PR TITLE
fix(protocol): namespace delivery card cache to avoid home-feed key collision

### DIFF
--- a/backend/src/services/opportunity-delivery.service.ts
+++ b/backend/src/services/opportunity-delivery.service.ts
@@ -19,7 +19,7 @@ import {
   OpportunityPresenter,
   canUserSeeOpportunity,
   gatherPresenterContext,
-  getOrCreateHomeCardBatch,
+  getOrCreateDeliveryCardBatch,
   type PresenterDatabase,
 } from '@indexnetwork/protocol';
 
@@ -410,7 +410,7 @@ export class OpportunityDeliveryService {
           detection: opp.detection,
         };
 
-        const cards = await getOrCreateHomeCardBatch(
+        const cards = await getOrCreateDeliveryCardBatch(
           this.cache,
           this.presenter,
           this.presenterDb,

--- a/backend/src/services/tests/opportunity-delivery.cache.spec.ts
+++ b/backend/src/services/tests/opportunity-delivery.cache.spec.ts
@@ -92,9 +92,9 @@ mock.module('../../lib/drizzle/drizzle', () => ({
 //   - gatherPresenterContext → returns minimal stub (no DB calls)
 //   - OpportunityPresenter   → stub class with trackable presentHomeCard
 //   - canUserSeeOpportunity  → always true
-//   - getOrCreateHomeCardBatch → use the REAL implementation so cache.mget/set are exercised
+//   - getOrCreateDeliveryCardBatch → use the REAL implementation so cache.mget/set are exercised
 
-import { getOrCreateHomeCardBatch as realGetOrCreate } from '@indexnetwork/protocol';
+import { getOrCreateDeliveryCardBatch as realGetOrCreate } from '@indexnetwork/protocol';
 
 const presentHomeCardMock = mock(async (_input: unknown) => ({
   ...STUB_CARD,
@@ -122,7 +122,7 @@ mock.module('@indexnetwork/protocol', () => {
     })),
 
     // Use the real implementation so cache.mget / cache.set are exercised
-    getOrCreateHomeCardBatch: realGetOrCreate,
+    getOrCreateDeliveryCardBatch: realGetOrCreate,
   };
 });
 
@@ -289,7 +289,7 @@ describe('OpportunityDeliveryService cache-aside wiring', () => {
     expect(mgetCalls.length).toBe(0);
   });
 
-  it('uses the correct cache key format: home:card:{id}:{status}:{viewerId}', async () => {
+  it('uses the correct cache key format: delivery:card:{id}:{status}:{viewerId}', async () => {
     const { OpportunityPresenter } = await import('@indexnetwork/protocol');
     const cache = makeMockCache(false);
     const svc = new OpportunityDeliveryService(
@@ -301,6 +301,6 @@ describe('OpportunityDeliveryService cache-aside wiring', () => {
     await renderCard(svc, OPP_ID, USER_ID);
 
     const key = cache.mgetCalls[0][0];
-    expect(key).toBe(`home:card:${OPP_ID}:${STUB_OPP.status}:${USER_ID}`);
+    expect(key).toBe(`delivery:card:${OPP_ID}:${STUB_OPP.status}:${USER_ID}`);
   });
 });

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -115,11 +115,11 @@ export { presentOpportunity } from "./opportunity/opportunity.presentation.js";
 export type { UserInfo } from "./opportunity/opportunity.presentation.js";
 export { stripUuids, stripIntroducerMentions } from "./opportunity/opportunity.presentation.js";
 export {
-  getOrCreateHomeCardBatch,
-  HOME_CARD_CACHE_TTL,
-  type CachedHomeCard,
+  getOrCreateDeliveryCardBatch,
+  DELIVERY_CARD_CACHE_TTL,
+  type CachedDeliveryCard,
   type OpportunityWithContext,
-} from "./opportunity/home-card.cache.js";
+} from "./opportunity/delivery-card.cache.js";
 
 // ─── Tools ────────────────────────────────────────────────────────────────────
 

--- a/packages/protocol/src/opportunity/delivery-card.cache.spec.ts
+++ b/packages/protocol/src/opportunity/delivery-card.cache.spec.ts
@@ -2,7 +2,7 @@
 process.env.OPENROUTER_API_KEY = 'test-key-unused';
 
 import { mock, describe, expect, it } from 'bun:test';
-import { getOrCreateHomeCardBatch } from './home-card.cache.js';
+import { getOrCreateDeliveryCardBatch } from './delivery-card.cache.js';
 import type { OpportunityPresenter } from './opportunity.presenter.js';
 import type { PresenterDatabase } from './opportunity.presenter.js';
 import type { Cache } from '../shared/interfaces/cache.interface.js';
@@ -14,7 +14,7 @@ mock.module('./opportunity.presenter.js', () => ({
   })),
 }));
 
-describe('getOrCreateHomeCardBatch', () => {
+describe('getOrCreateDeliveryCardBatch', () => {
   it('returns cached card without calling presenter on cache hit', async () => {
     const cachedCard = {
       opportunityId: 'opp-1',
@@ -51,7 +51,7 @@ describe('getOrCreateHomeCardBatch', () => {
     } as unknown as PresenterDatabase;
 
     const opportunities = [{ id: 'opp-1', status: 'pending', actors: [] }];
-    const result = await getOrCreateHomeCardBatch(
+    const result = await getOrCreateDeliveryCardBatch(
       mockCache,
       mockPresenter,
       mockPresenterDb,
@@ -104,7 +104,7 @@ describe('getOrCreateHomeCardBatch', () => {
       interpretation: { reasoning: 'test' },
     }];
 
-    const result = await getOrCreateHomeCardBatch(
+    const result = await getOrCreateDeliveryCardBatch(
       mockCache,
       mockPresenter,
       mockPresenterDb,
@@ -117,7 +117,7 @@ describe('getOrCreateHomeCardBatch', () => {
     expect(resultCard?.headline).toBe('Generated headline');
     expect(presentCalledCount).toBeGreaterThan(0);
     expect(setCalls.length).toBeGreaterThan(0);
-    expect(setCalls[0].key).toBe('home:card:opp-2:pending:user-1');
+    expect(setCalls[0].key).toBe('delivery:card:opp-2:pending:user-1');
     expect(setCalls[0].opts).toEqual({ ttl: 24 * 60 * 60 });
   });
 
@@ -146,7 +146,7 @@ describe('getOrCreateHomeCardBatch', () => {
     }];
 
     await expect(
-      getOrCreateHomeCardBatch(
+      getOrCreateDeliveryCardBatch(
         mockCache,
         mockPresenter,
         mockPresenterDb,
@@ -203,7 +203,7 @@ describe('getOrCreateHomeCardBatch', () => {
       { id: 'opp-2', status: 'pending', actors: [{ userId: 'user-1', role: 'candidate' }] },
     ];
 
-    const result = await getOrCreateHomeCardBatch(
+    const result = await getOrCreateDeliveryCardBatch(
       mockCache,
       mockPresenter,
       mockPresenterDb,

--- a/packages/protocol/src/opportunity/delivery-card.cache.ts
+++ b/packages/protocol/src/opportunity/delivery-card.cache.ts
@@ -2,7 +2,7 @@ import type { Cache } from '../shared/interfaces/cache.interface.js';
 import type { OpportunityPresenter, PresenterDatabase } from './opportunity.presenter.js';
 import { gatherPresenterContext } from './opportunity.presenter.js';
 
-export interface CachedHomeCard {
+export interface CachedDeliveryCard {
   opportunityId: string;
   headline: string;
   personalizedSummary: string;
@@ -18,27 +18,27 @@ export interface OpportunityWithContext {
   detection?: unknown;
 }
 
-export const HOME_CARD_CACHE_TTL = 24 * 60 * 60; // 24 hours
+export const DELIVERY_CARD_CACHE_TTL = 24 * 60 * 60; // 24 hours
 
-export async function getOrCreateHomeCardBatch(
+export async function getOrCreateDeliveryCardBatch(
   cache: Cache,
   presenter: OpportunityPresenter,
   presenterDb: PresenterDatabase,
   opportunities: OpportunityWithContext[],
   viewerId: string,
   options?: { ttl?: number }
-): Promise<Map<string, CachedHomeCard>> {
+): Promise<Map<string, CachedDeliveryCard>> {
   if (opportunities.length === 0) {
     return new Map();
   }
 
-  const ttl = options?.ttl ?? HOME_CARD_CACHE_TTL;
+  const ttl = options?.ttl ?? DELIVERY_CARD_CACHE_TTL;
   const keys = opportunities.map(
-    (opp) => `home:card:${opp.id}:${opp.status}:${viewerId}`
+    (opp) => `delivery:card:${opp.id}:${opp.status}:${viewerId}`
   );
-  const cached = await cache.mget<CachedHomeCard>(keys);
+  const cached = await cache.mget<CachedDeliveryCard>(keys);
 
-  const result = new Map<string, CachedHomeCard>();
+  const result = new Map<string, CachedDeliveryCard>();
   const misses: Array<{ opp: OpportunityWithContext; index: number }> = [];
 
   for (let i = 0; i < opportunities.length; i++) {
@@ -61,7 +61,7 @@ export async function getOrCreateHomeCardBatch(
       presenterInput.opportunityStatus = opp.status;
 
       const presented = await presenter.presentHomeCard(presenterInput);
-      const card: CachedHomeCard = {
+      const card: CachedDeliveryCard = {
         opportunityId: opp.id,
         headline: presented.headline,
         personalizedSummary: presented.personalizedSummary,


### PR DESCRIPTION
## Bug Fixes

The delivery card cache (used by `OpportunityDeliveryService` for OpenClaw notification rendering) and the home feed presenter cache both wrote to `home:card:{oppId}:{status}:{viewerId}` with **incompatible value shapes**:

- Home feed wrote a full `HomeCardItem` (name, userId, avatar, mainText, mutualIntentsLabel, narratorChip, …)
- Delivery wrote a stub `CachedHomeCard` (only headline, personalizedSummary, suggestedAction, narratorRemark)

Whichever ran first poisoned the other's reads. When delivery had cached an opportunity within the 24h TTL, the home view rendered the stub as `name=undefined`, `mutualIntentsLabel=undefined`, `mainText=undefined` → the frontend fell back to **"Someone / Potential connection / no description"**. `?noCache=true` worked because it bypassed the poisoned read and regenerated the full card.

The earlier fix (`7cd6c7fd3`, "skip caching home cards with unresolved names") guarded the home-feed write path but never fired on the delivery write — different code path entirely.

## Refactors

Rename the misleadingly-named delivery cache module and split its key namespace from the home feed:

- `home-card.cache.ts` → `delivery-card.cache.ts`
- `CachedHomeCard` → `CachedDeliveryCard`
- `getOrCreateHomeCardBatch` → `getOrCreateDeliveryCardBatch`
- `HOME_CARD_CACHE_TTL` → `DELIVERY_CARD_CACHE_TTL`
- Redis key prefix `home:card:` → `delivery:card:` (delivery only)

The home feed continues to own `home:card:` exclusively.

## Tests

- `packages/protocol/src/opportunity/delivery-card.cache.spec.ts` — updated key assertion and symbol references
- `backend/src/services/tests/opportunity-delivery.cache.spec.ts` — updated mock module exports and key-format assertion

Both pass (4/4 protocol, 6/6 backend).

## Versions

- `@indexnetwork/protocol`: 0.22.2 → 0.22.3

## Operational note

Existing poisoned entries in Redis (`home:card:*` written by the old delivery path before this change) will continue to render as broken cards until their 24h TTL expires. Optional: flush keys matching `home:card:*` after deploy to clear them immediately.

## Test plan

- [ ] Deploy to staging
- [ ] Open "Find your others" — confirm no "Someone / Potential connection" cards (or wait 24h for stale entries to expire / flush)
- [ ] Trigger an OpenClaw delivery for a fresh opportunity, then open the home view — same opportunity should render with full UI fields