### PR TITLE
fix(openclaw-plugin): route dispatch via origin.to/origin.provider

### DIFF
--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "indexnetwork-openclaw-plugin",
   "name": "Index Network",
   "description": "Index Network — find the right people and let them find you. Registers the Index Network MCP server on first use and hands off to its guidance.",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "configSchema": {
     "type": "object",
     "properties": {

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "indexnetwork-openclaw-plugin",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Index Network — OpenClaw plugin. Registers the Index Network MCP server and hands off to its guidance.",
   "license": "MIT",
   "private": false,

--- a/packages/openclaw-plugin/src/lib/delivery/main-agent.dispatcher.ts
+++ b/packages/openclaw-plugin/src/lib/delivery/main-agent.dispatcher.ts
@@ -72,6 +72,11 @@ interface SessionsMapEntry {
   lastTo?: string;
   lastChannel?: string;
   updatedAt?: number;
+  origin?: {
+    to?: string;
+    provider?: string;
+    surface?: string;
+  };
 }
 
 /** Routing target extracted from the user's most-recent chat session. */
@@ -85,17 +90,39 @@ interface ChatTarget {
 }
 
 /**
+ * Extracts the routing pair from a sessions.json entry. Prefers the
+ * current OpenClaw schema where chat info lives under `origin.to` and
+ * `origin.provider`/`origin.surface`. Falls back to a top-level `lastTo`
+ * of the form `<channel>:<id>` for legacy entries that still carry it.
+ */
+function readChannelTo(val: SessionsMapEntry): { channel: string; to: string } | undefined {
+  const originTo = typeof val.origin?.to === 'string' ? val.origin.to : '';
+  const originChannel =
+    (typeof val.origin?.provider === 'string' && val.origin.provider) ||
+    (typeof val.origin?.surface === 'string' && val.origin.surface) ||
+    '';
+  if (originTo && originChannel) {
+    return { channel: originChannel, to: originTo };
+  }
+  const lastTo = typeof val.lastTo === 'string' ? val.lastTo : '';
+  const colonIdx = lastTo.indexOf(':');
+  if (colonIdx > 0) {
+    return { channel: lastTo.slice(0, colonIdx), to: lastTo };
+  }
+  return undefined;
+}
+
+/**
  * Locates the user's most-recently-active chat-bound session by reading
  * `~/.openclaw/agents/main/sessions/sessions.json` and filtering for
- * sessions whose `lastTo` starts with a known chat-channel prefix.
+ * sessions whose channel (from `origin.provider` / `origin.surface`,
+ * with `lastTo` as legacy fallback) is a known chat-channel prefix.
  *
  * Returns the routing triple `{sessionKey, channel, to}` or `undefined`
  * when no such session exists. `/hooks/agent` needs all three together
  * to deliver to the channel — sessionKey alone makes the run "join" the
  * existing session, but the gateway still consults `channel` and `to`
- * for the actual delivery target. (Sessions.json's `lastTo` value is
- * already in `<channel>:<id>` form, so `channel` is the prefix and `to`
- * is the whole value.)
+ * for the actual delivery target.
  */
 async function findChatTarget(
   api: OpenClawPluginApi,
@@ -135,20 +162,17 @@ async function findChatTarget(
       if (key.startsWith('agent:main:hook:')) return false;
       if (key === 'agent:main:main') return false;
       if (key.startsWith('agent:main:index:')) return false;
-      const lastTo = typeof val.lastTo === 'string' ? val.lastTo : '';
-      const colonIdx = lastTo.indexOf(':');
-      if (colonIdx <= 0) return false;
-      const channel = lastTo.slice(0, colonIdx);
-      return CHAT_CHANNEL_PREFIXES.includes(channel);
+      const target = readChannelTo(val);
+      return target !== undefined && CHAT_CHANNEL_PREFIXES.includes(target.channel);
     })
     .sort(([, a], [, b]) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));
 
   const top = candidates[0];
   if (!top) return undefined;
 
-  const lastTo = top[1].lastTo as string;
-  const channel = lastTo.slice(0, lastTo.indexOf(':'));
-  return { sessionKey: top[0], channel, to: lastTo };
+  const target = readChannelTo(top[1]);
+  if (!target) return undefined;
+  return { sessionKey: top[0], channel: target.channel, to: target.to };
 }
 
 /**

--- a/packages/openclaw-plugin/src/tests/main-agent.dispatcher.spec.ts
+++ b/packages/openclaw-plugin/src/tests/main-agent.dispatcher.spec.ts
@@ -73,17 +73,21 @@ describe('dispatchToMainAgent', () => {
     }) as unknown as typeof fetch;
   }
 
-  it('targets the most recent chat-bound session via sessionKey + channel + to', async () => {
+  it('targets the most recent chat-bound session via origin.to + origin.provider (production schema)', async () => {
+    // Mirrors a real ~/.openclaw/agents/main/sessions/sessions.json — chat
+    // info lives under `origin`, not at the top level. This is the schema
+    // the running gateway writes; reading top-level `lastTo` would miss
+    // every real Telegram session and fall back to channel:"last".
     writeSessions({
       'agent:main:telegram:direct:69340471': {
         sessionId: 'sess-tg',
-        lastTo: 'telegram:69340471',
+        origin: { provider: 'telegram', surface: 'telegram', to: 'telegram:69340471' },
         updatedAt: 1000,
       },
       'agent:main:hook:abc-123': {
         // plugin-internal — should be skipped even if newer
         sessionId: 'sess-hook',
-        lastTo: 'telegram:69340471',
+        origin: { provider: 'telegram', surface: 'telegram', to: 'telegram:69340471' },
         updatedAt: 9999,
       },
       'agent:main:main': {
@@ -111,18 +115,54 @@ describe('dispatchToMainAgent', () => {
     expect(body.to).toBe('telegram:69340471');
   });
 
+  it('falls back to top-level lastTo when origin is missing (legacy schema)', async () => {
+    // Older sessions written before OpenClaw moved chat info under
+    // `origin` may still carry a top-level `lastTo`. Keep the fallback so
+    // we don't regress users mid-upgrade.
+    writeSessions({
+      'agent:main:telegram:direct:42': {
+        sessionId: 'sess-tg-legacy',
+        lastTo: 'telegram:42',
+        updatedAt: 1000,
+      },
+    });
+    mockOk();
+    await dispatchToMainAgent(mockApi, ctx);
+    const body = JSON.parse(captured[0].init?.body as string) as Record<string, unknown>;
+    expect(body.sessionKey).toBe('agent:main:telegram:direct:42');
+    expect(body.channel).toBe('telegram');
+    expect(body.to).toBe('telegram:42');
+  });
+
+  it('prefers origin over legacy lastTo when both are present', async () => {
+    // If a session entry happens to carry both, the current schema
+    // (origin) is authoritative. This pins the precedence so a future
+    // refactor can't accidentally invert it.
+    writeSessions({
+      'agent:main:telegram:direct:1': {
+        origin: { provider: 'telegram', surface: 'telegram', to: 'telegram:from-origin' },
+        lastTo: 'telegram:from-lastTo',
+        updatedAt: 1000,
+      },
+    });
+    mockOk();
+    await dispatchToMainAgent(mockApi, ctx);
+    const body = JSON.parse(captured[0].init?.body as string) as Record<string, unknown>;
+    expect(body.to).toBe('telegram:from-origin');
+  });
+
   it('picks most-recently-updated chat session when multiple exist', async () => {
     writeSessions({
       'agent:main:telegram:direct:111': {
-        lastTo: 'telegram:111',
+        origin: { provider: 'telegram', to: 'telegram:111' },
         updatedAt: 100,
       },
       'agent:main:whatsapp:direct:222': {
-        lastTo: 'whatsapp:222',
+        origin: { provider: 'whatsapp', to: 'whatsapp:222' },
         updatedAt: 500,
       },
       'agent:main:discord:dm:333': {
-        lastTo: 'discord:333',
+        origin: { provider: 'discord', to: 'discord:333' },
         updatedAt: 250,
       },
     });


### PR DESCRIPTION
## Summary

The dispatcher's `findChatTarget` was filtering sessions on a top-level `lastTo` field that doesn't exist in current OpenClaw `sessions.json` builds — real chat info lives under `origin.to` / `origin.provider` (`origin.surface`). Every chat-bound session was therefore missed and every ambient/digest dispatch silently fell back to `channel: "last"`, landing in an isolated session with no channel binding. The user never saw the agent's reply, even though the agent was running and calling `confirm_opportunity_delivery`.

Verified live against a running gateway: with the patch applied to \`~/.openclaw/extensions/indexnetwork-openclaw-plugin/\`, ambient discovery dispatched and the rendered opportunity (Chad Fowler, from a freshly-seeded Lisp/Clojure music-sequencer signal) reached the user's Telegram.

## Bug Fixes

- Read `origin.to` + `origin.provider` (or `origin.surface`) for chat routing; keep top-level `lastTo` as a legacy-schema fallback so users mid-upgrade aren't regressed.
- Bump openclaw-plugin 0.19.1 → 0.19.2 in both \`package.json\` and \`openclaw.plugin.json\` (lockstep per CLI install convention).

## Tests

- New: pins production schema (`origin.to` + `origin.provider`).
- New: pins `origin > lastTo` precedence so a future refactor can't invert priority.
- Existing legacy `lastTo` fallback test retained (mid-upgrade safety).
- 113/113 plugin tests pass (was 111; +2 net new).

## Test Plan

- [x] `bun test` in `packages/openclaw-plugin` (113 pass)
- [x] Live verification: patched `~/.openclaw` copy + restarted gateway → real Telegram message received from ambient pickup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Released version 0.19.2. Enhanced session routing logic to support the latest session schema with improved chat target resolution. Updated session handling to leverage new routing fields while maintaining full backward compatibility with legacy session formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->