### PR TITLE
feat: EdgeClaw auto-setup via openclaw index connect

### DIFF
--- a/backend/src/services/experiment.service.ts
+++ b/backend/src/services/experiment.service.ts
@@ -12,6 +12,8 @@ const logger = log.service.from('experiment');
 export interface ExperimentSignupResult {
   user: { id: string; email: string };
   apiKey: string;
+  /** Ready-to-run command to configure a self-hosted OpenClaw plugin. */
+  connectCommand: string;
   created: boolean;
 }
 
@@ -34,6 +36,7 @@ class ExperimentService {
     return {
       user: { id: user.id, email: user.email },
       apiKey,
+      connectCommand: this.buildConnectCommand(apiKey),
       created,
     };
   }
@@ -141,6 +144,15 @@ class ExperimentService {
     });
 
     return token.key;
+  }
+
+  private buildConnectCommand(apiKey: string): string {
+    const appUrl = process.env.APP_URL;
+    const urlFlag =
+      appUrl && appUrl !== 'https://index.network'
+        ? ` --url ${appUrl}`
+        : '';
+    return `openclaw index connect --api-key ${apiKey}${urlFlag}`;
   }
 }
 

--- a/backend/src/services/experiment.service.ts
+++ b/backend/src/services/experiment.service.ts
@@ -12,6 +12,7 @@ const logger = log.service.from('experiment');
 export interface ExperimentSignupResult {
   user: { id: string; email: string };
   apiKey: string;
+  agentId: string;
   /** Ready-to-run command to configure a self-hosted OpenClaw plugin. */
   connectCommand: string;
   created: boolean;
@@ -25,7 +26,7 @@ class ExperimentService {
     const { user, created } = await this.findOrCreateUser(normalizedEmail, networkId);
     await ensurePersonalNetwork(user.id);
     await this.joinExperimentNetwork(user.id, networkId);
-    const apiKey = await this.ensureAgentAndCreateToken(user.id);
+    const { apiKey, agentId } = await this.ensureAgentAndCreateToken(user.id);
 
     logger.info('[ExperimentService] Signup complete', {
       userId: user.id,
@@ -36,6 +37,7 @@ class ExperimentService {
     return {
       user: { id: user.id, email: user.email },
       apiKey,
+      agentId,
       connectCommand: this.buildConnectCommand(apiKey),
       created,
     };
@@ -100,7 +102,7 @@ class ExperimentService {
       .onConflictDoNothing();
   }
 
-  private async ensureAgentAndCreateToken(userId: string): Promise<string> {
+  private async ensureAgentAndCreateToken(userId: string): Promise<{ agentId: string; apiKey: string }> {
     const existingAgents = await db
       .select({ id: schema.agents.id })
       .from(schema.agents)
@@ -143,11 +145,11 @@ class ExperimentService {
       agentId,
     });
 
-    return token.key;
+    return { agentId, apiKey: token.key };
   }
 
   private buildConnectCommand(apiKey: string): string {
-    const appUrl = process.env.APP_URL;
+    const appUrl = (process.env.APP_URL ?? '').replace(/\/+$/, '');
     const urlFlag =
       appUrl && appUrl !== 'https://index.network'
         ? ` --url ${appUrl}`

--- a/backend/src/services/experiment.service.ts
+++ b/backend/src/services/experiment.service.ts
@@ -149,10 +149,10 @@ class ExperimentService {
   }
 
   private buildConnectCommand(apiKey: string): string {
-    const appUrl = (process.env.APP_URL ?? '').replace(/\/+$/, '');
+    const baseUrl = (process.env.FRONTEND_URL || process.env.APP_URL || '').replace(/\/+$/, '');
     const urlFlag =
-      appUrl && appUrl !== 'https://index.network'
-        ? ` --url ${appUrl}`
+      baseUrl && baseUrl !== 'https://index.network'
+        ? ` --url ${baseUrl}`
         : '';
     return `openclaw index connect --api-key ${apiKey}${urlFlag}`;
   }

--- a/docs/guides/edgeclaw-instaclaw-integration.md
+++ b/docs/guides/edgeclaw-instaclaw-integration.md
@@ -1,0 +1,104 @@
+# EdgeClaw × InstaClaw Integration Guide
+
+This guide is for the InstaClaw team. It describes how to provision an Edge City attendee's Index Network account and configure the OpenClaw plugin on their InstaClaw instance automatically — no user action required.
+
+---
+
+## Overview
+
+For each EdgeClaw attendee, InstaClaw needs to:
+
+1. Call the Index Network signup endpoint with the attendee's email.
+2. Receive back an `apiKey` and `agentId`.
+3. Write those values into the attendee's OpenClaw plugin config.
+
+That's it. The attendee's agent is then live and connected to the Edge City network.
+
+---
+
+## Step 1 — Call the signup endpoint
+
+```
+POST https://index.network/api/networks/<EDGE_CITY_NETWORK_ID>/signup
+```
+
+**Authentication:** Master API key in the `x-api-key` header. This key is shared with InstaClaw out of band.
+
+**Request body:**
+```json
+{ "email": "attendee@example.com" }
+```
+
+**Response (201 on first signup, 200 on repeat):**
+```json
+{
+  "user": {
+    "id": "user-uuid",
+    "email": "attendee@example.com"
+  },
+  "apiKey": "sk_live_...",
+  "agentId": "agent-uuid",
+  "connectCommand": "openclaw index connect --api-key sk_live_...",
+  "created": true
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `apiKey` | The attendee's personal agent API key. Used to authenticate against the Index Network MCP server. |
+| `agentId` | The attendee's personal agent UUID. Required in the plugin config. |
+| `connectCommand` | Pre-built CLI command for self-hosted OpenClaw users. InstaClaw can ignore this. |
+| `created` | `true` if a new account was created, `false` if the attendee already existed. |
+
+**Idempotent:** Calling this endpoint more than once for the same email always returns the same user. A fresh API key is issued on every call — store the latest one.
+
+---
+
+## Step 2 — Configure the plugin on the attendee's instance
+
+Write the following keys into the attendee's OpenClaw config under `plugins.entries.indexnetwork-openclaw-plugin.config`:
+
+| Config key | Value |
+|------------|-------|
+| `url` | `https://index.network` |
+| `apiKey` | Value of `apiKey` from the signup response |
+| `agentId` | Value of `agentId` from the signup response |
+
+**Full config path:** `plugins.entries.indexnetwork-openclaw-plugin.config`
+
+**Example resulting structure in `openclaw.json`:**
+```json
+{
+  "plugins": {
+    "entries": {
+      "indexnetwork-openclaw-plugin": {
+        "config": {
+          "url": "https://index.network",
+          "apiKey": "sk_live_...",
+          "agentId": "agent-uuid"
+        }
+      }
+    }
+  }
+}
+```
+
+The plugin reads these three keys on startup. Once written, the plugin connects automatically — no gateway restart needed if config is injected before the instance starts.
+
+---
+
+## Error handling
+
+| HTTP status | Meaning |
+|-------------|---------|
+| `200` | Attendee already exists — `apiKey` is a freshly issued key for the existing account |
+| `201` | New attendee created |
+| `400` | Missing or invalid email |
+| `401` | Invalid or missing master API key |
+| `500` | Internal error — retry with backoff |
+
+---
+
+## Questions
+
+Contact the Index Network team on the shared channel. Provide the `EDGE_CITY_NETWORK_ID` and the master API key over a secure channel before the event.

--- a/docs/superpowers/specs/2026-05-06-csv-upload-experiment-networks.md
+++ b/docs/superpowers/specs/2026-05-06-csv-upload-experiment-networks.md
@@ -1,0 +1,130 @@
+# CSV Upload for Experiment Networks
+
+**Date:** 2026-05-06  
+**Status:** Approved
+
+## Overview
+
+Allow owners of experiment networks to bulk-import members from a CSV file via the network settings page. Each row can carry email, name, bio, and any number of social links. Existing members are upserted rather than duplicated. The feature is restricted to experiment networks only.
+
+## CSV Schema
+
+Headers are case-insensitive. Column order is irrelevant. Unknown columns are treated as custom socials.
+
+| Column | Required | Behaviour |
+|--------|----------|-----------|
+| `email` | Yes | Normalized to lowercase + trim. Invalid format → row skipped. |
+| `name` | No | Falls back to email prefix if absent. |
+| `bio` | No | Maps to `userProfiles.identity.bio`. Empty cell = no change on upsert. |
+| `linkedin` | No | Stored as `userSocials` row with label `linkedin`. |
+| `github` | No | Stored as `userSocials` row with label `github`. |
+| `twitter` | No | Stored as `userSocials` row with label `twitter`. |
+| any other column | No | Stored as `userSocials` row with the column name as label. |
+
+Empty cells are treated as absent — they do not blank out existing values on upsert. A non-empty value always overwrites.
+
+Known social labels (`linkedin`, `github`, `twitter`, `telegram`) render with their respective icons in the profile UI. All other column names are stored with the column name as label and appear in the custom socials section.
+
+## Architecture & Data Flow
+
+```
+[Access Tab — experiment networks only]
+    │
+    ├─ File picker (CSV only, 10MB max via existing validateFile())
+    │
+    ├─ rows ≤ 500?
+    │     YES → PapaParse client-side → ImportRow[]
+    │     NO  → POST /networks/:id/members/import/parse (multipart) → ImportRow[]
+    │
+    ├─ Preview modal
+    │     • Valid rows: normal
+    │     • Invalid rows: highlighted red + inline reason
+    │     • Summary: "X will be imported · Y skipped"
+    │     • "Confirm import" CTA (disabled if 0 valid rows)
+    │
+    └─ Confirm → POST /networks/:id/members/import
+                  body: { members: ImportRow[] }
+                  → ExperimentService.importMembers(networkId, rows)
+                       ├─ signup(email) per row (upserts user + membership)
+                       ├─ update userProfiles.identity.bio if present
+                       └─ upsert userSocials rows per social column
+                  → { imported: number, skipped: number }
+                  → success toast
+```
+
+## Backend
+
+### New endpoints
+
+**`POST /networks/:id/members/import/parse`**
+- Auth: network owner/admin + network must be `isExperiment = true`
+- Body: `multipart/form-data` with CSV file
+- Returns: `{ valid: ImportRow[], invalid: { row: RawRow, reason: string }[] }`
+- Used only for the large-file path (rows > 500)
+
+**`POST /networks/:id/members/import`**
+- Auth: network owner/admin + network must be `isExperiment = true`
+- Body: `{ members: ImportRow[] }`
+- Calls `ExperimentService.importMembers(networkId, rows)`
+- Returns: `{ imported: number, skipped: number }`
+
+Both endpoints return 403 if the network is not an experiment network.
+
+### `ExperimentService.importMembers(networkId, rows)`
+
+For each valid row:
+1. `signup(email)` — upserts user + experiment network membership (existing method)
+2. Update `userProfiles.identity.bio` if `bio` is present
+3. Upsert `userSocials` rows for each social column
+
+Rows where `signup()` fails (e.g. invalid email that slipped through) are counted as skipped.
+
+### Types
+
+```ts
+type ImportRow = {
+  email: string
+  name?: string
+  bio?: string
+  socials: { label: string; value: string }[]
+}
+```
+
+## Frontend
+
+### Components
+
+**`CsvImportButton`** — small component rendered in the access tab only when `network.isExperiment === true`. Triggers a hidden `<input type="file" accept=".csv">`. On file select: validates via existing `validateFile()`, branches on row count threshold (500), produces `ImportRow[]`, opens `CsvPreviewModal`.
+
+**`CsvPreviewModal`** — modal showing:
+- Table with columns dynamically derived from the CSV (only columns present are shown)
+- Invalid rows highlighted red with inline reason
+- Summary bar: "X will be imported · Y skipped"
+- "Confirm import" CTA (disabled if 0 valid rows) + "Cancel"
+
+**Placement:** "Import CSV" button placed alongside the existing "Add by email" flow in the access tab of `NetworkSettingsPanel.tsx`.
+
+## Error Handling
+
+| Scenario | Behaviour |
+|---|---|
+| File is not CSV or exceeds 10MB | Rejected by `validateFile()`, inline error under button |
+| CSV has no `email` column | File-level error in modal: "CSV must have an email column", confirm blocked |
+| Row has empty or malformed email | Row highlighted red with reason, skipped on import |
+| All rows invalid | Confirm disabled, summary shows "0 will be imported" |
+| Backend parse fails (large file path) | Toast error, modal closes, user can retry |
+| Import endpoint error | Toast error, modal stays open so user does not lose their selection |
+| Email already a member | Upserted silently, counted as "imported" (not "skipped") |
+
+## Testing
+
+### Backend (integration tests in `backend/tests/`)
+- Import creates ghost users, upserts profiles and socials, adds memberships
+- Re-importing an existing member updates bio/socials without duplicating membership
+- Non-experiment network returns 403
+- Non-owner returns 403
+- Parse endpoint returns correct `ImportRow[]` for a valid CSV
+
+### Frontend (unit tests)
+- CSV parser util: known columns mapped correctly, unknown columns → custom socials, empty email → invalid row, case-insensitive headers
+- `CsvImportButton` not rendered for non-experiment networks

--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "indexnetwork-openclaw-plugin",
   "name": "Index Network",
   "description": "Index Network — find the right people and let them find you. Registers the Index Network MCP server on first use and hands off to its guidance.",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "configSchema": {
     "type": "object",
     "properties": {

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/openclaw-plugin",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "description": "Index Network — OpenClaw plugin. Find the right people and let them find you.",
   "license": "MIT",
   "private": false,

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -26,7 +26,7 @@ import * as testMessagePoller from './polling/test-message/test-message.poller.j
 import * as testMessageScheduler from './polling/test-message/test-message.scheduler.js';
 import * as acceptedOpportunityPoller from './polling/accepted-opportunity/accepted-opportunity.poller.js';
 import * as acceptedOpportunityScheduler from './polling/accepted-opportunity/accepted-opportunity.scheduler.js';
-import { registerSetupCli } from './setup/setup.cli.js';
+import { registerSetupCli, registerConnectCli } from './setup/setup.cli.js';
 import { deriveUrls } from './lib/utils/url.js';
 
 /** Prevents double-registration when OpenClaw calls register() more than once. */
@@ -51,6 +51,7 @@ function registerSetupCommand(api: OpenClawPluginApi): void {
         .command('index')
         .description('Manage Index Network plugin configuration');
       registerSetupCli(cmd as Parameters<typeof registerSetupCli>[0]);
+      registerConnectCli(cmd as Parameters<typeof registerSetupCli>[0]);
 
       // Deprecated alias — same handler, prints a warning. Remove in 0.23.0.
       const aliasCmd = (program as { command(n: string): { description(d: string): unknown } })

--- a/packages/openclaw-plugin/src/setup/setup.cli.ts
+++ b/packages/openclaw-plugin/src/setup/setup.cli.ts
@@ -320,6 +320,59 @@ function setConfigValue(cfg: Record<string, unknown>, dotPath: string, value: un
   obj[parts[parts.length - 1]] = value;
 }
 
+/**
+ * Registers the `openclaw index connect` CLI command.
+ *
+ * Usage:
+ *   openclaw index connect --api-key <key> [--url <url>]
+ *
+ * Reads the existing ~/.openclaw/openclaw.json (if any), runs a headless
+ * setup with the supplied key, and writes the result back to disk. Idempotent
+ * — safe to re-run with the same or a new key.
+ */
+export function registerConnectCli(
+  program: Parameters<typeof registerSetupCli>[0],
+): void {
+  // Guard against duplicate registration.
+  if (program.commands?.some((c) => c.name() === 'connect')) return;
+
+  type ConnectOpts = { apiKey: string; url: string };
+
+  (
+    program as unknown as {
+      command(n: string): {
+        description(d: string): {
+          requiredOption(f: string, d: string): {
+            option(f: string, d: string, dflt: string): {
+              action(fn: (opts: ConnectOpts) => Promise<void>): void;
+            };
+          };
+        };
+      };
+    }
+  )
+    .command('connect')
+    .description('Non-interactive setup using an API key (e.g. from EdgeClaw signup)')
+    .requiredOption('--api-key <key>', 'API key returned by the headless signup endpoint')
+    .option('--url <url>', 'Index Network frontend URL', 'https://index.network')
+    .action(async (opts: ConnectOpts) => {
+      const cfg = readOpenClawConfig();
+      try {
+        const updated = await runHeadlessSetup({
+          url: opts.url,
+          apiKey: opts.apiKey,
+          existingCfg: cfg,
+        });
+        fs.writeFileSync(CONFIG_PATH, JSON.stringify(updated, null, 2));
+        console.log('\n✓ Config written to ~/.openclaw/openclaw.json');
+        console.log('Restart the gateway to apply changes: openclaw gateway restart');
+      } catch (err) {
+        console.error(err instanceof Error ? err.message : String(err));
+        process.exitCode = 1;
+      }
+    });
+}
+
 export function registerSetupCli(
   program: {
     command(name: string): { description(d: string): { action(fn: () => Promise<void>): void } };

--- a/packages/openclaw-plugin/src/setup/setup.cli.ts
+++ b/packages/openclaw-plugin/src/setup/setup.cli.ts
@@ -259,7 +259,7 @@ export interface HeadlessSetupOptions {
 export async function runHeadlessSetup(
   opts: HeadlessSetupOptions,
 ): Promise<Record<string, unknown>> {
-  const url = opts.url ?? 'https://index.network';
+  const url = opts.url ?? DEFAULT_URL;
   const digestEnabled = opts.digestEnabled ?? true;
   const digestTime = opts.digestTime ?? '08:00';
   const mainAgentToolUse = opts.mainAgentToolUse ?? 'disabled';
@@ -355,7 +355,7 @@ export function registerConnectCli(
     .command('connect')
     .description('Non-interactive setup using an API key (e.g. from EdgeClaw signup)')
     .requiredOption('--api-key <key>', 'API key returned by the headless signup endpoint')
-    .option('--url <url>', 'Index Network frontend URL', 'https://index.network')
+    .option('--url <url>', 'Index Network frontend URL', DEFAULT_URL)
     .action(async (opts: ConnectOpts) => {
       const cfg = readOpenClawConfig();
       try {

--- a/packages/openclaw-plugin/src/setup/setup.cli.ts
+++ b/packages/openclaw-plugin/src/setup/setup.cli.ts
@@ -227,8 +227,9 @@ export async function runSetup(ctx: SetupContext): Promise<void> {
 
 /**
  * Options for non-interactive setup. All prompt/select values are pre-filled
- * from these options; no I/O is performed. `existingCfg` is deep-cloned so
- * the caller's object is never mutated.
+ * from these options; no interactive I/O is performed. Network I/O still
+ * occurs via `fetchAgentId`. `existingCfg` is deep-cloned so the caller's
+ * object is never mutated.
  */
 export interface HeadlessSetupOptions {
   /** Index Network URL. Defaults to 'https://index.network'. */
@@ -363,6 +364,7 @@ export function registerConnectCli(
           apiKey: opts.apiKey,
           existingCfg: cfg,
         });
+        fs.mkdirSync(path.dirname(CONFIG_PATH), { recursive: true });
         fs.writeFileSync(CONFIG_PATH, JSON.stringify(updated, null, 2));
         console.log('\n✓ Config written to ~/.openclaw/openclaw.json');
         console.log('Restart the gateway to apply changes: openclaw gateway restart');

--- a/packages/openclaw-plugin/src/setup/setup.cli.ts
+++ b/packages/openclaw-plugin/src/setup/setup.cli.ts
@@ -226,6 +226,73 @@ export async function runSetup(ctx: SetupContext): Promise<void> {
 }
 
 /**
+ * Options for non-interactive setup. All prompt/select values are pre-filled
+ * from these options; no I/O is performed. `existingCfg` is deep-cloned so
+ * the caller's object is never mutated.
+ */
+export interface HeadlessSetupOptions {
+  /** Index Network URL. Defaults to 'https://index.network'. */
+  url?: string;
+  /** API key (required). */
+  apiKey: string;
+  /** Enable daily digest. Defaults to true. */
+  digestEnabled?: boolean;
+  /** Digest time in HH:MM 24-hour local format. Defaults to '08:00'. */
+  digestTime?: string;
+  /** Main agent tool use mode. Defaults to 'disabled'. */
+  mainAgentToolUse?: 'enabled' | 'disabled';
+  /** Existing OpenClaw config snapshot. Defaults to empty. The object is deep-cloned; caller's copy is not mutated. */
+  existingCfg?: Record<string, unknown>;
+  /** Override the agentId resolution fetch. Useful for testing. */
+  fetchAgentId?: (protocolUrl: string, apiKey: string) => Promise<string>;
+}
+
+/**
+ * Non-interactive equivalent of {@link runSetup}. Builds a pre-filled
+ * {@link SetupContext} from `opts` (no readline, no prompts) and delegates
+ * to `runSetup`. Returns the complete, mutated OpenClaw config object — the
+ * caller is responsible for writing it to disk.
+ *
+ * @throws When `apiKey` is empty, or when `fetchAgentId` rejects.
+ */
+export async function runHeadlessSetup(
+  opts: HeadlessSetupOptions,
+): Promise<Record<string, unknown>> {
+  const url = opts.url ?? 'https://index.network';
+  const digestEnabled = opts.digestEnabled ?? true;
+  const digestTime = opts.digestTime ?? '08:00';
+  const mainAgentToolUse = opts.mainAgentToolUse ?? 'disabled';
+
+  // Deep-clone so we never mutate the caller's object.
+  const cfg: Record<string, unknown> = JSON.parse(
+    JSON.stringify(opts.existingCfg ?? {}),
+  );
+
+  const ctx: SetupContext = {
+    cfg,
+    prompt: async (label, promptOpts) => {
+      if (label === 'Index Network URL') return url;
+      // Handles both "API key" and "API key (leave blank to keep existing)"
+      if (label.startsWith('API key')) return opts.apiKey;
+      if (label.startsWith('Digest time')) return digestTime;
+      return promptOpts?.default ?? '';
+    },
+    select: async (label, choices) => {
+      if (label === 'Daily digest') return digestEnabled ? 'true' : 'false';
+      if (label === 'Main agent tool use during Index Network renders') return mainAgentToolUse;
+      return choices[0].value;
+    },
+    configSet: async (dotPath, value) => {
+      setConfigValue(cfg, dotPath, value);
+    },
+    fetchAgentId: opts.fetchAgentId ?? defaultFetchAgentId,
+  };
+
+  await runSetup(ctx);
+  return cfg;
+}
+
+/**
  * Read the OpenClaw config file, or return an empty object if missing.
  */
 function readOpenClawConfig(): Record<string, unknown> {

--- a/packages/openclaw-plugin/src/tests/setup-entry.spec.ts
+++ b/packages/openclaw-plugin/src/tests/setup-entry.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import { runSetup as setup } from '../setup/setup.cli.js';
+import { runSetup as setup, runHeadlessSetup } from '../setup/setup.cli.js';
 
 interface FakeCtx {
   ctx: Parameters<typeof setup>[0];
@@ -604,5 +604,163 @@ describe('setup wizard', () => {
 
     const newWrite = fake.configWrites.find((w) => w.path === 'mcp.servers.index');
     expect(newWrite).toBeDefined();
+  });
+});
+
+describe('headless setup', () => {
+  test('writes all required config keys with defaults', async () => {
+    const result = await runHeadlessSetup({
+      apiKey: 'key-headless',
+      fetchAgentId: async () => 'agent-headless',
+    });
+
+    const pluginCfg = (result as Record<string, unknown> & {
+      plugins: { entries: { 'indexnetwork-openclaw-plugin': { config: Record<string, unknown> } } };
+    }).plugins.entries['indexnetwork-openclaw-plugin'].config;
+
+    expect(pluginCfg.url).toBe('https://index.network');
+    expect(pluginCfg.apiKey).toBe('key-headless');
+    expect(pluginCfg.agentId).toBe('agent-headless');
+    expect(pluginCfg.digestEnabled).toBe('true');
+    expect(pluginCfg.digestTime).toBe('08:00');
+    expect(pluginCfg.mainAgentToolUse).toBe('disabled');
+  });
+
+  test('uses custom URL when provided', async () => {
+    const result = await runHeadlessSetup({
+      url: 'https://dev.index.network',
+      apiKey: 'key-headless',
+      fetchAgentId: async () => 'agent-headless',
+    });
+
+    const pluginCfg = (result as Record<string, unknown> & {
+      plugins: { entries: { 'indexnetwork-openclaw-plugin': { config: Record<string, unknown> } } };
+    }).plugins.entries['indexnetwork-openclaw-plugin'].config;
+
+    expect(pluginCfg.url).toBe('https://dev.index.network');
+  });
+
+  test('configures MCP server with correct URL and API key', async () => {
+    const result = await runHeadlessSetup({
+      apiKey: 'key-headless',
+      fetchAgentId: async () => 'agent-headless',
+    });
+
+    const mcp = (result as Record<string, unknown> & {
+      mcp: { servers: { index: { url: string; transport: string; headers: Record<string, string> } } };
+    }).mcp.servers.index;
+
+    expect(mcp.url).toBe('https://protocol.index.network/mcp');
+    expect(mcp.transport).toBe('streamable-http');
+    expect(mcp.headers['x-api-key']).toBe('key-headless');
+  });
+
+  test('respects digestEnabled=false', async () => {
+    const result = await runHeadlessSetup({
+      apiKey: 'key-headless',
+      digestEnabled: false,
+      fetchAgentId: async () => 'agent-headless',
+    });
+
+    const pluginCfg = (result as Record<string, unknown> & {
+      plugins: { entries: { 'indexnetwork-openclaw-plugin': { config: Record<string, unknown> } } };
+    }).plugins.entries['indexnetwork-openclaw-plugin'].config;
+
+    expect(pluginCfg.digestEnabled).toBe('false');
+    expect(pluginCfg.digestTime).toBeUndefined();
+  });
+
+  test('respects custom digestTime', async () => {
+    const result = await runHeadlessSetup({
+      apiKey: 'key-headless',
+      digestEnabled: true,
+      digestTime: '07:30',
+      fetchAgentId: async () => 'agent-headless',
+    });
+
+    const pluginCfg = (result as Record<string, unknown> & {
+      plugins: { entries: { 'indexnetwork-openclaw-plugin': { config: Record<string, unknown> } } };
+    }).plugins.entries['indexnetwork-openclaw-plugin'].config;
+
+    expect(pluginCfg.digestTime).toBe('07:30');
+  });
+
+  test('respects mainAgentToolUse=enabled', async () => {
+    const result = await runHeadlessSetup({
+      apiKey: 'key-headless',
+      mainAgentToolUse: 'enabled',
+      fetchAgentId: async () => 'agent-headless',
+    });
+
+    const pluginCfg = (result as Record<string, unknown> & {
+      plugins: { entries: { 'indexnetwork-openclaw-plugin': { config: Record<string, unknown> } } };
+    }).plugins.entries['indexnetwork-openclaw-plugin'].config;
+
+    expect(pluginCfg.mainAgentToolUse).toBe('enabled');
+  });
+
+  test('bootstraps hooks in the returned config', async () => {
+    const result = await runHeadlessSetup({
+      apiKey: 'key-headless',
+      fetchAgentId: async () => 'agent-headless',
+    });
+
+    const hooks = (result as Record<string, unknown> & {
+      hooks: { enabled: boolean; token: string; path: string; allowRequestSessionKey: boolean; allowedSessionKeyPrefixes: string[] };
+    }).hooks;
+
+    expect(hooks.enabled).toBe(true);
+    expect(typeof hooks.token).toBe('string');
+    expect(hooks.token.length).toBeGreaterThanOrEqual(32);
+    expect(hooks.path).toBe('/hooks');
+    expect(hooks.allowRequestSessionKey).toBe(true);
+    expect(hooks.allowedSessionKeyPrefixes).toContain('agent:main:');
+  });
+
+  test('throws when apiKey is empty', async () => {
+    await expect(
+      runHeadlessSetup({ apiKey: '', fetchAgentId: async () => 'x' }),
+    ).rejects.toThrow('API key is required');
+  });
+
+  test('surfaces fetchAgentId errors', async () => {
+    await expect(
+      runHeadlessSetup({
+        apiKey: 'key-headless',
+        fetchAgentId: async () => { throw new Error('Could not resolve agent from API key (HTTP 401).'); },
+      }),
+    ).rejects.toThrow('Could not resolve agent from API key');
+  });
+
+  test('passes protocolUrl (not frontendUrl) to fetchAgentId', async () => {
+    const calls: Array<{ protocolUrl: string; apiKey: string }> = [];
+    await runHeadlessSetup({
+      url: 'https://index.network',
+      apiKey: 'key-headless',
+      fetchAgentId: async (protocolUrl: string, apiKey: string) => { calls.push({ protocolUrl, apiKey }); return 'agent-x'; },
+    });
+    expect(calls).toEqual([{ protocolUrl: 'https://protocol.index.network', apiKey: 'key-headless' }]);
+  });
+
+  test('preserves existing config keys not written by setup', async () => {
+    const result = await runHeadlessSetup({
+      apiKey: 'key-headless',
+      existingCfg: { gateway: { port: 18789, auth: { token: 'gw-tok' } } },
+      fetchAgentId: async () => 'agent-headless',
+    });
+
+    const gw = (result as Record<string, unknown> & { gateway: { port: number } }).gateway;
+    expect(gw.port).toBe(18789);
+  });
+
+  test('does not mutate the existingCfg object passed in', async () => {
+    const original: Record<string, unknown> = { gateway: { port: 1 } };
+    const before = JSON.stringify(original);
+    await runHeadlessSetup({
+      apiKey: 'key-headless',
+      existingCfg: original,
+      fetchAgentId: async () => 'agent-headless',
+    });
+    expect(JSON.stringify(original)).toBe(before);
   });
 });


### PR DESCRIPTION
## Summary

- Adds `runHeadlessSetup()` to the openclaw-plugin — a non-interactive version of `runSetup` that takes pre-filled options and delegates to the existing wizard logic, returning the mutated config object for the caller to write to disk
- Registers `openclaw index connect --api-key <key> [--url <url>]` as a new CLI subcommand, enabling EdgeClaw attendees to configure the plugin with a single command after signup
- Extends the experiment signup response (`POST /networks/:id/signup`) with `agentId` and `connectCommand` so callers (e.g. InstaClaw) have everything they need in one request — no follow-up `GET /api/agents/me` call needed
- Adds `docs/guides/edgeclaw-instaclaw-integration.md` as a handoff doc for the InstaClaw team describing the exact integration flow
- Bumps `@indexnetwork/openclaw-plugin` to `0.25.0` (both `package.json` and `openclaw.plugin.json`)

## Test plan

- [ ] 42 tests pass in `packages/openclaw-plugin/src/tests/setup-entry.spec.ts` (30 existing + 12 new headless setup tests)
- [ ] `openclaw index connect --api-key <key>` writes correct config to `~/.openclaw/openclaw.json` and prints restart instructions
- [ ] `POST /networks/:id/signup` response includes `apiKey`, `agentId`, and `connectCommand`
- [ ] `connectCommand` includes `--url` flag only when `APP_URL` env var differs from `https://index.network`
- [ ] Re-running `openclaw index connect` with the same key is idempotent