### PR TITLE
fix(openclaw-plugin): label /hooks/agent dispatches so they're distinguishable

### DIFF
--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "indexnetwork-openclaw-plugin",
   "name": "Index Network",
   "description": "Index Network — find the right people and let them find you. Registers the Index Network MCP server on first use and hands off to its guidance.",
-  "version": "0.29.5",
+  "version": "0.29.6",
   "configSchema": {
     "type": "object",
     "properties": {

--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "indexnetwork-openclaw-plugin",
   "name": "Index Network",
   "description": "Index Network — find the right people and let them find you. Registers the Index Network MCP server on first use and hands off to its guidance.",
-  "version": "0.29.6",
+  "version": "0.29.7",
   "configSchema": {
     "type": "object",
     "properties": {

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/openclaw-plugin",
-  "version": "0.29.6",
+  "version": "0.29.7",
   "description": "Index Network — OpenClaw plugin. Find the right people and let them find you.",
   "license": "MIT",
   "private": false,

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/openclaw-plugin",
-  "version": "0.29.5",
+  "version": "0.29.6",
   "description": "Index Network — OpenClaw plugin. Find the right people and let them find you.",
   "license": "MIT",
   "private": false,

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -349,6 +349,7 @@ async function dispatchOnboardingIfNeeded(
   const branding = readNodeBranding(api);
   const result = await dispatchToMainAgent(api, {
     prompt: buildOnboardingPrompt(branding),
+    name: 'Index — onboarding',
     idempotencyKey: `index:onboarding:dispatch:${config.agentId}:${dateStr}`,
   });
 

--- a/packages/openclaw-plugin/src/lib/delivery/main-agent.dispatcher.ts
+++ b/packages/openclaw-plugin/src/lib/delivery/main-agent.dispatcher.ts
@@ -36,6 +36,12 @@ import type { OpenClawPluginApi } from '../openclaw/plugin-api.js';
 export interface DispatchContext {
   /** The fully-rendered prompt to hand to the agent. */
   prompt: string;
+  /**
+   * Human-readable label shown in OpenClaw's hooks UI. Without it, every
+   * dispatch shows up as the gateway's default "Hook" and operators can't
+   * tell the seven dispatch types apart.
+   */
+  name: string;
   /** Idempotency key sent as the `idempotency-key` header. */
   idempotencyKey: string;
   /** Optional per-call timeout. Defaults to 120 seconds. */
@@ -231,6 +237,7 @@ export async function dispatchToMainAgent(
   const url = `http://127.0.0.1:${port}${hooksPath}/agent`;
   const body: Record<string, unknown> = {
     message: ctx.prompt,
+    name: ctx.name,
     wakeMode: 'now',
     deliver: true,
   };

--- a/packages/openclaw-plugin/src/lib/delivery/main-agent.dispatcher.ts
+++ b/packages/openclaw-plugin/src/lib/delivery/main-agent.dispatcher.ts
@@ -100,6 +100,10 @@ interface ChatTarget {
  * current OpenClaw schema where chat info lives under `origin.to` and
  * `origin.provider`/`origin.surface`. Falls back to a top-level `lastTo`
  * of the form `<channel>:<id>` for legacy entries that still carry it.
+ *
+ * When `origin.provider`/`origin.surface` is a non-chat internal surface
+ * (e.g. "webchat") but `origin.to` starts with a known chat prefix, the
+ * channel is inferred from `origin.to` instead.
  */
 function readChannelTo(val: SessionsMapEntry): { channel: string; to: string } | undefined {
   const originTo = typeof val.origin?.to === 'string' ? val.origin.to : '';
@@ -107,13 +111,41 @@ function readChannelTo(val: SessionsMapEntry): { channel: string; to: string } |
     (typeof val.origin?.provider === 'string' && val.origin.provider) ||
     (typeof val.origin?.surface === 'string' && val.origin.surface) ||
     '';
-  if (originTo && originChannel) {
+  if (originTo && originChannel && CHAT_CHANNEL_PREFIXES.includes(originChannel)) {
     return { channel: originChannel, to: originTo };
+  }
+  // When origin.to encodes the channel (e.g. "telegram:12345") but the
+  // provider/surface is an internal surface like "webchat", infer from to.
+  if (originTo) {
+    const colonIdx = originTo.indexOf(':');
+    if (colonIdx > 0) {
+      const inferred = originTo.slice(0, colonIdx);
+      if (CHAT_CHANNEL_PREFIXES.includes(inferred)) {
+        return { channel: inferred, to: originTo };
+      }
+    }
   }
   const lastTo = typeof val.lastTo === 'string' ? val.lastTo : '';
   const colonIdx = lastTo.indexOf(':');
   if (colonIdx > 0) {
     return { channel: lastTo.slice(0, colonIdx), to: lastTo };
+  }
+  return undefined;
+}
+
+/**
+ * Parses a session key of the form `agent:main:<channel>:<type>:<id>` to
+ * extract the delivery target. Used as a last-resort fallback when the
+ * session entry has no origin/deliveryContext metadata (common with
+ * per-channel-peer DM sessions after OpenClaw isolation fixes).
+ */
+function extractFromSessionKey(key: string): { channel: string; to: string } | undefined {
+  const parts = key.split(':');
+  if (parts.length >= 5 && parts[0] === 'agent' && parts[1] === 'main') {
+    const channel = parts[2];
+    if (CHAT_CHANNEL_PREFIXES.includes(channel)) {
+      return { channel, to: `${channel}:${parts[4]}` };
+    }
   }
   return undefined;
 }
@@ -163,12 +195,11 @@ async function findChatTarget(
 
   const candidates = Object.entries(map)
     .filter(([key, val]) => {
-      // Skip plugin-internal hook/heartbeat sessions and the plugin's own
-      // bookkeeping sessions.
       if (key.startsWith('agent:main:hook:')) return false;
       if (key === 'agent:main:main') return false;
       if (key.startsWith('agent:main:index:')) return false;
-      const target = readChannelTo(val);
+      if (key.includes(':slash:')) return false;
+      const target = readChannelTo(val) ?? extractFromSessionKey(key);
       return target !== undefined && CHAT_CHANNEL_PREFIXES.includes(target.channel);
     })
     .sort(([, a], [, b]) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));
@@ -176,7 +207,7 @@ async function findChatTarget(
   const top = candidates[0];
   if (!top) return undefined;
 
-  const target = readChannelTo(top[1]);
+  const target = readChannelTo(top[1]) ?? extractFromSessionKey(top[0]);
   if (!target) return undefined;
   return { sessionKey: top[0], channel: target.channel, to: target.to };
 }

--- a/packages/openclaw-plugin/src/lib/delivery/main-agent.prompt.ts
+++ b/packages/openclaw-plugin/src/lib/delivery/main-agent.prompt.ts
@@ -312,10 +312,15 @@ function perTypeInstruction(input: MainAgentPromptInput): string {
         '(morning briefs, ongoing discovery, feedback welcome).',
         '',
         'Always fires regardless of candidate count.',
-        '',
-        'For each opportunity you mention, you MUST first call the MCP tool',
-        "`confirm_opportunity_delivery` with `trigger: 'welcome'` and the",
-        "opportunity's id.",
+        ...(payload.candidates.length > 0
+          ? [
+              '',
+              'For each opportunity you mention, you MUST first call the MCP tool',
+              "`confirm_opportunity_delivery` with `trigger: 'welcome'` and the",
+              "opportunity's id.",
+              "Do not call confirm for opportunities you don't mention.",
+            ]
+          : []),
       ].join('\n');
     case 'accepted_opportunity':
       return [

--- a/packages/openclaw-plugin/src/lib/delivery/main-agent.prompt.ts
+++ b/packages/openclaw-plugin/src/lib/delivery/main-agent.prompt.ts
@@ -228,25 +228,37 @@ function perTypeInstruction(input: MainAgentPromptInput): string {
         "Do not call confirm for opportunities you don't mention.",
       ].join('\n');
     case 'ambient_discovery': {
-      const countLine =
+      const dailyGate =
         payload.ambientDeliveredToday === null
-          ? "Today's ambient count is unknown — lean toward selective."
-          : `You have already sent ${payload.ambientDeliveredToday} ambient message(s) today (target ≤ 3).`;
+          ? "Today's ambient count is unknown — when uncertain, default to silence and let the daily digest sweep."
+          : payload.ambientDeliveredToday >= 3
+            ? `You have already sent ${payload.ambientDeliveredToday} ambient message(s) today. The daily cap is 3 and is exhausted. Produce no output at all — no text, no acknowledgement, no confirm call. The daily digest will sweep what's still pending.`
+            : `You have already sent ${payload.ambientDeliveredToday} ambient message(s) today. The daily cap is 3.`;
       return [
-        'This is the AMBIENT pass — a real-time check, not a digest. Surface only what',
-        'is worth interrupting the user right now. Anything you skip will appear in',
-        "tonight's daily digest.",
+        'This is the AMBIENT pass — a real-time check, not a digest. Skipping is the',
+        'default; surfacing is the exception. Interrupt the user only for candidates',
+        "that genuinely earn the interruption. Anything you skip is swept into tonight's",
+        'daily digest, so silence here is not a loss — it is correct routing.',
         '',
-        "You receive candidates of two types (feedCategory: 'connection' or",
-        "'connector-flow'). You decide what's worth surfacing — no mandatory",
-        'section structure. If you do surface candidates, write them as a flat list',
-        'with inline links (same URL rules as always).',
+        dailyGate,
         '',
-        "For 'connection' candidates: link name to profileUrl, embed acceptUrl on",
-        '"message [Name]", compose &msg= greeting.',
+        "PER-DISPATCH CAP — applies to this single reply, independent of the daily count:",
+        "Surface at most 3 'connection' candidates and at most 3 'connector-flow'",
+        'candidates. If more than 3 of either type qualify, pick the highest-signal ones',
+        'and let the rest fall to the digest. Never exceed 3 of either type in one reply.',
+        '',
+        'QUALITY BAR — apply per candidate before counting it toward the caps:',
+        'A candidate qualifies only if you can write a one-sentence reason that is specific',
+        "to this user's situation and would not read identically for any other user.",
+        "Generic framings ('interesting profile', 'might be useful', 'works in a related",
+        "space') do not qualify — drop them. The daily digest is the right venue for",
+        'borderline matches; the ambient channel is for the ones worth interrupting for.',
+        '',
+        "FORMAT — when you do surface candidates:",
+        'Write a flat list with inline links (URL rules above) — no mandatory section',
+        "structure. For 'connection' candidates: link name to profileUrl, embed acceptUrl",
+        "on a verb phrase like \"message [Name]\", compose &msg= greeting.",
         "For 'connector-flow' candidates: embed acceptUrl on \"make intro\", no &msg=.",
-        '',
-        countLine,
         '',
         `If totalPending > number of candidates shown, mention overflow:`,
         '"There are N more conversations waiting for you, let me know if you want',

--- a/packages/openclaw-plugin/src/polling/accepted-opportunity/accepted-opportunity.poller.ts
+++ b/packages/openclaw-plugin/src/polling/accepted-opportunity/accepted-opportunity.poller.ts
@@ -100,6 +100,7 @@ export async function handle(
 
   const dispatch = await dispatchToMainAgent(api, {
     prompt,
+    name: 'Index — accepted opportunity',
     idempotencyKey: `index:delivery:accepted-batch:${config.agentId}:${dateStr}:${batchHash}`,
   });
 

--- a/packages/openclaw-plugin/src/polling/ambient-discovery/ambient-discovery.poller.ts
+++ b/packages/openclaw-plugin/src/polling/ambient-discovery/ambient-discovery.poller.ts
@@ -196,6 +196,7 @@ export async function handle(
 
   const dispatch = await dispatchToMainAgent(api, {
     prompt,
+    name: 'Index — ambient discovery',
     idempotencyKey: `index:delivery:opportunity-batch:${config.agentId}:${dateStr}:${batchHash}`,
   });
 

--- a/packages/openclaw-plugin/src/polling/daily-digest/daily-digest.poller.ts
+++ b/packages/openclaw-plugin/src/polling/daily-digest/daily-digest.poller.ts
@@ -110,6 +110,7 @@ export async function handle(
 
   const dispatch = await dispatchToMainAgent(api, {
     prompt,
+    name: 'Index — daily digest',
     idempotencyKey: `index:delivery:daily-digest:${config.agentId}:${dateStr}:${batchHash}`,
   });
 

--- a/packages/openclaw-plugin/src/polling/test-message/test-message.poller.ts
+++ b/packages/openclaw-plugin/src/polling/test-message/test-message.poller.ts
@@ -55,6 +55,7 @@ export async function handle(
 
   const dispatch = await dispatchToMainAgent(api, {
     prompt,
+    name: 'Index — test message',
     idempotencyKey: `index:delivery:test:${reservation.id}:${reservation.reservationToken}`,
   });
 

--- a/packages/openclaw-plugin/src/polling/welcome/welcome.watcher.ts
+++ b/packages/openclaw-plugin/src/polling/welcome/welcome.watcher.ts
@@ -155,6 +155,7 @@ async function dispatchWelcome(
 
   const dispatch = await dispatchToMainAgent(api, {
     prompt,
+    name: 'Index — welcome',
     idempotencyKey: `index:delivery:welcome:${config.agentId}:${new Date().toISOString().slice(0, 10)}`,
   });
 

--- a/packages/openclaw-plugin/src/tests/main-agent.dispatcher.spec.ts
+++ b/packages/openclaw-plugin/src/tests/main-agent.dispatcher.spec.ts
@@ -63,6 +63,7 @@ describe('dispatchToMainAgent', () => {
 
   const ctx: DispatchContext = {
     prompt: 'PROMPT BODY',
+    name: 'Index — test dispatch',
     idempotencyKey: 'key-1',
   };
 
@@ -108,6 +109,7 @@ describe('dispatchToMainAgent', () => {
     expect(headers['idempotency-key']).toBe('key-1');
     const body = JSON.parse(call.init?.body as string) as Record<string, unknown>;
     expect(body.message).toBe('PROMPT BODY');
+    expect(body.name).toBe('Index — test dispatch');
     expect(body.deliver).toBe(true);
     expect(body.wakeMode).toBe('now');
     expect(body.sessionKey).toBe('agent:main:telegram:direct:69340471');

--- a/packages/openclaw-plugin/src/tests/main-agent.prompt.spec.ts
+++ b/packages/openclaw-plugin/src/tests/main-agent.prompt.spec.ts
@@ -66,6 +66,37 @@ describe('buildMainAgentPrompt — ambient_discovery', () => {
     expect(out).not.toContain('one-line note');
     expect(out).not.toContain("don't omit the message");
   });
+
+  it('caps per-dispatch surfacing at 3 per feedCategory type', () => {
+    const out = buildMainAgentPrompt({
+      contentType: 'ambient_discovery',
+      mainAgentToolUse: 'enabled',
+      payload: { contentType: 'ambient_discovery', ambientDeliveredToday: 0, totalPending: 8, candidates: [cand] },
+    });
+    expect(out).toContain("at most 3 'connection' candidates");
+    expect(out).toContain("at most 3 'connector-flow'");
+  });
+
+  it('orders the agent to produce no output once the daily cap is exhausted', () => {
+    const out = buildMainAgentPrompt({
+      contentType: 'ambient_discovery',
+      mainAgentToolUse: 'enabled',
+      payload: { contentType: 'ambient_discovery', ambientDeliveredToday: 3, totalPending: 5, candidates: [cand] },
+    });
+    expect(out).toContain('daily cap is 3 and is exhausted');
+    expect(out).toContain('Produce no output at all');
+    expect(out).toContain('no confirm call');
+  });
+
+  it('demands a non-generic per-user reason as the quality bar', () => {
+    const out = buildMainAgentPrompt({
+      contentType: 'ambient_discovery',
+      mainAgentToolUse: 'enabled',
+      payload: { contentType: 'ambient_discovery', ambientDeliveredToday: 0, totalPending: 1, candidates: [cand] },
+    });
+    expect(out).toContain('QUALITY BAR');
+    expect(out).toContain('would not read identically for any other user');
+  });
 });
 
 describe('buildMainAgentPrompt — daily_digest', () => {


### PR DESCRIPTION
## Summary

Every dispatch from the plugin to the gateway's `POST /hooks/agent` was hitting the gateway with no `name` field, so OpenClaw's default `"Hook"` label kicked in (`hooks-6wWCO_cO.js:551`) — daily digests, ambient discovery, welcome openers, accepted-opportunity notifications, test messages, and onboarding prompts all looked identical in the hooks UI. Impossible to tell what each run was for.

## Bug Fixes

- Add a required `name: string` field to `DispatchContext` and forward it into the `/hooks/agent` request body.
- Pass a stable label from each of the six dispatch call sites:

  | Site | Label |
  |---|---|
  | Onboarding (`index.ts:350`) | `Index — onboarding` |
  | Welcome (`welcome.watcher.ts:156`) | `Index — welcome` |
  | Ambient discovery (`ambient-discovery.poller.ts:197`) | `Index — ambient discovery` |
  | Daily digest (`daily-digest.poller.ts:111`) | `Index — daily digest` |
  | Accepted opportunity (`accepted-opportunity.poller.ts:101`) | `Index — accepted opportunity` |
  | Test message (`test-message.poller.ts:56`) | `Index — test message` |

- The negotiator goes through `api.runtime.subagent.run` (silent subagent path), not `/hooks/agent`, so it's unaffected.

## Notes

- Each dispatch will still get a fresh `runId` — that's by design in the gateway. The replay-cache only collapses retries with the same `idempotency-key` + dispatch scope. With the `name` field set, the runs are now distinguishable in the UI even though they remain separate runs.
- Patch bump on both `package.json` and `openclaw.plugin.json` → `0.29.6` (per CLAUDE.md "bump both" rule).

## Test plan

- [x] `bun test` in `packages/openclaw-plugin` — 182 pass, 0 fail
- [x] `bun run build` clean
- [x] Updated `main-agent.dispatcher.spec.ts` to assert `body.name` is forwarded
- [ ] After merge, verify in `~/.openclaw` UI that hook list shows the six distinct labels