### PR TITLE
feat(cli): redesign help output with grouped box-drawing panels

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -143,10 +143,11 @@
       },
     },
     "packages/openclaw-plugin": {
-      "name": "indexnetwork-openclaw-plugin",
-      "version": "0.20.0",
+      "name": "@indexnetwork/openclaw-plugin",
+      "version": "0.22.1",
       "devDependencies": {
         "@types/node": "^22.0.0",
+        "bun-types": "latest",
         "typescript": "^5.5.0",
       },
     },
@@ -465,6 +466,8 @@
     "@indexnetwork/claude-plugin": ["@indexnetwork/claude-plugin@workspace:packages/claude-plugin"],
 
     "@indexnetwork/cli": ["@indexnetwork/cli@workspace:packages/cli"],
+
+    "@indexnetwork/openclaw-plugin": ["@indexnetwork/openclaw-plugin@workspace:packages/openclaw-plugin"],
 
     "@indexnetwork/protocol": ["@indexnetwork/protocol@workspace:packages/protocol"],
 
@@ -916,7 +919,7 @@
 
     "@types/mysql": ["@types/mysql@2.15.27", "", { "dependencies": { "@types/node": "*" } }, "sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA=="],
 
-    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+    "@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
 
     "@types/node-cron": ["@types/node-cron@3.0.11", "", {}, "sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg=="],
 
@@ -1461,8 +1464,6 @@
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
     "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
-
-    "indexnetwork-openclaw-plugin": ["indexnetwork-openclaw-plugin@workspace:packages/openclaw-plugin"],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
@@ -2186,7 +2187,7 @@
 
     "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
 
-    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
 
@@ -2308,6 +2309,8 @@
 
     "@fastify/otel/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
+    "@indexnetwork/protocol/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
     "@langchain/langgraph/uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
     "@langchain/langgraph-api/langsmith": ["langsmith@0.2.15", "", { "dependencies": { "@types/uuid": "^10.0.0", "commander": "^10.0.1", "p-queue": "^6.6.2", "p-retry": "4", "semver": "^7.6.3", "uuid": "^10.0.0" }, "peerDependencies": { "openai": "*" }, "optionalPeers": ["openai"] }, "sha512-homtJU41iitqIZVuuLW7iarCzD4f39KcfP9RTBWav9jifhrsDa1Ez89Ejr+4qi72iuBu8Y5xykchsGVgiEZ93w=="],
@@ -2356,6 +2359,22 @@
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
+    "@types/busboy/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@types/connect/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@types/mysql/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@types/node-fetch/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@types/pg/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@types/tedious/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@types/ws/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@types/yauzl/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
@@ -2363,6 +2382,8 @@
     "better-auth/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "better-call/set-cookie-parser": ["set-cookie-parser@3.1.0", "", {}, "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw=="],
