### PR TITLE
refactor: rename MCP tool create_opportunities -> discover_opportunities (IND-270)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol",
-  "version": "0.21.3",
+  "version": "0.21.4",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/backend/src/controllers/tests/tool.controller.spec.ts
+++ b/backend/src/controllers/tests/tool.controller.spec.ts
@@ -248,16 +248,16 @@ describe("ToolController Integration", () => {
 
     // ── Opportunity (CLI: discover modes) ────────────────────────
 
-    test("create_opportunities with searchQuery (CLI: opportunity discover)", async () => {
-      const { status, data } = await invokeTool("create_opportunities", {
+    test("discover_opportunities with searchQuery (CLI: opportunity discover)", async () => {
+      const { status, data } = await invokeTool("discover_opportunities", {
         searchQuery: "AI engineer with privacy expertise",
       });
       expect(status).toBe(200);
       expect(String(data.error ?? "")).not.toContain("Invalid query");
     }, 120_000);
 
-    test("create_opportunities with targetUserId + searchQuery (CLI: discover --target)", async () => {
-      const { status, data } = await invokeTool("create_opportunities", {
+    test("discover_opportunities with targetUserId + searchQuery (CLI: discover --target)", async () => {
+      const { status, data } = await invokeTool("discover_opportunities", {
         targetUserId: testUserBId,
         searchQuery: "collaborate on open-source tooling",
       });
@@ -265,8 +265,8 @@ describe("ToolController Integration", () => {
       expect(String(data.error ?? "")).not.toContain("Invalid query");
     }, 120_000);
 
-    test("create_opportunities with partyUserIds + entities (CLI: discover --introduce)", async () => {
-      const { data } = await invokeTool("create_opportunities", {
+    test("discover_opportunities with partyUserIds + entities (CLI: discover --introduce)", async () => {
+      const { data } = await invokeTool("discover_opportunities", {
         partyUserIds: [testUserId, testUserBId],
         entities: [
           {

--- a/backend/tests/mcp.test.ts
+++ b/backend/tests/mcp.test.ts
@@ -107,7 +107,7 @@ describe('MCP Server Factory', () => {
       'read_intents',
       'create_intent',
       'read_user_profiles',
-      'create_opportunities',
+      'discover_opportunities',
       'update_opportunity',
       'list_contacts',
       'scrape_url',

--- a/docs/design/protocol-deep-dive.md
+++ b/docs/design/protocol-deep-dive.md
@@ -445,7 +445,7 @@ Tools bridge the ChatAgent to subgraphs. Each tool file defines LangChain tool f
 | `profile.tools.ts` | read_user_profiles, create_user_profile, update_user_profile | Profile Graph |
 | `intent.tools.ts` | read_intents, create_intent, update_intent, delete_intent, search_intents, create_intent_index, read_intent_indexes, delete_intent_index | Intent Graph, Intent Index Graph, Opportunity Graph (auto-discovery on create) |
 | `network.tools.ts` | read_indexes, read_users, create_index, update_index, delete_index, create_index_membership | Index Graph, Index Membership Graph |
-| `opportunity.tools.ts` | create_opportunities, list_my_opportunities, send_opportunity | Opportunity Graph |
+| `opportunity.tools.ts` | discover_opportunities, list_my_opportunities, send_opportunity | Opportunity Graph |
 | `contact.tools.ts` | add_contact, list_contacts, search_contacts | (direct service calls) |
 | `chat.tools.ts` | list_conversations, get_conversation | (direct `ChatSessionReader` calls) |
 | `utility.tools.ts` | scrape_url, confirm_action, cancel_action | (direct scraper call, pending action state) |
@@ -469,7 +469,7 @@ Tools that modify or delete data (update_intent, delete_intent, update_index, de
 
 ### Auto-discovery on intent creation
 
-When `create_intent` successfully creates an intent, it automatically triggers opportunity discovery by calling `create_opportunities` with the new intent context. This ensures fresh intents immediately produce relevant matches.
+When `create_intent` successfully creates an intent, it automatically triggers opportunity discovery by calling `discover_opportunities` with the new intent context. This ensures fresh intents immediately produce relevant matches.
 
 ## 5a. MCP Server
 

--- a/docs/design/protocol-deep-dive.md
+++ b/docs/design/protocol-deep-dive.md
@@ -445,7 +445,7 @@ Tools bridge the ChatAgent to subgraphs. Each tool file defines LangChain tool f
 | `profile.tools.ts` | read_user_profiles, create_user_profile, update_user_profile | Profile Graph |
 | `intent.tools.ts` | read_intents, create_intent, update_intent, delete_intent, search_intents, create_intent_index, read_intent_indexes, delete_intent_index | Intent Graph, Intent Index Graph, Opportunity Graph (auto-discovery on create) |
 | `network.tools.ts` | read_indexes, read_users, create_index, update_index, delete_index, create_index_membership | Index Graph, Index Membership Graph |
-| `opportunity.tools.ts` | discover_opportunities, list_my_opportunities, send_opportunity | Opportunity Graph |
+| `opportunity.tools.ts` | discover_opportunities, list_opportunities, update_opportunity | Opportunity Graph |
 | `contact.tools.ts` | add_contact, list_contacts, search_contacts | (direct service calls) |
 | `chat.tools.ts` | list_conversations, get_conversation | (direct `ChatSessionReader` calls) |
 | `utility.tools.ts` | scrape_url, confirm_action, cancel_action | (direct scraper call, pending action state) |

--- a/docs/handoffs/refactor-discover-opportunities-rename.md
+++ b/docs/handoffs/refactor-discover-opportunities-rename.md
@@ -1,0 +1,109 @@
+---
+trigger: "Rename MCP tool create_opportunities to discover_opportunities — the tool performs discovery, not creation, and the rest of the stack (queue job, service method) already uses the correct verb."
+type: refactor
+branch: refactor/discover-opportunities-rename
+base-branch: dev
+created: 2026-05-12
+version-bump: patch
+linear-issue: IND-270
+---
+
+## Related Files
+
+### Protocol tool layer
+- packages/protocol/src/opportunity/opportunity.tools.ts (canonical tool definition)
+- packages/protocol/src/chat/chat.agent.ts (auto-invoke logic, createOpportunitiesTool variable)
+- packages/protocol/src/chat/chat.prompt.ts
+- packages/protocol/src/chat/chat.prompt.modules.ts
+- packages/protocol/src/contact/contact.tools.ts
+- packages/protocol/src/intent/intent.tools.ts
+- packages/protocol/src/network/network.tools.ts
+- packages/protocol/src/shared/agent/utility.tools.ts
+- packages/protocol/src/opportunity/opportunity.discover.ts
+- packages/protocol/src/opportunity/opportunity.graph.ts
+- packages/protocol/src/opportunity/opportunity.state.ts
+
+### Protocol tests
+- packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
+- packages/protocol/src/chat/tests/chat.prompt.modules.spec.ts
+- packages/protocol/src/chat/tests/chat.prompt.spec.ts
+- packages/protocol/src/chat/tests/chat.agent.spec.ts
+- packages/protocol/src/chat/tests/chat.graph.mocks.ts
+- packages/protocol/src/opportunity/tests/opportunity.state.dedupAlreadyAccepted.spec.ts
+
+### Backend tests
+- backend/src/controllers/tests/tool.controller.spec.ts
+- backend/tests/mcp.test.ts
+
+### CLI
+- packages/cli/src/opportunity.command.ts
+- packages/cli/src/output/base.ts
+- packages/cli/tests/opportunity.command.test.ts
+- packages/cli/tests/tool-calls.test.ts
+
+### Frontend
+- frontend/src/components/chat/ToolCallsDisplay.tsx
+
+### Plugins + skill templates
+- packages/openclaw-plugin/skills/index-orchestrator/SKILL.md
+- packages/openclaw-plugin/src/polling/onboarding/onboarding.prompt.ts
+- packages/claude-plugin/skills/index-orchestrator/SKILL.md
+- packages/protocol/skills/openclaw/index-orchestrator.template.md
+- packages/protocol/skills/claude-plugin/index-orchestrator.template.md
+
+### Edgeclaw workspace
+- packages/edgeclaw/workspace/AGENTS.md
+- packages/edgeclaw/workspace/BOOTSTRAP.md
+- packages/edgeclaw/workspace/SOUL.md
+- packages/edgeclaw/workspace/TOOLS.md
+
+### Docs
+- docs/specs/api-reference.md
+- docs/specs/cli-reference.md
+- docs/design/protocol-deep-dive.md
+- docs/specs/2026-05-06-welcome-message-design.md
+- packages/protocol/src/README.md
+- packages/protocol/src/docs/Latent Opportunity Lifecycle.md
+
+## Relevant Docs
+- docs/specs/2026-05-12-discover-opportunities-rename-design.md (the design spec for this work)
+- docs/design/protocol-deep-dive.md (references the tool by name)
+- docs/specs/api-reference.md (lists the tool in the MCP tool reference)
+
+## Related Issues
+- IND-270 Rename MCP tool `create_opportunities` to `discover_opportunities` (Triage) — primary issue
+- Follow-up to be filed: queue job naming conventions (separate small issue per user direction)
+
+## Scope
+
+See `docs/specs/2026-05-12-discover-opportunities-rename-design.md` for the full design.
+
+Mechanical find-and-replace across ~38 files. No logic, behavior, schema, or queue changes.
+
+**Renames:**
+- `"create_opportunities"` (snake_case string) → `"discover_opportunities"` everywhere it appears as a tool name, prompt trigger, doc reference, CLI invocation, frontend display key, or test assertion.
+- `createOpportunities` / `createOpportunitiesTool` (camelCase variables holding the tool binding) → `discoverOpportunities` / `discoverOpportunitiesTool`.
+
+**Explicitly NOT renamed:**
+- `createOpportunitiesService` (frontend service factory, unrelated)
+- `createOpportunityTools` (factory function for the opportunity tool group, singular `Opportunity`)
+- BullMQ `discover_opportunities` job name (confirmed by user — keep queue name the same; a separate Linear issue will track queue naming conventions for the future)
+- `OpportunityQueue.handleDiscoverOpportunities` method
+- Service methods using `discoverOpportunities` (already correct)
+
+**Naming collision decision:** The MCP tool and the BullMQ job will share the string `"discover_opportunities"`. They sit at different layers (HTTP/MCP tool dispatch vs. Redis job dispatch). Runtime collision is impossible. Confirmed acceptable.
+
+**Verification gate:**
+- `bun run tsc` clean across backend, packages/protocol, packages/cli, frontend
+- Affected test suites pass (tool.factory.spec.ts, chat.prompt.modules.spec.ts, chat.prompt.spec.ts, chat.agent.spec.ts, tool.controller.spec.ts, mcp.test.ts, opportunity.command.test.ts, tool-calls.test.ts)
+- `bun run lint` clean
+- MCP `tools/list` exposes `discover_opportunities`; no `create_opportunities` remains
+- Regenerated SKILL.md files match updated templates
+
+**Version bumps (per CLAUDE.md finishing-a-branch):**
+- backend/package.json
+- packages/protocol/package.json
+- packages/cli/package.json
+- packages/claude-plugin/package.json
+- packages/openclaw-plugin/package.json AND packages/openclaw-plugin/openclaw.plugin.json (both must match)
+- frontend/package.json

--- a/docs/specs/2026-05-06-welcome-message-design.md
+++ b/docs/specs/2026-05-06-welcome-message-design.md
@@ -14,7 +14,7 @@ updated: 2026-05-06
 
 ## Problem
 
-After the user completes onboarding, there is no immediate follow-up message. The user calls `complete_onboarding()`, the onboarding subagent says "You're all set," and then silence until the next scheduled ambient or daily digest pass fires. The first intent is already captured during onboarding (Step 3), and `create_opportunities` runs at Step 4 — pending opportunities may already exist. The system should deliver a welcome message immediately, framing those initial results.
+After the user completes onboarding, there is no immediate follow-up message. The user calls `complete_onboarding()`, the onboarding subagent says "You're all set," and then silence until the next scheduled ambient or daily digest pass fires. The first intent is already captured during onboarding (Step 3), and `discover_opportunities` runs at Step 4 — pending opportunities may already exist. The system should deliver a welcome message immediately, framing those initial results.
 
 ## Solution
 

--- a/docs/specs/2026-05-12-discover-opportunities-rename-design.md
+++ b/docs/specs/2026-05-12-discover-opportunities-rename-design.md
@@ -1,0 +1,100 @@
+---
+title: Rename MCP tool `create_opportunities` → `discover_opportunities`
+type: spec
+tags: [mcp, tools, opportunity, refactor, naming]
+created: 2026-05-12
+updated: 2026-05-12
+linear: IND-270
+---
+
+## Summary
+
+The MCP tool currently named `create_opportunities` performs **discovery** — semantic search via HyDE embeddings, LLM evaluation, and pair scoring. The verb `create_` mismatches the actual semantic and contradicts the rest of the stack:
+
+- BullMQ job: `discover_opportunities` ✅
+- Service method: `discoverOpportunities` ✅
+- MCP tool: `create_opportunities` ❌ (the outlier)
+
+This spec aligns the MCP tool with the rest of the codebase by renaming it to `discover_opportunities`. Mechanical find-and-replace across ~38 files. No logic, behavior, or schema changes.
+
+## Motivation
+
+The misnamed tool reads as "make me some opportunities," when the actual semantic is "find people who match this query (and surface them as draft opportunities)." This:
+
+1. Misleads LLM callers about side-effect cost vs. read-only semantics.
+2. Conflicts with project voice (`directives.triage` / Index MCP voice prefers "discover" for exploration).
+3. Diverges from the queue/service naming already in place.
+
+## Scope
+
+### What is renamed
+
+- `"create_opportunities"` (snake_case string literal) → `"discover_opportunities"` everywhere it appears as:
+  - MCP tool `name` field (canonical definition in `packages/protocol/src/opportunity/opportunity.tools.ts`)
+  - Tool-call assertions in tests (`hasToolCall(..., "create_opportunities")`, `t.name === "create_opportunities"`)
+  - Prompt module triggers (`triggers: ["create_opportunities", ...]`)
+  - Cross-tool references in description strings (`contact.tools.ts`, `intent.tools.ts`, `network.tools.ts`, `utility.tools.ts`)
+  - Self-references inside the tool's own description and presentation messages
+  - CLI `client.callTool("create_opportunities", ...)` invocations
+  - CLI output label map
+  - Frontend `ToolCallsDisplay` switch entry
+  - Skill / template / docs markdown references
+- `createOpportunities` / `createOpportunitiesTool` (camelCase variables) → `discoverOpportunities` / `discoverOpportunitiesTool` where they hold the tool binding (e.g. `chat.agent.ts` `const createOpportunitiesTool = this.toolsByName.get(...)`)
+- `handleCreateIntentCallback` invocation comments that reference the renamed tool (string references inside comments)
+
+### What is NOT renamed
+
+- `createOpportunitiesService` in frontend — service factory (`createXService` pattern), unrelated to the MCP tool
+- `createOpportunityTools` function — factory that constructs all opportunity-related tool definitions (singular `Opportunity`)
+- BullMQ `discover_opportunities` job name — already correct
+- `OpportunityQueue.handleDiscoverOpportunities` method — already correct
+- `discoverOpportunitiesService` in `OpportunityService` / `OpportunityGraph` — already correct
+
+### Naming collision (queue job ↔ MCP tool)
+
+After the rename, the MCP tool and the BullMQ job will share the string `"discover_opportunities"`. They live at different layers (HTTP/MCP tool definition vs. Redis job name in `opportunity.queue.ts`). Runtime collision is impossible — the queue uses BullMQ's `queue.add(name, …)`, the MCP layer uses tool-name dispatch. Decision: **accept the collision**. The semantic match is the point; layer separation makes ambiguity low-risk for readers.
+
+## Affected files
+
+See IND-270 for the full inventory. High-level groups:
+
+- **Protocol tool layer**: `opportunity/opportunity.tools.ts`, `chat/chat.agent.ts`, `chat/chat.prompt.ts`, `chat/chat.prompt.modules.ts`, `contact/contact.tools.ts`, `intent/intent.tools.ts`, `network/network.tools.ts`, `shared/agent/utility.tools.ts`, `opportunity/opportunity.discover.ts`, `opportunity/opportunity.graph.ts`, `opportunity/opportunity.state.ts`
+- **Protocol tests**: `chat/tests/chat.prompt.modules.spec.ts`, `chat/tests/chat.prompt.spec.ts`, `chat/tests/chat.agent.spec.ts`, `chat/tests/chat.graph.mocks.ts`, `opportunity/tests/opportunity.state.dedupAlreadyAccepted.spec.ts`, `shared/agent/tests/tool.factory.spec.ts`
+- **Backend tests**: `backend/src/controllers/tests/tool.controller.spec.ts`, `backend/tests/mcp.test.ts`
+- **CLI**: `packages/cli/src/opportunity.command.ts`, `packages/cli/src/output/base.ts`, `packages/cli/tests/opportunity.command.test.ts`, `packages/cli/tests/tool-calls.test.ts`
+- **Frontend**: `frontend/src/components/chat/ToolCallsDisplay.tsx`
+- **Plugins**: `packages/openclaw-plugin/skills/index-orchestrator/SKILL.md`, `packages/openclaw-plugin/src/polling/onboarding/onboarding.prompt.ts`, `packages/claude-plugin/skills/index-orchestrator/SKILL.md`
+- **Skill templates** (sources of truth for SKILL.md generation): `packages/protocol/skills/openclaw/index-orchestrator.template.md`, `packages/protocol/skills/claude-plugin/index-orchestrator.template.md`
+- **Edgeclaw**: `packages/edgeclaw/workspace/AGENTS.md`, `BOOTSTRAP.md`, `SOUL.md`, `TOOLS.md`
+- **Docs**: `docs/specs/api-reference.md`, `docs/specs/cli-reference.md`, `docs/design/protocol-deep-dive.md`, `docs/specs/2026-05-06-welcome-message-design.md`, `packages/protocol/src/README.md`, `packages/protocol/src/docs/Latent Opportunity Lifecycle.md`
+
+## Out of scope
+
+- No DB migration, no API path change, no schema change.
+- No change to opportunity status, role, or visibility logic.
+- No queue rename.
+
+## Verification
+
+- `bun run tsc` clean for backend, `packages/protocol`, `packages/cli`, `frontend`
+- Targeted suites pass:
+  - `bun test src/shared/agent/tests/tool.factory.spec.ts`
+  - `bun test src/chat/tests/chat.prompt.modules.spec.ts`
+  - `bun test src/chat/tests/chat.prompt.spec.ts`
+  - `bun test src/chat/tests/chat.agent.spec.ts`
+  - `bun test src/controllers/tests/tool.controller.spec.ts` (in backend)
+  - `bun test tests/mcp.test.ts` (in backend)
+  - `bun test tests/opportunity.command.test.ts` (in packages/cli)
+  - `bun test tests/tool-calls.test.ts` (in packages/cli)
+- `bun run lint` clean
+- Manual: `mcp/tools/list` response includes `discover_opportunities`; no `create_opportunities` entry remains
+- After rebuild of skills (`scripts/build-skills.ts`), generated SKILL.md files match templates
+
+## Risks
+
+- **External callers**: Any external MCP client calling `create_opportunities` by name will break. Mitigation: this is an internal rename pre-1.0; no public deprecation window required. Edge city release notes should call out the rename if shipping concurrently.
+- **Snapshot tests**: Any snapshot containing the literal string `create_opportunities` will need regeneration. Caught by failing test runs.
+
+## Rollout
+
+Single PR. Merge to `dev`, push to upstream — subtree workflow propagates to `indexnetwork/cli`, `indexnetwork/protocol`, `indexnetwork/claude-plugin`, `indexnetwork/openclaw-plugin`. Plugin version bumps required (see CLAUDE.md "Finishing a Branch" — both `package.json` AND `openclaw.plugin.json` for openclaw-plugin).

--- a/docs/specs/api-reference.md
+++ b/docs/specs/api-reference.md
@@ -2942,13 +2942,13 @@ Tools are organized by domain. Each tool has its own input schema (see `GET /api
 | `create_intent_index` | Intent | Link an intent to an index |
 | `read_intent_indexes` | Intent | List indexes linked to an intent |
 | `delete_intent_index` | Intent | Unlink an intent from an index |
-| `read_indexes` | Index | List user's indexes |
-| `read_index_memberships` | Index | List members of an index |
-| `update_index` | Index | Update index settings (title, prompt) |
-| `create_index` | Index | Create a new index |
-| `delete_index` | Index | Delete an index |
-| `create_index_membership` | Index | Add a member to an index |
-| `delete_index_membership` | Index | Remove a member from an index |
+| `read_networks` | Network | List user's networks |
+| `read_network_memberships` | Network | List members of a network |
+| `update_network` | Network | Update network settings (title, prompt) |
+| `create_network` | Network | Create a new network |
+| `delete_network` | Network | Delete a network |
+| `create_network_membership` | Network | Add a member to a network |
+| `delete_network_membership` | Network | Remove a member from a network |
 | `discover_opportunities` | Opportunity | Discover opportunities (search, target, introduce) |
 | `list_opportunities` | Opportunity | List user's opportunities with filters |
 | `update_opportunity` | Opportunity | Accept or reject an opportunity. Accepting returns a `conversationId` (opens a DM between both parties) |

--- a/docs/specs/api-reference.md
+++ b/docs/specs/api-reference.md
@@ -2905,7 +2905,7 @@ Invoke a tool by name with a JSON query body.
 **Auth**: `AuthGuard`
 
 **Path params**:
-- `toolName` — Name of the tool to invoke (e.g. `read_intents`, `create_opportunities`)
+- `toolName` — Name of the tool to invoke (e.g. `read_intents`, `discover_opportunities`)
 
 **Request body**:
 ```json
@@ -2949,7 +2949,7 @@ Tools are organized by domain. Each tool has its own input schema (see `GET /api
 | `delete_index` | Index | Delete an index |
 | `create_index_membership` | Index | Add a member to an index |
 | `delete_index_membership` | Index | Remove a member from an index |
-| `create_opportunities` | Opportunity | Discover opportunities (search, target, introduce) |
+| `discover_opportunities` | Opportunity | Discover opportunities (search, target, introduce) |
 | `list_opportunities` | Opportunity | List user's opportunities with filters |
 | `update_opportunity` | Opportunity | Accept or reject an opportunity. Accepting returns a `conversationId` (opens a DM between both parties) |
 | `list_contacts` | Contact | List user's contacts |

--- a/docs/specs/cli-reference.md
+++ b/docs/specs/cli-reference.md
@@ -255,7 +255,7 @@ The `index opportunity` command exposes subcommands for managing opportunities f
 ### `index opportunity discover <query>`
 
 1. Reads credentials. Exits with error if not logged in.
-2. Calls the `create_opportunities` MCP tool via the Tool HTTP API with `{ searchQuery }`.
+2. Calls the `discover_opportunities` MCP tool via the Tool HTTP API with `{ searchQuery }`.
 3. Renders a table of discovered opportunities.
 
 Supports optional flags:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/frontend/src/components/chat/ToolCallsDisplay.tsx
+++ b/frontend/src/components/chat/ToolCallsDisplay.tsx
@@ -74,27 +74,31 @@ const TOOL_DESCRIPTIONS: Record<string, { action: string; running: string }> = {
     action: "Remove from network",
     running: "Removing signal from network...",
   },
-  read_indexes: {
+  read_networks: {
     action: "Check networks",
     running: "Checking your networks...",
   },
-  create_index: {
+  create_network: {
     action: "Create network",
     running: "Creating a new network...",
   },
-  update_index: {
+  update_network: {
     action: "Update network",
     running: "Updating network...",
   },
-  delete_index: {
+  delete_network: {
     action: "Delete network",
     running: "Deleting network...",
   },
-  create_index_membership: {
+  create_network_membership: {
     action: "Add member",
     running: "Adding member to network...",
   },
-  read_index_memberships: {
+  delete_network_membership: {
+    action: "Remove member",
+    running: "Removing member from network...",
+  },
+  read_network_memberships: {
     action: "Fetch memberships",
     running: "Fetching network memberships...",
   },

--- a/frontend/src/components/chat/ToolCallsDisplay.tsx
+++ b/frontend/src/components/chat/ToolCallsDisplay.tsx
@@ -98,7 +98,7 @@ const TOOL_DESCRIPTIONS: Record<string, { action: string; running: string }> = {
     action: "Fetch memberships",
     running: "Fetching network memberships...",
   },
-  create_opportunities: {
+  discover_opportunities: {
     action: "Find opportunities",
     running: "Searching for relevant connections...",
   },

--- a/frontend/src/components/chat/ToolCallsDisplay.tsx
+++ b/frontend/src/components/chat/ToolCallsDisplay.tsx
@@ -102,7 +102,7 @@ const TOOL_DESCRIPTIONS: Record<string, { action: string; running: string }> = {
     action: "Find opportunities",
     running: "Searching for relevant connections...",
   },
-  list_my_opportunities: {
+  list_opportunities: {
     action: "List opportunities",
     running: "Listing your opportunities...",
   },
@@ -859,7 +859,7 @@ interface TraceDisplayProps {
 }
 
 function RunningTimer({ startedAt }: { startedAt: number }) {
-  const [elapsed, setElapsed] = useState(Date.now() - startedAt);
+  const [elapsed, setElapsed] = useState(() => Date.now() - startedAt);
 
   useEffect(() => {
     const interval = setInterval(() => {

--- a/packages/claude-plugin/package.json
+++ b/packages/claude-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/claude-plugin",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Index Network Claude Code plugin — orchestrator and negotiator skills",
   "type": "module",
   "homepage": "https://index.network",

--- a/packages/claude-plugin/skills/index-orchestrator/SKILL.md
+++ b/packages/claude-plugin/skills/index-orchestrator/SKILL.md
@@ -78,7 +78,7 @@ If the user then wants to connect with this person, continue to Pattern 1a.
 
 For "find me a mentor", "who needs a React dev", "looking for investors":
 
-**Call `create_opportunities(searchQuery=user's request)` FIRST. Do NOT call `create_intent` unless the user explicitly says "save", "create", "add", or "remember" a signal.**
+**Call `discover_opportunities(searchQuery=user's request)` FIRST. Do NOT call `create_intent` unless the user explicitly says "save", "create", "add", or "remember" a signal.**
 
 - For "in my network" / "from my contacts" / "people I know": pass the personal index ID (`isPersonal: true`) as `networkId`
 - If the tool returns `suggestIntentCreationForVisibility: true` and `suggestedIntentDescription`: after presenting results, ask once: "Would you also like to create a signal for this so others can find you?" If yes, call `create_intent(description=suggestedIntentDescription)` and include the returned ` ```intent_proposal ` block verbatim
@@ -92,11 +92,11 @@ When the user mentions a specific person AND wants to connect:
 1. read_user_profiles(userId=X) + read_network_memberships(userId=X)
 2. Intersect their indexes with the current user's preloaded memberships → find shared indexes
 3. If no shared indexes: tell the user there is no connection path
-4. create_opportunities(targetUserId=X, searchQuery="<synthesized reason>")
+4. discover_opportunities(targetUserId=X, searchQuery="<synthesized reason>")
 5. Present the opportunity card
 ```
 
-Do NOT call `read_intents` before `create_opportunities` here — the tool fetches intents internally.
+Do NOT call `read_intents` before `discover_opportunities` here — the tool fetches intents internally.
 
 ## Pattern 2: Explicit intent/signal creation
 
@@ -139,7 +139,7 @@ Exception: for profile creation, pass URLs directly to `create_user_profile` —
 
 ## Pattern 5: Introduce two people
 
-**Always gather context before calling `create_opportunities`. The tool does NOT fetch data internally for introductions.**
+**Always gather context before calling `discover_opportunities`. The tool does NOT fetch data internally for introductions.**
 
 ```
 1. read_network_memberships(userId=A) + read_network_memberships(userId=B) → shared indexes
@@ -147,7 +147,7 @@ Exception: for profile creation, pass URLs directly to `create_user_profile` —
 3. read_user_profiles(userId=A) + read_user_profiles(userId=B)
 4. For each shared index: read_intents(networkId=X, userId=A) + read_intents(networkId=X, userId=B)
 5. Summarize: "Here's what I found about A and B..."
-6. create_opportunities(partyUserIds=[A,B], entities=[{userId:A, profile:{...}, intents:[...], networkId:sharedId}, {userId:B, ...}], hint="user's reason")
+6. discover_opportunities(partyUserIds=[A,B], entities=[{userId:A, profile:{...}, intents:[...], networkId:sharedId}, {userId:B, ...}], hint="user's reason")
 7. Present the draft introduction
 ```
 
@@ -158,7 +158,7 @@ The `entities` array must include each party's userId, full profile, intents fro
 When the user asks "who should I introduce to @Person" or "find connections for @Person":
 
 ```
-1. create_opportunities(introTargetUserId=mentionedUserId, searchQuery="<optional refinement>")
+1. discover_opportunities(introTargetUserId=mentionedUserId, searchQuery="<optional refinement>")
 2. Present the returned introduction cards
 ```
 
@@ -194,6 +194,6 @@ Handle community management silently: do not narrate "your indexes" or "your com
 
 ## Opportunities in chat
 
-Chat surfaces opportunities only from `create_opportunities` calls in this conversation. Do not offer to "list" or "show" all existing opportunities — those are on the home view. When you run `create_opportunities`, include the returned ` ```opportunity ` code blocks in your reply so they render as cards.
+Chat surfaces opportunities only from `discover_opportunities` calls in this conversation. Do not offer to "list" or "show" all existing opportunities — those are on the home view. When you run `discover_opportunities`, include the returned ` ```opportunity ` code blocks in your reply so they render as cards.
 
 **Only describe what the tool response confirms happened.** Status "pending" sends a notification — not a message or invite. Status "accepted" adds a contact. Never claim you sent messages or invites on the user's behalf.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/cli",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Command-line interface for Index Network",
   "license": "MIT",
   "type": "module",

--- a/packages/cli/src/opportunity.command.ts
+++ b/packages/cli/src/opportunity.command.ts
@@ -98,7 +98,7 @@ export async function handleOpportunity(
         await discoverIntroduction(client, userA, userB, hint, options.json);
       } else if (options.target) {
         if (!options.json) output.info("Discovering opportunities...");
-        const result = await client.callTool("create_opportunities", {
+        const result = await client.callTool("discover_opportunities", {
           targetUserId: options.target,
           searchQuery: query,
         });
@@ -109,7 +109,7 @@ export async function handleOpportunity(
         if (data?.message) output.dim(`  ${data.message}`);
       } else {
         if (!options.json) output.info("Discovering opportunities...");
-        const result = await client.callTool("create_opportunities", { searchQuery: query });
+        const result = await client.callTool("discover_opportunities", { searchQuery: query });
         if (options.json) { console.log(JSON.stringify(result)); return; }
         if (!result.success) { output.error(result.error ?? "Discovery failed", 1); return; }
         output.success("Discovery complete.");
@@ -172,7 +172,7 @@ async function opportunityStatusUpdate(
 
 /**
  * Gather profiles and intents for two users, find a shared index,
- * then call create_opportunities in introduction mode.
+ * then call discover_opportunities in introduction mode.
  */
 async function discoverIntroduction(
   client: ApiClient,
@@ -256,8 +256,8 @@ async function discoverIntroduction(
 
   if (!json) output.dim("  Profiles and intents gathered. Creating introduction...");
 
-  // Step 3: Call create_opportunities with full entity data
-  const result = await client.callTool("create_opportunities", {
+  // Step 3: Call discover_opportunities with full entity data
+  const result = await client.callTool("discover_opportunities", {
     partyUserIds: [userA, userB],
     entities,
     ...(hint ? { hint } : {}),

--- a/packages/cli/src/output/base.ts
+++ b/packages/cli/src/output/base.ts
@@ -119,7 +119,7 @@ const TOOL_DESCRIPTIONS: Record<string, string> = {
   delete_index: "Deleting index...",
   create_index_membership: "Adding member to index...",
   read_index_memberships: "Fetching index memberships...",
-  create_opportunities: "Searching for relevant connections...",
+  discover_opportunities: "Searching for relevant connections...",
   list_my_opportunities: "Listing your opportunities...",
   update_opportunity: "Updating opportunity status...",
   scrape_url: "Reading content from URL...",

--- a/packages/cli/src/output/base.ts
+++ b/packages/cli/src/output/base.ts
@@ -120,7 +120,7 @@ const TOOL_DESCRIPTIONS: Record<string, string> = {
   create_index_membership: "Adding member to index...",
   read_index_memberships: "Fetching index memberships...",
   discover_opportunities: "Searching for relevant connections...",
-  list_my_opportunities: "Listing your opportunities...",
+  list_opportunities: "Listing your opportunities...",
   update_opportunity: "Updating opportunity status...",
   scrape_url: "Reading content from URL...",
   read_docs: "Looking up documentation...",
@@ -129,7 +129,6 @@ const TOOL_DESCRIPTIONS: Record<string, string> = {
   list_contacts: "Listing your contacts...",
   add_contact: "Adding contact...",
   remove_contact: "Removing contact...",
-  send_opportunity: "Sending opportunity...",
 };
 
 /** Get a human-friendly description for a raw tool name. */

--- a/packages/cli/tests/opportunity.command.test.ts
+++ b/packages/cli/tests/opportunity.command.test.ts
@@ -257,7 +257,7 @@ describe("opportunity command behavior", () => {
           };
         }
 
-        if (toolName === "create_opportunities") {
+        if (toolName === "discover_opportunities") {
           return {
             success: true,
             data: {},
@@ -287,7 +287,7 @@ describe("opportunity command behavior", () => {
       console.log = log;
     }
 
-    expect(calls).not.toContain("create_opportunities");
+    expect(calls).not.toContain("discover_opportunities");
     expect(logs).toHaveLength(1);
     expect(logs[0]).toContain("\"success\":false");
     expect(logs[0]).toContain("profile lookup failed");

--- a/packages/cli/tests/tool-calls.test.ts
+++ b/packages/cli/tests/tool-calls.test.ts
@@ -277,8 +277,8 @@ describe("CLI tool call contracts", () => {
   // ── Opportunity ──────────────────────────────────────────────────
 
   describe("opportunity", () => {
-    it("discover (search) calls create_opportunities with searchQuery", async () => {
-      mock.setToolResponse("create_opportunities", { success: true, data: { message: "Found 3 matches" } });
+    it("discover (search) calls discover_opportunities with searchQuery", async () => {
+      mock.setToolResponse("discover_opportunities", { success: true, data: { message: "Found 3 matches" } });
 
       await handleOpportunity(client, "discover", {
         positionals: ["AI engineer with privacy expertise"],
@@ -286,14 +286,14 @@ describe("CLI tool call contracts", () => {
       });
 
       expect(mock.toolCalls).toHaveLength(1);
-      expect(mock.toolCalls[0].toolName).toBe("create_opportunities");
+      expect(mock.toolCalls[0].toolName).toBe("discover_opportunities");
       expect(mock.toolCalls[0].query).toEqual({
         searchQuery: "AI engineer with privacy expertise",
       });
     });
 
-    it("discover --target calls create_opportunities with targetUserId and searchQuery", async () => {
-      mock.setToolResponse("create_opportunities", { success: true, data: {} });
+    it("discover --target calls discover_opportunities with targetUserId and searchQuery", async () => {
+      mock.setToolResponse("discover_opportunities", { success: true, data: {} });
 
       await handleOpportunity(client, "discover", {
         target: "user-abc",
@@ -302,14 +302,14 @@ describe("CLI tool call contracts", () => {
       });
 
       expect(mock.toolCalls).toHaveLength(1);
-      expect(mock.toolCalls[0].toolName).toBe("create_opportunities");
+      expect(mock.toolCalls[0].toolName).toBe("discover_opportunities");
       expect(mock.toolCalls[0].query).toEqual({
         targetUserId: "user-abc",
         searchQuery: "collaborate on LLM tooling",
       });
     });
 
-    it("discover --introduce gathers entities then calls create_opportunities with partyUserIds + entities", async () => {
+    it("discover --introduce gathers entities then calls discover_opportunities with partyUserIds + entities", async () => {
       // Mock the prerequisite tool responses
       mock.setToolResponse("read_index_memberships", {
         success: true,
@@ -329,7 +329,7 @@ describe("CLI tool call contracts", () => {
           intents: [{ intentId: "i1", payload: "Looking for collaborators", summary: "Collab" }],
         },
       });
-      mock.setToolResponse("create_opportunities", { success: true, data: { message: "Draft created" } });
+      mock.setToolResponse("discover_opportunities", { success: true, data: { message: "Draft created" } });
 
       await handleOpportunity(client, "discover", {
         introduce: "user-a",
@@ -337,15 +337,15 @@ describe("CLI tool call contracts", () => {
         json: true,
       });
 
-      // Should have called: read_index_memberships x2, read_user_profiles x2, read_intents x2, create_opportunities x1
+      // Should have called: read_index_memberships x2, read_user_profiles x2, read_intents x2, discover_opportunities x1
       const toolNames = mock.toolCalls.map((c) => c.toolName);
       expect(toolNames.filter((n) => n === "read_index_memberships")).toHaveLength(2);
       expect(toolNames.filter((n) => n === "read_user_profiles")).toHaveLength(2);
       expect(toolNames.filter((n) => n === "read_intents")).toHaveLength(2);
-      expect(toolNames.filter((n) => n === "create_opportunities")).toHaveLength(1);
+      expect(toolNames.filter((n) => n === "discover_opportunities")).toHaveLength(1);
 
-      // Verify the final create_opportunities call has correct shape
-      const createCall = mock.toolCalls.find((c) => c.toolName === "create_opportunities")!;
+      // Verify the final discover_opportunities call has correct shape
+      const createCall = mock.toolCalls.find((c) => c.toolName === "discover_opportunities")!;
       expect(createCall.query.partyUserIds).toEqual(["user-a", "user-b"]);
       expect(createCall.query.entities).toBeArray();
       expect(createCall.query.hint).toBe("both working on privacy ML");
@@ -367,7 +367,7 @@ describe("CLI tool call contracts", () => {
       });
       mock.setToolResponse("read_user_profiles", { success: true, data: { profile: { name: "X" } } });
       mock.setToolResponse("read_intents", { success: true, data: { intents: [] } });
-      mock.setToolResponse("create_opportunities", { success: true, data: {} });
+      mock.setToolResponse("discover_opportunities", { success: true, data: {} });
 
       await handleOpportunity(client, "discover", {
         introduce: "user-a",
@@ -375,7 +375,7 @@ describe("CLI tool call contracts", () => {
         json: true,
       });
 
-      const createCall = mock.toolCalls.find((c) => c.toolName === "create_opportunities")!;
+      const createCall = mock.toolCalls.find((c) => c.toolName === "discover_opportunities")!;
       expect(createCall.query.partyUserIds).toEqual(["user-a", "user-b"]);
       expect(createCall.query.hint).toBeUndefined();
     });
@@ -392,8 +392,8 @@ describe("CLI tool call contracts", () => {
         json: true,
       });
 
-      // Should NOT have called create_opportunities — stopped at membership check
-      expect(mock.toolCalls.filter((c) => c.toolName === "create_opportunities")).toHaveLength(0);
+      // Should NOT have called discover_opportunities — stopped at membership check
+      expect(mock.toolCalls.filter((c) => c.toolName === "discover_opportunities")).toHaveLength(0);
       // Should only have the 2 membership lookups
       expect(mock.toolCalls).toHaveLength(2);
       expect(mock.toolCalls.every((c) => c.toolName === "read_index_memberships")).toBe(true);

--- a/packages/edgeclaw/workspace/AGENTS.md
+++ b/packages/edgeclaw/workspace/AGENTS.md
@@ -118,7 +118,7 @@ URI-encode the greeting and append it as `&msg=...` (or `?text=...` for `t.me`) 
 
 - Don't expose raw JSON, internal IDs, or internal vocabulary in user-facing replies.
 - Don't accept a received opportunity without the user's explicit approval in the current conversation.
-- Don't run discovery tools (`create_opportunities`, `list_opportunities`) during bootstrap onboarding.
+- Don't run discovery tools (`discover_opportunities`, `list_opportunities`) during bootstrap onboarding.
 - Don't compose a `&msg=` greeting for `connector-flow` candidates — only for `connection`. Connector accepts trigger an introduction approval, not a direct conversation.
 - Don't render link strips, action rows, or markdown tables of links in chat replies. Weave URLs into prose; the strip-the-URLs test in `TOOLS.md` is the rule.
 - `trash` > `rm`. When in doubt, ask.

--- a/packages/edgeclaw/workspace/BOOTSTRAP.md
+++ b/packages/edgeclaw/workspace/BOOTSTRAP.md
@@ -76,7 +76,7 @@ Run the welcome pass — follow `prompts/welcome.md`. It handles the message com
 ## Rules
 
 - Do not skip steps or reorder them.
-- Do not call `create_opportunities`, `list_opportunities`, or any other discovery tool **before Step 6**. Onboarding ends at `complete_onboarding()`; the welcome ambient pass is the first time discovery is allowed.
+- Do not call `discover_opportunities`, `list_opportunities`, or any other discovery tool **before Step 6**. Onboarding ends at `complete_onboarding()`; the welcome ambient pass is the first time discovery is allowed.
 - Do not mention Gmail or email import — they are not available in this flow.
 - Call `create_intent` at most once per user response.
 - If the user tries to do something else mid-onboarding, gently redirect: "Let's finish setting you up first, then we can dive into that."

--- a/packages/edgeclaw/workspace/SOUL.md
+++ b/packages/edgeclaw/workspace/SOUL.md
@@ -21,7 +21,7 @@ Translate, never dump. Synthesize results in natural language; never expose inte
 ## Boundaries
 
 - Never accept a received opportunity without explicit user approval in the current conversation.
-- Never call discovery tools (`create_opportunities`, `list_opportunities`) during the bootstrap onboarding flow — matches surface later through ambient passes.
+- Never call discovery tools (`discover_opportunities`, `list_opportunities`) during the bootstrap onboarding flow — matches surface later through ambient passes.
 - Never run heavy MCP work or load `MEMORY.md` in shared sessions (group chats, Discord, Telegram groups). Discovery is a private signal.
 - Negotiations are handled server-side. If the user asks, list them via `list_negotiations` or `get_negotiation`. Do not call `respond_to_negotiation`.
 - Don't exfiltrate private data. The personal index is *theirs*; don't quote it into shared spaces.

--- a/packages/edgeclaw/workspace/TOOLS.md
+++ b/packages/edgeclaw/workspace/TOOLS.md
@@ -9,7 +9,7 @@ The MCP server `index` is preinstalled — your only tool surface for everything
 - **Profile** — `create_user_profile`, `read_user_profiles`, `update_user_profile`
 - **Networks (communities)** — `read_networks`, `create_network`, `update_network`, `delete_network`, `read_network_memberships`, `create_network_membership`, `delete_network_membership`
 - **Signals (intents)** — `create_intent`, `read_intents`, `update_intent`, `delete_intent`, `search_intents`, `create_intent_index`, `read_intent_indexes`, `delete_intent_index`
-- **Discovery** — `create_opportunities`, `list_opportunities`, `update_opportunity`, `confirm_opportunity_delivery`
+- **Discovery** — `discover_opportunities`, `list_opportunities`, `update_opportunity`, `confirm_opportunity_delivery`
 - **Negotiations** — `list_negotiations`, `get_negotiation` (read-only — negotiations are handled server-side; do not call `respond_to_negotiation`)
 - **Conversations** — `list_conversations`, `get_conversation`
 - **Contacts** — `add_contact`, `import_contacts`, `import_gmail_contacts`, `list_contacts`, `search_contacts`, `remove_contact`

--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "indexnetwork-openclaw-plugin",
   "name": "Index Network",
   "description": "Index Network — find the right people and let them find you. Registers the Index Network MCP server on first use and hands off to its guidance.",
-  "version": "0.29.7",
+  "version": "0.29.8",
   "configSchema": {
     "type": "object",
     "properties": {

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/openclaw-plugin",
-  "version": "0.29.7",
+  "version": "0.29.8",
   "description": "Index Network — OpenClaw plugin. Find the right people and let them find you.",
   "license": "MIT",
   "private": false,

--- a/packages/openclaw-plugin/skills/index-orchestrator/SKILL.md
+++ b/packages/openclaw-plugin/skills/index-orchestrator/SKILL.md
@@ -82,7 +82,7 @@ If the user then wants to connect with this person, continue to Pattern 1a.
 
 For "find me a mentor", "who needs a React dev", "looking for investors":
 
-**Call `create_opportunities(searchQuery=user's request)` FIRST. Do NOT call `create_intent` unless the user explicitly says "save", "create", "add", or "remember" a signal.**
+**Call `discover_opportunities(searchQuery=user's request)` FIRST. Do NOT call `create_intent` unless the user explicitly says "save", "create", "add", or "remember" a signal.**
 
 - For "in my network" / "from my contacts" / "people I know": pass the personal index ID (`isPersonal: true`) as `networkId`
 - If the tool returns `suggestIntentCreationForVisibility: true` and `suggestedIntentDescription`: after presenting results, ask once: "Would you also like to create a signal for this so others can find you?" If yes, call `create_intent(description=suggestedIntentDescription)`
@@ -96,11 +96,11 @@ When the user mentions a specific person AND wants to connect:
 1. read_user_profiles(userId=X) + read_network_memberships(userId=X)
 2. Intersect their indexes with the current user's preloaded memberships → find shared indexes
 3. If no shared indexes: tell the user there is no connection path
-4. create_opportunities(targetUserId=X, searchQuery="<synthesized reason>")
+4. discover_opportunities(targetUserId=X, searchQuery="<synthesized reason>")
 5. Present the opportunity naturally
 ```
 
-Do NOT call `read_intents` before `create_opportunities` here — the tool fetches intents internally.
+Do NOT call `read_intents` before `discover_opportunities` here — the tool fetches intents internally.
 
 ## Pattern 2: Explicit intent/signal creation
 
@@ -141,7 +141,7 @@ Exception: for profile creation, pass URLs directly to `create_user_profile` —
 
 ## Pattern 5: Introduce two people
 
-**Always gather context before calling `create_opportunities`. The tool does NOT fetch data internally for introductions.**
+**Always gather context before calling `discover_opportunities`. The tool does NOT fetch data internally for introductions.**
 
 ```
 1. read_network_memberships(userId=A) + read_network_memberships(userId=B) → shared indexes
@@ -149,7 +149,7 @@ Exception: for profile creation, pass URLs directly to `create_user_profile` —
 3. read_user_profiles(userId=A) + read_user_profiles(userId=B)
 4. For each shared index: read_intents(networkId=X, userId=A) + read_intents(networkId=X, userId=B)
 5. Summarize: "Here's what I found about A and B..."
-6. create_opportunities(partyUserIds=[A,B], entities=[{userId:A, profile:{...}, intents:[...], networkId:sharedId}, {userId:B, ...}], hint="user's reason")
+6. discover_opportunities(partyUserIds=[A,B], entities=[{userId:A, profile:{...}, intents:[...], networkId:sharedId}, {userId:B, ...}], hint="user's reason")
 7. Present the draft introduction
 ```
 
@@ -160,7 +160,7 @@ The `entities` array must include each party's userId, full profile, intents fro
 When the user asks "who should I introduce to @Person" or "find connections for @Person":
 
 ```
-1. create_opportunities(introTargetUserId=mentionedUserId, searchQuery="<optional refinement>")
+1. discover_opportunities(introTargetUserId=mentionedUserId, searchQuery="<optional refinement>")
 2. Present the returned introduction candidates
 ```
 

--- a/packages/openclaw-plugin/src/polling/onboarding/onboarding.prompt.ts
+++ b/packages/openclaw-plugin/src/polling/onboarding/onboarding.prompt.ts
@@ -49,7 +49,7 @@ ${brandingClause}
 - If the user tries to do something else mid-onboarding, gently redirect: "Let's finish setting you up first, then we can dive into that."
 - Keep your tone warm, direct, and concise.
 - Only call \`complete_onboarding()\` at Step 4 — never earlier.
-- **Never call \`create_opportunities\`, \`list_opportunities\`, or any other discovery tool during onboarding.** Onboarding ends at \`complete_onboarding()\`; matches surface later through ambient polling. Inline discovery here adds latency and produces empty results for fresh users.
+- **Never call \`discover_opportunities\`, \`list_opportunities\`, or any other discovery tool during onboarding.** Onboarding ends at \`complete_onboarding()\`; matches surface later through ambient polling. Inline discovery here adds latency and produces empty results for fresh users.
 - Call \`create_intent\` at most once per user response. If verification rejects an intent, ask one clarifying question instead of paraphrasing and retrying.${branding ? `
 - You are operating on behalf of the **${branding.nodeName}** community. When you greet, acknowledge, or close, frame it around ${branding.nodeName} (not the generic "Index Network"). Do not invite the user to other communities — they are scoped to ${branding.nodeName}.` : ''}
 `;

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/skills/claude-plugin/index-orchestrator.template.md
+++ b/packages/protocol/skills/claude-plugin/index-orchestrator.template.md
@@ -37,7 +37,7 @@ If the user then wants to connect with this person, continue to Pattern 1a.
 
 For "find me a mentor", "who needs a React dev", "looking for investors":
 
-**Call `create_opportunities(searchQuery=user's request)` FIRST. Do NOT call `create_intent` unless the user explicitly says "save", "create", "add", or "remember" a signal.**
+**Call `discover_opportunities(searchQuery=user's request)` FIRST. Do NOT call `create_intent` unless the user explicitly says "save", "create", "add", or "remember" a signal.**
 
 - For "in my network" / "from my contacts" / "people I know": pass the personal index ID (`isPersonal: true`) as `networkId`
 - If the tool returns `suggestIntentCreationForVisibility: true` and `suggestedIntentDescription`: after presenting results, ask once: "Would you also like to create a signal for this so others can find you?" If yes, call `create_intent(description=suggestedIntentDescription)` and include the returned ` ```intent_proposal ` block verbatim
@@ -51,11 +51,11 @@ When the user mentions a specific person AND wants to connect:
 1. read_user_profiles(userId=X) + read_network_memberships(userId=X)
 2. Intersect their indexes with the current user's preloaded memberships → find shared indexes
 3. If no shared indexes: tell the user there is no connection path
-4. create_opportunities(targetUserId=X, searchQuery="<synthesized reason>")
+4. discover_opportunities(targetUserId=X, searchQuery="<synthesized reason>")
 5. Present the opportunity card
 ```
 
-Do NOT call `read_intents` before `create_opportunities` here — the tool fetches intents internally.
+Do NOT call `read_intents` before `discover_opportunities` here — the tool fetches intents internally.
 
 ## Pattern 2: Explicit intent/signal creation
 
@@ -98,7 +98,7 @@ Exception: for profile creation, pass URLs directly to `create_user_profile` —
 
 ## Pattern 5: Introduce two people
 
-**Always gather context before calling `create_opportunities`. The tool does NOT fetch data internally for introductions.**
+**Always gather context before calling `discover_opportunities`. The tool does NOT fetch data internally for introductions.**
 
 ```
 1. read_network_memberships(userId=A) + read_network_memberships(userId=B) → shared indexes
@@ -106,7 +106,7 @@ Exception: for profile creation, pass URLs directly to `create_user_profile` —
 3. read_user_profiles(userId=A) + read_user_profiles(userId=B)
 4. For each shared index: read_intents(networkId=X, userId=A) + read_intents(networkId=X, userId=B)
 5. Summarize: "Here's what I found about A and B..."
-6. create_opportunities(partyUserIds=[A,B], entities=[{userId:A, profile:{...}, intents:[...], networkId:sharedId}, {userId:B, ...}], hint="user's reason")
+6. discover_opportunities(partyUserIds=[A,B], entities=[{userId:A, profile:{...}, intents:[...], networkId:sharedId}, {userId:B, ...}], hint="user's reason")
 7. Present the draft introduction
 ```
 
@@ -117,7 +117,7 @@ The `entities` array must include each party's userId, full profile, intents fro
 When the user asks "who should I introduce to @Person" or "find connections for @Person":
 
 ```
-1. create_opportunities(introTargetUserId=mentionedUserId, searchQuery="<optional refinement>")
+1. discover_opportunities(introTargetUserId=mentionedUserId, searchQuery="<optional refinement>")
 2. Present the returned introduction cards
 ```
 
@@ -153,6 +153,6 @@ Handle community management silently: do not narrate "your indexes" or "your com
 
 ## Opportunities in chat
 
-Chat surfaces opportunities only from `create_opportunities` calls in this conversation. Do not offer to "list" or "show" all existing opportunities — those are on the home view. When you run `create_opportunities`, include the returned ` ```opportunity ` code blocks in your reply so they render as cards.
+Chat surfaces opportunities only from `discover_opportunities` calls in this conversation. Do not offer to "list" or "show" all existing opportunities — those are on the home view. When you run `discover_opportunities`, include the returned ` ```opportunity ` code blocks in your reply so they render as cards.
 
 **Only describe what the tool response confirms happened.** Status "pending" sends a notification — not a message or invite. Status "accepted" adds a contact. Never claim you sent messages or invites on the user's behalf.

--- a/packages/protocol/skills/openclaw/index-orchestrator.template.md
+++ b/packages/protocol/skills/openclaw/index-orchestrator.template.md
@@ -41,7 +41,7 @@ If the user then wants to connect with this person, continue to Pattern 1a.
 
 For "find me a mentor", "who needs a React dev", "looking for investors":
 
-**Call `create_opportunities(searchQuery=user's request)` FIRST. Do NOT call `create_intent` unless the user explicitly says "save", "create", "add", or "remember" a signal.**
+**Call `discover_opportunities(searchQuery=user's request)` FIRST. Do NOT call `create_intent` unless the user explicitly says "save", "create", "add", or "remember" a signal.**
 
 - For "in my network" / "from my contacts" / "people I know": pass the personal index ID (`isPersonal: true`) as `networkId`
 - If the tool returns `suggestIntentCreationForVisibility: true` and `suggestedIntentDescription`: after presenting results, ask once: "Would you also like to create a signal for this so others can find you?" If yes, call `create_intent(description=suggestedIntentDescription)`
@@ -55,11 +55,11 @@ When the user mentions a specific person AND wants to connect:
 1. read_user_profiles(userId=X) + read_network_memberships(userId=X)
 2. Intersect their indexes with the current user's preloaded memberships → find shared indexes
 3. If no shared indexes: tell the user there is no connection path
-4. create_opportunities(targetUserId=X, searchQuery="<synthesized reason>")
+4. discover_opportunities(targetUserId=X, searchQuery="<synthesized reason>")
 5. Present the opportunity naturally
 ```
 
-Do NOT call `read_intents` before `create_opportunities` here — the tool fetches intents internally.
+Do NOT call `read_intents` before `discover_opportunities` here — the tool fetches intents internally.
 
 ## Pattern 2: Explicit intent/signal creation
 
@@ -100,7 +100,7 @@ Exception: for profile creation, pass URLs directly to `create_user_profile` —
 
 ## Pattern 5: Introduce two people
 
-**Always gather context before calling `create_opportunities`. The tool does NOT fetch data internally for introductions.**
+**Always gather context before calling `discover_opportunities`. The tool does NOT fetch data internally for introductions.**
 
 ```
 1. read_network_memberships(userId=A) + read_network_memberships(userId=B) → shared indexes
@@ -108,7 +108,7 @@ Exception: for profile creation, pass URLs directly to `create_user_profile` —
 3. read_user_profiles(userId=A) + read_user_profiles(userId=B)
 4. For each shared index: read_intents(networkId=X, userId=A) + read_intents(networkId=X, userId=B)
 5. Summarize: "Here's what I found about A and B..."
-6. create_opportunities(partyUserIds=[A,B], entities=[{userId:A, profile:{...}, intents:[...], networkId:sharedId}, {userId:B, ...}], hint="user's reason")
+6. discover_opportunities(partyUserIds=[A,B], entities=[{userId:A, profile:{...}, intents:[...], networkId:sharedId}, {userId:B, ...}], hint="user's reason")
 7. Present the draft introduction
 ```
 
@@ -119,7 +119,7 @@ The `entities` array must include each party's userId, full profile, intents fro
 When the user asks "who should I introduce to @Person" or "find connections for @Person":
 
 ```
-1. create_opportunities(introTargetUserId=mentionedUserId, searchQuery="<optional refinement>")
+1. discover_opportunities(introTargetUserId=mentionedUserId, searchQuery="<optional refinement>")
 2. Present the returned introduction candidates
 ```
 

--- a/packages/protocol/src/README.md
+++ b/packages/protocol/src/README.md
@@ -77,7 +77,7 @@ packages/protocol/src/
 |------|-------|
 | `profile/profile.tools.ts` | `read_user_profiles`, `create_user_profile`, `update_user_profile`, `complete_onboarding` |
 | `intent/intent.tools.ts` | `read_intents`, `create_intent`, `update_intent`, `delete_intent`, `create_intent_index`, `read_intent_indexes`, `delete_intent_index` |
-| `network/network.tools.ts` | `read_indexes`, `read_index_memberships`, `create_index`, `update_index`, `delete_index`, `create_index_membership`, `delete_index_membership` |
+| `network/network.tools.ts` | `read_networks`, `read_network_memberships`, `create_network`, `update_network`, `delete_network`, `create_network_membership`, `delete_network_membership` |
 | `opportunity/opportunity.tools.ts` | `discover_opportunities`, `list_opportunities`, `update_opportunity` |
 | `contact/contact.tools.ts` | `import_contacts`, `list_contacts`, `add_contact`, `remove_contact` |
 | `integration/integration.tools.ts` | `import_gmail_contacts` |

--- a/packages/protocol/src/README.md
+++ b/packages/protocol/src/README.md
@@ -78,7 +78,7 @@ packages/protocol/src/
 | `profile/profile.tools.ts` | `read_user_profiles`, `create_user_profile`, `update_user_profile`, `complete_onboarding` |
 | `intent/intent.tools.ts` | `read_intents`, `create_intent`, `update_intent`, `delete_intent`, `create_intent_index`, `read_intent_indexes`, `delete_intent_index` |
 | `network/network.tools.ts` | `read_indexes`, `read_index_memberships`, `create_index`, `update_index`, `delete_index`, `create_index_membership`, `delete_index_membership` |
-| `opportunity/opportunity.tools.ts` | `create_opportunities`, `list_opportunities`, `update_opportunity` |
+| `opportunity/opportunity.tools.ts` | `discover_opportunities`, `list_opportunities`, `update_opportunity` |
 | `contact/contact.tools.ts` | `import_contacts`, `list_contacts`, `add_contact`, `remove_contact` |
 | `integration/integration.tools.ts` | `import_gmail_contacts` |
 | `shared/agent/utility.tools.ts` | `scrape_url`, `read_docs` |
@@ -219,7 +219,7 @@ sequenceDiagram
     participant CI as create_intent
     participant IC as IntentClarifier
     participant IG as Intent Graph
-    participant CO as create_opportunities
+    participant CO as discover_opportunities
     participant OG as Opportunity Graph
     participant HG as HyDE Graph
 

--- a/packages/protocol/src/chat/chat.agent.ts
+++ b/packages/protocol/src/chat/chat.agent.ts
@@ -508,7 +508,7 @@ export class ChatAgent {
     const hasSuccessfulCreateIntent = toolsUsed.some(
       (t) => t.name === "create_intent" && t.success,
     );
-    const hasSuccessfulCreateOpportunities = toolsUsed.some(
+    const hasSuccessfulDiscoverOpportunities = toolsUsed.some(
       (t) =>
         t.name === "discover_opportunities" &&
         t.success &&
@@ -525,7 +525,7 @@ export class ChatAgent {
     }
 
     // Check for hallucinated opportunity blocks
-    if (text.includes("```opportunity") && !hasSuccessfulCreateOpportunities) {
+    if (text.includes("```opportunity") && !hasSuccessfulDiscoverOpportunities) {
       // Use the user's original message as the search query — NOT fields from the
       // hallucinated JSON. The model fabricates person names and reasoning that have
       // nothing to do with the user's actual request, leading to wrong results and
@@ -554,7 +554,7 @@ export class ChatAgent {
     let result = text;
     let removedBlock = false;
 
-    const hasSuccessfulCreateOpportunities = toolsUsed.some(
+    const hasSuccessfulDiscoverOpportunities = toolsUsed.some(
       (t) =>
         t.name === "discover_opportunities" &&
         t.success &&
@@ -565,7 +565,7 @@ export class ChatAgent {
       (t) => t.name === "create_intent" && t.success,
     );
 
-    if (!hasSuccessfulCreateOpportunities && result.includes("```opportunity")) {
+    if (!hasSuccessfulDiscoverOpportunities && result.includes("```opportunity")) {
       const next = result.replace(/```opportunity\s*\n[\s\S]*?```/g, "");
       removedBlock ||= next !== result;
       result = next;

--- a/packages/protocol/src/chat/chat.agent.ts
+++ b/packages/protocol/src/chat/chat.agent.ts
@@ -397,7 +397,7 @@ export class ChatAgent {
           let resultStr =
             typeof result === "string" ? result : JSON.stringify(result);
 
-          if (tc.name === "create_opportunities") {
+          if (tc.name === "discover_opportunities") {
             const newResult = await this.handleCreateIntentCallback(resultStr, tc.args);
             if (newResult !== null) {
               resultStr = newResult;
@@ -438,8 +438,8 @@ export class ChatAgent {
   }
 
   /**
-   * When create_opportunities returned createIntentSuggested, call create_intent then create_opportunities.
-   * Returns the new create_opportunities result string or null if no callback / create_intent failed.
+   * When discover_opportunities returned createIntentSuggested, call create_intent then discover_opportunities.
+   * Returns the new discover_opportunities result string or null if no callback / create_intent failed.
    */
   private async handleCreateIntentCallback(
     resultStr: string,
@@ -462,10 +462,10 @@ export class ChatAgent {
       return null;
     }
     const createIntentTool = this.toolsByName.get("create_intent");
-    const createOpportunitiesTool = this.toolsByName.get("create_opportunities");
-    if (!createIntentTool || !createOpportunitiesTool) return null;
+    const discoverOpportunitiesTool = this.toolsByName.get("discover_opportunities");
+    if (!createIntentTool || !discoverOpportunitiesTool) return null;
 
-    logger.verbose("Create-intent signal: auto-calling create_intent then create_opportunities");
+    logger.verbose("Create-intent signal: auto-calling create_intent then discover_opportunities");
     const createIntentResult = await createIntentTool.invoke({
       description: parsed.data.suggestedIntentDescription,
       networkId: (originalArgs as { networkId?: string }).networkId,
@@ -479,13 +479,13 @@ export class ChatAgent {
       createIntentParsed = {};
     }
     if (createIntentParsed.success === false) {
-      logger.warn("Create-intent failed; not re-running create_opportunities", {
+      logger.warn("Create-intent failed; not re-running discover_opportunities", {
         error: createIntentParsed.error,
       });
       return null;
     }
 
-    const newResult = await createOpportunitiesTool.invoke(originalArgs);
+    const newResult = await discoverOpportunitiesTool.invoke(originalArgs);
     return typeof newResult === "string" ? newResult : JSON.stringify(newResult);
   }
 
@@ -510,7 +510,7 @@ export class ChatAgent {
     );
     const hasSuccessfulCreateOpportunities = toolsUsed.some(
       (t) =>
-        t.name === "create_opportunities" &&
+        t.name === "discover_opportunities" &&
         t.success &&
         !t.resultSummary?.startsWith("Found 0") &&
         !t.resultSummary?.startsWith("No matches"),
@@ -531,7 +531,7 @@ export class ChatAgent {
       // nothing to do with the user's actual request, leading to wrong results and
       // the model re-calling the tool with the correct query (doubling negotiation cost).
       const description = userMessage?.trim() || "find connections";
-      return { type: "opportunity", tool: "create_opportunities", description };
+      return { type: "opportunity", tool: "discover_opportunities", description };
     }
 
     return null;
@@ -556,7 +556,7 @@ export class ChatAgent {
 
     const hasSuccessfulCreateOpportunities = toolsUsed.some(
       (t) =>
-        t.name === "create_opportunities" &&
+        t.name === "discover_opportunities" &&
         t.success &&
         !t.resultSummary?.startsWith("Found 0") &&
         !t.resultSummary?.startsWith("No matches"),
@@ -591,7 +591,7 @@ export class ChatAgent {
 
   /**
    * Post-process a tool result: strip _graphTimings, extract summary/debugSteps,
-   * and optionally run create_opportunities → create_intent callback.
+   * and optionally run discover_opportunities → create_intent callback.
    *
    * Returns the normalized result string and extracted debug metadata so both
    * the normal streaming tool loop and the hallucination-recovery branch
@@ -609,8 +609,8 @@ export class ChatAgent {
   }> {
     let normalized = resultStr;
 
-    // Run create_intent callback for create_opportunities results
-    if (toolName === "create_opportunities") {
+    // Run create_intent callback for discover_opportunities results
+    if (toolName === "discover_opportunities") {
       const callbackResult = await this.handleCreateIntentCallback(normalized, toolArgs);
       if (callbackResult !== null) {
         normalized = callbackResult;

--- a/packages/protocol/src/chat/chat.prompt.modules.ts
+++ b/packages/protocol/src/chat/chat.prompt.modules.ts
@@ -88,13 +88,13 @@ export function extractRecentToolCalls(
 // ═══════════════════════════════════════════════════════════════════════════════
 
 /**
- * Checks whether recent tool calls include create_opportunities with
+ * Checks whether recent tool calls include discover_opportunities with
  * introduction-specific arguments (partyUserIds or introTargetUserId).
  */
 function hasIntroductionArgs(recentTools: IterationContext["recentTools"]): boolean {
   return recentTools.some(
     (t) =>
-      t.name === "create_opportunities" &&
+      t.name === "discover_opportunities" &&
       (t.args.partyUserIds || t.args.introTargetUserId),
   );
 }
@@ -105,7 +105,7 @@ function hasIntroductionArgs(recentTools: IterationContext["recentTools"]): bool
 
 const discoveryModule: PromptModule = {
   id: "discovery",
-  triggers: ["create_opportunities", "update_opportunity", "list_opportunities"],
+  triggers: ["discover_opportunities", "update_opportunity", "list_opportunities"],
   triggerFilter: (iterCtx) => !hasIntroductionArgs(iterCtx.recentTools),
   content: () => `
 ### 1. User wants to find connections or discover (default for connection-seeking)
@@ -116,7 +116,7 @@ For open-ended connection-seeking ("find me a mentor", "who needs a React dev", 
 
 **Network scoping**: When the user says "in my network", "from my contacts", "people I know", "among my connections", or similar network-scoping language, pass the user's **personal index ID** as \`networkId\`. The personal index (\`isPersonal: true\` in preloaded memberships) contains the user's contacts — scoping discovery to it restricts results to people the user already knows. If no network-scoping language is used, do not pass a personal index ID — let discovery run across all indexes as usual.
 
-- Call \`create_opportunities(searchQuery=user's request)\` IMMEDIATELY (with networkId when scoped).
+- Call \`discover_opportunities(searchQuery=user's request)\` IMMEDIATELY (with networkId when scoped).
 - Do NOT call \`create_intent\` unless the user **explicitly** asks to "create", "save", "add", or "remember" an intent/signal.
 - Phrases like "looking for X", "find me X", "I want to meet X", "I need X" are discovery requests — NOT intent creation requests.
 - If the tool returns \`createIntentSuggested\` and \`suggestedIntentDescription\`, the system will create an intent and retry discovery automatically; use the final result (candidates or "no matches") for your reply.
@@ -134,20 +134,20 @@ When the user mentions a specific person via @mention or name AND expresses inte
 1. If not already done: read_user_profiles(userId=X) + read_network_memberships(userId=X)
 2. Find shared indexes with the user (intersect with preloaded memberships)
 3. If no shared indexes: tell the user you can't find a connection path
-4. create_opportunities(targetUserId=X, searchQuery="<synthesized reason for connecting based on shared context>")
+4. discover_opportunities(targetUserId=X, searchQuery="<synthesized reason for connecting based on shared context>")
 5. Present the opportunity card
 \`\`\`
 
-**Do NOT call read_intents before create_opportunities here.** The opportunity tool fetches intents internally for both discovery and direct connection modes. Only introduction mode (partyUserIds + entities) requires pre-gathered intents.
+**Do NOT call read_intents before discover_opportunities here.** The opportunity tool fetches intents internally for both discovery and direct connection modes. Only introduction mode (partyUserIds + entities) requires pre-gathered intents.
 
 The searchQuery should be a brief description of why they'd connect (e.g. "shared interest in design and technology, both in Kernel community"). This gives the evaluator context for scoring.
 
 ### 7. Opportunities in chat
 
-- **create_opportunities** — discovers new connections (discovery, introduction, or direct connection).
+- **discover_opportunities** — discovers new connections (discovery, introduction, or direct connection).
 - **list_opportunities** — lists existing draft and pending opportunities the user can act on.
 
-When the user asks to review, revise, check, or see their current opportunities, call \`list_opportunities\`. Only use \`create_opportunities\` for discovery ("find me connections"), introductions, or direct connections.
+When the user asks to review, revise, check, or see their current opportunities, call \`list_opportunities\`. Only use \`discover_opportunities\` for discovery ("find me connections"), introductions, or direct connections.
 
 When either tool returns \`\`\`opportunity code blocks, include them verbatim in your reply so they render as cards.
 
@@ -156,26 +156,26 @@ Draft or latent opportunities can be sent (update_opportunity with status='pendi
 **CRITICAL: Only describe what the tool response confirms happened.** "pending" sends a notification — not a message or invite. "accepted" adds a contact — for ghost users, the invite email is sent only when the user opens a chat and messages them. Never claim you sent invites, connection requests, or messages on behalf of the user.
 
 ### Discovery-first; intent as follow-up
-- For connection-seeking (find connections, discover, who's looking for X), use \`create_opportunities(searchQuery=...)\` first. Do not lead with \`create_intent\` unless the user explicitly asks to create or save an intent.
+- For connection-seeking (find connections, discover, who's looking for X), use \`discover_opportunities(searchQuery=...)\` first. Do not lead with \`create_intent\` unless the user explicitly asks to create or save an intent.
 - When the tool returns \`createIntentSuggested\`, the system may create an intent and retry; respond from the final discovery result.
 - Visibility-signal follow-up: apply the Pattern 1 rule above (\`suggestIntentCreationForVisibility\` → ask once; on yes, call \`create_intent(description=suggestedIntentDescription)\` and include the returned \`\`\`intent_proposal block).
 - When the tool response says "These are all the connections I found", suggest the user create a signal so others can discover them. Use the existing \`suggestIntentCreationForVisibility\` flow: call \`create_intent(description=suggestedIntentDescription)\` if the user agrees. Do not ask "Would you like to see more?" when there are no more candidates.
 - **Introducer exception**: Never suggest signal/intent creation when \`introTargetUserId\` was used. The search describes the other person's needs, not the signed-in user's — creating a signal from it would be meaningless.
-- Only call \`create_opportunities\` for: (a) discovery ("find me connections"), (b) introductions between two other people, or (c) direct connection with a specific mentioned person (Pattern 1a).
+- Only call \`discover_opportunities\` for: (a) discovery ("find me connections"), (b) introductions between two other people, or (c) direct connection with a specific mentioned person (Pattern 1a).
 `,
 };
 
 const introductionModule: PromptModule = {
   id: "introduction",
-  triggers: ["create_opportunities"],
+  triggers: ["discover_opportunities"],
   excludes: ["discovery"],
   triggerFilter: (iterCtx) => hasIntroductionArgs(iterCtx.recentTools),
   content: () => `
 ### 6. Introduce two people
 
-**An introduction is always between exactly two people.** Do not call create_opportunities for an introduction unless you have exactly two parties (two distinct people to introduce to each other). The entities array must have exactly two entities. The introducer (current user) must not be included in the entities array; entities must refer to two distinct other users.
+**An introduction is always between exactly two people.** Do not call discover_opportunities for an introduction unless you have exactly two parties (two distinct people to introduce to each other). The entities array must have exactly two entities. The introducer (current user) must not be included in the entities array; entities must refer to two distinct other users.
 
-**You MUST gather all context before calling create_opportunities. The tool does NOT fetch data internally.**
+**You MUST gather all context before calling discover_opportunities. The tool does NOT fetch data internally.**
 
 \`\`\`
 1. read_network_memberships(userId=A) + read_network_memberships(userId=B)  → find shared networks
@@ -183,7 +183,7 @@ const introductionModule: PromptModule = {
 3. read_user_profiles(userId=A) + read_user_profiles(userId=B)
 4. For each shared index: read_intents(networkId=X, userId=A) + read_intents(networkId=X, userId=B)
 5. Summarize to user: "Here's what I found about A and B..."
-6. create_opportunities(partyUserIds=[A,B], entities=[{userId:A, profile:{...}, intents:[...], networkId:shared}, {userId:B, ...}], hint="user's reason")
+6. discover_opportunities(partyUserIds=[A,B], entities=[{userId:A, profile:{...}, intents:[...], networkId:shared}, {userId:B, ...}], hint="user's reason")
 7. Present the draft introduction
 \`\`\`
 
@@ -195,7 +195,7 @@ The entities array must include each party's userId, profile data, intents from 
 
 \`\`\`
 1. Identify the person's userId from the @mention (call it mentionedUserId)
-2. create_opportunities(introTargetUserId=mentionedUserId, searchQuery="<optional refinement>")
+2. discover_opportunities(introTargetUserId=mentionedUserId, searchQuery="<optional refinement>")
 3. Present the returned cards (they will be formatted as introduction cards automatically)
 \`\`\`
 

--- a/packages/protocol/src/chat/chat.prompt.ts
+++ b/packages/protocol/src/chat/chat.prompt.ts
@@ -140,7 +140,7 @@ ${ctx.networkId ? `6. **Community discovery (skipped — already in scoped commu
    - IMMEDIATELY proceed to step 8 in the SAME response — do NOT stop and wait for the user to approve the proposal
 
 8. **Wrap up** (must happen in the same response as step 7)
-   - Call \`create_opportunities(searchQuery="[user's intent description]")\` to discover initial matches based on their intent
+   - Call \`discover_opportunities(searchQuery="[user's intent description]")\` to discover initial matches based on their intent
    - If opportunities found: present them naturally, e.g. "I already found some relevant people based on what you're looking for:" followed by the opportunity cards
    - If no opportunities found: "No matches yet, but I'll keep looking in the background."
    - Call \`complete_onboarding()\` — this is REQUIRED and marks onboarding as finished
@@ -277,7 +277,7 @@ All tools are simple read/write operations. No hidden logic.
 | **create_intent_index** | intentId, networkId | Link intent to index |
 | **read_intent_indexes** | intentId?, networkId?, userId? | Read intent↔index links |
 | **delete_intent_index** | intentId, networkId | Unlink intent from index |
-| **create_opportunities** | searchQuery?, networkId?, targetUserId?, partyUserIds?, entities?, hint? | Discovery (query text), Direct connection (targetUserId + searchQuery), or Introduction (partyUserIds + entities + hint). |
+| **discover_opportunities** | searchQuery?, networkId?, targetUserId?, partyUserIds?, entities?, hint? | Discovery (query text), Direct connection (targetUserId + searchQuery), or Introduction (partyUserIds + entities + hint). |
 | **list_opportunities** | networkId? | List draft and pending opportunities the user can act on. Use when user wants to review existing opportunities. |
 | **update_opportunity** | opportunityId, status | Change status: pending (send draft or latent), accepted, rejected, expired |
 | **scrape_url** | url, objective? | Extract text from web page |
@@ -372,7 +372,7 @@ What NOT to narrate (group silently with the main action):
 - Markdown: **bold** for emphasis, bullets for lists. Concise but complete.
 - **Never expose IDs, UUIDs, field names, tool names, or code** to the user. Never mention internal tool names (e.g. read_user_profiles, create_intent, scrape_url) or suggest the user call them. Tools are invisible infrastructure — the user should only see natural language.
 - **Never use internal vocabulary** (intent, index, opportunity, profile) in replies. In user-facing replies, avoid mentioning indexes (or communities) unless the user asked or it's one of: sign-up, leave, owner settings. Use neutral language otherwise.
-- **Opportunity cards**: Never write a \`\`\`opportunity block yourself — always call create_opportunities first. Only the tool provides valid, correctly-formatted blocks. When create_opportunities returns \`\`\`opportunity code blocks, you MUST include them exactly as-is in your response. These blocks are rendered as interactive cards in the UI. Do NOT summarize or rephrase them — copy them verbatim. Include a brief framing sentence (1–2 sentences max), then paste the cards one after another. Do NOT write individual descriptions for each person — the cards are self-contained and show the explanation. Do not enumerate or introduce each match in text before showing the cards.
+- **Opportunity cards**: Never write a \`\`\`opportunity block yourself — always call discover_opportunities first. Only the tool provides valid, correctly-formatted blocks. When discover_opportunities returns \`\`\`opportunity code blocks, you MUST include them exactly as-is in your response. These blocks are rendered as interactive cards in the UI. Do NOT summarize or rephrase them — copy them verbatim. Include a brief framing sentence (1–2 sentences max), then paste the cards one after another. Do NOT write individual descriptions for each person — the cards are self-contained and show the explanation. Do not enumerate or introduce each match in text before showing the cards.
 - **Intent proposal cards**: Never write a \`\`\`intent_proposal block yourself — always call create_intent first. When create_intent returns \`\`\`intent_proposal code blocks, include them exactly as-is in your response (they contain proposalId and description; only the tool provides valid blocks). These blocks are rendered as interactive cards. Add a brief note that creating this intent enables background discovery of relevant people.
 - For person references, prefer first names in user-facing copy. Use full names only when needed to disambiguate people with the same first name.
 - Do not label intents as "goals" in user-facing language. Prefer: "what you're looking for", "your signals", "your interests".

--- a/packages/protocol/src/chat/tests/__snapshots__/chat.prompt.modules.spec.ts.snap
+++ b/packages/protocol/src/chat/tests/__snapshots__/chat.prompt.modules.spec.ts.snap
@@ -150,7 +150,7 @@ All tools are simple read/write operations. No hidden logic.
 | **create_intent_index** | intentId, networkId | Link intent to index |
 | **read_intent_indexes** | intentId?, networkId?, userId? | Read intent↔index links |
 | **delete_intent_index** | intentId, networkId | Unlink intent from index |
-| **create_opportunities** | searchQuery?, networkId?, targetUserId?, partyUserIds?, entities?, hint? | Discovery (query text), Direct connection (targetUserId + searchQuery), or Introduction (partyUserIds + entities + hint). |
+| **discover_opportunities** | searchQuery?, networkId?, targetUserId?, partyUserIds?, entities?, hint? | Discovery (query text), Direct connection (targetUserId + searchQuery), or Introduction (partyUserIds + entities + hint). |
 | **list_opportunities** | networkId? | List draft and pending opportunities the user can act on. Use when user wants to review existing opportunities. |
 | **update_opportunity** | opportunityId, status | Change status: pending (send draft or latent), accepted, rejected, expired |
 | **scrape_url** | url, objective? | Extract text from web page |
@@ -221,7 +221,7 @@ What NOT to narrate (group silently with the main action):
 - Markdown: **bold** for emphasis, bullets for lists. Concise but complete.
 - **Never expose IDs, UUIDs, field names, tool names, or code** to the user. Never mention internal tool names (e.g. read_user_profiles, create_intent, scrape_url) or suggest the user call them. Tools are invisible infrastructure — the user should only see natural language.
 - **Never use internal vocabulary** (intent, index, opportunity, profile) in replies. In user-facing replies, avoid mentioning indexes (or communities) unless the user asked or it's one of: sign-up, leave, owner settings. Use neutral language otherwise.
-- **Opportunity cards**: Never write a \`\`\`opportunity block yourself — always call create_opportunities first. Only the tool provides valid, correctly-formatted blocks. When create_opportunities returns \`\`\`opportunity code blocks, you MUST include them exactly as-is in your response. These blocks are rendered as interactive cards in the UI. Do NOT summarize or rephrase them — copy them verbatim. Include a brief framing sentence (1–2 sentences max), then paste the cards one after another. Do NOT write individual descriptions for each person — the cards are self-contained and show the explanation. Do not enumerate or introduce each match in text before showing the cards.
+- **Opportunity cards**: Never write a \`\`\`opportunity block yourself — always call discover_opportunities first. Only the tool provides valid, correctly-formatted blocks. When discover_opportunities returns \`\`\`opportunity code blocks, you MUST include them exactly as-is in your response. These blocks are rendered as interactive cards in the UI. Do NOT summarize or rephrase them — copy them verbatim. Include a brief framing sentence (1–2 sentences max), then paste the cards one after another. Do NOT write individual descriptions for each person — the cards are self-contained and show the explanation. Do not enumerate or introduce each match in text before showing the cards.
 - **Intent proposal cards**: Never write a \`\`\`intent_proposal block yourself — always call create_intent first. When create_intent returns \`\`\`intent_proposal code blocks, include them exactly as-is in your response (they contain proposalId and description; only the tool provides valid blocks). These blocks are rendered as interactive cards. Add a brief note that creating this intent enables background discovery of relevant people.
 - For person references, prefer first names in user-facing copy. Use full names only when needed to disambiguate people with the same first name.
 - Do not label intents as "goals" in user-facing language. Prefer: "what you're looking for", "your signals", "your interests".
@@ -385,7 +385,7 @@ All tools are simple read/write operations. No hidden logic.
 | **create_intent_index** | intentId, networkId | Link intent to index |
 | **read_intent_indexes** | intentId?, networkId?, userId? | Read intent↔index links |
 | **delete_intent_index** | intentId, networkId | Unlink intent from index |
-| **create_opportunities** | searchQuery?, networkId?, targetUserId?, partyUserIds?, entities?, hint? | Discovery (query text), Direct connection (targetUserId + searchQuery), or Introduction (partyUserIds + entities + hint). |
+| **discover_opportunities** | searchQuery?, networkId?, targetUserId?, partyUserIds?, entities?, hint? | Discovery (query text), Direct connection (targetUserId + searchQuery), or Introduction (partyUserIds + entities + hint). |
 | **list_opportunities** | networkId? | List draft and pending opportunities the user can act on. Use when user wants to review existing opportunities. |
 | **update_opportunity** | opportunityId, status | Change status: pending (send draft or latent), accepted, rejected, expired |
 | **scrape_url** | url, objective? | Extract text from web page |
@@ -459,7 +459,7 @@ What NOT to narrate (group silently with the main action):
 - Markdown: **bold** for emphasis, bullets for lists. Concise but complete.
 - **Never expose IDs, UUIDs, field names, tool names, or code** to the user. Never mention internal tool names (e.g. read_user_profiles, create_intent, scrape_url) or suggest the user call them. Tools are invisible infrastructure — the user should only see natural language.
 - **Never use internal vocabulary** (intent, index, opportunity, profile) in replies. In user-facing replies, avoid mentioning indexes (or communities) unless the user asked or it's one of: sign-up, leave, owner settings. Use neutral language otherwise.
-- **Opportunity cards**: Never write a \`\`\`opportunity block yourself — always call create_opportunities first. Only the tool provides valid, correctly-formatted blocks. When create_opportunities returns \`\`\`opportunity code blocks, you MUST include them exactly as-is in your response. These blocks are rendered as interactive cards in the UI. Do NOT summarize or rephrase them — copy them verbatim. Include a brief framing sentence (1–2 sentences max), then paste the cards one after another. Do NOT write individual descriptions for each person — the cards are self-contained and show the explanation. Do not enumerate or introduce each match in text before showing the cards.
+- **Opportunity cards**: Never write a \`\`\`opportunity block yourself — always call discover_opportunities first. Only the tool provides valid, correctly-formatted blocks. When discover_opportunities returns \`\`\`opportunity code blocks, you MUST include them exactly as-is in your response. These blocks are rendered as interactive cards in the UI. Do NOT summarize or rephrase them — copy them verbatim. Include a brief framing sentence (1–2 sentences max), then paste the cards one after another. Do NOT write individual descriptions for each person — the cards are self-contained and show the explanation. Do not enumerate or introduce each match in text before showing the cards.
 - **Intent proposal cards**: Never write a \`\`\`intent_proposal block yourself — always call create_intent first. When create_intent returns \`\`\`intent_proposal code blocks, include them exactly as-is in your response (they contain proposalId and description; only the tool provides valid blocks). These blocks are rendered as interactive cards. Add a brief note that creating this intent enables background discovery of relevant people.
 - For person references, prefer first names in user-facing copy. Use full names only when needed to disambiguate people with the same first name.
 - Do not label intents as "goals" in user-facing language. Prefer: "what you're looking for", "your signals", "your interests".
@@ -578,7 +578,7 @@ This is the user's first conversation. They just signed up. Guide them through s
    - IMMEDIATELY proceed to step 8 in the SAME response — do NOT stop and wait for the user to approve the proposal
 
 8. **Wrap up** (must happen in the same response as step 7)
-   - Call \`create_opportunities(searchQuery="[user's intent description]")\` to discover initial matches based on their intent
+   - Call \`discover_opportunities(searchQuery="[user's intent description]")\` to discover initial matches based on their intent
    - If opportunities found: present them naturally, e.g. "I already found some relevant people based on what you're looking for:" followed by the opportunity cards
    - If no opportunities found: "No matches yet, but I'll keep looking in the background."
    - Call \`complete_onboarding()\` — this is REQUIRED and marks onboarding as finished
@@ -709,7 +709,7 @@ All tools are simple read/write operations. No hidden logic.
 | **create_intent_index** | intentId, networkId | Link intent to index |
 | **read_intent_indexes** | intentId?, networkId?, userId? | Read intent↔index links |
 | **delete_intent_index** | intentId, networkId | Unlink intent from index |
-| **create_opportunities** | searchQuery?, networkId?, targetUserId?, partyUserIds?, entities?, hint? | Discovery (query text), Direct connection (targetUserId + searchQuery), or Introduction (partyUserIds + entities + hint). |
+| **discover_opportunities** | searchQuery?, networkId?, targetUserId?, partyUserIds?, entities?, hint? | Discovery (query text), Direct connection (targetUserId + searchQuery), or Introduction (partyUserIds + entities + hint). |
 | **list_opportunities** | networkId? | List draft and pending opportunities the user can act on. Use when user wants to review existing opportunities. |
 | **update_opportunity** | opportunityId, status | Change status: pending (send draft or latent), accepted, rejected, expired |
 | **scrape_url** | url, objective? | Extract text from web page |
@@ -780,7 +780,7 @@ What NOT to narrate (group silently with the main action):
 - Markdown: **bold** for emphasis, bullets for lists. Concise but complete.
 - **Never expose IDs, UUIDs, field names, tool names, or code** to the user. Never mention internal tool names (e.g. read_user_profiles, create_intent, scrape_url) or suggest the user call them. Tools are invisible infrastructure — the user should only see natural language.
 - **Never use internal vocabulary** (intent, index, opportunity, profile) in replies. In user-facing replies, avoid mentioning indexes (or communities) unless the user asked or it's one of: sign-up, leave, owner settings. Use neutral language otherwise.
-- **Opportunity cards**: Never write a \`\`\`opportunity block yourself — always call create_opportunities first. Only the tool provides valid, correctly-formatted blocks. When create_opportunities returns \`\`\`opportunity code blocks, you MUST include them exactly as-is in your response. These blocks are rendered as interactive cards in the UI. Do NOT summarize or rephrase them — copy them verbatim. Include a brief framing sentence (1–2 sentences max), then paste the cards one after another. Do NOT write individual descriptions for each person — the cards are self-contained and show the explanation. Do not enumerate or introduce each match in text before showing the cards.
+- **Opportunity cards**: Never write a \`\`\`opportunity block yourself — always call discover_opportunities first. Only the tool provides valid, correctly-formatted blocks. When discover_opportunities returns \`\`\`opportunity code blocks, you MUST include them exactly as-is in your response. These blocks are rendered as interactive cards in the UI. Do NOT summarize or rephrase them — copy them verbatim. Include a brief framing sentence (1–2 sentences max), then paste the cards one after another. Do NOT write individual descriptions for each person — the cards are self-contained and show the explanation. Do not enumerate or introduce each match in text before showing the cards.
 - **Intent proposal cards**: Never write a \`\`\`intent_proposal block yourself — always call create_intent first. When create_intent returns \`\`\`intent_proposal code blocks, include them exactly as-is in your response (they contain proposalId and description; only the tool provides valid blocks). These blocks are rendered as interactive cards. Add a brief note that creating this intent enables background discovery of relevant people.
 - For person references, prefer first names in user-facing copy. Use full names only when needed to disambiguate people with the same first name.
 - Do not label intents as "goals" in user-facing language. Prefer: "what you're looking for", "your signals", "your interests".
@@ -901,7 +901,7 @@ This is the user's first conversation. They just signed up. Guide them through s
    - IMMEDIATELY proceed to step 8 in the SAME response — do NOT stop and wait for the user to approve the proposal
 
 8. **Wrap up** (must happen in the same response as step 7)
-   - Call \`create_opportunities(searchQuery="[user's intent description]")\` to discover initial matches based on their intent
+   - Call \`discover_opportunities(searchQuery="[user's intent description]")\` to discover initial matches based on their intent
    - If opportunities found: present them naturally, e.g. "I already found some relevant people based on what you're looking for:" followed by the opportunity cards
    - If no opportunities found: "No matches yet, but I'll keep looking in the background."
    - Call \`complete_onboarding()\` — this is REQUIRED and marks onboarding as finished
@@ -1032,7 +1032,7 @@ All tools are simple read/write operations. No hidden logic.
 | **create_intent_index** | intentId, networkId | Link intent to index |
 | **read_intent_indexes** | intentId?, networkId?, userId? | Read intent↔index links |
 | **delete_intent_index** | intentId, networkId | Unlink intent from index |
-| **create_opportunities** | searchQuery?, networkId?, targetUserId?, partyUserIds?, entities?, hint? | Discovery (query text), Direct connection (targetUserId + searchQuery), or Introduction (partyUserIds + entities + hint). |
+| **discover_opportunities** | searchQuery?, networkId?, targetUserId?, partyUserIds?, entities?, hint? | Discovery (query text), Direct connection (targetUserId + searchQuery), or Introduction (partyUserIds + entities + hint). |
 | **list_opportunities** | networkId? | List draft and pending opportunities the user can act on. Use when user wants to review existing opportunities. |
 | **update_opportunity** | opportunityId, status | Change status: pending (send draft or latent), accepted, rejected, expired |
 | **scrape_url** | url, objective? | Extract text from web page |
@@ -1103,7 +1103,7 @@ What NOT to narrate (group silently with the main action):
 - Markdown: **bold** for emphasis, bullets for lists. Concise but complete.
 - **Never expose IDs, UUIDs, field names, tool names, or code** to the user. Never mention internal tool names (e.g. read_user_profiles, create_intent, scrape_url) or suggest the user call them. Tools are invisible infrastructure — the user should only see natural language.
 - **Never use internal vocabulary** (intent, index, opportunity, profile) in replies. In user-facing replies, avoid mentioning indexes (or communities) unless the user asked or it's one of: sign-up, leave, owner settings. Use neutral language otherwise.
-- **Opportunity cards**: Never write a \`\`\`opportunity block yourself — always call create_opportunities first. Only the tool provides valid, correctly-formatted blocks. When create_opportunities returns \`\`\`opportunity code blocks, you MUST include them exactly as-is in your response. These blocks are rendered as interactive cards in the UI. Do NOT summarize or rephrase them — copy them verbatim. Include a brief framing sentence (1–2 sentences max), then paste the cards one after another. Do NOT write individual descriptions for each person — the cards are self-contained and show the explanation. Do not enumerate or introduce each match in text before showing the cards.
+- **Opportunity cards**: Never write a \`\`\`opportunity block yourself — always call discover_opportunities first. Only the tool provides valid, correctly-formatted blocks. When discover_opportunities returns \`\`\`opportunity code blocks, you MUST include them exactly as-is in your response. These blocks are rendered as interactive cards in the UI. Do NOT summarize or rephrase them — copy them verbatim. Include a brief framing sentence (1–2 sentences max), then paste the cards one after another. Do NOT write individual descriptions for each person — the cards are self-contained and show the explanation. Do not enumerate or introduce each match in text before showing the cards.
 - **Intent proposal cards**: Never write a \`\`\`intent_proposal block yourself — always call create_intent first. When create_intent returns \`\`\`intent_proposal code blocks, include them exactly as-is in your response (they contain proposalId and description; only the tool provides valid blocks). These blocks are rendered as interactive cards. Add a brief note that creating this intent enables background discovery of relevant people.
 - For person references, prefer first names in user-facing copy. Use full names only when needed to disambiguate people with the same first name.
 - Do not label intents as "goals" in user-facing language. Prefer: "what you're looking for", "your signals", "your interests".
@@ -1274,7 +1274,7 @@ All tools are simple read/write operations. No hidden logic.
 | **create_intent_index** | intentId, networkId | Link intent to index |
 | **read_intent_indexes** | intentId?, networkId?, userId? | Read intent↔index links |
 | **delete_intent_index** | intentId, networkId | Unlink intent from index |
-| **create_opportunities** | searchQuery?, networkId?, targetUserId?, partyUserIds?, entities?, hint? | Discovery (query text), Direct connection (targetUserId + searchQuery), or Introduction (partyUserIds + entities + hint). |
+| **discover_opportunities** | searchQuery?, networkId?, targetUserId?, partyUserIds?, entities?, hint? | Discovery (query text), Direct connection (targetUserId + searchQuery), or Introduction (partyUserIds + entities + hint). |
 | **list_opportunities** | networkId? | List draft and pending opportunities the user can act on. Use when user wants to review existing opportunities. |
 | **update_opportunity** | opportunityId, status | Change status: pending (send draft or latent), accepted, rejected, expired |
 | **scrape_url** | url, objective? | Extract text from web page |
@@ -1293,7 +1293,7 @@ For open-ended connection-seeking ("find me a mentor", "who needs a React dev", 
 
 **Network scoping**: When the user says "in my network", "from my contacts", "people I know", "among my connections", or similar network-scoping language, pass the user's **personal index ID** as \`networkId\`. The personal index (\`isPersonal: true\` in preloaded memberships) contains the user's contacts — scoping discovery to it restricts results to people the user already knows. If no network-scoping language is used, do not pass a personal index ID — let discovery run across all indexes as usual.
 
-- Call \`create_opportunities(searchQuery=user's request)\` IMMEDIATELY (with networkId when scoped).
+- Call \`discover_opportunities(searchQuery=user's request)\` IMMEDIATELY (with networkId when scoped).
 - Do NOT call \`create_intent\` unless the user **explicitly** asks to "create", "save", "add", or "remember" an intent/signal.
 - Phrases like "looking for X", "find me X", "I want to meet X", "I need X" are discovery requests — NOT intent creation requests.
 - If the tool returns \`createIntentSuggested\` and \`suggestedIntentDescription\`, the system will create an intent and retry discovery automatically; use the final result (candidates or "no matches") for your reply.
@@ -1311,20 +1311,20 @@ When the user mentions a specific person via @mention or name AND expresses inte
 1. If not already done: read_user_profiles(userId=X) + read_network_memberships(userId=X)
 2. Find shared indexes with the user (intersect with preloaded memberships)
 3. If no shared indexes: tell the user you can't find a connection path
-4. create_opportunities(targetUserId=X, searchQuery="<synthesized reason for connecting based on shared context>")
+4. discover_opportunities(targetUserId=X, searchQuery="<synthesized reason for connecting based on shared context>")
 5. Present the opportunity card
 \`\`\`
 
-**Do NOT call read_intents before create_opportunities here.** The opportunity tool fetches intents internally for both discovery and direct connection modes. Only introduction mode (partyUserIds + entities) requires pre-gathered intents.
+**Do NOT call read_intents before discover_opportunities here.** The opportunity tool fetches intents internally for both discovery and direct connection modes. Only introduction mode (partyUserIds + entities) requires pre-gathered intents.
 
 The searchQuery should be a brief description of why they'd connect (e.g. "shared interest in design and technology, both in Kernel community"). This gives the evaluator context for scoring.
 
 ### 7. Opportunities in chat
 
-- **create_opportunities** — discovers new connections (discovery, introduction, or direct connection).
+- **discover_opportunities** — discovers new connections (discovery, introduction, or direct connection).
 - **list_opportunities** — lists existing draft and pending opportunities the user can act on.
 
-When the user asks to review, revise, check, or see their current opportunities, call \`list_opportunities\`. Only use \`create_opportunities\` for discovery ("find me connections"), introductions, or direct connections.
+When the user asks to review, revise, check, or see their current opportunities, call \`list_opportunities\`. Only use \`discover_opportunities\` for discovery ("find me connections"), introductions, or direct connections.
 
 When either tool returns \`\`\`opportunity code blocks, include them verbatim in your reply so they render as cards.
 
@@ -1333,12 +1333,12 @@ Draft or latent opportunities can be sent (update_opportunity with status='pendi
 **CRITICAL: Only describe what the tool response confirms happened.** "pending" sends a notification — not a message or invite. "accepted" adds a contact — for ghost users, the invite email is sent only when the user opens a chat and messages them. Never claim you sent invites, connection requests, or messages on behalf of the user.
 
 ### Discovery-first; intent as follow-up
-- For connection-seeking (find connections, discover, who's looking for X), use \`create_opportunities(searchQuery=...)\` first. Do not lead with \`create_intent\` unless the user explicitly asks to create or save an intent.
+- For connection-seeking (find connections, discover, who's looking for X), use \`discover_opportunities(searchQuery=...)\` first. Do not lead with \`create_intent\` unless the user explicitly asks to create or save an intent.
 - When the tool returns \`createIntentSuggested\`, the system may create an intent and retry; respond from the final discovery result.
 - Visibility-signal follow-up: apply the Pattern 1 rule above (\`suggestIntentCreationForVisibility\` → ask once; on yes, call \`create_intent(description=suggestedIntentDescription)\` and include the returned \`\`\`intent_proposal block).
 - When the tool response says "These are all the connections I found", suggest the user create a signal so others can discover them. Use the existing \`suggestIntentCreationForVisibility\` flow: call \`create_intent(description=suggestedIntentDescription)\` if the user agrees. Do not ask "Would you like to see more?" when there are no more candidates.
 - **Introducer exception**: Never suggest signal/intent creation when \`introTargetUserId\` was used. The search describes the other person's needs, not the signed-in user's — creating a signal from it would be meaningless.
-- Only call \`create_opportunities\` for: (a) discovery ("find me connections"), (b) introductions between two other people, or (c) direct connection with a specific mentioned person (Pattern 1a).
+- Only call \`discover_opportunities\` for: (a) discovery ("find me connections"), (b) introductions between two other people, or (c) direct connection with a specific mentioned person (Pattern 1a).
 
 
 ### 2. User explicitly wants to create or save an intent
@@ -1514,7 +1514,7 @@ What NOT to narrate (group silently with the main action):
 - Markdown: **bold** for emphasis, bullets for lists. Concise but complete.
 - **Never expose IDs, UUIDs, field names, tool names, or code** to the user. Never mention internal tool names (e.g. read_user_profiles, create_intent, scrape_url) or suggest the user call them. Tools are invisible infrastructure — the user should only see natural language.
 - **Never use internal vocabulary** (intent, index, opportunity, profile) in replies. In user-facing replies, avoid mentioning indexes (or communities) unless the user asked or it's one of: sign-up, leave, owner settings. Use neutral language otherwise.
-- **Opportunity cards**: Never write a \`\`\`opportunity block yourself — always call create_opportunities first. Only the tool provides valid, correctly-formatted blocks. When create_opportunities returns \`\`\`opportunity code blocks, you MUST include them exactly as-is in your response. These blocks are rendered as interactive cards in the UI. Do NOT summarize or rephrase them — copy them verbatim. Include a brief framing sentence (1–2 sentences max), then paste the cards one after another. Do NOT write individual descriptions for each person — the cards are self-contained and show the explanation. Do not enumerate or introduce each match in text before showing the cards.
+- **Opportunity cards**: Never write a \`\`\`opportunity block yourself — always call discover_opportunities first. Only the tool provides valid, correctly-formatted blocks. When discover_opportunities returns \`\`\`opportunity code blocks, you MUST include them exactly as-is in your response. These blocks are rendered as interactive cards in the UI. Do NOT summarize or rephrase them — copy them verbatim. Include a brief framing sentence (1–2 sentences max), then paste the cards one after another. Do NOT write individual descriptions for each person — the cards are self-contained and show the explanation. Do not enumerate or introduce each match in text before showing the cards.
 - **Intent proposal cards**: Never write a \`\`\`intent_proposal block yourself — always call create_intent first. When create_intent returns \`\`\`intent_proposal code blocks, include them exactly as-is in your response (they contain proposalId and description; only the tool provides valid blocks). These blocks are rendered as interactive cards. Add a brief note that creating this intent enables background discovery of relevant people.
 - For person references, prefer first names in user-facing copy. Use full names only when needed to disambiguate people with the same first name.
 - Do not label intents as "goals" in user-facing language. Prefer: "what you're looking for", "your signals", "your interests".

--- a/packages/protocol/src/chat/tests/chat.agent.spec.ts
+++ b/packages/protocol/src/chat/tests/chat.agent.spec.ts
@@ -64,7 +64,7 @@ function createMockTools() {
       ),
     },
     {
-      name: "create_opportunities",
+      name: "discover_opportunities",
       description: "Find opportunities",
       schema: {},
       invoke: mock(async () =>
@@ -203,7 +203,7 @@ I've created an intent for you!`;
     expect(callCount).toBe(2);
   }, 15000);
 
-  it("auto-invokes create_opportunities when hallucinated opportunity block is detected", async () => {
+  it("auto-invokes discover_opportunities when hallucinated opportunity block is detected", async () => {
     const agent = await ChatAgent.create({
       database: {
         getUser: async () => ({ id: "test-user", name: "Test User", email: "test@example.com", location: null, socials: {} }),
@@ -249,9 +249,9 @@ I've created an intent for you!`;
       writer,
     );
 
-    // create_opportunities auto-invoked with searchQuery from user's message (not hallucinated block)
+    // discover_opportunities auto-invoked with searchQuery from user's message (not hallucinated block)
     const createOpsTool = capturedTools.find(
-      (t) => t.name === "create_opportunities",
+      (t) => t.name === "discover_opportunities",
     )!;
     expect(createOpsTool.invoke).toHaveBeenCalledTimes(1);
     const callArgs = createOpsTool.invoke.mock.calls[0][0] as Record<

--- a/packages/protocol/src/chat/tests/chat.graph.mocks.ts
+++ b/packages/protocol/src/chat/tests/chat.graph.mocks.ts
@@ -86,7 +86,7 @@ const defaultOwnedIndex = (): OwnedIndex => ({
 /** Actor shape for opportunity mocks (role determines visibility). */
 export type MockOpportunityActor = { networkId: string; userId: string; role: "introducer" | "patient" | "agent" | "peer" | "party"; intent?: string };
 
-/** Build a minimal Opportunity for list_my_opportunities / discover_opportunities tests. */
+/** Build a minimal Opportunity for list_opportunities / discover_opportunities tests. */
 export function mockOpportunity(overrides: {
   id?: string;
   status?: OpportunityStatus;

--- a/packages/protocol/src/chat/tests/chat.graph.mocks.ts
+++ b/packages/protocol/src/chat/tests/chat.graph.mocks.ts
@@ -86,7 +86,7 @@ const defaultOwnedIndex = (): OwnedIndex => ({
 /** Actor shape for opportunity mocks (role determines visibility). */
 export type MockOpportunityActor = { networkId: string; userId: string; role: "introducer" | "patient" | "agent" | "peer" | "party"; intent?: string };
 
-/** Build a minimal Opportunity for list_my_opportunities / create_opportunities tests. */
+/** Build a minimal Opportunity for list_my_opportunities / discover_opportunities tests. */
 export function mockOpportunity(overrides: {
   id?: string;
   status?: OpportunityStatus;

--- a/packages/protocol/src/chat/tests/chat.prompt.modules.spec.ts
+++ b/packages/protocol/src/chat/tests/chat.prompt.modules.spec.ts
@@ -28,13 +28,13 @@ describe("extractRecentToolCalls", () => {
       new AIMessage({
         content: "",
         tool_calls: [
-          { id: "tc1", name: "create_opportunities", args: { searchQuery: "mentor" }, type: "tool_call" },
+          { id: "tc1", name: "discover_opportunities", args: { searchQuery: "mentor" }, type: "tool_call" },
         ],
       }),
-      new ToolMessage({ tool_call_id: "tc1", content: "results...", name: "create_opportunities" }),
+      new ToolMessage({ tool_call_id: "tc1", content: "results...", name: "discover_opportunities" }),
     ];
     const result = extractRecentToolCalls(messages);
-    expect(result).toEqual([{ name: "create_opportunities", args: { searchQuery: "mentor" } }]);
+    expect(result).toEqual([{ name: "discover_opportunities", args: { searchQuery: "mentor" } }]);
   });
 
   test("collects tool calls from ALL AI messages since last HumanMessage", () => {
@@ -50,14 +50,14 @@ describe("extractRecentToolCalls", () => {
       new AIMessage({
         content: "",
         tool_calls: [
-          { id: "tc2", name: "create_opportunities", args: { searchQuery: "mentor" }, type: "tool_call" },
+          { id: "tc2", name: "discover_opportunities", args: { searchQuery: "mentor" }, type: "tool_call" },
         ],
       }),
-      new ToolMessage({ tool_call_id: "tc2", content: "results...", name: "create_opportunities" }),
+      new ToolMessage({ tool_call_id: "tc2", content: "results...", name: "discover_opportunities" }),
     ];
     const result = extractRecentToolCalls(messages);
     expect(result).toHaveLength(2);
-    expect(result.map((t) => t.name)).toEqual(["read_user_profiles", "create_opportunities"]);
+    expect(result.map((t) => t.name)).toEqual(["read_user_profiles", "discover_opportunities"]);
   });
 
   test("resets scope on new HumanMessage", () => {
@@ -137,7 +137,7 @@ describe("resolveModules", () => {
 
   test("returns empty string when isOnboarding is true (modules skipped)", () => {
     const iterCtx: IterationContext = {
-      recentTools: [{ name: "create_opportunities", args: {} }],
+      recentTools: [{ name: "discover_opportunities", args: {} }],
       currentMessage: undefined,
       ctx: mockCtx({ isOnboarding: true }),
     };
@@ -145,9 +145,9 @@ describe("resolveModules", () => {
     expect(result).toBe("");
   });
 
-  test("activates discovery module on create_opportunities trigger", () => {
+  test("activates discovery module on discover_opportunities trigger", () => {
     const iterCtx: IterationContext = {
-      recentTools: [{ name: "create_opportunities", args: { searchQuery: "mentor" } }],
+      recentTools: [{ name: "discover_opportunities", args: { searchQuery: "mentor" } }],
       ctx: mockCtx(),
     };
     const result = resolveModules(iterCtx);
@@ -159,7 +159,7 @@ describe("resolveModules", () => {
 
   test("activates introduction module (excludes discovery) when partyUserIds present", () => {
     const iterCtx: IterationContext = {
-      recentTools: [{ name: "create_opportunities", args: { partyUserIds: ["a", "b"] } }],
+      recentTools: [{ name: "discover_opportunities", args: { partyUserIds: ["a", "b"] } }],
       ctx: mockCtx(),
     };
     const result = resolveModules(iterCtx);
@@ -171,7 +171,7 @@ describe("resolveModules", () => {
 
   test("activates introduction module when introTargetUserId present", () => {
     const iterCtx: IterationContext = {
-      recentTools: [{ name: "create_opportunities", args: { introTargetUserId: "user-x" } }],
+      recentTools: [{ name: "discover_opportunities", args: { introTargetUserId: "user-x" } }],
       ctx: mockCtx(),
     };
     const result = resolveModules(iterCtx);
@@ -277,7 +277,7 @@ describe("resolveModules", () => {
   test("multiple modules can activate simultaneously", () => {
     const iterCtx: IterationContext = {
       recentTools: [
-        { name: "create_opportunities", args: { searchQuery: "AI" } },
+        { name: "discover_opportunities", args: { searchQuery: "AI" } },
         { name: "read_user_profiles", args: { query: "Bob" } },
       ],
       ctx: mockCtx(),
@@ -499,7 +499,7 @@ describe("buildSystemContent snapshot identity", () => {
     // so use discovery-style args to get discovery + skip introduction)
     const iterCtx: IterationContext = {
       recentTools: [
-        { name: "create_opportunities", args: { searchQuery: "AI" } }, // discovery
+        { name: "discover_opportunities", args: { searchQuery: "AI" } }, // discovery
         { name: "update_opportunity", args: {} },
         { name: "create_intent", args: {} },                          // intent-creation
         { name: "update_intent", args: {} },                          // intent-management
@@ -519,7 +519,7 @@ describe("buildSystemContent snapshot identity", () => {
   test("with iterCtx containing discovery tools, output includes discovery patterns", () => {
     const ctx = makeCtx();
     const iterCtx: IterationContext = {
-      recentTools: [{ name: "create_opportunities", args: { searchQuery: "AI" } }],
+      recentTools: [{ name: "discover_opportunities", args: { searchQuery: "AI" } }],
       ctx,
     };
     const output = buildSystemContent(ctx, iterCtx);

--- a/packages/protocol/src/chat/tests/chat.prompt.spec.ts
+++ b/packages/protocol/src/chat/tests/chat.prompt.spec.ts
@@ -115,7 +115,7 @@ function withUserTurn(
 // ─── Tests ─────────────────────────────────────────────────────────────────────
 
 describe("Multi-step: discovery flow", () => {
-  test("iteration 1 (no tools yet) → no modules; iteration 2 (after create_opportunities) → discovery module", () => {
+  test("iteration 1 (no tools yet) → no modules; iteration 2 (after discover_opportunities) → discovery module", () => {
     const ctx = makeCtx();
 
     // Iteration 1: user just sent the message, no tool calls yet
@@ -124,8 +124,8 @@ describe("Multi-step: discovery flow", () => {
     const iter1Result = resolveModules(iter1);
     expect(iter1Result).toBe("");
 
-    // Iteration 2: agent called create_opportunities
-    const iter2Messages = withToolCall(iter1Messages, "create_opportunities", {
+    // Iteration 2: agent called discover_opportunities
+    const iter2Messages = withToolCall(iter1Messages, "discover_opportunities", {
       searchQuery: "mentor in AI",
     });
     const iter2 = iterCtxFrom(iter2Messages, ctx);
@@ -138,9 +138,9 @@ describe("Multi-step: discovery flow", () => {
   test("discovery module persists across iterations within same turn", () => {
     const ctx = makeCtx();
 
-    // Iteration 2: agent called create_opportunities
+    // Iteration 2: agent called discover_opportunities
     let messages: BaseMessage[] = [new HumanMessage("find me a mentor")];
-    messages = withToolCall(messages, "create_opportunities", { searchQuery: "mentor" });
+    messages = withToolCall(messages, "discover_opportunities", { searchQuery: "mentor" });
 
     // Iteration 3: agent then called read_user_profiles (person-lookup joins)
     messages = withToolCall(messages, "read_user_profiles", { query: "Bob" });
@@ -160,7 +160,7 @@ describe("Multi-step: discovery → signal follow-up (multi-turn)", () => {
 
     // Turn 1: discovery
     let turn1: BaseMessage[] = [new HumanMessage("find me a mentor in AI")];
-    turn1 = withToolCall(turn1, "create_opportunities", { searchQuery: "mentor" });
+    turn1 = withToolCall(turn1, "discover_opportunities", { searchQuery: "mentor" });
 
     // Verify turn 1 has discovery module
     const turn1Ctx = iterCtxFrom(turn1, ctx);
@@ -181,14 +181,14 @@ describe("Multi-step: discovery → signal follow-up (multi-turn)", () => {
     const turn2PostTool = iterCtxFrom(turn2, ctx);
     const turn2Result = resolveModules(turn2PostTool);
 
-    // Intent-creation active, discovery gone (no create_opportunities in turn 2)
+    // Intent-creation active, discovery gone (no discover_opportunities in turn 2)
     expect(turn2Result).toContain("### 2. User explicitly wants to create or save an intent");
     expect(turn2Result).not.toContain("### 1. User wants to find connections");
   });
 });
 
 describe("Multi-step: person lookup → direct connection", () => {
-  test("@mention triggers mentions module, then read_user_profiles adds person-lookup, then create_opportunities adds discovery", () => {
+  test("@mention triggers mentions module, then read_user_profiles adds person-lookup, then discover_opportunities adds discovery", () => {
     const ctx = makeCtx();
 
     // Iteration 1: user mentions someone
@@ -209,8 +209,8 @@ describe("Multi-step: person lookup → direct connection", () => {
     expect(iter2Result).toContain("### 0. User asks about a specific person by name");
     expect(iter2Result).toContain("@[Display Name](userId)");
 
-    // Iteration 3: agent decides to connect → calls create_opportunities
-    messages = withToolCall(messages, "create_opportunities", {
+    // Iteration 3: agent decides to connect → calls discover_opportunities
+    messages = withToolCall(messages, "discover_opportunities", {
       targetUserId: "user-alice",
       searchQuery: "shared interest in AI",
     });
@@ -224,7 +224,7 @@ describe("Multi-step: person lookup → direct connection", () => {
 });
 
 describe("Multi-step: introduction flow with exclusion", () => {
-  test("gathering context activates person-lookup + shared-context; create_opportunities with partyUserIds activates introduction and excludes discovery", () => {
+  test("gathering context activates person-lookup + shared-context; discover_opportunities with partyUserIds activates introduction and excludes discovery", () => {
     const ctx = makeCtx();
 
     // Iteration 1: user asks to introduce two people
@@ -244,8 +244,8 @@ describe("Multi-step: introduction flow with exclusion", () => {
     expect(iter2Result).not.toContain("### 6. Introduce two people");
     expect(iter2Result).not.toContain("### 1. User wants to find connections");
 
-    // Iteration 3: agent calls create_opportunities with partyUserIds (introduction)
-    messages = withToolCall(messages, "create_opportunities", {
+    // Iteration 3: agent calls discover_opportunities with partyUserIds (introduction)
+    messages = withToolCall(messages, "discover_opportunities", {
       partyUserIds: ["user-a", "user-b"],
       entities: [],
     });
@@ -310,10 +310,10 @@ describe("Multi-step: buildSystemContent integration", () => {
     const iter1Prompt = buildSystemContent(ctx, iter1Ctx);
     expect(iter1Prompt).toBe(baseline);
 
-    // Iteration 2: after create_opportunities → modules injected
+    // Iteration 2: after discover_opportunities → modules injected
     const iter2Messages = withToolCall(
       iter1Messages,
-      "create_opportunities",
+      "discover_opportunities",
       { searchQuery: "AI" },
     );
     const iter2Ctx = iterCtxFrom(iter2Messages, ctx);
@@ -332,7 +332,7 @@ describe("Multi-step: buildSystemContent integration", () => {
 
     // Turn 1: discovery active
     let turn1: BaseMessage[] = [new HumanMessage("find mentors")];
-    turn1 = withToolCall(turn1, "create_opportunities", { searchQuery: "mentors" });
+    turn1 = withToolCall(turn1, "discover_opportunities", { searchQuery: "mentors" });
     const turn1Prompt = buildSystemContent(ctx, iterCtxFrom(turn1, ctx));
     expect(turn1Prompt).toContain("### 1. User wants to find connections");
 
@@ -345,10 +345,10 @@ describe("Multi-step: buildSystemContent integration", () => {
 });
 
 describe("Multi-step: disambiguation edge cases", () => {
-  test("create_opportunities with both searchQuery and partyUserIds → introduction wins (partyUserIds is the intro signal)", () => {
+  test("discover_opportunities with both searchQuery and partyUserIds → introduction wins (partyUserIds is the intro signal)", () => {
     const ctx = makeCtx();
     let messages: BaseMessage[] = [new HumanMessage("connect these two people")];
-    messages = withToolCall(messages, "create_opportunities", {
+    messages = withToolCall(messages, "discover_opportunities", {
       searchQuery: "AI collaboration",
       partyUserIds: ["user-a", "user-b"],
     });
@@ -359,12 +359,12 @@ describe("Multi-step: disambiguation edge cases", () => {
     expect(result).not.toContain("### 1. User wants to find connections or discover");
   });
 
-  test("create_opportunities with introTargetUserId (discover-for-person) → introduction wins", () => {
+  test("discover_opportunities with introTargetUserId (discover-for-person) → introduction wins", () => {
     const ctx = makeCtx();
     let messages: BaseMessage[] = [
       new HumanMessage("who should I introduce to @[Alice](user-a)?"),
     ];
-    messages = withToolCall(messages, "create_opportunities", {
+    messages = withToolCall(messages, "discover_opportunities", {
       introTargetUserId: "user-a",
     });
 
@@ -375,13 +375,13 @@ describe("Multi-step: disambiguation edge cases", () => {
     expect(result).not.toContain("### 1. User wants to find connections or discover");
   });
 
-  test("two create_opportunities calls — one discovery, one introduction — introduction excludes discovery", () => {
+  test("two discover_opportunities calls — one discovery, one introduction — introduction excludes discovery", () => {
     const ctx = makeCtx();
     let messages: BaseMessage[] = [new HumanMessage("help me connect")];
     // First call: discovery-style
-    messages = withToolCall(messages, "create_opportunities", { searchQuery: "AI" });
+    messages = withToolCall(messages, "discover_opportunities", { searchQuery: "AI" });
     // Second call: introduction-style
-    messages = withToolCall(messages, "create_opportunities", {
+    messages = withToolCall(messages, "discover_opportunities", {
       partyUserIds: ["user-a", "user-b"],
     });
 
@@ -517,7 +517,7 @@ describe("Chat Prompt Dynamic Modules", () => {
   });
 
   describe("Discovery routing (core rule, no module needed)", () => {
-    test("'find me a mentor in AI' calls create_opportunities, not create_intent", async () => {
+    test("'find me a mentor in AI' calls discover_opportunities, not create_intent", async () => {
       const compiledGraph = factory.createGraph();
 
       const output = await compiledGraph.invoke({
@@ -527,14 +527,14 @@ describe("Chat Prompt Dynamic Modules", () => {
 
       await assertLLM(
         output,
-        "Agent must have called create_opportunities tool (not create_intent). Response should present connections or state no matches found.",
+        "Agent must have called discover_opportunities tool (not create_intent). Response should present connections or state no matches found.",
       );
 
       expect(output.responseText).toBeDefined();
       expect(output.responseText!.length).toBeGreaterThan(0);
 
-      // Deterministic: agent must have called create_opportunities, not create_intent
-      expect(hasToolCall(output.messages ?? [], "create_opportunities")).toBe(true);
+      // Deterministic: agent must have called discover_opportunities, not create_intent
+      expect(hasToolCall(output.messages ?? [], "discover_opportunities")).toBe(true);
       expect(hasToolCall(output.messages ?? [], "create_intent")).toBe(false);
     }, 180000);
   });
@@ -605,7 +605,7 @@ describe("Chat Prompt Dynamic Modules", () => {
       });
 
       expect(turn1.responseText).toBeDefined();
-      expect(hasToolCall(turn1.messages, "create_opportunities")).toBe(true);
+      expect(hasToolCall(turn1.messages, "discover_opportunities")).toBe(true);
 
       // ── Turn 2: user asks to create a signal from the discovery ──
       const turn2Messages = [
@@ -670,7 +670,7 @@ describe("Chat Prompt Dynamic Modules", () => {
   // ─── Multi-turn: @mention → person lookup → direct connection ────────────
 
   describe("Multi-turn: @mention → person lookup → direct connection", () => {
-    test("turn 1: look up @mentioned person; turn 2: connect us → agent calls create_opportunities with targetUserId", async () => {
+    test("turn 1: look up @mentioned person; turn 2: connect us → agent calls discover_opportunities with targetUserId", async () => {
       const mentionDb = createChatGraphMockDb({
         getUser: (userId: string) => {
           if (userId === "user-alice")
@@ -721,10 +721,10 @@ describe("Chat Prompt Dynamic Modules", () => {
       expect(turn2.responseText).toBeDefined();
       expect(turn2.responseText!.length).toBeGreaterThan(0);
 
-      // Agent should have called create_opportunities for direct connection.
-      // Check full turn2 messages — turn1 didn't call create_opportunities,
+      // Agent should have called discover_opportunities for direct connection.
+      // Check full turn2 messages — turn1 didn't call discover_opportunities,
       // so any occurrence is from turn 2.
-      expect(hasToolCall(turn2.messages, "create_opportunities")).toBe(true);
+      expect(hasToolCall(turn2.messages, "discover_opportunities")).toBe(true);
     }, 300000);
   });
 
@@ -853,16 +853,16 @@ describe("Chat Prompt Dynamic Modules", () => {
       expect(turn2.responseText).toBeDefined();
       expect(turn2.responseText!.length).toBeGreaterThan(0);
 
-      // Agent should have called create_opportunities (discovery), not read_indexes
+      // Agent should have called discover_opportunities (discovery), not read_indexes
       const turn2NewMessages = turn2.messages.slice(turn1.messages.length + 1);
-      expect(hasToolCall(turn2NewMessages, "create_opportunities")).toBe(true);
+      expect(hasToolCall(turn2NewMessages, "discover_opportunities")).toBe(true);
     }, 300000);
   });
 
   // ─── Introduction: triggerFilter + excludes disambiguation ────────────────
 
   describe("Introduction between two mentioned people", () => {
-    test("'introduce @Alice and @Bob' → agent gathers context and calls create_opportunities with partyUserIds", async () => {
+    test("'introduce @Alice and @Bob' → agent gathers context and calls discover_opportunities with partyUserIds", async () => {
       const introDb = createChatGraphMockDb({
         getUser: (userId: string) => {
           if (userId === "user-alice")
@@ -919,11 +919,11 @@ describe("Chat Prompt Dynamic Modules", () => {
       expect(result.responseText).toBeDefined();
       expect(result.responseText!.length).toBeGreaterThan(0);
 
-      // Agent must have called create_opportunities with partyUserIds (introduction flow)
-      expect(hasToolCall(result.messages, "create_opportunities")).toBe(true);
+      // Agent must have called discover_opportunities with partyUserIds (introduction flow)
+      expect(hasToolCall(result.messages, "discover_opportunities")).toBe(true);
       const oppArgs = getToolCallArgs(
         result.messages,
-        "create_opportunities",
+        "discover_opportunities",
       );
       // partyUserIds or introTargetUserId should be present — this is an introduction, not a discovery
       const isIntroduction =

--- a/packages/protocol/src/contact/contact.tools.ts
+++ b/packages/protocol/src/contact/contact.tools.ts
@@ -57,9 +57,9 @@ export function createContactTools(defineTool: DefineTool, deps: ToolDeps) {
       "(via import_contacts, add_contact, or import_gmail_contacts) stored as members of their personal index.\n\n" +
       "**When to use:** To see who's in the user's network, find a contact's userId for other operations, " +
       "or check if a specific person is already a contact.\n\n" +
-      "**Returns:** Array of contacts, each with: userId (use with read_user_profiles or create_opportunities), " +
+      "**Returns:** Array of contacts, each with: userId (use with read_user_profiles or discover_opportunities), " +
       "name, email, avatar URL, and isGhost (true = no account yet, profile enriched from public data). " +
-      "Use the userId with read_user_profiles(userId) to get the full profile, or with create_opportunities(targetUserId) to connect.",
+      "Use the userId with read_user_profiles(userId) to get the full profile, or with discover_opportunities(targetUserId) to connect.",
     querySchema: z.object({
       limit: z.number().optional().describe('Maximum number of contacts to return. Omit to return all contacts. Use for large networks to paginate results.'),
     }),
@@ -98,7 +98,7 @@ export function createContactTools(defineTool: DefineTool, deps: ToolDeps) {
       "The contact can then appear in opportunity discovery within the user's personal index.\n\n" +
       "**When to use:** When the user wants to add a specific person (e.g. 'add john@example.com to my network').\n\n" +
       "**Returns:** Confirmation with the contact's userId and whether a new ghost user was created (isNewGhost). " +
-      "Use the userId with create_opportunities(targetUserId) to find connection opportunities.",
+      "Use the userId with discover_opportunities(targetUserId) to find connection opportunities.",
     querySchema: z.object({
       email: z.string().describe('Email address of the person to add. Used as unique identifier — if already a contact, the operation is idempotent.'),
       name: z.string().optional().describe('Full name of the contact. Optional — if omitted, the email prefix is used as name. Provide when known for better profile enrichment.'),
@@ -150,7 +150,7 @@ export function createContactTools(defineTool: DefineTool, deps: ToolDeps) {
     description:
       "Searches the authenticated user's personal network by name or email (case-insensitive substring). " +
       "Use when the user refers to a contact by partial name or email and you need their userId for another tool " +
-      "(e.g. read_user_profiles, create_opportunities).\n\n" +
+      "(e.g. read_user_profiles, discover_opportunities).\n\n" +
       "**When to use:** Before list_contacts when the network is large — returns only matching contacts, bounded by limit.\n\n" +
       "**Returns:** Array of matching contacts: userId, name, email, avatar, isGhost.",
     querySchema: z.object({

--- a/packages/protocol/src/docs/Latent Opportunity Lifecycle.md
+++ b/packages/protocol/src/docs/Latent Opportunity Lifecycle.md
@@ -202,7 +202,7 @@ graph LR
 |-------|------------------|
 | **OpportunityEvaluator** | Assigns valency (Agent / Patient / Peer). System prompt explains that this choice controls who sees the opportunity and when — Agent last, Patient early, Peer both. |
 | **OpportunityPresenter** | Receives `viewerRole`. Suggests role-appropriate actions (e.g. patient: "Send a message to start the conversation"; agent: "Someone is interested — check their message"; introducer: "Share this with [name]"). |
-| **Chat agent** | Prompt explains role-based visibility in natural language (no jargon). Tool descriptions state that send_opportunity notifies "the next person in the connection" based on roles, and that list_opportunities only returns opportunities the user is allowed to see. |
+| **Chat agent** | Prompt explains role-based visibility in natural language (no jargon). Tool descriptions state that `update_opportunity` with `status: "pending"` notifies "the next person in the connection" based on roles, and that `list_opportunities` only returns opportunities the user is allowed to see. |
 
 ## Chat Tools
 
@@ -210,7 +210,7 @@ graph LR
 |------|----------|
 | `discover_opportunities` | Invokes opportunity graph; creates draft (latent) opportunities. Discovered opportunities may not all be visible to the user depending on their role in each match. |
 | `list_opportunities` | Returns opportunities the user is allowed to see (role + status). Filtered by visibility guard in `getOpportunitiesForUser`. |
-| `send_opportunity` | Promotes latent → pending. System notifies the appropriate next person by role (patient if sent by introducer, agent if sent by patient, other peer if sent by peer). |
+| `update_opportunity` (with `status: "pending"`) | Promotes latent → pending. System notifies the appropriate next person by role (patient if sent by introducer, agent if sent by patient, other peer if sent by peer). |
 
 ## Data Flow (Discovery and Send)
 

--- a/packages/protocol/src/docs/Latent Opportunity Lifecycle.md
+++ b/packages/protocol/src/docs/Latent Opportunity Lifecycle.md
@@ -208,13 +208,13 @@ graph LR
 
 | Tool | Behavior |
 |------|----------|
-| `create_opportunities` | Invokes opportunity graph; creates draft (latent) opportunities. Discovered opportunities may not all be visible to the user depending on their role in each match. |
+| `discover_opportunities` | Invokes opportunity graph; creates draft (latent) opportunities. Discovered opportunities may not all be visible to the user depending on their role in each match. |
 | `list_opportunities` | Returns opportunities the user is allowed to see (role + status). Filtered by visibility guard in `getOpportunitiesForUser`. |
 | `send_opportunity` | Promotes latent → pending. System notifies the appropriate next person by role (patient if sent by introducer, agent if sent by patient, other peer if sent by peer). |
 
 ## Data Flow (Discovery and Send)
 
-Discovery flow is unchanged: user or agent calls `create_opportunities` → graph runs Prep through Persist → opportunities created as latent. List and send use the same graph in read/send mode; `getOpportunitiesForUser` applies the role-based visibility guard so only allowed opportunities are returned. On send, only the next-tier role is notified.
+Discovery flow is unchanged: user or agent calls `discover_opportunities` → graph runs Prep through Persist → opportunities created as latent. List and send use the same graph in read/send mode; `getOpportunitiesForUser` applies the role-based visibility guard so only allowed opportunities are returned. On send, only the next-tier role is notified.
 
 ## Hyde Documents and Semantic Search
 

--- a/packages/protocol/src/intent/intent.tools.ts
+++ b/packages/protocol/src/intent/intent.tools.ts
@@ -158,7 +158,7 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       "and returns a proposal widget. The proposal is NOT yet persisted — the user must approve it first.\n\n" +
       "**Returns:** An intent_proposal code block that MUST be included verbatim in the response. The frontend renders it as an interactive " +
       "card the user can approve or skip. On approval, the intent is persisted, indexed, and discovery begins.\n\n" +
-      "**Next steps after approval:** The intent is automatically linked to relevant indexes. Call create_opportunities(searchQuery) to explicitly trigger discovery, " +
+      "**Next steps after approval:** The intent is automatically linked to relevant indexes. Call discover_opportunities(searchQuery) to explicitly trigger discovery, " +
       "or wait for background processing to find matches.\n\n" +
       "**Specificity gate.** Before calling this tool, judge whether the description is concrete enough to be " +
       "useful for matching. If the user says \"find a job\", \"meet people\", or \"learn something\", that's too " +
@@ -671,7 +671,7 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       "Text-searches the authenticated user's own active signals by description. Case-insensitive substring " +
       "match over the signal's payload and summary. Use when the user references a past signal they wrote " +
       '("find my signal about React mentorship") or wants to audit what they\'ve posted.\n\n' +
-      "For discovery of OTHER users' signals that match a query, use create_opportunities(searchQuery=...) " +
+      "For discovery of OTHER users' signals that match a query, use discover_opportunities(searchQuery=...) " +
       "instead — that runs semantic matching across the user's networks.\n\n" +
       "**Returns:** `intents: [{ id, payload, summary, createdAt }]`, most recent first, up to `limit` (default 25).",
     querySchema: z.object({

--- a/packages/protocol/src/network/network.tools.ts
+++ b/packages/protocol/src/network/network.tools.ts
@@ -12,7 +12,7 @@ export function createNetworkTools(defineTool: DefineTool, deps: ToolDeps) {
     name: "read_networks",
     description:
       "Lists the authenticated user's networks (communities), including ones they own and public communities they can join.\n\n" +
-      "**When to use:** To find network IDs for scoping other operations (read_intents, create_opportunities, read_network_memberships), " +
+      "**When to use:** To find network IDs for scoping other operations (read_intents, discover_opportunities, read_network_memberships), " +
       "or to show the user which communities they belong to.\n\n" +
       "**Returns:** Up to three lists — `memberOf` (networks the user joined), `owns` (networks the user created), and `publicNetworks` " +
       "(publicly joinable communities the user is not yet a member of). Entries in `memberOf` include `isPersonal` set to `true` for the user's " +
@@ -339,7 +339,7 @@ export function createNetworkTools(defineTool: DefineTool, deps: ToolDeps) {
       "(complementary matches) between members. The index's prompt guides what kinds of intents belong.\n\n" +
       "**When to use:** When the user wants to create a new community — e.g. a professional network, interest group, or project team.\n\n" +
       "**Returns:** The new index's networkId (UUID) and title. Use the networkId to add members (create_network_membership), " +
-      "link intents (create_intent_index), or run discovery (create_opportunities with networkId).",
+      "link intents (create_intent_index), or run discovery (discover_opportunities with networkId).",
     querySchema: z.object({
       title: z.string().describe("Display name of the index (e.g. 'AI Founders Berlin', 'Design Co-op'). Required."),
       prompt: z.string().optional().describe("Description of what this community is about (e.g. 'Early-stage AI/ML founders in Berlin looking for co-founders, advisors, and investors'). Used by the system to evaluate which intents belong in this index. Highly recommended for better auto-assignment."),

--- a/packages/protocol/src/opportunity/opportunity.discover.ts
+++ b/packages/protocol/src/opportunity/opportunity.discover.ts
@@ -6,7 +6,7 @@
  * old hardcoded strategy selection. Returns formatted candidates (enriched with
  * profile name/bio) for chat display.
  *
- * Used by the create_opportunities chat tool.
+ * Used by the discover_opportunities chat tool.
  */
 
 import type { Opportunity, ChatGraphCompositeDatabase } from "../shared/interfaces/database.interface.js";
@@ -66,7 +66,7 @@ export interface DiscoverInput {
    * Which flow is invoking discovery. Drives the graph's trigger-aware branches
    * in persist (initial status) and negotiate (park window + streaming). When
    * omitted, the graph defaults to 'ambient'. Pass 'orchestrator' from the
-   * chat `create_opportunities` tool so users see drafts stream in and the
+   * chat `discover_opportunities` tool so users see drafts stream in and the
    * accepted-pair lookup surfaces existing connections.
    */
   trigger?: 'ambient' | 'orchestrator';
@@ -152,7 +152,7 @@ export interface DiscoverResult {
   /**
    * Orchestrator-only: accepted opportunities the persist step found between the
    * discoverer and a candidate counterparty (status='accepted'). Populated from
-   * OpportunityGraphState.dedupAlreadyAccepted. Used by the create_opportunities
+   * OpportunityGraphState.dedupAlreadyAccepted. Used by the discover_opportunities
    * tool to tell the LLM "this pair is already connected — open the existing
    * chat rather than creating a new draft". Empty for the ambient trigger.
    */

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -2247,7 +2247,7 @@ export class OpportunityGraphFactory {
             : null;
 
           // Orchestrator-only: collect already-accepted pairs so Task 7's
-          // create_opportunities tool can tell the LLM "these pairs are
+          // discover_opportunities tool can tell the LLM "these pairs are
           // already connected, surface the existing chat rather than
           // creating a new draft". Runs in parallel across unique
           // counterparties (a single evaluator pass can return multiple
@@ -2704,7 +2704,7 @@ export class OpportunityGraphFactory {
             return {
               readResult: {
                 count: 0,
-                message: 'You have no opportunities yet. Use create_opportunities to search for connections.',
+                message: 'You have no opportunities yet. Use discover_opportunities to search for connections.',
                 opportunities: [],
               },
             };

--- a/packages/protocol/src/opportunity/opportunity.state.ts
+++ b/packages/protocol/src/opportunity/opportunity.state.ts
@@ -219,7 +219,7 @@ export const OpportunityGraphState = Annotation.Root({
   /**
    * Accepted opportunities the persist node discovered between the discoverer
    * and a candidate actor (same pair, status='accepted'). The orchestrator
-   * branch populates this so the create_opportunities tool (Task 7) can tell
+   * branch populates this so the discover_opportunities tool (Task 7) can tell
    * the LLM "these pairs are already connected, surface the existing chat
    * rather than creating a new draft". Always empty for the ambient trigger.
    *

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -230,8 +230,8 @@ function buildOpportunityPresentation(
 export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
   const { database, userDb, systemDb, graphs, embedder, cache } = deps;
 
-  const createOpportunities = defineTool({
-    name: "create_opportunities",
+  const discoverOpportunities = defineTool({
+    name: "discover_opportunities",
     description:
       "Creates opportunities — discovered connections between users based on complementary intents. Opportunities are the core output " +
       "of the discovery engine, representing potential valuable connections between people.\n\n" +
@@ -270,7 +270,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
       continueFrom: z
         .string()
         .optional()
-        .describe("Pagination token: pass the discoveryId from a previous create_opportunities result to evaluate the next batch of candidates. Do not combine with other mode parameters."),
+        .describe("Pagination token: pass the discoveryId from a previous discover_opportunities result to evaluate the next batch of candidates. Do not combine with other mode parameters."),
       searchQuery: z
         .string()
         .optional()
@@ -332,7 +332,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         .describe(
           "Introduction mode: pre-gathered profile and intent data for each party being introduced. " +
           "Each entry needs userId, networkId (the shared index), and optionally profile (name, bio, skills, interests) and intents (intentId, payload). " +
-          "Gather this data by calling read_user_profiles and read_intents for each party BEFORE calling create_opportunities. " +
+          "Gather this data by calling read_user_profiles and read_intents for each party BEFORE calling discover_opportunities. " +
           "All entities must share the same networkId (the shared index where both parties are members).",
         ),
       hint: z
@@ -421,7 +421,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         const isIntroducerContinuation = !!query.introTargetUserId?.trim();
         const totalRemaining = (result.pagination?.remaining ?? 0) + extraFromCap;
         if (totalRemaining > 0 && result.pagination?.discoveryId) {
-          message += `\n\nThere are ${totalRemaining} more candidates. Ask if the user wants to see more — they can say "show me more" and you should call create_opportunities with continueFrom="${result.pagination.discoveryId}".`;
+          message += `\n\nThere are ${totalRemaining} more candidates. Ask if the user wants to see more — they can say "show me more" and you should call discover_opportunities with continueFrom="${result.pagination.discoveryId}".`;
         } else if (isIntroducerContinuation) {
           message += `\n\nThese are all the introduction candidates I found for this person.`;
         } else {
@@ -743,7 +743,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
           createIntentSuggested: true,
           suggestedIntentDescription: result.suggestedIntentDescription,
           message:
-            "No matching opportunities found. Call create_intent with the suggested description, then create_opportunities again.",
+            "No matching opportunities found. Call create_intent with the suggested description, then discover_opportunities again.",
           summary: "No matches found",
           ...(result.pagination ? { pagination: result.pagination } : {}),
           debugSteps: allDebugSteps,
@@ -828,7 +828,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
 
       const totalRemaining = (result.pagination?.remaining ?? 0) + extraFromCap;
       if (totalRemaining > 0 && result.pagination?.discoveryId) {
-        message += `\n\nThere are ${totalRemaining} more candidates. Ask if the user wants to see more — they can say "show me more" and you should call create_opportunities with continueFrom="${result.pagination.discoveryId}".`;
+        message += `\n\nThere are ${totalRemaining} more candidates. Ask if the user wants to see more — they can say "show me more" and you should call discover_opportunities with continueFrom="${result.pagination.discoveryId}".`;
       } else if (isIntroducerFlow) {
         message += `\n\nThese are all the introduction candidates I found for this person.`;
       } else {
@@ -936,7 +936,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
           count: 0,
           summary: "No opportunities yet",
           message:
-            "You have no opportunities yet. Use create_opportunities to find connections.",
+            "You have no opportunities yet. Use discover_opportunities to find connections.",
         });
       }
 
@@ -1133,7 +1133,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
           count: 0,
           summary: "No opportunities yet",
           message:
-            "You have no opportunities yet. Use create_opportunities to find connections.",
+            "You have no opportunities yet. Use discover_opportunities to find connections.",
         });
       }
 
@@ -1156,17 +1156,17 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
       "Updates an opportunity's status, advancing it through the connection lifecycle.\n\n" +
       "**Status transitions:**\n" +
       "- `pending`: Sends a draft opportunity to the other party. They'll be notified and can accept or reject. " +
-      "This is the primary action after create_opportunities returns a draft.\n" +
+      "This is the primary action after discover_opportunities returns a draft.\n" +
       "- `accepted`: Accept a received opportunity — opens a direct conversation between both parties. Returns a conversationId to surface to the user.\n" +
       "- `rejected`: Decline a received opportunity.\n" +
       "- `expired`: Mark as expired (typically done by the system after timeout).\n\n" +
-      "**When to use:** After create_opportunities or list_opportunities returns opportunity cards. " +
+      "**When to use:** After discover_opportunities or list_opportunities returns opportunity cards. " +
       "The user clicks 'Send' (pending), 'Accept', or 'Reject' on the card, and the agent calls this tool.\n\n" +
       "**Returns:** Confirmation with the new status and notification details (who was notified).",
     querySchema: z.object({
       opportunityId: z
         .string()
-        .describe("The UUID of the opportunity to update. Get from create_opportunities or list_opportunities results."),
+        .describe("The UUID of the opportunity to update. Get from discover_opportunities or list_opportunities results."),
       status: z
         .enum(["pending", "accepted", "rejected", "expired"])
         .describe(
@@ -1287,5 +1287,5 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
     },
   });
 
-  return [createOpportunities, listOpportunities, updateOpportunity, confirmOpportunityDelivery] as const;
+  return [discoverOpportunities, listOpportunities, updateOpportunity, confirmOpportunityDelivery] as const;
 }

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -233,8 +233,8 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
   const discoverOpportunities = defineTool({
     name: "discover_opportunities",
     description:
-      "Creates opportunities — discovered connections between users based on complementary intents. Opportunities are the core output " +
-      "of the discovery engine, representing potential valuable connections between people.\n\n" +
+      "Discovers opportunities — connections between users based on complementary intents — and persists them as drafts. " +
+      "Opportunities are the core output of the discovery engine, representing potential valuable connections between people.\n\n" +
       "**NOT for person lookup** — use read_user_profiles(query=name) to find people by name.\n\n" +
       "**Four modes:**\n" +
       "1. **Discovery** (most common): pass `searchQuery` and/or `networkId`. The system finds other users in shared indexes " +

--- a/packages/protocol/src/opportunity/tests/opportunity.state.dedupAlreadyAccepted.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.state.dedupAlreadyAccepted.spec.ts
@@ -1,7 +1,7 @@
 /**
  * Unit tests for the `dedupAlreadyAccepted` state field introduced in Plan B
  * Task 6. The orchestrator branch of the persist node populates this so the
- * create_opportunities tool (Task 7) can tell the LLM when candidate pairs
+ * discover_opportunities tool (Task 7) can tell the LLM when candidate pairs
  * already have an accepted opportunity and should reuse the existing chat.
  */
 

--- a/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
+++ b/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for chat tools (createChatTools, read_intents, read_indexes, read_users, create_opportunities, send_opportunity, etc.).
+ * Unit tests for chat tools (createChatTools, read_intents, read_indexes, read_users, discover_opportunities, send_opportunity, etc.).
  */
 /** Config */
 import { config } from "dotenv";
@@ -357,12 +357,12 @@ describe("createChatTools", () => {
     expect(tools.find((t: { name: string }) => t.name === "read_network_memberships")).toBeDefined();
   });
 
-  test("includes list_opportunities alongside create_opportunities and update_opportunity", async () => {
+  test("includes list_opportunities alongside discover_opportunities and update_opportunity", async () => {
     const mockDb = createMockDatabase(async () => []);
     const context: ToolContext = { userId: testUserId, database: mockDb, embedder: mockEmbedder, scraper: mockScraper, ...mockProtocolDeps };
     const tools = await createChatTools(context);
     expect(tools.find((t: { name: string }) => t.name === "list_opportunities")).toBeDefined();
-    expect(tools.find((t: { name: string }) => t.name === "create_opportunities")).toBeDefined();
+    expect(tools.find((t: { name: string }) => t.name === "discover_opportunities")).toBeDefined();
     expect(tools.find((t: { name: string }) => t.name === "update_opportunity")).toBeDefined();
   });
 });
@@ -1011,12 +1011,12 @@ describe("update_intent and delete_intent (Phase 3 index-scoping)", () => {
   });
 });
 
-describe("create_opportunities tool", () => {
-  test("returns a tool named create_opportunities with schema containing searchQuery, optional networkId, and optional intentId", async () => {
+describe("discover_opportunities tool", () => {
+  test("returns a tool named discover_opportunities with schema containing searchQuery, optional networkId, and optional intentId", async () => {
     const mockDb = createMockDatabase(async () => []);
     const context: ToolContext = { userId: testUserId, database: mockDb, embedder: mockEmbedder, scraper: mockScraper, ...mockProtocolDeps };
     const tools = await createChatTools(context);
-    const tool = tools.find((t: { name: string }) => t.name === "create_opportunities");
+    const tool = tools.find((t: { name: string }) => t.name === "discover_opportunities");
     expect(tool).toBeDefined();
     const schema = (tool as { schema?: { shape?: Record<string, unknown> } }).schema;
     const shape = schema?.shape ?? (tool as { schema?: { schema?: { shape?: Record<string, unknown> } } }).schema?.schema?.shape;
@@ -1031,7 +1031,7 @@ describe("create_opportunities tool", () => {
     });
     const context: ToolContext = { userId: testUserId, database: mockDb, embedder: mockEmbedder, scraper: mockScraper, ...mockProtocolDeps };
     const tools = await createChatTools(context);
-    const tool = tools.find((t: { name: string }) => t.name === "create_opportunities") as { invoke: (args: { searchQuery: string; networkId?: string }) => Promise<string> };
+    const tool = tools.find((t: { name: string }) => t.name === "discover_opportunities") as { invoke: (args: { searchQuery: string; networkId?: string }) => Promise<string> };
     const result = await tool.invoke({ searchQuery: "Find a co-founder" });
     const parsed = JSON.parse(result);
     expect(parsed.success).toBe(true);
@@ -1043,7 +1043,7 @@ describe("create_opportunities tool", () => {
     const mockDb = createMockDatabase(async () => [], { isNetworkMember: async () => true });
     const context: ToolContext = { userId: testUserId, database: mockDb, embedder: mockEmbedder, scraper: mockScraper, ...mockProtocolDeps };
     const tools = await createChatTools(context);
-    const tool = tools.find((t: { name: string }) => t.name === "create_opportunities") as {
+    const tool = tools.find((t: { name: string }) => t.name === "discover_opportunities") as {
       invoke: (args: { partyUserIds?: string[]; entities?: unknown[] }) => Promise<string>;
     };
     const result = await tool.invoke({
@@ -1059,7 +1059,7 @@ describe("create_opportunities tool", () => {
     const mockDb = createMockDatabase(async () => [], { isNetworkMember: async () => true });
     const context: ToolContext = { userId: testUserId, database: mockDb, embedder: mockEmbedder, scraper: mockScraper, ...mockProtocolDeps };
     const tools = await createChatTools(context);
-    const tool = tools.find((t: { name: string }) => t.name === "create_opportunities") as {
+    const tool = tools.find((t: { name: string }) => t.name === "discover_opportunities") as {
       invoke: (args: { partyUserIds?: string[]; entities?: Array<{ userId: string; networkId?: string }> }) => Promise<string>;
     };
     const errorMessageRe = /networkId|shared index|required/i;
@@ -1100,7 +1100,7 @@ describe("create_opportunities tool", () => {
     });
     const context: ToolContext = { userId: testUserId, database: mockDb, embedder: mockEmbedder, scraper: mockScraper, ...mockProtocolDeps };
     const tools = await createChatTools(context);
-    const tool = tools.find((t: { name: string }) => t.name === "create_opportunities") as {
+    const tool = tools.find((t: { name: string }) => t.name === "discover_opportunities") as {
       invoke: (args: {
         partyUserIds?: string[];
         entities?: Array<{ userId: string; profile?: Record<string, unknown>; networkId: string }>;
@@ -1142,7 +1142,7 @@ describe("create_opportunities tool", () => {
     });
     const context: ToolContext = { userId: testUserId, database: mockDb, embedder: mockEmbedder, scraper: mockScraper, ...mockProtocolDeps };
     const tools = await createChatTools(context);
-    const tool = tools.find((t: { name: string }) => t.name === "create_opportunities") as {
+    const tool = tools.find((t: { name: string }) => t.name === "discover_opportunities") as {
       invoke: (args: {
         partyUserIds?: string[];
         entities?: Array<{ userId: string; profile?: Record<string, unknown>; networkId: string }>;
@@ -1190,7 +1190,7 @@ describe("create_opportunities tool", () => {
     });
     const context: ToolContext = { userId: testUserId, database: mockDb, embedder: mockEmbedder, scraper: mockScraper, ...mockProtocolDeps };
     const tools = await createChatTools(context);
-    const tool = tools.find((t: { name: string }) => t.name === "create_opportunities") as {
+    const tool = tools.find((t: { name: string }) => t.name === "discover_opportunities") as {
       invoke: (args: {
         partyUserIds?: string[];
         entities?: Array<{ userId: string; profile?: Record<string, unknown>; networkId: string }>;
@@ -1236,7 +1236,7 @@ describe("create_opportunities tool", () => {
     });
     const context: ToolContext = { userId: testUserId, database: mockDb, embedder: mockEmbedder, scraper: mockScraper, ...mockProtocolDeps };
     const tools = await createChatTools(context);
-    const tool = tools.find((t: { name: string }) => t.name === "create_opportunities") as {
+    const tool = tools.find((t: { name: string }) => t.name === "discover_opportunities") as {
       invoke: (args: {
         entities?: Array<{ userId: string; profile?: Record<string, unknown>; networkId: string }>;
       }) => Promise<string>;
@@ -1290,7 +1290,7 @@ describe("create_opportunities tool", () => {
     });
     const context: ToolContext = { userId: testUserId, database: mockDb, embedder: mockEmbedder, scraper: mockScraper, ...mockProtocolDeps };
     const tools = await createChatTools(context);
-    const tool = tools.find((t: { name: string }) => t.name === "create_opportunities") as {
+    const tool = tools.find((t: { name: string }) => t.name === "discover_opportunities") as {
       invoke: (args: { searchQuery: string }) => Promise<string>;
     };
     const searchQuery = "looking for investors for my game project";
@@ -1330,7 +1330,7 @@ describe("create_opportunities tool", () => {
     });
     const context: ToolContext = { userId: testUserId, database: mockDb, embedder: mockEmbedder, scraper: mockScraper, ...mockProtocolDeps };
     const tools = await createChatTools(context);
-    const tool = tools.find((t: { name: string }) => t.name === "create_opportunities") as {
+    const tool = tools.find((t: { name: string }) => t.name === "discover_opportunities") as {
       invoke: (args: { searchQuery?: string }) => Promise<string>;
     };
     const result = await tool.invoke({ searchQuery: "" });
@@ -1368,7 +1368,7 @@ describe("create_opportunities tool", () => {
     });
     const context: ToolContext = { userId: testUserId, database: mockDb, embedder: mockEmbedder, scraper: mockScraper, ...mockProtocolDeps };
     const tools = await createChatTools(context);
-    const tool = tools.find((t: { name: string }) => t.name === "create_opportunities") as {
+    const tool = tools.find((t: { name: string }) => t.name === "discover_opportunities") as {
       invoke: (args: { searchQuery: string; introTargetUserId: string }) => Promise<string>;
     };
     const result = await tool.invoke({
@@ -1404,7 +1404,7 @@ describe("create_opportunities tool", () => {
     });
     const context: ToolContext = { userId: testUserId, database: mockDb, embedder: mockEmbedder, scraper: mockScraper, ...mockProtocolDeps };
     const tools = await createChatTools(context);
-    const tool = tools.find((t: { name: string }) => t.name === "create_opportunities") as {
+    const tool = tools.find((t: { name: string }) => t.name === "discover_opportunities") as {
       invoke: (args: { searchQuery: string; introTargetUserId: string }) => Promise<string>;
     };
     const result = await tool.invoke({
@@ -1444,7 +1444,7 @@ describe("create_opportunities tool", () => {
     });
     const context: ToolContext = { userId: testUserId, database: mockDb, embedder: mockEmbedder, scraper: mockScraper, ...mockProtocolDeps };
     const tools = await createChatTools(context);
-    const tool = tools.find((t: { name: string }) => t.name === "create_opportunities") as {
+    const tool = tools.find((t: { name: string }) => t.name === "discover_opportunities") as {
       invoke: (args: { searchQuery: string }) => Promise<string>;
     };
     const result = await tool.invoke({ searchQuery: "looking for co-founders" });
@@ -1488,7 +1488,7 @@ describe("create_opportunities tool", () => {
     });
     const context: ToolContext = { userId: testUserId, database: mockDb, embedder: mockEmbedder, scraper: mockScraper, ...mockProtocolDeps };
     const tools = await createChatTools(context);
-    const tool = tools.find((t: { name: string }) => t.name === "create_opportunities") as {
+    const tool = tools.find((t: { name: string }) => t.name === "discover_opportunities") as {
       invoke: (args: { searchQuery: string }) => Promise<string>;
     };
     const result = await tool.invoke({ searchQuery: "looking for co-founders" });
@@ -1517,7 +1517,7 @@ describe("create_opportunities tool", () => {
     const mockDb = createMockDatabase(async () => [], {});
     const context: ToolContext = { userId: testUserId, database: mockDb, embedder: mockEmbedder, scraper: mockScraper, ...mockProtocolDeps };
     const tools = await createChatTools(context);
-    const tool = tools.find((t: { name: string }) => t.name === "create_opportunities") as {
+    const tool = tools.find((t: { name: string }) => t.name === "discover_opportunities") as {
       invoke: (args: { continueFrom: string }) => Promise<string>;
     };
     const result = await tool.invoke({ continueFrom: "disc-continue-123" });
@@ -1549,7 +1549,7 @@ describe("create_opportunities tool", () => {
     const mockDb = createMockDatabase(async () => [], {});
     const context: ToolContext = { userId: testUserId, database: mockDb, embedder: mockEmbedder, scraper: mockScraper, ...mockProtocolDeps };
     const tools = await createChatTools(context);
-    const tool = tools.find((t: { name: string }) => t.name === "create_opportunities") as {
+    const tool = tools.find((t: { name: string }) => t.name === "discover_opportunities") as {
       invoke: (args: { continueFrom: string; introTargetUserId: string }) => Promise<string>;
     };
     const result = await tool.invoke({

--- a/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
+++ b/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for chat tools (createChatTools, read_intents, read_indexes, read_users, discover_opportunities, send_opportunity, etc.).
+ * Unit tests for chat tools (createChatTools, read_intents, read_indexes, read_users, discover_opportunities, update_opportunity, etc.).
  */
 /** Config */
 import { config } from "dotenv";

--- a/packages/protocol/src/shared/agent/utility.tools.ts
+++ b/packages/protocol/src/shared/agent/utility.tools.ts
@@ -109,7 +109,7 @@ Intents are the core unit of discovery — they represent what users are seeking
 
 Opportunities represent discovered connections between users — potential matches worth pursuing.
 
-1. **Detection** (create_opportunities): The opportunity graph finds users whose intents semantically complement each other within shared indexes. Uses HyDE embeddings for retrieval and an LLM evaluator for scoring.
+1. **Detection** (discover_opportunities): The opportunity graph finds users whose intents semantically complement each other within shared indexes. Uses HyDE embeddings for retrieval and an LLM evaluator for scoring.
 2. **Roles**: Each opportunity assigns roles to actors:
    - **introducer**: The person who triggered the introduction (may be the system or another user)
    - **party**: The people being connected (typically 2)
@@ -120,13 +120,13 @@ Opportunities represent discovered connections between users — potential match
    - **rejected**: One party declined.
    - **expired**: Timed out without response.
 4. **Creation Modes**:
-   - **Discovery**: Automatic — system finds matches based on intent overlap (create_opportunities with searchQuery)
-   - **Introduction**: Manual — a user introduces two specific people (create_opportunities with partyUserIds + entities)
-   - **Direct**: One-to-one — connect with a specific person (create_opportunities with targetUserId)
+   - **Discovery**: Automatic — system finds matches based on intent overlap (discover_opportunities with searchQuery)
+   - **Introduction**: Manual — a user introduces two specific people (discover_opportunities with partyUserIds + entities)
+   - **Direct**: One-to-one — connect with a specific person (discover_opportunities with targetUserId)
 5. **Presentation**: Each opportunity includes personalized match reasoning, confidence score, and suggested next action.
 
 ### Opportunity Workflow
-1. create_opportunities(searchQuery="AI engineers") → returns draft opportunity cards
+1. discover_opportunities(searchQuery="AI engineers") → returns draft opportunity cards
 2. update_opportunity(opportunityId, status="pending") → sends to other party
 3. Other party sees opportunity → calls update_opportunity(status="accepted" or "rejected")`,
 
@@ -145,7 +145,7 @@ Indexes (also called "networks") are communities where members share what they'r
 1. create_network(title, prompt) → creates new community, you become owner
 2. create_network_membership(networkId, userId) → invite members
 3. Members create intents → auto-assigned to the index based on prompt
-4. create_opportunities(networkId) → discover matches within this community`,
+4. discover_opportunities(networkId) → discover matches within this community`,
 
         profiles: `## Profile System
 
@@ -172,13 +172,13 @@ Contacts are people in a user's personal network, stored as members of their per
 
 - **Adding contacts**: Via import_contacts (bulk), add_contact (single email), or import_gmail_contacts (Google integration).
 - **Ghost users**: When a contact email doesn't match an existing account, a ghost user is created. Ghost users are enriched with public profile data and participate in opportunity matching — they can be discovered even before joining the platform.
-- **Personal index scope**: Pass the personal index networkId to create_opportunities to scope discovery to just the user's contacts.
+- **Personal index scope**: Pass the personal index networkId to discover_opportunities to scope discovery to just the user's contacts.
 - **Contact data**: Each contact has userId, name, email, avatar, and isGhost flag.
 
 ### Contact Workflow
 1. import_contacts or import_gmail_contacts → bulk add to network
 2. list_contacts → view all contacts with userId
-3. create_opportunities(networkId=personalIndexId) → find matches among contacts
+3. discover_opportunities(networkId=personalIndexId) → find matches among contacts
 4. add_contact(email) → add individual contact
 5. remove_contact(contactUserId) → remove from network`,
 
@@ -187,7 +187,7 @@ Contacts are people in a user's personal network, stored as members of their per
 Discovery is the process of finding meaningful connections between users based on their intents and profiles.
 
 ### How Discovery Works
-1. **Trigger**: Runs automatically when an intent is created, or explicitly when create_opportunities is called.
+1. **Trigger**: Runs automatically when an intent is created, or explicitly when discover_opportunities is called.
 2. **Pipeline**: Preparation (gather user context) → Scope (determine which indexes to search) → Candidate retrieval (semantic matching via HyDE embeddings) → Evaluation (LLM scores relevance and complementarity) → Ranking → Persist as opportunities.
 3. **Semantic matching**: Uses HyDE (Hypothetical Document Embeddings) to find candidate intents that complement the source. This goes beyond keyword matching — it understands conceptual relationships.
 4. **Evaluation**: An LLM evaluator agent scores each candidate match on relevance, complementarity, and actionability. Low-scoring matches are filtered out.
@@ -209,29 +209,29 @@ Discovery is the process of finding meaningful connections between users based o
 3. read_networks() → see available communities
 4. create_network_membership(networkId) → join a community
 5. create_intent(description) → post what you're looking for
-6. create_opportunities(searchQuery) → find matches
+6. discover_opportunities(searchQuery) → find matches
 
 ### Finding Connections
 1. read_networks() → list user's communities (get networkId)
-2. create_opportunities(searchQuery, networkId) → discover matches
+2. discover_opportunities(searchQuery, networkId) → discover matches
 3. Review opportunity cards → update_opportunity(opportunityId, status="pending") to send
 
 ### Making an Introduction
 1. read_network_memberships(networkId) → find members in shared community
 2. read_user_profiles(userId) → get profiles of both parties
 3. read_intents(networkId, userId) → get intents of both parties
-4. create_opportunities(partyUserIds=[id1,id2], entities=[...], hint="reason") → create introduction
+4. discover_opportunities(partyUserIds=[id1,id2], entities=[...], hint="reason") → create introduction
 
 ### Managing Contacts
 1. import_gmail_contacts() or import_contacts([...]) → add contacts
 2. list_contacts() → view network
-3. create_opportunities(networkId=personalIndexId) → find matches among contacts
+3. discover_opportunities(networkId=personalIndexId) → find matches among contacts
 
 ### Creating a Community
 1. create_network(title, prompt) → create index
 2. create_network_membership(networkId, userId) → invite members
 3. Members create intents → auto-indexed
-4. create_opportunities(networkId) → discover connections within community`,
+4. discover_opportunities(networkId) → discover connections within community`,
 
         authentication: `## Authentication & API Access
 
@@ -269,7 +269,7 @@ Discovery is the process of finding meaningful connections between users based o
 - After creating intents, proactively suggest or run discovery to find matches.
 
 ### Discovery Workflow
-- After creating intents, proactively suggest running discovery: \`create_opportunities(searchQuery=...)\`
+- After creating intents, proactively suggest running discovery: \`discover_opportunities(searchQuery=...)\`
 - Present discovered opportunities in natural language with the counterpart's name, match reasoning, and suggested next steps.
 - Do not reference "cards", "panels", or any web UI elements.
 


### PR DESCRIPTION
## Summary

Renames the MCP tool `create_opportunities` -> `discover_opportunities`. The tool performs discovery (semantic candidate matching), not creation; the underlying service method and BullMQ job already use the correct verb. This commit aligns the tool name with the rest of the stack.

Mechanical find-and-replace, no logic/schema/queue changes. The BullMQ job string keeps the name `discover_opportunities` — runtime collision is impossible (HTTP/MCP dispatch vs. Redis dispatch live at different layers). A follow-up Linear issue will track queue naming conventions.

## Refactors

- Protocol tool layer (`opportunity.tools.ts`, chat agent/prompt/modules, cross-tool descriptions in contact/intent/network/utility tools, opportunity graph/state/discover)
- CLI source + tests
- Frontend chat tool display map
- Plugin skill templates + regenerated SKILL.md files (openclaw-plugin, claude-plugin)
- OpenClaw onboarding prompt
- Edgeclaw workspace docs (AGENTS, BOOTSTRAP, SOUL, TOOLS)
- Backend test fixtures (`tool.controller.spec`, `mcp.test`)

## Documentation

- API reference (tool listing + endpoint params)
- CLI reference (`opportunity discover` description)
- Protocol deep-dive (tool/graph mapping, intent auto-discovery note)
- Protocol README + Latent Opportunity Lifecycle
- Welcome message design spec

## Excluded by design

- `createOpportunitiesService` (frontend service factory — unrelated namespace)
- `createOpportunityTools` (singular `Opportunity`, factory for the opportunity tool group)
- BullMQ `discover_opportunities` job name + `OpportunityQueue.handleDiscoverOpportunities`

## Versions

Patch bump on every touched package:
- backend 0.21.3 -> 0.21.4
- @indexnetwork/protocol 0.30.1 -> 0.30.2
- @indexnetwork/cli 0.10.3 -> 0.10.4
- @indexnetwork/claude-plugin 0.1.2 -> 0.1.3
- @indexnetwork/openclaw-plugin 0.29.7 -> 0.29.8 (package.json + openclaw.plugin.json kept identical)
- frontend 0.7.3 -> 0.7.4

## Test plan

- [x] tsc clean on backend, packages/protocol, packages/cli, frontend (pre-existing `packages/cli/src/main.ts:278` error untouched)
- [x] Backend lint clean
- [x] Affected protocol unit specs pass (chat.prompt, chat.prompt.modules, opportunity.state.dedupAlreadyAccepted)
- [x] CLI tests pass (47/47)
- [x] Skill templates regenerated via `bun scripts/build-skills.ts`
- [x] Grep confirms no remaining `create_opportunities` outside meta-docs (handoff + design spec describing this rename)
- [ ] Verify MCP `tools/list` exposes `discover_opportunities` in a live server before deploy

Closes IND-270.