### PR TITLE
fix(opportunity): append ?link_preview=false to minted short URLs + log actionability

### DIFF
--- a/backend/src/protocol-init.ts
+++ b/backend/src/protocol-init.ts
@@ -33,7 +33,7 @@ import { opportunityDeliveryService } from "./services/opportunity-delivery.serv
 import { enrichUserProfile } from "./lib/parallel/parallel";
 import { negotiationTimeoutQueue } from "./queues/negotiation-timeout.queue";
 import { signConnectToken } from "./services/connect-token.service";
-import { mintConnectLink as mintConnectLinkSvc } from "./services/connect-link.service";
+import { mintConnectLink as mintConnectLinkSvc, buildConnectShortUrl } from "./services/connect-link.service";
 import type { MintConnectLink, ProtocolDeps } from '@indexnetwork/protocol';
 
 /**
@@ -58,7 +58,7 @@ export function createDefaultProtocolDeps(): ProtocolDeps {
   ).replace(/\/+$/, '');
   const mintConnectLink: MintConnectLink = async ({ userId, opportunityId, kind, greeting }) => {
     const { code } = await mintConnectLinkSvc({ userId, opportunityId, kind, greeting });
-    return { url: `${apiBaseUrl}/c/${code}?link_preview=false` };
+    return { url: buildConnectShortUrl(apiBaseUrl, code) };
   };
   return {
     database: chatDatabaseAdapter,

--- a/backend/src/protocol-init.ts
+++ b/backend/src/protocol-init.ts
@@ -58,7 +58,7 @@ export function createDefaultProtocolDeps(): ProtocolDeps {
   ).replace(/\/+$/, '');
   const mintConnectLink: MintConnectLink = async ({ userId, opportunityId, kind, greeting }) => {
     const { code } = await mintConnectLinkSvc({ userId, opportunityId, kind, greeting });
-    return { url: `${apiBaseUrl}/c/${code}` };
+    return { url: `${apiBaseUrl}/c/${code}?link_preview=false` };
   };
   return {
     database: chatDatabaseAdapter,

--- a/backend/src/services/connect-link.service.ts
+++ b/backend/src/services/connect-link.service.ts
@@ -17,6 +17,18 @@ function generateCode(): string {
   return out;
 }
 
+/**
+ * Compose the short connect-link URL surfaced to chat clients.
+ *
+ * `?link_preview=false` is the rendering hint chat-gateway runtimes (e.g.
+ * OpenClaw's Telegram delivery) use to suppress the link-preview card.
+ * Pinning the suffix here lets the URL shape evolve in one place and lets
+ * tests assert the contract directly.
+ */
+export function buildConnectShortUrl(apiBaseUrl: string, code: string): string {
+  return `${apiBaseUrl}/c/${code}?link_preview=false`;
+}
+
 export interface MintArgs {
   userId: string;
   opportunityId: string;

--- a/backend/src/services/tests/connect-link.service.spec.ts
+++ b/backend/src/services/tests/connect-link.service.spec.ts
@@ -7,7 +7,7 @@ import { eq } from 'drizzle-orm';
 
 import db from '../../lib/drizzle/drizzle';
 import { connectLinks, opportunities, users } from '../../schemas/database.schema';
-import { mintConnectLink, resolveConnectLink } from '../connect-link.service';
+import { mintConnectLink, resolveConnectLink, buildConnectShortUrl } from '../connect-link.service';
 
 const USER_ID = `cl-svc-user-${Date.now()}`;
 const OPP_ID = `cl-svc-opp-${Date.now()}`;
@@ -108,5 +108,21 @@ describe('connect-link service', () => {
     expect(resolved?.userId).toBe(USER_ID);
     expect(resolved?.greeting).toBe('second greeting');
     expect(await resolveConnectLink(a.code)).toBeNull();
+  });
+});
+
+describe('buildConnectShortUrl', () => {
+  test('appends ?link_preview=false to the short URL', () => {
+    expect(buildConnectShortUrl('https://protocol.example.com', 'AbCd123456')).toBe(
+      'https://protocol.example.com/c/AbCd123456?link_preview=false',
+    );
+  });
+
+  test('does not double-encode when apiBaseUrl has no trailing slash', () => {
+    // Caller already strips trailing slashes in protocol-init.ts before invoking
+    // this helper; verify the helper composes cleanly with the stripped form.
+    expect(buildConnectShortUrl('https://protocol.example.com', 'xyz')).toMatch(
+      /^https:\/\/protocol\.example\.com\/c\/xyz\?link_preview=false$/,
+    );
   });
 });

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "0.30.7",
+  "version": "0.30.8",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -112,6 +112,13 @@ export async function attachActionableLinks(
     viewerRole: card.viewerRole,
     viewerApproved: opts.viewerApproved,
   });