+
+    "bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -2386,9 +2407,9 @@
 
     "frontend/@types/node": ["@types/node@20.19.39", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw=="],
 
-    "htmlparser2/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+    "happy-dom/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
-    "indexnetwork-openclaw-plugin/@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
+    "htmlparser2/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "langchain/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
@@ -2510,6 +2531,8 @@
 
     "@fastify/otel/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
+    "@indexnetwork/protocol/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
     "@langchain/langgraph-api/langsmith/commander": ["commander@10.0.1", "", {}, "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="],
 
     "@langchain/langgraph-api/langsmith/p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
@@ -2528,21 +2551,35 @@
 
     "@prisma/instrumentation/@opentelemetry/instrumentation/import-in-the-middle": ["import-in-the-middle@2.0.6", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw=="],
 
+    "@types/busboy/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "@types/connect/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "@types/mysql/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "@types/node-fetch/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "@types/pg/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "@types/tedious/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "@types/ws/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "@types/yauzl/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+
+    "bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "color/color-convert/color-name": ["color-name@2.1.0", "", {}, "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="],
 
-    "frontend/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
-
-    "indexnetwork-openclaw-plugin/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+    "happy-dom/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "log-update/slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "openai/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "protocol/@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
-
-    "protocol/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 
@@ -2609,5 +2646,7 @@
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "protocol/@types/bun/bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "protocol/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
     },
     "backend": {
       "name": "protocol",
-      "version": "0.14.1",
+      "version": "0.17.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.939.0",
         "@aws-sdk/s3-request-presigner": "^3.983.0",
@@ -67,7 +67,7 @@
     },
     "frontend": {
       "name": "frontend",
-      "version": "0.6.3",
+      "version": "0.7.0",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.2",
@@ -124,11 +124,11 @@
     },
     "packages/claude-plugin": {
       "name": "@indexnetwork/claude-plugin",
-      "version": "0.1.1",
+      "version": "0.1.2",
     },
     "packages/cli": {
       "name": "@indexnetwork/cli",
-      "version": "0.10.0",
+      "version": "0.10.2",
       "bin": {
         "index": "bin/index.cjs",
       },
@@ -136,15 +136,15 @@
         "@types/bun": "latest",
       },
       "optionalDependencies": {
-        "@indexnetwork/cli-darwin-arm64": "0.10.0",
-        "@indexnetwork/cli-darwin-x64": "0.10.0",
-        "@indexnetwork/cli-linux-arm64": "0.10.0",
-        "@indexnetwork/cli-linux-x64": "0.10.0",
+        "@indexnetwork/cli-darwin-arm64": "0.10.2",
+        "@indexnetwork/cli-darwin-x64": "0.10.2",
+        "@indexnetwork/cli-linux-arm64": "0.10.2",
+        "@indexnetwork/cli-linux-x64": "0.10.2",
       },
     },
     "packages/openclaw-plugin": {
       "name": "indexnetwork-openclaw-plugin",
-      "version": "0.15.2",
+      "version": "0.20.0",
       "devDependencies": {
         "@types/node": "^22.0.0",
         "typescript": "^5.5.0",
@@ -152,7 +152,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "0.21.1",
+      "version": "0.23.0",
       "dependencies": {
         "@langchain/core": "^1.1.17",
         "@langchain/langgraph": "^1.1.2",

--- a/packages/cli/bun.lock
+++ b/packages/cli/bun.lock
@@ -7,22 +7,14 @@
         "@types/bun": "latest",
       },
       "optionalDependencies": {
-        "@indexnetwork/cli-darwin-arm64": "0.9.1",
-        "@indexnetwork/cli-darwin-x64": "0.9.1",
-        "@indexnetwork/cli-linux-arm64": "0.9.1",
-        "@indexnetwork/cli-linux-x64": "0.9.1",
+        "@indexnetwork/cli-darwin-arm64": "0.10.2",
+        "@indexnetwork/cli-darwin-x64": "0.10.2",
+        "@indexnetwork/cli-linux-arm64": "0.10.2",
+        "@indexnetwork/cli-linux-x64": "0.10.2",
       },
     },
   },
   "packages": {
-    "@indexnetwork/cli-darwin-arm64": ["@indexnetwork/cli-darwin-arm64@0.9.1", "", { "os": "darwin", "cpu": "arm64", "bin": { "index": "bin/index" } }, "sha512-VR5TXNXTgyciF1tfrAgamHFOHt/9LJ4/IVmfM/Y043sjTJONW7WLtWR4u9YWKY2Sq4Ezy1JlMzVzMbpMbrDnww=="],
-
-    "@indexnetwork/cli-darwin-x64": ["@indexnetwork/cli-darwin-x64@0.9.1", "", { "os": "darwin", "cpu": "x64", "bin": { "index": "bin/index" } }, "sha512-uNfvYdrXrwiIox18tQUCgVfAbD3KIwzJY/iqPKLE+LEd+h4NYfl1l+Zm/kQIwlz67Re/k1jSL3c3L2iW/YhG/g=="],
-
-    "@indexnetwork/cli-linux-arm64": ["@indexnetwork/cli-linux-arm64@0.9.1", "", { "os": "linux", "cpu": "arm64", "bin": { "index": "bin/index" } }, "sha512-XDbIWe7Pg6iPtjRfdBt/x4VcDOqAQ7HTd5XWYrmyruQXmP0s5xqZRuEm3VaPZ6bX16iSwEnSex0xUgN1+rNZNA=="],
-
-    "@indexnetwork/cli-linux-x64": ["@indexnetwork/cli-linux-x64@0.9.1", "", { "os": "linux", "cpu": "x64", "bin": { "index": "bin/index" } }, "sha512-6FoWJkaGnkr5YnAl7fH5HGr/KhVj5iyGVihr94fQyPNjmqNfRwlqHY0TroVbcaGzemjhngeDxf667sMKPGghyw=="],
-
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],

