### PR TITLE
feat: EdgeClaw integrations row + master-key rotation (IND-302)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol",
-  "version": "0.21.8",
+  "version": "0.22.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/backend/src/controllers/network.controller.ts
+++ b/backend/src/controllers/network.controller.ts
@@ -516,14 +516,7 @@ export class NetworkController {
       logger.verbose('Master key rotated', { networkId: params.id, userId: user.id });
       return Response.json({ masterKey: result.masterKey });
     } catch (err: unknown) {
-      const msg = errorMessage(err);
-      logger.error('Master key rotation failed', { networkId: params.id, error: msg });
-      if (msg.includes('Not an experiment network')) {
-        return Response.json({ error: msg }, { status: 400 });
-      }
-      if (msg.includes('Owner-only')) {
-        return Response.json({ error: msg }, { status: 403 });
-      }
+      logger.error('Master key rotation failed', { networkId: params.id, error: errorMessage(err) });
       throw err;
     }
   }
@@ -541,8 +534,8 @@ export class NetworkController {
     if (!(network as Record<string, unknown>).isExperiment) {
       throw Response.json({ error: 'This operation is only available for experiment networks' }, { status: 403 });
     }
-    const owner = (network as Record<string, unknown>).user as { id: string } | undefined;
-    if (owner?.id !== userId) {
+    const isOwner = await networkService.isIndexOwner(networkId, userId);
+    if (!isOwner) {
       throw Response.json({ error: 'Owner-only operation' }, { status: 403 });
     }
   }

--- a/backend/src/controllers/network.controller.ts
+++ b/backend/src/controllers/network.controller.ts
@@ -494,6 +494,40 @@ export class NetworkController {
     }
   }
 
+  /**
+   * Rotate the master key on an experiment network. Owner-only. The plaintext
+   * is returned in the response body exactly once; the previous key stops
+   * working immediately. Every owner of the network also receives the new
+   * key by email.
+   */
+  @Post('/:id/rotate-master-key')
+  @UseGuards(AuthOrApiKeyGuard)
+  async rotateMasterKey(req: Request, user: AuthenticatedUser, params: Record<string, string>) {
+    try {
+      await assertAgentNetworkScope(req, params.id);
+      await this.assertExperimentOwner(params.id, user.id);
+    } catch (err) {
+      if (err instanceof Response) return err;
+      throw err;
+    }
+
+    try {
+      const result = await networkService.rotateExperimentMasterKey(params.id, user.id);
+      logger.verbose('Master key rotated', { networkId: params.id, userId: user.id });
+      return Response.json({ masterKey: result.masterKey });
+    } catch (err: unknown) {
+      const msg = errorMessage(err);
+      logger.error('Master key rotation failed', { networkId: params.id, error: msg });
+      if (msg.includes('Not an experiment network')) {
+        return Response.json({ error: msg }, { status: 400 });
+      }
+      if (msg.includes('Owner-only')) {
+        return Response.json({ error: msg }, { status: 403 });
+      }
+      throw err;
+    }
+  }
+
   private async assertExperimentOwner(networkId: string, userId: string): Promise<void> {
     let network: Awaited<ReturnType<typeof networkService.getNetworkById>>;
     try {

--- a/backend/src/controllers/tests/network.controller.spec.ts
+++ b/backend/src/controllers/tests/network.controller.spec.ts
@@ -273,6 +273,55 @@ describe("NetworkController Integration", () => {
     });
   });
 
