### PR TITLE
fix: expose list_opportunities to chat agent

### DIFF
--- a/packages/protocol/src/chat/chat.prompt.modules.ts
+++ b/packages/protocol/src/chat/chat.prompt.modules.ts
@@ -105,7 +105,7 @@ function hasIntroductionArgs(recentTools: IterationContext["recentTools"]): bool
 
 const discoveryModule: PromptModule = {
   id: "discovery",
-  triggers: ["create_opportunities", "update_opportunity"],
+  triggers: ["create_opportunities", "update_opportunity", "list_opportunities"],
   triggerFilter: (iterCtx) => !hasIntroductionArgs(iterCtx.recentTools),
   content: () => `
 ### 1. User wants to find connections or discover (default for connection-seeking)
@@ -144,7 +144,12 @@ The searchQuery should be a brief description of why they'd connect (e.g. "share
 
 ### 7. Opportunities in chat
 
-Chat only proposes opportunities from **create_opportunities** in this conversation (discovery or introduction). Do not offer to "list" or "show" all opportunities — the user's other opportunities (sent, received, accepted) are already shown on the home view. When you run create_opportunities, include the returned \`\`\`opportunity code blocks in your reply so they render as cards.
+- **create_opportunities** — discovers new connections (discovery, introduction, or direct connection).
+- **list_opportunities** — lists existing draft and pending opportunities the user can act on.
+
+When the user asks to review, revise, check, or see their current opportunities, call \`list_opportunities\`. Only use \`create_opportunities\` for discovery ("find me connections"), introductions, or direct connections.
+
+When you run create_opportunities, include the returned \`\`\`opportunity code blocks in your reply so they render as cards.
 
 Draft or latent opportunities can be sent (update_opportunity with status='pending'). Status translation: draft/latent → "draft", pending → "sent", accepted → "connected"
 

--- a/packages/protocol/src/chat/chat.prompt.modules.ts
+++ b/packages/protocol/src/chat/chat.prompt.modules.ts
@@ -149,7 +149,7 @@ The searchQuery should be a brief description of why they'd connect (e.g. "share
 
 When the user asks to review, revise, check, or see their current opportunities, call \`list_opportunities\`. Only use \`create_opportunities\` for discovery ("find me connections"), introductions, or direct connections.
 
-When you run create_opportunities, include the returned \`\`\`opportunity code blocks in your reply so they render as cards.
+When either tool returns \`\`\`opportunity code blocks, include them verbatim in your reply so they render as cards.
 
 Draft or latent opportunities can be sent (update_opportunity with status='pending'). Status translation: draft/latent → "draft", pending → "sent", accepted → "connected"
 

--- a/packages/protocol/src/chat/chat.prompt.ts
+++ b/packages/protocol/src/chat/chat.prompt.ts
@@ -274,7 +274,7 @@ All tools are simple read/write operations. No hidden logic.
 | **read_intent_indexes** | intentId?, networkId?, userId? | Read intent↔index links |
 | **delete_intent_index** | intentId, networkId | Unlink intent from index |
 | **create_opportunities** | searchQuery?, networkId?, targetUserId?, partyUserIds?, entities?, hint? | Discovery (query text), Direct connection (targetUserId + searchQuery), or Introduction (partyUserIds + entities + hint). |
-| **list_opportunities** | networkId? | List pending opportunities (sent, awaiting response). Use when user wants to review existing opportunities. |
+| **list_opportunities** | networkId? | List draft and pending opportunities the user can act on. Use when user wants to review existing opportunities. |
 | **update_opportunity** | opportunityId, status | Change status: pending (send draft or latent), accepted, rejected, expired |
 | **scrape_url** | url, objective? | Extract text from web page |
 | **read_docs** | topic? | Protocol documentation |

--- a/packages/protocol/src/chat/chat.prompt.ts
+++ b/packages/protocol/src/chat/chat.prompt.ts
@@ -274,6 +274,7 @@ All tools are simple read/write operations. No hidden logic.
 | **read_intent_indexes** | intentId?, networkId?, userId? | Read intent↔index links |
 | **delete_intent_index** | intentId, networkId | Unlink intent from index |
 | **create_opportunities** | searchQuery?, networkId?, targetUserId?, partyUserIds?, entities?, hint? | Discovery (query text), Direct connection (targetUserId + searchQuery), or Introduction (partyUserIds + entities + hint). |
+| **list_opportunities** | networkId? | List pending opportunities (sent, awaiting response). Use when user wants to review existing opportunities. |
 | **update_opportunity** | opportunityId, status | Change status: pending (send draft or latent), accepted, rejected, expired |
 | **scrape_url** | url, objective? | Extract text from web page |
 | **read_docs** | topic? | Protocol documentation |

--- a/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
+++ b/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
@@ -357,11 +357,11 @@ describe("createChatTools", () => {
     expect(tools.find((t: { name: string }) => t.name === "read_network_memberships")).toBeDefined();
   });
 
-  test("does not include list_opportunities (chat only proposes opportunities from create_opportunities; home shows the rest)", async () => {
+  test("includes list_opportunities alongside create_opportunities and update_opportunity", async () => {
     const mockDb = createMockDatabase(async () => []);
     const context: ToolContext = { userId: testUserId, database: mockDb, embedder: mockEmbedder, scraper: mockScraper, ...mockProtocolDeps };
     const tools = await createChatTools(context);
-    expect(tools.find((t: { name: string }) => t.name === "list_opportunities")).toBeUndefined();
+    expect(tools.find((t: { name: string }) => t.name === "list_opportunities")).toBeDefined();
     expect(tools.find((t: { name: string }) => t.name === "create_opportunities")).toBeDefined();
     expect(tools.find((t: { name: string }) => t.name === "update_opportunity")).toBeDefined();
   });

--- a/packages/protocol/src/shared/agent/tool.factory.ts
+++ b/packages/protocol/src/shared/agent/tool.factory.ts
@@ -192,12 +192,9 @@ export async function createChatTools(
     ? createNegotiationTools(defineTool, toolDeps)
     : [];
 
-  // Chat only proposes opportunities from the conversation (create_opportunities).
-  // Other opportunities are shown on the home view; do not give the agent list_opportunities.
   // confirm_opportunity_delivery is an OpenClaw-delivery ledger write and must not be
   // callable from regular chat sessions.
   const chatOpportunityToolExclusions = new Set([
-    "list_opportunities",
     "confirm_opportunity_delivery",
   ]);
   const opportunityToolsForChat = opportunityTools.filter(


### PR DESCRIPTION
## Summary
- Removed `list_opportunities` from `chatOpportunityToolExclusions` in the tool factory so the chat agent can call it
- Added `list_opportunities` to the discovery prompt module triggers and tools reference table
- Updated prompt guidance to distinguish "review existing opportunities" (`list_opportunities`) from "find new connections" (`create_opportunities`)
- Updated test assertion from expecting exclusion to expecting inclusion

## Context
When a user asked "revise my opportunities" in chat, the agent had no way to fetch existing draft/pending opportunities — `list_opportunities` was explicitly stripped from the chat tool set. The only available opportunity tool was `create_opportunities`, so the agent ran discovery instead of listing existing matches. The MCP path (tool registry) already included `list_opportunities`; only the chat path excluded it.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `tool.factory.spec.ts` — "includes list_opportunities alongside create_opportunities and update_opportunity" passes
- [ ] Manual: ask "show my opportunities" in chat and verify `list_opportunities` is called instead of `create_opportunities`