--- a/packages/cli/npm/darwin-arm64/package.json
+++ b/packages/cli/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/cli-darwin-arm64",
-  "version": "0.10.0",
+  "version": "0.10.2",
   "description": "Platform-specific binary for @indexnetwork/cli (macOS arm64)",
   "license": "MIT",
   "os": [

--- a/packages/cli/npm/darwin-x64/package.json
+++ b/packages/cli/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/cli-darwin-x64",
-  "version": "0.10.0",
+  "version": "0.10.2",
   "description": "Platform-specific binary for @indexnetwork/cli (macOS x64)",
   "license": "MIT",
   "os": [

--- a/packages/cli/npm/linux-arm64/package.json
+++ b/packages/cli/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/cli-linux-arm64",
-  "version": "0.10.0",
+  "version": "0.10.2",
   "description": "Platform-specific binary for @indexnetwork/cli (Linux arm64)",
   "license": "MIT",
   "os": [

--- a/packages/cli/npm/linux-x64/package.json
+++ b/packages/cli/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/cli-linux-x64",
-  "version": "0.10.0",
+  "version": "0.10.2",
   "description": "Platform-specific binary for @indexnetwork/cli (Linux x64)",
   "license": "MIT",
   "os": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,10 +20,10 @@
     "publish:all": "bun scripts/publish.ts"
   },
   "optionalDependencies": {
-    "@indexnetwork/cli-linux-x64": "0.10.0",
-    "@indexnetwork/cli-linux-arm64": "0.10.0",
-    "@indexnetwork/cli-darwin-x64": "0.10.0",
-    "@indexnetwork/cli-darwin-arm64": "0.10.0"
+    "@indexnetwork/cli-linux-x64": "0.10.2",
+    "@indexnetwork/cli-linux-arm64": "0.10.2",
+    "@indexnetwork/cli-darwin-x64": "0.10.2",
+    "@indexnetwork/cli-darwin-arm64": "0.10.2"
   },
   "devDependencies": {
     "@types/bun": "latest"

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -27,7 +27,7 @@ import * as output from "./output";
 
 const DEFAULT_API_URL = "https://protocol.index.network";
 const DEFAULT_APP_URL = "https://index.network";
-const VERSION = "0.10.0";
+const VERSION = "0.10.2";
 
 /** Unicode box-drawing (rounded), same style as Honcho CLI. */
 const BOX = { tl: "\u256d", tr: "\u256e", bl: "\u2570", br: "\u256f", h: "\u2500", v: "\u2502" } as const;

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -29,90 +29,117 @@ const DEFAULT_API_URL = "https://protocol.index.network";
 const DEFAULT_APP_URL = "https://index.network";
 const VERSION = "0.10.0";
 
-const HELP_TEXT = `
-Index CLI v${VERSION}
+/** Unicode box-drawing (rounded), same style as Honcho CLI. */
+const BOX = { tl: "\u256d", tr: "\u256e", bl: "\u2570", br: "\u256f", h: "\u2500", v: "\u2502" } as const;
 
-Usage:
-  index login                           Authenticate via browser (uses existing session or OAuth)
-  index login --token <token>           Authenticate with a manually provided token
-  index logout                          Clear stored session
-  index conversation                    Chat with the AI agent (interactive REPL)
-  index conversation "message"          One-shot message to the AI agent
-  index conversation --session <id>     Resume a specific chat session
-  index conversation sessions           List AI chat sessions
-  index conversation list               List all conversations (H2A + H2H)
-  index conversation with <user-id>     Open or resume a DM with a user
-  index conversation show <id>          Show messages in a conversation
-  index conversation send <id> <msg>    Send a message
-  index conversation stream             Listen for real-time events (SSE)
-  index profile                         Show your profile
-  index profile show <user-id>          Show another user's profile
-  index profile sync                    Regenerate your profile
-  index profile search <query>          Search user profiles
-  index profile create [--linkedin <url>] [--github <url>] [--twitter <url>]
-                                        Create your profile from social URLs
-  index profile update <action> [--details <text>]
-                                        Update your profile
-  index intent list [--archived] [--limit <n>]  List your signals
-  index intent show <id>               Show signal details
-  index intent create <content>        Create a signal from natural language
-  index intent update <id> <content>   Update a signal's description
-  index intent archive <id>            Archive a signal
-  index intent link <id> <network-id>  Link a signal to a network
-  index intent unlink <id> <network-id> Unlink a signal from a network
-  index intent links <id>              Show linked networks for a signal
-  index negotiation list               List your agent's negotiations
-  index negotiation list --limit <n>   Limit results
-  index negotiation list --since <t>   Filter by time (ISO date or 1h, 2d, 1w)
-  index negotiation show <id>          Show negotiation turn-by-turn details (accepts short ID)
-  index opportunity list                List your opportunities
-  index opportunity list --status <s>   Filter by status (pending|accepted|rejected|expired)
-  index opportunity list --limit <n>    Limit results
-  index opportunity show <id>           Show full opportunity details
-  index opportunity accept <id>         Accept an opportunity
-  index opportunity reject <id>         Reject an opportunity
-  index opportunity discover <query>    Discover opportunities by search query
-  index network list                    List your networks
-  index network create <name>           Create a new network
-  index network show <id>               Show network details and members
-  index network update <id> [--title <t>] [--prompt <p>]
-                                        Update a network
-  index network delete <id>             Delete a network
-  index network join <id>               Join a public network
-  index network leave <id>              Leave a network
-  index network invite <id> <email>     Invite a user by email
-  index contact list                    List your contacts
-  index contact add <email>             Add a contact by email
-  index contact remove <email>          Remove a contact
-  index contact import --gmail          Import contacts from Gmail
-  index scrape <url>                    Extract content from a URL
-  index onboarding complete             Mark onboarding as complete
-  index sync                            Sync context to ~/.index/context.json
-  index sync --json                     Output synced context to stdout
-  index --help                          Show this help message
-  index --version                       Show version
+function visualLen(s: string): number {
+  return output.stripAnsi(s).length;
+}
 
-Options:
-  --api-url <url>     Override the API server URL (default: ${DEFAULT_API_URL})
-  --app-url <url>     Override the app URL for login (default: ${DEFAULT_APP_URL})
-  --token <token>, -t Provide a bearer token directly (skips browser flow)
-  --session <id>, -s  Resume a specific chat session
-  --archived          Include archived signals (intent list)
-  --status <status>   Filter opportunities by status
-  --limit <n>         Limit number of results
-  --since <date>      Filter by time (ISO date or duration like 1h, 2d, 1w)
-  --json              Output raw JSON instead of formatted text
-  --name <name>       Name for contact add
-  --gmail             Import source flag for contact import
-  --objective <text>  Objective for scrape command
-  --target <uid>      Target user for opportunity discover
-  --introduce <uid>   Source user for introduction discovery
-  --linkedin <url>    LinkedIn URL for profile create
-  --github <url>      GitHub URL for profile create
-  --twitter <url>     Twitter URL for profile create
-  --title <text>      Title for network update
-  --details <text>    Details for profile update
-`;
+function padVisual(s: string, width: number): string {
+  return s + " ".repeat(Math.max(0, width - visualLen(s)));
+}
+
+/**
+ * Print a bordered panel with a title in the top edge.
+ *
+ * @param title - Short label embedded after `╭─`
+ * @param rows - Inner lines (no border chars); each should start with a leading space for alignment.
+ */
+function panel(title: string, rows: string[]): void {
+  const innerW = Math.max(
+    52,
+    title.length + 4,
+    ...rows.map((r) => visualLen(r)),
+  );
+  const dashRun = Math.max(1, innerW - title.length - 3);
+  const innerTop = `${BOX.h} ${title} ${BOX.h.repeat(dashRun)}`;
+  console.log(`${output.GRAY}${BOX.tl}${innerTop}${BOX.tr}${output.RESET}`);
+  for (const row of rows) {
+    console.log(`${output.GRAY}${BOX.v}${output.RESET}${padVisual(row, innerW)}${output.GRAY}${BOX.v}${output.RESET}`);
+  }
+  console.log(`${output.GRAY}${BOX.bl}${BOX.h.repeat(innerW)}${BOX.br}${output.RESET}\n`);
+}
+
+function helpRowDim(leftW: number, left: string, right: string): string {
+  const pad = Math.max(0, leftW - left.length);
+  return ` ${output.GRAY}${left}${" ".repeat(pad)} ${right}${output.RESET}`;
+}
+
+function helpRowCmd(leftW: number, left: string, right: string): string {
+  const pad = Math.max(0, leftW - left.length);
+  return ` ${output.BOLD}${output.CYAN}${left}${output.RESET}${" ".repeat(pad)} ${right}`;
+}
+
+function helpRowCont(leftW: number, right: string): string {
+  return ` ${" ".repeat(leftW)} ${right}`;
+}
+
+/** Print grouped help (rounded panels). */
+function renderHelp(): void {
+  const gsLefts = ["index login", 'index intent create "..."', "index negotiation list", "index opportunity list"];
+  const gsLW = Math.max(...gsLefts.map((s) => s.length));
+
+  const cmdLefts = [
+    "pattern",
+    "example",
+    "intent",
+    "negotiation",
+    "opportunity",
+    "profile",
+    "conversation",
+    "network",
+    "contact",
+    "scrape",
+    "sync",
+    "onboarding",
+  ];
+  const cmdLW = Math.max(...cmdLefts.map((s) => s.length));
+
+  const optLefts = ["--api-url <url>", "--token <token>", "--json", "--help", "--version"];
+  const optLW = Math.max(...optLefts.map((s) => s.length));
+
+  console.log();
+  console.log(
+    `  ${output.BOLD}${output.CYAN}I N D E X${output.RESET}  ${output.GRAY}cli${output.RESET}`,
+  );
+  console.log(`  ${output.GRAY}v${VERSION}${output.RESET}\n`);
+
+  panel("getting started", [
+    helpRowCmd(gsLW, "index login", "authenticate via browser"),
+    helpRowCmd(gsLW, 'index intent create "..."', "describe what you're looking for"),
+    helpRowCmd(gsLW, "index negotiation list", "see agent debates in progress"),
+    helpRowCmd(gsLW, "index opportunity list", "see what was found for you"),
+  ]);
+
+  panel("commands", [
+    helpRowDim(cmdLW, "pattern", "index <command> [args] [options]"),
+    helpRowDim(cmdLW, "example", 'index intent create "looking for a CTO"'),
+    "",
+    helpRowCmd(cmdLW, "intent", "list · show · create · update · archive"),
+    helpRowCont(cmdLW, "link · unlink · links"),
+    helpRowCmd(cmdLW, "negotiation", "list · show"),
+    helpRowCmd(cmdLW, "opportunity", "list · show · accept · reject · discover"),
+    "",
+    helpRowCmd(cmdLW, "profile", "show · sync · search · create · update"),
+    helpRowCmd(cmdLW, "conversation", "sessions · list · with · show · send · stream"),
+    helpRowCmd(cmdLW, "network", "list · create · show · update · delete"),
+    helpRowCont(cmdLW, "join · leave · invite"),
+    helpRowCmd(cmdLW, "contact", "list · add · remove · import"),
+    "",
+    helpRowCmd(cmdLW, "scrape", "extract content from a URL"),
+    helpRowCmd(cmdLW, "sync", "download your context locally"),
+    helpRowCmd(cmdLW, "onboarding", "finish account setup"),
+  ]);
+
+  panel("options", [
+    helpRowDim(optLW, "--api-url <url>", "override API server URL"),
+    helpRowDim(optLW, "--token <token>", "provide bearer token directly"),
+    helpRowDim(optLW, "--json", "output raw JSON"),
+    helpRowDim(optLW, "--help", "show help for any command"),
+    helpRowDim(optLW, "--version", "show version"),
+  ]);
+}
 
 // ── Auth helper ──────────────────────────────────────────────────────
 
@@ -221,7 +248,7 @@ async function main(): Promise<void> {
   // Commands that don't require authentication
   switch (args.command) {
     case "help":
-      console.log(HELP_TEXT);
+      renderHelp();
       return;
     case "version":
       console.log(VERSION);

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -77,8 +77,28 @@ function helpRowCont(leftW: number, right: string): string {
 
 /** Print grouped help (rounded panels). */
 function renderHelp(): void {
-  const gsLefts = ["index login", 'index intent create "..."', "index negotiation list", "index opportunity list"];
+  const gsLefts = [
+    "index login",
+    "index login --token <token>",
+    "index logout",
+    'index intent create "..."',
+    "index negotiation list",
+    "index opportunity list",
+  ];
   const gsLW = Math.max(...gsLefts.map((s) => s.length));
+
+  const formsLefts = [
+    'index conversation "message"',
+    "index conversation --session <id>",
+    "index sync --json",
+    "index profile create",
+    "index profile update",
+    "index intent list",
+    "index negotiation list",
+    "index opportunity list",
+    "index opportunity discover",
+  ];
+  const formsLW = Math.max(...formsLefts.map((s) => s.length));
 
   const cmdLefts = [
     "pattern",
@@ -96,7 +116,29 @@ function renderHelp(): void {
   ];
   const cmdLW = Math.max(...cmdLefts.map((s) => s.length));
 
-  const optLefts = ["--api-url <url>", "--token <token>", "--json", "--help", "--version"];
+  const optLefts = [
+    "--api-url <url>",
+    "--app-url <url>",
+    "--token <token>",
+    "--session <id>",
+    "--archived",
+    "--status <status>",
+    "--limit <n>",
+    "--since <date>",
+    "--json",
+    "--name <name>",
+    "--gmail",
+    "--objective <text>",
+    "--target <uid>",
+    "--introduce <uid>",
+    "--linkedin <url>",
+    "--github <url>",
+    "--twitter <url>",
+    "--title <text>",
+    "--details <text>",
+    "--help",
+    "--version",
+  ];
   const optLW = Math.max(...optLefts.map((s) => s.length));
 
   console.log();
@@ -107,9 +149,24 @@ function renderHelp(): void {
 
   panel("getting started", [
     helpRowCmd(gsLW, "index login", "authenticate via browser"),
+    helpRowCmd(gsLW, "index login --token <token>", "authenticate with a bearer token"),
+    helpRowCmd(gsLW, "index logout", "clear stored session"),
     helpRowCmd(gsLW, 'index intent create "..."', "describe what you're looking for"),
     helpRowCmd(gsLW, "index negotiation list", "see agent debates in progress"),
     helpRowCmd(gsLW, "index opportunity list", "see what was found for you"),
+  ]);
+
+  panel("common forms", [
+    helpRowCmd(formsLW, 'index conversation "message"', "send a one-shot agent message"),
+    helpRowCmd(formsLW, "index conversation --session <id>", "resume an agent chat session"),
+    helpRowCmd(formsLW, "index sync --json", "print synced context as JSON"),
+    "",
+    helpRowCmd(formsLW, "index profile create", "use social URL flags"),
+    helpRowCmd(formsLW, "index profile update", "use action text or --details"),
+    helpRowCmd(formsLW, "index intent list", "supports --archived and --limit"),
+    helpRowCmd(formsLW, "index negotiation list", "supports --since and --limit"),
+    helpRowCmd(formsLW, "index opportunity list", "supports --status and --limit"),
+    helpRowCmd(formsLW, "index opportunity discover", "supports --target and --introduce"),
   ]);
 
   panel("commands", [
@@ -134,8 +191,24 @@ function renderHelp(): void {
 
   panel("options", [
     helpRowDim(optLW, "--api-url <url>", "override API server URL"),
+    helpRowDim(optLW, "--app-url <url>", "override app URL for login"),
     helpRowDim(optLW, "--token <token>", "provide bearer token directly"),
+    helpRowDim(optLW, "--session <id>", "resume a chat session"),
+    helpRowDim(optLW, "--archived", "include archived signals"),
+    helpRowDim(optLW, "--status <status>", "filter opportunities by status"),
+    helpRowDim(optLW, "--limit <n>", "limit number of results"),
+    helpRowDim(optLW, "--since <date>", "filter by ISO date or duration"),
     helpRowDim(optLW, "--json", "output raw JSON"),
+    helpRowDim(optLW, "--name <name>", "name for contact add"),
+    helpRowDim(optLW, "--gmail", "import contacts from Gmail"),
+    helpRowDim(optLW, "--objective <text>", "objective for scrape command"),
+    helpRowDim(optLW, "--target <uid>", "target user for opportunity discovery"),
+    helpRowDim(optLW, "--introduce <uid>", "source user for introduction discovery"),
+    helpRowDim(optLW, "--linkedin <url>", "LinkedIn URL for profile create"),
+    helpRowDim(optLW, "--github <url>", "GitHub URL for profile create"),
+    helpRowDim(optLW, "--twitter <url>", "Twitter URL for profile create"),
+    helpRowDim(optLW, "--title <text>", "title for network update"),
+    helpRowDim(optLW, "--details <text>", "details for profile update"),
     helpRowDim(optLW, "--help", "show help for any command"),
     helpRowDim(optLW, "--version", "show version"),
   ]);

--- a/packages/cli/tests/help-output.test.ts
+++ b/packages/cli/tests/help-output.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+
+import { stripAnsi } from "../src/output";
+
+const CLI_ROOT = join(import.meta.dir, "..");
+
+function renderHelp(): string {
+  const result = spawnSync("bun", ["src/main.ts", "--help"], {
+    cwd: CLI_ROOT,
+    encoding: "utf-8",
+  });
+
+  expect(result.status).toBe(0);
+  expect(result.stderr).toBe("");
+  return stripAnsi(result.stdout);
+}
+
+describe("main help output", () => {
+  it("documents supported command forms and options", () => {
+    const help = renderHelp();
+
+    for (const expected of [
+      "index login --token <token>",
+      "index logout",
+      'index conversation "message"',
+      "index conversation --session <id>",
+      "index sync --json",
+      "--app-url <url>",
+      "--session <id>",
+      "--archived",
+      "--status <status>",
+      "--since <date>",
+      "--objective <text>",
+      "--target <uid>",
+      "--introduce <uid>",
+      "--details <text>",
+    ]) {
+      expect(help).toContain(expected);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Replace monolithic `HELP_TEXT` string with structured `renderHelp()` function using Unicode box-drawing panels (rounded corners)
- Group commands into "getting started", "commands", and "options" sections for better readability
- Add color formatting with bold/cyan for commands and gray for meta/options

## Test plan
- [ ] Run `index --help` and verify the new grouped panel layout renders correctly
- [ ] Verify terminal color/ANSI output looks correct in different terminals

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved CLI help output with rounded box-style borders, aligned columns, and padded sections for "Getting Started", "Commands", and "Options" for clearer, more readable help text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->