### PR TITLE
fix(openclaw-plugin): don't back off ambient poll on empty results

### DIFF
--- a/packages/openclaw-plugin/README.md
+++ b/packages/openclaw-plugin/README.md
@@ -105,7 +105,7 @@ The digest ranks all pending opportunities by relevance and passes the top N to 
 
 - **Duplicate registration guard** — if OpenClaw calls `register()` more than once per process, only the first call takes effect.
 - **In-flight deduplication** — turns already being handled are not re-launched on subsequent poll cycles.
-- **Exponential backoff** — on repeated failures (backend unreachable, subagent errors), the poll interval doubles up to ~8 minutes, then resets on the next successful communication.
+- **Exponential backoff** — on real errors (backend unreachable, dispatch failure), the ambient poll interval doubles up to a cap (~80 minutes), then resets on the next successful communication. "No pending opportunities" is a healthy idle state and does NOT trigger backoff — the poller stays at the 5-minute base interval so newly-surfaced opportunities aren't delayed.
 - **Startup diagnostics** — on first poll, the plugin checks backend reachability and logs an actionable warning if `protocolUrl` is misconfigured.
 
 ### Model used for rendering

--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "indexnetwork-openclaw-plugin",
   "name": "Index Network",
   "description": "Index Network — find the right people and let them find you. Registers the Index Network MCP server on first use and hands off to its guidance.",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "configSchema": {
     "type": "object",
     "properties": {

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "indexnetwork-openclaw-plugin",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "description": "Index Network — OpenClaw plugin. Registers the Index Network MCP server and hands off to its guidance.",
   "license": "MIT",
   "private": false,

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -188,8 +188,11 @@ export function register(api: OpenClawPluginApi): void {
     match: 'exact',
     handler: async (_req, res) => {
       try {
-        const result = await ambientDiscoveryPoller.handle(api, { baseUrl, agentId, apiKey, frontendUrl });
-        if (!result) {
+        const outcome = await ambientDiscoveryPoller.handle(api, { baseUrl, agentId, apiKey, frontendUrl });
+        // Back off only on real errors (backend unreachable / dispatch failed).
+        // 'empty' is a healthy idle state — keep polling at base interval so
+        // newly-surfaced opportunities aren't delayed by stale backoff.
+        if (outcome === 'error') {
           ambientDiscoveryScheduler.increaseBackoff(api.logger);
         } else {
           ambientDiscoveryScheduler.resetBackoff();

--- a/packages/openclaw-plugin/src/polling/ambient-discovery/ambient-discovery.poller.ts
+++ b/packages/openclaw-plugin/src/polling/ambient-discovery/ambient-discovery.poller.ts
@@ -33,13 +33,17 @@ let lastOpportunityBatchHash: string | null = null;
  * the agent didn't surface this cycle do not roll over. The dedup hash
  * prevents back-to-back redispatch of the same set.
  *
- * @returns `true` when a dispatch landed, `false` when nothing was
- *          eligible, the batch was unchanged, or dispatch failed.
+ * @returns
+ *   - `'dispatched'` — a dispatch landed (or dispatched but confirm failed; either way, backend was reachable and content moved).
+ *   - `'empty'` — backend reached, but nothing to dispatch (no opportunities, all filtered out, or batch unchanged since last cycle). This is a healthy idle state, not a failure.
+ *   - `'error'` — the backend was unreachable or returned an error, OR dispatch to the main agent failed. The scheduler should back off only on this case.
  */
+export type AmbientDiscoveryOutcome = 'dispatched' | 'empty' | 'error';
+
 export async function handle(
   api: OpenClawPluginApi,
   config: AmbientDiscoveryConfig,
-): Promise<boolean> {
+): Promise<AmbientDiscoveryOutcome> {
   const pendingUrl = `${config.baseUrl}/api/agents/${config.agentId}/opportunities/pending?limit=${PENDING_LIMIT}`;
 
   let res: Response;
@@ -51,13 +55,13 @@ export async function handle(
     });
   } catch (err) {
     api.logger.warn(`Ambient discovery fetch errored: ${err instanceof Error ? err.message : String(err)}`);
-    return false;
+    return 'error';
   }
 
   if (!res.ok) {
     const text = await res.text().catch(() => '');
     api.logger.warn(`Ambient discovery fetch failed: ${res.status} ${text}`);
-    return false;
+    return 'error';
   }
 
   const body = (await res.json()) as {
@@ -70,7 +74,7 @@ export async function handle(
 
   if (!body.opportunities.length) {
     api.logger.info('Ambient discovery: no pending opportunities');
-    return false;
+    return 'empty';
   }
 
   const candidates = body.opportunities
@@ -87,14 +91,14 @@ export async function handle(
       skipUrl: `${config.frontendUrl}/opportunities/${o.opportunityId}/skip`,
     }));
 
-  if (!candidates.length) return false;
+  if (!candidates.length) return 'empty';
 
   const dateStr = new Date().toISOString().slice(0, 10);
   const batchHash = hashOpportunityBatch(candidates.map((c) => c.opportunityId));
 
   if (batchHash === lastOpportunityBatchHash) {
     api.logger.info('Opportunity batch unchanged since last poll — skipping main-agent dispatch.');
-    return false;
+    return 'empty';
   }
 
   const mainAgentToolUse = readMainAgentToolUse(api);
@@ -111,7 +115,7 @@ export async function handle(
   });
 
   if (!dispatch.delivered) {
-    return false;
+    return 'error';
   }
 
   const batchIds = candidates.map((c) => c.opportunityId);
@@ -127,7 +131,7 @@ export async function handle(
     api.logger.warn(
       'Ambient discovery: confirm failed; leaving dedup hash unchanged so the batch retries next cycle.',
     );
-    return true;
+    return 'dispatched';
   }
 
   lastOpportunityBatchHash = batchHash;
@@ -137,7 +141,7 @@ export async function handle(
     { agentId: config.agentId },
   );
 
-  return true;
+  return 'dispatched';
 }
 
 /** Reset module-level state. Exposed for tests only. */

--- a/packages/openclaw-plugin/src/tests/opportunity-batch.spec.ts
+++ b/packages/openclaw-plugin/src/tests/opportunity-batch.spec.ts
@@ -94,10 +94,10 @@ describe('handleAmbientDiscovery (hooks-only path)', () => {
     expect(sink.pendingUrls[0]).toContain('limit=10');
   });
 
-  it('returns false when /pending is empty (no hook dispatch)', async () => {
+  it('returns "empty" when /pending is empty (no hook dispatch, no backoff)', async () => {
     const sink = mockBackend([]);
     const result = await handleAmbientDiscovery(mockApi, cfg);
-    expect(result).toBe(false);
+    expect(result).toBe('empty');
     expect(sink.hookCalls).toHaveLength(0);
   });
 
@@ -106,14 +106,18 @@ describe('handleAmbientDiscovery (hooks-only path)', () => {
       { opportunityId: OPP_1, counterpartUserId: 'user-1', rendered: { headline: 'H', personalizedSummary: 'S', suggestedAction: 'A', narratorRemark: '' } },
     ]);
     const result = await handleAmbientDiscovery(mockApi, cfg);
-    expect(result).toBe(true);
+    expect(result).toBe('dispatched');
     expect(sink.hookCalls).toHaveLength(1);
     const hookCall = sink.hookCalls[0];
     expect(hookCall.headers?.authorization).toBe('Bearer hooks-tok');
     const body = hookCall.body as { message: string; deliver: boolean; channel: string };
     expect(body.message).toContain('Real-time alert');
     expect(body.deliver).toBe(true);
-    expect(body.channel).toBe('last');
+    // `channel` resolves either to a chat-bound channel (when a real
+    // sessions.json exists on the machine running the test) or to 'last'
+    // (the unbound fallback). Both are acceptable here — channel routing
+    // is verified in `main-agent.dispatcher.spec.ts`.
+    expect(typeof body.channel).toBe('string');
   });
 
   it('confirms ALL batch IDs after successful dispatch (no scrape)', async () => {
@@ -132,17 +136,17 @@ describe('handleAmbientDiscovery (hooks-only path)', () => {
       { opportunityId: OPP_1, counterpartUserId: null, rendered: { headline: 'H', personalizedSummary: 'S', suggestedAction: 'A', narratorRemark: '' } },
     ]);
     const result = await handleAmbientDiscovery(mockApi, cfg);
-    expect(result).toBe(false);
+    expect(result).toBe('empty');
     expect(sink.hookCalls).toHaveLength(0);
   });
 
-  it('returns false when dispatch fails (config_error)', async () => {
+  it('returns "error" when dispatch fails (config_error)', async () => {
     mockApi.config = { gateway: { port: 18789 } };
     const sink = mockBackend([
       { opportunityId: OPP_1, counterpartUserId: 'user-1', rendered: { headline: 'H', personalizedSummary: 'S', suggestedAction: 'A', narratorRemark: '' } },
     ]);
     const result = await handleAmbientDiscovery(mockApi, cfg);
-    expect(result).toBe(false);
+    expect(result).toBe('error');
     expect(sink.hookCalls).toHaveLength(0);
     expect(sink.confirmCalls).toHaveLength(0);
   });


### PR DESCRIPTION
## Summary

Ambient discovery's exponential backoff fired on every \"no pending opportunities\" response, indistinguishable from real errors. After ~5 quiet polls, the interval saturated at the 16× cap (80 minutes) and stayed there — so when a fresh opportunity finally landed, the user could wait up to an hour and a half for the next poll to pick it up.

## Bug Fix

- **`packages/openclaw-plugin/src/polling/ambient-discovery/ambient-discovery.poller.ts`** — Replaced the `Promise<boolean>` return with `Promise<'dispatched' | 'empty' | 'error'>`. \"Empty\" covers no opportunities, no eligible candidates, or dedup-skipped batches. \"Error\" covers fetch failures, non-2xx responses, and dispatch failures.
- **`packages/openclaw-plugin/src/index.ts`** — Route handler now calls `increaseBackoff` only on `'error'`. Both `'dispatched'` and `'empty'` reset to the 5-minute base interval.

## Tests

- Existing tests updated for the new return shape (`'empty'` for empty `/pending`, `'dispatched'` for happy path, `'error'` for dispatch failure).
- All 110 plugin tests pass.
- Loosened a brittle assertion in `opportunity-batch.spec.ts` that asserted `body.channel === 'last'` — that fails on developer machines that have a real `~/.openclaw/agents/main/sessions/sessions.json` (PR #707's session-targeting code reads it). Channel routing has its own dedicated test in `main-agent.dispatcher.spec.ts`.

## Documentation

- README resilience section now distinguishes real errors from idle state in the backoff description.

## Version

\`0.18.1\` → \`0.18.2\` (both \`package.json\` and \`openclaw.plugin.json\`).

## Test Plan

- [x] All 110 plugin tests pass
- [ ] Reviewer to confirm: a stretch of empty polls keeps logging \`Ambient discovery: no pending opportunities\` without the \`backing off — next poll in ...\` line that previously appeared on every cycle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Bumped plugin version to 0.18.2

* **Improvements**
  * Refined resilience behavior: backoff now only applies to critical failures (backend unreachable, dispatch failure), not subagent errors
  * Increased maximum backoff time from ~8 minutes to ~80 minutes
  * Polling maintains 5-minute base interval when no pending opportunities exist to avoid delaying newly surfaced opportunities

* **Documentation**
  * Updated resilience documentation to reflect new backoff behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->