### PR TITLE
fix(mcp): propagate network-scoped agent into context.networkId

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/mcp/mcp.server.ts
+++ b/packages/protocol/src/mcp/mcp.server.ts
@@ -10,7 +10,7 @@ import { McpServer, fromJsonSchema } from '@modelcontextprotocol/server';
 import type { ServerContext, JsonSchemaType } from '@modelcontextprotocol/server';
 
 import type { McpAuthResolver } from '../shared/interfaces/auth.interface.js';
-import type { ToolDeps } from '../shared/agent/tool.helpers.js';
+import type { ToolDeps, ResolvedToolContext } from '../shared/agent/tool.helpers.js';
 import { resolveChatContext } from '../shared/agent/tool.helpers.js';
 import { createToolRegistry } from '../shared/agent/tool.registry.js';
 import { protocolLogger } from '../shared/observability/protocol.logger.js';
@@ -154,6 +154,42 @@ export const computeAgentIndexScope = (
 };
 
 /**
+ * Promotes a network-scoped agent's bound network into the resolved tool
+ * context as the implicit chat scope. Every tool that branches on
+ * `context.networkId` (read_networks, read_intents, read_user_profiles,
+ * opportunity tools, etc.) then enforces scope automatically — without this
+ * step the DB-level `indexScope` clamp guards cross-user data but tools that
+ * shape their response off `context.networkId` (notably `read_networks`'
+ * `publicNetworks` branch) would still leak the global view.
+ *
+ * No-op when there is no scope, or when an explicit chat scope is already
+ * set (a user-driven index-scoped chat must keep precedence over the agent
+ * binding — which would be a strict subset anyway, since the API key cannot
+ * reach beyond its bound network).
+ */
+export const applyNetworkScopeToContext = (
+  context: ResolvedToolContext,
+  networkScopeId: string | null | undefined,
+): void => {
+  if (!networkScopeId) return;
+  if (context.networkId) return;
+
+  context.networkId = networkScopeId;
+  const bound = context.userNetworks.find((m) => m.networkId === networkScopeId);
+  if (!bound) return;
+
+  context.indexName = bound.networkTitle;
+  context.scopedIndex = {
+    id: bound.networkId,
+    title: bound.networkTitle,
+    prompt: bound.indexPrompt ?? null,
+  };
+  const isOwner = bound.permissions?.includes('owner') ?? false;
+  context.scopedMembershipRole = isOwner ? 'owner' : 'member';
+  context.isOwner = isOwner;
+};
+
+/**
  * Creates an MCP server with all protocol tools registered.
  * Tools resolve auth per-request via the HTTP request available in ServerContext.
  *
@@ -253,6 +289,13 @@ export function createMcpServer(
           if (agentId) {
             context.agentId = agentId;
           }
+
+          // Network-scoped agents inherit their bound network as the implicit chat
+          // scope. Every tool that branches on `context.networkId` then enforces
+          // the same boundary the DB-level `indexScope` clamp enforces below —
+          // most importantly `read_networks`, which would otherwise return the
+          // global `publicNetworks` catalog for unscoped contexts.
+          applyNetworkScopeToContext(context, networkScopeId);
 
           // Gate: API-key callers (background agents) must register before using most tools.
           // OAuth/JWT session callers (human MCP clients such as Claude Code) are exempt —

--- a/packages/protocol/src/mcp/tests/apply-network-scope-to-context.spec.ts
+++ b/packages/protocol/src/mcp/tests/apply-network-scope-to-context.spec.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from 'bun:test';
+
+import { applyNetworkScopeToContext } from '../mcp.server.js';
+import type { ResolvedToolContext } from '../../shared/agent/tool.helpers.js';
+
+const memberships = [
+  {
+    networkId: 'personal-1',
+    networkTitle: 'Personal',
+    indexPrompt: null,
+    permissions: ['owner'],
+    memberPrompt: null,
+    autoAssign: true,
+    isPersonal: true,
+    joinedAt: new Date('2026-01-01'),
+  },
+  {
+    networkId: 'experiment-net',
+    networkTitle: 'Edge City',
+    indexPrompt: 'Builders shipping at the edge',
+    permissions: ['member'],
+    memberPrompt: null,
+    autoAssign: true,
+    isPersonal: false,
+    joinedAt: new Date('2026-01-02'),
+  },
+  {
+    networkId: 'community-B',
+    networkTitle: 'Other Community',
+    indexPrompt: 'Something else',
+    permissions: ['owner'],
+    memberPrompt: null,
+    autoAssign: true,
+    isPersonal: false,
+    joinedAt: new Date('2026-01-03'),
+  },
+];
+
+const baseContext = (): ResolvedToolContext => ({
+  userId: 'user-1',
+  userName: 'Alice',
+  userEmail: 'alice@test',
+  user: { id: 'user-1', name: 'Alice', email: 'alice@test' } as never,
+  userProfile: null as never,
+  userNetworks: memberships,
+  isOnboarding: false,
+  hasName: true,
+  isMcp: true,
+});
+
+describe('applyNetworkScopeToContext', () => {
+  test('no-op when scope is null', () => {
+    const ctx = baseContext();
+    applyNetworkScopeToContext(ctx, null);
+    expect(ctx.networkId).toBeUndefined();
+    expect(ctx.indexName).toBeUndefined();
+    expect(ctx.scopedIndex).toBeUndefined();
+    expect(ctx.scopedMembershipRole).toBeUndefined();
+    expect(ctx.isOwner).toBeUndefined();
+  });
+
+  test('no-op when scope is undefined', () => {
+    const ctx = baseContext();
+    applyNetworkScopeToContext(ctx, undefined);
+    expect(ctx.networkId).toBeUndefined();
+  });
+
+  test('preserves an explicit chat scope when one is already set', () => {
+    const ctx = baseContext();
+    ctx.networkId = 'community-B';
+    ctx.indexName = 'Other Community';
+    applyNetworkScopeToContext(ctx, 'experiment-net');
+    expect(ctx.networkId).toBe('community-B');
+    expect(ctx.indexName).toBe('Other Community');
+  });
+
+  test('promotes networkScopeId into context.networkId when bound network is in memberships', () => {
+    const ctx = baseContext();
+    applyNetworkScopeToContext(ctx, 'experiment-net');
+
+    expect(ctx.networkId).toBe('experiment-net');
+    expect(ctx.indexName).toBe('Edge City');
+    expect(ctx.scopedIndex).toEqual({
+      id: 'experiment-net',
+      title: 'Edge City',
+      prompt: 'Builders shipping at the edge',
+    });
+    expect(ctx.scopedMembershipRole).toBe('member');
+    expect(ctx.isOwner).toBe(false);
+  });
+
+  test('marks owner when permissions include owner', () => {
+    const ctx = baseContext();
+    applyNetworkScopeToContext(ctx, 'community-B');
+
+    expect(ctx.networkId).toBe('community-B');
+    expect(ctx.scopedMembershipRole).toBe('owner');
+    expect(ctx.isOwner).toBe(true);
+  });
+
+  test('promotes networkId even when bound network is not in memberships (defensive)', () => {
+    const ctx = baseContext();
+    applyNetworkScopeToContext(ctx, 'unknown-network');
+
+    // We still apply the network scope so downstream tools refuse cross-scope access.
+    // indexName/scopedIndex remain unset because we have no authoritative title/prompt.
+    expect(ctx.networkId).toBe('unknown-network');
+    expect(ctx.indexName).toBeUndefined();
+    expect(ctx.scopedIndex).toBeUndefined();
+  });
+});

--- a/packages/protocol/src/negotiation/negotiation.graph.ts
+++ b/packages/protocol/src/negotiation/negotiation.graph.ts
@@ -55,6 +55,10 @@ export class NegotiationGraphFactory {
           type: "negotiation",
           sourceUserId: state.sourceUser.id,
           candidateUserId: state.candidateUser.id,
+          // Denormalized so MCP scope checks (negotiation tools, list/get/respond)
+          // can filter by network without re-loading the parked turnContext or
+          // joining through the opportunity.
+          networkId: state.indexContext.networkId,
           ...(state.opportunityId && { opportunityId: state.opportunityId }),
           maxTurns,
         });

--- a/packages/protocol/src/negotiation/negotiation.tools.ts
+++ b/packages/protocol/src/negotiation/negotiation.tools.ts
@@ -21,6 +21,27 @@ const logger = protocolLogger('NegotiationTools');
 export const AMBIENT_PARK_WINDOW_MS = 5 * 60 * 1000;
 
 /**
+ * Pulls the negotiation's network from task metadata. Tasks created after the
+ * scope hardening carry `metadata.networkId` directly; older tasks only have
+ * the network embedded in the parked `turnContext.indexContext.networkId`.
+ * Returns `null` for legacy tasks where neither field is present — callers
+ * scoped by `context.networkId` must reject these defensively rather than
+ * fall through to a global view.
+ */
+function readTaskNetworkId(meta: {
+  networkId?: string;
+  turnContext?: { indexContext?: { networkId?: string } };
+} | null): string | null {
+  if (!meta) return null;
+  if (typeof meta.networkId === 'string' && meta.networkId.trim()) return meta.networkId;
+  const fromTurnContext = meta.turnContext?.indexContext?.networkId;
+  if (typeof fromTurnContext === 'string' && fromTurnContext.trim()) return fromTurnContext;
+  return null;
+}
+
+const SCOPE_DENIAL = 'Access denied: this negotiation is not in your bound network scope.';
+
+/**
  * Creates negotiation MCP tools for external agent access.
  * Exposes negotiation state for listing, reading, and responding to bilateral negotiations.
  */
