### PR TITLE
fix(networks): route experiment-network email entry to invite endpoint

### DIFF
--- a/backend/src/controllers/network.controller.ts
+++ b/backend/src/controllers/network.controller.ts
@@ -9,6 +9,8 @@ import { networkService } from '../services/network.service';
 
 const logger = log.controller.from('network');
 
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
@@ -110,8 +112,7 @@ export class NetworkController {
       });
     }
 
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(body.email)) {
+    if (!EMAIL_REGEX.test(body.email)) {
       return new Response(JSON.stringify({ error: 'Invalid email format' }), {
         status: 400,
         headers: { 'Content-Type': 'application/json' },
@@ -281,9 +282,10 @@ export class NetworkController {
 
   /**
    * Invite a single member to an experiment network by email. Owner-only.
-   * Idempotent: re-inviting an existing user just ensures membership.
-   * For new users, provisions a network-scoped agent + API key and emails the
-   * invitation with a connect command.
+   * Idempotent: re-inviting a user who already has a network-scoped agent is
+   * a no-op (no key minted, no email). When the user does NOT yet have a
+   * scoped agent — newly created users and pre-existing ghost contacts alike
+   * — provisions one and emails the invitation with a connect command.
    */
   @Post('/:id/members/invite')
   @UseGuards(AuthOrApiKeyGuard)
@@ -301,8 +303,7 @@ export class NetworkController {
     if (!email) {
       return Response.json({ error: 'email is required' }, { status: 400 });
     }
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(email)) {
+    if (!EMAIL_REGEX.test(email)) {
       return Response.json({ error: 'Invalid email format' }, { status: 400 });
     }
 
@@ -385,7 +386,6 @@ export class NetworkController {
     const emailIdx = headers.indexOf('email');
     if (emailIdx === -1) return { valid: [], invalid: [] };
 
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     const knownCols = new Set(['email', 'name', 'bio', 'location']);
     const valid: ImportRow[] = [];
     const invalid: { row: Record<string, string>; reason: string }[] = [];
@@ -400,7 +400,7 @@ export class NetworkController {
         invalid.push({ row, reason: 'Missing email' });
         continue;
       }
-      if (!emailRegex.test(email)) {
+      if (!EMAIL_REGEX.test(email)) {
         invalid.push({ row, reason: 'Invalid email format' });
         continue;
       }

--- a/backend/src/controllers/network.controller.ts
+++ b/backend/src/controllers/network.controller.ts
@@ -4,6 +4,7 @@ import { ExperimentMasterKeyGuard, type ExperimentNetwork } from '../guards/expe
 import { log } from '../lib/log';
 import { Controller, Delete, Get, Patch, Post, Put, UseGuards } from '../lib/router/router.decorators';
 import { experimentService, type ImportRow } from '../services/experiment.service';
+import { networkInvitationService } from '../services/network-invitation.service';
 import { networkService } from '../services/network.service';
 
 const logger = log.controller.from('network');
@@ -275,6 +276,50 @@ export class NetworkController {
     } catch (err: unknown) {
       logger.error('CSV parse failed', { networkId: params.id, error: errorMessage(err) });
       return Response.json({ error: 'Failed to parse CSV' }, { status: 400 });
+    }
+  }
+
+  /**
+   * Invite a single member to an experiment network by email. Owner-only.
+   * Idempotent: re-inviting an existing user just ensures membership.
+   * For new users, provisions a network-scoped agent + API key and emails the
+   * invitation with a connect command.
+   */
+  @Post('/:id/members/invite')
+  @UseGuards(AuthOrApiKeyGuard)
+  async inviteMember(req: Request, user: AuthenticatedUser, params: Record<string, string>) {
+    try {
+      await assertAgentNetworkScope(req, params.id);
+      await this.assertExperimentOwner(params.id, user.id);
+    } catch (err) {
+      if (err instanceof Response) return err;
+      throw err;
+    }
+
+    const body = await req.json().catch(() => ({})) as { email?: string; name?: string };
+    const email = typeof body.email === 'string' ? body.email.trim() : '';
+    if (!email) {
+      return Response.json({ error: 'email is required' }, { status: 400 });
+    }
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      return Response.json({ error: 'Invalid email format' }, { status: 400 });
+    }
+
+    try {
+      const result = await networkInvitationService.invite({
+        networkId: params.id,
+        email,
+        name: body.name,
+      });
+      return Response.json({
+        user: { id: result.user.id, email: result.user.email },
+        created: result.created,
+        agentProvisioned: result.agentProvisioned,
+      }, { status: result.created ? 201 : 200 });
+    } catch (err: unknown) {
+      logger.error('Invite by email failed', { networkId: params.id, error: errorMessage(err) });
+      return Response.json({ error: 'Invite failed' }, { status: 500 });
     }
   }
 

--- a/backend/src/controllers/network.controller.ts
+++ b/backend/src/controllers/network.controller.ts
@@ -306,19 +306,26 @@ export class NetworkController {
       return Response.json({ error: 'Invalid email format' }, { status: 400 });
     }
 
+    const name = typeof body.name === 'string' ? body.name.trim().slice(0, 200) : undefined;
+
     try {
       const result = await networkInvitationService.invite({
         networkId: params.id,
         email,
-        name: body.name,
+        name: name || undefined,
       });
       return Response.json({
         user: { id: result.user.id, email: result.user.email },
         created: result.created,
+        alreadyMember: result.alreadyMember,
         agentProvisioned: result.agentProvisioned,
       }, { status: result.created ? 201 : 200 });
     } catch (err: unknown) {
-      logger.error('Invite by email failed', { networkId: params.id, error: errorMessage(err) });
+      const msg = errorMessage(err);
+      if (msg.includes('email exists but is filtered out')) {
+        return Response.json({ error: msg }, { status: 409 });
+      }
+      logger.error('Invite by email failed', { networkId: params.id, error: msg });
       return Response.json({ error: 'Invite failed' }, { status: 500 });
     }
   }

--- a/backend/src/controllers/tests/network.controller.spec.ts
+++ b/backend/src/controllers/tests/network.controller.spec.ts
@@ -2,8 +2,18 @@
 import { config } from "dotenv";
 config({ path: '.env.test' });
 
-import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { describe, test, expect, beforeAll, afterAll, mock } from "bun:test";
+
+const sendEmailSpy = mock(async () => ({ data: null, skipped: false }));
+mock.module('../../lib/email/transport.helper', () => ({
+  executeSendEmail: sendEmailSpy,
+}));
+
+import { inArray } from "drizzle-orm";
+
 import { NetworkController } from "../network.controller";
+import db from "../../lib/drizzle/drizzle";
+import * as schema from "../../schemas/database.schema";
 import { UserDatabaseAdapter, NetworkGraphDatabaseAdapter } from "../../adapters/database.adapter";
 import type { AuthenticatedUser } from "../../guards/auth.guard";
 
@@ -160,6 +170,106 @@ describe("NetworkController Integration", () => {
 
       expect(res.status).toBe(200);
       expect(data).toBeDefined();
+    });
+  });
+
+  describe("POST /:id/members/invite (experiment networks)", () => {
+    let experimentNetworkId: string;
+    const inviteeUserIds: string[] = [];
+
+    beforeAll(async () => {
+      const req = new Request("http://localhost/networks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: "Invite Test Experiment", isExperiment: true }),
+      });
+      const res = await controller.create(req, mockUser());
+      const data = (await res.json()) as { network?: { id: string } };
+      experimentNetworkId = data.network!.id;
+    });
+
+    afterAll(async () => {
+      if (inviteeUserIds.length > 0) {
+        // FK chain: agent_permissions.user_id and apikey.user_id cascade on user
+        // delete; networkMembers and personalNetworks do NOT, so clean those
+        // explicitly before dropping the users.
+        const personalRows = await db
+          .select({ networkId: schema.personalNetworks.networkId })
+          .from(schema.personalNetworks)
+          .where(inArray(schema.personalNetworks.userId, inviteeUserIds));
+        const personalNetworkIds = personalRows.map((r) => r.networkId);
+
+        await db.delete(schema.networkMembers).where(inArray(schema.networkMembers.userId, inviteeUserIds));
+        await db.delete(schema.personalNetworks).where(inArray(schema.personalNetworks.userId, inviteeUserIds));
+        await db.delete(schema.users).where(inArray(schema.users.id, inviteeUserIds));
+        if (personalNetworkIds.length > 0) {
+          await db.delete(schema.networks).where(inArray(schema.networks.id, personalNetworkIds));
+        }
+      }
+      if (experimentNetworkId) await indexAdapter.deleteNetworkAndMembers(experimentNetworkId);
+    });
+
+    test("returns 400 when email is missing", async () => {
+      const req = new Request(`http://localhost/networks/${experimentNetworkId}/members/invite`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      const res = await controller.inviteMember(req, mockUser(), { id: experimentNetworkId });
+      const data = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(400);
+      expect(data.error).toBe("email is required");
+    });
+
+    test("returns 400 when email format is invalid", async () => {
+      const req = new Request(`http://localhost/networks/${experimentNetworkId}/members/invite`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: "not-an-email" }),
+      });
+      const res = await controller.inviteMember(req, mockUser(), { id: experimentNetworkId });
+      const data = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(400);
+      expect(data.error).toBe("Invalid email format");
+    });
+
+    test("returns 403 when network is not an experiment network", async () => {
+      const req = new Request(`http://localhost/networks/${createdIndexId}/members/invite`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: `target-${Date.now()}@example.com` }),
+      });
+      const res = await controller.inviteMember(req, mockUser(), { id: createdIndexId });
+
+      expect(res.status).toBe(403);
+    });
+
+    test("returns 201 with provisioned flags for a new email", async () => {
+      sendEmailSpy.mockClear();
+      const inviteeEmail = `invitee-${Date.now()}@example.com`;
+      const req = new Request(`http://localhost/networks/${experimentNetworkId}/members/invite`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: inviteeEmail }),
+      });
+      const res = await controller.inviteMember(req, mockUser(), { id: experimentNetworkId });
+      const data = (await res.json()) as {
+        user?: { id: string; email: string };
+        created?: boolean;
+        alreadyMember?: boolean;
+        agentProvisioned?: boolean;
+      };
+
+      expect(res.status).toBe(201);
+      expect(data.created).toBe(true);
+      expect(data.alreadyMember).toBe(false);
+      expect(data.agentProvisioned).toBe(true);
+      expect(data.user?.email).toBe(inviteeEmail);
+      expect(sendEmailSpy).toHaveBeenCalledTimes(1);
+
+      if (data.user?.id) inviteeUserIds.push(data.user.id);
     });
   });
 

