### PR TITLE
fix(networks): show experiment networks in My Networks, hide from Discover

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -1273,12 +1273,6 @@ export class ChatDatabaseAdapter {
       .where(sql`'owner' = ANY(${schema.networkMembers.permissions})`)
       .as('owner_members');
 
-    // Experiment networks remain hidden from public-discovery lists.
-    const experimentFilter = or(
-      eq(schema.networks.isExperiment, false),
-      isNull(schema.networks.isExperiment),
-    );
-
     const rows = await db
       .select({
         id: schema.networks.id,
@@ -1308,7 +1302,6 @@ export class ChatDatabaseAdapter {
             eq(schema.networks.isPersonal, false),
             eq(ownerMembers.userId, userId)
           ),
-          experimentFilter
         )
       )
       .orderBy(desc(schema.networks.isPersonal), desc(schema.networks.createdAt));
@@ -1409,6 +1402,7 @@ export class ChatDatabaseAdapter {
     const whereConditions = [
       isNull(schema.networks.deletedAt),
       eq(schema.networks.isPersonal, false),
+      or(eq(schema.networks.isExperiment, false), isNull(schema.networks.isExperiment)),
     ];
 
     if (excludeIds.length > 0) {


### PR DESCRIPTION
## Summary

- `getNetworksForUser` was applying an experiment-network filter even though the query is already scoped to the user's own memberships — owners couldn't see their experiment networks in the **My Networks** tab. Drop the filter there.
- `getPublicIndexesNotJoined` had no experiment filter at all, so experiment networks could surface in **Discover**. Add `isExperiment IS NOT TRUE` so experiments stay private as intended.
- Bumps backend to 0.21.3.

## Test plan

- [ ] Owner of an experiment network sees it in My Networks
- [ ] Member (non-owner) of an experiment network sees it in My Networks
- [ ] Discover does not list any experiment network
- [ ] Regular (non-experiment) public networks still appear in Discover