+  logger.info("Opportunity actionability decision", {
+    opportunityId: card.opportunityId,
+    status: card.status,
+    viewerRole: card.viewerRole,
+    viewerApproved: opts.viewerApproved,
+    kind: kind ?? "none",
+  });
   if (kind === null) return;
 
   try {

--- a/packages/protocol/src/shared/agent/tool.factory.ts
+++ b/packages/protocol/src/shared/agent/tool.factory.ts
@@ -84,7 +84,7 @@ export async function createChatTools(
   }) {
     return tool(
       async (query: z.infer<T>) => {
-        logger.verbose(`Tool: ${opts.name}`, {
+        logger.info(`Tool: ${opts.name}`, {
           context: { userId: resolvedContext.userId, networkId: resolvedContext.networkId },
           query,
         });

--- a/packages/protocol/src/shared/agent/tool.factory.ts
+++ b/packages/protocol/src/shared/agent/tool.factory.ts
@@ -21,7 +21,7 @@ import {
   type ToolDeps,
   resolveChatContext,
 } from "./tool.helpers.js";
-import { error } from "./tool.helpers.js";
+import { error, redactSensitiveFields } from "./tool.helpers.js";
 import { createProfileTools } from "../../profile/profile.tools.js";
 import { createIntentTools } from "../../intent/intent.tools.js";
 import { createNetworkTools } from "../../network/network.tools.js";
@@ -86,7 +86,7 @@ export async function createChatTools(
       async (query: z.infer<T>) => {
         logger.info(`Tool: ${opts.name}`, {
           context: { userId: resolvedContext.userId, networkId: resolvedContext.networkId },
-          query,
+          query: redactSensitiveFields(query),
         });
         try {
           return await opts.handler({ context: resolvedContext, query });


### PR DESCRIPTION
## Summary

Two related fixes:

1. The MCP-path `acceptUrl` (a short URL `${apiBaseUrl}/c/<code>` minted by the backend's `mintConnectLink` adapter) was missing the `?link_preview=false` hint that the profileUrl picked up in #770. As a result, Telegram still rendered a link preview for the connect link when there was no preview-worthy URL elsewhere in the message. The fix wires the suffix in at the backend composition root (`protocol-init.ts`), where the adapter is configured — the protocol package itself stays unaware of channel rendering concerns.
2. Adds per-card actionability logging so when an agent surfaces N opportunities but only M of them have an `acceptUrl`, you can see in the logs exactly which (`status × viewerRole × viewerApproved`) combination resolved to which `kind` (or `none`).

## Bug Fixes

- **opportunity**: `backend/src/protocol-init.ts` mintConnectLink adapter now returns short URLs of the form `${apiBaseUrl}/c/<code>?link_preview=false`. Treats `?link_preview=false` as backend-side rendering config, mirroring how profileUrls already carry it. The protocol package's `attachActionableLinks` just echoes whatever the adapter returns.

## Observability

- **opportunity.tools**: New info-level `"Opportunity actionability decision"` log in `attachActionableLinks` — per card, surfaces `opportunityId`, `status`, `viewerRole`, `viewerApproved`, and resolved `kind` (or `"none"`). Makes the silent "card returned but not actionable" path visible.
- **tool.factory**: MCP tool-invocation log (`"Tool: <name>"` with `userId`, `networkId`, `query`) promoted from `verbose` to `info` so it's visible at the default log level without needing `LOG_LEVEL=verbose` on Railway.

## Other

- Bumps `@indexnetwork/protocol` 0.30.7 → 0.30.8.

## Test plan

- [x] `bun test packages/protocol/src/opportunity/tests/opportunity.tools.spec.ts` — 40/40 pass; new log line fires in test output
- [x] `tsc --noEmit` clean in `packages/protocol` and `backend`
- [ ] Re-test EdgeClaw: send a message that surfaces multiple opportunities; verify (a) Telegram no longer shows a preview for the connect-link URL, (b) Railway logs show one `Opportunity actionability decision` line per card with the resolved kind