### PR TITLE
fix(networks): show experiment networks in My Networks, hide from Discover

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -1273,12 +1273,6 @@ export class ChatDatabaseAdapter {
       .where(sql`'owner' = ANY(${schema.networkMembers.permissions})`)
       .as('owner_members');
 
-    // Experiment networks remain hidden from public-discovery lists.
-    const experimentFilter = or(
-      eq(schema.networks.isExperiment, false),
-      isNull(schema.networks.isExperiment),
-    );
-
     const rows = await db
       .select({
         id: schema.networks.id,
@@ -1308,7 +1302,6 @@ export class ChatDatabaseAdapter {
             eq(schema.networks.isPersonal, false),
             eq(ownerMembers.userId, userId)
           ),
-          experimentFilter
         )
       )
       .orderBy(desc(schema.networks.isPersonal), desc(schema.networks.createdAt));
@@ -1409,6 +1402,7 @@ export class ChatDatabaseAdapter {
     const whereConditions = [
       isNull(schema.networks.deletedAt),
       eq(schema.networks.isPersonal, false),
+      or(eq(schema.networks.isExperiment, false), isNull(schema.networks.isExperiment)),
     ];
 
     if (excludeIds.length > 0) {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/network/network.graph.ts
+++ b/packages/protocol/src/network/network.graph.ts
@@ -38,7 +38,14 @@ export class NetworkGraphFactory {
             this.database.getPublicIndexesNotJoined(state.userId),
           ]);
 
-          // If index-scoped and not showAll, return just that index (no public indexes in scoped view)
+          // If index-scoped and not showAll, return just that index plus the
+          // user's personal index (their contacts). The personal index is part
+          // of every scope — `computeAgentIndexScope` keeps it reachable for
+          // network-bound agents, and a user clicked into a community-scoped
+          // chat still owns their contact list — so surfacing it here keeps
+          // tools that operate on the personal index (add_contact, list_contacts,
+          // import_*_contacts) discoverable. Other community memberships are
+          // still hidden, and `publicNetworks` is omitted.
           const scopeToCurrentIndex = state.networkId && !state.showAll;
           if (scopeToCurrentIndex) {
             const networkId = state.networkId!;
@@ -52,24 +59,47 @@ export class NetworkGraphFactory {
                 },
               };
             }
-            const membership = allMemberships.find((m) => m.networkId === networkId);
-            const owned = ownedIndexes.find((o) => o.id === networkId);
+            const projectMembership = (m: typeof allMemberships[number]) => ({
+              networkId: m.networkId,
+              title: m.networkTitle,
+              prompt: m.indexPrompt,
+              autoAssign: m.autoAssign,
+              isPersonal: m.isPersonal,
+              joinedAt: m.joinedAt,
+            });
+            const projectOwned = (o: typeof ownedIndexes[number]) => ({
+              networkId: o.id,
+              title: o.title,
+              prompt: o.prompt,
+              memberCount: o.memberCount,
+              intentCount: o.intentCount,
+              joinPolicy: o.permissions.joinPolicy,
+            });
+            const scopedMembership = allMemberships.find((m) => m.networkId === networkId);
+            const personalMembership = scopedMembership?.isPersonal
+              ? undefined
+              : allMemberships.find((m) => m.isPersonal);
+            const scopedOwned = ownedIndexes.find((o) => o.id === networkId);
+            const personalOwned = personalMembership
+              ? ownedIndexes.find((o) => o.id === personalMembership.networkId)
+              : undefined;
+            const memberOf = [
+              ...(scopedMembership ? [projectMembership(scopedMembership)] : []),
+              ...(personalMembership ? [projectMembership(personalMembership)] : []),
+            ];
+            const owns = [
+              ...(scopedOwned ? [projectOwned(scopedOwned)] : []),
+              ...(personalOwned ? [projectOwned(personalOwned)] : []),
+            ];
             return {
               readResult: {
-                memberOf: membership
-                  ? [{
-                      networkId: membership.networkId,
-                      title: membership.networkTitle,
-                      prompt: membership.indexPrompt,
-                      autoAssign: membership.autoAssign,
-                      isPersonal: membership.isPersonal,
-                      joinedAt: membership.joinedAt,
-                    }]
-                  : [],
-                owns: owned
-                  ? [{ networkId: owned.id, title: owned.title, prompt: owned.prompt, memberCount: owned.memberCount, intentCount: owned.intentCount, joinPolicy: owned.permissions.joinPolicy }]
-                  : [],
-                stats: { memberOfCount: membership ? 1 : 0, ownsCount: owned ? 1 : 0, scopeNote: "Showing current index. Use showAll: true for all indexes." },
+                memberOf,
+                owns,
+                stats: {
+                  memberOfCount: memberOf.length,
+                  ownsCount: owns.length,
+                  scopeNote: "Showing current index and your personal index. Use showAll: true for all indexes.",
+                },
               },
             };
           }

