### PR TITLE
fix(opportunities): anchor scope filter on requester's own actor.networkId

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol",
-  "version": "0.21.5",
+  "version": "0.21.6",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -4144,12 +4144,14 @@ export class OpportunityDatabaseAdapter {
     }
     if (options?.status) conditions.push(eq(opportunities.status, options.status as typeof opportunities.$inferSelect.status));
     if (options?.networkId) {
-      conditions.push(sql`(
-        ${opportunities.context}->>'networkId' = ${options.networkId}
-        OR EXISTS (
-          SELECT 1 FROM jsonb_array_elements(${opportunities.actors}) AS actor
-          WHERE actor->>'networkId' = ${options.networkId}
-        )
+      // Strict per-actor scope: the requesting user's own actor entry must be
+      // anchored on the bound network. The looser pre-fix check (any actor or
+      // context.networkId matching) leaked cross-network opps to scoped readers
+      // when a counterpart was on the bound network but the viewer wasn't.
+      conditions.push(sql`EXISTS (
+        SELECT 1 FROM jsonb_array_elements(${opportunities.actors}) AS actor
+        WHERE actor->>'userId' = ${userId}
+          AND actor->>'networkId' = ${options.networkId}
       )`);
     }
     if (options?.statuses?.length) {
@@ -4170,7 +4172,14 @@ export class OpportunityDatabaseAdapter {
     networkId: string,
     options?: { status?: string; limit?: number; offset?: number }
   ): Promise<OpportunityRow[]> {
-    const conditions = [sql`${opportunities.context}->>'networkId' = ${networkId}`];
+    // Actor-anchored scope: an opportunity belongs to the network when at
+    // least one actor was matched there. Replaces an earlier `context.networkId`
+    // tag check — that field is a denormalization, not the source of truth, and
+    // can drift from `actors[].networkId` in mixed-network introducer flows.
+    const conditions = [sql`EXISTS (
+      SELECT 1 FROM jsonb_array_elements(${opportunities.actors}) AS actor
+      WHERE actor->>'networkId' = ${networkId}
+    )`];
     if (options?.status) conditions.push(eq(opportunities.status, options.status as typeof opportunities.$inferSelect.status));
     let q = db
       .select()

--- a/backend/src/adapters/tests/database.adapter.spec.ts
+++ b/backend/src/adapters/tests/database.adapter.spec.ts
@@ -660,6 +660,92 @@ describe('OpportunityDatabaseAdapter', () => {
     });
   });
 
+  describe('network-scope filter (getOpportunitiesForUser)', () => {
+    it('does not leak when a counterpart actor lives on the scoped network but the viewer\'s own actor is elsewhere', async () => {
+      // The viewer (userA) is anchored on otherNetworkId in this opportunity.
+      // A counterpart (userB) is anchored on fixture.networkId. The old filter
+      // (visibility @> [{userId}]  AND  EXISTS actor.networkId = X) treats those
+      // two facts independently and lets the opp through when querying with
+      // networkId = fixture.networkId. The strict per-actor filter must exclude it.
+      const otherNetworkId = uuidv4();
+      await db.insert(networks).values({
+        id: otherNetworkId,
+        title: TEST_PREFIX + 'Other Network',
+        prompt: 'Other network prompt',
+      });
+      await db.insert(networkMembers).values({
+        networkId: otherNetworkId,
+        userId: fixture.userAId,
+        permissions: ['member'],
+        autoAssign: false,
+      });
+
+      const created = await adapter.createOpportunity({
+        detection: { source: 'opportunity_graph', createdBy: 'agent-opportunity-finder', timestamp: new Date().toISOString() },
+        actors: [
+          { networkId: otherNetworkId, userId: fixture.userAId, role: 'patient' },
+          { networkId: fixture.networkId, userId: fixture.userBId, role: 'agent' },
+        ],
+        interpretation: { category: 'collaboration', reasoning: 'Cross-network scope leak', confidence: 0.8 },
+        context: { networkId: otherNetworkId },
+        confidence: '0.8',
+        status: 'pending',
+      });
+
+      try {
+        const scopedToFixture = await adapter.getOpportunitiesForUser(fixture.userAId, { networkId: fixture.networkId });
+        expect(scopedToFixture.some((o) => o.id === created.id)).toBe(false);
+
+        // Sanity: with the correct scope the opp is visible to userA.
+        const scopedToActual = await adapter.getOpportunitiesForUser(fixture.userAId, { networkId: otherNetworkId });
+        expect(scopedToActual.some((o) => o.id === created.id)).toBe(true);
+      } finally {
+        // Opp's context.networkId is otherNetworkId, so the afterAll cleanup
+        // (which filters by fixture.networkId) won't touch it — clean explicitly.
+        await db.delete(opportunities).where(eq(opportunities.id, created.id));
+        await db.delete(networkMembers).where(eq(networkMembers.networkId, otherNetworkId));
+        await db.delete(networks).where(eq(networks.id, otherNetworkId));
+      }
+    });
+
+    it('getOpportunitiesForNetwork keys on actor.networkId, not context.networkId', async () => {
+      // Opp's `context.networkId` points at fixture.networkId, but no actor is
+      // anchored there — both actors live on otherNetworkId. The old context-
+      // tagged check returned the opp; the actor-anchored check excludes it
+      // and instead returns the opp on the actors' actual network.
+      const otherNetworkId = uuidv4();
+      await db.insert(networks).values({
+        id: otherNetworkId,
+        title: TEST_PREFIX + 'Other Network 2',
+        prompt: 'Other network prompt',
+      });
+
+      const created = await adapter.createOpportunity({
+        detection: { source: 'opportunity_graph', createdBy: 'agent-opportunity-finder', timestamp: new Date().toISOString() },
+        actors: [
+          { networkId: otherNetworkId, userId: fixture.userAId, role: 'patient' },
+          { networkId: otherNetworkId, userId: fixture.userBId, role: 'agent' },
+        ],
+        interpretation: { category: 'collaboration', reasoning: 'Context-vs-actor mismatch', confidence: 0.8 },
+        // Stale / drifted context tag — actors are the source of truth.
+        context: { networkId: fixture.networkId },
+        confidence: '0.8',
+        status: 'pending',
+      });
+
+      try {
+        const forFixture = await adapter.getOpportunitiesForNetwork(fixture.networkId);
+        expect(forFixture.some((o) => o.id === created.id)).toBe(false);
+
+        const forOther = await adapter.getOpportunitiesForNetwork(otherNetworkId);
+        expect(forOther.some((o) => o.id === created.id)).toBe(true);
+      } finally {
+        await db.delete(opportunities).where(eq(opportunities.id, created.id));
+        await db.delete(networks).where(eq(networks.id, otherNetworkId));
+      }
+    });
+  });
+
   describe('draft visibility (getOpportunitiesForUser)', () => {
     it('without conversationId excludes draft opportunities', async () => {
       const created = await adapter.createOpportunity({

--- a/docs/design/architecture-overview.md
+++ b/docs/design/architecture-overview.md
@@ -266,6 +266,7 @@ Every tool and negotiation endpoint checks the caller's `agent_permissions` for 
 
 - **HTTP**: `backend/src/guards/agent-scope.guard.ts` exposes `resolveAgentNetworkScope(req)`, `assertAgentNetworkScope(req, networkId)`, and `withAgentScope(req, user)`. Network/intent/opportunity controllers assert on writes that take a path-param networkId, and filter list endpoints via `withAgentScope`. Mismatches throw `ScopeViolationError`, mapped to HTTP 403 in `main.ts`.
 - **MCP**: the auth resolver also returns `networkScopeId`. `computeAgentIndexScope` (in `packages/protocol/src/mcp/mcp.server.ts`) clamps `indexScope` to `[networkScopeId, personalIndex]` before constructing per-request scoped DBs, so every downstream tool call is bounded.
+- **DB (opportunity reads)**: `OpportunityDatabaseAdapter.getOpportunitiesForUser` requires the requesting user's *own* actor entry to be anchored on the bound network — `EXISTS actor WHERE userId=$1 AND networkId=$2`, not two independent `actors @>` checks. `update_opportunity` mirrors the rule. `actors[].networkId` is the source of truth for scope; the `opportunity.context.networkId` denormalization is no longer consulted by security-relevant filters.
 
 The primary use case is bulk experiment-network onboarding: `networkInvitationService.invite({ networkId, email })` provisions user + network-scoped agent + API key + invitation email. Possession of the email account *is* the user's verification — there is no separate `users.experimentNetworkId` column anymore.
 

--- a/docs/domain/networks.md
+++ b/docs/domain/networks.md
@@ -117,6 +117,8 @@ Opportunities can be discovered within the scope of a single network. When disco
 
 This enables focused discovery within communities: a new member joining a network triggers discovery only against other members of that same network, and results are contextualized by the network's stated purpose.
 
+An opportunity's relationship to a network is recorded per-actor: each `OpportunityActor` row carries the `networkId` where that user was matched. Read-time scope filters (e.g. listing or acting on opportunities under a network-scoped agent) require the *requesting user's own* actor entry to be anchored on the bound network — a counterpart's presence on the network is not enough, because mixed-network introducer flows can place actors of a single opportunity on different networks. The `opportunity.context.networkId` field is a denormalization for legacy callers and is not consulted by scope checks.
+
 ---
 
 ## Network Integrations

--- a/docs/domain/networks.md
+++ b/docs/domain/networks.md
@@ -117,7 +117,7 @@ Opportunities can be discovered within the scope of a single network. When disco
 
 This enables focused discovery within communities: a new member joining a network triggers discovery only against other members of that same network, and results are contextualized by the network's stated purpose.
 
-An opportunity's relationship to a network is recorded per-actor: each `OpportunityActor` row carries the `networkId` where that user was matched. Read-time scope filters (e.g. listing or acting on opportunities under a network-scoped agent) require the *requesting user's own* actor entry to be anchored on the bound network — a counterpart's presence on the network is not enough, because mixed-network introducer flows can place actors of a single opportunity on different networks. The `opportunity.context.networkId` field is a denormalization for legacy callers and is not consulted by scope checks.
+An opportunity's relationship to a network is recorded per-actor: each entry in the `opportunities.actors` JSONB array carries the `networkId` where that user was matched. Read-time scope filters (e.g. listing or acting on opportunities under a network-scoped agent) require the *requesting user's own* actor entry to be anchored on the bound network — a counterpart's presence on the network is not enough, because mixed-network introducer flows can place actors of a single opportunity on different networks. The `opportunity.context.networkId` field is a denormalization for legacy callers and is not consulted by scope checks.
 
 ---
 

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "0.30.4",
+  "version": "0.30.5",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -149,11 +149,14 @@ export async function attachActionableLinks(
 /**
  * Statuses for which `update_opportunity` must refuse mutations.
  * - `accepted` / `rejected` / `expired`: terminal outcomes.
+ * - `negotiating`: in-flight system-driven turn; user-driven mutations would
+ *   race the negotiation graph. The graph itself transitions out of this state.
  */
 const UPDATE_OPPORTUNITY_BLOCKED_STATUSES = new Set<OpportunityStatus>([
   "accepted",
   "rejected",
   "expired",
+  "negotiating",
 ]);
 
 /**

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -1357,12 +1357,16 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         return error(`This opportunity is already ${opportunity.status} and cannot be updated.`);
       }
 
-      // Strict scope enforcement: when chat is index-scoped, verify opportunity is in that index
+      // Strict scope enforcement: when chat is index-scoped, the caller's own
+      // actor entry on this opportunity must be anchored on the bound network.
+      // Mirrors the per-actor filter in getOpportunitiesForUser — relying on
+      // `context.networkId` or any-actor matches would let a counterpart's
+      // network presence shadow a viewer whose own actor is elsewhere.
       if (context.networkId) {
-        const opportunityIndexId =
-          opportunity.context?.networkId ??
-          opportunity.actors?.find((a) => a.networkId === context.networkId)?.networkId;
-        if (!opportunityIndexId || opportunityIndexId !== context.networkId) {
+        const callerOnBoundNetwork = opportunity.actors?.some(
+          (a) => a.userId === context.userId && a.networkId === context.networkId,
+        );
+        if (!callerOnBoundNetwork) {
           return error("Opportunity not found.");
         }
       }

--- a/packages/protocol/src/opportunity/tests/update-opportunity.spec.ts
+++ b/packages/protocol/src/opportunity/tests/update-opportunity.spec.ts
@@ -142,3 +142,65 @@ describe("update_opportunity — actor guard", () => {
     expect(result.success).toBe(true);
   });
 });
+
+describe("update_opportunity — network scope guard", () => {
+  const BOUND_NETWORK = "bound-network-id";
+  const OTHER_NETWORK = "other-network-id";
+
+  function scopedContext(networkId: string): ResolvedToolContext {
+    const ctx = makeContext(CALLER_ID);
+    (ctx as { networkId?: string }).networkId = networkId;
+    return ctx;
+  }
+
+  function mixedNetworkOpportunity(callerNetworkId: string, otherNetworkId: string): Opportunity {
+    return {
+      id: OPP_ID,
+      status: "pending",
+      actors: [
+        { userId: CALLER_ID, role: "party", networkId: callerNetworkId },
+        { userId: OTHER_ID,  role: "party", networkId: otherNetworkId },
+      ],
+    } as unknown as Opportunity;
+  }
+
+  test("blocks update when caller's actor is on a different network than the bound scope, even if a counterpart is on the bound network", async () => {
+    // Mirror the read-path leak: bound scope = BOUND_NETWORK, the caller is
+    // anchored on OTHER_NETWORK, only the counterpart is on BOUND_NETWORK.
+    // The old check (`actors.find((a) => a.networkId === context.networkId)`)
+    // matched the counterpart and let the update through.
+    const deps = {
+      systemDb: {
+        getOpportunity: async () => mixedNetworkOpportunity(OTHER_NETWORK, BOUND_NETWORK),
+      },
+      graphs: {
+        opportunity: { invoke: async () => ({ mutationResult: { success: true, opportunityId: OPP_ID, message: "ok" } }) },
+      },
+    } as unknown as ToolDeps;
+
+    const tool = captureTool(deps);
+    const result = JSON.parse(
+      await tool.handler({ context: scopedContext(BOUND_NETWORK), query: { opportunityId: OPP_ID, status: "accepted" } })
+    );
+    expect(result.success).toBe(false);
+    // Privacy: same opaque message as the actor guard so callers can't probe scope.
+    expect(result.error).toMatch(/not found/i);
+  });
+
+  test("allows update when caller's own actor is on the bound network", async () => {
+    const deps = {
+      systemDb: {
+        getOpportunity: async () => mixedNetworkOpportunity(BOUND_NETWORK, OTHER_NETWORK),
+      },
+      graphs: {
+        opportunity: { invoke: async () => ({ mutationResult: { success: true, opportunityId: OPP_ID, message: "ok" } }) },
+      },
+    } as unknown as ToolDeps;
+
+    const tool = captureTool(deps);
+    const result = JSON.parse(
+      await tool.handler({ context: scopedContext(BOUND_NETWORK), query: { opportunityId: OPP_ID, status: "accepted" } })
+    );
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes a cross-network leak observed via EdgeClaw: a network-scoped MCP caller could see opportunities where _any_ actor — not necessarily their own — was anchored on the bound network. The old SQL filter combined a visibility `actors @> [{userId, role}]` check with an independent `actors @> [{networkId}]` check; the two could match different actor entries on the same opportunity.

## Bug Fixes

- **`OpportunityDatabaseAdapter.getOpportunitiesForUser`** — replace the lax `context.networkId = X OR any actor.networkId = X` clause with a strict `EXISTS actor WHERE userId=$1 AND networkId=$2` per-actor predicate. Closes the EdgeClaw cross-network leak.
- **`OpportunityDatabaseAdapter.getOpportunitiesForNetwork`** — swap the `context.networkId = X` tag check for an `EXISTS actor.networkId = X` predicate; `context.networkId` is a denormalization and can drift from `actors[].networkId` in mixed-network introducer flows.
- **`update_opportunity` MCP tool — scope guard** — mirror the read-side rule: the caller's own actor must be anchored on the bound network. Previously the fallback `opportunity.actors?.find((a) => a.networkId === context.networkId)` matched a counterpart's actor and let the write through.
- **`update_opportunity` MCP tool — `negotiating` block** — add `'negotiating'` to `UPDATE_OPPORTUNITY_BLOCKED_STATUSES` so user-driven mutations don't race the in-flight negotiation graph. Closes a pre-existing failing test surfaced by Copilot review.

## Refactors

None.

## Documentation

- `docs/design/architecture-overview.md` — add a third "DB (opportunity reads)" enforcement bullet under network-scoped agents, naming the per-actor predicate as the source of truth.
- `docs/domain/networks.md` — clarify that an opportunity's network relationship is per-actor (each entry in the `opportunities.actors` JSONB array), and that `context.networkId` is a denormalization not consulted by scope checks.

## Tests

- New `network-scope filter (getOpportunitiesForUser)` describe in `backend/src/adapters/tests/database.adapter.spec.ts`:
  - Cross-network actor leak repro — confirmed failing pre-fix, green post-fix.
  - Actor-vs-context-tag divergence case for `getOpportunitiesForNetwork`.
- New `update_opportunity — network scope guard` describe in `packages/protocol/src/opportunity/tests/update-opportunity.spec.ts`:
  - Blocks update when caller's actor is on a different network than bound scope.
  - Allows update when caller's own actor is on the bound network.
- Pre-existing `update_opportunity — state machine > blocks update while opportunity is negotiating` now passes (was red on `upstream/dev`).
- `bun test backend/src/adapters/tests/database.adapter.spec.ts` — 74/74 pass.
- `bun test packages/protocol/src/opportunity/tests/update-opportunity.spec.ts` — 8/8 pass.
- `bun test backend/src/queues/tests/intent.queue.spec.ts` — 18/18 pass (rule-1 `networkScopeId` clamp coverage intact).
- `tsc --noEmit` on both `backend` and `packages/protocol` — 0 errors.

## Version bumps

- `@indexnetwork/protocol`: 0.30.4 → 0.30.5
- `backend` (private app workspace): 0.21.5 → 0.21.6

## Out of scope (follow-ups)

- The `context.networkId` field stays on the schema and continues to be written by creators. No reads gate on it anymore. A follow-up migration could drop it once nothing else writes/reads it.
- `getOpportunitiesForNetwork`'s semantics shift slightly: it now returns opportunities where _at least one actor_ is on the network, rather than opps tagged with the network in `context`. For typical opportunities (all actors share networkId), the result is identical; for mixed-network introducer opps, the new version is more honest.