### PR TITLE
fix(frontend): rename InstaClaw to OpenClaw and label experiment networks

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/frontend/src/app/networks/[id]/page.tsx
+++ b/frontend/src/app/networks/[id]/page.tsx
@@ -183,7 +183,7 @@ export default function NetworkDetailPage({ networkIdOverride, basePath }: Netwo
                       {isPublic
                         ? <Globe className="w-3.5 h-3.5" />
                         : <Lock className="w-3.5 h-3.5" />}
-                      {isPublic ? 'Public' : 'Private'}
+                      {isPublic ? 'Public' : network.isExperiment ? 'Experiment' : 'Private'}
                     </span>
                     {network._count?.members !== undefined && (
                       <span className="flex items-center gap-1.5 text-xs text-gray-500">

--- a/frontend/src/components/NetworkSettingsPanel.tsx
+++ b/frontend/src/components/NetworkSettingsPanel.tsx
@@ -839,7 +839,7 @@ export default function NetworkSettingsPanel({ index, onDeleted, activeTab }: Ne
                 OpenClaw plugin config
               </p>
               <p className="text-xs text-gray-500 mb-3">
-                Hand to InstaClaw admins to merge into <code className="px-1 py-0.5 bg-gray-100 rounded text-[11px] font-ibm-plex-mono">openclaw.json</code> under <code className="px-1 py-0.5 bg-gray-100 rounded text-[11px] font-ibm-plex-mono">plugins.entries.indexnetwork-openclaw-plugin.config</code>.
+                Hand to OpenClaw admins to merge into <code className="px-1 py-0.5 bg-gray-100 rounded text-[11px] font-ibm-plex-mono">openclaw.json</code> under <code className="px-1 py-0.5 bg-gray-100 rounded text-[11px] font-ibm-plex-mono">plugins.entries.indexnetwork-openclaw-plugin.config</code>.
               </p>
               <CopyableBox
                 value={JSON.stringify(


### PR DESCRIPTION
## Summary

- Plugin config caption now reads "Hand to OpenClaw admins" (was "InstaClaw")
- Network detail header shows "Experiment" instead of "Private" for experiment networks — experiments are private by design but the label should reflect their purpose
- Bumps frontend to 0.7.3