+  describe("POST /:id/rotate-master-key", () => {
+    let rotateNetworkId: string;
+
+    beforeAll(async () => {
+      const req = new Request("http://localhost/networks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: "Rotate Master Key Test", isExperiment: true }),
+      });
+      const res = await controller.create(req, mockUser());
+      const data = (await res.json()) as { network?: { id: string } };
+      rotateNetworkId = data.network!.id;
+    });
+
+    afterAll(async () => {
+      if (rotateNetworkId) await indexAdapter.deleteNetworkAndMembers(rotateNetworkId);
+    });
+
+    test("returns 200 with a fresh masterKey for the owner", async () => {
+      const req = new Request(`http://localhost/networks/${rotateNetworkId}/rotate-master-key`, {
+        method: "POST",
+      });
+      const res = await controller.rotateMasterKey(req, mockUser(), { id: rotateNetworkId });
+      const data = (await res.json()) as { masterKey?: string };
+
+      expect(res.status).toBe(200);
+      expect(data.masterKey).toBeTruthy();
+      expect(data.masterKey!.length).toBe(64);
+    });
+
+    test("returns 403 when network is not an experiment", async () => {
+      const req = new Request(`http://localhost/networks/${createdIndexId}/rotate-master-key`, {
+        method: "POST",
+      });
+      const res = await controller.rotateMasterKey(req, mockUser(), { id: createdIndexId });
+      expect(res.status).toBe(403);
+    });
+
+    test("returns 404 when network does not exist", async () => {
+      const fakeId = "00000000-0000-0000-0000-000000000000";
+      const req = new Request(`http://localhost/networks/${fakeId}/rotate-master-key`, {
+        method: "POST",
+      });
+      const res = await controller.rotateMasterKey(req, mockUser(), { id: fakeId });
+      // assertExperimentOwner returns 404 for null networks but 403 for any other access failure → accept either
+      expect([403, 404]).toContain(res.status);
+    });
+  });
+
   describe("DELETE /:id", () => {
     test("should return 200 and success when owner", async () => {
       const req = new Request("http://localhost/networks/" + createdIndexId, { method: "DELETE" });

--- a/backend/src/guards/experiment.guard.ts
+++ b/backend/src/guards/experiment.guard.ts
@@ -1,13 +1,8 @@
 import { and, eq, isNull } from 'drizzle-orm';
 
 import db from '../lib/drizzle/drizzle';
+import { hashMasterKey } from '../lib/experiment/master-key';
 import * as schema from '../schemas/database.schema';
-
-async function hashKey(key: string): Promise<string> {
-  const encoded = new TextEncoder().encode(key);
-  const hash = await crypto.subtle.digest('SHA-256', encoded);
-  return Buffer.from(hash).toString('base64url');
-}
 
 export interface ExperimentNetwork {
   id: string;
@@ -55,7 +50,7 @@ export async function ExperimentMasterKeyGuard(
     });
   }
 
-  const hashedKey = await hashKey(apiKey);
+  const hashedKey = await hashMasterKey(apiKey);
   if (hashedKey !== network.experimentMasterKeyHash) {
     throw new Response(JSON.stringify({ error: 'Forbidden' }), {
       status: 403,

--- a/backend/src/guards/tests/experiment.guard.spec.ts
+++ b/backend/src/guards/tests/experiment.guard.spec.ts
@@ -1,0 +1,92 @@
+import { config } from 'dotenv';
+config({ path: '.env.test' });
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { eq, inArray } from 'drizzle-orm';
+
+import db from '../../lib/drizzle/drizzle';
+import * as schema from '../../schemas/database.schema';
+import { generateMasterKey } from '../../lib/experiment/master-key';
+import { ExperimentMasterKeyGuard } from '../experiment.guard';
+import { networkService } from '../../services/network.service';
+
+describe('ExperimentMasterKeyGuard after rotation', () => {
+  let networkId: string;
+  let ownerId: string;
+  let originalKey: string;
+  const cleanupUserIds: string[] = [];
+  const cleanupNetworkIds: string[] = [];
+
+  beforeAll(async () => {
+    const stamp = Date.now();
+    const generated = await generateMasterKey();
+    originalKey = generated.key;
+
+    const [owner] = await db.insert(schema.users)
+      .values({ email: `guard-rot-${stamp}@test.dev`, name: 'Guard Owner', emailVerified: true })
+      .returning({ id: schema.users.id });
+    ownerId = owner.id;
+    cleanupUserIds.push(ownerId);
+
+    const initialHash = generated.hash;
+    const [n] = await db.insert(schema.networks)
+      .values({
+        title: 'Guard Rotation Test',
+        isPersonal: false,
+        isExperiment: true,
+        experimentMasterKeyHash: initialHash,
+        permissions: { joinPolicy: 'invite_only', invitationLink: null, allowGuestVibeCheck: false },
+      })
+      .returning({ id: schema.networks.id });
+    networkId = n.id;
+    cleanupNetworkIds.push(networkId);
+    await db.insert(schema.networkMembers).values({ networkId, userId: ownerId, permissions: ['owner'] });
+  });
+
+  afterAll(async () => {
+    if (cleanupNetworkIds.length > 0) {
+      await db.delete(schema.networkMembers).where(inArray(schema.networkMembers.networkId, cleanupNetworkIds));
+      await db.delete(schema.networks).where(inArray(schema.networks.id, cleanupNetworkIds));
+    }
+    if (cleanupUserIds.length > 0) {
+      await db.delete(schema.users).where(inArray(schema.users.id, cleanupUserIds));
+    }
+  });
+
+  test('original key validates before rotation, new key validates after, old key is rejected after', async () => {
+    const before = await ExperimentMasterKeyGuard(
+      new Request(`http://localhost/networks/${networkId}/signup`, {
+        method: 'POST',
+        headers: { 'x-api-key': originalKey },
+      }),
+      { id: networkId },
+    );
+    expect(before.id).toBe(networkId);
+
+    const { masterKey: newKey } = await networkService.rotateExperimentMasterKey(networkId, ownerId);
+
+    const after = await ExperimentMasterKeyGuard(
+      new Request(`http://localhost/networks/${networkId}/signup`, {
+        method: 'POST',
+        headers: { 'x-api-key': newKey },
+      }),
+      { id: networkId },
+    );
+    expect(after.id).toBe(networkId);
+
+    let rejected: Response | null = null;
+    try {
+      await ExperimentMasterKeyGuard(
+        new Request(`http://localhost/networks/${networkId}/signup`, {
+          method: 'POST',
+          headers: { 'x-api-key': originalKey },
+        }),
+        { id: networkId },
+      );
+    } catch (err) {
+      if (err instanceof Response) rejected = err;
+    }
+    expect(rejected).not.toBeNull();
+    expect(rejected!.status).toBe(403);
+  });
+});

--- a/backend/src/lib/email/templates/network-master-key-rotated.template.spec.ts
+++ b/backend/src/lib/email/templates/network-master-key-rotated.template.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test';
+
+import { networkMasterKeyRotatedTemplate } from './network-master-key-rotated.template';
+
+describe('networkMasterKeyRotatedTemplate', () => {
+  const baseParams = {
+    networkName: 'Edge Esmeralda 2026',
+    actorDisplay: 'Yanki Yuksel',
+    newKey: 'ix-master-key-plaintext-example',
+    integrationsUrl: 'https://index.network/networks/abc-123/integrations',
+  };
+
+  test('subject includes the network name', () => {
+    const out = networkMasterKeyRotatedTemplate(baseParams);
+    expect(out.subject).toBe('Master key rotated for Edge Esmeralda 2026');
+  });
+
+  test('html body contains the new key and the actor', () => {
+    const out = networkMasterKeyRotatedTemplate(baseParams);
+    expect(out.html).toContain('ix-master-key-plaintext-example');
+    expect(out.html).toContain('Yanki Yuksel');
+    expect(out.html).toContain('Edge Esmeralda 2026');
+    expect(out.html).toContain('https://index.network/networks/abc-123/integrations');
+  });
+
+  test('text body contains the new key and the actor', () => {
+    const out = networkMasterKeyRotatedTemplate(baseParams);
+    expect(out.text).toContain('ix-master-key-plaintext-example');
+    expect(out.text).toContain('Yanki Yuksel');
+    expect(out.text).toContain('Edge Esmeralda 2026');
+  });
+
+  test('escapes html in network name', () => {
+    const out = networkMasterKeyRotatedTemplate({
+      ...baseParams,
+      networkName: '<script>alert(1)</script>',
+    });
+    expect(out.html).not.toContain('<script>alert(1)</script>');
+    expect(out.html).toContain('&lt;script&gt;');
+  });
+
+  test('strips control chars from the subject network name', () => {
+    const out = networkMasterKeyRotatedTemplate({
+      ...baseParams,
+      networkName: 'Evil\r\nBcc: attacker@example.com',
+    });
+    expect(out.subject).not.toMatch(/[\r\n\t\f\v\0]/);
+  });
+
+  test('escapes html in newKey', () => {
+    const out = networkMasterKeyRotatedTemplate({
+      ...baseParams,
+      newKey: '<script>alert(1)</script>',
+    });
+    expect(out.html).not.toContain('<script>alert(1)</script>');
+    expect(out.html).toContain('&lt;script&gt;');
+  });
+});

--- a/backend/src/lib/email/templates/network-master-key-rotated.template.ts
+++ b/backend/src/lib/email/templates/network-master-key-rotated.template.ts
@@ -1,0 +1,54 @@
+import { escapeHtml, sanitizeUrlForHref } from '../../escapeHtml';
+
+export interface NetworkMasterKeyRotatedParams {
+  networkName: string;
+  actorDisplay: string;
+  newKey: string;
+  integrationsUrl: string;
+}
+
+export interface NetworkMasterKeyRotatedEmail {
+  subject: string;
+  html: string;
+  text: string;
+}
+
+/**
+ * One-time delivery of a rotated master key to every owner of an experiment
+ * network. The plaintext key is shown inline; the recipient must store it in
+ * a secret manager — Index Network does not retain a recoverable copy.
+ */
+export const networkMasterKeyRotatedTemplate = (
+  p: NetworkMasterKeyRotatedParams,
+): NetworkMasterKeyRotatedEmail => {
+  const safeNetwork = escapeHtml(p.networkName);
+  const safeActor = escapeHtml(p.actorDisplay);
+  const safeKey = escapeHtml(p.newKey);
+  const safeUrl = escapeHtml(sanitizeUrlForHref(p.integrationsUrl));
+  // Strip CR/LF and other control chars from the network name before splicing
+  // it into the Subject header — defends against header injection.
+  const subjectName = p.networkName.replace(/[\r\n\t\f\v\0]+/g, ' ').trim().slice(0, 200);
+
+  return {
+    subject: `Master key rotated for ${subjectName}`,
+    html: `<div style="font-family: Arial, sans-serif;">
+  <p>The master key for <strong>${safeNetwork}</strong> has just been rotated by <strong>${safeActor}</strong>.</p>
+  <p>The previous key is no longer valid. Any backend (InstaClaw, EdgeOS) still using the old key will return 403 until it is reconfigured.</p>
+  <p>Your new master key (shown only once):</p>
+  <pre style="font-family: monospace; background: #f6f6f6; padding: 12px; border-radius: 6px;">${safeKey}</pre>
+  <p>Treat this like a password — store it in your backend's secret manager. You can view the integration on the <a href="${safeUrl}">${safeNetwork} integrations tab</a>.</p>
+  <div style="margin-top: 20px; text-align: center;">
+    <img src="https://index.network/logo.png" alt="Index" style="height: 24px; opacity: 0.5;" />
+  </div>
+</div>`,
+    text: `The master key for ${p.networkName} has just been rotated by ${p.actorDisplay}.
+
+The previous key is no longer valid. Any backend (InstaClaw, EdgeOS) still using the old key will return 403 until it is reconfigured.
+
+Your new master key (shown only once):
+
+${p.newKey}
+
+Treat this like a password — store it in your backend's secret manager. Integrations tab: ${p.integrationsUrl}`,
+  };
+};

--- a/backend/src/lib/experiment/master-key.ts
+++ b/backend/src/lib/experiment/master-key.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared helpers for the experiment-network master key. Owns the alphabet,
+ * length, and hashing scheme so that key generation and key verification
+ * cannot drift out of sync.
+ *
+ * The plaintext key is shown to the operator exactly once (at creation or
+ * after rotation). The database stores only the SHA-256/base64url hash.
+ */
+
+const KEY_ALPHABET = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const KEY_LENGTH = 64;
+
+export async function hashMasterKey(plaintext: string): Promise<string> {
+  const encoded = new TextEncoder().encode(plaintext);
+  const digest = await crypto.subtle.digest('SHA-256', encoded);
+  return Buffer.from(digest).toString('base64url');
+}
+
+export async function generateMasterKey(): Promise<{ key: string; hash: string }> {
+  const bytes = crypto.getRandomValues(new Uint8Array(KEY_LENGTH));
+  let key = '';
+  for (let i = 0; i < KEY_LENGTH; i++) {
+    key += KEY_ALPHABET[bytes[i] % KEY_ALPHABET.length];
+  }
+  const hash = await hashMasterKey(key);
+  return { key, hash };
+}

--- a/backend/src/services/network.service.ts
+++ b/backend/src/services/network.service.ts
@@ -351,6 +351,18 @@ export class NetworkService {
   }
 
   /**
+   * Check whether a user holds the `'owner'` permission on a network.
+   * Delegates to the adapter's permission-based check (network_members.permissions).
+   *
+   * @param networkId - The network ID
+   * @param userId - The user ID to check
+   * @returns `true` if the user is an owner, `false` otherwise
+   */
+  async isIndexOwner(networkId: string, userId: string): Promise<boolean> {
+    return this.adapter.isIndexOwner(networkId, userId);
+  }
+
+  /**
    * Assert that an index is not a personal index.
    * @throws Error if the index is personal.
    */
@@ -465,8 +477,8 @@ export class NetworkService {
 
     const actor = owners.find((o) => o.userId === actorUserId);
     const actorDisplay = actor?.name || actor?.email || 'an owner';
-    const appUrl = process.env.APP_URL || 'https://index.network';
-    const integrationsUrl = `${appUrl}/networks/${networkId}/integrations`;
+    const frontendUrl = (process.env.FRONTEND_URL || process.env.APP_URL || 'https://index.network').replace(/\/+$/, '');
+    const integrationsUrl = `${frontendUrl}/networks/${networkId}/integrations`;
 
     const rendered = networkMasterKeyRotatedTemplate({
       networkName,

--- a/backend/src/services/network.service.ts
+++ b/backend/src/services/network.service.ts
@@ -1,9 +1,11 @@
-import { eq } from 'drizzle-orm';
+import { and, eq, isNull, sql } from 'drizzle-orm';
 
 import db from '../lib/drizzle/drizzle';
 import { log } from '../lib/log';
 import { ChatDatabaseAdapter } from '../adapters/database.adapter';
 import { generateMasterKey } from '../lib/experiment/master-key';
+import { executeSendEmail } from '../lib/email/transport.helper';
+import { networkMasterKeyRotatedTemplate } from '../lib/email/templates/network-master-key-rotated.template';
 import { validateKey } from '../lib/keys';
 import * as schema from '../schemas/database.schema';
 
@@ -373,6 +375,118 @@ export class NetworkService {
     if (network?.isExperiment) {
       throw new Error('Cannot modify join policy on experiment networks');
     }
+  }
+
+  /**
+   * Rotate the master key on an experiment network. The plaintext is returned
+   * exactly once and never persisted; the hash replaces the existing
+   * `experiment_master_key_hash`. Every owner of the network receives an
+   * email with the new key.
+   *
+   * @param networkId - The experiment network ID
+   * @param userId - The requesting user ID (must be an owner)
+   * @returns The new plaintext master key (shown once; only the hash is stored)
+   * @throws Error('Not an experiment network') when the target is not an
+   *         experiment or has no existing hash.
+   * @throws Error('Owner-only operation') when the caller is not an owner.
+   */
+  async rotateExperimentMasterKey(networkId: string, userId: string): Promise<{ masterKey: string }> {
+    logger.verbose('[NetworkService] Rotating experiment master key', { networkId, userId });
+
+    const [network] = await db
+      .select({
+        id: schema.networks.id,
+        title: schema.networks.title,
+        isExperiment: schema.networks.isExperiment,
+        experimentMasterKeyHash: schema.networks.experimentMasterKeyHash,
+        deletedAt: schema.networks.deletedAt,
+      })
+      .from(schema.networks)
+      .where(eq(schema.networks.id, networkId))
+      .limit(1);
+
+    if (!network || network.deletedAt || !network.isExperiment || !network.experimentMasterKeyHash) {
+      throw new Error('Not an experiment network');
+    }
+
+    const isOwner = await this.adapter.isIndexOwner(networkId, userId);
+    if (!isOwner) {
+      throw new Error('Owner-only operation');
+    }
+
+    const { key, hash } = await generateMasterKey();
+    await db.update(schema.networks)
+      .set({ experimentMasterKeyHash: hash })
+      .where(eq(schema.networks.id, networkId));
+
+    // Pre-fetch owners synchronously so the fire-and-forget path only does fast
+    // email sends and never blocks on a DB round-trip after the key is committed.
+    const owners = await db
+      .select({
+        userId: schema.users.id,
+        email: schema.users.email,
+        name: schema.users.name,
+      })
+      .from(schema.networkMembers)
+      .innerJoin(schema.users, eq(schema.users.id, schema.networkMembers.userId))
+      .where(and(
+        eq(schema.networkMembers.networkId, networkId),
+        sql`'owner' = ANY(${schema.networkMembers.permissions})`,
+        isNull(schema.networkMembers.deletedAt),
+        isNull(schema.users.deletedAt),
+      ));
+
+    // Dispatch emails fire-and-forget — rotation has already committed.
+    this.dispatchRotationEmails(network.id, network.title, userId, key, owners)
+      .catch((err) => logger.error('[NetworkService] Rotation email dispatch failed', { networkId, error: err }));
+
+    return { masterKey: key };
+  }
+
+  /**
+   * Email every owner of the network the new plaintext key.
+   * Fire-and-forget; per-recipient errors are swallowed so one bad address
+   * cannot block delivery to the others.
+   *
+   * @param networkId - The network whose owners to notify
+   * @param networkName - The human-readable network title for the email body
+   * @param actorUserId - The user who initiated the rotation (used for display name)
+   * @param newKey - The new plaintext master key to include in the email
+   * @param owners - Pre-fetched owner records (userId, email, name)
+   */
+  private async dispatchRotationEmails(
+    networkId: string,
+    networkName: string,
+    actorUserId: string,
+    newKey: string,
+    owners: Array<{ userId: string; email: string; name: string | null }>,
+  ): Promise<void> {
+    if (owners.length === 0) return;
+
+    const actor = owners.find((o) => o.userId === actorUserId);
+    const actorDisplay = actor?.name || actor?.email || 'an owner';
+    const appUrl = process.env.APP_URL || 'https://index.network';
+    const integrationsUrl = `${appUrl}/networks/${networkId}/integrations`;
+
+    const rendered = networkMasterKeyRotatedTemplate({
+      networkName,
+      actorDisplay,
+      newKey,
+      integrationsUrl,
+    });
+
+    await Promise.all(owners.map(async (o) => {
+      try {
+        await executeSendEmail({
+          to: o.email,
+          subject: rendered.subject,
+          html: rendered.html,
+          text: rendered.text,
+        });
+      } catch (err) {
+        logger.error('[NetworkService] Rotation email failed for owner', { to: o.email, error: err });
+      }
+    }));
   }
 }
 

--- a/backend/src/services/network.service.ts
+++ b/backend/src/services/network.service.ts
@@ -3,6 +3,7 @@ import { eq } from 'drizzle-orm';
 import db from '../lib/drizzle/drizzle';
 import { log } from '../lib/log';
 import { ChatDatabaseAdapter } from '../adapters/database.adapter';
+import { generateMasterKey } from '../lib/experiment/master-key';
 import { validateKey } from '../lib/keys';
 import * as schema from '../schemas/database.schema';
 
@@ -57,17 +58,7 @@ export class NetworkService {
     logger.verbose('[NetworkService] Creating experiment network', { userId, title: data.title });
 
     // Generate master key
-    const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
-    const bytes = crypto.getRandomValues(new Uint8Array(64));
-    let masterKey = '';
-    for (let i = 0; i < 64; i++) {
-      masterKey += chars[bytes[i] % chars.length];
-    }
-
-    // Hash the key
-    const encoded = new TextEncoder().encode(masterKey);
-    const hashBuffer = await crypto.subtle.digest('SHA-256', encoded);
-    const masterKeyHash = Buffer.from(hashBuffer).toString('base64url');
+    const { key: masterKey, hash: masterKeyHash } = await generateMasterKey();
 
     // Create network with experiment flags
     const network = await this.adapter.createNetwork({

--- a/backend/src/services/tests/network.service.master-key-rotation.spec.ts
+++ b/backend/src/services/tests/network.service.master-key-rotation.spec.ts
@@ -1,0 +1,127 @@
+import { config } from 'dotenv';
+config({ path: '.env.test' });
+
+import { afterAll, beforeAll, describe, expect, mock, test } from 'bun:test';
+import { eq, inArray } from 'drizzle-orm';
+
+const sendSpy = mock(async (_args: { to: string; subject: string; html: string; text: string }) => ({ data: null, skipped: false }));
+mock.module('../../lib/email/transport.helper', () => ({
+  executeSendEmail: sendSpy,
+}));
+
+import db from '../../lib/drizzle/drizzle';
+import * as schema from '../../schemas/database.schema';
+import { hashMasterKey } from '../../lib/experiment/master-key';
+import { networkService } from '../network.service';
+
+describe('networkService.rotateExperimentMasterKey', () => {
+  let networkId: string;
+  let nonExperimentNetworkId: string;
+  let ownerId: string;
+  let coOwnerId: string;
+  let nonOwnerId: string;
+  const cleanupNetworkIds: string[] = [];
+  const cleanupUserIds: string[] = [];
+
+  beforeAll(async () => {
+    const stamp = Date.now();
+    const [owner] = await db.insert(schema.users)
+      .values({ email: `rotate-owner-${stamp}@test.dev`, name: 'Rotate Owner', emailVerified: true })
+      .returning({ id: schema.users.id });
+    const [coOwner] = await db.insert(schema.users)
+      .values({ email: `rotate-coowner-${stamp}@test.dev`, name: 'Co Owner', emailVerified: true })
+      .returning({ id: schema.users.id });
+    const [nonOwner] = await db.insert(schema.users)
+      .values({ email: `rotate-nonowner-${stamp}@test.dev`, name: 'Non Owner', emailVerified: true })
+      .returning({ id: schema.users.id });
+    ownerId = owner.id;
+    coOwnerId = coOwner.id;
+    nonOwnerId = nonOwner.id;
+    cleanupUserIds.push(ownerId, coOwnerId, nonOwnerId);
+
+    const initialHash = await hashMasterKey('initial-plaintext-for-test');
+    const [n] = await db.insert(schema.networks)
+      .values({
+        title: 'Rotate Test Experiment',
+        isPersonal: false,
+        isExperiment: true,
+        experimentMasterKeyHash: initialHash,
+        permissions: { joinPolicy: 'invite_only', invitationLink: null, allowGuestVibeCheck: false },
+      })
+      .returning({ id: schema.networks.id });
+    networkId = n.id;
+    cleanupNetworkIds.push(networkId);
+
+    await db.insert(schema.networkMembers).values([
+      { networkId, userId: ownerId, permissions: ['owner'] },
+      { networkId, userId: coOwnerId, permissions: ['owner'] },
+      { networkId, userId: nonOwnerId, permissions: ['member'] },
+    ]);
+
+    const [nx] = await db.insert(schema.networks)
+      .values({ title: 'Rotate Test Non-Experiment', isPersonal: false, isExperiment: false })
+      .returning({ id: schema.networks.id });
+    nonExperimentNetworkId = nx.id;
+    cleanupNetworkIds.push(nonExperimentNetworkId);
+    await db.insert(schema.networkMembers).values({ networkId: nonExperimentNetworkId, userId: ownerId, permissions: ['owner'] });
+  });
+
+  afterAll(async () => {
+    if (cleanupNetworkIds.length > 0) {
+      await db.delete(schema.networkMembers).where(inArray(schema.networkMembers.networkId, cleanupNetworkIds));
+      await db.delete(schema.networks).where(inArray(schema.networks.id, cleanupNetworkIds));
+    }
+    if (cleanupUserIds.length > 0) {
+      await db.delete(schema.users).where(inArray(schema.users.id, cleanupUserIds));
+    }
+  });
+
+  test('rotates the hash and returns a fresh plaintext key', async () => {
+    sendSpy.mockClear();
+
+    const [before] = await db
+      .select({ hash: schema.networks.experimentMasterKeyHash })
+      .from(schema.networks)
+      .where(eq(schema.networks.id, networkId));
+
+    const result = await networkService.rotateExperimentMasterKey(networkId, ownerId);
+
+    expect(result.masterKey).toBeTruthy();
+    expect(result.masterKey.length).toBe(64);
+
+    const [after] = await db
+      .select({ hash: schema.networks.experimentMasterKeyHash })
+      .from(schema.networks)
+      .where(eq(schema.networks.id, networkId));
+    expect(after.hash).not.toBe(before.hash);
+    const expectedHash = await hashMasterKey(result.masterKey);
+    expect(after.hash).toBe(expectedHash);
+  });
+
+  test('emails every owner of the network', async () => {
+    sendSpy.mockClear();
+    await networkService.rotateExperimentMasterKey(networkId, ownerId);
+
+    // Email dispatch is fire-and-forget; await a microtask flush.
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(sendSpy.mock.calls.length).toBe(2);
+    const recipients = sendSpy.mock.calls.map((c) => (c[0] as { to: string }).to).sort();
+    expect(recipients).toEqual([
+      expect.stringContaining('rotate-coowner'),
+      expect.stringContaining('rotate-owner'),
+    ]);
+  });
+
+  test('throws when the network is not an experiment', async () => {
+    await expect(
+      networkService.rotateExperimentMasterKey(nonExperimentNetworkId, ownerId),
+    ).rejects.toThrow(/not an experiment/i);
+  });
+
+  test('throws when the caller is not an owner', async () => {
+    await expect(
+      networkService.rotateExperimentMasterKey(networkId, nonOwnerId),
+    ).rejects.toThrow(/owner/i);
+  });
+});

--- a/backend/src/services/tests/network.service.master-key-rotation.spec.ts
+++ b/backend/src/services/tests/network.service.master-key-rotation.spec.ts
@@ -96,6 +96,9 @@ describe('networkService.rotateExperimentMasterKey', () => {
     expect(after.hash).not.toBe(before.hash);
     const expectedHash = await hashMasterKey(result.masterKey);
     expect(after.hash).toBe(expectedHash);
+
+    // Drain the fire-and-forget dispatch before the next test mockClears the spy.
+    await new Promise((r) => setTimeout(r, 50));
   });
 
   test('emails every owner of the network', async () => {

--- a/docs/specs/api-reference.md
+++ b/docs/specs/api-reference.md
@@ -1593,6 +1593,27 @@ Soft-delete an index. Owner only.
 { "success": true }
 ```
 
+### POST /api/networks/:id/rotate-master-key
+
+Rotate the master key on an experiment network. Owner only. The plaintext is returned exactly once; the previous key stops working immediately. Every owner of the network also receives the new key by email.
+
+**Auth**: `AuthOrApiKeyGuard` (session or API key)
+
+**Path params**:
+- `id` — Network ID
+
+**Request body**: none
+
+**Response**:
+```json
+{
+  "masterKey": "<plaintext-64-chars>"
+}
+```
+
+**Errors**:
+- `403` — Caller is not an owner of an experiment network (covers both "not an experiment" and "not an owner" — the controller's pre-check returns 403 for both).
+
 ### GET /api/networks/:id/members
 
 Get members of an index. Owner only.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/frontend/src/components/NetworkSettingsPanel.tsx
+++ b/frontend/src/components/NetworkSettingsPanel.tsx
@@ -18,6 +18,7 @@ import { Member } from '@/services/networks';
 import { validateFiles, validateFile } from '@/lib/file-validation';
 import { parseCsvText, type ImportRow, type ParsedCsvResult } from '@/lib/csv-import';
 import CsvPreviewModal from '@/components/modals/CsvPreviewModal';
+import MasterKeyDialog from '@/components/MasterKeyDialog';
 
 /** Toolkits available for connection. Add entries here when enabling new Composio integrations. */
 const AVAILABLE_TOOLKITS = ['gmail', 'slack'] as const;
@@ -87,6 +88,11 @@ export default function NetworkSettingsPanel({ index, onDeleted, activeTab }: Ne
   const [csvPreview, setCsvPreview] = useState<ParsedCsvResult | null>(null);
   const [csvError, setCsvError] = useState<string | null>(null);
   const [showCsvModal, setShowCsvModal] = useState(false);
+
+  const [showRotateConfirm, setShowRotateConfirm] = useState(false);
+  const [rotateConfirmationText, setRotateConfirmationText] = useState('');
+  const [isRotating, setIsRotating] = useState(false);
+  const [rotatedMasterKey, setRotatedMasterKey] = useState<string | null>(null);
 
   /* eslint-disable react-hooks/set-state-in-effect -- syncs local form state from prop changes */
   useEffect(() => {
@@ -333,6 +339,24 @@ export default function NetworkSettingsPanel({ index, onDeleted, activeTab }: Ne
       error('Failed to resend invitation');
     } finally {
       setIsResendInFlight(false);
+    }
+  };
+
+  const handleConfirmRotate = async () => {
+    if (isRotating) return;
+    if (rotateConfirmationText !== currentIndex.title) return;
+    setIsRotating(true);
+    try {
+      const result = await indexesService.rotateMasterKey(index.id);
+      setShowRotateConfirm(false);
+      setRotateConfirmationText('');
+      setRotatedMasterKey(result.masterKey);
+      success('Master key rotated — old key is now invalid');
+    } catch (err) {
+      console.error('Master key rotation failed', err);
+      error('Failed to rotate master key');
+    } finally {
+      setIsRotating(false);
     }
   };
 
@@ -934,6 +958,48 @@ export default function NetworkSettingsPanel({ index, onDeleted, activeTab }: Ne
               );
             })}
           </div>
+
+          {currentIndex.isExperiment && (
+            <div className="pt-2">
+              <div className="flex items-start gap-3 p-3 border border-gray-200 rounded-sm">
+                <img
+                  src="/integrations/edgeclaw.png"
+                  width={24}
+                  height={24}
+                  alt="EdgeClaw"
+                  className="flex-shrink-0 mt-0.5"
+                  onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                />
+                <div className="flex-1 min-w-0 space-y-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <div className="text-sm font-medium text-black">EdgeClaw</div>
+                      <div className="text-xs text-gray-500">Server-side signup for experiment attendees</div>
+                    </div>
+                    <Button
+                      variant="outline"
+                      onClick={() => setShowRotateConfirm(true)}
+                      disabled={isRotating}
+                    >
+                      <RotateCw className="h-3.5 w-3.5 mr-1.5" />
+                      Rotate key
+                    </Button>
+                  </div>
+                  <div>
+                    <div className="text-xs font-semibold text-gray-400 uppercase tracking-wider font-ibm-plex-mono mb-1.5">Signup endpoint</div>
+                    <CopyableBox value={typeof window !== 'undefined' ? `${window.location.origin}/api/networks/${currentIndex.id}/signup` : `/api/networks/${currentIndex.id}/signup`} />
+                  </div>
+                  <div>
+                    <div className="text-xs font-semibold text-gray-400 uppercase tracking-wider font-ibm-plex-mono mb-1.5">Master key</div>
+                    <CopyableBox value={'•••••••• (shown once at creation — rotate for a new one)'} />
+                  </div>
+                  <p className="text-xs text-gray-500">
+                    Used server-side by InstaClaw and EdgeOS. Never expose in user-facing apps.
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
         </div>
       )}
 
@@ -948,6 +1014,35 @@ export default function NetworkSettingsPanel({ index, onDeleted, activeTab }: Ne
               <AlertDialog.Cancel asChild><Button variant="outline">Cancel</Button></AlertDialog.Cancel>
               <Button onClick={handleDeleteIndex} disabled={isDeletingIndex || !isDeleteConfirmationValid} className="bg-red-600 hover:bg-red-700 text-white">
                 {isDeletingIndex ? 'Deleting...' : 'Delete'}
+              </Button>
+            </div>
+          </AlertDialog.Content>
+        </AlertDialog.Portal>
+      </AlertDialog.Root>
+
+      <AlertDialog.Root open={showRotateConfirm} onOpenChange={(open) => { if (!open) { setShowRotateConfirm(false); setRotateConfirmationText(''); } }}>
+        <AlertDialog.Portal>
+          <AlertDialog.Overlay className="fixed inset-0 bg-black/50 z-[100]" />
+          <AlertDialog.Content className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-white rounded-sm shadow-lg p-6 w-full max-w-md z-[100] focus:outline-none">
+            <AlertDialog.Title className="text-lg font-bold text-gray-900 mb-4">Rotate master key</AlertDialog.Title>
+            <AlertDialog.Description className="text-sm text-gray-600 mb-4">
+              Rotating issues a new master key and immediately revokes the current one. Any backend using the old key (InstaClaw, EdgeOS) will stop working until you redeploy it with the new key. We will also email the new key to every owner of this network. Type the network name to confirm.
+            </AlertDialog.Description>
+            <Input
+              value={rotateConfirmationText}
+              onChange={(e) => setRotateConfirmationText(e.target.value)}
+              placeholder={currentIndex.title}
+              className="mb-4"
+            />
+            <div className="flex justify-end gap-3">
+              <AlertDialog.Cancel asChild>
+                <Button variant="outline" disabled={isRotating}>Cancel</Button>
+              </AlertDialog.Cancel>
+              <Button
+                onClick={handleConfirmRotate}
+                disabled={isRotating || rotateConfirmationText !== currentIndex.title}
+              >
+                {isRotating ? 'Rotating...' : 'Rotate'}
               </Button>
             </div>
           </AlertDialog.Content>
@@ -1033,6 +1128,14 @@ export default function NetworkSettingsPanel({ index, onDeleted, activeTab }: Ne
           columns={csvPreview.columns}
           hasEmailColumn={csvPreview.hasEmailColumn}
           onConfirm={handleCsvConfirm}
+        />
+      )}
+
+      {rotatedMasterKey && (
+        <MasterKeyDialog
+          open={!!rotatedMasterKey}
+          masterKey={rotatedMasterKey}
+          onClose={() => setRotatedMasterKey(null)}
         />
       )}
     </>

--- a/frontend/src/services/networks.ts
+++ b/frontend/src/services/networks.ts
@@ -355,6 +355,12 @@ export const createIndexesService = (api: ReturnType<typeof useAuthenticatedAPI>
   ): Promise<{ rotated: boolean; email: string }> => {
     return api.post(`/networks/${networkId}/members/${memberId}/resend-invite`, {});
   },
+
+  // Rotate the master key on an experiment network. Plaintext is returned
+  // exactly once; the old key stops working immediately.
+  rotateMasterKey: async (networkId: string): Promise<{ masterKey: string }> => {
+    return api.post<{ masterKey: string }>(`/networks/${networkId}/rotate-master-key`, {});
+  },
 });
 
 // Non-authenticated service for public endpoints

--- a/packages/edgeclaw/README.md
+++ b/packages/edgeclaw/README.md
@@ -52,6 +52,8 @@ x-api-key: <masterKey>
 
 The master key is issued once when the experiment network is created in the Index Network dashboard and is never re-shown. It is **server-side only** — never expose it in the EdgeOS portal frontend, user-visible config, the public repo, or attendee-facing copy-paste.
 
+The master key can be **rotated** from the integrations tab of the network's settings page in the Index Network dashboard. Rotation issues a new plaintext key (shown once) and emails it to every owner of the network; the previous key is invalidated immediately. Use this when the key is lost or to revoke an existing one.
+
 ### POST /api/networks/:id/signup
 
 Provisions (or re-provisions) an attendee's Index Network account and returns an API key bound to a network-scoped agent. No email is sent — the caller is responsible for delivering the key to the attendee.


### PR DESCRIPTION
## Summary

Adds an **EdgeClaw** row to the network integrations tab on experiment networks, and a `POST /networks/:id/rotate-master-key` endpoint that lets owners recover a lost master key.

The master key authenticates server-side calls to `POST /networks/:id/signup` from InstaClaw / EdgeOS. Today, the plaintext is shown exactly once at experiment-network creation (only the SHA-256 hash is persisted). If the operator misses that one-time reveal, the only recovery path was recreating the network. This PR closes that gap.

Linear: [IND-302](https://linear.app/indexnetwork/issue/IND-302/edgeclaw-row-on-network-integrations-tab-with-master-key-rotation)
Spec: `docs/superpowers/specs/2026-05-14-edgeclaw-network-integration-design.md`
Plan: `docs/superpowers/plans/2026-05-14-edgeclaw-network-integration.md`

## New features

- **Frontend** — EdgeClaw row in `NetworkSettingsPanel`'s integrations tab, gated by `currentIndex.isExperiment`. Shows the signup endpoint, a masked master-key placeholder, and a **Rotate key** button. Typed-confirm dialog mirrors the delete-network UX; on success, the existing `MasterKeyDialog` reveals the new plaintext key once.
- **Backend** — `POST /api/networks/:id/rotate-master-key`. Owner-only, experiment-network-only. Generates a fresh 64-char master key, replaces the stored hash, returns the plaintext once, and emails it to every owner of the network via the existing Resend transport. Email dispatch is fire-and-forget per recipient.

## Refactors

- Extracts the inline master-key alphabet, length, and SHA-256/base64url hashing from `NetworkService.createExperimentNetwork` and `ExperimentMasterKeyGuard` into a shared `backend/src/lib/experiment/master-key.ts` so creation and rotation can't drift apart.

## Documentation

- New endpoint section in `docs/specs/api-reference.md`.
- Rotation paragraph appended to the **Integration API → Authentication** section of `packages/edgeclaw/README.md`.

## Tests

- `network-master-key-rotated.template.spec.ts` — pure-function template test (6 cases incl. XSS escape on both `networkName` and `newKey`, and CR/LF subject-injection defense).
- `network.service.master-key-rotation.spec.ts` — service-level integration tests covering rotation correctness, owner email broadcast, non-experiment rejection, non-owner rejection.
- Extended `network.controller.spec.ts` with three rotate-master-key cases (200 owner, 403 non-experiment, 403/404 unknown).
- New `experiment.guard.spec.ts` — full lifecycle: original key validates before rotation, new key validates after, old key rejected after.
- 29 tests pass across the four spec files; backend `tsc --noEmit` and ESLint clean on touched files.

## Security notes

- Owner check enforced at two layers: controller `assertExperimentOwner` and service `adapter.isIndexOwner`.
- Email template HTML-escapes all four user-controlled fields (`networkName`, `actorDisplay`, `newKey`, `integrationsUrl`), pipes the integrations URL through `sanitizeUrlForHref` to block `javascript:` schemes, and strips CR/LF/tab/form-feed/null from the Subject header.
- Owner recipient query filters both \`users.deletedAt IS NULL\` and \`networkMembers.deletedAt IS NULL\` so revoked owners do not receive a fresh key.

## Versions

- \`backend\` 0.21.7 → **0.22.0** (new public endpoint).
- \`frontend\` 0.7.4 → **0.8.0** (new UI surface).
- No subtree package versions touched.

## Test plan

- [ ] Create a new experiment network in the UI; confirm the one-time \`MasterKeyDialog\` appears at creation.
- [ ] On the experiment network's **Integrations** tab, confirm the EdgeClaw row renders alongside Gmail/Slack.
- [ ] Click **Rotate key** → typed-confirm dialog → confirm Rotate stays disabled until network name matches → on submit, the \`MasterKeyDialog\` shows a fresh 64-char key.
- [ ] \`curl -X POST /api/networks/<id>/signup -H "x-api-key: <new-key>"\` succeeds; same call with the prior key returns 403.
- [ ] If \`RESEND_API_KEY\` is set + \`EMAIL_PRODUCTION_MODE != true\`, the rotation email is appended to \`backend/email-debug.md\` for every owner.
- [ ] On a non-experiment network's Integrations tab, the EdgeClaw row does NOT render.