### PR TITLE
feat(openclaw-plugin): onboarding guard and OpenClaw-native onboarding flow (IND-248)

### DIFF
--- a/backend/src/controllers/agent.controller.ts
+++ b/backend/src/controllers/agent.controller.ts
@@ -12,7 +12,6 @@ import {
   UnauthorizedError,
 } from '../services/negotiation-polling.service';
 import { opportunityDeliveryService } from '../services/opportunity-delivery.service';
-import { userService } from '../services/user.service';
 
 const agentTestMessageService = new AgentTestMessageService();
 
@@ -186,12 +185,8 @@ export class AgentController {
     }
 
     try {
-      const [agent, userData] = await Promise.all([
-        agentService.getById(agentId, user.id),
-        userService.findById(user.id),
-      ]);
-      const onboardingCompletedAt = userData?.onboarding?.completedAt ?? null;
-      return Response.json({ agent, onboardingCompletedAt });
+      const result = await agentService.getMe(agentId, user.id);
+      return Response.json(result);
     } catch (err) {
       return jsonError(parseErrorMessage(err), errorStatus(err, 404));
     }

--- a/backend/src/controllers/agent.controller.ts
+++ b/backend/src/controllers/agent.controller.ts
@@ -12,6 +12,7 @@ import {
   UnauthorizedError,
 } from '../services/negotiation-polling.service';
 import { opportunityDeliveryService } from '../services/opportunity-delivery.service';
+import { userService } from '../services/user.service';
 
 const agentTestMessageService = new AgentTestMessageService();
 
@@ -185,8 +186,12 @@ export class AgentController {
     }
 
     try {
-      const agent = await agentService.getById(agentId, user.id);
-      return Response.json({ agent });
+      const [agent, userData] = await Promise.all([
+        agentService.getById(agentId, user.id),
+        userService.findById(user.id),
+      ]);
+      const onboardingCompletedAt = userData?.onboarding?.completedAt ?? null;
+      return Response.json({ agent, onboardingCompletedAt });
     } catch (err) {
       return jsonError(parseErrorMessage(err), errorStatus(err, 404));
     }

--- a/backend/src/services/agent.service.ts
+++ b/backend/src/services/agent.service.ts
@@ -13,6 +13,7 @@ import {
   agentTokenAdapter,
   type AgentTokenStore,
 } from '../adapters/agent-token.adapter';
+import { userDatabaseAdapter } from '../adapters/database.adapter';
 import { log } from '../lib/log';
 
 const logger = log.service.from('AgentService');
@@ -102,6 +103,15 @@ export class AgentService {
     }
 
     return this.sanitizeAgent(agent, userId);
+  }
+
+  async getMe(agentId: string, userId: string): Promise<{ agent: AgentWithRelations; onboardingCompletedAt: string | null }> {
+    const [agent, user] = await Promise.all([
+      this.getById(agentId, userId),
+      userDatabaseAdapter.findById(userId),
+    ]);
+    const onboardingCompletedAt = user?.onboarding?.completedAt ?? null;
+    return { agent, onboardingCompletedAt };
   }
 
   async listForUser(userId: string): Promise<AgentWithRelations[]> {

--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "indexnetwork-openclaw-plugin",
   "name": "Index Network",
   "description": "Index Network — find the right people and let them find you. Registers the Index Network MCP server on first use and hands off to its guidance.",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "configSchema": {
     "type": "object",
     "properties": {

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/openclaw-plugin",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "Index Network — OpenClaw plugin. Find the right people and let them find you.",
   "license": "MIT",
   "private": false,

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -28,6 +28,9 @@ import * as acceptedOpportunityPoller from './polling/accepted-opportunity/accep
 import * as acceptedOpportunityScheduler from './polling/accepted-opportunity/accepted-opportunity.scheduler.js';
 import { registerSetupCli, registerConnectCli } from './setup/setup.cli.js';
 import { deriveUrls } from './lib/utils/url.js';
+import { isOnboardingComplete, _resetForTesting as _resetOnboardingStatus } from './polling/onboarding/onboarding.status.js';
+import { buildOnboardingPrompt } from './polling/onboarding/onboarding.prompt.js';
+import { dispatchToMainAgent } from './lib/delivery/main-agent.dispatcher.js';
 
 /** Prevents double-registration when OpenClaw calls register() more than once. */
 let registered = false;
@@ -295,6 +298,11 @@ export function register(api: OpenClawPluginApi): void {
   setTimeout(() => {
     checkBackendReachability(api, baseUrl);
   }, 5_000).unref();
+
+  // Onboarding prompt dispatch — fires once per day while onboarding is pending.
+  setTimeout(() => {
+    dispatchOnboardingIfNeeded(api, { baseUrl, agentId, apiKey });
+  }, 5_000).unref();
 }
 
 // --- Plugin entry ---
@@ -323,6 +331,29 @@ function checkBackendReachability(api: OpenClawPluginApi, baseUrl: string): void
   });
 }
 