--- a/backend/src/services/network-invitation.service.ts
+++ b/backend/src/services/network-invitation.service.ts
@@ -86,13 +86,20 @@ class NetworkInvitationService {
   }
 
   private async hasScopedAgent(userId: string, networkId: string): Promise<boolean> {
+    // Inner-join on agents and require deletedAt IS NULL: agentDatabaseAdapter
+    // .deleteAgent() soft-deletes the agent and hard-deletes its api keys but
+    // leaves the agent_permissions row intact. Without the join, a user whose
+    // agent has been deleted would short-circuit re-provisioning and end up
+    // with no working key.
     const [row] = await db
       .select({ id: schema.agentPermissions.id })
       .from(schema.agentPermissions)
+      .innerJoin(schema.agents, eq(schema.agents.id, schema.agentPermissions.agentId))
       .where(and(
         eq(schema.agentPermissions.userId, userId),
         eq(schema.agentPermissions.scope, 'network'),
         eq(schema.agentPermissions.scopeId, networkId),
+        isNull(schema.agents.deletedAt),
       ))
       .limit(1);
     return Boolean(row);

--- a/backend/src/services/network-invitation.service.ts
+++ b/backend/src/services/network-invitation.service.ts
@@ -21,10 +21,12 @@ export interface InviteParams {
 
 export interface InviteResult {
   user: { id: string; email: string };
-  /** Raw API key; only present when a new agent was provisioned. Null when reusing an existing user. */
+  /** Raw API key; only present when a scoped agent was provisioned in this call. */
   apiKey: string | null;
   /** True if the user was newly created. */
   created: boolean;
+  /** True if the user was already a member of this network. */
+  alreadyMember: boolean;
   /** True if the agent + permissions + key were created in this call. */
   agentProvisioned: boolean;
 }
@@ -40,9 +42,10 @@ export const SCOPED_INVITED_AGENT_ACTIONS = [
 class NetworkInvitationService {
   /**
    * Idempotent invite. Ensures user, personal network, and network membership
-   * always exist; for newly-created users only, also provisions a network-
-   * scoped personal agent and an API key. Returns the raw key once on first
-   * creation; subsequent invites for the same user return null.
+   * always exist; provisions a network-scoped personal agent and API key
+   * (and emails the connect command) whenever the user does not already have
+   * a scoped agent for this network. Reusing a user who was created via
+   * another path (e.g. ghost contact) still yields a key + email.
    *
    * @param params - networkId, email, optional name
    * @returns InviteResult — see field docs
@@ -52,11 +55,15 @@ class NetworkInvitationService {
     const { user, created } = await this.findOrCreateUser(email, params.name);
 
     await ensurePersonalNetwork(user.id);
-    await this.joinNetwork(user.id, params.networkId);
+    const { alreadyMember } = await this.joinNetwork(user.id, params.networkId);
 
-    if (!created) {
-      logger.info('[NetworkInvitation] Reusing existing user', { userId: user.id, networkId: params.networkId });
-      return { user, apiKey: null, created: false, agentProvisioned: false };
+    const hasAgent = await this.hasScopedAgent(user.id, params.networkId);
+    if (hasAgent) {
+      logger.info('[NetworkInvitation] Skipping provisioning; scoped agent already exists', {
+        userId: user.id,
+        networkId: params.networkId,
+      });
+      return { user, apiKey: null, created, alreadyMember, agentProvisioned: false };
     }
 
     const apiKey = await this.provisionScopedAgent(user.id, params.networkId);
@@ -75,7 +82,20 @@ class NetworkInvitationService {
       networkId: params.networkId,
     });
 
-    return { user, apiKey, created: true, agentProvisioned: true };
+    return { user, apiKey, created, alreadyMember, agentProvisioned: true };
+  }
+
+  private async hasScopedAgent(userId: string, networkId: string): Promise<boolean> {
+    const [row] = await db
+      .select({ id: schema.agentPermissions.id })
+      .from(schema.agentPermissions)
+      .where(and(
+        eq(schema.agentPermissions.userId, userId),
+        eq(schema.agentPermissions.scope, 'network'),
+        eq(schema.agentPermissions.scopeId, networkId),
+      ))
+      .limit(1);
+    return Boolean(row);
   }
 
   private async lookupNetworkName(networkId: string): Promise<string> {
@@ -167,11 +187,13 @@ class NetworkInvitationService {
     return { user: newUser, created: true };
   }
 
-  private async joinNetwork(userId: string, networkId: string): Promise<void> {
-    await db
+  private async joinNetwork(userId: string, networkId: string): Promise<{ alreadyMember: boolean }> {
+    const inserted = await db
       .insert(schema.networkMembers)
       .values({ networkId, userId, permissions: ['member'], autoAssign: true })
-      .onConflictDoNothing();
+      .onConflictDoNothing()
+      .returning({ userId: schema.networkMembers.userId });
+    return { alreadyMember: inserted.length === 0 };
   }
 
   /**

--- a/backend/src/services/tests/network-invitation.service.spec.ts
+++ b/backend/src/services/tests/network-invitation.service.spec.ts
@@ -61,6 +61,7 @@ describe('networkInvitationService.invite', () => {
     cleanupUserIds.push(result.user.id);
 
     expect(result.created).toBe(true);
+    expect(result.alreadyMember).toBe(false);
     expect(result.agentProvisioned).toBe(true);
     expect(result.apiKey).toBeTruthy();
     expect(result.user.email).toBe(email);
@@ -92,8 +93,8 @@ describe('networkInvitationService.invite', () => {
     expect(perms.every((p) => p.scope === 'network' && p.scopeId === networkId)).toBe(true);
   });
 
-  test('reuses existing user and does NOT issue a new key', async () => {
-    const email = `existing-${Date.now()}@test.dev`;
+  test('existing user without scoped agent (e.g. ghost contact) gets provisioned + emailed', async () => {
+    const email = `ghost-${Date.now()}@test.dev`;
     const [existing] = await db.insert(schema.users)
       .values({ email, name: email, emailVerified: true })
       .returning({ id: schema.users.id });
@@ -103,30 +104,26 @@ describe('networkInvitationService.invite', () => {
     const result = await networkInvitationService.invite({ networkId, email });
 
     expect(result.created).toBe(false);
-    expect(result.agentProvisioned).toBe(false);
-    expect(result.apiKey).toBeNull();
+    expect(result.alreadyMember).toBe(false);
+    expect(result.agentProvisioned).toBe(true);
+    expect(result.apiKey).toBeTruthy();
     expect(result.user.id).toBe(existing.id);
-    expect(sendSpy).toHaveBeenCalledTimes(0);
-
-    const [member] = await db
-      .select({ networkId: schema.networkMembers.networkId })
-      .from(schema.networkMembers)
-      .where(and(
-        eq(schema.networkMembers.userId, existing.id),
-        eq(schema.networkMembers.networkId, networkId),
-      ));
-    expect(member).toBeTruthy();
+    expect(sendSpy).toHaveBeenCalledTimes(1);
   });
 
-  test('idempotent: invite twice for the same new email yields one user, one agent, one key', async () => {
-    const email = `idempotent-${Date.now()}@test.dev`;
+  test('existing user with scoped agent: no new key, no email, alreadyMember reflects state', async () => {
+    const email = `provisioned-${Date.now()}@test.dev`;
     const first = await networkInvitationService.invite({ networkId, email });
     cleanupUserIds.push(first.user.id);
+
+    sendSpy.mockClear();
     const second = await networkInvitationService.invite({ networkId, email });
 
     expect(second.user.id).toBe(first.user.id);
     expect(second.created).toBe(false);
+    expect(second.alreadyMember).toBe(true);
     expect(second.agentProvisioned).toBe(false);
     expect(second.apiKey).toBeNull();
+    expect(sendSpy).toHaveBeenCalledTimes(0);
   });
 });

--- a/docs/specs/api-reference.md
+++ b/docs/specs/api-reference.md
@@ -1828,6 +1828,47 @@ Import validated rows (from `/import/parse`) into the network. Owner-only, exper
 
 ---
 
+### POST /api/networks/:id/members/invite
+
+Invite a single member to an experiment network by email. Owner-only, experiment networks only. Idempotent: re-inviting an existing user just ensures membership; no fresh key is issued and no email is re-sent.
+
+**Auth**: `AuthOrApiKeyGuard`; caller must own the network.
+
+**Path params**:
+- `id` — Network ID (must be an experiment network).
+
+**Request body**:
+```json
+{ "email": "attendee@example.com", "name": "Optional Name" }
+```
+
+**Response 201** (new account created): A network-scoped personal agent and API key are provisioned, and an invitation email containing the connect command is sent.
+```json
+{
+  "user": { "id": "user-uuid", "email": "attendee@example.com" },
+  "created": true,
+  "agentProvisioned": true
+}
+```
+
+**Response 200** (existing account): The user is added to the network if they aren't already a member; no new key is minted and no email is sent.
+```json
+{
+  "user": { "id": "user-uuid", "email": "attendee@example.com" },
+  "created": false,
+  "agentProvisioned": false
+}
+```
+
+The raw API key is delivered only via the invitation email and is never returned in this response. Use `POST /api/networks/:id/signup` (master-key auth) for headless flows that need the key in-band.
+
+**Errors**:
+- `400` — Missing or malformed email.
+- `403` — Not the network owner, not an experiment network, or scope violation.
+- `500` — Provisioning failed.
+
+---
+
 ## Integration
 
 **Controller prefix**: `/integrations`

--- a/docs/specs/api-reference.md
+++ b/docs/specs/api-reference.md
@@ -1830,7 +1830,7 @@ Import validated rows (from `/import/parse`) into the network. Owner-only, exper
 
 ### POST /api/networks/:id/members/invite
 
-Invite a single member to an experiment network by email. Owner-only, experiment networks only. Idempotent: re-inviting an existing user just ensures membership; no fresh key is issued and no email is re-sent.
+Invite a single member to an experiment network by email. Owner-only, experiment networks only. Idempotent on the (user, network) pair: re-inviting a user who already has a network-scoped agent is a no-op (no key minted, no email re-sent). A user who exists but lacks a scoped agent for this network — e.g. a ghost contact created via personal-import — is provisioned and emailed the same way a brand-new user is.
 
 **Auth**: `AuthOrApiKeyGuard`; caller must own the network.
 
@@ -1842,29 +1842,43 @@ Invite a single member to an experiment network by email. Owner-only, experiment
 { "email": "attendee@example.com", "name": "Optional Name" }
 ```
 
-**Response 201** (new account created): A network-scoped personal agent and API key are provisioned, and an invitation email containing the connect command is sent.
+**Response 201** (user newly created): A network-scoped personal agent and API key are provisioned, and an invitation email containing the connect command is sent.
 ```json
 {
   "user": { "id": "user-uuid", "email": "attendee@example.com" },
   "created": true,
+  "alreadyMember": false,
   "agentProvisioned": true
 }
 ```
 
-**Response 200** (existing account): The user is added to the network if they aren't already a member; no new key is minted and no email is sent.
-```json
-{
-  "user": { "id": "user-uuid", "email": "attendee@example.com" },
-  "created": false,
-  "agentProvisioned": false
-}
-```
+**Response 200** (user already exists): Status code is 200 regardless of whether a scoped agent had to be provisioned. Examples:
+
+- Pre-existing user without a scoped agent (e.g. ghost contact) — agent + key minted, invitation email sent:
+  ```json
+  {
+    "user": { "id": "user-uuid", "email": "attendee@example.com" },
+    "created": false,
+    "alreadyMember": false,
+    "agentProvisioned": true
+  }
+  ```
+- Pre-existing user already provisioned and already a member — pure no-op:
+  ```json
+  {
+    "user": { "id": "user-uuid", "email": "attendee@example.com" },
+    "created": false,
+    "alreadyMember": true,
+    "agentProvisioned": false
+  }
+  ```
 
 The raw API key is delivered only via the invitation email and is never returned in this response. Use `POST /api/networks/:id/signup` (master-key auth) for headless flows that need the key in-band.
 
 **Errors**:
 - `400` — Missing or malformed email.
 - `403` — Not the network owner, not an experiment network, or scope violation.
+- `409` — Email belongs to a soft-deleted account and cannot be invited.
 - `500` — Provisioning failed.
 
 ---

--- a/frontend/src/components/NetworkSettingsPanel.tsx
+++ b/frontend/src/components/NetworkSettingsPanel.tsx
@@ -283,6 +283,13 @@ export default function NetworkSettingsPanel({ index, onDeleted, activeTab }: Ne
   };
 
   const handleAddMember = async (memberUser: Member) => {
+    if (currentIndex.isExperiment) {
+      // Experiment networks need scoped-agent + API-key + invite email even
+      // when the invitee already exists in the inviter's contacts; route
+      // through the invite endpoint, which is idempotent for existing users.
+      await handleInviteMember(memberUser.email);
+      return;
+    }
     try {
       const newMember = await indexesService.addMember(index.id, memberUser.id, ['member']);
       setMembers(prev => [...prev, newMember]);

--- a/frontend/src/components/NetworkSettingsPanel.tsx
+++ b/frontend/src/components/NetworkSettingsPanel.tsx
@@ -330,6 +330,25 @@ export default function NetworkSettingsPanel({ index, onDeleted, activeTab }: Ne
     }
   };
 
+  const handleInviteMember = async (email: string) => {
+    if (isAddingContact) return;
+    setIsAddingContact(true);
+    try {
+      const result = await indexesService.inviteMember(index.id, email);
+      setMemberSearchQuery('');
+      setSuggestedUsers([]);
+      setShowSuggestions(false);
+      setSearchHasQueried(false);
+      await loadMembers();
+      success(result.created ? 'Invitation sent' : 'Member added');
+    } catch (err) {
+      console.error('Error inviting member:', err);
+      error('Failed to invite member');
+    } finally {
+      setIsAddingContact(false);
+    }
+  };
+
   const autoImportContacts = async (toolkit: string) => {
     const svc = createIntegrationsService(api);
     info(`Importing contacts from ${toolkitLabel(toolkit)}...`, undefined, 30000);
@@ -702,13 +721,15 @@ export default function NetworkSettingsPanel({ index, onDeleted, activeTab }: Ne
                   {memberSearchQuery.includes('@') ? (
                     <button
                       className="w-full flex items-center gap-2.5 px-3 py-2.5 hover:bg-gray-50 text-left disabled:opacity-50"
-                      onClick={() => handleAddContact(memberSearchQuery)}
+                      onClick={() => currentIndex.isExperiment ? handleInviteMember(memberSearchQuery) : handleAddContact(memberSearchQuery)}
                       disabled={isAddingContact}
                     >
                       <div className="h-6 w-6 bg-gray-100 rounded-full flex items-center justify-center flex-shrink-0">
                         <Plus className="h-3.5 w-3.5 text-gray-500" />
                       </div>
-                      <span className="text-sm text-black flex-1 truncate">Add "{memberSearchQuery}"</span>
+                      <span className="text-sm text-black flex-1 truncate">
+                        {currentIndex.isExperiment ? `Invite "${memberSearchQuery}"` : `Add "${memberSearchQuery}"`}
+                      </span>
                     </button>
                   ) : (
                     <div className="px-3 py-2.5 text-sm text-gray-400">No results found</div>

--- a/frontend/src/components/NetworkSettingsPanel.tsx
+++ b/frontend/src/components/NetworkSettingsPanel.tsx
@@ -315,12 +315,12 @@ export default function NetworkSettingsPanel({ index, onDeleted, activeTab }: Ne
     }
   };
 
-  const [isAddingContact, setIsAddingContact] = useState(false);
+  const [isAddingMember, setIsAddingMember] = useState(false);
   const CONTACTS_PAGE_SIZE = 10;
 
   const handleAddContact = async (email: string) => {
-    if (isAddingContact) return;
-    setIsAddingContact(true);
+    if (isAddingMember) return;
+    setIsAddingMember(true);
     try {
       await usersService.addContact(email);
       setMemberSearchQuery('');
@@ -333,13 +333,13 @@ export default function NetworkSettingsPanel({ index, onDeleted, activeTab }: Ne
       console.error('Error adding contact:', err);
       error('Failed to add contact');
     } finally {
-      setIsAddingContact(false);
+      setIsAddingMember(false);
     }
   };
 
   const handleInviteMember = async (email: string) => {
-    if (isAddingContact) return;
-    setIsAddingContact(true);
+    if (isAddingMember) return;
+    setIsAddingMember(true);
     try {
       const result = await indexesService.inviteMember(index.id, email);
       setMemberSearchQuery('');
@@ -347,12 +347,17 @@ export default function NetworkSettingsPanel({ index, onDeleted, activeTab }: Ne
       setShowSuggestions(false);
       setSearchHasQueried(false);
       await loadMembers();
-      success(result.created ? 'Invitation sent' : 'Member added');
+      const toast = result.created
+        ? 'Invitation sent'
+        : result.alreadyMember
+          ? 'Already a member'
+          : 'Member added';
+      success(toast);
     } catch (err) {
       console.error('Error inviting member:', err);
       error('Failed to invite member');
     } finally {
-      setIsAddingContact(false);
+      setIsAddingMember(false);
     }
   };
 
@@ -729,7 +734,7 @@ export default function NetworkSettingsPanel({ index, onDeleted, activeTab }: Ne
                     <button
                       className="w-full flex items-center gap-2.5 px-3 py-2.5 hover:bg-gray-50 text-left disabled:opacity-50"
                       onClick={() => currentIndex.isExperiment ? handleInviteMember(memberSearchQuery) : handleAddContact(memberSearchQuery)}
-                      disabled={isAddingContact}
+                      disabled={isAddingMember}
                     >
                       <div className="h-6 w-6 bg-gray-100 rounded-full flex items-center justify-center flex-shrink-0">
                         <Plus className="h-3.5 w-3.5 text-gray-500" />

--- a/frontend/src/components/NetworkSettingsPanel.tsx
+++ b/frontend/src/components/NetworkSettingsPanel.tsx
@@ -347,7 +347,10 @@ export default function NetworkSettingsPanel({ index, onDeleted, activeTab }: Ne
       setShowSuggestions(false);
       setSearchHasQueried(false);
       await loadMembers();
-      const toast = result.created
+      // agentProvisioned is the source-of-truth for whether an invite email
+      // went out — true for both newly-created users and pre-existing users
+      // who didn't yet have a scoped agent for this network.
+      const toast = result.agentProvisioned
         ? 'Invitation sent'
         : result.alreadyMember
           ? 'Already a member'

--- a/frontend/src/services/networks.ts
+++ b/frontend/src/services/networks.ts
@@ -342,6 +342,11 @@ export const createIndexesService = (api: ReturnType<typeof useAuthenticatedAPI>
   importMembers: async (networkId: string, members: Array<{ email: string; name?: string; bio?: string; location?: string; socials: { label: string; value: string }[] }>): Promise<{ imported: number; skipped: number }> => {
     return api.post(`/networks/${networkId}/members/import`, { members });
   },
+
+  // Invite a single member to an experiment network by email
+  inviteMember: async (networkId: string, email: string, name?: string): Promise<{ user: { id: string; email: string }; created: boolean; agentProvisioned: boolean }> => {
+    return api.post(`/networks/${networkId}/members/invite`, { email, name });
+  },
 });
 
 // Non-authenticated service for public endpoints

--- a/frontend/src/services/networks.ts
+++ b/frontend/src/services/networks.ts
@@ -344,7 +344,7 @@ export const createIndexesService = (api: ReturnType<typeof useAuthenticatedAPI>
   },
 
   // Invite a single member to an experiment network by email
-  inviteMember: async (networkId: string, email: string, name?: string): Promise<{ user: { id: string; email: string }; created: boolean; agentProvisioned: boolean }> => {
+  inviteMember: async (networkId: string, email: string, name?: string): Promise<{ user: { id: string; email: string }; created: boolean; alreadyMember: boolean; agentProvisioned: boolean }> => {
     return api.post(`/networks/${networkId}/members/invite`, { email, name });
   },
 });


### PR DESCRIPTION
## Summary

Fixes adding a member to an experiment network from the settings panel. The "Add by email" path was silently routing the new user into the inviter's personal index instead of the experiment network, the experiment's member list never updated, and no API-key invitation email was sent. The dropdown-suggestion path had the same root cause for users who happened to already be in the inviter's contacts.

## Bug Fixes

- New owner-authed `POST /networks/:id/members/invite` endpoint that delegates to `networkInvitationService.invite()` (ensure user → join network → provision a network-scoped agent + API key → email the connect command). 201 on user creation, 200 otherwise. 409 when the email belongs to a soft-deleted account.
- `NetworkSettingsPanel` now branches on `currentIndex.isExperiment` for both the typed-email and suggestion-row paths, sending both through the new endpoint instead of `usersService.addContact` / `addMember`.
- Provisioning is now gated on whether a `agent_permissions` row exists for `(userId, networkId)` rather than the user-was-just-created flag, so pre-existing ghost contacts still get a key + email when invited. The query joins on `agents.deletedAt IS NULL` so a previously-deleted agent does not block re-provisioning.
- `joinNetwork` returns whether the user was already a member; the invite endpoint surfaces `alreadyMember` in the response so the UI toast can distinguish "Invitation sent" / "Already a member" / "Member added". The toast keys on `agentProvisioned` (the source-of-truth signal that an email went out).
- Soft-deleted-email errors from `findOrCreateUser` are now mapped to 409 instead of being collapsed into a generic 500.

## Refactors

- Hoist `EMAIL_REGEX` to a module-level constant in `network.controller.ts` so the three call sites (signup, inviteMember, parseCsvText) share one definition.
- Rename `isAddingContact` → `isAddingMember` now that the flag gates two handlers.

## Documentation

- `docs/specs/api-reference.md` — new `POST /networks/:id/members/invite` entry covering 201/200/409 responses with the `alreadyMember` and `agentProvisioned` signals; explicit note that the API key only ever ships in the invite email, not the response.

## Tests

- `backend/src/services/tests/network-invitation.service.spec.ts` — extend with the ghost-contact case (existing user, no scoped agent → provisioned + emailed) and the `alreadyMember` no-op case.
- `backend/src/controllers/tests/network.controller.spec.ts` — new integration tests for `inviteMember` covering 400 missing email, 400 invalid format, 403 non-experiment, 201 happy path with email-spy assertions.

## Test plan

- [x] `bun test src/services/tests/network-invitation.service.spec.ts` (3/3 pass)
- [x] `bun test src/controllers/tests/network.controller.spec.ts` (15/15 pass — new tests included)
- [x] `bun test tests/network-scoped-import.test.ts` (2/2 pass — CSV import path still works)
- [ ] Smoke on Railway dev: invite an unknown email → see "Invitation sent" toast, member appears in roster, invitee receives email with API key + connect command.
- [ ] Smoke on Railway dev: invite the same email twice → second click shows "Already a member" with no second email.