### PR TITLE
chore(frontend): bump version to 0.7.2

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",


### PR DESCRIPTION
Version bump for the OpenClaw plugin config JSON UI added in #742 / #743. Sister PR of the main-targeted bump.