### PR TITLE
fix(onboarding): drop inline discovery, force node-branded welcome opener

### DIFF
--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "indexnetwork-openclaw-plugin",
   "name": "Index Network",
   "description": "Index Network — find the right people and let them find you. Registers the Index Network MCP server on first use and hands off to its guidance.",
-  "version": "0.29.3",
+  "version": "0.29.4",
   "configSchema": {
     "type": "object",
     "properties": {

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/openclaw-plugin",
-  "version": "0.29.3",
+  "version": "0.29.4",
   "description": "Index Network — OpenClaw plugin. Find the right people and let them find you.",
   "license": "MIT",
   "private": false,

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -32,6 +32,7 @@ import { deriveUrls } from './lib/utils/url.js';
 import { isOnboardingComplete, _resetForTesting as _resetOnboardingStatus } from './polling/onboarding/onboarding.status.js';
 import { buildOnboardingPrompt } from './polling/onboarding/onboarding.prompt.js';
 import { dispatchToMainAgent } from './lib/delivery/main-agent.dispatcher.js';
+import { readNodeBranding } from './lib/delivery/config.js';
 
 /** Prevents double-registration when OpenClaw calls register() more than once. */
 let registered = false;
@@ -345,8 +346,9 @@ async function dispatchOnboardingIfNeeded(
   if (complete) return;
 
   const dateStr = new Date().toISOString().slice(0, 10);
+  const branding = readNodeBranding(api);
   const result = await dispatchToMainAgent(api, {
-    prompt: buildOnboardingPrompt(),
+    prompt: buildOnboardingPrompt(branding),
     idempotencyKey: `index:onboarding:dispatch:${config.agentId}:${dateStr}`,
   });
 

--- a/packages/openclaw-plugin/src/lib/delivery/main-agent.prompt.ts
+++ b/packages/openclaw-plugin/src/lib/delivery/main-agent.prompt.ts
@@ -130,14 +130,17 @@ function normalizeBrandingField(value: string): string {
 
 function buildBrandingClause(branding: { nodeName: string; nodeDescription?: string; nodeContext?: string }): string {
   const name = normalizeBrandingField(branding.nodeName);
-  const parts = [`COMMUNITY CONTEXT: This notification comes from the "${name}" community.`];
+  const parts = [
+    `COMMUNITY CONTEXT: The user's community is "${name}" — this is their home on Index Network for this notification.`,
+    `When you greet, address, or reference the community, use the literal string "${name}". Never substitute "Index", "Index Network", or any other placeholder for the community name.`,
+  ];
   if (branding.nodeDescription) {
-    parts.push(normalizeBrandingField(branding.nodeDescription));
+    parts.push(`COMMUNITY DESCRIPTION (use as the second sentence of any welcome opener, paraphrased to fit your voice): ${normalizeBrandingField(branding.nodeDescription)}`);
   }
   if (branding.nodeContext) {
-    parts.push(normalizeBrandingField(branding.nodeContext));
+    parts.push(`COMMUNITY CONTEXT NOTE (background you can draw on): ${normalizeBrandingField(branding.nodeContext)}`);
   }
-  return parts.join(' ');
+  return parts.join('\n');
 }
 
 const INPUT_AS_DATA_CLAUSE = [
@@ -263,7 +266,18 @@ function perTypeInstruction(input: MainAgentPromptInput): string {
       return [
         'This is a WELCOME message — the user just finished onboarding and created their first signal.',
         '',
-        'Present candidates in up to two sections based on their feedCategory field:',
+        'OPENER (REQUIRED when branding is provided above): The first line of your reply MUST be exactly',
+        '"Welcome to {COMMUNITY_NAME}" — where {COMMUNITY_NAME} is the literal community name supplied',
+        'in the branding clause earlier in this prompt. When no branding clause is present, fall back to',
+        '"Welcome to Index Network". Never substitute "Index", "your community", or any placeholder for',
+        'the community name when a name is given. The opener stands on its own line.',
+        '',
+        'SECOND PARAGRAPH (only when a branding description / context-note is provided): 2–3 sentences',
+        'situating the user inside the community. Paraphrase the description and context-note from the',
+        'branding clause; do not copy them verbatim. End with a sentence like "Here\'s what landed in',
+        'the first pass." that bridges into the candidate sections.',
+        '',
+        'Then present candidates in up to two sections based on their feedCategory field:',
         '',
         'SECTION 1 — DIRECT CONNECTIONS (feedCategory = \'connection\'):',
         'Open with a count line (e.g. "3 conversations waiting").',
@@ -279,9 +293,10 @@ function perTypeInstruction(input: MainAgentPromptInput): string {
         'Do NOT compose a &msg= greeting for connector candidates.',
         '',
         'Skip any section with zero candidates. If both sections are empty,',
-        'acknowledge warmly that the system is actively looking.',
+        'acknowledge warmly that the system is actively looking — but the opener',
+        'and second paragraph still fire regardless of candidate count.',
         '',
-        'Close with a short "from here" paragraph — frame what happens next',
+        'Close with a short "From here" paragraph — frame what happens next',
         '(morning briefs, ongoing discovery, feedback welcome).',
         '',
         'Always fires regardless of candidate count.',

--- a/packages/openclaw-plugin/src/polling/onboarding/onboarding.prompt.ts
+++ b/packages/openclaw-plugin/src/polling/onboarding/onboarding.prompt.ts
@@ -1,12 +1,22 @@
-// Gmail import excluded — requires OAuth in a browser, not suitable for chat-channel delivery.
-export function buildOnboardingPrompt(): string {
-  return `You are the Index agent. The user has just connected to Index Network via OpenClaw and needs to complete their onboarding. Walk them through the following steps in order. Do not skip steps.
+import type { NodeBranding } from '../../lib/delivery/config.js';
 
+// Gmail import excluded — requires OAuth in a browser, not suitable for chat-channel delivery.
+export function buildOnboardingPrompt(branding?: NodeBranding | null): string {
+  const brandingClause = branding ? buildBrandingClause(branding) : '';
+  const greeting = branding
+    ? `"Hey, I'm Index — welcome to ${branding.nodeName}. I help the right people find you — and help you find them."`
+    : `"Hey, I'm Index. I help the right people find you — and help you find them."`;
+  const closing = branding
+    ? `"You're all set in ${branding.nodeName}. I'll keep an eye out for relevant people in the background — you'll hear from me when something comes up."`
+    : `"You're all set. I'll keep an eye out for relevant people in the background — you'll hear from me when something comes up."`;
+
+  return `You are the Index agent. The user has just connected to Index Network via OpenClaw and needs to complete their onboarding. Walk them through the following steps in order. Do not skip steps.
+${brandingClause}
 ## Onboarding Flow
 
 ### Step 1 — Greet and create profile
-- Greet the user warmly: "Hey, I'm Index. I help the right people find you — and help you find them."
-- Briefly explain what Index does: learn about them, find relevant people, surface connections in the background.
+- Greet the user warmly: ${greeting}
+- Briefly explain what Index does${branding ? ` in the context of ${branding.nodeName}` : ''}: learn about them, find relevant people, surface connections in the background.
 - Call \`create_user_profile()\` with no arguments to look up their public profile from their name and email.
 - While processing, narrate: "> Looking you up…"
 - Present the profile summary naturally: "Here's what I found: [summary]. Does that sound right?"
@@ -26,23 +36,37 @@ export function buildOnboardingPrompt(): string {
 
 ### Step 3 — Intent capture
 - Ask: "Now tell me — what are you open to right now? Building something together, thinking through a problem, exploring partnerships, hiring, or raising?"
-- When they respond, call \`create_intent(description="[their response]")\`.
-- Briefly acknowledge the intent was saved: "Got it — I'll keep an eye out for relevant people."
+- When they respond, call \`create_intent(description="[their response]")\` ONCE. If the call returns an error or the intent is rejected as too vague, ask the user a single clarifying follow-up question — do NOT silently retry \`create_intent\` with a paraphrased version. Each call runs a multi-stage LLM verification graph and silent retries make onboarding feel hung for tens of seconds.
+- Once \`create_intent\` succeeds, briefly acknowledge: "Got it — I'll keep an eye out for relevant people."
 
-### Step 4 — Initial match
-- Call \`create_opportunities(searchQuery="[the intent description from Step 3]")\` to surface initial matches.
-- If matches found, present them naturally: "I already found some relevant people based on what you're looking for."
-- If no matches: "No matches yet, but I'll keep looking in the background."
-
-### Step 5 — Complete onboarding
+### Step 4 — Complete onboarding
 - Call \`complete_onboarding()\`. This is required — do not skip it.
-- Close with: "You're all set. I'll keep an eye out for more relevant people — you'll hear from me when something comes up."
+- Close with: ${closing}
 
 ## Rules
 - Do not skip steps or reorder them.
 - Do not mention Gmail or email import — they are not available in this flow.
 - If the user tries to do something else mid-onboarding, gently redirect: "Let's finish setting you up first, then we can dive into that."
 - Keep your tone warm, direct, and concise.
-- Only call \`complete_onboarding()\` at Step 5 — never earlier.
+- Only call \`complete_onboarding()\` at Step 4 — never earlier.
+- **Never call \`create_opportunities\`, \`list_opportunities\`, or any other discovery tool during onboarding.** Onboarding ends at \`complete_onboarding()\`; matches surface later through ambient polling. Inline discovery here adds latency and produces empty results for fresh users.
+- Call \`create_intent\` at most once per user response. If verification rejects an intent, ask one clarifying question instead of paraphrasing and retrying.${branding ? `
+- You are operating on behalf of the **${branding.nodeName}** community. When you greet, acknowledge, or close, frame it around ${branding.nodeName} (not the generic "Index Network"). Do not invite the user to other communities — they are scoped to ${branding.nodeName}.` : ''}
 `;
+}
+
+function normalizeField(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function buildBrandingClause(branding: NodeBranding): string {
+  const name = normalizeField(branding.nodeName);
+  const parts = [`\nCOMMUNITY CONTEXT: This onboarding is for the "${name}" community on Index Network. Frame greetings, acknowledgements, and the close around ${name}.`];
+  if (branding.nodeDescription) {
+    parts.push(normalizeField(branding.nodeDescription));
+  }
+  if (branding.nodeContext) {
+    parts.push(normalizeField(branding.nodeContext));
+  }
+  return parts.join(' ') + '\n';
 }


### PR DESCRIPTION
## Summary

Two issues observed while testing experiment-network invitee onboarding through Telegram:

1. **Inline \`create_opportunities\` during onboarding** — Step 4 of the OpenClaw onboarding prompt fired \`create_opportunities\` after intent capture. For a fresh invitee this is wasted compute (no peers yet) and adds tens of seconds of LLM-graph latency. The user's transcript also showed 3× silent \`create_intent\` retries when the first call's verifier rejected "I am looking for work" as too vague — onboarding hung for ~2 minutes.

2. **Welcome message ignored node branding** — \`welcome.watcher\` already passed \`branding\` (nodeName / nodeDescription / nodeContext) to \`buildMainAgentPrompt\`, but the \`contentType: 'welcome'\` per-type instruction never told the LLM to use it. Result: "Welcome to Index, Yanek!" instead of the spec'd "Welcome to {nodeName}" form from IND-247.

## Bug Fixes

- **\`packages/openclaw-plugin/src/polling/onboarding/onboarding.prompt.ts\`**
  - Removed Step 4 (Initial match / \`create_opportunities\`) entirely. Onboarding ends at \`complete_onboarding()\`; discovery happens through the existing welcome.watcher → ambient-discovery flow.
  - Tightened Step 3: \`create_intent\` is called ONCE per user response. If verification rejects as too vague, ask one clarifying question — never silently paraphrase-and-retry.
  - Added branding parameter (\`NodeBranding\`) so the onboarding greeting and close are node-anchored when branding is configured. Unbranded fallback unchanged.

- **\`packages/openclaw-plugin/src/lib/delivery/main-agent.prompt.ts\`**
  - \`buildBrandingClause\` now directs the LLM to use the literal community name verbatim and labels description/context-note as paraphrase sources for the welcome opener.
  - \`welcome\` per-type instruction mandates an explicit \`"Welcome to {COMMUNITY_NAME}"\` opener on its own line plus a branding-anchored second paragraph that bridges into the two-section layout.

- **\`packages/openclaw-plugin/src/index.ts\`**
  - \`dispatchOnboardingIfNeeded\` reads branding from plugin config via the existing \`readNodeBranding\` helper and threads it into \`buildOnboardingPrompt\`.

## Tests

All 183 plugin tests still pass. The existing \`buildMainAgentPrompt\` branding tests stay green (the new instruction wording avoids the "COMMUNITY CONTEXT" literal so the negative-case test continues to pass).

## Versions

- \`@indexnetwork/openclaw-plugin\`: 0.29.3 → 0.29.4 (both \`package.json\` and \`openclaw.plugin.json\`).

## Test plan

- [ ] After publish + reinstall, fresh invitee onboards through Telegram. Onboarding flow stops at \`complete_onboarding()\` — no \`create_opportunities\` call. Single \`create_intent\` per user response.
- [ ] Welcome.watcher fires within ~15s of onboarding completion. Welcome message opens with \`"Welcome to {nodeName}"\` (e.g. "Welcome to Experia"), not "Welcome to Index".
- [ ] Second paragraph paraphrases \`nodeDescription\` and bridges into the existing "N conversations waiting" / "Help your community" sections.

## Out of scope (note for follow-up)

- "No further response from me." — emitted by OpenClaw runtime when the agent has nothing to say after onboarding completes. Not in our codebase; needs OpenClaw-side fix.