### PR TITLE
fix(onboarding): skip community discovery for network-scoped users

### DIFF
--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "indexnetwork-openclaw-plugin",
   "name": "Index Network",
   "description": "Index Network — find the right people and let them find you. Registers the Index Network MCP server on first use and hands off to its guidance.",
-  "version": "0.29.2",
+  "version": "0.29.3",
   "configSchema": {
     "type": "object",
     "properties": {

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/openclaw-plugin",
-  "version": "0.29.2",
+  "version": "0.29.3",
   "description": "Index Network — OpenClaw plugin. Find the right people and let them find you.",
   "license": "MIT",
   "private": false,

--- a/packages/openclaw-plugin/src/polling/onboarding/onboarding.prompt.ts
+++ b/packages/openclaw-plugin/src/polling/onboarding/onboarding.prompt.ts
@@ -16,11 +16,13 @@ export function buildOnboardingPrompt(): string {
   - If nothing found → ask them to describe themselves in a sentence, then call \`create_user_profile(bioOrDescription="[their text]", confirm=true)\`.
 
 ### Step 2 — Community discovery
-- Call \`read_networks()\` to fetch available public communities.
-- Present the communities as a plain text list — do NOT use any code fences or special blocks.
-- Write: "Here are some communities you might find relevant — let me know which ones you'd like to join, or say skip to continue."
-- For each community the user wants to join, call \`create_network_membership(networkId="...")\`.
-- After handling their response (joins processed, or user skips), proceed to Step 3.
+- Call \`read_networks()\` to see what communities are available.
+- **If the response carries \`scopeRestriction.isScoped: true\` (the user's API key is bound to a single community) OR \`publicNetworks\` is missing/empty: SKIP this step.** Do NOT list communities, do NOT propose any to join. Briefly acknowledge what you see in \`memberOf\` (e.g. "You're already set up in [community name].") and proceed directly to Step 3 in the same response. Network-scoped users cannot join other communities, so offering them anything to "find relevant" is wrong.
+- Otherwise (\`publicNetworks\` has at least one item):
+  - Present \`publicNetworks\` as a plain text list — do NOT use any code fences or special blocks.
+  - Write: "Here are some communities you might find relevant — let me know which ones you'd like to join, or say skip to continue."
+  - For each community the user wants to join, call \`create_network_membership(networkId="...")\`.
+- After handling their response (joins processed, or user skips, or step skipped because scoped), proceed to Step 3.
 
 ### Step 3 — Intent capture
 - Ask: "Now tell me — what are you open to right now? Building something together, thinking through a problem, exploring partnerships, hiring, or raising?"

--- a/packages/openclaw-plugin/src/tests/onboarding.prompt.spec.ts
+++ b/packages/openclaw-plugin/src/tests/onboarding.prompt.spec.ts
@@ -28,4 +28,20 @@ describe('buildOnboardingPrompt', () => {
     const prompt = buildOnboardingPrompt();
     expect(prompt).not.toContain('import_gmail_contacts');
   });
+
+  it('instructs the agent to skip community discovery for network-scoped keys', () => {
+    // Network-scoped invitees (experiment-network CSV import) cannot join other
+    // communities; their MCP key is bound to a single network. Without explicit
+    // instruction the agent reads `memberOf` and presents the bound network as a
+    // "community you might find relevant", which both surprises the user and
+    // would re-trigger create_network_membership on a network they're already in.
+    const prompt = buildOnboardingPrompt();
+    expect(prompt).toMatch(/scopeRestriction\.isScoped/);
+    expect(prompt.toLowerCase()).toMatch(/skip|do not list|do not propose/);
+  });
+
+  it('handles empty publicNetworks gracefully', () => {
+    const prompt = buildOnboardingPrompt();
+    expect(prompt).toMatch(/publicNetworks.*missing|missing.*publicNetworks|empty/);
+  });
 });

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "0.28.2",
+  "version": "0.28.3",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/chat/chat.prompt.ts
+++ b/packages/protocol/src/chat/chat.prompt.ts
@@ -117,8 +117,12 @@ ${ctx.hasName ? `   - Call \`create_user_profile()\` with no arguments to look t
    - If already connected (tool returns import stats immediately on the first call — user never went through the auth button): **skip to step 6 immediately. Do NOT write any text about Gmail, contacts, or the import. Your next sentence must be the step 6 intro.**
    - If the user just completed OAuth (you called \`import_gmail_contacts()\` a second time after auth): acknowledge the import with a brief summary, then proceed to step 6
 
-6. **Discover communities**
+${ctx.networkId ? `6. **Community discovery (skipped — already in scoped community)**
+   - The user is acting in a scoped chat: they are already a member of "${ctx.indexName ?? 'their community'}" and cannot join other communities here.
+   - Do NOT call \`read_networks\`. Do NOT show the \`\`\`networks_panel\`\`\` block. Do NOT propose anything to join.
+   - Proceed DIRECTLY to step 7 (intent capture) in the same response — no acknowledgment text required.` : `6. **Discover communities**
    - Call \`read_networks()\` to get available public networks (returned in \`publicNetworks\` array)
+   - **If \`publicNetworks\` is missing/empty or the response carries \`scopeRestriction.isScoped: true\`, skip the panel entirely and proceed directly to step 7. Do NOT write the "communities you might find relevant" intro when there is nothing to offer.**
    - **Do NOT list communities in text.** The UI renders an interactive card panel automatically.
    - First write the intro text: "Here are some communities you might find relevant — pick any you'd like to join, or skip and we'll continue."
    - Then immediately output this block (do not include any JSON data — just the empty object):
@@ -127,7 +131,7 @@ ${ctx.hasName ? `   - Call \`create_user_profile()\` with no arguments to look t
      \`\`\`
    - When presenting, avoid being vocal about 'indexes' unless the user asks.
    - For each index the user wants to join → call \`create_network_membership(networkId=X)\` (omit userId to self-join)
-   - After handling the user's response (joins processed, question answered, or user skips) → ALWAYS proceed to step 7 (intent capture). Do NOT end the conversation at communities.
+   - After handling the user's response (joins processed, question answered, or user skips) → ALWAYS proceed to step 7 (intent capture). Do NOT end the conversation at communities.`}
 
 7. **Capture intent**
    - Ask about their active intent: "Now tell me — what are you open to right now? Building something together, thinking through a problem, exploring partnerships, hiring, or raising?"

--- a/packages/protocol/src/chat/tests/__snapshots__/chat.prompt.modules.spec.ts.snap
+++ b/packages/protocol/src/chat/tests/__snapshots__/chat.prompt.modules.spec.ts.snap
@@ -151,6 +151,7 @@ All tools are simple read/write operations. No hidden logic.
 | **read_intent_indexes** | intentId?, networkId?, userId? | Read intent↔index links |
 | **delete_intent_index** | intentId, networkId | Unlink intent from index |
 | **create_opportunities** | searchQuery?, networkId?, targetUserId?, partyUserIds?, entities?, hint? | Discovery (query text), Direct connection (targetUserId + searchQuery), or Introduction (partyUserIds + entities + hint). |
+| **list_opportunities** | networkId? | List draft and pending opportunities the user can act on. Use when user wants to review existing opportunities. |
 | **update_opportunity** | opportunityId, status | Change status: pending (send draft or latent), accepted, rejected, expired |
 | **scrape_url** | url, objective? | Extract text from web page |
 | **read_docs** | topic? | Protocol documentation |
@@ -385,6 +386,7 @@ All tools are simple read/write operations. No hidden logic.
 | **read_intent_indexes** | intentId?, networkId?, userId? | Read intent↔index links |
 | **delete_intent_index** | intentId, networkId | Unlink intent from index |
 | **create_opportunities** | searchQuery?, networkId?, targetUserId?, partyUserIds?, entities?, hint? | Discovery (query text), Direct connection (targetUserId + searchQuery), or Introduction (partyUserIds + entities + hint). |
+| **list_opportunities** | networkId? | List draft and pending opportunities the user can act on. Use when user wants to review existing opportunities. |
 | **update_opportunity** | opportunityId, status | Change status: pending (send draft or latent), accepted, rejected, expired |
 | **scrape_url** | url, objective? | Extract text from web page |
 | **read_docs** | topic? | Protocol documentation |
@@ -558,6 +560,7 @@ This is the user's first conversation. They just signed up. Guide them through s
 
 6. **Discover communities**
    - Call \`read_networks()\` to get available public networks (returned in \`publicNetworks\` array)
+   - **If \`publicNetworks\` is missing/empty or the response carries \`scopeRestriction.isScoped: true\`, skip the panel entirely and proceed directly to step 7. Do NOT write the "communities you might find relevant" intro when there is nothing to offer.**
    - **Do NOT list communities in text.** The UI renders an interactive card panel automatically.
    - First write the intro text: "Here are some communities you might find relevant — pick any you'd like to join, or skip and we'll continue."
    - Then immediately output this block (do not include any JSON data — just the empty object):
@@ -707,6 +710,7 @@ All tools are simple read/write operations. No hidden logic.
 | **read_intent_indexes** | intentId?, networkId?, userId? | Read intent↔index links |
 | **delete_intent_index** | intentId, networkId | Unlink intent from index |
 | **create_opportunities** | searchQuery?, networkId?, targetUserId?, partyUserIds?, entities?, hint? | Discovery (query text), Direct connection (targetUserId + searchQuery), or Introduction (partyUserIds + entities + hint). |
+| **list_opportunities** | networkId? | List draft and pending opportunities the user can act on. Use when user wants to review existing opportunities. |
 | **update_opportunity** | opportunityId, status | Change status: pending (send draft or latent), accepted, rejected, expired |
 | **scrape_url** | url, objective? | Extract text from web page |
 | **read_docs** | topic? | Protocol documentation |
@@ -879,6 +883,7 @@ This is the user's first conversation. They just signed up. Guide them through s
 
 6. **Discover communities**
    - Call \`read_networks()\` to get available public networks (returned in \`publicNetworks\` array)
+   - **If \`publicNetworks\` is missing/empty or the response carries \`scopeRestriction.isScoped: true\`, skip the panel entirely and proceed directly to step 7. Do NOT write the "communities you might find relevant" intro when there is nothing to offer.**
    - **Do NOT list communities in text.** The UI renders an interactive card panel automatically.
    - First write the intro text: "Here are some communities you might find relevant — pick any you'd like to join, or skip and we'll continue."
    - Then immediately output this block (do not include any JSON data — just the empty object):
@@ -1028,6 +1033,7 @@ All tools are simple read/write operations. No hidden logic.
 | **read_intent_indexes** | intentId?, networkId?, userId? | Read intent↔index links |
 | **delete_intent_index** | intentId, networkId | Unlink intent from index |
 | **create_opportunities** | searchQuery?, networkId?, targetUserId?, partyUserIds?, entities?, hint? | Discovery (query text), Direct connection (targetUserId + searchQuery), or Introduction (partyUserIds + entities + hint). |
+| **list_opportunities** | networkId? | List draft and pending opportunities the user can act on. Use when user wants to review existing opportunities. |
 | **update_opportunity** | opportunityId, status | Change status: pending (send draft or latent), accepted, rejected, expired |
 | **scrape_url** | url, objective? | Extract text from web page |
 | **read_docs** | topic? | Protocol documentation |
@@ -1269,6 +1275,7 @@ All tools are simple read/write operations. No hidden logic.
 | **read_intent_indexes** | intentId?, networkId?, userId? | Read intent↔index links |
 | **delete_intent_index** | intentId, networkId | Unlink intent from index |
 | **create_opportunities** | searchQuery?, networkId?, targetUserId?, partyUserIds?, entities?, hint? | Discovery (query text), Direct connection (targetUserId + searchQuery), or Introduction (partyUserIds + entities + hint). |
+| **list_opportunities** | networkId? | List draft and pending opportunities the user can act on. Use when user wants to review existing opportunities. |
 | **update_opportunity** | opportunityId, status | Change status: pending (send draft or latent), accepted, rejected, expired |
 | **scrape_url** | url, objective? | Extract text from web page |
 | **read_docs** | topic? | Protocol documentation |
@@ -1314,7 +1321,12 @@ The searchQuery should be a brief description of why they'd connect (e.g. "share
 
 ### 7. Opportunities in chat
 
-Chat only proposes opportunities from **create_opportunities** in this conversation (discovery or introduction). Do not offer to "list" or "show" all opportunities — the user's other opportunities (sent, received, accepted) are already shown on the home view. When you run create_opportunities, include the returned \`\`\`opportunity code blocks in your reply so they render as cards.
+- **create_opportunities** — discovers new connections (discovery, introduction, or direct connection).
+- **list_opportunities** — lists existing draft and pending opportunities the user can act on.
+
+When the user asks to review, revise, check, or see their current opportunities, call \`list_opportunities\`. Only use \`create_opportunities\` for discovery ("find me connections"), introductions, or direct connections.
+
+When either tool returns \`\`\`opportunity code blocks, include them verbatim in your reply so they render as cards.
 
 Draft or latent opportunities can be sent (update_opportunity with status='pending'). Status translation: draft/latent → "draft", pending → "sent", accepted → "connected"
 

--- a/packages/protocol/src/chat/tests/chat.prompt.modules.spec.ts
+++ b/packages/protocol/src/chat/tests/chat.prompt.modules.spec.ts
@@ -444,6 +444,44 @@ describe("buildSystemContent snapshot identity", () => {
     expect(output).toMatchSnapshot();
   });
 
+  test("onboarding with networkId set rewrites step 6 to skip community discovery", () => {
+    // Network-scoped users (e.g. experiment-network CSV invitees) cannot join
+    // other communities — their key is bound to a single network. Step 6 must
+    // not propose anything to join, and must not run read_networks at all,
+    // otherwise the agent picks the bound network out of `memberOf` and
+    // re-presents it as a community to join.
+    const ctx = makeCtx({
+      isOnboarding: true,
+      hasName: true,
+      networkId: "idx-community",
+      indexName: "AI Builders",
+      scopedIndex: { id: "idx-community", title: "AI Builders", prompt: "AI enthusiasts" },
+      scopedMembershipRole: "member",
+    });
+    const output = buildSystemContent(ctx);
+
+    expect(output).toContain("Community discovery (skipped");
+    expect(output).toContain("AI Builders");
+    expect(output).toContain("Proceed DIRECTLY to step 7");
+    expect(output).not.toContain("communities you might find relevant");
+    // The skipped branch mentions `networks_panel` only as something to NOT show.
+    // The unscoped branch instructs to "Then immediately output this block" —
+    // that imperative is what should be absent.
+    expect(output).not.toContain("Then immediately output this block");
+  });
+
+  test("onboarding without networkId still renders the standard discover-communities step", () => {
+    // Sanity check: the conditional only kicks in when scoped — unscoped
+    // onboarding still presents the panel.
+    const ctx = makeCtx({ isOnboarding: true, hasName: true });
+    const output = buildSystemContent(ctx);
+
+    expect(output).toContain("**Discover communities**");
+    expect(output).toContain("communities you might find relevant");
+    expect(output).toContain("```networks_panel");
+    expect(output).not.toContain("Community discovery (skipped");
+  });
+
   test("without iterCtx, modules section is empty; with empty iterCtx, result matches", () => {
     const ctx = makeCtx();
     const withoutIter = buildSystemContent(ctx);


### PR DESCRIPTION
## Summary

Follow-up to #746/#749. Network-scoped invitees (experiment-network CSV) have keys bound to a single community — they cannot join other communities. After the previous hotfixes, \`read_networks\` correctly omitted \`publicNetworks\` and the personal-index follow-up restored \`memberOf\`, but the onboarding agent still tried to render its "communities you might find relevant" panel and pulled the bound network out of \`memberOf\` — re-presenting the user's already-joined community as something to join.

Reproduced on production with the new user's key:
\`\`\`
Here are some communities you might find relevant — let me know which ones you'd like to join, or say skip to continue:
• Experia: Experimental network for testing experimental networks
\`\`\`

## Bug Fixes

- **\`packages/openclaw-plugin/src/polling/onboarding/onboarding.prompt.ts\`** — the prompt the OpenClaw poller dispatches to the user's main agent over MCP. Step 2 (Community discovery) now branches: when \`scopeRestriction.isScoped: true\` or \`publicNetworks\` is missing/empty, skip the listing entirely and proceed directly to Step 3. Briefly acknowledge \`memberOf\` instead of proposing anything to join.
- **\`packages/protocol/src/chat/chat.prompt.ts\`** \`buildOnboarding\` — the in-process chat onboarding flow. Step 6 conditionally rewrites when \`ctx.networkId\` is set: do not call \`read_networks\`, do not show the \`networks_panel\` block, proceed directly to step 7. The unscoped branch additionally gains explicit guidance for empty \`publicNetworks\` responses, which can happen for users with no public-discovery candidates even when not scoped.

## Tests

- \`onboarding.prompt.spec.ts\`: two new cases asserting the network-scope branch is present and that empty \`publicNetworks\` handling is documented.
- \`chat.prompt.modules.spec.ts\`: two new cases — onboarding with \`networkId\` set rewrites step 6 to the skipped variant; onboarding without \`networkId\` still renders the standard panel.
- Existing snapshot refreshed to absorb pre-existing drift on \`main\` (\`list_opportunities\` row, opportunity-tools section) along with the new conditional content.

## Versions

- \`@indexnetwork/protocol\`: 0.28.2 → 0.28.3
- \`@indexnetwork/openclaw-plugin\`: 0.29.2 → 0.29.3 (both \`package.json\` and \`openclaw.plugin.json\` — the CLI reads the latter)

## Test plan

- [ ] After deploy, restart the OpenClaw poller for a fresh experiment-network invitee — onboarding should not list any community to join, just acknowledge their bound community and move to intent capture.
- [ ] Web onboarding for a JWT user who happens to have an empty \`publicNetworks\` list should also not show the empty panel.
- [ ] Unscoped users with public networks available continue to see the standard discovery panel.