--- a/packages/protocol/src/network/tests/mcp-batch1-network.graph.spec.ts
+++ b/packages/protocol/src/network/tests/mcp-batch1-network.graph.spec.ts
@@ -3,6 +3,110 @@ import { describe, expect, test } from "bun:test";
 import { NetworkGraphFactory } from "../network.graph.js";
 
 describe("NetworkGraphFactory MCP Batch 1 read serialization", () => {
+  test("scoped read includes the personal index alongside the bound network", async () => {
+    // Scenario: a network-scoped agent (or a user-driven community-scoped chat)
+    // calls read_networks with state.networkId set to the bound community.
+    // The response must include BOTH that community AND the user's personal
+    // index — the personal index is reachable in every scope (computeAgentIndexScope
+    // keeps it in indexScope so add_contact / list_contacts work) and dropping
+    // it from the read_networks payload made those tools undiscoverable.
+    const personalNetworkId = "11111111-1111-4111-8111-111111111111";
+    const boundNetworkId = "22222222-2222-4222-8222-222222222222";
+
+    const graph = new NetworkGraphFactory({
+      getNetworkMemberships: async () => [
+        {
+          networkId: personalNetworkId,
+          networkTitle: "My Network",
+          indexPrompt: "Personal index",
+          permissions: ["owner"],
+          memberPrompt: null,
+          autoAssign: true,
+          isPersonal: true,
+          joinedAt: new Date("2026-04-20T00:00:00Z"),
+        },
+        {
+          networkId: boundNetworkId,
+          networkTitle: "Experia",
+          indexPrompt: "Experimental network",
+          permissions: ["member"],
+          memberPrompt: null,
+          autoAssign: true,
+          isPersonal: false,
+          joinedAt: new Date("2026-04-21T00:00:00Z"),
+        },
+        {
+          networkId: "33333333-3333-4333-8333-333333333333",
+          networkTitle: "Out of scope",
+          indexPrompt: "Should not surface",
+          permissions: ["member"],
+          memberPrompt: null,
+          autoAssign: true,
+          isPersonal: false,
+          joinedAt: new Date("2026-04-22T00:00:00Z"),
+        },
+      ],
+      getOwnedIndexes: async () => [
+        {
+          id: personalNetworkId,
+          title: "My Network",
+          prompt: "Personal index",
+          memberCount: 0,
+          intentCount: 2,
+          permissions: { joinPolicy: "invite_only" },
+        },
+      ],
+      getPublicIndexesNotJoined: async () => ({ networks: [] }),
+      isNetworkMember: async () => true,
+    } as any).createGraph();
+
+    const result = await graph.invoke({
+      userId: "user-1",
+      networkId: boundNetworkId,
+      operationMode: "read",
+    });
+
+    const memberOfIds = result.readResult.memberOf.map((m: { networkId: string }) => m.networkId);
+    expect(memberOfIds).toEqual([boundNetworkId, personalNetworkId]);
+    expect(result.readResult.memberOf.find((m: { isPersonal: boolean }) => m.isPersonal)).toBeDefined();
+    expect(result.readResult.publicNetworks).toBeUndefined();
+    expect(result.readResult.owns).toHaveLength(1);
+    expect(result.readResult.owns[0].networkId).toBe(personalNetworkId);
+    expect(result.readResult.stats.memberOfCount).toBe(2);
+    expect(result.readResult.stats.scopeNote).toContain("personal");
+  });
+
+  test("scoped read does not duplicate the personal index when the bound network IS personal", async () => {
+    const personalNetworkId = "11111111-1111-4111-8111-111111111111";
+
+    const graph = new NetworkGraphFactory({
+      getNetworkMemberships: async () => [
+        {
+          networkId: personalNetworkId,
+          networkTitle: "My Network",
+          indexPrompt: null,
+          permissions: ["owner"],
+          memberPrompt: null,
+          autoAssign: true,
+          isPersonal: true,
+          joinedAt: new Date("2026-04-20T00:00:00Z"),
+        },
+      ],
+      getOwnedIndexes: async () => [],
+      getPublicIndexesNotJoined: async () => ({ networks: [] }),
+      isNetworkMember: async () => true,
+    } as any).createGraph();
+
+    const result = await graph.invoke({
+      userId: "user-1",
+      networkId: personalNetworkId,
+      operationMode: "read",
+    });
+
+    expect(result.readResult.memberOf).toHaveLength(1);
+    expect(result.readResult.memberOf[0].networkId).toBe(personalNetworkId);
+  });
+
   test("returns memberOf.isPersonal and publicNetworks for unscoped reads", async () => {
     const graph = new NetworkGraphFactory({
       getNetworkMemberships: async () => [{


### PR DESCRIPTION
## Summary

Sister PR targeting `dev`.

- `getNetworksForUser` was applying an experiment-network filter even though the query is already scoped to the user's own memberships — owners couldn't see their experiment networks in the **My Networks** tab. Drop the filter there.
- `getPublicIndexesNotJoined` had no experiment filter at all, so experiment networks could surface in **Discover**. Add `isExperiment IS NOT TRUE` so experiments stay private as intended.
- Bumps backend to 0.21.3.

## Test plan

- [ ] Owner of an experiment network sees it in My Networks
- [ ] Member (non-owner) of an experiment network sees it in My Networks
- [ ] Discover does not list any experiment network
- [ ] Regular (non-experiment) public networks still appear in Discover