### PR TITLE
fix(openclaw-plugin): drop welcomeSent flag, always poll until dispatch

### DIFF
--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "indexnetwork-openclaw-plugin",
   "name": "Index Network",
   "description": "Index Network — find the right people and let them find you. Registers the Index Network MCP server on first use and hands off to its guidance.",
-  "version": "0.29.4",
+  "version": "0.29.5",
   "configSchema": {
     "type": "object",
     "properties": {

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/openclaw-plugin",
-  "version": "0.29.4",
+  "version": "0.29.5",
   "description": "Index Network — OpenClaw plugin. Find the right people and let them find you.",
   "license": "MIT",
   "private": false,

--- a/packages/openclaw-plugin/src/lib/delivery/config.ts
+++ b/packages/openclaw-plugin/src/lib/delivery/config.ts
@@ -13,28 +13,6 @@ export function readMainAgentToolUse(api: OpenClawPluginApi): MainAgentToolUse {
   return v === 'enabled' ? 'enabled' : 'disabled';
 }
 
-/**
- * Reads `welcomeSent` from plugin config. Defaults to `false`;
- * only the literal boolean `true` indicates welcome has been sent.
- *
- * @param api - OpenClaw plugin API instance.
- * @returns `true` if welcome has been sent, `false` otherwise.
- */
-export function readWelcomeSent(api: OpenClawPluginApi): boolean {
-  const v = api.pluginConfig['welcomeSent'];
-  return v === true;
-}
-
-/**
- * Writes `welcomeSent = true` to plugin config. Used after successful
- * welcome dispatch to prevent re-sending.
- *
- * @param api - OpenClaw plugin API instance.
- */
-export function writeWelcomeSent(api: OpenClawPluginApi): void {
-  api.pluginConfig['welcomeSent'] = true;
-}
-
 /** Branding fields optionally set in plugin config. */
 export interface NodeBranding {
   nodeName: string;

--- a/packages/openclaw-plugin/src/polling/welcome/welcome.watcher.ts
+++ b/packages/openclaw-plugin/src/polling/welcome/welcome.watcher.ts
@@ -4,18 +4,23 @@
  *
  * Lifecycle:
  * 1. Called from `register()` in index.ts after the onboarding dispatch.
- * 2. On start, checks `readWelcomeSent()` — if already true, returns (no-op).
- * 3. Sets a 15-second interval that:
- *    - Calls `isOnboardingComplete()`
- *    - If false → no-op, wait for next tick
- *    - If true → dispatch welcome, write `welcomeSent`, clear interval and exit
- * 4. Self-terminates after successful dispatch or if `welcomeSent` is found true.
+ * 2. Sets a 15-second polling interval. Each tick:
+ *    - Calls `isOnboardingComplete()`.
+ *    - If false → no-op, wait for next tick.
+ *    - If true → dispatch welcome and clear the interval.
+ * 3. Self-terminates after one successful dispatch (per plugin process).
+ *
+ * Dedup is delegated to the dispatcher's per-day idempotency key. There is
+ * deliberately no persistent `welcomeSent` flag in plugin config: a stale
+ * `true` value from a previous onboarding cycle would silently suppress every
+ * future welcome on the same plugin install, which is more painful than the
+ * cost of a duplicate idempotent dispatch.
  */
 
 import type { OpenClawPluginApi } from '../../lib/openclaw/plugin-api.js';
 import { dispatchToMainAgent } from '../../lib/delivery/main-agent.dispatcher.js';
 import { buildMainAgentPrompt } from '../../lib/delivery/main-agent.prompt.js';
-import { readMainAgentToolUse, readWelcomeSent, writeWelcomeSent, readNodeBranding } from '../../lib/delivery/config.js';
+import { readMainAgentToolUse, readNodeBranding } from '../../lib/delivery/config.js';
 import { fetchConnectToken } from '../../lib/utils/connect-token.js';
 import { isOnboardingComplete } from '../onboarding/onboarding.status.js';
 
@@ -32,20 +37,13 @@ const POLL_INTERVAL_MS = 15_000; // 15 seconds
 let intervalHandle: NodeJS.Timeout | undefined;
 
 /**
- * Starts the welcome watcher. Returns immediately if welcomeSent is already true.
- * Otherwise, sets up a 15-second polling interval that checks onboarding completion
- * and dispatches the welcome message when ready.
+ * Starts the welcome watcher. Sets up a 15-second polling interval; the
+ * per-tick logic decides whether to dispatch.
  */
 export async function start(
   api: OpenClawPluginApi,
   config: WelcomeWatcherConfig,
 ): Promise<void> {
-  // If welcome was already sent, nothing to do.
-  if (readWelcomeSent(api)) {
-    api.logger.debug('Welcome already sent, skipping watcher.');
-    return;
-  }
-
   api.logger.debug('Starting welcome watcher.');
 
   intervalHandle = setInterval(() => void _tick(api, config), POLL_INTERVAL_MS);
@@ -73,8 +71,7 @@ export async function _tick(
     clearInterval(intervalHandle);
     intervalHandle = undefined;
 
-    const ok = await dispatchWelcome(api, config);
-    if (ok) writeWelcomeSent(api);
+    await dispatchWelcome(api, config);
   } catch (err) {
     api.logger.warn(
       `Welcome watcher tick errored: ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/openclaw-plugin/src/tests/welcome.watcher.spec.ts
+++ b/packages/openclaw-plugin/src/tests/welcome.watcher.spec.ts
@@ -98,24 +98,13 @@ describe('welcome watcher', () => {
     welcomeWatcher._resetForTesting();
   });
 
-  it('skips immediately if welcomeSent is already true', async () => {
-    mockApi.pluginConfig['welcomeSent'] = true;
-    mockBackend(false, []);
-
-    await welcomeWatcher.start(mockApi, cfg);
-
-    const debugCalls = mockApi.logger.debug.mock.calls.map((c) => c[0]);
-    expect(debugCalls.some((c) => typeof c === 'string' && c.includes('already sent'))).toBe(true);
-  });
-
-  it('starts polling when welcomeSent is false', async () => {
+  it('starts polling unconditionally', async () => {
     mockBackend(false, []);
 
     await welcomeWatcher.start(mockApi, cfg);
 
     const debugCalls = mockApi.logger.debug.mock.calls.map((c) => c[0]);
     expect(debugCalls.some((c) => typeof c === 'string' && c.includes('welcome watcher'))).toBe(true);
-    expect(mockApi.pluginConfig['welcomeSent']).not.toBe(true);
   });
 
   it('tick does nothing when onboarding is not complete', async () => {
@@ -123,12 +112,11 @@ describe('welcome watcher', () => {
 
     await welcomeWatcher._tick(mockApi, cfg);
 
-    expect(mockApi.pluginConfig['welcomeSent']).not.toBe(true);
     const debugCalls = mockApi.logger.debug.mock.calls.map((c) => c[0]);
     expect(debugCalls.some((c) => typeof c === 'string' && c.includes('not yet complete'))).toBe(true);
   });
 
-  it('dispatches welcome with zero candidates and writes welcomeSent', async () => {
+  it('dispatches welcome with zero candidates', async () => {
     const sink = mockBackend(true, []);
 
     await welcomeWatcher._tick(mockApi, cfg);
@@ -139,7 +127,6 @@ describe('welcome watcher', () => {
     const msg = sink.hookCalls[0].body?.message;
     expect(typeof msg).toBe('string');
     expect(msg as string).toContain('WELCOME');
-    expect(mockApi.pluginConfig['welcomeSent']).toBe(true);
   });
 
   it('dispatches welcome with candidates including connect tokens', async () => {
@@ -176,7 +163,6 @@ describe('welcome watcher', () => {
     expect(msg).toContain('mock-jwt-token');
     expect(msg).toContain('/u/user-alice');
     expect(msg).toContain('/u/user-bob');
-    expect(mockApi.pluginConfig['welcomeSent']).toBe(true);
   });
 
   it('filters out opportunities without counterpartUserId', async () => {
@@ -210,15 +196,13 @@ describe('welcome watcher', () => {
     const msg = sink.hookCalls[0].body?.message as string;
     expect(msg).toContain('Bob does ML');
     expect(msg).not.toContain('No counterpart');
-    expect(mockApi.pluginConfig['welcomeSent']).toBe(true);
   });
 
-  it('does not write welcomeSent when hook dispatch returns non-2xx', async () => {
+  it('logs a warning when hook dispatch returns non-2xx', async () => {
     mockBackend(true, [], 500);
 
     await welcomeWatcher._tick(mockApi, cfg);
 
-    expect(mockApi.pluginConfig['welcomeSent']).not.toBe(true);
     const warnCalls = mockApi.logger.warn.mock.calls.map((c) => c[0]);
     expect(warnCalls.some((c) => typeof c === 'string' && c.includes('dispatch failed'))).toBe(true);
   });


### PR DESCRIPTION
## Summary

The welcome.watcher gated on a persistent \`welcomeSent\` plugin-config flag. If \`welcomeSent: true\` at start, the watcher skipped polling entirely and never dispatched a fresh welcome on re-onboarding. The flag also masked dispatch failures (silent no-op + flag stays false → next start tries again, but if anything is wrong with the plugin config the user just sees nothing).

Reproduced: experiment-network invitee finishes onboarding; welcome.watcher dispatches a welcome successfully (or fails silently). User re-onboards against the same plugin install; watcher sees the stale flag (or its absence with another stuck state) and never re-arms.

## Bug Fixes

- Removed \`readWelcomeSent\` / \`writeWelcomeSent\` from \`packages/openclaw-plugin/src/lib/delivery/config.ts\`.
- \`welcome.watcher.ts\` now starts unconditionally, polls every 15s, and dispatches on the first observed onboarding completion. After dispatch, it clears its interval (per-process) and exits.
- Dedup is delegated to the dispatcher's existing per-day idempotency key: \`index:delivery:welcome:${agentId}:${YYYY-MM-DD}\`. Same-day duplicates remain prevented; cross-restart, cross-cycle behaviour now does the right thing (re-fire on a new onboarding cycle).

## Tests

\`packages/openclaw-plugin/src/tests/welcome.watcher.spec.ts\` updated:
- Dropped \`welcomeSent\`-set assertions from dispatch tests.
- Replaced "skips when welcomeSent already true" with "starts polling unconditionally".
- Kept not-complete / candidate-rendering / counterpart-filter / hook-failure paths.

All 182 plugin tests pass.

## Versions

- \`@indexnetwork/openclaw-plugin\`: 0.29.4 → 0.29.5 (both \`package.json\` and \`openclaw.plugin.json\`).

## Test plan

- [ ] Fresh experiment-network invitee onboards via Telegram; welcome dispatches within ~15s of \`complete_onboarding()\`. Welcome opens with "Welcome to {nodeName}" per the per-type instruction landed in #755.
- [ ] Repeating the test against the same plugin install with a different invitee (or the same user re-onboarded) — welcome still fires.