### PR TITLE
fix(protocol): mint actionable connect-links + stop UUID exposure in MCP

### DIFF
--- a/backend/src/services/opportunity-delivery.service.ts
+++ b/backend/src/services/opportunity-delivery.service.ts
@@ -30,7 +30,7 @@ import { RedisCacheAdapter } from '../adapters/cache.adapter';
 import { chatDatabaseAdapter } from '../adapters/database.adapter';
 import db from '../lib/drizzle/drizzle';
 import { log } from '../lib/log';
-import { normalizeTelegramHandle } from '../lib/utils/telegram-handle';
+import { normalizeTelegramHandle } from '@indexnetwork/protocol';
 import { conversations } from '../schemas/conversation.schema';
 import { agents, opportunities, opportunityDeliveries, userSocials, users } from '../schemas/database.schema';
 

--- a/backend/src/services/opportunity.service.ts
+++ b/backend/src/services/opportunity.service.ts
@@ -11,7 +11,7 @@ import { RedisCacheAdapter } from '../adapters/cache.adapter';
 import { opportunityQueue } from '../queues/opportunity.queue';
 import db from '../lib/drizzle/drizzle';
 import { userSocials } from '../schemas/database.schema';
-import { normalizeTelegramHandle } from '../lib/utils/telegram-handle';
+import { normalizeTelegramHandle } from '@indexnetwork/protocol';
 
 const logger = log.service.from("OpportunityService");
 

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -127,6 +127,7 @@ export {
 export { createToolRegistry } from "./shared/agent/tool.registry.js";
 export { createAgentTools } from './agent/agent.tools.js';
 export { AMBIENT_PARK_WINDOW_MS } from './negotiation/negotiation.tools.js';
+export { normalizeTelegramHandle } from './shared/utils/telegram-handle.js';
 
 // ─── MCP ──────────────────────────────────────────────────────────────────────
 

--- a/packages/protocol/src/opportunity/opportunity.discover.ts
+++ b/packages/protocol/src/opportunity/opportunity.discover.ts
@@ -9,7 +9,7 @@
  * Used by the discover_opportunities chat tool.
  */
 
-import type { Opportunity, ChatGraphCompositeDatabase } from "../shared/interfaces/database.interface.js";
+import type { Opportunity, ChatGraphCompositeDatabase, UserRecord } from "../shared/interfaces/database.interface.js";
 import type { Cache } from "../shared/interfaces/cache.interface.js";
 import type { OpportunityGraphOptions, CandidateMatch } from "./opportunity.state.js";
 import {
@@ -104,6 +104,10 @@ export interface FormattedDiscoveryCandidate {
   homeCardPresentation?: HomeCardPresentationResult;
   /** Viewer's role in this opportunity. */
   viewerRole?: string;
+  /** Whether the viewer (as introducer) has approved the introduction. */
+  viewerApproved?: boolean;
+  /** Full user record for the candidate (needed for socials / Telegram fallback). */
+  candidateUser?: UserRecord | null;
   /** Whether the counterpart is a ghost (not yet onboarded) user. */
   isGhost?: boolean;
   /** Narrator chip for home card display (name + remark, with optional avatar/userId for introducer). */
@@ -240,6 +244,8 @@ async function enrichOpportunities(
         opportunity: opp,
         candidateUserId,
         viewerRole: viewerActor?.role ?? "party",
+        viewerApproved: viewerActor?.approved === true,
+        candidateUser,
         profile,
         confidence,
       };
@@ -499,6 +505,8 @@ async function enrichOpportunities(
         score: item.confidence,
         status: chatSessionId && !existingOpportunityIds?.has(item.opportunity.id) ? "draft" : item.opportunity.status,
         viewerRole: item.viewerRole,
+        viewerApproved: item.viewerApproved,
+        candidateUser: item.candidateUser,
         isGhost,
         ...(presentations?.[idx] && { presentation: presentations[idx] }),
         ...(homeCard && {

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -25,8 +25,12 @@ const logger = protocolLogger("ChatTools:Opportunity");
  *
  * - `connect` — pending opp where viewer is a non-introducer party. Clicking
  *   flips the opp to accepted and opens the chat with the counterpart.
- * - `approve_introduction` — draft opp where viewer is an unapproved
- *   introducer. Clicking flips approved=true and triggers negotiation.
+ * - `approve_introduction` — draft or latent opp where viewer is an unapproved
+ *   introducer. Clicking flips approved=true and triggers negotiation. The
+ *   `draft` case comes from `create_opportunities` intro mode; the `latent`
+ *   case comes from background-discovered connector-flow cards surfaced in
+ *   `list_opportunities`. In both, status remains pre-send and the `/c/<code>`
+ *   link is the only MCP path to approve.
  * - `outreach` — accepted opp where viewer is a non-introducer party.
  *   Clicking opens the existing chat (no state change).
  *
@@ -47,7 +51,7 @@ export function resolveActionableLinkKind(input: {
   if (status === "pending") {
     return isIntroducer ? null : "connect";
   }
-  if (status === "draft") {
+  if (status === "draft" || status === "latent") {
     if (!isIntroducer) return null;
     return viewerApproved === true ? null : "approve_introduction";
   }
@@ -965,7 +969,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
               viewerId: context.userId,
               viewerApproved: source?.viewerApproved,
               counterpartUser: source?.candidateUser ?? null,
-              counterpartUserId: card.userId ?? "",
+              counterpartUserId: source?.userId ?? card.userId,
               mintConnectLink,
               frontendUrl: deps.frontendUrl,
             });

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -67,6 +67,8 @@ export function resolveActionableLinkKind(input: {
  * look like URLs (e.g. `"t.me/alice?evil=1"`), contain special characters, or
  * are shorter than 5 chars are treated as invalid and fall through to the web
  * profile URL rather than producing a malformed `t.me` link.
+ *
+ * Trailing slashes on frontendUrl are stripped before concatenation.
  */
 export function buildProfileUrl(
   counterpartUser:
@@ -81,7 +83,10 @@ export function buildProfileUrl(
   );
   const telegramHandle = normalizeTelegramHandle(telegramSocial?.value);
   if (telegramHandle) return `https://t.me/${telegramHandle}`;
-  if (frontendUrl) return `${frontendUrl}/u/${counterpartUserId}?link_preview=false`;
+  if (frontendUrl) {
+    const base = frontendUrl.replace(/\/+$/, "");
+    return `${base}/u/${counterpartUserId}?link_preview=false`;
+  }
   return undefined;
 }
 
@@ -303,10 +308,14 @@ type OpportunityCardLike = Record<string, unknown> & {
  * "include EXACTLY as-is" directive so the frontend card renderer can parse
  * and render interactive cards.
  *
- * MCP (`isMcp=true`): emits prose (name, reason, status, opportunityId per
- * card) with an explicit reminder to synthesize in natural language and not
- * dump raw fields or IDs. MCP clients have no card renderer, so code fences
- * would surface as raw JSON to end users.
+ * MCP (`isMcp=true`): emits prose (name, reason, status, profileUrl when
+ * present, acceptUrl when present, feedCategory when present) and includes
+ * `opportunityId` ONLY for cards without an `acceptUrl` — exposing the UUID
+ * alongside an actionable link gave LLMs a foothold to hallucinate bare
+ * `/api/opportunities/<id>/connect` URLs (see IND-271). The trailing
+ * instruction reminds the agent to synthesize in natural language and never
+ * fabricate URLs for cards that don't have them. MCP clients have no card
+ * renderer, so code fences would surface as raw JSON to end users.
  */
 export function buildOpportunityPresentation(
   cards: OpportunityCardLike[],

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -718,6 +718,22 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
               }
             : {}),
         };
+
+        if (context.isMcp && deps.mintConnectLink) {
+          await attachActionableLinks(cardData as Record<string, unknown> & {
+            opportunityId: string;
+            viewerRole: string;
+            status: string;
+          }, {
+            viewerId: context.userId,
+            viewerApproved: false,
+            counterpartUser,
+            counterpartUserId: firstPartyId,
+            mintConnectLink: deps.mintConnectLink,
+            frontendUrl: deps.frontendUrl,
+          });
+        }
+
         return success({
           found: true,
           count: 1,

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -937,6 +937,27 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
       const displayedCards = allCardData.slice(0, CHAT_DISPLAY_LIMIT);
       const extraFromCap = allCardData.length - displayedCards.length;
 
+      if (context.isMcp && deps.mintConnectLink) {
+        const mintConnectLink = deps.mintConnectLink;
+        await Promise.all(
+          displayedCards.map(async (card, idx) => {
+            const source = result.opportunities?.[idx];
+            await attachActionableLinks(card as Record<string, unknown> & {
+              opportunityId: string;
+              viewerRole: string;
+              status: string;
+            }, {
+              viewerId: context.userId,
+              viewerApproved: source?.viewerApproved,
+              counterpartUser: source?.candidateUser ?? null,
+              counterpartUserId: card.userId ?? "",
+              mintConnectLink,
+              frontendUrl: deps.frontendUrl,
+            });
+          }),
+        );
+      }
+
       let message = buildOpportunityPresentation(displayedCards, {
         isMcp: context.isMcp ?? false,
         leadIn: `Found ${displayedCards.length} potential connection(s).`,

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -13,6 +13,7 @@ import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import type { Opportunity, OpportunityStatus } from "../shared/interfaces/database.interface.js";
 import type { ConnectLinkKind } from "../shared/interfaces/connect-link.interface.js";
 import { selectByComposition } from "./opportunity.utils.js";
+import { normalizeTelegramHandle } from "../shared/utils/telegram-handle.js";
 
 const logger = protocolLogger("ChatTools:Opportunity");
 
@@ -57,6 +58,11 @@ export function resolveActionableLinkKind(input: {
  * Build the agent-facing profile link for a counterpart. Telegram DM if a
  * public handle is on file, otherwise the web profile URL. Returns `undefined`
  * only if no fallback is possible (no Telegram AND no frontendUrl configured).
+ *
+ * Telegram handles are validated via `normalizeTelegramHandle` — values that
+ * look like URLs (e.g. `"t.me/alice?evil=1"`), contain special characters, or
+ * are shorter than 5 chars are treated as invalid and fall through to the web
+ * profile URL rather than producing a malformed `t.me` link.
  */
 export function buildProfileUrl(
   counterpartUser:
@@ -69,7 +75,7 @@ export function buildProfileUrl(
   const telegramSocial = counterpartUser?.socials?.find(
     (s) => s.label?.toLowerCase() === "telegram",
   );
-  const telegramHandle = telegramSocial?.value?.trim().replace(/^@/, "");
+  const telegramHandle = normalizeTelegramHandle(telegramSocial?.value);
   if (telegramHandle) return `https://t.me/${telegramHandle}`;
   if (frontendUrl) return `${frontendUrl}/u/${counterpartUserId}?link_preview=false`;
   return undefined;
@@ -325,7 +331,7 @@ export function buildOpportunityPresentation(
     const hasLinks = cards.some((c) => c.acceptUrl);
     const hasOpportunityIds = cards.some((c) => !c.acceptUrl);
     const linkInstructions = hasLinks
-      ? `Link each person's name to their profileUrl and embed acceptUrl on a short verb phrase (e.g. "message [Name]" for connection, "make intro" for connector-flow). The acceptUrl is opaque and self-contained — embed it verbatim. Do NOT append, encode, or modify any part of any URL. Never render link strips or tables — weave URLs into prose. `
+      ? `For each card that has an acceptUrl, embed it on a short verb phrase (e.g. "message [Name]" for connection, "make intro" for connector-flow). For each card that has a profileUrl, link the person's name to it. Some cards may have neither — render those as plain text and never fabricate URLs for them. The acceptUrl is opaque and self-contained — embed it verbatim. Do NOT append, encode, or modify any part of any URL. Never render link strips or tables — weave URLs into prose. `
       : "";
     const idInstructions = hasOpportunityIds
       ? `Use opportunityId values only when calling update_opportunity (send/accept/reject).`

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -17,6 +17,43 @@ import { selectByComposition } from "./opportunity.utils.js";
 const logger = protocolLogger("ChatTools:Opportunity");
 
 /**
+ * Pure status × role → ConnectLinkKind matrix.
+ *
+ * Returns the kind of short-link the viewer can act on directly, or `null` if
+ * no direct link makes sense for this combination. Non-null kinds map to:
+ *
+ * - `connect` — pending opp where viewer is a non-introducer party. Clicking
+ *   flips the opp to accepted and opens the chat with the counterpart.
+ * - `approve_introduction` — draft opp where viewer is an unapproved
+ *   introducer. Clicking flips approved=true and triggers negotiation.
+ * - `outreach` — accepted opp where viewer is a non-introducer party.
+ *   Clicking opens the existing chat (no state change).
+ *
+ * Callers that pass `viewerApproved: undefined` for a fresh draft (e.g.
+ * `create_opportunities` paths that just inserted the row with approved=false)
+ * get `approve_introduction` — the default matches the just-created state.
+ */
+export function resolveActionableLinkKind(input: {
+  status: string;
+  viewerRole: string;
+  viewerApproved?: boolean;
+}): ConnectLinkKind | null {
+  const { status, viewerRole, viewerApproved } = input;
+  const isIntroducer = viewerRole === "introducer";
+  if (status === "accepted") {
+    return isIntroducer ? null : "outreach";
+  }
+  if (status === "pending") {
+    return isIntroducer ? null : "connect";
+  }
+  if (status === "draft") {
+    if (!isIntroducer) return null;
+    return viewerApproved === true ? null : "approve_introduction";
+  }
+  return null;
+}
+
+/**
  * Statuses for which `update_opportunity` must refuse mutations.
  * - `accepted` / `rejected` / `expired`: terminal outcomes.
  */

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -1158,54 +1158,27 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
           );
 
           // For MCP callers (e.g. Edge Claw), mint a connect token and attach
-          // acceptUrl + profileUrl so the agent can embed actionable links.
-          // Prefer the counterpart's Telegram handle for the profile link
-          // (one click → DM draft) and fall back to the web profile URL only
-          // when no public Telegram handle is on file.
+          // acceptUrl + profileUrl when the (status, viewerRole) is actionable
+          // for the viewer. Non-actionable combos (sender-on-draft,
+          // pending-on-introducer-waiting, rejected, etc.) deliberately get
+          // no link — the LLM would otherwise hallucinate `/api/.../connect`
+          // URLs from the exposed opportunityId.
           if (context.isMcp && deps.mintConnectLink) {
-            try {
-              const isIntroducer = cardData.viewerRole === "introducer";
-              const isAccepted = opp.status === "accepted";
-              const feedCategory = isIntroducer ? "connector-flow" : "connection";
-              const kind: ConnectLinkKind = isAccepted
-                ? "outreach"
-                : isIntroducer
-                  ? "approve_introduction"
-                  : "connect";
-
-              // The list path uses minimal card data (no LLM presenter), so no
-              // greeting is available to snapshot here. The mint endpoint stores
-              // null and the redirect path falls back to the live presenter.
-              const greeting = null;
-
-              const { url } = await deps.mintConnectLink({
-                userId: context.userId,
-                opportunityId: opp.id,
-                kind,
-                greeting,
-              });
-
-              const telegramSocial = counterpartUser?.socials?.find(
-                (s) => s.label?.toLowerCase() === "telegram",
-              );
-              const telegramHandle = telegramSocial?.value?.trim().replace(/^@/, "");
-              const profileUrl = telegramHandle
-                ? `https://t.me/${telegramHandle}`
-                : deps.frontendUrl
-                  ? `${deps.frontendUrl}/u/${counterpartUserId}?link_preview=false`
-                  : undefined;
-
-              (cardData as Record<string, unknown>).acceptUrl = url;
-              if (profileUrl) {
-                (cardData as Record<string, unknown>).profileUrl = profileUrl;
-              }
-              (cardData as Record<string, unknown>).feedCategory = feedCategory;
-            } catch (err) {
-              logger.warn("Failed to mint MCP opportunity links — surfacing card without acceptUrl/profileUrl", {
-                opportunityId: opp.id,
-                error: err instanceof Error ? err.message : String(err),
-              });
-            }
+            const viewerActor = opp.actors.find((a) => a.userId === context.userId);
+            const viewerApproved =
+              viewerActor?.role === "introducer" ? viewerActor.approved === true : undefined;
+            await attachActionableLinks(cardData as Record<string, unknown> & {
+              opportunityId: string;
+              viewerRole: string;
+              status: string;
+            }, {
+              viewerId: context.userId,
+              viewerApproved,
+              counterpartUser,
+              counterpartUserId,
+              mintConnectLink: deps.mintConnectLink,
+              frontendUrl: deps.frontendUrl,
+            });
           }
 
           cardDataList.push(cardData);

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -298,7 +298,7 @@ type OpportunityCardLike = Record<string, unknown> & {
  * dump raw fields or IDs. MCP clients have no card renderer, so code fences
  * would surface as raw JSON to end users.
  */
-function buildOpportunityPresentation(
+export function buildOpportunityPresentation(
   cards: OpportunityCardLike[],
   opts: { isMcp: boolean; leadIn: string; label?: "opportunity" | "opportunities" },
 ): string {
@@ -313,20 +313,29 @@ function buildOpportunityPresentation(
         if (card.profileUrl) lines.push(`   profileUrl: ${card.profileUrl}`);
         if (card.acceptUrl) lines.push(`   acceptUrl: ${card.acceptUrl}`);
         if (card.feedCategory) lines.push(`   feedCategory: ${card.feedCategory}`);
-        lines.push(`   opportunityId: ${card.opportunityId}`);
+        // Only surface opportunityId when there's no acceptUrl. Exposing the
+        // UUID alongside an actionable link gives the LLM a foothold to
+        // hallucinate bare `/api/opportunities/<id>/connect` URLs.
+        if (!card.acceptUrl) {
+          lines.push(`   opportunityId: ${card.opportunityId}`);
+        }
         return lines.join("\n");
       })
       .join("\n\n");
     const hasLinks = cards.some((c) => c.acceptUrl);
+    const hasOpportunityIds = cards.some((c) => !c.acceptUrl);
     const linkInstructions = hasLinks
       ? `Link each person's name to their profileUrl and embed acceptUrl on a short verb phrase (e.g. "message [Name]" for connection, "make intro" for connector-flow). The acceptUrl is opaque and self-contained — embed it verbatim. Do NOT append, encode, or modify any part of any URL. Never render link strips or tables — weave URLs into prose. `
+      : "";
+    const idInstructions = hasOpportunityIds
+      ? `Use opportunityId values only when calling update_opportunity (send/accept/reject).`
       : "";
     return (
       `${opts.leadIn}\n\n${prose}\n\n` +
       `Summarize these for the user in natural prose — mention first names and a brief match reason per connection. ` +
       `${linkInstructions}` +
       `Do NOT print raw JSON, field labels, opportunityIds, or confidence scores. ` +
-      `Use opportunityId values only when calling update_opportunity (send/accept/reject).`
+      `${idInstructions}`
     );
   }
 

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -27,7 +27,7 @@ const logger = protocolLogger("ChatTools:Opportunity");
  *   flips the opp to accepted and opens the chat with the counterpart.
  * - `approve_introduction` — draft or latent opp where viewer is an unapproved
  *   introducer. Clicking flips approved=true and triggers negotiation. The
- *   `draft` case comes from `create_opportunities` intro mode; the `latent`
+ *   `draft` case comes from `discover_opportunities` intro mode; the `latent`
  *   case comes from background-discovered connector-flow cards surfaced in
  *   `list_opportunities`. In both, status remains pre-send and the `/c/<code>`
  *   link is the only MCP path to approve.
@@ -35,7 +35,7 @@ const logger = protocolLogger("ChatTools:Opportunity");
  *   Clicking opens the existing chat (no state change).
  *
  * Callers that pass `viewerApproved: undefined` for a fresh draft (e.g.
- * `create_opportunities` paths that just inserted the row with approved=false)
+ * `discover_opportunities` paths that just inserted the row with approved=false)
  * get `approve_introduction` — the default matches the just-created state.
  */
 export function resolveActionableLinkKind(input: {

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -54,6 +54,84 @@ export function resolveActionableLinkKind(input: {
 }
 
 /**
+ * Build the agent-facing profile link for a counterpart. Telegram DM if a
+ * public handle is on file, otherwise the web profile URL. Returns `undefined`
+ * only if no fallback is possible (no Telegram AND no frontendUrl configured).
+ */
+export function buildProfileUrl(
+  counterpartUser:
+    | { socials?: Array<{ label?: string | null; value?: string | null }> | null }
+    | null
+    | undefined,
+  counterpartUserId: string,
+  frontendUrl: string | undefined,
+): string | undefined {
+  const telegramSocial = counterpartUser?.socials?.find(
+    (s) => s.label?.toLowerCase() === "telegram",
+  );
+  const telegramHandle = telegramSocial?.value?.trim().replace(/^@/, "");
+  if (telegramHandle) return `https://t.me/${telegramHandle}`;
+  if (frontendUrl) return `${frontendUrl}/u/${counterpartUserId}?link_preview=false`;
+  return undefined;
+}
+
+/**
+ * Mint a short-link for `card` if the (status, viewerRole, viewerApproved)
+ * combination is actionable; mutate the card in place with `acceptUrl`,
+ * `profileUrl`, and `feedCategory`. No-op (and no DB call) if not actionable.
+ *
+ * Swallows mint errors after logging — the card is still returned without an
+ * `acceptUrl`, matching the prior `list_opportunities` resilience behavior.
+ */
+export async function attachActionableLinks(
+  card: Record<string, unknown> & {
+    opportunityId: string;
+    viewerRole: string;
+    status: string;
+  },
+  opts: {
+    viewerId: string;
+    viewerApproved?: boolean;
+    counterpartUser:
+      | { socials?: Array<{ label?: string | null; value?: string | null }> | null }
+      | null
+      | undefined;
+    counterpartUserId: string;
+    mintConnectLink: NonNullable<ToolDeps["mintConnectLink"]>;
+    frontendUrl: string | undefined;
+  },
+): Promise<void> {
+  const kind = resolveActionableLinkKind({
+    status: card.status,
+    viewerRole: card.viewerRole,
+    viewerApproved: opts.viewerApproved,
+  });
+  if (kind === null) return;
+
+  try {
+    const { url } = await opts.mintConnectLink({
+      userId: opts.viewerId,
+      opportunityId: card.opportunityId,
+      kind,
+      greeting: null,
+    });
+    card.acceptUrl = url;
+    card.feedCategory = card.viewerRole === "introducer" ? "connector-flow" : "connection";
+    const profileUrl = buildProfileUrl(opts.counterpartUser, opts.counterpartUserId, opts.frontendUrl);
+    if (profileUrl) card.profileUrl = profileUrl;
+  } catch (err) {
+    logger.warn(
+      "Failed to mint MCP opportunity link — surfacing card without acceptUrl/profileUrl",
+      {
+        opportunityId: card.opportunityId,
+        kind,
+        error: err instanceof Error ? err.message : String(err),
+      },
+    );
+  }
+}
+
+/**
  * Statuses for which `update_opportunity` must refuse mutations.
  * - `accepted` / `rejected` / `expired`: terminal outcomes.
  */

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.spec.ts
@@ -173,7 +173,7 @@ describe('buildMinimalOpportunityCard - introducer discovery (IND-140)', () => {
   });
 });
 
-import { resolveActionableLinkKind, buildOpportunityPresentation } from "../opportunity.tools.js";
+import { resolveActionableLinkKind, buildOpportunityPresentation, attachActionableLinks, buildProfileUrl } from "../opportunity.tools.js";
 
 describe("resolveActionableLinkKind — actionability matrix", () => {
   test("accepted + non-introducer → outreach", () => {
@@ -222,6 +222,272 @@ describe("resolveActionableLinkKind — actionability matrix", () => {
     expect(resolveActionableLinkKind({ status: "rejected", viewerRole: "party" })).toBeNull();
     expect(resolveActionableLinkKind({ status: "latent", viewerRole: "party" })).toBeNull();
     expect(resolveActionableLinkKind({ status: "expired", viewerRole: "introducer", viewerApproved: false })).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// attachActionableLinks — mutation and resilience
+// ---------------------------------------------------------------------------
+
+type TestCard = Record<string, unknown> & {
+  opportunityId: string;
+  viewerRole: string;
+  status: string;
+};
+
+function makeCard(
+  overrides: Partial<TestCard> & { opportunityId: string; viewerRole: string; status: string },
+): TestCard {
+  return { name: "Counterpart", ...overrides };
+}
+
+function makeMintSpy(url = "https://api.test/c/AAAAAAAAAA") {
+  const calls: Array<{ userId: string; opportunityId: string; kind: string; greeting?: string | null }> = [];
+  const mintConnectLink = async (args: { userId: string; opportunityId: string; kind: string; greeting?: string | null }) => {
+    calls.push(args);
+    return { url };
+  };
+  return { mintConnectLink, calls };
+}
+
+describe("attachActionableLinks — mutation and resilience", () => {
+  test("pending + party → mints connect, attaches all fields", async () => {
+    const card = makeCard({ opportunityId: "opp-1", viewerRole: "party", status: "pending" });
+    const { mintConnectLink, calls } = makeMintSpy();
+    await attachActionableLinks(card, {
+      viewerId: "user-1",
+      counterpartUser: { socials: [{ label: "telegram", value: "alice" }] },
+      counterpartUserId: "counterpart-1",
+      mintConnectLink,
+      frontendUrl: "https://app.test",
+    });
+    expect(calls.length).toBe(1);
+    expect(calls[0]).toMatchObject({ userId: "user-1", opportunityId: "opp-1", kind: "connect", greeting: null });
+    expect(card.acceptUrl).toBe("https://api.test/c/AAAAAAAAAA");
+    expect(card.profileUrl).toBe("https://t.me/alice");
+    expect(card.feedCategory).toBe("connection");
+  });
+
+  test("accepted + party → mints outreach, feedCategory=connection", async () => {
+    const card = makeCard({ opportunityId: "opp-2", viewerRole: "party", status: "accepted" });
+    const { mintConnectLink, calls } = makeMintSpy();
+    await attachActionableLinks(card, {
+      viewerId: "user-2",
+      counterpartUser: null,
+      counterpartUserId: "counterpart-2",
+      mintConnectLink,
+      frontendUrl: "https://app.test",
+    });
+    expect(calls.length).toBe(1);
+    expect(calls[0].kind).toBe("outreach");
+    expect(card.feedCategory).toBe("connection");
+  });
+
+  test("draft + introducer + viewerApproved=false → mints approve_introduction, feedCategory=connector-flow", async () => {
+    const card = makeCard({ opportunityId: "opp-3", viewerRole: "introducer", status: "draft" });
+    const { mintConnectLink, calls } = makeMintSpy();
+    await attachActionableLinks(card, {
+      viewerId: "user-3",
+      viewerApproved: false,
+      counterpartUser: null,
+      counterpartUserId: "counterpart-3",
+      mintConnectLink,
+      frontendUrl: "https://app.test",
+    });
+    expect(calls.length).toBe(1);
+    expect(calls[0].kind).toBe("approve_introduction");
+    expect(card.feedCategory).toBe("connector-flow");
+  });
+
+  test("draft + introducer + viewerApproved=true → no mint, card unchanged", async () => {
+    const card = makeCard({ opportunityId: "opp-4", viewerRole: "introducer", status: "draft" });
+    const { mintConnectLink, calls } = makeMintSpy();
+    await attachActionableLinks(card, {
+      viewerId: "user-4",
+      viewerApproved: true,
+      counterpartUser: null,
+      counterpartUserId: "counterpart-4",
+      mintConnectLink,
+      frontendUrl: "https://app.test",
+    });
+    expect(calls.length).toBe(0);
+    expect(card.acceptUrl).toBeUndefined();
+    expect(card.profileUrl).toBeUndefined();
+    expect(card.feedCategory).toBeUndefined();
+  });
+
+  test("draft + party (sender) → no mint, card unchanged", async () => {
+    const card = makeCard({ opportunityId: "opp-5", viewerRole: "party", status: "draft" });
+    const { mintConnectLink, calls } = makeMintSpy();
+    await attachActionableLinks(card, {
+      viewerId: "user-5",
+      counterpartUser: null,
+      counterpartUserId: "counterpart-5",
+      mintConnectLink,
+      frontendUrl: "https://app.test",
+    });
+    expect(calls.length).toBe(0);
+    expect(card.acceptUrl).toBeUndefined();
+    expect(card.profileUrl).toBeUndefined();
+    expect(card.feedCategory).toBeUndefined();
+  });
+
+  test("pending + introducer → no mint, card unchanged", async () => {
+    const card = makeCard({ opportunityId: "opp-6", viewerRole: "introducer", status: "pending" });
+    const { mintConnectLink, calls } = makeMintSpy();
+    await attachActionableLinks(card, {
+      viewerId: "user-6",
+      counterpartUser: null,
+      counterpartUserId: "counterpart-6",
+      mintConnectLink,
+      frontendUrl: "https://app.test",
+    });
+    expect(calls.length).toBe(0);
+    expect(card.acceptUrl).toBeUndefined();
+  });
+
+  test("accepted + introducer → no mint, card unchanged", async () => {
+    const card = makeCard({ opportunityId: "opp-7", viewerRole: "introducer", status: "accepted" });
+    const { mintConnectLink, calls } = makeMintSpy();
+    await attachActionableLinks(card, {
+      viewerId: "user-7",
+      counterpartUser: null,
+      counterpartUserId: "counterpart-7",
+      mintConnectLink,
+      frontendUrl: "https://app.test",
+    });
+    expect(calls.length).toBe(0);
+    expect(card.acceptUrl).toBeUndefined();
+  });
+
+  test("rejected (any role) → no mint, card unchanged", async () => {
+    const card = makeCard({ opportunityId: "opp-8", viewerRole: "party", status: "rejected" });
+    const { mintConnectLink, calls } = makeMintSpy();
+    await attachActionableLinks(card, {
+      viewerId: "user-8",
+      counterpartUser: null,
+      counterpartUserId: "counterpart-8",
+      mintConnectLink,
+      frontendUrl: "https://app.test",
+    });
+    expect(calls.length).toBe(0);
+    expect(card.acceptUrl).toBeUndefined();
+  });
+
+  test("profileUrl falls back to web URL when no Telegram social", async () => {
+    const card = makeCard({ opportunityId: "opp-9", viewerRole: "party", status: "pending" });
+    const { mintConnectLink } = makeMintSpy();
+    await attachActionableLinks(card, {
+      viewerId: "user-9",
+      counterpartUser: { socials: [] },
+      counterpartUserId: "counterpart-9",
+      mintConnectLink,
+      frontendUrl: "https://app.test",
+    });
+    expect(card.profileUrl).toBe(`https://app.test/u/counterpart-9?link_preview=false`);
+  });
+
+  test("profileUrl is undefined when no Telegram AND no frontendUrl", async () => {
+    const card = makeCard({ opportunityId: "opp-10", viewerRole: "party", status: "pending" });
+    const { mintConnectLink } = makeMintSpy();
+    await attachActionableLinks(card, {
+      viewerId: "user-10",
+      counterpartUser: { socials: [] },
+      counterpartUserId: "counterpart-10",
+      mintConnectLink,
+      frontendUrl: undefined,
+    });
+    expect("profileUrl" in card).toBe(false);
+    expect(card.acceptUrl).toBe("https://api.test/c/AAAAAAAAAA");
+    expect(card.feedCategory).toBe("connection");
+  });
+
+  test("mint error is swallowed; card has no acceptUrl/profileUrl/feedCategory", async () => {
+    const card = makeCard({ opportunityId: "opp-11", viewerRole: "party", status: "pending" });
+    const mintConnectLink = async (_args: { userId: string; opportunityId: string; kind: string; greeting?: string | null }) => {
+      throw new Error("DB down");
+    };
+    await expect(
+      attachActionableLinks(card, {
+        viewerId: "user-11",
+        counterpartUser: null,
+        counterpartUserId: "counterpart-11",
+        mintConnectLink,
+        frontendUrl: "https://app.test",
+      }),
+    ).resolves.toBeUndefined();
+    expect(card.acceptUrl).toBeUndefined();
+    expect(card.profileUrl).toBeUndefined();
+    expect(card.feedCategory).toBeUndefined();
+  });
+
+  test("Telegram handle strips leading @", async () => {
+    const card = makeCard({ opportunityId: "opp-12", viewerRole: "party", status: "pending" });
+    const { mintConnectLink } = makeMintSpy();
+    await attachActionableLinks(card, {
+      viewerId: "user-12",
+      counterpartUser: { socials: [{ label: "telegram", value: "@bob" }] },
+      counterpartUserId: "counterpart-12",
+      mintConnectLink,
+      frontendUrl: "https://app.test",
+    });
+    expect(card.profileUrl).toBe("https://t.me/bob");
+  });
+
+  test("Telegram label match is case-insensitive", async () => {
+    const card = makeCard({ opportunityId: "opp-13", viewerRole: "party", status: "pending" });
+    const { mintConnectLink } = makeMintSpy();
+    await attachActionableLinks(card, {
+      viewerId: "user-13",
+      counterpartUser: { socials: [{ label: "Telegram", value: "carol" }] },
+      counterpartUserId: "counterpart-13",
+      mintConnectLink,
+      frontendUrl: "https://app.test",
+    });
+    expect(card.profileUrl).toBe("https://t.me/carol");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildProfileUrl — edge cases
+// ---------------------------------------------------------------------------
+
+describe("buildProfileUrl — edge cases", () => {
+  test("whitespace in Telegram value is trimmed", () => {
+    const result = buildProfileUrl(
+      { socials: [{ label: "telegram", value: "  dan  " }] },
+      "user-dan",
+      "https://app.test",
+    );
+    expect(result).toBe("https://t.me/dan");
+  });
+
+  test("socials is null → falls through to frontendUrl", () => {
+    const result = buildProfileUrl(
+      { socials: null },
+      "user-null",
+      "https://app.test",
+    );
+    expect(result).toBe("https://app.test/u/user-null?link_preview=false");
+  });
+
+  test("counterpartUser itself is null → falls through to frontendUrl", () => {
+    const result = buildProfileUrl(null, "user-none", "https://app.test");
+    expect(result).toBe("https://app.test/u/user-none?link_preview=false");
+  });
+
+  test("no Telegram and no frontendUrl → returns undefined", () => {
+    const result = buildProfileUrl({ socials: [] }, "user-undef", undefined);
+    expect(result).toBeUndefined();
+  });
+
+  test("Telegram value is empty string → falls through to frontendUrl", () => {
+    const result = buildProfileUrl(
+      { socials: [{ label: "telegram", value: "" }] },
+      "user-empty",
+      "https://app.test",
+    );
+    expect(result).toBe("https://app.test/u/user-empty?link_preview=false");
   });
 });
 

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.spec.ts
@@ -173,7 +173,7 @@ describe('buildMinimalOpportunityCard - introducer discovery (IND-140)', () => {
   });
 });
 
-import { resolveActionableLinkKind } from "../opportunity.tools.js";
+import { resolveActionableLinkKind, buildOpportunityPresentation } from "../opportunity.tools.js";
 
 describe("resolveActionableLinkKind — actionability matrix", () => {
   test("accepted + non-introducer → outreach", () => {
@@ -222,5 +222,55 @@ describe("resolveActionableLinkKind — actionability matrix", () => {
     expect(resolveActionableLinkKind({ status: "rejected", viewerRole: "party" })).toBeNull();
     expect(resolveActionableLinkKind({ status: "latent", viewerRole: "party" })).toBeNull();
     expect(resolveActionableLinkKind({ status: "expired", viewerRole: "introducer", viewerApproved: false })).toBeNull();
+  });
+});
+
+describe("buildOpportunityPresentation — MCP opportunityId omission", () => {
+  test("omits opportunityId line when card has an acceptUrl", () => {
+    const out = buildOpportunityPresentation(
+      [{
+        opportunityId: "opp-actionable-1",
+        name: "Alice",
+        mainText: "Both work on protocol design.",
+        status: "pending",
+        acceptUrl: "https://api.test/c/Abc1234567",
+        profileUrl: "https://t.me/alice",
+        feedCategory: "connection",
+      }],
+      { isMcp: true, leadIn: "Found 1 connection." },
+    );
+
+    expect(out).not.toContain("opportunityId: opp-actionable-1");
+    expect(out).toContain("acceptUrl: https://api.test/c/Abc1234567");
+    expect(out).not.toContain("Use opportunityId values only when calling update_opportunity");
+  });
+
+  test("keeps opportunityId line when card has NO acceptUrl (draft sender etc.)", () => {
+    const out = buildOpportunityPresentation(
+      [{
+        opportunityId: "opp-draft-sender-1",
+        name: "Bob",
+        mainText: "You can offer DevOps mentorship.",
+        status: "draft",
+      }],
+      { isMcp: true, leadIn: "Found 1 draft." },
+    );
+
+    expect(out).toContain("opportunityId: opp-draft-sender-1");
+    expect(out).toContain("Use opportunityId values only when calling update_opportunity");
+  });
+
+  test("mixed actionability: keeps id only for non-actionable cards, keeps instruction", () => {
+    const out = buildOpportunityPresentation(
+      [
+        { opportunityId: "opp-actionable", name: "Alice", status: "pending", acceptUrl: "https://api.test/c/Abc1234567" },
+        { opportunityId: "opp-draft-sender", name: "Bob", status: "draft" },
+      ],
+      { isMcp: true, leadIn: "Found 2." },
+    );
+
+    expect(out).not.toContain("opportunityId: opp-actionable");
+    expect(out).toContain("opportunityId: opp-draft-sender");
+    expect(out).toContain("Use opportunityId values only when calling update_opportunity");
   });
 });

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.spec.ts
@@ -1,7 +1,7 @@
 import { config } from "dotenv";
 config({ path: ".env.development", override: true });
 
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, test } from "bun:test";
 import type { Opportunity } from "../../shared/interfaces/database.interface.js";
 import { buildMinimalOpportunityCard } from "../opportunity.tools.js";
 
@@ -170,5 +170,57 @@ describe('buildMinimalOpportunityCard - introducer discovery (IND-140)', () => {
     expect(card.viewerRole).toBe('introducer');
     expect(card.primaryActionLabel).toBe('Good match');
     expect(card.headline).toBe('Target User → Bob');
+  });
+});
+
+import { resolveActionableLinkKind } from "../opportunity.tools.js";
+
+describe("resolveActionableLinkKind — actionability matrix", () => {
+  test("accepted + non-introducer → outreach", () => {
+    expect(resolveActionableLinkKind({ status: "accepted", viewerRole: "party" })).toBe("outreach");
+    expect(resolveActionableLinkKind({ status: "accepted", viewerRole: "agent" })).toBe("outreach");
+    expect(resolveActionableLinkKind({ status: "accepted", viewerRole: "patient" })).toBe("outreach");
+    expect(resolveActionableLinkKind({ status: "accepted", viewerRole: "peer" })).toBe("outreach");
+  });
+
+  test("accepted + introducer → null", () => {
+    expect(resolveActionableLinkKind({ status: "accepted", viewerRole: "introducer" })).toBeNull();
+  });
+
+  test("pending + non-introducer → connect", () => {
+    expect(resolveActionableLinkKind({ status: "pending", viewerRole: "party" })).toBe("connect");
+    expect(resolveActionableLinkKind({ status: "pending", viewerRole: "patient" })).toBe("connect");
+    expect(resolveActionableLinkKind({ status: "pending", viewerRole: "agent" })).toBe("connect");
+  });
+
+  test("pending + introducer → null", () => {
+    expect(resolveActionableLinkKind({ status: "pending", viewerRole: "introducer" })).toBeNull();
+  });
+
+  test("draft + introducer + unapproved → approve_introduction", () => {
+    expect(
+      resolveActionableLinkKind({ status: "draft", viewerRole: "introducer", viewerApproved: false }),
+    ).toBe("approve_introduction");
+    // undefined defaults to "unapproved" for fresh drafts coming from create_opportunities
+    expect(
+      resolveActionableLinkKind({ status: "draft", viewerRole: "introducer" }),
+    ).toBe("approve_introduction");
+  });
+
+  test("draft + introducer + approved → null", () => {
+    expect(
+      resolveActionableLinkKind({ status: "draft", viewerRole: "introducer", viewerApproved: true }),
+    ).toBeNull();
+  });
+
+  test("draft + non-introducer → null (sender needs update_opportunity)", () => {
+    expect(resolveActionableLinkKind({ status: "draft", viewerRole: "party" })).toBeNull();
+    expect(resolveActionableLinkKind({ status: "draft", viewerRole: "agent" })).toBeNull();
+  });
+
+  test("terminal / unknown statuses → null", () => {
+    expect(resolveActionableLinkKind({ status: "rejected", viewerRole: "party" })).toBeNull();
+    expect(resolveActionableLinkKind({ status: "latent", viewerRole: "party" })).toBeNull();
+    expect(resolveActionableLinkKind({ status: "expired", viewerRole: "introducer", viewerApproved: false })).toBeNull();
   });
 });

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.spec.ts
@@ -201,7 +201,7 @@ describe("resolveActionableLinkKind — actionability matrix", () => {
     expect(
       resolveActionableLinkKind({ status: "draft", viewerRole: "introducer", viewerApproved: false }),
     ).toBe("approve_introduction");
-    // undefined defaults to "unapproved" for fresh drafts coming from create_opportunities
+    // undefined defaults to "unapproved" for fresh drafts coming from discover_opportunities
     expect(
       resolveActionableLinkKind({ status: "draft", viewerRole: "introducer" }),
     ).toBe("approve_introduction");

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.spec.ts
@@ -220,8 +220,29 @@ describe("resolveActionableLinkKind — actionability matrix", () => {
 
   test("terminal / unknown statuses → null", () => {
     expect(resolveActionableLinkKind({ status: "rejected", viewerRole: "party" })).toBeNull();
-    expect(resolveActionableLinkKind({ status: "latent", viewerRole: "party" })).toBeNull();
     expect(resolveActionableLinkKind({ status: "expired", viewerRole: "introducer", viewerApproved: false })).toBeNull();
+  });
+
+  test("latent + introducer + unapproved → approve_introduction (connector-flow before approval)", () => {
+    expect(
+      resolveActionableLinkKind({ status: "latent", viewerRole: "introducer", viewerApproved: false }),
+    ).toBe("approve_introduction");
+    // undefined defaults match "unapproved" — same as draft.
+    expect(
+      resolveActionableLinkKind({ status: "latent", viewerRole: "introducer" }),
+    ).toBe("approve_introduction");
+  });
+
+  test("latent + introducer + approved → null (negotiation in flight)", () => {
+    expect(
+      resolveActionableLinkKind({ status: "latent", viewerRole: "introducer", viewerApproved: true }),
+    ).toBeNull();
+  });
+
+  test("latent + non-introducer → null (chat surface filters this case out anyway)", () => {
+    expect(resolveActionableLinkKind({ status: "latent", viewerRole: "party" })).toBeNull();
+    expect(resolveActionableLinkKind({ status: "latent", viewerRole: "agent" })).toBeNull();
+    expect(resolveActionableLinkKind({ status: "latent", viewerRole: "patient" })).toBeNull();
   });
 });
 

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.spec.ts
@@ -543,6 +543,25 @@ describe("buildProfileUrl — edge cases", () => {
       ),
     ).toBe("https://app.test/u/user-y?link_preview=false");
   });
+
+  test("strips trailing slash(es) from frontendUrl before concatenation", () => {
+    expect(
+      buildProfileUrl(
+        { socials: null },
+        "user-x",
+        "https://app.test/",
+      ),
+    ).toBe("https://app.test/u/user-x?link_preview=false");
+
+    // Multiple trailing slashes also collapse.
+    expect(
+      buildProfileUrl(
+        { socials: null },
+        "user-x",
+        "https://app.test///",
+      ),
+    ).toBe("https://app.test/u/user-x?link_preview=false");
+  });
 });
 
 describe("buildOpportunityPresentation — MCP opportunityId omission", () => {

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.spec.ts
@@ -426,12 +426,12 @@ describe("attachActionableLinks — mutation and resilience", () => {
     const { mintConnectLink } = makeMintSpy();
     await attachActionableLinks(card, {
       viewerId: "user-12",
-      counterpartUser: { socials: [{ label: "telegram", value: "@bob" }] },
+      counterpartUser: { socials: [{ label: "telegram", value: "@bobby" }] },
       counterpartUserId: "counterpart-12",
       mintConnectLink,
       frontendUrl: "https://app.test",
     });
-    expect(card.profileUrl).toBe("https://t.me/bob");
+    expect(card.profileUrl).toBe("https://t.me/bobby");
   });
 
   test("Telegram label match is case-insensitive", async () => {
@@ -455,11 +455,11 @@ describe("attachActionableLinks — mutation and resilience", () => {
 describe("buildProfileUrl — edge cases", () => {
   test("whitespace in Telegram value is trimmed", () => {
     const result = buildProfileUrl(
-      { socials: [{ label: "telegram", value: "  dan  " }] },
+      { socials: [{ label: "telegram", value: "  danny  " }] },
       "user-dan",
       "https://app.test",
     );
-    expect(result).toBe("https://t.me/dan");
+    expect(result).toBe("https://t.me/danny");
   });
 
   test("socials is null → falls through to frontendUrl", () => {
@@ -488,6 +488,39 @@ describe("buildProfileUrl — edge cases", () => {
       "https://app.test",
     );
     expect(result).toBe("https://app.test/u/user-empty?link_preview=false");
+  });
+
+  test("URL-like Telegram value is safely normalized (strips URL prefix + query params)", () => {
+    // normalizeTelegramHandle strips the t.me/ prefix and query params, leaving
+    // the bare handle. This is safer than the old code that interpolated the raw value.
+    expect(
+      buildProfileUrl(
+        { socials: [{ label: "telegram", value: "t.me/alice?evil=1" }] },
+        "user-z",
+        "https://app.test",
+      ),
+    ).toBe("https://t.me/alice");
+  });
+
+  test("invalid Telegram handle (newline injected) falls back to frontend URL", () => {
+    // Newlines break the regex validation — result is null, falls back to web URL.
+    expect(
+      buildProfileUrl(
+        { socials: [{ label: "telegram", value: "alice\nevil" }] },
+        "user-z",
+        "https://app.test",
+      ),
+    ).toBe("https://app.test/u/user-z?link_preview=false");
+  });
+
+  test("Telegram handle below 5 chars falls back to frontend URL", () => {
+    expect(
+      buildProfileUrl(
+        { socials: [{ label: "telegram", value: "bob" }] },
+        "user-y",
+        "https://app.test",
+      ),
+    ).toBe("https://app.test/u/user-y?link_preview=false");
   });
 });
 

--- a/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
+++ b/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
@@ -2207,7 +2207,7 @@ describe("createChatTools — MCP connect-link wiring", () => {
     expect(parsed.data.message).toContain(`acceptUrl: ${FAKE_URL}`);
   });
 
-  test("create_opportunities intro mode mints approve_introduction for the introducer", async () => {
+  test("discover_opportunities intro mode mints approve_introduction for the introducer", async () => {
     const mintCalls: Array<{ opportunityId: string; kind: string }> = [];
     const mintConnectLink = async (args: { userId: string; opportunityId: string; kind: string; greeting?: string | null }) => {
       mintCalls.push({ opportunityId: args.opportunityId, kind: args.kind });
@@ -2252,7 +2252,7 @@ describe("createChatTools — MCP connect-link wiring", () => {
     } as ToolContext;
 
     const tools = await createChatTools(context, buildMcpResolvedContext());
-    const createTool = tools.find((t: { name: string }) => t.name === "create_opportunities") as { invoke: (args: unknown) => Promise<string> };
+    const createTool = tools.find((t: { name: string }) => t.name === "discover_opportunities") as { invoke: (args: unknown) => Promise<string> };
 
     const raw = await createTool.invoke({
       partyUserIds: ["party-a", "party-b"],

--- a/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
+++ b/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
@@ -2109,45 +2109,6 @@ describe("createChatTools — MCP connect-link wiring", () => {
     expect(parsed.data.message).not.toContain("acceptUrl:");
   });
 
-  test("list_opportunities mints outreach for accepted + party", async () => {
-    const mintCalls: Array<{ userId: string; opportunityId: string; kind: string; greeting: string | null | undefined }> = [];
-    const mintConnectLink = async (args: { userId: string; opportunityId: string; kind: string; greeting?: string | null }) => {
-      mintCalls.push({ userId: args.userId, opportunityId: args.opportunityId, kind: args.kind, greeting: args.greeting ?? null });
-      return { url: FAKE_URL };
-    };
-
-    const acceptedDb: ChatGraphCompositeDatabase = createMockDatabase(async () => [], {
-      getOpportunitiesForUser: async () => [{ ...buildOpp(), status: "accepted" }],
-      getUser: async (uid: string) => {
-        if (uid === VIEWER_ID) return { id: uid, name: "Viewer" };
-        if (uid === COUNTERPART_ID) return { id: uid, name: "Counterpart" };
-        return null;
-      },
-      getProfile: async () => null,
-    } as unknown as MockOverrides);
-
-    const context: ToolContext = {
-      userId: VIEWER_ID,
-      database: acceptedDb,
-      embedder: mockEmbedder,
-      scraper: mockScraper,
-      ...mockProtocolDeps,
-      mintConnectLink,
-      apiBaseUrl: API_BASE_URL,
-      frontendUrl: FRONTEND_URL,
-    } as ToolContext;
-
-    const tools = await createChatTools(context, buildMcpResolvedContext());
-    const listTool = tools.find((t: { name: string }) => t.name === "list_opportunities") as { invoke: (args: unknown) => Promise<string> };
-    const raw = await listTool.invoke({});
-    const parsed = JSON.parse(raw);
-
-    expect(parsed.success).toBe(true);
-    expect(mintCalls.length).toBe(1);
-    expect(mintCalls[0].kind).toBe("outreach");
-    expect(parsed.data.message).toContain(`acceptUrl: ${FAKE_URL}`);
-  });
-
   test("list_opportunities does NOT mint for pending + introducer", async () => {
     const mintCalls: Array<unknown> = [];
     const mintConnectLink = async () => {

--- a/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
+++ b/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
@@ -2108,6 +2108,68 @@ describe("createChatTools — MCP connect-link wiring", () => {
     expect(mintCalls.length).toBe(0); // sender-on-draft must not mint
     expect(parsed.data.message).not.toContain("acceptUrl:");
   });
+
+  test("create_opportunities intro mode mints approve_introduction for the introducer", async () => {
+    const mintCalls: Array<{ opportunityId: string; kind: string }> = [];
+    const mintConnectLink = async (args: { userId: string; opportunityId: string; kind: string; greeting?: string | null }) => {
+      mintCalls.push({ opportunityId: args.opportunityId, kind: args.kind });
+      return { url: FAKE_URL };
+    };
+
+    const introDb: ChatGraphCompositeDatabase = createMockDatabase(async () => [], {
+      isNetworkMember: async () => true,
+      opportunityExistsBetweenActors: async () => false,
+      findOverlappingOpportunities: async () => [],
+      createOpportunity: async (data: { actors?: Array<{ userId: string; role: string; approved?: boolean }>; interpretation?: Record<string, unknown>; detection?: Record<string, unknown>; context?: Record<string, unknown>; confidence?: unknown; status?: string }) =>
+        ({
+          id: "opp-intro-1",
+          detection: data.detection,
+          actors: data.actors ?? [],
+          interpretation: data.interpretation ?? { reasoning: "Both build infra for decentralized discovery.", confidence: 0.8 },
+          context: data.context,
+          confidence: data.confidence,
+          status: "draft",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          expiresAt: null,
+        }) as import("../../interfaces/database.interface").Opportunity,
+      getUser: async (uid: string) => {
+        if (uid === VIEWER_ID) return { id: uid, name: "Viewer" };
+        if (uid === "party-a") return { id: uid, name: "Party A" };
+        if (uid === "party-b") return { id: uid, name: "Party B" };
+        return null;
+      },
+      getProfile: async () => null,
+    } as unknown as MockOverrides);
+
+    const context: ToolContext = {
+      userId: VIEWER_ID,
+      database: introDb,
+      embedder: mockEmbedder,
+      scraper: mockScraper,
+      ...mockProtocolDeps,
+      mintConnectLink,
+      apiBaseUrl: API_BASE_URL,
+      frontendUrl: FRONTEND_URL,
+    } as ToolContext;
+
+    const tools = await createChatTools(context, buildMcpResolvedContext());
+    const createTool = tools.find((t: { name: string }) => t.name === "create_opportunities") as { invoke: (args: unknown) => Promise<string> };
+
+    const raw = await createTool.invoke({
+      partyUserIds: ["party-a", "party-b"],
+      entities: [
+        { userId: "party-a", profile: { name: "Party A" }, intents: [], networkId: "idx-1" },
+        { userId: "party-b", profile: { name: "Party B" }, intents: [], networkId: "idx-1" },
+      ],
+    });
+    const parsed = JSON.parse(raw);
+
+    expect(parsed.success).toBe(true);
+    expect(mintCalls.length).toBe(1);
+    expect(mintCalls[0]).toMatchObject({ opportunityId: "opp-intro-1", kind: "approve_introduction" });
+    expect(parsed.data.message).toContain(`acceptUrl: ${FAKE_URL}`);
+  }, 60000);
 });
 
 afterAll(() => mock.restore());

--- a/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
+++ b/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
@@ -2195,6 +2195,57 @@ describe("createChatTools — MCP connect-link wiring", () => {
     expect(parsed.data.message).not.toContain("acceptUrl:");
   });
 
+  test("list_opportunities mints approve_introduction for latent + introducer (unapproved)", async () => {
+    const mintCalls: Array<{ opportunityId: string; kind: string }> = [];
+    const mintConnectLink = async (args: { userId: string; opportunityId: string; kind: string; greeting?: string | null }) => {
+      mintCalls.push({ opportunityId: args.opportunityId, kind: args.kind });
+      return { url: FAKE_URL };
+    };
+
+    const latentDb: ChatGraphCompositeDatabase = createMockDatabase(async () => [], {
+      getOpportunitiesForUser: async () => [
+        {
+          ...buildOpp(),
+          id: "opp-latent-intro",
+          status: "latent",
+          actors: [
+            { userId: VIEWER_ID, role: "introducer", approved: false },
+            { userId: COUNTERPART_ID, role: "patient" },
+            { userId: "third-party", role: "agent" },
+          ],
+        },
+      ],
+      getUser: async (uid: string) => {
+        if (uid === VIEWER_ID) return { id: uid, name: "Viewer" };
+        if (uid === COUNTERPART_ID) return { id: uid, name: "Counterpart" };
+        if (uid === "third-party") return { id: uid, name: "Third" };
+        return null;
+      },
+      getProfile: async () => null,
+    } as unknown as MockOverrides);
+
+    const context: ToolContext = {
+      userId: VIEWER_ID,
+      database: latentDb,
+      embedder: mockEmbedder,
+      scraper: mockScraper,
+      ...mockProtocolDeps,
+      mintConnectLink,
+      apiBaseUrl: API_BASE_URL,
+      frontendUrl: FRONTEND_URL,
+    } as ToolContext;
+
+    const tools = await createChatTools(context, buildMcpResolvedContext());
+    const listTool = tools.find((t: { name: string }) => t.name === "list_opportunities") as { invoke: (args: unknown) => Promise<string> };
+    const raw = await listTool.invoke({});
+    const parsed = JSON.parse(raw);
+
+    expect(parsed.success).toBe(true);
+    expect(mintCalls.length).toBe(1);
+    expect(mintCalls[0]).toMatchObject({ opportunityId: "opp-latent-intro", kind: "approve_introduction" });
+    expect(parsed.data.message).toContain(`acceptUrl: ${FAKE_URL}`);
+  });
+
   test("create_opportunities intro mode mints approve_introduction for the introducer", async () => {
     const mintCalls: Array<{ opportunityId: string; kind: string }> = [];
     const mintConnectLink = async (args: { userId: string; opportunityId: string; kind: string; greeting?: string | null }) => {

--- a/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
+++ b/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
@@ -2109,6 +2109,92 @@ describe("createChatTools — MCP connect-link wiring", () => {
     expect(parsed.data.message).not.toContain("acceptUrl:");
   });
 
+  test("list_opportunities mints outreach for accepted + party", async () => {
+    const mintCalls: Array<{ userId: string; opportunityId: string; kind: string; greeting: string | null | undefined }> = [];
+    const mintConnectLink = async (args: { userId: string; opportunityId: string; kind: string; greeting?: string | null }) => {
+      mintCalls.push({ userId: args.userId, opportunityId: args.opportunityId, kind: args.kind, greeting: args.greeting ?? null });
+      return { url: FAKE_URL };
+    };
+
+    const acceptedDb: ChatGraphCompositeDatabase = createMockDatabase(async () => [], {
+      getOpportunitiesForUser: async () => [{ ...buildOpp(), status: "accepted" }],
+      getUser: async (uid: string) => {
+        if (uid === VIEWER_ID) return { id: uid, name: "Viewer" };
+        if (uid === COUNTERPART_ID) return { id: uid, name: "Counterpart" };
+        return null;
+      },
+      getProfile: async () => null,
+    } as unknown as MockOverrides);
+
+    const context: ToolContext = {
+      userId: VIEWER_ID,
+      database: acceptedDb,
+      embedder: mockEmbedder,
+      scraper: mockScraper,
+      ...mockProtocolDeps,
+      mintConnectLink,
+      apiBaseUrl: API_BASE_URL,
+      frontendUrl: FRONTEND_URL,
+    } as ToolContext;
+
+    const tools = await createChatTools(context, buildMcpResolvedContext());
+    const listTool = tools.find((t: { name: string }) => t.name === "list_opportunities") as { invoke: (args: unknown) => Promise<string> };
+    const raw = await listTool.invoke({});
+    const parsed = JSON.parse(raw);
+
+    expect(parsed.success).toBe(true);
+    expect(mintCalls.length).toBe(1);
+    expect(mintCalls[0].kind).toBe("outreach");
+    expect(parsed.data.message).toContain(`acceptUrl: ${FAKE_URL}`);
+  });
+
+  test("list_opportunities does NOT mint for pending + introducer", async () => {
+    const mintCalls: Array<unknown> = [];
+    const mintConnectLink = async () => {
+      mintCalls.push(1);
+      return { url: FAKE_URL };
+    };
+
+    const introducerDb: ChatGraphCompositeDatabase = createMockDatabase(async () => [], {
+      getOpportunitiesForUser: async () => [
+        {
+          ...buildOpp(),
+          status: "pending",
+          actors: [
+            { userId: VIEWER_ID, role: "introducer", approved: false },
+            { userId: COUNTERPART_ID, role: "party" },
+          ],
+        },
+      ],
+      getUser: async (uid: string) => {
+        if (uid === VIEWER_ID) return { id: uid, name: "Viewer" };
+        if (uid === COUNTERPART_ID) return { id: uid, name: "Counterpart" };
+        return null;
+      },
+      getProfile: async () => null,
+    } as unknown as MockOverrides);
+
+    const context: ToolContext = {
+      userId: VIEWER_ID,
+      database: introducerDb,
+      embedder: mockEmbedder,
+      scraper: mockScraper,
+      ...mockProtocolDeps,
+      mintConnectLink,
+      apiBaseUrl: API_BASE_URL,
+      frontendUrl: FRONTEND_URL,
+    } as ToolContext;
+
+    const tools = await createChatTools(context, buildMcpResolvedContext());
+    const listTool = tools.find((t: { name: string }) => t.name === "list_opportunities") as { invoke: (args: unknown) => Promise<string> };
+    const raw = await listTool.invoke({});
+    const parsed = JSON.parse(raw);
+
+    expect(parsed.success).toBe(true);
+    expect(mintCalls.length).toBe(0);
+    expect(parsed.data.message).not.toContain("acceptUrl:");
+  });
+
   test("create_opportunities intro mode mints approve_introduction for the introducer", async () => {
     const mintCalls: Array<{ opportunityId: string; kind: string }> = [];
     const mintConnectLink = async (args: { userId: string; opportunityId: string; kind: string; greeting?: string | null }) => {

--- a/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
+++ b/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
@@ -2068,6 +2068,46 @@ describe("createChatTools — MCP connect-link wiring", () => {
     // No acceptUrl line in the MCP prose when no adapter is wired.
     expect(parsed.data.message).not.toContain("acceptUrl:");
   });
+
+  test("does NOT mint when opp is non-actionable (draft + party = sender, no link)", async () => {
+    const mintCalls: Array<unknown> = [];
+    const mintConnectLink = async () => {
+      mintCalls.push(1);
+      return { url: FAKE_URL };
+    };
+
+    const draftDb: ChatGraphCompositeDatabase = createMockDatabase(async () => [], {
+      getOpportunitiesForUser: async () => [
+        { ...buildOpp(), status: "draft" },
+      ],
+      getUser: async (uid: string) => {
+        if (uid === VIEWER_ID) return { id: uid, name: "Viewer" };
+        if (uid === COUNTERPART_ID) return { id: uid, name: "Counterpart" };
+        return null;
+      },
+      getProfile: async () => null,
+    } as unknown as MockOverrides);
+
+    const context: ToolContext = {
+      userId: VIEWER_ID,
+      database: draftDb,
+      embedder: mockEmbedder,
+      scraper: mockScraper,
+      ...mockProtocolDeps,
+      mintConnectLink,
+      apiBaseUrl: API_BASE_URL,
+      frontendUrl: FRONTEND_URL,
+    } as ToolContext;
+
+    const tools = await createChatTools(context, buildMcpResolvedContext());
+    const listTool = tools.find((t: { name: string }) => t.name === "list_opportunities") as { invoke: (args: unknown) => Promise<string> };
+    const raw = await listTool.invoke({});
+    const parsed = JSON.parse(raw);
+
+    expect(parsed.success).toBe(true);
+    expect(mintCalls.length).toBe(0); // sender-on-draft must not mint
+    expect(parsed.data.message).not.toContain("acceptUrl:");
+  });
 });
 
 afterAll(() => mock.restore());

--- a/packages/protocol/src/shared/utils/telegram-handle.ts
+++ b/packages/protocol/src/shared/utils/telegram-handle.ts
@@ -1,12 +1,14 @@
 /**
  * Normalize a raw Telegram social value into a bare handle.
- * Strips URL prefixes (t.me, telegram.me), @ prefix, query/hash/path suffixes.
+ * Trims surrounding whitespace, strips URL prefixes (t.me, telegram.me),
+ * strips @ prefix, and strips query/hash/path suffixes.
  * Returns null if the result is not a valid Telegram handle (5-32 alphanumeric/underscore chars).
  */
 export function normalizeTelegramHandle(raw: string | null | undefined): string | null {
   if (!raw) return null;
 
   const stripped = raw
+    .trim()
     .replace(/^(?:https?:\/\/)?(?:t\.me|telegram\.me)\//, '')
     .replace(/^@/, '')
     .split(/[/?#]/)[0];

--- a/packages/protocol/src/shared/utils/tests/telegram-handle.spec.ts
+++ b/packages/protocol/src/shared/utils/tests/telegram-handle.spec.ts
@@ -1,0 +1,84 @@
+import { describe, test, expect } from 'bun:test';
+import { normalizeTelegramHandle } from '../telegram-handle.js';
+
+describe('normalizeTelegramHandle', () => {
+  test('returns null for null input', () => {
+    expect(normalizeTelegramHandle(null)).toBeNull();
+  });
+
+  test('returns null for undefined input', () => {
+    expect(normalizeTelegramHandle(undefined)).toBeNull();
+  });
+
+  test('returns null for empty string', () => {
+    expect(normalizeTelegramHandle('')).toBeNull();
+  });
+
+  test('returns bare handle as-is', () => {
+    expect(normalizeTelegramHandle('seref_k')).toBe('seref_k');
+  });
+
+  test('strips @ prefix', () => {
+    expect(normalizeTelegramHandle('@seref_k')).toBe('seref_k');
+  });
+
+  test('strips https://t.me/ prefix', () => {
+    expect(normalizeTelegramHandle('https://t.me/seref_k')).toBe('seref_k');
+  });
+
+  test('strips https://telegram.me/ prefix', () => {
+    expect(normalizeTelegramHandle('https://telegram.me/seref_k')).toBe('seref_k');
+  });
+
+  test('strips http:// prefix (no TLS)', () => {
+    expect(normalizeTelegramHandle('http://t.me/some_user')).toBe('some_user');
+  });
+
+  test('strips query params after handle', () => {
+    expect(normalizeTelegramHandle('https://t.me/seref_k?start=abc')).toBe('seref_k');
+  });
+
+  test('strips hash fragment after handle', () => {
+    expect(normalizeTelegramHandle('https://t.me/seref_k#section')).toBe('seref_k');
+  });
+
+  test('strips trailing slash (path separator)', () => {
+    expect(normalizeTelegramHandle('https://t.me/seref_k/')).toBe('seref_k');
+  });
+
+  test('handles t.me URL without protocol prefix', () => {
+    expect(normalizeTelegramHandle('t.me/my_handle')).toBe('my_handle');
+  });
+
+  test('returns null for handle shorter than 5 chars', () => {
+    expect(normalizeTelegramHandle('abcd')).toBeNull();
+    expect(normalizeTelegramHandle('bob')).toBeNull();
+  });
+
+  test('returns null for handle longer than 32 chars', () => {
+    expect(normalizeTelegramHandle('a'.repeat(33))).toBeNull();
+  });
+
+  test('accepts handle at exactly 5 chars', () => {
+    expect(normalizeTelegramHandle('ab_cd')).toBe('ab_cd');
+  });
+
+  test('accepts handle at exactly 32 chars', () => {
+    const handle = 'a'.repeat(32);
+    expect(normalizeTelegramHandle(handle)).toBe(handle);
+  });
+
+  test('URL-like value with query chars is safely normalized (strips prefix + query)', () => {
+    // t.me/alice?evil=1 → strips t.me/ prefix, strips ?evil=1, extracts "alice"
+    // This is the safe behavior — raw value is never interpolated verbatim.
+    expect(normalizeTelegramHandle('t.me/alice?evil=1')).toBe('alice');
+  });
+
+  test('returns null for handle with invalid chars (spaces)', () => {
+    expect(normalizeTelegramHandle('hello world')).toBeNull();
+  });
+
+  test('returns null for handle with special chars', () => {
+    expect(normalizeTelegramHandle('user!name')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes IND-271.

## New Features
- Pure helper `resolveActionableLinkKind` (status × role × viewerApproved → ConnectLinkKind matrix).
- Helpers `attachActionableLinks` + `buildProfileUrl` to mint `/c/<code>` short-links for MCP opportunity cards only when the viewer has a direct action.
- MCP `create_opportunities` (intro and discovery modes) now mints actionable links — closes the gap that caused agents to hallucinate `/api/opportunities/<uuid>/connect`.

## Bug Fixes
- `list_opportunities` no longer mints connect-tokens for non-actionable opportunities (e.g. draft-sender, pending-introducer).
- MCP presenter no longer surfaces the bare `opportunityId` UUID when a card has an `acceptUrl` — removes the foothold the LLM used to invent the bare endpoint pattern.
- `buildProfileUrl` validates Telegram handles via `normalizeTelegramHandle` (`^[A-Za-z0-9_]{5,32}$` + URL-prefix strip + whitespace trim). Invalid handles fall back to the web profile URL.

## Refactors
- Moved `normalizeTelegramHandle` from `backend/src/lib/utils/` into the protocol package (`packages/protocol/src/shared/utils/telegram-handle.ts`) so the protocol-layer helper and the backend service share a single source of truth.

## Documentation
- TSDoc on each new helper documents the actionability rules, the defaulting behavior of `viewerApproved`, and the fall-through for invalid Telegram handles.

## Tests
- 18 new unit tests for `attachActionableLinks` + `buildProfileUrl` (matrix, profileUrl resolution, mint-error resilience, Telegram handle validation including URL-like and short-handle fall-through).
- 8-row matrix tests for `resolveActionableLinkKind`.
- 3 MCP presenter tests covering opportunityId omission across actionability combinations.
- 6 integration tests in `tool.factory.spec.ts` for the MCP wiring: gating + mint kinds (connect / outreach / approve_introduction) + introducer-waiting non-mint.
- 19 unit tests for `normalizeTelegramHandle` in `packages/protocol/src/shared/utils/tests/telegram-handle.spec.ts`.

Bumped `@indexnetwork/protocol` to `0.30.2`.

## Test plan
- [x] `bun --env-file=../../backend/.env.development test src/opportunity/tests/opportunity.tools.spec.ts` — all pass
- [x] `bun --env-file=../../backend/.env.development test src/shared/agent/tests/tool.factory.spec.ts -t "MCP connect-link wiring"` — 6/6 pass
- [x] `bun --env-file=../../backend/.env.development test src/shared/utils/tests/telegram-handle.spec.ts` — 19/19 pass
- [x] `bun run tsc --noEmit` in both `packages/protocol` and `backend` — clean
- [ ] Manual MCP smoke via openclaw-plugin / Claude Code against a dev backend — verify `/c/<code>` appears for actionable cards from edgeclaw and no bare `/api/opportunities/.../connect` URL anywhere

Pre-existing failures in `tool.factory.spec.ts` (~11 unrelated tests) are baseline and not addressed in this PR.