### PR TITLE
feat(networks): OpenClaw plugin config JSON on experiment networks

### DIFF
--- a/frontend/src/components/NetworkSettingsPanel.tsx
+++ b/frontend/src/components/NetworkSettingsPanel.tsx
@@ -25,6 +25,7 @@ const toolkitLabel = (t: string) => TOOLKIT_LABELS[t] ?? t;
 import NetworkAvatar, { resolveNetworkImageSrc } from '@/components/IndexAvatar';
 import UserAvatar from '@/components/UserAvatar';
 import GhostBadge from '@/components/GhostBadge';
+import CopyableBox from '@/components/CopyableBox';
 import { useNavigate } from 'react-router';
 
 interface NetworkSettingsPanelProps {
@@ -830,6 +831,33 @@ export default function NetworkSettingsPanel({ index, onDeleted, activeTab }: Ne
             </>
             )}
           </div>
+
+          {/* OpenClaw plugin config — experiment networks only */}
+          {currentIndex.isExperiment && (
+            <div>
+              <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider font-ibm-plex-mono mb-4">
+                OpenClaw plugin config
+              </p>
+              <p className="text-xs text-gray-500 mb-3">
+                Hand to InstaClaw admins to merge into <code className="px-1 py-0.5 bg-gray-100 rounded text-[11px] font-ibm-plex-mono">openclaw.json</code> under <code className="px-1 py-0.5 bg-gray-100 rounded text-[11px] font-ibm-plex-mono">plugins.entries.indexnetwork-openclaw-plugin.config</code>.
+              </p>
+              <CopyableBox
+                value={JSON.stringify(
+                  {
+                    url: typeof window !== 'undefined' ? window.location.origin : 'https://index.network',
+                    digestEnabled: 'true',
+                    digestTime: '08:00',
+                    mainAgentToolUse: 'disabled',
+                    nodeName: currentIndex.title ?? '',
+                    nodeDescription: currentIndex.prompt ?? '',
+                    nodeContext: '',
+                  },
+                  null,
+                  2,
+                )}
+              />
+            </div>
+          )}
 
         </div>
       )}


### PR DESCRIPTION
## Summary

- Adds a copyable plugin config snippet on the experimental network's **Access** tab
- Pre-fills `nodeName` from `network.title` and `nodeDescription` from `network.prompt`; leaves `nodeContext` blank for the InstaClaw admin to fill in
- Hardcodes `digestEnabled`, `digestTime`, `mainAgentToolUse`, and uses `window.location.origin` for `url`
- Lets InstaClaw admins drop the JSON under `plugins.entries.indexnetwork-openclaw-plugin.config` so end members only run `openclaw index connect --api-key <key>`

## Test plan

- [ ] Open the Access tab on a non-experiment network → the new section is hidden
- [ ] Open the Access tab on an experiment network → JSON renders with the network's title/prompt
- [ ] Click the JSON box → "Copied" feedback appears, clipboard contains the snippet
- [ ] Confirm the JSON keys match what `runHeadlessSetup` reads (`url`, `digestEnabled`, `digestTime`, `mainAgentToolUse`, `nodeName`, `nodeDescription`, `nodeContext`)