@@ -62,8 +83,23 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
         const tasks = await negotiationDatabase.getTasksForUser(context.userId, dbState ? { state: dbState } : undefined);
 
         const negotiations = await Promise.all(tasks.map(async (task) => {
-          const meta = task.metadata as { sourceUserId?: string; candidateUserId?: string; type?: string; maxTurns?: number } | null;
+          const meta = task.metadata as {
+            sourceUserId?: string;
+            candidateUserId?: string;
+            type?: string;
+            maxTurns?: number;
+            networkId?: string;
+            turnContext?: { indexContext?: { networkId?: string } };
+          } | null;
           if (meta?.type !== 'negotiation') return null;
+
+          // Network-scope filter: when caller's API key carries a network-bound
+          // agent, drop tasks whose network differs (or whose network we cannot
+          // determine — defense in depth for legacy tasks).
+          if (context.networkId) {
+            const taskNetworkId = readTaskNetworkId(meta);
+            if (taskNetworkId !== context.networkId) return null;
+          }
 
           const isSource = meta.sourceUserId === context.userId;
           const counterpartyId = isSource ? meta.candidateUserId : meta.sourceUserId;
@@ -167,6 +203,7 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
           type?: string;
           maxTurns?: number;
           opportunityId?: string;
+          networkId?: string;
           turnContext?: {
             sourceUser: UserNegotiationContext;
             candidateUser: UserNegotiationContext;
@@ -177,6 +214,16 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
         } | null;
         if (meta?.type !== 'negotiation') {
           return error('Negotiation not found.');
+        }
+
+        // Network-scope check: a network-bound agent must not read negotiations
+        // outside its bound network. Run before the participant check so we
+        // don't leak existence-vs-membership signal across scopes.
+        if (context.networkId) {
+          const taskNetworkId = readTaskNetworkId(meta);
+          if (taskNetworkId !== context.networkId) {
+            return error(SCOPE_DENIAL);
+          }
         }
 
         // Access control: user must be source or candidate
@@ -318,9 +365,25 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
           return error('Negotiation not found.');
         }
 
-        const meta = task.metadata as { sourceUserId?: string; candidateUserId?: string; type?: string; maxTurns?: number } | null;
+        const meta = task.metadata as {
+          sourceUserId?: string;
+          candidateUserId?: string;
+          type?: string;
+          maxTurns?: number;
+          networkId?: string;
+          turnContext?: { indexContext?: { networkId?: string } };
+        } | null;
         if (meta?.type !== 'negotiation') {
           return error('Negotiation not found.');
+        }
+
+        // Network-scope check (mirrors get_negotiation): a network-bound agent
+        // must not act on negotiations outside its bound network.
+        if (context.networkId) {
+          const taskNetworkId = readTaskNetworkId(meta);
+          if (taskNetworkId !== context.networkId) {
+            return error(SCOPE_DENIAL);
+          }
         }
 
         // Validate negotiation is waiting for agent input (or claimed via polling)

--- a/packages/protocol/src/negotiation/tests/negotiation.tools.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.tools.spec.ts
@@ -3,13 +3,14 @@ import { z } from "zod";
 import { createNegotiationTools } from "../negotiation.tools.js";
 import type { ToolDeps, ResolvedToolContext } from "../../shared/agent/tool.helpers.js";
 
-function makeContext(userId = "user-src"): ResolvedToolContext {
+function makeContext(userId = "user-src", networkId?: string): ResolvedToolContext {
   return {
     userId,
     user: { id: userId, name: "Alice", email: "a@test" } as never,
     userProfile: null,
     userNetworks: [],
     isMcp: true,
+    ...(networkId ? { networkId } : {}),
   } as unknown as ResolvedToolContext;
 }
 
@@ -23,12 +24,23 @@ function captureTool(name: string, deps: Partial<ToolDeps>) {
   return captured!;
 }
 
-function makeTask(state: string, sourceUserId: string, candidateUserId: string) {
+function makeTask(
+  state: string,
+  sourceUserId: string,
+  candidateUserId: string,
+  options: { networkId?: string; id?: string } = {},
+) {
   return {
-    id: "task-1",
+    id: options.id ?? "task-1",
     conversationId: "conv-1",
     state,
-    metadata: { type: "negotiation", sourceUserId, candidateUserId, maxTurns: 6 },
+    metadata: {
+      type: "negotiation",
+      sourceUserId,
+      candidateUserId,
+      maxTurns: 6,
+      ...(options.networkId ? { networkId: options.networkId } : {}),
+    },
     createdAt: new Date("2026-01-01"),
     updatedAt: new Date("2026-01-02"),
   };
@@ -437,5 +449,160 @@ describe("respond_to_negotiation — handler", () => {
 
     const result = JSON.parse(raw);
     expect(result.data.message).toContain("Question submitted");
+  });
+});
+
+// ── network-scope enforcement ─────────────────────────────────────────────────
+//
+// When `context.networkId` is set (i.e. the caller's API key carries a
+// network-scoped agent), every negotiation tool must refuse to surface or act
+// on tasks tied to a different network. Tasks created before this hardening
+// landed have no `networkId` in their metadata; for those legacy tasks we fall
+// back to the per-task `turnContext.indexContext.networkId` once it has been
+// persisted (after the first park).
+
+describe("list_negotiations — network scope", () => {
+  test("filters out tasks not in the caller's bound network when context.networkId is set", async () => {
+    const inScope = makeTask("working", "user-src", "user-cand", { id: "task-in", networkId: "net-A" });
+    const outOfScope = makeTask("working", "user-src", "user-cand", { id: "task-out", networkId: "net-B" });
+
+    const deps = {
+      negotiationDatabase: {
+        getTasksForUser: async () => [inScope, outOfScope],
+        getMessagesForConversation: async () => [],
+      },
+    };
+
+    const tool = captureTool("list_negotiations", deps);
+    const result = JSON.parse(
+      await tool.handler({ context: makeContext("user-src", "net-A"), query: {} })
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data.negotiations).toHaveLength(1);
+    expect(result.data.negotiations[0].id).toBe("task-in");
+  });
+
+  test("returns all tasks when context.networkId is unset (global agent)", async () => {
+    const t1 = makeTask("working", "user-src", "user-cand", { id: "task-1", networkId: "net-A" });
+    const t2 = makeTask("working", "user-src", "user-cand", { id: "task-2", networkId: "net-B" });
+
+    const deps = {
+      negotiationDatabase: {
+        getTasksForUser: async () => [t1, t2],
+        getMessagesForConversation: async () => [],
+      },
+    };
+
+    const tool = captureTool("list_negotiations", deps);
+    const result = JSON.parse(
+      await tool.handler({ context: makeContext("user-src"), query: {} })
+    );
+
+    expect(result.data.negotiations).toHaveLength(2);
+  });
+
+  test("excludes legacy tasks (no networkId in metadata) when caller is scoped", async () => {
+    // Defense in depth: a network-bound agent must not see negotiations whose
+    // network we cannot prove. Legacy tasks created before this change have no
+    // `metadata.networkId` and no parked `turnContext` — we drop them rather
+    // than fall back to the global view.
+    const legacy = makeTask("working", "user-src", "user-cand", { id: "task-legacy" });
+
+    const deps = {
+      negotiationDatabase: {
+        getTasksForUser: async () => [legacy],
+        getMessagesForConversation: async () => [],
+      },
+    };
+
+    const tool = captureTool("list_negotiations", deps);
+    const result = JSON.parse(
+      await tool.handler({ context: makeContext("user-src", "net-A"), query: {} })
+    );
+
+    expect(result.data.negotiations).toHaveLength(0);
+  });
+});
+
+describe("get_negotiation — network scope", () => {
+  test("returns access denied when task is in a different network than caller's scope", async () => {
+    const task = makeTask("working", "user-src", "user-cand", { networkId: "net-B" });
+
+    const deps = {
+      negotiationDatabase: {
+        getTask: async () => task,
+        getMessagesForConversation: async () => [],
+        getArtifactsForTask: async () => [],
+      },
+    };
+
+    const tool = captureTool("get_negotiation", deps);
+    const result = JSON.parse(
+      await tool.handler({
+        context: makeContext("user-src", "net-A"),
+        query: { negotiationId: "task-1" },
+      })
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/network scope|not in your bound|not in scope/i);
+  });
+
+  test("returns the task when task's network matches caller's scope", async () => {
+    const task = makeTask("working", "user-src", "user-cand", { networkId: "net-A" });
+
+    const deps = {
+      negotiationDatabase: {
+        getTask: async () => task,
+        getMessagesForConversation: async () => [],
+        getArtifactsForTask: async () => [],
+      },
+    };
+
+    const tool = captureTool("get_negotiation", deps);
+    const result = JSON.parse(
+      await tool.handler({
+        context: makeContext("user-src", "net-A"),
+        query: { negotiationId: "task-1" },
+      })
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data.id).toBe("task-1");
+  });
+});
+
+describe("respond_to_negotiation — network scope", () => {
+  test("refuses to respond on a task from a different network", async () => {
+    const outOfScope = {
+      ...makeTask("waiting_for_agent", "user-src", "user-cand", { networkId: "net-B" }),
+    };
+
+    const deps = {
+      negotiationDatabase: {
+        getTask: async () => outOfScope,
+        getMessagesForConversation: async () => [],
+        createMessage: async () => { throw new Error("must not be called"); },
+        updateTaskState: async () => { throw new Error("must not be called"); },
+        createArtifact: async () => { throw new Error("must not be called"); },
+      },
+      negotiationTimeoutQueue: { cancelTimeout: async () => {}, enqueueTimeout: async () => {} },
+    };
+
+    const tool = captureTool("respond_to_negotiation", deps);
+    const raw = await tool.handler({
+      context: makeContext("user-src", "net-A"),
+      query: {
+        negotiationId: "task-1",
+        action: "accept",
+        reasoning: "looks good",
+        suggestedRoles: { ownUser: "peer", otherUser: "peer" },
+      },
+    });
+
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/network scope|not in your bound|not in scope/i);
   });
 });


### PR DESCRIPTION
## Summary

Network-scoped API keys (`agent_permissions.scope='network'`) had their DB-level `indexScope` clamp working for cross-user reads, but `ResolvedToolContext.networkId` was never set. Tools that branch on it — most importantly `read_networks` — therefore returned the global `publicNetworks` catalog and the full membership list to scoped agents. In production this surfaced as: an experimental-network member is offered out-of-scope communities ("Brooklyn Runners club", "Index Early Birds") during onboarding, clicks one, joins it, and ends up with a membership outside their bound scope.

Production trace confirmed the leak:
- agent's `agent_permissions` is correctly `scope: "network", scopeId: "<experiment-net>"`
- `read_networks` returned three memberships (experiment + a clicked-from-onboarding community + personal) and one public network — none of which a scoped agent should see

## Bug Fixes

- **`mcp.server.ts`**: new exported helper `applyNetworkScopeToContext(context, networkScopeId)` promotes the agent's bound network into `context.networkId` (and `indexName`, `scopedIndex`, `scopedMembershipRole`, `isOwner`) immediately after `resolveChatContext`. Once set, every existing tool scope check fires automatically — `read_networks` returns only the bound network in `memberOf`, no `publicNetworks`; `read_intents` / `read_user_profiles` / `read_network_memberships` / opportunity tools all enforce the same boundary. No-op for global agents; user-driven explicit chat scope (`request.body.networkId`) keeps precedence.

- **`negotiation.graph.ts`**: denormalize `networkId: state.indexContext.networkId` onto task metadata at creation, so the negotiation tools can scope-filter without joining through the opportunity or waiting for the parked turnContext.

- **`negotiation.tools.ts`**:
  - `list_negotiations` now drops tasks whose network differs from `context.networkId` (legacy rows without a derivable networkId are dropped too — defense in depth).
  - `get_negotiation` and `respond_to_negotiation` short-circuit with "this negotiation is not in your bound network scope" before any participant check, so existence-vs-membership doesn't leak across scopes.
  - New `readTaskNetworkId(meta)` helper reads `meta.networkId` first, falls back to `meta.turnContext?.indexContext?.networkId`, returns `null` for legacy rows.

## Tests

- `packages/protocol/src/mcp/tests/apply-network-scope-to-context.spec.ts` — 6 cases covering propagation, owner detection, the explicit-chat-scope precedence rule, and the defensive-fallback when the bound network isn't in the user's memberships.
- `packages/protocol/src/negotiation/tests/negotiation.tools.spec.ts` — extended with three new `describe` blocks covering scope-filter on `list_negotiations`, scope-deny on `get_negotiation` and `respond_to_negotiation`, and the legacy-task drop.

35/35 of the new tests pass; `mcp + network + negotiation` test sweep is green except for the pre-existing `MCP_INSTRUCTIONS` 2500-char budget test (unrelated, predates this PR).

## Versions

- `@indexnetwork/protocol`: 0.28.0 → 0.28.1 (bug fix, backward-compatible).

## Test plan

- [ ] After merge, hit `/mcp` with a known network-scoped key and call `read_networks` — expect only the bound network in `memberOf`, no `publicNetworks`.
- [ ] `list_negotiations` with a scoped key returns only tasks tied to the bound network.
- [ ] `get_negotiation` / `respond_to_negotiation` against a task in a different network return the new "not in your bound network scope" error.
- [ ] Onboarding for a freshly invited experimental-network member no longer surfaces out-of-scope public communities.