### PR TITLE
fix(openclaw-plugin): preserve pre-baked node branding on connect

### DIFF
--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "indexnetwork-openclaw-plugin",
   "name": "Index Network",
   "description": "Index Network — find the right people and let them find you. Registers the Index Network MCP server on first use and hands off to its guidance.",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "configSchema": {
     "type": "object",
     "properties": {

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/openclaw-plugin",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "description": "Index Network — OpenClaw plugin. Find the right people and let them find you.",
   "license": "MIT",
   "private": false,

--- a/packages/openclaw-plugin/src/setup/setup.cli.ts
+++ b/packages/openclaw-plugin/src/setup/setup.cli.ts
@@ -154,37 +154,9 @@ export async function runSetup(ctx: SetupContext): Promise<void> {
   ]);
   await ctx.configSet(`${configPrefix}.mainAgentToolUse`, mainAgentToolUse || 'disabled');
 
-  // --- Community branding (optional) ---
-  const existingNodeName = existing('nodeName');
-  const nodeNameRaw = await ctx.prompt(
-    'Community name (optional, leave blank to clear)',
-    { default: existingNodeName || '' },
-  );
-  const nodeName = nodeNameRaw.trim();
-  if (nodeName) {
-    await ctx.configSet(`${configPrefix}.nodeName`, nodeName);
-
-    const existingDesc = existing('nodeDescription');
-    const nodeDescriptionRaw = await ctx.prompt(
-      'Community description (optional, leave blank to clear)',
-      { default: existingDesc || '' },
-    );
-    const nodeDescription = nodeDescriptionRaw.trim();
-    await ctx.configSet(`${configPrefix}.nodeDescription`, nodeDescription || undefined);
-
-    const existingCtx = existing('nodeContext');
-    const nodeContextRaw = await ctx.prompt(
-      'Community context / focus area (optional, leave blank to clear)',
-      { default: existingCtx || '' },
-    );
-    const nodeContext = nodeContextRaw.trim();
-    await ctx.configSet(`${configPrefix}.nodeContext`, nodeContext || undefined);
-  } else {
-    // Blank nodeName clears all branding fields
-    await ctx.configSet(`${configPrefix}.nodeName`, undefined);
-    await ctx.configSet(`${configPrefix}.nodeDescription`, undefined);
-    await ctx.configSet(`${configPrefix}.nodeContext`, undefined);
-  }
+  // Branding (nodeName/nodeDescription/nodeContext) is intentionally not
+  // prompted — values come from the network owner's pre-baked config or
+  // default to Index Network. Pre-existing values are preserved.
 
   // --- Bootstrap gateway hooks (required for /hooks/agent dispatch) ---
   // The plugin dispatches notifications via POST /hooks/agent, which requires
@@ -275,12 +247,6 @@ export interface HeadlessSetupOptions {
   digestTime?: string;
   /** Main agent tool use mode. Defaults to 'disabled'. */
   mainAgentToolUse?: 'enabled' | 'disabled';
-  /** Optional community branding name. */
-  nodeName?: string;
-  /** Optional community branding description. */
-  nodeDescription?: string;
-  /** Optional community branding context/focus area. */
-  nodeContext?: string;
   /** Existing OpenClaw config snapshot. Defaults to empty. The object is deep-cloned; caller's copy is not mutated. */
   existingCfg?: Record<string, unknown>;
   /** Override the agentId resolution fetch. Useful for testing. */
@@ -315,9 +281,6 @@ export async function runHeadlessSetup(
       // Handles both "API key" and "API key (leave blank to keep existing)"
       if (label.startsWith('API key')) return opts.apiKey;
       if (label.startsWith('Digest time')) return digestTime;
-      if (label.startsWith('Community name')) return opts.nodeName ?? '';
-      if (label.startsWith('Community description')) return opts.nodeDescription ?? '';
-      if (label.startsWith('Community context')) return opts.nodeContext ?? '';
       return promptOpts?.default ?? '';
     },
     select: async (label, choices) => {


### PR DESCRIPTION
## Summary

The wizard was prompting for `nodeName` / `nodeDescription` / `nodeContext`. In headless mode (`openclaw index connect --api-key ...`), those prompts auto-resolved to empty strings, taking the "blank nodeName clears all branding fields" path and wiping the config a network owner had pre-baked into `openclaw.json`.

Drop the branding prompts entirely. Branding is now only set by the network owner's pre-baked config (or defaults to Index Network), so re-running connect no longer touches node fields.

Bumps `openclaw-plugin` to **0.29.2** (both `package.json` and `openclaw.plugin.json`).

## Test plan

- [ ] Pre-bake `nodeName`/`nodeDescription`/`nodeContext` into `openclaw.json`, run `openclaw index connect --api-key <key>`, confirm node fields are preserved
- [ ] Run interactive `openclaw index connect` against a fresh config — no branding prompts shown
- [ ] Existing 42 setup-entry tests still pass