### PR TITLE
fix(auth): JWT issuer/audience claim hardening

### DIFF
--- a/backend/src/controllers/mcp.controller.ts
+++ b/backend/src/controllers/mcp.controller.ts
@@ -163,7 +163,7 @@ function getOrCompileGraphs(): ToolDeps['graphs'] {
 // ═══════════════════════════════════════════════════════════════════════════════
 
 const JWKS = createRemoteJWKSet(
-  new URL(`${BASE_URL}/api/auth/jwks`),
+  new URL('/api/auth/jwks', BASE_URL),
 );
 
 function parseApiKeyMetadata(raw: string | null | undefined): { agentId?: string } {

--- a/backend/src/controllers/mcp.controller.ts
+++ b/backend/src/controllers/mcp.controller.ts
@@ -38,7 +38,7 @@ import { mintConnectLink as mintConnectLinkSvc, buildConnectShortUrl } from '../
 import { IntentGraphFactory, ProfileGraphFactory, OpportunityGraphFactory, HydeGraphFactory, NetworkGraphFactory, NetworkMembershipGraphFactory, IntentNetworkGraphFactory, NegotiationGraphFactory, HydeGenerator, LensInferrer, IntentIndexer, createMcpServer, ChatGraphFactory } from '@indexnetwork/protocol';
 import type { HydeGraphDatabase, ToolDeps, McpAuthResolver, ScopedDepsFactory, Embedder, ChatGraphCompositeDatabase } from '@indexnetwork/protocol';
 
-import { BASE_URL } from '../lib/betterauth/betterauth';
+import { BASE_URL, JWT_AUDIENCE } from '../lib/betterauth/betterauth';
 import { log } from '../lib/log';
 import { resolveAgentNetworkScopeById } from '../guards/agent-scope.guard';
 
@@ -193,7 +193,7 @@ const authResolver: McpAuthResolver = {
         // there is no network scope to compute; the field is explicitly null
         // (not omitted) so callers cannot conflate "no scope" with "scope unset".
         try {
-          const { payload } = await jwtVerify(token, JWKS);
+          const { payload } = await jwtVerify(token, JWKS, { issuer: BASE_URL, audience: JWT_AUDIENCE });
           if (typeof payload.id === 'string') return { userId: payload.id, isSessionAuth: true, networkScopeId: null };
           if (typeof payload.sub === 'string') return { userId: payload.sub, isSessionAuth: true, networkScopeId: null };
           throw new Error('JWT payload missing user ID');

--- a/backend/src/guards/auth.guard.ts
+++ b/backend/src/guards/auth.guard.ts
@@ -12,7 +12,7 @@ export interface AuthenticatedUser {
 }
 
 const JWKS = createRemoteJWKSet(
-  new URL(`http://localhost:${process.env.PORT || 3001}/api/auth/jwks`)
+  new URL(`${BASE_URL}/api/auth/jwks`)
 );
 
 /**

--- a/backend/src/guards/auth.guard.ts
+++ b/backend/src/guards/auth.guard.ts
@@ -3,6 +3,7 @@ import { eq } from 'drizzle-orm';
 
 import db from '../lib/drizzle/drizzle';
 import { apikeys, users } from '../schemas/database.schema';
+import { BASE_URL, JWT_AUDIENCE } from '../lib/betterauth/betterauth';
 
 export interface AuthenticatedUser {
   id: string;
@@ -28,7 +29,7 @@ export const AuthGuard = async (req: Request): Promise<AuthenticatedUser> => {
     throw new Error('Access token required');
   }
   try {
-    const { payload } = await jwtVerify(token, JWKS);
+    const { payload } = await jwtVerify(token, JWKS, { issuer: BASE_URL, audience: JWT_AUDIENCE });
     return {
       id: payload.id as string,
       email: (payload.email as string) ?? null,

--- a/backend/src/guards/auth.guard.ts
+++ b/backend/src/guards/auth.guard.ts
@@ -12,7 +12,7 @@ export interface AuthenticatedUser {
 }
 
 const JWKS = createRemoteJWKSet(
-  new URL(`${BASE_URL}/api/auth/jwks`)
+  new URL('/api/auth/jwks', BASE_URL)
 );
 
 /**

--- a/backend/src/lib/betterauth/betterauth.ts
+++ b/backend/src/lib/betterauth/betterauth.ts
@@ -9,6 +9,8 @@ const logger = log.server.from("betterauth");
 export const BASE_URL =
   process.env.BASE_URL || `http://localhost:${process.env.PORT || 3001}`;
 
+export const JWT_AUDIENCE = BASE_URL;
+
 export const APP_URL =
   process.env.FRONTEND_URL || process.env.APP_URL || 'https://index.network';
 
@@ -106,6 +108,7 @@ export function createAuth(deps: AuthDeps) {
       jwt({
         jwt: {
           issuer: BASE_URL,
+          audience: JWT_AUDIENCE,
           expirationTime: "1h",
           definePayload: ({ user }) => ({
             id: user.id,

--- a/backend/tests/auth.jwt-claims.test.ts
+++ b/backend/tests/auth.jwt-claims.test.ts
@@ -47,7 +47,7 @@ describe('jwtVerify claim validation', () => {
 
   it('rejects a token with wrong aud', async () => {
     const { privateKey, JWKS } = await makeTestJWKS();
-    const token = await signToken(privateKey, { iss: BASE_URL, aud: 'https://other-service.example.com' });
+    const token = await signToken(privateKey, { iss: BASE_URL, aud: `${JWT_AUDIENCE}-wrong` });
     let err: unknown;
     try { await jwtVerify(token, JWKS, { issuer: BASE_URL, audience: JWT_AUDIENCE }); } catch (e) { err = e; }
     expect(err).toBeInstanceOf(joseErrors.JWTClaimValidationFailed);
@@ -55,7 +55,7 @@ describe('jwtVerify claim validation', () => {
 
   it('rejects a token with wrong iss', async () => {
     const { privateKey, JWKS } = await makeTestJWKS();
-    const token = await signToken(privateKey, { iss: 'https://dev.index.network', aud: JWT_AUDIENCE });
+    const token = await signToken(privateKey, { iss: `${BASE_URL}-wrong`, aud: JWT_AUDIENCE });
     let err: unknown;
     try { await jwtVerify(token, JWKS, { issuer: BASE_URL, audience: JWT_AUDIENCE }); } catch (e) { err = e; }
     expect(err).toBeInstanceOf(joseErrors.JWTClaimValidationFailed);

--- a/backend/tests/auth.jwt-claims.test.ts
+++ b/backend/tests/auth.jwt-claims.test.ts
@@ -40,32 +40,32 @@ describe('jwtVerify claim validation', () => {
   it('rejects a token missing aud', async () => {
     const { privateKey, JWKS } = await makeTestJWKS();
     const token = await signToken(privateKey, { iss: BASE_URL });
-    expect(
-      jwtVerify(token, JWKS, { issuer: BASE_URL, audience: JWT_AUDIENCE }),
-    ).rejects.toBeInstanceOf(joseErrors.JWTClaimValidationFailed);
+    let err: unknown;
+    try { await jwtVerify(token, JWKS, { issuer: BASE_URL, audience: JWT_AUDIENCE }); } catch (e) { err = e; }
+    expect(err).toBeInstanceOf(joseErrors.JWTClaimValidationFailed);
   });
 
   it('rejects a token with wrong aud', async () => {
     const { privateKey, JWKS } = await makeTestJWKS();
     const token = await signToken(privateKey, { iss: BASE_URL, aud: 'https://other-service.example.com' });
-    expect(
-      jwtVerify(token, JWKS, { issuer: BASE_URL, audience: JWT_AUDIENCE }),
-    ).rejects.toBeInstanceOf(joseErrors.JWTClaimValidationFailed);
+    let err: unknown;
+    try { await jwtVerify(token, JWKS, { issuer: BASE_URL, audience: JWT_AUDIENCE }); } catch (e) { err = e; }
+    expect(err).toBeInstanceOf(joseErrors.JWTClaimValidationFailed);
   });
 
   it('rejects a token with wrong iss', async () => {
     const { privateKey, JWKS } = await makeTestJWKS();
     const token = await signToken(privateKey, { iss: 'https://dev.index.network', aud: JWT_AUDIENCE });
-    expect(
-      jwtVerify(token, JWKS, { issuer: BASE_URL, audience: JWT_AUDIENCE }),
-    ).rejects.toBeInstanceOf(joseErrors.JWTClaimValidationFailed);
+    let err: unknown;
+    try { await jwtVerify(token, JWKS, { issuer: BASE_URL, audience: JWT_AUDIENCE }); } catch (e) { err = e; }
+    expect(err).toBeInstanceOf(joseErrors.JWTClaimValidationFailed);
   });
 
   it('rejects a token missing both iss and aud', async () => {
     const { privateKey, JWKS } = await makeTestJWKS();
     const token = await signToken(privateKey, {});
-    expect(
-      jwtVerify(token, JWKS, { issuer: BASE_URL, audience: JWT_AUDIENCE }),
-    ).rejects.toBeInstanceOf(joseErrors.JWTClaimValidationFailed);
+    let err: unknown;
+    try { await jwtVerify(token, JWKS, { issuer: BASE_URL, audience: JWT_AUDIENCE }); } catch (e) { err = e; }
+    expect(err).toBeInstanceOf(joseErrors.JWTClaimValidationFailed);
   });
 });

--- a/backend/tests/auth.jwt-claims.test.ts
+++ b/backend/tests/auth.jwt-claims.test.ts
@@ -8,8 +8,7 @@ import {
   errors as joseErrors,
 } from 'jose';
 
-const BASE_URL = 'http://localhost:3001';
-const JWT_AUDIENCE = BASE_URL;
+import { BASE_URL, JWT_AUDIENCE } from '../src/lib/betterauth/betterauth';
 
 async function makeTestJWKS() {
   const { privateKey, publicKey } = await generateKeyPair('RS256');
@@ -41,7 +40,7 @@ describe('jwtVerify claim validation', () => {
   it('rejects a token missing aud', async () => {
     const { privateKey, JWKS } = await makeTestJWKS();
     const token = await signToken(privateKey, { iss: BASE_URL });
-    await expect(
+    expect(
       jwtVerify(token, JWKS, { issuer: BASE_URL, audience: JWT_AUDIENCE }),
     ).rejects.toBeInstanceOf(joseErrors.JWTClaimValidationFailed);
   });
@@ -49,7 +48,7 @@ describe('jwtVerify claim validation', () => {
   it('rejects a token with wrong aud', async () => {
     const { privateKey, JWKS } = await makeTestJWKS();
     const token = await signToken(privateKey, { iss: BASE_URL, aud: 'https://other-service.example.com' });
-    await expect(
+    expect(
       jwtVerify(token, JWKS, { issuer: BASE_URL, audience: JWT_AUDIENCE }),
     ).rejects.toBeInstanceOf(joseErrors.JWTClaimValidationFailed);
   });
@@ -57,7 +56,7 @@ describe('jwtVerify claim validation', () => {
   it('rejects a token with wrong iss', async () => {
     const { privateKey, JWKS } = await makeTestJWKS();
     const token = await signToken(privateKey, { iss: 'https://dev.index.network', aud: JWT_AUDIENCE });
-    await expect(
+    expect(
       jwtVerify(token, JWKS, { issuer: BASE_URL, audience: JWT_AUDIENCE }),
     ).rejects.toBeInstanceOf(joseErrors.JWTClaimValidationFailed);
   });
@@ -65,7 +64,7 @@ describe('jwtVerify claim validation', () => {
   it('rejects a token missing both iss and aud', async () => {
     const { privateKey, JWKS } = await makeTestJWKS();
     const token = await signToken(privateKey, {});
-    await expect(
+    expect(
       jwtVerify(token, JWKS, { issuer: BASE_URL, audience: JWT_AUDIENCE }),
     ).rejects.toBeInstanceOf(joseErrors.JWTClaimValidationFailed);
   });

--- a/backend/tests/auth.jwt-claims.test.ts
+++ b/backend/tests/auth.jwt-claims.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  generateKeyPair,
+  SignJWT,
+  createLocalJWKSet,
+  exportJWK,
+  jwtVerify,
+  errors as joseErrors,
+} from 'jose';
+
+const BASE_URL = 'http://localhost:3001';
+const JWT_AUDIENCE = BASE_URL;
+
+async function makeTestJWKS() {
+  const { privateKey, publicKey } = await generateKeyPair('RS256');
+  const jwk = await exportJWK(publicKey);
+  const JWKS = createLocalJWKSet({ keys: [{ ...jwk, kid: 'test-kid', use: 'sig', alg: 'RS256' }] });
+  return { privateKey, JWKS };
+}
+
+async function signToken(
+  privateKey: CryptoKey,
+  claims: { iss?: string; aud?: string | string[] },
+) {
+  let builder = new SignJWT({ id: 'user-123', email: 'test@example.com' })
+    .setProtectedHeader({ alg: 'RS256', kid: 'test-kid' })
+    .setExpirationTime('1h');
+  if (claims.iss !== undefined) builder = builder.setIssuer(claims.iss);
+  if (claims.aud !== undefined) builder = builder.setAudience(claims.aud);
+  return builder.sign(privateKey);
+}
+
+describe('jwtVerify claim validation', () => {
+  it('accepts a token with correct iss and aud', async () => {
+    const { privateKey, JWKS } = await makeTestJWKS();
+    const token = await signToken(privateKey, { iss: BASE_URL, aud: JWT_AUDIENCE });
+    const { payload } = await jwtVerify(token, JWKS, { issuer: BASE_URL, audience: JWT_AUDIENCE });
+    expect(payload.id).toBe('user-123');
+  });
+
+  it('rejects a token missing aud', async () => {
+    const { privateKey, JWKS } = await makeTestJWKS();
+    const token = await signToken(privateKey, { iss: BASE_URL });
+    await expect(
+      jwtVerify(token, JWKS, { issuer: BASE_URL, audience: JWT_AUDIENCE }),
+    ).rejects.toBeInstanceOf(joseErrors.JWTClaimValidationFailed);
+  });
+
+  it('rejects a token with wrong aud', async () => {
+    const { privateKey, JWKS } = await makeTestJWKS();
+    const token = await signToken(privateKey, { iss: BASE_URL, aud: 'https://other-service.example.com' });
+    await expect(
+      jwtVerify(token, JWKS, { issuer: BASE_URL, audience: JWT_AUDIENCE }),
+    ).rejects.toBeInstanceOf(joseErrors.JWTClaimValidationFailed);
+  });
+
+  it('rejects a token with wrong iss', async () => {
+    const { privateKey, JWKS } = await makeTestJWKS();
+    const token = await signToken(privateKey, { iss: 'https://dev.index.network', aud: JWT_AUDIENCE });
+    await expect(
+      jwtVerify(token, JWKS, { issuer: BASE_URL, audience: JWT_AUDIENCE }),
+    ).rejects.toBeInstanceOf(joseErrors.JWTClaimValidationFailed);
+  });
+
+  it('rejects a token missing both iss and aud', async () => {
+    const { privateKey, JWKS } = await makeTestJWKS();
+    const token = await signToken(privateKey, {});
+    await expect(
+      jwtVerify(token, JWKS, { issuer: BASE_URL, audience: JWT_AUDIENCE }),
+    ).rejects.toBeInstanceOf(joseErrors.JWTClaimValidationFailed);
+  });
+});


### PR DESCRIPTION
## Summary

- Export `JWT_AUDIENCE = BASE_URL` from `betterauth.ts` as a named constant; add `audience: JWT_AUDIENCE` to the `jwt()` plugin config so all issued tokens carry the `aud` claim
- Pass `{ issuer: BASE_URL, audience: JWT_AUDIENCE }` to both `jwtVerify` call sites (`auth.guard.ts` and `mcp.controller.ts`) so tokens missing or carrying wrong claims are rejected
- Use `BASE_URL` for the JWKS endpoint URL in `auth.guard.ts` (was hardcoded to `localhost`)
- Add 5 contract tests in `backend/tests/auth.jwt-claims.test.ts` covering: correct claims accepted, missing `aud` rejected, wrong `aud` rejected, wrong `iss` rejected, both missing rejected

## Test Plan

- [ ] `bun test tests/auth.jwt-claims.test.ts` — all 5 pass
- [ ] Deploy to dev and verify JWT-authenticated flows (magic link login → CLI token) still work
- [ ] Verify existing `x-api-key` headless access is unaffected (separate auth path)

Closes IND-257