### PR TITLE
refactor(openclaw-plugin): merge setup into connect as unified command

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/frontend/src/lib/mcp-config.ts
+++ b/frontend/src/lib/mcp-config.ts
@@ -8,7 +8,7 @@ export const OPENCLAW_INSTALL_CMD =
   "openclaw plugins install @indexnetwork/openclaw-plugin";
 export const OPENCLAW_UPDATE_CMD =
   "openclaw plugins update @indexnetwork/openclaw-plugin";
-export const OPENCLAW_SETUP_CMD = "openclaw index setup";
+export const OPENCLAW_SETUP_CMD = "openclaw index connect";
 export const OPENCLAW_GATEWAY_RESTART_CMD = "openclaw gateway restart";
 
 function yamlDoubleQuoted(value: string): string {

--- a/frontend/src/lib/mcp-config.ts
+++ b/frontend/src/lib/mcp-config.ts
@@ -1,6 +1,6 @@
 const DEFAULT_PROTOCOL_URL = import.meta.env.DEV
   ? "http://localhost:3001"
-  : "https://api.index.network";
+  : "https://protocol.index.network";
 const PROTOCOL_URL = import.meta.env.VITE_PROTOCOL_URL || DEFAULT_PROTOCOL_URL;
 const MCP_URL = `${PROTOCOL_URL}/mcp`;
 

--- a/packages/openclaw-plugin/README.md
+++ b/packages/openclaw-plugin/README.md
@@ -8,7 +8,7 @@ The Index Network plugin for OpenClaw. Opportunities surface inside your existin
 
 ```bash
 openclaw plugins install @indexnetwork/openclaw-plugin
-openclaw index setup
+openclaw index connect
 ```
 
 The wizard asks for your Index Network URL and API key (generated at https://index.network/agents), then bootstraps everything else.
@@ -27,7 +27,7 @@ On first run the bootstrap skill registers the Index Network MCP server in your 
 - **Persistent session** (recommended) — paste a personal agent key generated at https://index.network/agents. Every tool call is authenticated automatically.
 - **Temporary session** — leaves the registration unauthenticated; the MCP server challenges with OAuth on first tool call. Only works if your runtime can open a browser window.
 
-After auth, the plugin starts its polling loops and registers the `openclaw index setup` CLI command. Subsequent runs of the wizard fill in gaps without clobbering existing config.
+After auth, the plugin starts its polling loops and registers the `openclaw index connect` CLI command. Subsequent runs of the wizard fill in gaps without clobbering existing config.
 
 ## Configuration
 
@@ -43,7 +43,7 @@ The plugin reads these keys under `plugins.entries.indexnetwork-openclaw-plugin.
 | `digestEnabled` | `true` | Set `false` to disable daily digest. |
 | `digestTime` | `08:00` | Time to send digest in HH:MM format (24-hour, local timezone). |
 
-Prefer `openclaw index setup` over manual edits — it resolves your `agentId` from the API key automatically and keeps `hooks.*` configured correctly for opportunity dispatch.
+Prefer `openclaw index connect` over manual edits — it resolves your `agentId` from the API key automatically and keeps `hooks.*` configured correctly for opportunity dispatch.
 
 ## Daily digest
 
@@ -72,7 +72,7 @@ Configure OpenClaw's log scrubbing at the workspace level if you want either pat
 **OAuth never opens a browser** — switch to persistent session mode.
 
 **Opportunities picked up but not rendered** — check OpenClaw gateway logs:
-- `Cannot dispatch to main agent: hooks.enabled=false or hooks.token unset` → re-run `openclaw index setup` to bootstrap hooks.
+- `Cannot dispatch to main agent: hooks.enabled=false or hooks.token unset` → re-run `openclaw index connect` to bootstrap hooks.
 - `/hooks/agent returned 401: hooks.token rejected` → run `openclaw config unset hooks.token` and re-run setup.
 - `/hooks/agent returned 404` → confirm `hooks.enabled=true` in `~/.openclaw/openclaw.json`.
 

--- a/packages/openclaw-plugin/README.md
+++ b/packages/openclaw-plugin/README.md
@@ -73,7 +73,7 @@ Configure OpenClaw's log scrubbing at the workspace level if you want either pat
 
 **Opportunities picked up but not rendered** — check OpenClaw gateway logs:
 - `Cannot dispatch to main agent: hooks.enabled=false or hooks.token unset` → re-run `openclaw index connect` to bootstrap hooks.
-- `/hooks/agent returned 401: hooks.token rejected` → run `openclaw config unset hooks.token` and then run `openclaw index connect`.
+- `/hooks/agent returned 401: hooks.token rejected` → run `openclaw config unset hooks.token` and re-run `openclaw index connect`.
 - `/hooks/agent returned 404` → confirm `hooks.enabled=true` in `~/.openclaw/openclaw.json`.
 
 **Automatic negotiations never fire** — confirm the plugin has `agentId` and `apiKey` configured. Check OpenClaw gateway logs for poll errors. Verify your agent exists at https://index.network/agents.

--- a/packages/openclaw-plugin/README.md
+++ b/packages/openclaw-plugin/README.md
@@ -73,7 +73,7 @@ Configure OpenClaw's log scrubbing at the workspace level if you want either pat
 
 **Opportunities picked up but not rendered** — check OpenClaw gateway logs:
 - `Cannot dispatch to main agent: hooks.enabled=false or hooks.token unset` → re-run `openclaw index connect` to bootstrap hooks.
-- `/hooks/agent returned 401: hooks.token rejected` → run `openclaw config unset hooks.token` and re-run setup.
+- `/hooks/agent returned 401: hooks.token rejected` → run `openclaw config unset hooks.token` and then run `openclaw index connect`.
 - `/hooks/agent returned 404` → confirm `hooks.enabled=true` in `~/.openclaw/openclaw.json`.
 
 **Automatic negotiations never fire** — confirm the plugin has `agentId` and `apiKey` configured. Check OpenClaw gateway logs for poll errors. Verify your agent exists at https://index.network/agents.

--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "indexnetwork-openclaw-plugin",
   "name": "Index Network",
   "description": "Index Network — find the right people and let them find you. Registers the Index Network MCP server on first use and hands off to its guidance.",
-  "version": "0.28.3",
+  "version": "0.29.0",
   "configSchema": {
     "type": "object",
     "properties": {

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/openclaw-plugin",
-  "version": "0.28.3",
+  "version": "0.29.0",
   "description": "Index Network — OpenClaw plugin. Find the right people and let them find you.",
   "license": "MIT",
   "private": false,

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -12,7 +12,7 @@
  * Daily digest is scheduled directly (no HTTP route needed).
  *
  * Uses `definePluginEntry` from the OpenClaw plugin SDK so that CLI commands
- * (e.g. `openclaw index setup`) are properly registered.
+ * (e.g. `openclaw index connect`) are properly registered.
  */
 
 import type { OpenClawPluginApi } from './lib/openclaw/plugin-api.js';
@@ -37,7 +37,7 @@ import { dispatchToMainAgent } from './lib/delivery/main-agent.dispatcher.js';
 let registered = false;
 
 /**
- * Registers the `openclaw index setup` CLI command if the host supports
+ * Registers the `openclaw index connect` CLI command if the host supports
  * `registerCli`. Also registers `openclaw index-network setup` as a deprecated
  * alias for one minor version (drop in 0.23.0).
  *
@@ -86,7 +86,7 @@ function ensureMcpServer(api: OpenClawPluginApi, baseUrl: string, apiKey: string
     return;
   }
   if (!apiKey) {
-    api.logger.warn('API key not configured — skipping MCP auto-registration. Run `openclaw index setup`.');
+    api.logger.warn('API key not configured — skipping MCP auto-registration. Run `openclaw index connect`.');
     return;
   }
 
@@ -139,7 +139,7 @@ export function register(api: OpenClawPluginApi): void {
   }
   registered = true;
 
-  // Register `openclaw index setup` CLI command unconditionally
+  // Register `openclaw index connect` CLI command unconditionally
   registerSetupCommand(api);
 
   const agentId = readConfig(api, 'agentId');
@@ -147,7 +147,7 @@ export function register(api: OpenClawPluginApi): void {
 
   if (!agentId || !apiKey) {
     api.logger.warn(
-      'Index Network plugin not configured. Run `openclaw index setup` to complete setup.',
+      'Index Network plugin not configured. Run `openclaw index connect` to complete setup.',
     );
     return;
   }
@@ -156,7 +156,7 @@ export function register(api: OpenClawPluginApi): void {
   const legacyProtocolUrl = readConfig(api, 'protocolUrl');
   if (!urlFromConfig && legacyProtocolUrl) {
     api.logger.warn(
-      'Plugin config uses deprecated "protocolUrl". Run `openclaw index setup` to migrate to the new "url" field.',
+      'Plugin config uses deprecated "protocolUrl". Run `openclaw index connect` to migrate to the new "url" field.',
     );
   }
   const configUrl = urlFromConfig || legacyProtocolUrl || 'https://index.network';

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -39,7 +39,7 @@ let registered = false;
 /**
  * Registers the `openclaw index connect` CLI command if the host supports
  * `registerCli`. Also registers `openclaw index-network setup` as a deprecated
- * alias for one minor version (drop in 0.23.0).
+ * alias (to be dropped in a future release).
  *
  * Safe to call even when the plugin is unconfigured.
  */
@@ -57,12 +57,12 @@ function registerSetupCommand(api: OpenClawPluginApi): void {
       registerConnectCli(cmd as Parameters<typeof registerSetupCli>[0]);
       registerSetupCli(cmd as Parameters<typeof registerSetupCli>[0]);
 
-      // Deprecated alias — same handler, prints a warning. Remove in 0.23.0.
+      // Deprecated alias — same handler, prints a warning.
       const aliasCmd = (program as { command(n: string): { description(d: string): unknown } })
         .command('index-network')
         .description('[Deprecated — use `openclaw index`] Manage Index Network plugin configuration');
       registerSetupCli(aliasCmd as Parameters<typeof registerSetupCli>[0], {
-        deprecationWarning: 'Note: `openclaw index-network setup` is deprecated. Use `openclaw index connect` instead. The alias will be removed in 0.23.0.',
+        deprecationWarning: 'Note: `openclaw index-network setup` is deprecated. Use `openclaw index connect` instead.',
       });
     },
     {

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -54,15 +54,15 @@ function registerSetupCommand(api: OpenClawPluginApi): void {
       const cmd = (program as { command(n: string): { description(d: string): unknown } })
         .command('index')
         .description('Manage Index Network plugin configuration');
-      registerSetupCli(cmd as Parameters<typeof registerSetupCli>[0]);
       registerConnectCli(cmd as Parameters<typeof registerSetupCli>[0]);
+      registerSetupCli(cmd as Parameters<typeof registerSetupCli>[0]);
 
       // Deprecated alias — same handler, prints a warning. Remove in 0.23.0.
       const aliasCmd = (program as { command(n: string): { description(d: string): unknown } })
         .command('index-network')
         .description('[Deprecated — use `openclaw index`] Manage Index Network plugin configuration');
       registerSetupCli(aliasCmd as Parameters<typeof registerSetupCli>[0], {
-        deprecationWarning: 'Note: `openclaw index-network setup` is deprecated. Use `openclaw index setup` instead. The alias will be removed in 0.23.0.',
+        deprecationWarning: 'Note: `openclaw index-network setup` is deprecated. Use `openclaw index connect` instead. The alias will be removed in 0.23.0.',
       });
     },
     {

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -146,9 +146,13 @@ export function register(api: OpenClawPluginApi): void {
   const apiKey = readConfig(api, 'apiKey');
 
   if (!agentId || !apiKey) {
-    api.logger.warn(
-      'Index Network plugin not configured. Run `openclaw index connect` to complete setup.',
-    );
+    // Only warn in gateway context — suppress during CLI invocations (e.g. `openclaw index connect`)
+    // where register() is called before the config is written.
+    if (process.argv.some((a) => a === 'gateway')) {
+      api.logger.warn(
+        'Index Network plugin not configured. Run `openclaw index connect` to complete setup.',
+      );
+    }
     return;
   }
 

--- a/packages/openclaw-plugin/src/lib/delivery/main-agent.dispatcher.ts
+++ b/packages/openclaw-plugin/src/lib/delivery/main-agent.dispatcher.ts
@@ -209,7 +209,7 @@ export async function dispatchToMainAgent(
   if (!hooksEnabled || !hooksToken) {
     api.logger.warn(
       'Cannot dispatch to main agent: hooks.enabled=false or hooks.token unset. ' +
-        'Run `openclaw index setup` to bootstrap hooks.',
+        'Run `openclaw index connect` to bootstrap hooks.',
     );
     return { delivered: false, error: 'config_error' };
   }

--- a/packages/openclaw-plugin/src/lib/delivery/main-agent.dispatcher.ts
+++ b/packages/openclaw-plugin/src/lib/delivery/main-agent.dispatcher.ts
@@ -11,7 +11,7 @@
  * gateway creates an isolated session with no channel binding and the
  * reply has nowhere to go.
  *
- * Required gateway config (bootstrapped by `openclaw index setup`):
+ * Required gateway config (bootstrapped by `openclaw index connect`):
  *  - `hooks.enabled = true`
  *  - `hooks.token`   = a non-empty secret distinct from `gateway.auth.token`
  *  - `hooks.path`    = a sub-path, defaulting to `/hooks`

--- a/packages/openclaw-plugin/src/setup/setup.cli.ts
+++ b/packages/openclaw-plugin/src/setup/setup.cli.ts
@@ -370,15 +370,29 @@ async function runInteractiveSetup(cfg: Record<string, unknown>): Promise<void> 
     cfg,
     prompt: async (label, opts) => {
       const defaultSuffix = opts?.default ? ` [${opts.default}]` : '';
+      if (opts?.secret) {
+        // Suppress readline echo for secret input (e.g. API key).
+        const rlAny = rl as unknown as { _writeToOutput: (s: string) => void };
+        const orig = rlAny._writeToOutput;
+        rlAny._writeToOutput = () => {};
+        process.stdout.write(`${label}${defaultSuffix}: `);
+        const answer = await rl.question('');
+        rlAny._writeToOutput = orig;
+        process.stdout.write('\n');
+        return answer.trim() || opts?.default || '';
+      }
       const answer = await rl.question(`${label}${defaultSuffix}: `);
       return answer.trim() || opts?.default || '';
     },
     select: async (label, choices) => {
-      console.log(`\n${label}:`);
-      choices.forEach((c, i) => console.log(`  ${i + 1}. ${c.label}`));
-      const answer = await rl.question('Selection: ');
-      const idx = parseInt(answer.trim(), 10) - 1;
-      return choices[idx]?.value ?? '';
+      while (true) {
+        console.log(`\n${label}:`);
+        choices.forEach((c, i) => console.log(`  ${i + 1}. ${c.label}`));
+        const answer = await rl.question('Selection: ');
+        const idx = parseInt(answer.trim(), 10) - 1;
+        if (choices[idx]) return choices[idx].value;
+        console.log(`  Please enter a number between 1 and ${choices.length}.`);
+      }
     },
     configSet: async (dotPath, value) => {
       setConfigValue(cfg, dotPath, value);

--- a/packages/openclaw-plugin/src/setup/setup.cli.ts
+++ b/packages/openclaw-plugin/src/setup/setup.cli.ts
@@ -3,7 +3,7 @@
  *
  * Registered via `api.registerCli()` and invoked as:
  *
- *   openclaw index setup
+ *   openclaw index connect
  *
  * Collects url, apiKey, and mainAgentToolUse, resolves the caller's
  * agentId from the API key via GET /api/agents/me, then writes plugin
@@ -204,7 +204,7 @@ export async function runSetup(ctx: SetupContext): Promise<void> {
   if (existingHooksToken && existingHooksToken === gatewayAuthToken) {
     throw new Error(
       'hooks.token must be distinct from gateway.auth.token. ' +
-        'Run `openclaw config unset hooks.token` and re-run setup to regenerate.',
+        'Run `openclaw config unset hooks.token` and re-run `openclaw index connect` to regenerate.',
     );
   }
 

--- a/packages/openclaw-plugin/src/setup/setup.cli.ts
+++ b/packages/openclaw-plugin/src/setup/setup.cli.ts
@@ -388,6 +388,7 @@ async function runInteractiveSetup(cfg: Record<string, unknown>): Promise<void> 
 
   try {
     await runSetup(ctx);
+    fs.mkdirSync(path.dirname(CONFIG_PATH), { recursive: true });
     fs.writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2));
     console.log('\n✓ Config written to ~/.openclaw/openclaw.json');
     console.log('Restart the gateway to apply changes: openclaw gateway restart');

--- a/packages/openclaw-plugin/src/setup/setup.cli.ts
+++ b/packages/openclaw-plugin/src/setup/setup.cli.ts
@@ -363,15 +363,53 @@ function setConfigValue(cfg: Record<string, unknown>, dotPath: string, value: un
   obj[parts[parts.length - 1]] = value;
 }
 
+async function runInteractiveSetup(cfg: Record<string, unknown>): Promise<void> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+  const ctx: SetupContext = {
+    cfg,
+    prompt: async (label, opts) => {
+      const defaultSuffix = opts?.default ? ` [${opts.default}]` : '';
+      const answer = await rl.question(`${label}${defaultSuffix}: `);
+      return answer.trim() || opts?.default || '';
+    },
+    select: async (label, choices) => {
+      console.log(`\n${label}:`);
+      choices.forEach((c, i) => console.log(`  ${i + 1}. ${c.label}`));
+      const answer = await rl.question('Selection: ');
+      const idx = parseInt(answer.trim(), 10) - 1;
+      return choices[idx]?.value ?? '';
+    },
+    configSet: async (dotPath, value) => {
+      setConfigValue(cfg, dotPath, value);
+    },
+    fetchAgentId: defaultFetchAgentId,
+  };
+
+  try {
+    await runSetup(ctx);
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2));
+    console.log('\n✓ Config written to ~/.openclaw/openclaw.json');
+    console.log('Restart the gateway to apply changes: openclaw gateway restart');
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exitCode = 1;
+  } finally {
+    rl.close();
+  }
+}
+
 /**
  * Registers the `openclaw index connect` CLI command.
  *
  * Usage:
- *   openclaw index connect --api-key <key> [--url <url>]
+ *   openclaw index connect                             # interactive wizard
+ *   openclaw index connect --api-key <key>             # non-interactive, all defaults
+ *   openclaw index connect --api-key <key> --url <url> --digest-time 09:00 --no-digest
  *
- * Reads the existing ~/.openclaw/openclaw.json (if any), runs a headless
- * setup with the supplied key, and writes the result back to disk. Idempotent
- * — safe to re-run with the same or a new key.
+ * Without --api-key the interactive wizard runs. With --api-key a headless
+ * setup runs using the supplied flags (all optional, defaulting to sensible
+ * values). Idempotent — safe to re-run with the same or a new key.
  */
 export function registerConnectCli(
   program: Parameters<typeof registerSetupCli>[0],
@@ -379,40 +417,50 @@ export function registerConnectCli(
   // Guard against duplicate registration.
   if (program.commands?.some((c) => c.name() === 'connect')) return;
 
-  type ConnectOpts = { apiKey: string; url: string };
+  interface CommandBuilder {
+    description(d: string): CommandBuilder;
+    option(f: string, d: string, dflt?: string): CommandBuilder;
+    action(fn: (opts: ConnectOpts) => Promise<void>): void;
+  }
+  type ConnectOpts = {
+    apiKey?: string;
+    url: string;
+    digestTime?: string;
+    /** false when --no-digest is passed; true otherwise (commander default). */
+    digest: boolean;
+    mainAgentToolUse?: string;
+  };
 
-  (
-    program as unknown as {
-      command(n: string): {
-        description(d: string): {
-          requiredOption(f: string, d: string): {
-            option(f: string, d: string, dflt: string): {
-              action(fn: (opts: ConnectOpts) => Promise<void>): void;
-            };
-          };
-        };
-      };
-    }
-  )
+  (program as unknown as { command(n: string): CommandBuilder })
     .command('connect')
-    .description('Non-interactive setup using an API key (e.g. from EdgeClaw signup)')
-    .requiredOption('--api-key <key>', 'API key returned by the headless signup endpoint')
-    .option('--url <url>', 'Index Network frontend URL', DEFAULT_URL)
+    .description('Connect to Index Network (no flags: interactive wizard; --api-key: non-interactive)')
+    .option('--api-key <key>', 'API key for non-interactive setup')
+    .option('--url <url>', 'Index Network URL', DEFAULT_URL)
+    .option('--digest-time <HH:MM>', 'Digest time in 24-hour local time (non-interactive)')
+    .option('--no-digest', 'Disable daily digest (non-interactive)')
+    .option('--main-agent-tool-use <mode>', 'Main agent tool use: enabled | disabled (non-interactive)')
     .action(async (opts: ConnectOpts) => {
       const cfg = readOpenClawConfig();
-      try {
-        const updated = await runHeadlessSetup({
-          url: opts.url,
-          apiKey: opts.apiKey,
-          existingCfg: cfg,
-        });
-        fs.mkdirSync(path.dirname(CONFIG_PATH), { recursive: true });
-        fs.writeFileSync(CONFIG_PATH, JSON.stringify(updated, null, 2));
-        console.log('\n✓ Config written to ~/.openclaw/openclaw.json');
-        console.log('Restart the gateway to apply changes: openclaw gateway restart');
-      } catch (err) {
-        console.error(err instanceof Error ? err.message : String(err));
-        process.exitCode = 1;
+      if (opts.apiKey) {
+        try {
+          const updated = await runHeadlessSetup({
+            url: opts.url,
+            apiKey: opts.apiKey,
+            digestEnabled: opts.digest,
+            digestTime: opts.digestTime,
+            mainAgentToolUse: opts.mainAgentToolUse as 'enabled' | 'disabled' | undefined,
+            existingCfg: cfg,
+          });
+          fs.mkdirSync(path.dirname(CONFIG_PATH), { recursive: true });
+          fs.writeFileSync(CONFIG_PATH, JSON.stringify(updated, null, 2));
+          console.log('\n✓ Config written to ~/.openclaw/openclaw.json');
+          console.log('Restart the gateway to apply changes: openclaw gateway restart');
+        } catch (err) {
+          console.error(err instanceof Error ? err.message : String(err));
+          process.exitCode = 1;
+        }
+      } else {
+        await runInteractiveSetup(cfg);
       }
     });
 }
@@ -427,47 +475,16 @@ export function registerSetupCli(
   // Guard against duplicate registration — OpenClaw may invoke the callback multiple times.
   if (program.commands?.some((c) => c.name() === 'setup')) return;
 
+  const deprecationWarning =
+    opts?.deprecationWarning ??
+    'Note: `openclaw index setup` is deprecated. Use `openclaw index connect` instead.';
+
   program
     .command('setup')
-    .description('Interactive setup wizard for Index Network')
+    .description('[Deprecated] Interactive setup wizard — use `openclaw index connect` instead')
     .action(async () => {
-      if (opts?.deprecationWarning) {
-        console.warn(opts.deprecationWarning);
-      }
-
+      console.warn(deprecationWarning);
       const cfg = readOpenClawConfig();
-      const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-
-      const ctx: SetupContext = {
-        cfg,
-        prompt: async (label, opts) => {
-          const defaultSuffix = opts?.default ? ` [${opts.default}]` : '';
-          const answer = await rl.question(`${label}${defaultSuffix}: `);
-          return answer.trim() || opts?.default || '';
-        },
-        select: async (label, choices) => {
-          console.log(`\n${label}:`);
-          choices.forEach((c, i) => console.log(`  ${i + 1}. ${c.label}`));
-          const answer = await rl.question('Selection: ');
-          const idx = parseInt(answer.trim(), 10) - 1;
-          return choices[idx]?.value ?? '';
-        },
-        configSet: async (dotPath, value) => {
-          setConfigValue(cfg, dotPath, value);
-        },
-        fetchAgentId: defaultFetchAgentId,
-      };
-
-      try {
-        await runSetup(ctx);
-        fs.writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2));
-        console.log('\n✓ Config written to ~/.openclaw/openclaw.json');
-        console.log('Restart the gateway to apply changes: openclaw gateway restart');
-      } catch (err) {
-        console.error(err instanceof Error ? err.message : String(err));
-        process.exitCode = 1;
-      } finally {
-        rl.close();
-      }
+      await runInteractiveSetup(cfg);
     });
 }

--- a/packages/openclaw-plugin/src/tests/index.spec.ts
+++ b/packages/openclaw-plugin/src/tests/index.spec.ts
@@ -158,12 +158,12 @@ describe('register(api)', () => {
     expect((fake.configSetCalls[0].value as any).url).toBe('https://protocol.index.network/mcp');
   });
 
-  test('warns user to run openclaw index setup when not configured', () => {
+  test('warns user to run openclaw index connect when not configured', () => {
     const fake = buildFakeApi({});
     register(fake.api);
 
     const warnMsg = fake.logger.warn.mock.calls[0]?.[0];
-    expect(warnMsg).toContain('openclaw index setup');
+    expect(warnMsg).toContain('openclaw index connect');
   });
 
   test('falls back to protocolUrl and warns about migration', () => {
@@ -176,7 +176,7 @@ describe('register(api)', () => {
     const warnCalls = fake.logger.warn.mock.calls as string[][];
     const migrationWarn = warnCalls.find((args) => args[0].includes('deprecated'));
     expect(migrationWarn).toBeTruthy();
-    expect(migrationWarn![0]).toContain('openclaw index setup');
+    expect(migrationWarn![0]).toContain('openclaw index connect');
 
     expect(fake.configSetCalls.length).toBe(1);
     expect((fake.configSetCalls[0].value as any).url).toBe('https://protocol.index.network/mcp');

--- a/packages/openclaw-plugin/src/tests/index.spec.ts
+++ b/packages/openclaw-plugin/src/tests/index.spec.ts
@@ -63,11 +63,11 @@ describe('register(api)', () => {
     _resetForTesting();
   });
 
-  test('logs warning and does not start polling without agentId/apiKey', () => {
+  test('does not warn or start polling without agentId/apiKey (non-gateway context)', () => {
     const fake = buildFakeApi({});
     register(fake.api);
 
-    expect(fake.logger.warn).toHaveBeenCalled();
+    expect(fake.logger.warn).not.toHaveBeenCalled();
     expect(fake.logger.info).not.toHaveBeenCalled();
   });
 
@@ -158,12 +158,27 @@ describe('register(api)', () => {
     expect((fake.configSetCalls[0].value as any).url).toBe('https://protocol.index.network/mcp');
   });
 
-  test('warns user to run openclaw index connect when not configured', () => {
+  test('does not warn during CLI invocations (no "gateway" in argv)', () => {
     const fake = buildFakeApi({});
     register(fake.api);
 
-    const warnMsg = fake.logger.warn.mock.calls[0]?.[0];
-    expect(warnMsg).toContain('openclaw index connect');
+    const warnCalls = fake.logger.warn.mock.calls as string[][];
+    const configWarn = warnCalls.find((args) => args[0].includes('not configured'));
+    expect(configWarn).toBeUndefined();
+  });
+
+  test('warns in gateway context when not configured', () => {
+    const orig = process.argv;
+    process.argv = [...orig, 'gateway'];
+    try {
+      const fake = buildFakeApi({});
+      register(fake.api);
+
+      const warnMsg = (fake.logger.warn.mock.calls as string[][])[0]?.[0];
+      expect(warnMsg).toContain('openclaw index connect');
+    } finally {
+      process.argv = orig;
+    }
   });
 
   test('falls back to protocolUrl and warns about migration', () => {


### PR DESCRIPTION
## Summary

- `openclaw index connect` (no flags) now runs the interactive wizard — previously `openclaw index setup`
- `openclaw index connect --api-key <key>` runs the non-interactive headless path, with optional `--url`, `--digest-time`, `--no-digest`, `--main-agent-tool-use` flags
- `openclaw index setup` is kept but deprecated: always prints a warning pointing to `connect`
- Updated `OPENCLAW_SETUP_CMD` in the frontend and all README references from `index setup` → `index connect`

## Test plan

- [ ] All 180 existing unit tests pass (`bun test` in `packages/openclaw-plugin`)
- [ ] `openclaw index connect` (no flags) launches interactive wizard
- [ ] `openclaw index connect --api-key <key>` completes non-interactively with defaults
- [ ] `openclaw index connect --api-key <key> --url https://dev.index.network --digest-time 09:00` applies overrides
- [ ] `openclaw index connect --api-key <key> --no-digest` writes `digestEnabled: false`
- [ ] `openclaw index setup` still works but prints deprecation warning
- [ ] Frontend agent pages show `openclaw index connect` as the setup command