+async function dispatchOnboardingIfNeeded(
+  api: OpenClawPluginApi,
+  config: { baseUrl: string; agentId: string; apiKey: string },
+): Promise<void> {
+  const complete = await isOnboardingComplete(api, config);
+  if (complete) return;
+
+  const dateStr = new Date().toISOString().slice(0, 10);
+  const result = await dispatchToMainAgent(api, {
+    prompt: buildOnboardingPrompt(),
+    idempotencyKey: `index:onboarding:dispatch:${config.agentId}:${dateStr}`,
+  });
+
+  if (result.delivered) {
+    api.logger.info('Onboarding prompt dispatched to main agent.', { agentId: config.agentId });
+  } else {
+    api.logger.warn('Onboarding prompt dispatch failed — will retry on next gateway restart.', {
+      agentId: config.agentId,
+      error: result.error,
+    });
+  }
+}
+
 function readConfig(api: OpenClawPluginApi, key: string): string {
   const val = api.pluginConfig[key];
   return typeof val === 'string' ? val : '';
@@ -334,6 +365,7 @@ function readConfig(api: OpenClawPluginApi, key: string): string {
  */
 export function _resetForTesting(): void {
   registered = false;
+  _resetOnboardingStatus();
   negotiatorPoller._resetForTesting();
   negotiatorScheduler._resetForTesting();
   dailyDigestScheduler._resetForTesting();

--- a/packages/openclaw-plugin/src/polling/accepted-opportunity/accepted-opportunity.poller.ts
+++ b/packages/openclaw-plugin/src/polling/accepted-opportunity/accepted-opportunity.poller.ts
@@ -3,6 +3,7 @@ import { dispatchToMainAgent } from '../../lib/delivery/main-agent.dispatcher.js
 import { buildMainAgentPrompt } from '../../lib/delivery/main-agent.prompt.js';
 import { readMainAgentToolUse } from '../../lib/delivery/config.js';
 import { hashOpportunityBatch } from '../../lib/utils/hash.js';
+import { isOnboardingComplete } from '../onboarding/onboarding.status.js';
 
 export interface AcceptedOpportunityConfig {
   baseUrl: string;
@@ -20,6 +21,11 @@ export async function handle(
   api: OpenClawPluginApi,
   config: AcceptedOpportunityConfig,
 ): Promise<AcceptedOpportunityOutcome> {
+  if (!await isOnboardingComplete(api, config)) {
+    api.logger.debug('Accepted opportunity: onboarding not complete, skipping.');
+    return 'empty';
+  }
+
   const acceptedUrl = `${config.baseUrl}/api/agents/${config.agentId}/opportunities/accepted?limit=${ACCEPTED_LIMIT}`;
 
   let res: Response;

--- a/packages/openclaw-plugin/src/polling/ambient-discovery/ambient-discovery.poller.ts
+++ b/packages/openclaw-plugin/src/polling/ambient-discovery/ambient-discovery.poller.ts
@@ -4,6 +4,7 @@ import { buildMainAgentPrompt } from '../../lib/delivery/main-agent.prompt.js';
 import { readMainAgentToolUse } from '../../lib/delivery/config.js';
 import { hashOpportunityBatch } from '../../lib/utils/hash.js';
 import { fetchConnectToken } from '../../lib/utils/connect-token.js';
+import { isOnboardingComplete } from '../../polling/onboarding/onboarding.status.js';
 
 export interface AmbientDiscoveryConfig {
   baseUrl: string;
@@ -96,6 +97,11 @@ export async function handle(
   api: OpenClawPluginApi,
   config: AmbientDiscoveryConfig,
 ): Promise<AmbientDiscoveryOutcome> {
+  if (!await isOnboardingComplete(api, config)) {
+    api.logger.debug('Ambient discovery: onboarding not complete, skipping.');
+    return 'empty';
+  }
+
   const pendingUrl = `${config.baseUrl}/api/agents/${config.agentId}/opportunities/pending?limit=${PENDING_LIMIT}`;
 
   let res: Response;

--- a/packages/openclaw-plugin/src/polling/ambient-discovery/ambient-discovery.poller.ts
+++ b/packages/openclaw-plugin/src/polling/ambient-discovery/ambient-discovery.poller.ts
@@ -4,7 +4,7 @@ import { buildMainAgentPrompt } from '../../lib/delivery/main-agent.prompt.js';
 import { readMainAgentToolUse } from '../../lib/delivery/config.js';
 import { hashOpportunityBatch } from '../../lib/utils/hash.js';
 import { fetchConnectToken } from '../../lib/utils/connect-token.js';
-import { isOnboardingComplete } from '../../polling/onboarding/onboarding.status.js';
+import { isOnboardingComplete } from '../onboarding/onboarding.status.js';
 
 export interface AmbientDiscoveryConfig {
   baseUrl: string;

--- a/packages/openclaw-plugin/src/polling/daily-digest/daily-digest.poller.ts
+++ b/packages/openclaw-plugin/src/polling/daily-digest/daily-digest.poller.ts
@@ -4,6 +4,7 @@ import { buildMainAgentPrompt } from '../../lib/delivery/main-agent.prompt.js';
 import { readMainAgentToolUse } from '../../lib/delivery/config.js';
 import { hashOpportunityBatch } from '../../lib/utils/hash.js';
 import { fetchConnectToken } from '../../lib/utils/connect-token.js';
+import { isOnboardingComplete } from '../../polling/onboarding/onboarding.status.js';
 
 export interface DailyDigestConfig {
   baseUrl: string;
@@ -26,6 +27,11 @@ export async function handle(
   api: OpenClawPluginApi,
   config: DailyDigestConfig,
 ): Promise<boolean> {
+  if (!await isOnboardingComplete(api, config)) {
+    api.logger.debug('Daily digest: onboarding not complete, skipping.');
+    return false;
+  }
+
   const pendingUrl = `${config.baseUrl}/api/agents/${config.agentId}/opportunities/pending?limit=${PENDING_LIMIT}`;
 
   let res: Response;

--- a/packages/openclaw-plugin/src/polling/negotiator/negotiator.poller.ts
+++ b/packages/openclaw-plugin/src/polling/negotiator/negotiator.poller.ts
@@ -2,6 +2,7 @@ import type { OpenClawPluginApi } from '../../lib/openclaw/plugin-api.js';
 import { readModel } from '../../lib/openclaw/plugin-api.js';
 
 import { turnPrompt } from './negotiation-turn.prompt.js';
+import { isOnboardingComplete } from '../onboarding/onboarding.status.js';
 
 export type NegotiatorPollResult = 'handled' | 'idle' | 'network_error';
 
@@ -26,6 +27,11 @@ export async function handle(
   api: OpenClawPluginApi,
   config: NegotiatorConfig,
 ): Promise<NegotiatorPollResult> {
+  if (!await isOnboardingComplete(api, config)) {
+    api.logger.debug('Negotiator: onboarding not complete, skipping.');
+    return 'idle';
+  }
+
   const pickupUrl = `${config.baseUrl}/api/agents/${config.agentId}/negotiations/pickup`;
 
   const res = await fetch(pickupUrl, {

--- a/packages/openclaw-plugin/src/polling/onboarding/onboarding.prompt.ts
+++ b/packages/openclaw-plugin/src/polling/onboarding/onboarding.prompt.ts
@@ -1,14 +1,4 @@
-/**
- * Builds the onboarding prompt dispatched to the user's main OpenClaw agent
- * after initial plugin setup, when onboarding has not yet been completed.
- *
- * The agent has access to Index Network MCP tools and can drive the full
- * onboarding flow on the user's chat channel (Telegram, WhatsApp, etc.)
- * without the user visiting index.network.
- *
- * Gmail import (`import_gmail_contacts`) is intentionally excluded — it
- * requires OAuth in a browser and is not appropriate for chat-channel delivery.
- */
+// Gmail import excluded — requires OAuth in a browser, not suitable for chat-channel delivery.
 export function buildOnboardingPrompt(): string {
   return `You are the Index agent. The user has just connected to Index Network via OpenClaw and needs to complete their onboarding. Walk them through the following steps in order. Do not skip steps.
 

--- a/packages/openclaw-plugin/src/polling/onboarding/onboarding.prompt.ts
+++ b/packages/openclaw-plugin/src/polling/onboarding/onboarding.prompt.ts
@@ -1,0 +1,56 @@
+/**
+ * Builds the onboarding prompt dispatched to the user's main OpenClaw agent
+ * after initial plugin setup, when onboarding has not yet been completed.
+ *
+ * The agent has access to Index Network MCP tools and can drive the full
+ * onboarding flow on the user's chat channel (Telegram, WhatsApp, etc.)
+ * without the user visiting index.network.
+ *
+ * Gmail import (`import_gmail_contacts`) is intentionally excluded — it
+ * requires OAuth in a browser and is not appropriate for chat-channel delivery.
+ */
+export function buildOnboardingPrompt(): string {
+  return `You are the Index agent. The user has just connected to Index Network via OpenClaw and needs to complete their onboarding. Walk them through the following steps in order. Do not skip steps.
+
+## Onboarding Flow
+
+### Step 1 — Greet and create profile
+- Greet the user warmly: "Hey, I'm Index. I help the right people find you — and help you find them."
+- Briefly explain what Index does: learn about them, find relevant people, surface connections in the background.
+- Call \`create_user_profile()\` with no arguments to look up their public profile from their name and email.
+- While processing, narrate: "> Looking you up…"
+- Present the profile summary naturally: "Here's what I found: [summary]. Does that sound right?"
+- Wait for their confirmation:
+  - If yes → call \`create_user_profile(confirm=true)\` to save and proceed to Step 2.
+  - If no / wants edits → call \`create_user_profile(bioOrDescription="[their correction]", confirm=true)\` with their corrections, then proceed to Step 2.
+  - If nothing found → ask them to describe themselves in a sentence, then call \`create_user_profile(bioOrDescription="[their text]", confirm=true)\`.
+
+### Step 2 — Community discovery
+- Call \`read_networks()\` to fetch available public communities.
+- Present the communities as a plain text list — do NOT use any code fences or special blocks.
+- Write: "Here are some communities you might find relevant — let me know which ones you'd like to join, or say skip to continue."
+- For each community the user wants to join, call \`create_network_membership(networkId="...")\`.
+- After handling their response (joins processed, or user skips), proceed to Step 3.
+
+### Step 3 — Intent capture
+- Ask: "Now tell me — what are you open to right now? Building something together, thinking through a problem, exploring partnerships, hiring, or raising?"
+- When they respond, call \`create_intent(description="[their response]")\`.
+- Briefly acknowledge the intent was saved: "Got it — I'll keep an eye out for relevant people."
+
+### Step 4 — Initial match
+- Call \`create_opportunities(searchQuery="[the intent description from Step 3]")\` to surface initial matches.
+- If matches found, present them naturally: "I already found some relevant people based on what you're looking for."
+- If no matches: "No matches yet, but I'll keep looking in the background."
+
+### Step 5 — Complete onboarding
+- Call \`complete_onboarding()\`. This is required — do not skip it.
+- Close with: "You're all set. I'll keep an eye out for more relevant people — you'll hear from me when something comes up."
+
+## Rules
+- Do not skip steps or reorder them.
+- Do not mention Gmail or email import — they are not available in this flow.
+- If the user tries to do something else mid-onboarding, gently redirect: "Let's finish setting you up first, then we can dive into that."
+- Keep your tone warm, direct, and concise.
+- Only call \`complete_onboarding()\` at Step 5 — never earlier.
+`;
+}

--- a/packages/openclaw-plugin/src/polling/onboarding/onboarding.status.ts
+++ b/packages/openclaw-plugin/src/polling/onboarding/onboarding.status.ts
@@ -1,0 +1,53 @@
+import type { OpenClawPluginApi } from '../../lib/openclaw/plugin-api.js';
+
+export interface OnboardingStatusConfig {
+  baseUrl: string;
+  agentId: string;
+  apiKey: string;
+}
+
+let cachedComplete: boolean | undefined = undefined;
+let cachedForApiKey: string | undefined = undefined;
+
+/**
+ * Returns true when the user has completed onboarding (`onboardingCompletedAt`
+ * is set on the backend). Caches `true` forever for the same API key — onboarding
+ * completion is a one-way transition. Re-queries when the API key changes.
+ * Returns `false` conservatively on network errors or non-2xx responses so
+ * dispatches remain gated on a flaky connection.
+ */
+export async function isOnboardingComplete(
+  api: OpenClawPluginApi,
+  config: OnboardingStatusConfig,
+): Promise<boolean> {
+  if (cachedComplete === true && cachedForApiKey === config.apiKey) return true;
+
+  try {
+    const res = await fetch(`${config.baseUrl}/api/agents/me`, {
+      headers: { 'x-api-key': config.apiKey },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) {
+      api.logger.warn('Onboarding status check failed', { status: res.status });
+      return false;
+    }
+    const body = (await res.json()) as { onboardingCompletedAt?: string | null };
+    const complete = body.onboardingCompletedAt != null;
+    if (complete) {
+      cachedComplete = true;
+      cachedForApiKey = config.apiKey;
+    }
+    return complete;
+  } catch (err) {
+    api.logger.warn('Onboarding status check errored', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return false;
+  }
+}
+
+/** Reset module-level state. Exposed for tests only. */
+export function _resetForTesting(): void {
+  cachedComplete = undefined;
+  cachedForApiKey = undefined;
+}

--- a/packages/openclaw-plugin/src/tests/accepted-opportunity.poller.spec.ts
+++ b/packages/openclaw-plugin/src/tests/accepted-opportunity.poller.spec.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+import { handle, _resetForTesting } from '../polling/accepted-opportunity/accepted-opportunity.poller.js';
+import { _resetForTesting as _resetOnboardingStatus } from '../polling/onboarding/onboarding.status.js';
+import type { OpenClawPluginApi } from '../lib/openclaw/plugin-api.js';
+
+function makeApi(): OpenClawPluginApi {
+  return {
+    id: 'indexnetwork-openclaw-plugin',
+    name: 'Index Network',
+    pluginConfig: {},
+    config: {
+      gateway: { port: 18789 },
+      hooks: { enabled: true, token: 'hooks-tok', path: '/hooks' },
+    },
+    runtime: {
+      subagent: {
+        run: mock(async () => ({ runId: 'unused' })),
+        waitForRun: mock(async () => ({ result: null })),
+        getSessionMessages: mock(async () => ({ messages: [] })),
+      },
+    },
+    logger: {
+      debug: mock(() => {}),
+      info: mock(() => {}),
+      warn: mock(() => {}),
+      error: mock(() => {}),
+    },
+    registerHttpRoute: mock(() => {}),
+  };
+}
+
+const cfg = { baseUrl: 'https://test.example.com', agentId: 'agent-1', apiKey: 'key-abc' };
+
+let originalFetch: typeof global.fetch;
+
+beforeEach(() => { originalFetch = global.fetch; _resetForTesting(); _resetOnboardingStatus(); });
+afterEach(() => { global.fetch = originalFetch; _resetForTesting(); _resetOnboardingStatus(); });
+
+describe('accepted-opportunity poller onboarding guard', () => {
+  it('returns "empty" without hitting backend when onboarding is not complete', async () => {
+    global.fetch = mock(async (input: RequestInfo) => {
+      const url = String(input);
+      if (url.includes('/api/agents/me')) {
+        return new Response(JSON.stringify({ agent: {}, onboardingCompletedAt: null }), { status: 200 });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as unknown as typeof fetch;
+
+    const result = await handle(makeApi(), cfg);
+    expect(result).toBe('empty');
+  });
+});

--- a/packages/openclaw-plugin/src/tests/daily-digest.test.ts
+++ b/packages/openclaw-plugin/src/tests/daily-digest.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 
-import { handle as handleDailyDigest } from '../polling/daily-digest/daily-digest.poller.js';
+import { handle, handle as handleDailyDigest } from '../polling/daily-digest/daily-digest.poller.js';
+import { _resetForTesting as _resetOnboardingStatus } from '../polling/onboarding/onboarding.status.js';
 import type { OpenClawPluginApi } from '../lib/openclaw/plugin-api.js';
 
 const OPP_1 = '11111111-1111-1111-1111-111111111111';
@@ -42,6 +43,9 @@ function mockBackend(opportunities: unknown[], hookStatus = 200, confirmStatus =
   const sink: FetchSink = { pendingUrls: [], hookCalls: [], confirmCalls: [] };
   global.fetch = mock(async (input: RequestInfo, init?: RequestInit) => {
     const url = String(input);
+    if (url.includes('/api/agents/me')) {
+      return new Response(JSON.stringify({ agent: {}, onboardingCompletedAt: '2026-05-05T10:00:00.000Z' }), { status: 200 });
+    }
     if (url.includes('/connect-token')) {
       return new Response(JSON.stringify({ token: 'mock-jwt-token' }), { status: 200 });
     }
@@ -73,11 +77,13 @@ describe('handleDailyDigest (hooks-only path)', () => {
 
   beforeEach(() => {
     originalFetch = global.fetch;
+    _resetOnboardingStatus();
     mockApi = makeApi();
   });
 
   afterEach(() => {
     global.fetch = originalFetch;
+    _resetOnboardingStatus();
   });
 
   const cfg = {
@@ -154,5 +160,18 @@ describe('handleDailyDigest (hooks-only path)', () => {
     expect(result).toBe(true);
     expect(sink.hookCalls).toHaveLength(1);
     expect(sink.confirmCalls).toHaveLength(0);
+  });
+
+  it('returns false without hitting backend when onboarding is not complete', async () => {
+    global.fetch = mock(async (input: RequestInfo) => {
+      const url = String(input);
+      if (url.includes('/api/agents/me')) {
+        return new Response(JSON.stringify({ agent: {}, onboardingCompletedAt: null }), { status: 200 });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as unknown as typeof fetch;
+
+    const result = await handle(mockApi, cfg);
+    expect(result).toBe(false);
   });
 });

--- a/packages/openclaw-plugin/src/tests/daily-digest.test.ts
+++ b/packages/openclaw-plugin/src/tests/daily-digest.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 
-import { handle, handle as handleDailyDigest } from '../polling/daily-digest/daily-digest.poller.js';
+import { handle as handleDailyDigest } from '../polling/daily-digest/daily-digest.poller.js';
 import { _resetForTesting as _resetOnboardingStatus } from '../polling/onboarding/onboarding.status.js';
 import type { OpenClawPluginApi } from '../lib/openclaw/plugin-api.js';
 
@@ -171,7 +171,7 @@ describe('handleDailyDigest (hooks-only path)', () => {
       throw new Error(`Unexpected fetch: ${url}`);
     }) as unknown as typeof fetch;
 
-    const result = await handle(mockApi, cfg);
+    const result = await handleDailyDigest(mockApi, cfg);
     expect(result).toBe(false);
   });
 });

--- a/packages/openclaw-plugin/src/tests/negotiator.poller.spec.ts
+++ b/packages/openclaw-plugin/src/tests/negotiator.poller.spec.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+import { handle } from '../polling/negotiator/negotiator.poller.js';
+import { _resetForTesting as _resetOnboardingStatus } from '../polling/onboarding/onboarding.status.js';
+import type { OpenClawPluginApi } from '../lib/openclaw/plugin-api.js';
+
+function makeApi(): OpenClawPluginApi {
+  return {
+    id: 'indexnetwork-openclaw-plugin',
+    name: 'Index Network',
+    pluginConfig: {},
+    config: {},
+    runtime: {
+      subagent: {
+        run: mock(async () => ({ runId: 'unused' })),
+        waitForRun: mock(async () => ({ result: null })),
+        getSessionMessages: mock(async () => ({ messages: [] })),
+      },
+    },
+    logger: {
+      debug: mock(() => {}),
+      info: mock(() => {}),
+      warn: mock(() => {}),
+      error: mock(() => {}),
+    },
+    registerHttpRoute: mock(() => {}),
+  };
+}
+
+const cfg = { baseUrl: 'https://test.example.com', agentId: 'agent-1', apiKey: 'key-abc' };
+
+let originalFetch: typeof global.fetch;
+
+beforeEach(() => { originalFetch = global.fetch; _resetOnboardingStatus(); });
+afterEach(() => { global.fetch = originalFetch; _resetOnboardingStatus(); });
+
+describe('negotiator poller onboarding guard', () => {
+  it('returns "idle" without hitting pickup endpoint when onboarding is not complete', async () => {
+    global.fetch = mock(async (input: RequestInfo) => {
+      const url = String(input);
+      if (url.includes('/api/agents/me')) {
+        return new Response(JSON.stringify({ agent: {}, onboardingCompletedAt: null }), { status: 200 });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as unknown as typeof fetch;
+
+    const result = await handle(makeApi(), cfg);
+    expect(result).toBe('idle');
+  });
+});

--- a/packages/openclaw-plugin/src/tests/onboarding.prompt.spec.ts
+++ b/packages/openclaw-plugin/src/tests/onboarding.prompt.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'bun:test';
+
+import { buildOnboardingPrompt } from '../polling/onboarding/onboarding.prompt.js';
+
+describe('buildOnboardingPrompt', () => {
+  it('contains profile creation instructions', () => {
+    const prompt = buildOnboardingPrompt();
+    expect(prompt).toContain('create_user_profile');
+  });
+
+  it('contains community discovery instructions', () => {
+    const prompt = buildOnboardingPrompt();
+    expect(prompt).toContain('read_networks');
+    expect(prompt).toContain('create_network_membership');
+  });
+
+  it('contains intent capture instructions', () => {
+    const prompt = buildOnboardingPrompt();
+    expect(prompt).toContain('create_intent');
+  });
+
+  it('contains complete_onboarding instruction', () => {
+    const prompt = buildOnboardingPrompt();
+    expect(prompt).toContain('complete_onboarding');
+  });
+
+  it('does NOT mention import_gmail_contacts', () => {
+    const prompt = buildOnboardingPrompt();
+    expect(prompt).not.toContain('import_gmail_contacts');
+  });
+});

--- a/packages/openclaw-plugin/src/tests/onboarding.status.spec.ts
+++ b/packages/openclaw-plugin/src/tests/onboarding.status.spec.ts
@@ -12,6 +12,13 @@ function makeApi(): OpenClawPluginApi {
     name: 'Index Network',
     pluginConfig: {},
     config: {},
+    runtime: {
+      subagent: {
+        run: mock(async () => ({ runId: 'unused' })),
+        waitForRun: mock(async () => ({ result: null })),
+        getSessionMessages: mock(async () => ({ messages: [] })),
+      },
+    },
     logger: {
       debug: mock(() => {}),
       info: mock(() => {}),

--- a/packages/openclaw-plugin/src/tests/onboarding.status.spec.ts
+++ b/packages/openclaw-plugin/src/tests/onboarding.status.spec.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+import {
+  isOnboardingComplete,
+  _resetForTesting,
+} from '../polling/onboarding/onboarding.status.js';
+import type { OpenClawPluginApi } from '../lib/openclaw/plugin-api.js';
+
+function makeApi(): OpenClawPluginApi {
+  return {
+    id: 'indexnetwork-openclaw-plugin',
+    name: 'Index Network',
+    pluginConfig: {},
+    config: {},
+    logger: {
+      debug: mock(() => {}),
+      info: mock(() => {}),
+      warn: mock(() => {}),
+      error: mock(() => {}),
+    },
+    registerHttpRoute: mock(() => {}),
+  };
+}
+
+const cfg = { baseUrl: 'https://test.example.com', agentId: 'agent-1', apiKey: 'key-abc' };
+
+let originalFetch: typeof global.fetch;
+
+beforeEach(() => {
+  originalFetch = global.fetch;
+  _resetForTesting();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  _resetForTesting();
+});
+
+describe('isOnboardingComplete', () => {
+  it('returns false when onboardingCompletedAt is null', async () => {
+    global.fetch = mock(async () =>
+      new Response(JSON.stringify({ agent: {}, onboardingCompletedAt: null }), { status: 200 }),
+    ) as unknown as typeof fetch;
+    const result = await isOnboardingComplete(makeApi(), cfg);
+    expect(result).toBe(false);
+  });
+
+  it('returns true when onboardingCompletedAt is a non-null ISO string', async () => {
+    global.fetch = mock(async () =>
+      new Response(
+        JSON.stringify({ agent: {}, onboardingCompletedAt: '2026-05-05T10:00:00.000Z' }),
+        { status: 200 },
+      ),
+    ) as unknown as typeof fetch;
+    const result = await isOnboardingComplete(makeApi(), cfg);
+    expect(result).toBe(true);
+  });
+
+  it('caches true — second call with same API key never hits backend', async () => {
+    let callCount = 0;
+    global.fetch = mock(async () => {
+      callCount++;
+      return new Response(
+        JSON.stringify({ agent: {}, onboardingCompletedAt: '2026-05-05T10:00:00.000Z' }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    await isOnboardingComplete(makeApi(), cfg);
+    await isOnboardingComplete(makeApi(), cfg);
+    expect(callCount).toBe(1);
+  });
+
+  it('re-queries when API key changes even if previously cached true', async () => {
+    let callCount = 0;
+    global.fetch = mock(async () => {
+      callCount++;
+      return new Response(
+        JSON.stringify({ agent: {}, onboardingCompletedAt: '2026-05-05T10:00:00.000Z' }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    await isOnboardingComplete(makeApi(), { ...cfg, apiKey: 'key-abc' });
+    await isOnboardingComplete(makeApi(), { ...cfg, apiKey: 'key-xyz' });
+    expect(callCount).toBe(2);
+  });
+
+  it('returns false conservatively on network error', async () => {
+    global.fetch = mock(async () => {
+      throw new Error('connection refused');
+    }) as unknown as typeof fetch;
+    const result = await isOnboardingComplete(makeApi(), cfg);
+    expect(result).toBe(false);
+  });
+
+  it('returns false conservatively on non-2xx response', async () => {
+    global.fetch = mock(async () =>
+      new Response('Unauthorized', { status: 401 }),
+    ) as unknown as typeof fetch;
+    const result = await isOnboardingComplete(makeApi(), cfg);
+    expect(result).toBe(false);
+  });
+});

--- a/packages/openclaw-plugin/src/tests/opportunity-batch.spec.ts
+++ b/packages/openclaw-plugin/src/tests/opportunity-batch.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 
 import { handle as handleAmbientDiscovery, _resetForTesting } from '../polling/ambient-discovery/ambient-discovery.poller.js';
+import { _resetForTesting as _resetOnboardingStatus } from '../polling/onboarding/onboarding.status.js';
 import type { OpenClawPluginApi } from '../lib/openclaw/plugin-api.js';
 
 const OPP_1 = '11111111-1111-1111-1111-111111111111';
@@ -65,6 +66,9 @@ function mockBackend(
   // surface it as a test failure rather than silently 200.
   global.fetch = mock(async (input: RequestInfo, init?: RequestInit) => {
     const url = String(input);
+    if (url.includes('/api/agents/me')) {
+      return new Response(JSON.stringify({ agent: {}, onboardingCompletedAt: '2026-05-05T10:00:00.000Z' }), { status: 200 });
+    }
     if (url.includes('/connect-token')) {
       return new Response(JSON.stringify({ token: 'mock-jwt-token' }), { status: 200 });
     }
@@ -94,12 +98,14 @@ describe('handleAmbientDiscovery (hooks-only path)', () => {
   beforeEach(() => {
     originalFetch = global.fetch;
     _resetForTesting();
+    _resetOnboardingStatus();
     mockApi = makeApi();
   });
 
   afterEach(() => {
     global.fetch = originalFetch;
     _resetForTesting();
+    _resetOnboardingStatus();
   });
 
   const cfg = {
@@ -233,5 +239,18 @@ describe('handleAmbientDiscovery (hooks-only path)', () => {
     const body = sink.hookCalls[0].body as { message: string };
     const payload = extractInputPayload(body.message) as { ambientDeliveredToday: number | null };
     expect(payload.ambientDeliveredToday).toBeNull();
+  });
+
+  it('returns "empty" without hitting /pending when onboarding is not complete', async () => {
+    global.fetch = mock(async (input: RequestInfo) => {
+      const url = String(input);
+      if (url.includes('/api/agents/me')) {
+        return new Response(JSON.stringify({ agent: {}, onboardingCompletedAt: null }), { status: 200 });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as unknown as typeof fetch;
+
+    const result = await handleAmbientDiscovery(mockApi, cfg);
+    expect(result).toBe('empty');
   });
 });


### PR DESCRIPTION
## Summary

- Extends `GET /api/agents/me` with `onboardingCompletedAt: string | null` (read from existing `users.onboarding` JSON column — no migration)
- New `onboarding.status.ts` module: `isOnboardingComplete()` checks the backend and caches `true` forever per API key (one-way transition); re-queries on key change; returns `false` conservatively on errors
- New `onboarding.prompt.ts`: builds the onboarding prompt dispatched to the user's main OpenClaw agent — guides them through profile → communities → intent → `complete_onboarding()` via MCP tools, entirely on their chat channel (no browser required); Gmail import excluded
- Four pollers gated on onboarding completion: ambient-discovery, daily-digest, negotiator, accepted-opportunity; test-message remains ungated (delivery probe)
- On `register()` startup, if onboarding is not complete, dispatches the onboarding prompt via `dispatchToMainAgent` with a day-scoped idempotency key (`index:onboarding:dispatch:{agentId}:{date}`) — fires at most once per day until onboarding is done

## Test Plan

- [ ] 151 plugin tests pass (`bun test` in `packages/openclaw-plugin`)
- [ ] Backend typecheck clean (`bunx tsc --noEmit` in `backend/`)
- [ ] Plugin typecheck clean (`bunx tsc --noEmit` in `packages/openclaw-plugin/`)
- [ ] `GET /api/agents/me` with an agent-bound API key returns `onboardingCompletedAt` field
- [ ] Ambient discovery, daily digest, negotiator, accepted-opportunity pollers all return their skip value when `onboardingCompletedAt` is null
- [ ] Test-message poller works regardless of onboarding state
- [ ] On gateway restart with a fresh (non-onboarded) user, onboarding prompt is dispatched to the main agent on their chat channel
- [ ] After `complete_onboarding()` is called, pollers resume dispatching on the next cycle