### PR TITLE
feat(mcp): per-request surface header for connect-link redirects

### DIFF
--- a/backend/drizzle/0069_add_connect_link_preferred_surface.sql
+++ b/backend/drizzle/0069_add_connect_link_preferred_surface.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "connect_links" ADD COLUMN "preferred_surface" text;

--- a/backend/drizzle/meta/0069_snapshot.json
+++ b/backend/drizzle/meta/0069_snapshot.json
@@ -1,0 +1,4033 @@
+{
+  "id": "fc3ecc77-c885-45ea-bf6c-bc741b534e57",
+  "prevId": "ec108811-106a-4a92-97c3-bdb536df31cd",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_permissions": {
+      "name": "agent_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "permission_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actions": {
+          "name": "actions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_permissions_agent_id_idx": {
+          "name": "agent_permissions_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_permissions_user_id_idx": {
+          "name": "agent_permissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_permissions_agent_user_idx": {
+          "name": "agent_permissions_agent_user_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_agent_permissions_global": {
+          "name": "uniq_agent_permissions_global",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_permissions\".\"scope\" = 'global'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_permissions_agent_id_agents_id_fk": {
+          "name": "agent_permissions_agent_id_agents_id_fk",
+          "tableFrom": "agent_permissions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_permissions_user_id_users_id_fk": {
+          "name": "agent_permissions_user_id_users_id_fk",
+          "tableFrom": "agent_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_messages": {
+      "name": "agent_test_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_token": {
+          "name": "reservation_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reserved_at": {
+          "name": "reserved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_test_messages_agent_pending": {
+          "name": "idx_agent_test_messages_agent_pending",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reserved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_messages_agent_id_agents_id_fk": {
+          "name": "agent_test_messages_agent_id_agents_id_fk",
+          "tableFrom": "agent_test_messages",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_messages_requested_by_user_id_users_id_fk": {
+          "name": "agent_test_messages_requested_by_user_id_users_id_fk",
+          "tableFrom": "agent_test_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_transports": {
+      "name": "agent_transports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "transport_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_transports_agent_id_idx": {
+          "name": "agent_transports_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_transports_agent_id_agents_id_fk": {
+          "name": "agent_transports_agent_id_agents_id_fk",
+          "tableFrom": "agent_transports",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "agent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_on_opportunity": {
+          "name": "notify_on_opportunity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "daily_summary_enabled": {
+          "name": "daily_summary_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "handle_negotiations": {
+          "name": "handle_negotiations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_daily_summary_at": {
+          "name": "last_daily_summary_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agents_owner_id_idx": {
+          "name": "agents_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_type_idx": {
+          "name": "agents_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_last_seen_at_idx": {
+          "name": "agents_last_seen_at_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_users_id_fk": {
+          "name": "agents_owner_id_users_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apikey_user_id_users_id_fk": {
+          "name": "apikey_user_id_users_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connect_links": {
+      "name": "connect_links",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "greeting": {
+          "name": "greeting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_surface": {
+          "name": "preferred_surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connect_links_kind_recipient_uq": {
+          "name": "connect_links_kind_recipient_uq",
+          "columns": [
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connect_links_expires_at_idx": {
+          "name": "connect_links_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connect_links_user_id_users_id_fk": {
+          "name": "connect_links_user_id_users_id_fk",
+          "tableFrom": "connect_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connect_links_opportunity_id_opportunities_id_fk": {
+          "name": "connect_links_opportunity_id_opportunities_id_fk",
+          "tableFrom": "connect_links",
+          "tableTo": "opportunities",
+          "columnsFrom": [
+            "opportunity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "files_user_id_users_id_fk": {
+          "name": "files_user_id_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hyde_documents": {
+      "name": "hyde_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_text": {
+          "name": "source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_corpus": {
+          "name": "target_corpus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hyde_text": {
+          "name": "hyde_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hyde_embedding": {
+          "name": "hyde_embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "hyde_source_idx": {
+          "name": "hyde_source_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_strategy_idx": {
+          "name": "hyde_strategy_idx",
+          "columns": [
+            {
+              "expression": "strategy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_embedding_idx": {
+          "name": "hyde_embedding_idx",
+          "columns": [
+            {
+              "expression": "hyde_embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "hyde_expires_idx": {
+          "name": "hyde_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_source_strategy_unique": {
+          "name": "hyde_source_strategy_unique",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "strategy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_corpus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.intent_networks": {
+      "name": "intent_networks",
+      "schema": "",
+      "columns": {
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relevancy_score": {
+          "name": "relevancy_score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "intent_networks_network_id_idx": {
+          "name": "intent_networks_network_id_idx",
+          "columns": [
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intent_networks_intent_id_intents_id_fk": {
+          "name": "intent_networks_intent_id_intents_id_fk",
+          "tableFrom": "intent_networks",
+          "tableTo": "intents",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "intent_networks_network_id_networks_id_fk": {
+          "name": "intent_networks_network_id_networks_id_fk",
+          "tableFrom": "intent_networks",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "intent_networks_intent_id_network_id_pk": {
+          "name": "intent_networks_intent_id_network_id_pk",
+          "columns": [
+            "intent_id",
+            "network_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.intents": {
+      "name": "intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_incognito": {
+          "name": "is_incognito",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "semantic_entropy": {
+          "name": "semantic_entropy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "referential_anchor": {
+          "name": "referential_anchor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intent_mode": {
+          "name": "intent_mode",
+          "type": "intent_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ATTRIBUTIVE'"
+        },
+        "speech_act_type": {
+          "name": "speech_act_type",
+          "type": "speech_act_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "felicity_authority": {
+          "name": "felicity_authority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "felicity_sincerity": {
+          "name": "felicity_sincerity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "felicity_clarity": {
+          "name": "felicity_clarity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "intent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {
+        "embeddingIndex": {
+          "name": "embeddingIndex",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intents_user_id_users_id_fk": {
+          "name": "intents_user_id_users_id_fk",
+          "tableFrom": "intents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.links": {
+      "name": "links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "links_user_id_users_id_fk": {
+          "name": "links_user_id_users_id_fk",
+          "tableFrom": "links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.network_integrations": {
+      "name": "network_integrations",
+      "schema": "",
+      "columns": {
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolkit": {
+          "name": "toolkit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "network_integrations_network_id_networks_id_fk": {
+          "name": "network_integrations_network_id_networks_id_fk",
+          "tableFrom": "network_integrations",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "network_integrations_network_id_toolkit_pk": {
+          "name": "network_integrations_network_id_toolkit_pk",
+          "columns": [
+            "network_id",
+            "toolkit"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.network_members": {
+      "name": "network_members",
+      "schema": "",
+      "columns": {
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_assign": {
+          "name": "auto_assign",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "network_members_network_id_networks_id_fk": {
+          "name": "network_members_network_id_networks_id_fk",
+          "tableFrom": "network_members",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "network_members_user_id_users_id_fk": {
+          "name": "network_members_user_id_users_id_fk",
+          "tableFrom": "network_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "network_members_network_id_user_id_pk": {
+          "name": "network_members_network_id_user_id_pk",
+          "columns": [
+            "network_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.networks": {
+      "name": "networks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_experiment": {
+          "name": "is_experiment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "experiment_master_key_hash": {
+          "name": "experiment_master_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"joinPolicy\":\"invite_only\",\"invitationLink\":null,\"allowGuestVibeCheck\":false}'::json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "indexes_key_unique": {
+          "name": "indexes_key_unique",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_access_token_client_id_idx": {
+          "name": "oauth_access_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_user_id_idx": {
+          "name": "oauth_access_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_users_id_fk": {
+          "name": "oauth_access_token_user_id_users_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_access_token_unique": {
+          "name": "oauth_access_token_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        },
+        "oauth_access_token_refresh_token_unique": {
+          "name": "oauth_access_token_refresh_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_application": {
+      "name": "oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_application_user_id_idx": {
+          "name": "oauth_application_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_application_user_id_users_id_fk": {
+          "name": "oauth_application_user_id_users_id_fk",
+          "tableFrom": "oauth_application",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_application_client_id_unique": {
+          "name": "oauth_application_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_id_idx": {
+          "name": "oauth_consent_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_user_id_idx": {
+          "name": "oauth_consent_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_users_id_fk": {
+          "name": "oauth_consent_user_id_users_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunities": {
+      "name": "opportunities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "detection": {
+          "name": "detection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actors": {
+          "name": "actors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interpretation": {
+          "name": "interpretation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "opportunity_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "opportunities_status_idx": {
+          "name": "opportunities_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunities_accepted_by_users_id_fk": {
+          "name": "opportunities_accepted_by_users_id_fk",
+          "tableFrom": "opportunities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "accepted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunity_deliveries": {
+      "name": "opportunity_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivered_at_status": {
+          "name": "delivered_at_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_token": {
+          "name": "reservation_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reserved_at": {
+          "name": "reserved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_opp_deliveries_committed": {
+          "name": "uniq_opp_deliveries_committed",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "delivered_at_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"opportunity_deliveries\".\"delivered_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_opp_deliveries_open_reservations": {
+          "name": "idx_opp_deliveries_open_reservations",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reserved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"opportunity_deliveries\".\"delivered_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunity_deliveries_opportunity_id_opportunities_id_fk": {
+          "name": "opportunity_deliveries_opportunity_id_opportunities_id_fk",
+          "tableFrom": "opportunity_deliveries",
+          "tableTo": "opportunities",
+          "columnsFrom": [
+            "opportunity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "opportunity_deliveries_user_id_users_id_fk": {
+          "name": "opportunity_deliveries_user_id_users_id_fk",
+          "tableFrom": "opportunity_deliveries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "opportunity_deliveries_agent_id_agents_id_fk": {
+          "name": "opportunity_deliveries_agent_id_agents_id_fk",
+          "tableFrom": "opportunity_deliveries",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_networks": {
+      "name": "personal_networks",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "personal_networks_network_id_unique": {
+          "name": "personal_networks_network_id_unique",
+          "columns": [
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_networks_user_id_users_id_fk": {
+          "name": "personal_networks_user_id_users_id_fk",
+          "tableFrom": "personal_networks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "personal_networks_network_id_networks_id_fk": {
+          "name": "personal_networks_network_id_networks_id_fk",
+          "tableFrom": "personal_networks",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "personal_networks_user_id_pk": {
+          "name": "personal_networks_user_id_pk",
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_settings": {
+      "name": "user_notification_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"connectionUpdates\":true,\"weeklyNewsletter\":true}'::json"
+        },
+        "unsubscribe_token": {
+          "name": "unsubscribe_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_settings_user_id_users_id_fk": {
+          "name": "user_notification_settings_user_id_users_id_fk",
+          "tableFrom": "user_notification_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_notification_settings_user_id_unique": {
+          "name": "user_notification_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_notification_settings_unsubscribe_token_unique": {
+          "name": "user_notification_settings_unsubscribe_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "unsubscribe_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity": {
+          "name": "identity",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "narrative": {
+          "name": "narrative",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "implicit_intents": {
+          "name": "implicit_intents",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_profiles_embedding_idx": {
+          "name": "user_profiles_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_profiles_user_id_unique": {
+          "name": "user_profiles_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_socials": {
+      "name": "user_socials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_socials_user_id": {
+          "name": "idx_user_socials_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_user_socials_user_label": {
+          "name": "uniq_user_socials_user_label",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_socials\".\"label\" <> 'custom'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_socials_user_id_users_id_fk": {
+          "name": "user_socials_user_id_users_id_fk",
+          "tableFrom": "user_socials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro": {
+          "name": "intro",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding": {
+          "name": "onboarding",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::json"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UTC'"
+        },
+        "last_weekly_email_sent_at": {
+          "name": "last_weekly_email_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_ghost": {
+          "name": "is_ghost",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_key_unique": {
+          "name": "users_key_unique",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artifacts": {
+      "name": "artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "artifacts_task_id_idx": {
+          "name": "artifacts_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifacts_task_id_tasks_id_fk": {
+          "name": "artifacts_task_id_tasks_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session_summaries": {
+      "name": "chat_session_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_message_id": {
+          "name": "from_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_message_id": {
+          "name": "to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "digest": {
+          "name": "digest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chat_session_summaries_session_latest_idx": {
+          "name": "chat_session_summaries_session_latest_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_session_summaries_conversation_id_conversations_id_fk": {
+          "name": "chat_session_summaries_conversation_id_conversations_id_fk",
+          "tableFrom": "chat_session_summaries",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_session_summaries_from_message_id_messages_id_fk": {
+          "name": "chat_session_summaries_from_message_id_messages_id_fk",
+          "tableFrom": "chat_session_summaries",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "from_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "chat_session_summaries_to_message_id_messages_id_fk": {
+          "name": "chat_session_summaries_to_message_id_messages_id_fk",
+          "tableFrom": "chat_session_summaries",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "to_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_metadata": {
+      "name": "conversation_metadata",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_metadata_conversation_id_conversations_id_fk": {
+          "name": "conversation_metadata_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_metadata",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_participants": {
+      "name": "conversation_participants",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_type": {
+          "name": "participant_type",
+          "type": "participant_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "hidden_at": {
+          "name": "hidden_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversation_participants_participant_id_idx": {
+          "name": "conversation_participants_participant_id_idx",
+          "columns": [
+            {
+              "expression": "participant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_participants_conversation_id_idx": {
+          "name": "conversation_participants_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_participants_conversation_id_conversations_id_fk": {
+          "name": "conversation_participants_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_participants",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_participants_conversation_id_participant_id_pk": {
+          "name": "conversation_participants_conversation_id_participant_id_pk",
+          "columns": [
+            "conversation_id",
+            "participant_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dm_pair": {
+          "name": "dm_pair",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversations_dm_pair_idx": {
+          "name": "conversations_dm_pair_idx",
+          "columns": [
+            {
+              "expression": "dm_pair",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "message_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_task_ids": {
+          "name": "reference_task_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_conversation_id_created_at_idx": {
+          "name": "messages_conversation_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_sender_id_idx": {
+          "name": "messages_sender_id_idx",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_task_id_idx": {
+          "name": "messages_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_task_id_tasks_id_fk": {
+          "name": "messages_task_id_tasks_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "task_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "status_message": {
+          "name": "status_message",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_timestamp": {
+          "name": "status_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_agent_id": {
+          "name": "claimed_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tasks_conversation_id_idx": {
+          "name": "tasks_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_state_idx": {
+          "name": "tasks_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_metadata_opportunity_id_idx": {
+          "name": "tasks_metadata_opportunity_id_idx",
+          "columns": [
+            {
+              "expression": "(\"metadata\"->>'opportunityId')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"tasks\".\"metadata\"->>'type' = 'negotiation'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_conversation_id_conversations_id_fk": {
+          "name": "tasks_conversation_id_conversations_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_status": {
+      "name": "agent_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive"
+      ]
+    },
+    "public.agent_type": {
+      "name": "agent_type",
+      "schema": "public",
+      "values": [
+        "personal",
+        "system"
+      ]
+    },
+    "public.intent_mode": {
+      "name": "intent_mode",
+      "schema": "public",
+      "values": [
+        "REFERENTIAL",
+        "ATTRIBUTIVE"
+      ]
+    },
+    "public.intent_status": {
+      "name": "intent_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "PAUSED",
+        "FULFILLED",
+        "EXPIRED"
+      ]
+    },
+    "public.opportunity_status": {
+      "name": "opportunity_status",
+      "schema": "public",
+      "values": [
+        "latent",
+        "draft",
+        "negotiating",
+        "pending",
+        "stalled",
+        "accepted",
+        "rejected",
+        "expired"
+      ]
+    },
+    "public.permission_scope": {
+      "name": "permission_scope",
+      "schema": "public",
+      "values": [
+        "global",
+        "node",
+        "network"
+      ]
+    },
+    "public.source_type": {
+      "name": "source_type",
+      "schema": "public",
+      "values": [
+        "file",
+        "integration",
+        "link",
+        "discovery_form",
+        "enrichment"
+      ]
+    },
+    "public.speech_act_type": {
+      "name": "speech_act_type",
+      "schema": "public",
+      "values": [
+        "COMMISSIVE",
+        "DIRECTIVE"
+      ]
+    },
+    "public.transport_channel": {
+      "name": "transport_channel",
+      "schema": "public",
+      "values": [
+        "mcp"
+      ]
+    },
+    "public.message_role": {
+      "name": "message_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "agent"
+      ]
+    },
+    "public.participant_type": {
+      "name": "participant_type",
+      "schema": "public",
+      "values": [
+        "user",
+        "agent"
+      ]
+    },
+    "public.task_state": {
+      "name": "task_state",
+      "schema": "public",
+      "values": [
+        "submitted",
+        "working",
+        "input_required",
+        "completed",
+        "failed",
+        "canceled",
+        "rejected",
+        "auth_required",
+        "waiting_for_agent",
+        "claimed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -484,6 +484,13 @@
       "when": 1778793654646,
       "tag": "0068_replace_chat_session_summaries_index",
       "breakpoints": true
+    },
+    {
+      "idx": 69,
+      "version": "7",
+      "when": 1778852025988,
+      "tag": "0069_add_connect_link_preferred_surface",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/controllers/connect-link.controller.ts
+++ b/backend/src/controllers/connect-link.controller.ts
@@ -145,20 +145,33 @@ export class ConnectLinkController {
       const result = await opportunityService.startChat(link.opportunityId, link.userId);
       if ('error' in result) return jsonError(result.error, result.status);
 
-      const handle = await opportunityService.getCounterpartTelegramHandle(result.counterpartUserId);
-      const target = handle
-        ? (greeting ? `https://t.me/${handle}?text=${encodeURIComponent(greeting)}` : `https://t.me/${handle}`)
-        : (greeting
-            ? `${frontendUrl}/u/${result.counterpartUserId}/chat?msg=${encodeURIComponent(greeting)}`
-            : `${frontendUrl}/u/${result.counterpartUserId}/chat`);
+      // Receiver surface determines redirect target. preferredSurface = 'telegram'
+      // means the click came from a Telegram-rendering MCP client (EdgeClaw) and
+      // we should attempt the t.me deep link. Anything else (including NULL on
+      // pre-rollout rows) goes to the web frontend.
+      if (link.preferredSurface === 'telegram') {
+        const handle = await opportunityService.getCounterpartTelegramHandle(result.counterpartUserId);
+        const target = handle
+          ? (greeting ? `https://t.me/${handle}?text=${encodeURIComponent(greeting)}` : `https://t.me/${handle}`)
+          : (greeting
+              ? `${frontendUrl}/u/${result.counterpartUserId}/chat?msg=${encodeURIComponent(greeting)}`
+              : `${frontendUrl}/u/${result.counterpartUserId}/chat`);
+        return Response.json({ url: target });
+      }
+
+      const target = greeting
+        ? `${frontendUrl}/u/${result.counterpartUserId}/chat?msg=${encodeURIComponent(greeting)}`
+        : `${frontendUrl}/u/${result.counterpartUserId}/chat`;
       return Response.json({ url: target });
     }
 
     if (link.kind === 'outreach') {
-      const handle = await opportunityService.getCounterpartTelegramHandleForOpp(link.opportunityId, link.userId);
-      if (handle) {
-        const target = greeting ? `https://t.me/${handle}?text=${encodeURIComponent(greeting)}` : `https://t.me/${handle}`;
-        return Response.json({ url: target });
+      if (link.preferredSurface === 'telegram') {
+        const handle = await opportunityService.getCounterpartTelegramHandleForOpp(link.opportunityId, link.userId);
+        if (handle) {
+          const target = greeting ? `https://t.me/${handle}?text=${encodeURIComponent(greeting)}` : `https://t.me/${handle}`;
+          return Response.json({ url: target });
+        }
       }
       const conversationId = await opportunityService.getConversationIdForOpp(link.opportunityId, link.userId);
       const target = conversationId

--- a/backend/src/controllers/mcp.controller.ts
+++ b/backend/src/controllers/mcp.controller.ts
@@ -63,13 +63,14 @@ const apiBaseUrl = (
   'http://localhost:3001'
 ).replace(/\/+$/, '');
 
-const mintConnectLink = async ({ userId, opportunityId, kind, greeting }: {
+const mintConnectLink = async ({ userId, opportunityId, kind, greeting, preferredSurface }: {
   userId: string;
   opportunityId: string;
   kind: ConnectLinkKind;
   greeting?: string | null;
+  preferredSurface?: 'telegram' | 'web';
 }): Promise<{ url: string }> => {
-  const { code } = await mintConnectLinkSvc({ userId, opportunityId, kind, greeting });
+  const { code } = await mintConnectLinkSvc({ userId, opportunityId, kind, greeting, preferredSurface });
   return { url: buildConnectShortUrl(apiBaseUrl, code) };
 };
 
@@ -214,7 +215,8 @@ export function parseClientSurface(raw: string | null): 'telegram' | 'web' {
 }
 
 const authResolver: McpAuthResolver = {
-  async resolveIdentity(request: Request): Promise<{ userId: string; agentId?: string; isSessionAuth?: boolean; networkScopeId?: string | null }> {
+  async resolveIdentity(request: Request): Promise<{ userId: string; agentId?: string; isSessionAuth?: boolean; networkScopeId?: string | null; clientSurface?: 'telegram' | 'web' }> {
+    const clientSurface = parseClientSurface(request.headers.get('x-index-surface'));
     const authHeader = request.headers.get('Authorization');
     const [scheme, token] = authHeader?.split(/\s+/, 2) ?? [];
 
@@ -228,8 +230,8 @@ const authResolver: McpAuthResolver = {
         // (not omitted) so callers cannot conflate "no scope" with "scope unset".
         try {
           const { payload } = await jwtVerify(token, JWKS, { issuer: BASE_URL, audience: JWT_AUDIENCE });
-          if (typeof payload.id === 'string') return { userId: payload.id, isSessionAuth: true, networkScopeId: null };
-          if (typeof payload.sub === 'string') return { userId: payload.sub, isSessionAuth: true, networkScopeId: null };
+          if (typeof payload.id === 'string') return { userId: payload.id, isSessionAuth: true, networkScopeId: null, clientSurface };
+          if (typeof payload.sub === 'string') return { userId: payload.sub, isSessionAuth: true, networkScopeId: null, clientSurface };
           throw new Error('JWT payload missing user ID');
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
@@ -248,7 +250,7 @@ const authResolver: McpAuthResolver = {
           });
           if (res.ok) {
             const data = await res.json() as { userId?: string } | null;
-            if (data?.userId) return { userId: data.userId, isSessionAuth: true, networkScopeId: null };
+            if (data?.userId) return { userId: data.userId, isSessionAuth: true, networkScopeId: null, clientSurface };
           }
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
@@ -314,12 +316,13 @@ const authResolver: McpAuthResolver = {
               userId,
               ...(metadata.agentId ? { agentId: metadata.agentId } : {}),
               networkScopeId,
+              clientSurface,
             };
           }
         }
 
         if (sessionUserId) {
-          return { userId: sessionUserId, networkScopeId: null };
+          return { userId: sessionUserId, networkScopeId: null, clientSurface };
         }
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);

--- a/backend/src/controllers/mcp.controller.ts
+++ b/backend/src/controllers/mcp.controller.ts
@@ -184,6 +184,8 @@ function parseApiKeyMetadata(raw: string | null | undefined): { agentId?: string
   }
 }
 
+// Module-scope on purpose: dedupes the warn across the process lifetime so an
+// unknown header value only logs once per server process, not once per request.
 const seenInvalidSurfaces = new Set<string>();
 
 /**
@@ -202,6 +204,7 @@ export function parseClientSurface(raw: string | null): 'telegram' | 'web' {
   const normalized = raw.trim().toLowerCase();
   if (normalized === '') return 'web';
   if (normalized === 'telegram') return 'telegram';
+  // Short-circuit for the known-valid value so explicit `web` doesn't trigger the unknown-value warn.
   if (normalized === 'web') return 'web';
   if (!seenInvalidSurfaces.has(normalized)) {
     seenInvalidSurfaces.add(normalized);

--- a/backend/src/controllers/mcp.controller.ts
+++ b/backend/src/controllers/mcp.controller.ts
@@ -184,6 +184,32 @@ function parseApiKeyMetadata(raw: string | null | undefined): { agentId?: string
   }
 }
 
+const seenInvalidSurfaces = new Set<string>();
+
+/**
+ * Normalize the `x-index-surface` request header to one of the two values the
+ * connect-link click handler understands.
+ *
+ * Absent or unrecognized values collapse to `'web'` — the new default. Only
+ * `'telegram'` activates the t.me redirect path at click time.
+ *
+ * @param raw - The raw header value (case-insensitive; whitespace-trimmed).
+ * @returns `'telegram'` if and only if the trimmed lower-case value is exactly
+ *   `'telegram'`; `'web'` otherwise (including for `null`, `''`, and unknowns).
+ */
+export function parseClientSurface(raw: string | null): 'telegram' | 'web' {
+  if (raw === null) return 'web';
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === '') return 'web';
+  if (normalized === 'telegram') return 'telegram';
+  if (normalized === 'web') return 'web';
+  if (!seenInvalidSurfaces.has(normalized)) {
+    seenInvalidSurfaces.add(normalized);
+    console.warn(`[mcp] unknown x-index-surface value "${normalized}" — coercing to "web"`);
+  }
+  return 'web';
+}
+
 const authResolver: McpAuthResolver = {
   async resolveIdentity(request: Request): Promise<{ userId: string; agentId?: string; isSessionAuth?: boolean; networkScopeId?: string | null }> {
     const authHeader = request.headers.get('Authorization');

--- a/backend/src/controllers/tests/mcp-surface.test.ts
+++ b/backend/src/controllers/tests/mcp-surface.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test';
+
+import { parseClientSurface } from '../mcp.controller';
+
+describe('parseClientSurface', () => {
+  test('returns "web" when header is null', () => {
+    expect(parseClientSurface(null)).toBe('web');
+  });
+
+  test('returns "web" when header is empty string', () => {
+    expect(parseClientSurface('')).toBe('web');
+  });
+
+  test('returns "telegram" for canonical lowercase value', () => {
+    expect(parseClientSurface('telegram')).toBe('telegram');
+  });
+
+  test('returns "telegram" regardless of case', () => {
+    expect(parseClientSurface('Telegram')).toBe('telegram');
+    expect(parseClientSurface('TELEGRAM')).toBe('telegram');
+  });
+
+  test('trims whitespace before matching', () => {
+    expect(parseClientSurface('  telegram  ')).toBe('telegram');
+    expect(parseClientSurface('\ttelegram\n')).toBe('telegram');
+  });
+
+  test('returns "web" for explicit web value', () => {
+    expect(parseClientSurface('web')).toBe('web');
+    expect(parseClientSurface('WEB')).toBe('web');
+  });
+
+  test('coerces unknown values to "web"', () => {
+    expect(parseClientSurface('slack')).toBe('web');
+    expect(parseClientSurface('foo')).toBe('web');
+    expect(parseClientSurface('true')).toBe('web');
+  });
+});

--- a/backend/src/controllers/tests/mcp-surface.test.ts
+++ b/backend/src/controllers/tests/mcp-surface.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, spyOn, test } from 'bun:test';
 
 import { parseClientSurface } from '../mcp.controller';
 
@@ -34,5 +34,18 @@ describe('parseClientSurface', () => {
     expect(parseClientSurface('slack')).toBe('web');
     expect(parseClientSurface('foo')).toBe('web');
     expect(parseClientSurface('true')).toBe('web');
+  });
+
+  test('warns exactly once per unknown value, not on subsequent calls', () => {
+    const spy = spyOn(console, 'warn');
+    // Use a value not seen by any earlier test so the Set is empty for it.
+    parseClientSurface('zz-novel-unknown-value');
+    parseClientSurface('zz-novel-unknown-value');
+    parseClientSurface('zz-novel-unknown-value');
+    const callCount = spy.mock.calls.filter((call) =>
+      typeof call[0] === 'string' && call[0].includes('zz-novel-unknown-value')
+    ).length;
+    expect(callCount).toBe(1);
+    spy.mockRestore();
   });
 });

--- a/backend/src/schemas/database.schema.ts
+++ b/backend/src/schemas/database.schema.ts
@@ -91,6 +91,7 @@ export const connectLinks = pgTable(
       .references(() => opportunities.id, { onDelete: 'cascade' }),
     kind: text('kind').notNull(),
     greeting: text('greeting'),
+    preferredSurface: text('preferred_surface'), // null = web; 'telegram' activates t.me redirect
     expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
   },

--- a/backend/src/services/connect-link.service.ts
+++ b/backend/src/services/connect-link.service.ts
@@ -174,7 +174,14 @@ export async function resolveConnectLink(code: string): Promise<ResolvedLink | n
     opportunityId: row.opportunityId,
     kind: row.kind as ConnectLinkKind,
     greeting: row.greeting,
-    preferredSurface: row.preferredSurface as 'telegram' | 'web' | null,
+    // The DB column is unconstrained text — narrow defensively so any non-
+    // canonical value (a new surface added without normalization, a hand-edited
+    // row, a typo) collapses to null rather than silently passing through the
+    // type-cast and being interpreted later as `'telegram' | 'web'`.
+    preferredSurface:
+      row.preferredSurface === 'telegram' || row.preferredSurface === 'web'
+        ? row.preferredSurface
+        : null,
   };
 }
 

--- a/backend/src/services/connect-link.service.ts
+++ b/backend/src/services/connect-link.service.ts
@@ -34,6 +34,7 @@ export interface MintArgs {
   opportunityId: string;
   kind: ConnectLinkKind;
   greeting?: string | null;
+  preferredSurface?: 'telegram' | 'web' | null;
 }
 
 /**
@@ -50,6 +51,7 @@ export async function mintConnectLink({
   opportunityId,
   kind,
   greeting,
+  preferredSurface,
 }: MintArgs): Promise<{ code: string; greeting: string | null }> {
   const now = new Date();
 
@@ -76,13 +78,18 @@ export async function mintConnectLink({
   const expiresAt = new Date(now.getTime() + TTL_DAYS * 24 * 60 * 60 * 1000);
 
   if (existing) {
-    // Expired row — rotate code + greeting + expiresAt in place.
+    // Expired row — rotate code + greeting + preferredSurface + expiresAt in place.
     for (let attempt = 0; attempt < 3; attempt++) {
       const code = generateCode();
       try {
         const [row] = await db
           .update(connectLinks)
-          .set({ code, greeting: greeting ?? null, expiresAt })
+          .set({
+            code,
+            greeting: greeting ?? null,
+            preferredSurface: preferredSurface ?? null,
+            expiresAt,
+          })
           .where(
             and(
               eq(connectLinks.opportunityId, opportunityId),
@@ -106,7 +113,15 @@ export async function mintConnectLink({
     try {
       const [row] = await db
         .insert(connectLinks)
-        .values({ code, userId, opportunityId, kind, greeting: greeting ?? null, expiresAt })
+        .values({
+          code,
+          userId,
+          opportunityId,
+          kind,
+          greeting: greeting ?? null,
+          preferredSurface: preferredSurface ?? null,
+          expiresAt,
+        })
         .returning();
       return { code: row.code, greeting: row.greeting };
     } catch (err) {
@@ -137,6 +152,7 @@ export interface ResolvedLink {
   opportunityId: string;
   kind: ConnectLinkKind;
   greeting: string | null;
+  preferredSurface: 'telegram' | 'web' | null;
 }
 
 /**
@@ -158,6 +174,7 @@ export async function resolveConnectLink(code: string): Promise<ResolvedLink | n
     opportunityId: row.opportunityId,
     kind: row.kind as ConnectLinkKind,
     greeting: row.greeting,
+    preferredSurface: row.preferredSurface as 'telegram' | 'web' | null,
   };
 }
 

--- a/backend/tests/connect-link.surface.test.ts
+++ b/backend/tests/connect-link.surface.test.ts
@@ -1,0 +1,170 @@
+import '../src/startup.env';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { and, eq } from 'drizzle-orm';
+
+import { ConnectLinkController } from '../src/controllers/connect-link.controller';
+import db from '../src/lib/drizzle/drizzle';
+import {
+  connectLinks,
+  networkMembers,
+  networks,
+  opportunities,
+  personalNetworks,
+  userSocials,
+  users,
+} from '../src/schemas/database.schema';
+import { mintConnectLink } from '../src/services/connect-link.service';
+
+const FRONTEND_URL = (process.env.FRONTEND_URL || process.env.APP_URL || 'https://index.network')
+  .replace(/\/+$/, '');
+
+function makeRequest(path: string): Request {
+  return new Request(`http://localhost${path}`, { method: 'GET' });
+}
+
+const CALLER_ID = `cl-surface-caller-${Date.now()}`;
+const COUNTERPART_ID = `cl-surface-counterpart-${Date.now()}`;
+const OPP_ID = `cl-surface-opp-${Date.now()}`;
+
+describe('GET /c/:code/go — surface-aware redirect', () => {
+  let controller: ConnectLinkController;
+
+  beforeAll(async () => {
+    controller = new ConnectLinkController();
+
+    await db.insert(users).values([
+      { id: CALLER_ID, email: `${CALLER_ID}@test`, name: 'CL Surface Caller' },
+      { id: COUNTERPART_ID, email: `${COUNTERPART_ID}@test`, name: 'CL Surface Counterpart' },
+    ]);
+
+    await db.insert(opportunities).values({
+      id: OPP_ID,
+      // Two actors so startChat can resolve a counterpart.
+      actors: [
+        { userId: CALLER_ID, networkId: 'n/a', role: 'seeker' },
+        { userId: COUNTERPART_ID, networkId: 'n/a', role: 'responder' },
+      ],
+      detection: { source: 'test', timestamp: new Date().toISOString(), createdBy: CALLER_ID },
+      interpretation: { category: 'test', reasoning: 'surface-test', confidence: 0.9 },
+      context: { networkId: 'n/a' },
+      confidence: '0.9',
+      status: 'pending',
+    });
+  });
+
+  afterAll(async () => {
+    await db.delete(connectLinks).where(eq(connectLinks.userId, CALLER_ID));
+    await db.delete(opportunities).where(eq(opportunities.id, OPP_ID));
+    await db.delete(userSocials).where(eq(userSocials.userId, COUNTERPART_ID));
+
+    // startChat → upsertContactMembership → ensurePersonalNetwork creates
+    // personal_networks + networks + network_members for each actor. Delete
+    // these child rows before the users rows to satisfy FK constraints.
+    // Collect the personal network IDs so we can drop the networks row too.
+    const personalNetworkRows = await db
+      .select({ networkId: personalNetworks.networkId })
+      .from(personalNetworks)
+      .where(
+        and(
+          eq(personalNetworks.userId, CALLER_ID),
+        ),
+      );
+    const counterpartPersonalNetworkRows = await db
+      .select({ networkId: personalNetworks.networkId })
+      .from(personalNetworks)
+      .where(eq(personalNetworks.userId, COUNTERPART_ID));
+
+    await db.delete(networkMembers).where(eq(networkMembers.userId, CALLER_ID));
+    await db.delete(networkMembers).where(eq(networkMembers.userId, COUNTERPART_ID));
+    await db.delete(personalNetworks).where(eq(personalNetworks.userId, CALLER_ID));
+    await db.delete(personalNetworks).where(eq(personalNetworks.userId, COUNTERPART_ID));
+
+    // Also drop the personal network rows themselves and any network_members
+    // that reference them (e.g. the counterpart added as a contact).
+    for (const { networkId } of [...personalNetworkRows, ...counterpartPersonalNetworkRows]) {
+      await db.delete(networkMembers).where(eq(networkMembers.networkId, networkId));
+      await db.delete(networks).where(eq(networks.id, networkId));
+    }
+
+    await db.delete(users).where(eq(users.id, CALLER_ID));
+    await db.delete(users).where(eq(users.id, COUNTERPART_ID));
+  });
+
+  // `mintConnectLink` has a unique index on (opportunityId, userId, kind), so
+  // each test reuses or rotates the same row. Wipe the row before each test
+  // so the surface stamp is exactly what the test sets — first-mint-wins
+  // would otherwise let an earlier test's surface leak.
+  beforeEach(async () => {
+    await db.delete(connectLinks).where(
+      and(
+        eq(connectLinks.opportunityId, OPP_ID),
+        eq(connectLinks.userId, CALLER_ID),
+      ),
+    );
+    await db.delete(userSocials).where(eq(userSocials.userId, COUNTERPART_ID));
+  });
+
+  test('preferredSurface=telegram + counterpart has TG handle → t.me URL', async () => {
+    await db.insert(userSocials).values({
+      userId: COUNTERPART_ID,
+      label: 'telegram',
+      value: 'counterpart_handle',
+    });
+
+    const { code } = await mintConnectLink({
+      userId: CALLER_ID,
+      opportunityId: OPP_ID,
+      kind: 'connect',
+      greeting: 'hello there',
+      preferredSurface: 'telegram',
+    });
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), undefined, { code });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { url: string };
+    expect(body.url).toMatch(/^https:\/\/t\.me\/counterpart_handle/);
+    expect(body.url).toContain('text=hello%20there');
+  });
+
+  test('preferredSurface=telegram + counterpart has no TG handle → web fallback', async () => {
+    // No userSocials row — the beforeEach wiped it.
+
+    const { code } = await mintConnectLink({
+      userId: CALLER_ID,
+      opportunityId: OPP_ID,
+      kind: 'connect',
+      greeting: 'hello there',
+      preferredSurface: 'telegram',
+    });
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), undefined, { code });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { url: string };
+    expect(body.url).not.toMatch(/^https:\/\/t\.me/);
+    expect(body.url).toContain(`${FRONTEND_URL}/u/${COUNTERPART_ID}/chat`);
+    expect(body.url).toContain('msg=hello%20there');
+  });
+
+  test('preferredSurface unset + counterpart has TG handle → web URL (behavior change)', async () => {
+    await db.insert(userSocials).values({
+      userId: COUNTERPART_ID,
+      label: 'telegram',
+      value: 'counterpart_handle',
+    });
+
+    const { code } = await mintConnectLink({
+      userId: CALLER_ID,
+      opportunityId: OPP_ID,
+      kind: 'connect',
+      greeting: 'hello there',
+      // preferredSurface omitted — persists as NULL, treated as web.
+    });
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), undefined, { code });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { url: string };
+    expect(body.url).not.toMatch(/^https:\/\/t\.me/);
+    expect(body.url).toContain(`${FRONTEND_URL}/u/${COUNTERPART_ID}/chat`);
+  });
+});

--- a/backend/tests/connect-link.surface.test.ts
+++ b/backend/tests/connect-link.surface.test.ts
@@ -65,11 +65,7 @@ describe('GET /c/:code/go — surface-aware redirect', () => {
     const personalNetworkRows = await db
       .select({ networkId: personalNetworks.networkId })
       .from(personalNetworks)
-      .where(
-        and(
-          eq(personalNetworks.userId, CALLER_ID),
-        ),
-      );
+      .where(eq(personalNetworks.userId, CALLER_ID));
     const counterpartPersonalNetworkRows = await db
       .select({ networkId: personalNetworks.networkId })
       .from(personalNetworks)

--- a/docs/superpowers/plans/2026-05-15-mcp-surface-header.md
+++ b/docs/superpowers/plans/2026-05-15-mcp-surface-header.md
@@ -1,0 +1,1351 @@
+# MCP surface header for connect-link redirects — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Linear:** [IND-303](https://linear.app/indexnetwork/issue/IND-303/per-request-surface-header-for-mcp-connect-link-redirects-edgeclaw)
+**Spec:** [`docs/superpowers/specs/2026-05-15-mcp-surface-header-design.md`](../specs/2026-05-15-mcp-surface-header-design.md)
+
+**Goal:** Make `/c/{code}` short-link click-time redirects choose between `t.me/{handle}` and the web frontend chat URL based on the receiver's surface (declared by the MCP client via `x-index-surface: telegram | web`), not just the target's Telegram availability. EdgeClaw becomes the only caller that activates the Telegram redirect path.
+
+**Architecture:** Per-request `x-index-surface` header travels through the MCP auth path into a new `clientSurface` field on the per-request `ResolvedToolContext`. Tool handlers thread it into `mintConnectLink`, which persists `preferred_surface` on each `connect_links` row at insert time (and on rotation of expired rows). The click handler reads the column from the resolved row and branches the redirect. Default is `web` — `telegram` is opt-in via the header.
+
+**Tech Stack:** Bun + TypeScript, Drizzle ORM + PostgreSQL, `@indexnetwork/protocol` workspace package (built to `dist/`), MCP SDK with `x-api-key` auth, `bun test` for tests.
+
+---
+
+## File map
+
+**Created:**
+- `backend/drizzle/0067_add_connect_link_preferred_surface.sql` — schema migration
+- `backend/tests/connect-link.surface.test.ts` — integration tests covering the three click-time branches
+- `backend/src/controllers/tests/mcp-surface.test.ts` — unit test for `parseClientSurface`
+
+**Modified — backend:**
+- `backend/src/schemas/database.schema.ts` — add `preferredSurface` column on `connectLinks` (line 82-105 region)
+- `backend/drizzle/meta/_journal.json` — register migration `0067`
+- `backend/src/services/connect-link.service.ts` — `mintConnectLink` accepts/persists/rotates `preferredSurface`; `ResolvedLink` carries it
+- `backend/src/controllers/mcp.controller.ts` — `parseClientSurface` helper; `authResolver.resolveIdentity` returns `clientSurface`; adapter forwards `preferredSurface` into `mintConnectLinkSvc`
+- `backend/src/controllers/connect-link.controller.ts` — `connect` and `outreach` branch on `link.preferredSurface`
+
+**Modified — protocol (rebuilt on every edit so backend picks up changes):**
+- `packages/protocol/src/shared/interfaces/auth.interface.ts` — extend `McpAuthResolver.resolveIdentity` return shape with `clientSurface`
+- `packages/protocol/src/shared/interfaces/connect-link.interface.ts` — extend `MintConnectLink` args with `preferredSurface`
+- `packages/protocol/src/shared/agent/tool.helpers.ts` — add `clientSurface` to `ResolvedToolContext`
+- `packages/protocol/src/mcp/mcp.server.ts` — thread `identity.clientSurface` into `context.clientSurface`
+- `packages/protocol/src/opportunity/opportunity.tools.ts` — `attachActionableLinks` accepts/forwards `preferredSurface`; 3 call sites pass `context.clientSurface`
+- `packages/protocol/src/shared/agent/tests/tool.factory.spec.ts` — extend existing `mintConnectLink` test to assert forwarding
+
+**Modified — EdgeClaw:**
+- `packages/edgeclaw/install/install_index.ts` — write `x-index-surface: telegram` next to `x-api-key`
+
+**Version bumps before merge (per `CLAUDE.md` finishing-a-branch checklist):**
+- `packages/protocol/package.json` (npm-published subtree — minor bump because of public interface change)
+- `packages/edgeclaw/package.json` (patch bump)
+
+---
+
+## Background notes for the implementing engineer
+
+- **Workspace resolution.** Backend depends on `@indexnetwork/protocol` as `workspace:*` (`backend/package.json:43`). The protocol package exports from `dist/index.js`, not `src/`. **After every edit under `packages/protocol/src/`, you must run `bun run build` in `packages/protocol/` before backend tests will see the change.** Most tasks below include the build step explicitly.
+- **`ResolvedToolContext` vs `ToolContext`.** The spec mentions "ToolContext"; the actual runtime per-request context object the tool handlers receive is the type `ResolvedToolContext` in `packages/protocol/src/shared/agent/tool.helpers.ts:47` — that's where `isMcp` and `agentId` already live, and that's the right home for `clientSurface`. The `ToolContext` type (same file, line 86) is the deps shape (carries the `mintConnectLink` function itself, not per-call values).
+- **Migration naming.** Drizzle generates random names. After `bun run db:generate`, rename the generated `.sql` file to `0067_add_connect_link_preferred_surface.sql` AND update the matching `tag` field in `drizzle/meta/_journal.json`. Verify by running `bun run db:generate` again — it should report "No schema changes".
+- **Test isolation.** `bun test path/to/file.ts` runs a single test file; the full suite is slow. Always target the specific file you are working on.
+- **Worktree.** Per `CLAUDE.md`, use a worktree off `dev`. Suggested folder name: `.worktrees/ind-303-mcp-surface-header`; suggested branch: `yanki/ind-303-mcp-surface-header` (matches Linear's auto-suggestion).
+
+---
+
+## Setup: create worktree
+
+- [ ] **Step 1: Create worktree from `dev`**
+
+```bash
+cd /Users/aposto/Projects/index
+git worktree add .worktrees/ind-303-mcp-surface-header -b yanki/ind-303-mcp-surface-header dev
+bun run worktree:setup ind-303-mcp-surface-header
+```
+
+Expected: worktree created, `.env` symlinks in place, `bun install` completes.
+
+- [ ] **Step 2: Verify build from clean state**
+
+```bash
+cd /Users/aposto/Projects/index/.worktrees/ind-303-mcp-surface-header
+cd packages/protocol && bun run build && cd ../..
+cd backend && bun run lint && cd ..
+```
+
+Expected: protocol builds without errors; lint passes.
+
+All subsequent task steps assume the working directory is the worktree root (`.worktrees/ind-303-mcp-surface-header`) unless otherwise stated.
+
+---
+
+## Task 1: `parseClientSurface` helper + unit test
+
+Pure function with a small surface area. TDD it first because it anchors the rest of the auth-path change.
+
+**Files:**
+- Create: `backend/src/controllers/tests/mcp-surface.test.ts`
+- Modify: `backend/src/controllers/mcp.controller.ts` (add `parseClientSurface` near the existing `parseApiKeyMetadata` helper around line 169)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/src/controllers/tests/mcp-surface.test.ts`:
+
+```ts
+import { describe, expect, test } from 'bun:test';
+
+import { parseClientSurface } from '../mcp.controller';
+
+describe('parseClientSurface', () => {
+  test('returns "web" when header is null', () => {
+    expect(parseClientSurface(null)).toBe('web');
+  });
+
+  test('returns "web" when header is empty string', () => {
+    expect(parseClientSurface('')).toBe('web');
+  });
+
+  test('returns "telegram" for canonical lowercase value', () => {
+    expect(parseClientSurface('telegram')).toBe('telegram');
+  });
+
+  test('returns "telegram" regardless of case', () => {
+    expect(parseClientSurface('Telegram')).toBe('telegram');
+    expect(parseClientSurface('TELEGRAM')).toBe('telegram');
+  });
+
+  test('trims whitespace before matching', () => {
+    expect(parseClientSurface('  telegram  ')).toBe('telegram');
+    expect(parseClientSurface('\ttelegram\n')).toBe('telegram');
+  });
+
+  test('returns "web" for explicit web value', () => {
+    expect(parseClientSurface('web')).toBe('web');
+    expect(parseClientSurface('WEB')).toBe('web');
+  });
+
+  test('coerces unknown values to "web"', () => {
+    expect(parseClientSurface('slack')).toBe('web');
+    expect(parseClientSurface('foo')).toBe('web');
+    expect(parseClientSurface('true')).toBe('web');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+```bash
+cd backend
+bun test src/controllers/tests/mcp-surface.test.ts
+```
+
+Expected: failure with module-not-found / `parseClientSurface is not exported` error.
+
+- [ ] **Step 3: Implement `parseClientSurface` in `mcp.controller.ts`**
+
+Open `backend/src/controllers/mcp.controller.ts`. After the existing `parseApiKeyMetadata` function (around line 169-180), add:
+
+```ts
+const seenInvalidSurfaces = new Set<string>();
+
+/**
+ * Normalize the `x-index-surface` request header to one of the two values the
+ * connect-link click handler understands.
+ *
+ * Absent or unrecognized values collapse to `'web'` — the new default. Only
+ * `'telegram'` activates the t.me redirect path at click time.
+ *
+ * @param raw - The raw header value (case-insensitive; whitespace-trimmed).
+ * @returns `'telegram'` if and only if the trimmed lower-case value is exactly
+ *   `'telegram'`; `'web'` otherwise (including for `null`, `''`, and unknowns).
+ */
+export function parseClientSurface(raw: string | null): 'telegram' | 'web' {
+  if (raw === null) return 'web';
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === '') return 'web';
+  if (normalized === 'telegram') return 'telegram';
+  if (normalized === 'web') return 'web';
+  if (!seenInvalidSurfaces.has(normalized)) {
+    seenInvalidSurfaces.add(normalized);
+    console.warn(`[mcp] unknown x-index-surface value "${normalized}" — coercing to "web"`);
+  }
+  return 'web';
+}
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+```bash
+bun test src/controllers/tests/mcp-surface.test.ts
+```
+
+Expected: all 8 cases pass.
+
+- [ ] **Step 5: Type-check the whole controller**
+
+```bash
+bunx tsc --noEmit -p .
+```
+
+Expected: no errors. (If you see errors unrelated to this change, note them but do not fix here.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/controllers/mcp.controller.ts src/controllers/tests/mcp-surface.test.ts
+git commit -m "feat(mcp): parseClientSurface header normalizer + unit tests"
+```
+
+---
+
+## Task 2: Schema column + migration
+
+`connect_links.preferred_surface` is the persistence layer for the per-call surface signal.
+
+**Files:**
+- Modify: `backend/src/schemas/database.schema.ts` (line 82-105 — `connectLinks` table)
+- Create: `backend/drizzle/0067_add_connect_link_preferred_surface.sql`
+- Modify: `backend/drizzle/meta/_journal.json`
+- Modify: `backend/drizzle/meta/0067_snapshot.json` (auto-generated; keep as-is)
+
+- [ ] **Step 1: Add the column to the schema**
+
+Open `backend/src/schemas/database.schema.ts`. In the `connectLinks` table definition (around line 82), insert `preferredSurface` between `greeting` and `expiresAt`:
+
+```ts
+export const connectLinks = pgTable(
+  'connect_links',
+  {
+    code: text('code').primaryKey(),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    opportunityId: text('opportunity_id')
+      .notNull()
+      .references(() => opportunities.id, { onDelete: 'cascade' }),
+    kind: text('kind').notNull(),
+    greeting: text('greeting'),
+    preferredSurface: text('preferred_surface'),  // null = web; 'telegram' activates t.me redirect
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    uqKindPerRecipient: uniqueIndex('connect_links_kind_recipient_uq').on(
+      t.opportunityId,
+      t.userId,
+      t.kind,
+    ),
+    idxExpires: index('connect_links_expires_at_idx').on(t.expiresAt),
+  }),
+);
+```
+
+- [ ] **Step 2: Generate the migration**
+
+```bash
+cd backend
+bun run db:generate
+```
+
+Expected: drizzle-kit emits a new file under `backend/drizzle/` with a random name (e.g. `0067_funky_lockjaw.sql`) and updates `drizzle/meta/_journal.json` + `drizzle/meta/0067_snapshot.json`.
+
+Inspect the new `.sql` file — it should be a single `ALTER TABLE "connect_links" ADD COLUMN "preferred_surface" text;` statement.
+
+- [ ] **Step 3: Rename the migration to the canonical name**
+
+```bash
+ls drizzle/0067_*.sql
+# note the filename, e.g. 0067_funky_lockjaw.sql
+mv drizzle/0067_funky_lockjaw.sql drizzle/0067_add_connect_link_preferred_surface.sql
+```
+
+Then open `backend/drizzle/meta/_journal.json` and update the entry whose `idx` is 67. Change `"tag": "0067_funky_lockjaw"` to `"tag": "0067_add_connect_link_preferred_surface"`. Do NOT rename `0067_snapshot.json`.
+
+- [ ] **Step 4: Verify the migration is idempotent and the schema is fully captured**
+
+```bash
+bun run db:generate
+```
+
+Expected: `No schema changes, nothing to migrate`.
+
+- [ ] **Step 5: Apply the migration locally**
+
+```bash
+bun run db:migrate
+```
+
+Expected: migration applies cleanly. If you have a fresh dev DB, this should succeed without rollback.
+
+- [ ] **Step 6: Smoke-check the column exists**
+
+```bash
+bun --print "
+import db from './src/lib/drizzle/drizzle';
+import { sql } from 'drizzle-orm';
+const r = await db.execute(sql\`SELECT column_name, data_type FROM information_schema.columns WHERE table_name = 'connect_links' AND column_name = 'preferred_surface'\`);
+console.log(r.rows);
+"
+```
+
+Expected: prints `[ { column_name: 'preferred_surface', data_type: 'text' } ]`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/schemas/database.schema.ts drizzle/0067_add_connect_link_preferred_surface.sql drizzle/meta/_journal.json drizzle/meta/0067_snapshot.json
+git commit -m "feat(db): add preferred_surface column to connect_links
+
+Nullable text column persists the receiving surface declared at mint time so
+the /c/{code} click handler can branch redirects between t.me and the web
+frontend. NULL is treated as web."
+```
+
+---
+
+## Task 3: `mintConnectLink` service — persist & resolve `preferredSurface`
+
+Extend the service to accept the new arg, persist it on insert, re-stamp it on rotation of expired rows, and return it from `resolveConnectLink`. First-mint-wins for un-expired reuse (matches `greeting` semantics).
+
+**Files:**
+- Modify: `backend/src/services/connect-link.service.ts`
+
+- [ ] **Step 1: Extend `MintArgs` and `ResolvedLink` types**
+
+Open `backend/src/services/connect-link.service.ts`. Extend `MintArgs` (line 32) and `ResolvedLink` (line 134):
+
+```ts
+export interface MintArgs {
+  userId: string;
+  opportunityId: string;
+  kind: ConnectLinkKind;
+  greeting?: string | null;
+  preferredSurface?: 'telegram' | 'web' | null;
+}
+```
+
+```ts
+export interface ResolvedLink {
+  code: string;
+  userId: string;
+  opportunityId: string;
+  kind: ConnectLinkKind;
+  greeting: string | null;
+  preferredSurface: 'telegram' | 'web' | null;
+}
+```
+
+- [ ] **Step 2: Update the function signature and body**
+
+In `mintConnectLink` (line 48), destructure `preferredSurface`:
+
+```ts
+export async function mintConnectLink({
+  userId,
+  opportunityId,
+  kind,
+  greeting,
+  preferredSurface,
+}: MintArgs): Promise<{ code: string; greeting: string | null }> {
+```
+
+In the **fresh insert** path (line 104-130), add `preferredSurface` to the insert values:
+
+```ts
+  // No prior row — fresh insert.
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const code = generateCode();
+    try {
+      const [row] = await db
+        .insert(connectLinks)
+        .values({
+          code,
+          userId,
+          opportunityId,
+          kind,
+          greeting: greeting ?? null,
+          preferredSurface: preferredSurface ?? null,
+          expiresAt,
+        })
+        .returning();
+      return { code: row.code, greeting: row.greeting };
+    } catch (err) {
+      // ...racing-row recovery unchanged
+```
+
+In the **expired-row rotation** path (line 78-101), add `preferredSurface` to the `.set()` payload:
+
+```ts
+  if (existing) {
+    // Expired row — rotate code + greeting + preferredSurface + expiresAt in place.
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const code = generateCode();
+      try {
+        const [row] = await db
+          .update(connectLinks)
+          .set({
+            code,
+            greeting: greeting ?? null,
+            preferredSurface: preferredSurface ?? null,
+            expiresAt,
+          })
+          .where(
+            and(
+              eq(connectLinks.opportunityId, opportunityId),
+              eq(connectLinks.userId, userId),
+              eq(connectLinks.kind, kind),
+            ),
+          )
+          .returning();
+        return { code: row.code, greeting: row.greeting };
+```
+
+The **idempotent reuse** path (line 72-74) stays unchanged — a still-fresh row returns its existing `code` and `greeting`. First mint wins for surface too; we intentionally do not update an un-expired row's surface.
+
+- [ ] **Step 3: Update `resolveConnectLink` to return `preferredSurface`**
+
+In `resolveConnectLink` (line 148), include the new field in the returned object:
+
+```ts
+export async function resolveConnectLink(code: string): Promise<ResolvedLink | null> {
+  const [row] = await db
+    .select()
+    .from(connectLinks)
+    .where(and(eq(connectLinks.code, code), gt(connectLinks.expiresAt, new Date())))
+    .limit(1);
+  if (!row) return null;
+  return {
+    code: row.code,
+    userId: row.userId,
+    opportunityId: row.opportunityId,
+    kind: row.kind as ConnectLinkKind,
+    greeting: row.greeting,
+    preferredSurface: row.preferredSurface as 'telegram' | 'web' | null,
+  };
+}
+```
+
+- [ ] **Step 4: Type-check**
+
+```bash
+cd backend
+bunx tsc --noEmit -p .
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/connect-link.service.ts
+git commit -m "feat(connect-link): persist preferredSurface at mint time
+
+mintConnectLink accepts an optional preferredSurface, writes it on fresh
+insert, and re-stamps it on rotation of expired rows. Idempotent reuse of a
+still-fresh row preserves the existing surface — first mint wins for the
+link's lifetime. resolveConnectLink surfaces the column to callers."
+```
+
+---
+
+## Task 4: Click-time branch in `connect-link.controller.ts`
+
+`GET /c/:code/go` reads `link.preferredSurface` and branches the redirect.
+
+**Files:**
+- Modify: `backend/src/controllers/connect-link.controller.ts` (line 131-178)
+
+- [ ] **Step 1: Update the `connect` branch (line 144-155)**
+
+Open `backend/src/controllers/connect-link.controller.ts`. Replace the body of the `if (link.kind === 'connect')` block with:
+
+```ts
+    if (link.kind === 'connect') {
+      const result = await opportunityService.startChat(link.opportunityId, link.userId);
+      if ('error' in result) return jsonError(result.error, result.status);
+
+      // Receiver surface determines redirect target. preferredSurface = 'telegram'
+      // means the click came from a Telegram-rendering MCP client (EdgeClaw) and
+      // we should attempt the t.me deep link. Anything else (including NULL on
+      // pre-rollout rows) goes to the web frontend.
+      if (link.preferredSurface === 'telegram') {
+        const handle = await opportunityService.getCounterpartTelegramHandle(result.counterpartUserId);
+        const target = handle
+          ? (greeting ? `https://t.me/${handle}?text=${encodeURIComponent(greeting)}` : `https://t.me/${handle}`)
+          : (greeting
+              ? `${frontendUrl}/u/${result.counterpartUserId}/chat?msg=${encodeURIComponent(greeting)}`
+              : `${frontendUrl}/u/${result.counterpartUserId}/chat`);
+        return Response.json({ url: target });
+      }
+
+      const target = greeting
+        ? `${frontendUrl}/u/${result.counterpartUserId}/chat?msg=${encodeURIComponent(greeting)}`
+        : `${frontendUrl}/u/${result.counterpartUserId}/chat`;
+      return Response.json({ url: target });
+    }
+```
+
+- [ ] **Step 2: Update the `outreach` branch (line 157-168)**
+
+Replace the body of the `if (link.kind === 'outreach')` block with:
+
+```ts
+    if (link.kind === 'outreach') {
+      if (link.preferredSurface === 'telegram') {
+        const handle = await opportunityService.getCounterpartTelegramHandleForOpp(link.opportunityId, link.userId);
+        if (handle) {
+          const target = greeting ? `https://t.me/${handle}?text=${encodeURIComponent(greeting)}` : `https://t.me/${handle}`;
+          return Response.json({ url: target });
+        }
+      }
+      const conversationId = await opportunityService.getConversationIdForOpp(link.opportunityId, link.userId);
+      const target = conversationId
+        ? `${frontendUrl}/conversations/${conversationId}${greeting ? `?msg=${encodeURIComponent(greeting)}` : ''}`
+        : frontendUrl;
+      return Response.json({ url: target });
+    }
+```
+
+The `approve_introduction` branch (line 170-174) is unchanged.
+
+- [ ] **Step 3: Type-check**
+
+```bash
+cd backend
+bunx tsc --noEmit -p .
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/controllers/connect-link.controller.ts
+git commit -m "feat(connect-link): branch click redirect on link.preferredSurface
+
+Telegram redirect path is gated on the mint-time surface declared by the
+calling MCP client. Anything other than preferredSurface='telegram' (the
+new default for non-EdgeClaw callers) routes to the web frontend chat URL."
+```
+
+---
+
+## Task 5: Integration test for `/c/{code}/go` branching
+
+Three matrices: telegram-surface + target-has-TG → t.me; telegram-surface + no TG → web fallback; web-surface (NULL) + target-has-TG → web (the behavior change).
+
+**Files:**
+- Create: `backend/tests/connect-link.surface.test.ts`
+
+- [ ] **Step 1: Inspect existing integration tests to match conventions**
+
+```bash
+ls backend/tests/
+head -60 backend/tests/$(ls backend/tests/ | head -1)
+```
+
+Look at how an existing test bootstraps DB, creates a user, and hits an HTTP route. Mirror that pattern — load `.env` at top, import from `bun:test`, use the live `db` adapter, and either call the controller directly or use the live Bun server.
+
+- [ ] **Step 2: Write the failing integration test**
+
+Create `backend/tests/connect-link.surface.test.ts`. Adapt the bootstrap pieces (DB connection, test user fixture, fixture cleanup) from a nearby integration test; the test logic itself is:
+
+```ts
+// Load env before importing app code.
+import './setup-env';   // or whatever pattern the other tests use
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+
+import db from '../src/lib/drizzle/drizzle';
+import { connectLinks, opportunities, userSocials, users } from '../src/schemas/database.schema';
+import { eq } from 'drizzle-orm';
+import { mintConnectLink } from '../src/services/connect-link.service';
+import { ConnectLinkController } from '../src/controllers/connect-link.controller';
+
+const FRONTEND_URL = process.env.FRONTEND_URL || process.env.APP_URL || 'https://index.network';
+
+describe('GET /c/:code/go — surface-aware redirect', () => {
+  const ids: { userId: string; counterpartId: string; opportunityId: string } = {
+    userId: '',
+    counterpartId: '',
+    opportunityId: '',
+  };
+
+  beforeAll(async () => {
+    // create caller, counterpart, opportunity — adapt to local fixture helpers
+    // record IDs on `ids`
+  });
+
+  afterAll(async () => {
+    // delete fixtures created above
+    await db.delete(connectLinks).where(eq(connectLinks.userId, ids.userId));
+    await db.delete(opportunities).where(eq(opportunities.id, ids.opportunityId));
+    await db.delete(userSocials).where(eq(userSocials.userId, ids.counterpartId));
+    await db.delete(users).where(eq(users.id, ids.userId));
+    await db.delete(users).where(eq(users.id, ids.counterpartId));
+  });
+
+  test('preferredSurface=telegram + target has TG → t.me URL', async () => {
+    // Ensure counterpart has a telegram social row
+    await db.insert(userSocials).values({
+      userId: ids.counterpartId,
+      label: 'telegram',
+      value: 'counterpart_handle',
+    }).onConflictDoNothing();
+
+    const { code } = await mintConnectLink({
+      userId: ids.userId,
+      opportunityId: ids.opportunityId,
+      kind: 'connect',
+      preferredSurface: 'telegram',
+    });
+
+    const controller = new ConnectLinkController();
+    const res = await controller.go(new Request(`http://test/c/${code}/go`), null, { code });
+    const body = await (res as Response).json() as { url: string };
+
+    expect(body.url).toMatch(/^https:\/\/t\.me\/counterpart_handle/);
+  });
+
+  test('preferredSurface=telegram + target has no TG → web fallback', async () => {
+    await db.delete(userSocials).where(eq(userSocials.userId, ids.counterpartId));
+
+    const { code } = await mintConnectLink({
+      userId: ids.userId,
+      opportunityId: ids.opportunityId,
+      kind: 'connect',
+      preferredSurface: 'telegram',
+    });
+
+    const controller = new ConnectLinkController();
+    const res = await controller.go(new Request(`http://test/c/${code}/go`), null, { code });
+    const body = await (res as Response).json() as { url: string };
+
+    expect(body.url).toContain(`${FRONTEND_URL}/u/${ids.counterpartId}/chat`);
+  });
+
+  test('preferredSurface=null + target has TG → web URL (behavior change)', async () => {
+    await db.insert(userSocials).values({
+      userId: ids.counterpartId,
+      label: 'telegram',
+      value: 'counterpart_handle',
+    }).onConflictDoNothing();
+
+    const { code } = await mintConnectLink({
+      userId: ids.userId,
+      opportunityId: ids.opportunityId,
+      kind: 'connect',
+      // preferredSurface omitted — should persist as NULL
+    });
+
+    const controller = new ConnectLinkController();
+    const res = await controller.go(new Request(`http://test/c/${code}/go`), null, { code });
+    const body = await (res as Response).json() as { url: string };
+
+    expect(body.url).not.toMatch(/^https:\/\/t\.me/);
+    expect(body.url).toContain(`${FRONTEND_URL}/u/${ids.counterpartId}/chat`);
+  });
+});
+```
+
+> Notes: between tests the `mintConnectLink` is idempotent for `(opportunityId, userId, kind)` — to mint a *fresh* row with a different surface for the same opportunity you must either delete the prior row or use a different `kind` per test. The cleanest approach is to delete the row by user+opportunity+kind in each test's setup. Adapt the fixtures accordingly.
+
+- [ ] **Step 3: Run the test and verify the failing cases fail for the right reason**
+
+```bash
+cd backend
+bun test tests/connect-link.surface.test.ts
+```
+
+Expected: tests pass if Tasks 2-4 were implemented correctly. If they fail, fix the implementation — do not weaken the test.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/connect-link.surface.test.ts
+git commit -m "test(connect-link): integration tests for surface-aware redirect"
+```
+
+---
+
+## Task 6: Protocol — extend `McpAuthResolver` return type
+
+The protocol-layer interface for the auth resolver needs to carry `clientSurface` so the MCP server can read it from the identity.
+
+**Files:**
+- Modify: `packages/protocol/src/shared/interfaces/auth.interface.ts`
+
+- [ ] **Step 1: Extend the return type**
+
+Open `packages/protocol/src/shared/interfaces/auth.interface.ts`. Replace the `resolveIdentity` declaration with:
+
+```ts
+  /**
+   * Extracts and validates the authenticated identity from the request.
+   *
+   * @param request - The incoming HTTP request
+   * @returns The authenticated user's UUID, optional agent UUID, auth method,
+   *   `networkScopeId` if the caller's API key is bound to a network-scoped
+   *   agent, and `clientSurface` declaring which kind of UI is rendering the
+   *   MCP response (drives connect-link redirect choice at click time).
+   *
+   *   When `networkScopeId` is set, the MCP server clamps `indexScope` to that
+   *   single network plus the user's personal index — every downstream tool
+   *   then operates against that clamped scope.
+   *
+   *   `isSessionAuth` is true for OAuth/JWT bearer sessions — the agent-
+   *   registration gate in the MCP server is skipped for these callers.
+   *
+   *   `clientSurface` is read from the `x-index-surface` request header by the
+   *   backend implementation. Absent or unknown values collapse to `'web'`.
+   *   Only `'telegram'` activates the t.me redirect path on `/c/{code}` clicks.
+   *
+   * @throws Error if authentication fails (no token, invalid token, etc.)
+   */
+  resolveIdentity(request: Request): Promise<{
+    userId: string;
+    agentId?: string;
+    isSessionAuth?: boolean;
+    networkScopeId?: string | null;
+    clientSurface?: 'telegram' | 'web';
+  }>;
+```
+
+- [ ] **Step 2: Rebuild the protocol package**
+
+```bash
+cd packages/protocol
+bun run build
+```
+
+Expected: no errors. (Errors at this point would be unrelated downstream type issues — fix them only if directly caused by this change.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd ../..
+git add packages/protocol/src/shared/interfaces/auth.interface.ts
+git commit -m "feat(protocol): add clientSurface to McpAuthResolver identity
+
+Optional 'telegram' | 'web' field declares the receiver's rendering surface.
+Backend reads it from the x-index-surface request header. Absent in legacy
+implementations — treated as 'web' downstream."
+```
+
+---
+
+## Task 7: Protocol — extend `MintConnectLink` interface
+
+The interface that protocol tools call to mint connect links.
+
+**Files:**
+- Modify: `packages/protocol/src/shared/interfaces/connect-link.interface.ts`
+
+- [ ] **Step 1: Extend the call signature**
+
+Open `packages/protocol/src/shared/interfaces/connect-link.interface.ts`. Replace the interface with:
+
+```ts
+/**
+ * Kind of connect link being minted. Determines the action endpoint the short
+ * URL eventually redirects to (per-status: pending+introducer ->
+ * approve_introduction, accepted -> outreach, otherwise -> connect).
+ */
+export type ConnectLinkKind = 'connect' | 'approve_introduction' | 'outreach';
+
+/**
+ * Mints (or reuses) a short link for the given recipient and kind, snapshotting
+ * the greeting and the caller's preferred surface onto the link record. Returns
+ * the full public URL.
+ *
+ * `preferredSurface` is stamped onto the row at insert time and drives the
+ * click-time redirect on `/c/{code}/go`: only `'telegram'` activates the t.me
+ * deep-link path; everything else (including `undefined`, persisted as NULL)
+ * routes to the web frontend chat URL.
+ */
+export interface MintConnectLink {
+  (args: {
+    userId: string;
+    opportunityId: string;
+    kind: ConnectLinkKind;
+    greeting?: string | null;
+    preferredSurface?: 'telegram' | 'web';
+  }): Promise<{ url: string }>;
+}
+```
+
+- [ ] **Step 2: Rebuild the protocol package**
+
+```bash
+cd packages/protocol
+bun run build
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd ../..
+git add packages/protocol/src/shared/interfaces/connect-link.interface.ts
+git commit -m "feat(protocol): add preferredSurface to MintConnectLink args"
+```
+
+---
+
+## Task 8: Protocol — add `clientSurface` to `ResolvedToolContext`
+
+The per-request context object that tool handlers receive needs to carry the surface so call sites can forward it.
+
+**Files:**
+- Modify: `packages/protocol/src/shared/agent/tool.helpers.ts` (around line 73-76)
+
+- [ ] **Step 1: Extend `ResolvedToolContext`**
+
+Open `packages/protocol/src/shared/agent/tool.helpers.ts`. In the `ResolvedToolContext` interface (line 47-77), after the `agentId?: string;` line, add:
+
+```ts
+  /** Agent ID when the request originates from an API key linked to an agent. */
+  agentId?: string;
+  /**
+   * Receiver's rendering surface declared by the MCP client via the
+   * `x-index-surface` request header. `'telegram'` means the MCP response is
+   * being rendered inside a Telegram chat (today, only EdgeClaw); anything
+   * else (including `undefined`) is treated as web. Forwarded into
+   * `mintConnectLink` so the click-time redirect can branch.
+   */
+  clientSurface?: 'telegram' | 'web';
+}
+```
+
+- [ ] **Step 2: Rebuild the protocol package**
+
+```bash
+cd packages/protocol
+bun run build
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd ../..
+git add packages/protocol/src/shared/agent/tool.helpers.ts
+git commit -m "feat(protocol): add clientSurface to ResolvedToolContext"
+```
+
+---
+
+## Task 9: Protocol — thread `clientSurface` from identity into context in `mcp.server.ts`
+
+**Files:**
+- Modify: `packages/protocol/src/mcp/mcp.server.ts` (around line 284-298)
+
+- [ ] **Step 1: Destructure `clientSurface` from the identity and stamp it on the context**
+
+Open `packages/protocol/src/mcp/mcp.server.ts`. Find the block around line 284:
+
+```ts
+          const { userId, agentId, isSessionAuth, networkScopeId } = await authResolver.resolveIdentity(httpReq);
+
+          // Resolve chat context for the user (mark as MCP — no interactive UI available)
+          const context = await resolveChatContext({ database: deps.database, userId });
+          context.isMcp = true;
+          if (agentId) {
+            context.agentId = agentId;
+          }
+```
+
+Replace with:
+
+```ts
+          const { userId, agentId, isSessionAuth, networkScopeId, clientSurface } = await authResolver.resolveIdentity(httpReq);
+
+          // Resolve chat context for the user (mark as MCP — no interactive UI available)
+          const context = await resolveChatContext({ database: deps.database, userId });
+          context.isMcp = true;
+          if (agentId) {
+            context.agentId = agentId;
+          }
+          if (clientSurface) {
+            context.clientSurface = clientSurface;
+          }
+```
+
+- [ ] **Step 2: Rebuild the protocol package**
+
+```bash
+cd packages/protocol
+bun run build
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd ../..
+git add packages/protocol/src/mcp/mcp.server.ts
+git commit -m "feat(protocol): thread clientSurface from identity into ToolContext"
+```
+
+---
+
+## Task 10: Protocol — `attachActionableLinks` forwards `preferredSurface`
+
+Three call sites pass `context.clientSurface` through.
+
+**Files:**
+- Modify: `packages/protocol/src/opportunity/opportunity.tools.ts` (line 92-145, 751-764, 1037-1054, 1326-1341)
+
+- [ ] **Step 1: Update `attachActionableLinks` to accept and forward `preferredSurface`**
+
+Open `packages/protocol/src/opportunity/opportunity.tools.ts`. In `attachActionableLinks` (line 92), extend `opts`:
+
+```ts
+export async function attachActionableLinks(
+  card: Record<string, unknown> & {
+    opportunityId: string;
+    viewerRole: string;
+    status: string;
+  },
+  opts: {
+    viewerId: string;
+    viewerApproved?: boolean;
+    counterpartUser:
+      | { socials?: Array<{ label?: string | null; value?: string | null }> | null }
+      | null
+      | undefined;
+    counterpartUserId: string;
+    mintConnectLink: NonNullable<ToolDeps["mintConnectLink"]>;
+    frontendUrl: string | undefined;
+    preferredSurface?: 'telegram' | 'web';
+  },
+): Promise<void> {
+```
+
+Forward it in the `mintConnectLink` call (line 125):
+
+```ts
+  try {
+    const { url } = await opts.mintConnectLink({
+      userId: opts.viewerId,
+      opportunityId: card.opportunityId,
+      kind,
+      greeting: null,
+      preferredSurface: opts.preferredSurface,
+    });
+```
+
+- [ ] **Step 2: Update the three call sites to pass `context.clientSurface`**
+
+**Call site 1 — line 751-764.** Change:
+
+```ts
+        if (context.isMcp && deps.mintConnectLink) {
+          await attachActionableLinks(cardData as Record<string, unknown> & {
+            opportunityId: string;
+            viewerRole: string;
+            status: string;
+          }, {
+            viewerId: context.userId,
+            viewerApproved: false,
+            counterpartUser,
+            counterpartUserId: firstPartyId,
+            mintConnectLink: deps.mintConnectLink,
+            frontendUrl: deps.frontendUrl,
+            preferredSurface: context.clientSurface,
+          });
+        }
+```
+
+**Call site 2 — line 1037-1052.** Find the block and add `preferredSurface: context.clientSurface,` inside the `opts` object passed to `attachActionableLinks`. (The block iterates per-card via `Promise.all`; preserve the `mintConnectLink = deps.mintConnectLink;` capture line so closure semantics are unchanged.)
+
+**Call site 3 — line 1326-1341.** Same — add `preferredSurface: context.clientSurface,` to the `opts` object.
+
+Read each call site fully before editing — the `await attachActionableLinks(...)` call structure should be obvious; the only change is the new prop.
+
+- [ ] **Step 3: Rebuild the protocol package**
+
+```bash
+cd packages/protocol
+bun run build
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd ../..
+git add packages/protocol/src/opportunity/opportunity.tools.ts
+git commit -m "feat(protocol): forward clientSurface into mintConnectLink calls"
+```
+
+---
+
+## Task 11: Protocol — extend `tool.factory.spec.ts` to assert surface forwarding
+
+The existing test at `tool.factory.spec.ts:2004` (`"invokes deps.mintConnectLink and surfaces the returned URL as acceptUrl"`) confirms the mint function is called. Extend it to also assert `preferredSurface` is forwarded when set on the context.
+
+**Files:**
+- Modify: `packages/protocol/src/shared/agent/tests/tool.factory.spec.ts`
+
+- [ ] **Step 1: Read the existing test to understand the fixture shape**
+
+```bash
+sed -n '2000,2050p' packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
+```
+
+The test invokes `mintConnectLink` via the tool registry. Note how the captured call args are shaped — you will assert the new field on the same captured args.
+
+- [ ] **Step 2: Add a new test below the existing one**
+
+In `tool.factory.spec.ts` immediately after the existing `"invokes deps.mintConnectLink..."` test (around line 2040), add:
+
+```ts
+  test("forwards preferredSurface from context.clientSurface into mintConnectLink", async () => {
+    let captured: { preferredSurface?: 'telegram' | 'web' } | null = null;
+    const mintConnectLink = async (args: {
+      userId: string;
+      opportunityId: string;
+      kind: string;
+      greeting?: string | null;
+      preferredSurface?: 'telegram' | 'web';
+    }) => {
+      captured = args;
+      return { url: 'https://test/c/ABC1234567' };
+    };
+
+    // Reuse the same fixture shape as the test directly above this one,
+    // but set context.clientSurface = 'telegram' before invoking the tool.
+    // ... (adapt fixture setup from the existing test)
+
+    expect(captured).not.toBeNull();
+    expect(captured!.preferredSurface).toBe('telegram');
+  });
+```
+
+Adapt the fixture setup to match the existing test's invocation pattern — the key delta is setting `context.clientSurface = 'telegram'` on the resolved context before invoking the tool.
+
+- [ ] **Step 3: Run the test**
+
+```bash
+cd packages/protocol
+bun test src/shared/agent/tests/tool.factory.spec.ts
+```
+
+Expected: existing tests still pass; the new test passes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd ../..
+git add packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
+git commit -m "test(protocol): assert clientSurface flows into mintConnectLink args"
+```
+
+---
+
+## Task 12: Backend — wire `parseClientSurface` into `authResolver` and forward to `mintConnectLinkSvc`
+
+This is the integration point: backend reads the header, returns `clientSurface` from `resolveIdentity`, and the inline `mintConnectLink` adapter passes `preferredSurface` to the service from Task 3.
+
+**Files:**
+- Modify: `backend/src/controllers/mcp.controller.ts`
+
+- [ ] **Step 1: Update the inline `mintConnectLink` adapter (line 62-72)**
+
+Open `backend/src/controllers/mcp.controller.ts`. Find the inline adapter:
+
+```ts
+const mintConnectLink = async ({ userId, opportunityId, kind, greeting }: {
+  userId: string;
+  opportunityId: string;
+  kind: ConnectLinkKind;
+  greeting?: string | null;
+}): Promise<{ url: string }> => {
+  const { code } = await mintConnectLinkSvc({ userId, opportunityId, kind, greeting });
+  return { url: buildConnectShortUrl(BASE_URL, code) };
+};
+```
+
+Replace with:
+
+```ts
+const mintConnectLink = async ({ userId, opportunityId, kind, greeting, preferredSurface }: {
+  userId: string;
+  opportunityId: string;
+  kind: ConnectLinkKind;
+  greeting?: string | null;
+  preferredSurface?: 'telegram' | 'web';
+}): Promise<{ url: string }> => {
+  const { code } = await mintConnectLinkSvc({ userId, opportunityId, kind, greeting, preferredSurface });
+  return { url: buildConnectShortUrl(BASE_URL, code) };
+};
+```
+
+- [ ] **Step 2: Read the header at the top of `authResolver.resolveIdentity` and return `clientSurface` on every success path**
+
+In `authResolver.resolveIdentity` (around line 183), capture the header value at the top of the function:
+
+```ts
+  async resolveIdentity(request: Request): Promise<{ userId: string; agentId?: string; isSessionAuth?: boolean; networkScopeId?: string | null; clientSurface?: 'telegram' | 'web' }> {
+    const clientSurface = parseClientSurface(request.headers.get('x-index-surface'));
+
+    // ...existing bearer-token branch...
+```
+
+Then in **every** `return { ... }` that yields a successful identity — there are four of them — add `clientSurface` to the returned object:
+
+- Line ~197 (JWT bearer with `payload.id`):
+  ```ts
+  if (typeof payload.id === 'string') return { userId: payload.id, isSessionAuth: true, networkScopeId: null, clientSurface };
+  ```
+- Line ~198 (JWT bearer with `payload.sub`):
+  ```ts
+  if (typeof payload.sub === 'string') return { userId: payload.sub, isSessionAuth: true, networkScopeId: null, clientSurface };
+  ```
+- Line ~217 (session lookup success):
+  ```ts
+  if (data?.userId) return { userId: data.userId, isSessionAuth: true, networkScopeId: null, clientSurface };
+  ```
+- Line ~279-283 (API-key path with valid row):
+  ```ts
+  return {
+    userId,
+    ...(metadata.agentId ? { agentId: metadata.agentId } : {}),
+    networkScopeId,
+    clientSurface,
+  };
+  ```
+- Line ~288 (fallback to `sessionUserId` after API-key DB miss):
+  ```ts
+  return { userId: sessionUserId, networkScopeId: null, clientSurface };
+  ```
+
+- [ ] **Step 3: Update the `resolveIdentity` return type at the protocol interface implementation site**
+
+The interface from Task 6 now requires `clientSurface?`. Confirm `authResolver` still satisfies `McpAuthResolver` by running tsc:
+
+```bash
+cd backend
+bunx tsc --noEmit -p .
+```
+
+Expected: no errors. Common failure mode is a missing `clientSurface` on one of the success paths — fix any that you missed.
+
+- [ ] **Step 4: Smoke-test the wire path end to end**
+
+Start the backend dev server in one terminal:
+
+```bash
+cd backend
+bun run dev
+```
+
+In another terminal, with a valid API key in `$API_KEY` (e.g. one from your local dev DB):
+
+```bash
+curl -s -X POST http://localhost:3001/mcp \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $API_KEY" \
+  -H "x-index-surface: telegram" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | head -50
+```
+
+Expected: response includes a list of tools (no auth error). The header is non-load-bearing for `tools/list`, but this confirms the request is accepted with the new header present.
+
+Stop the dev server.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/controllers/mcp.controller.ts
+git commit -m "feat(mcp): plumb x-index-surface header through auth identity
+
+authResolver.resolveIdentity reads x-index-surface, normalizes via
+parseClientSurface, and returns clientSurface on every success path. The
+inline mintConnectLink adapter forwards preferredSurface to
+mintConnectLinkSvc so the connect_links row is stamped at mint time."
+```
+
+---
+
+## Task 13: EdgeClaw — declare the surface header at install time
+
+The entire EdgeClaw change is one extra header entry.
+
+**Files:**
+- Modify: `packages/edgeclaw/install/install_index.ts` (line 43-53)
+
+- [ ] **Step 1: Update `writeMcpServerEntry`**
+
+Open `packages/edgeclaw/install/install_index.ts`. Replace `writeMcpServerEntry`:
+
+```ts
+function writeMcpServerEntry(apiKey: string): void {
+  const mcpEntry = JSON.stringify({
+    url: PROTOCOL_MCP_URL,
+    transport: "streamable-http",
+    headers: {
+      "x-api-key": apiKey,
+      "x-index-surface": "telegram",
+    },
+  });
+  console.log("→ writing mcp.servers.index");
+  execSync(`openclaw config set mcp.servers.index '${mcpEntry}' --strict-json`, {
+    stdio: ["ignore", "ignore", "inherit"],
+  });
+}
+```
+
+- [ ] **Step 2: Type-check the package**
+
+```bash
+cd packages/edgeclaw
+bunx tsc --noEmit -p . 2>/dev/null || true
+```
+
+Expected: no errors (or this package has no tsconfig — skip with no concern).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd ../..
+git add packages/edgeclaw/install/install_index.ts
+git commit -m "feat(edgeclaw): declare x-index-surface: telegram in MCP entry"
+```
+
+---
+
+## Task 14: Version bumps + finishing checks
+
+Per `CLAUDE.md` finishing-a-branch checklist.
+
+- [ ] **Step 1: Bump `@indexnetwork/protocol` version**
+
+Public-interface changes (`McpAuthResolver`, `MintConnectLink`, `ResolvedToolContext`) are additive and optional — minor bump.
+
+```bash
+cd packages/protocol
+# current: 0.30.8 → 0.31.0
+bun --print "
+import { readFileSync, writeFileSync } from 'fs';
+const p = JSON.parse(readFileSync('package.json', 'utf8'));
+const [maj, min] = p.version.split('.').map(Number);
+p.version = \`\${maj}.\${min + 1}.0\`;
+writeFileSync('package.json', JSON.stringify(p, null, 2) + '\n');
+console.log('Bumped protocol →', p.version);
+"
+```
+
+- [ ] **Step 2: Bump `packages/edgeclaw/package.json`**
+
+Patch bump (consumer change only, no public-interface change).
+
+```bash
+cd ../edgeclaw
+bun --print "
+import { readFileSync, writeFileSync } from 'fs';
+const p = JSON.parse(readFileSync('package.json', 'utf8'));
+const [maj, min, patch] = p.version.split('.').map(Number);
+p.version = \`\${maj}.\${min}.\${patch + 1}\`;
+writeFileSync('package.json', JSON.stringify(p, null, 2) + '\n');
+console.log('Bumped edgeclaw →', p.version);
+"
+cd ../..
+```
+
+- [ ] **Step 3: Run protocol tests + lint**
+
+```bash
+cd packages/protocol
+bun test src/shared/agent/tests/tool.factory.spec.ts
+cd ../..
+```
+
+Expected: all pass (including the new test from Task 11).
+
+- [ ] **Step 4: Run backend tests for the affected files**
+
+```bash
+cd backend
+bun test src/controllers/tests/mcp-surface.test.ts
+bun test tests/connect-link.surface.test.ts
+bun run lint
+cd ..
+```
+
+Expected: all pass; lint clean.
+
+- [ ] **Step 5: Final type-check both packages**
+
+```bash
+cd backend && bunx tsc --noEmit -p . && cd ..
+cd packages/protocol && bunx tsc --noEmit -p . && cd ../..
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit version bumps**
+
+```bash
+git add packages/protocol/package.json packages/edgeclaw/package.json
+git commit -m "chore(release): bump protocol→0.31.0, edgeclaw patch"
+```
+
+- [ ] **Step 7: Push branch and open PR**
+
+```bash
+git push -u origin yanki/ind-303-mcp-surface-header
+gh pr create --title "feat(mcp): per-request surface header for connect-link redirects (IND-303)" --body "$(cat <<'EOF'
+## Summary
+
+- New per-request `x-index-surface: telegram | web` MCP header. Absent or unknown → `web` (the new default).
+- `connect_links.preferred_surface` persisted at mint time; rotated on expired-row rotation; first mint wins for un-expired reuse.
+- `/c/{code}/go` click handler branches `connect` and `outreach` kinds on the persisted surface.
+- EdgeClaw declares `x-index-surface: telegram` in `install_index.ts`. No other client wired in this slice.
+
+## Behavior change
+
+Non-EdgeClaw callers currently receive a `t.me/...` URL whenever the target has a Telegram handle. After this ships, they receive the web frontend chat URL instead. This is the deliberate strict reading of "Telegram redirect happens only when the receiver is on Telegram."
+
+Pre-rollout `connect_links` rows have `preferred_surface = NULL` and now redirect to web. Acceptable trade-off given the 30-day TTL.
+
+## Test plan
+
+- [ ] `cd backend && bun test src/controllers/tests/mcp-surface.test.ts` — parseClientSurface unit tests
+- [ ] `cd backend && bun test tests/connect-link.surface.test.ts` — three click-time matrices
+- [ ] `cd packages/protocol && bun test src/shared/agent/tests/tool.factory.spec.ts` — surface forwarding through tool factory
+- [ ] Local smoke: start dev server, hit MCP with `x-index-surface: telegram` and confirm a minted link's `connect_links.preferred_surface = 'telegram'` in the DB
+
+## Linear
+
+Closes IND-303.
+
+## Files
+
+Spec: `docs/superpowers/specs/2026-05-15-mcp-surface-header-design.md`
+EOF
+)"
+```
+
+- [ ] **Step 8: Request a Copilot review**
+
+```bash
+gh pr edit $(gh pr view --json number -q .number) --add-reviewer @copilot
+```
+
+---
+
+## Cleanup after merge
+
+(Per `CLAUDE.md` finishing-a-branch step 7.) After PR merge into `dev`:
+
+- [ ] Delete the Linear-suggested branch locally and remotely: `git branch -D yanki/ind-303-mcp-surface-header && git push origin --delete yanki/ind-303-mcp-surface-header`
+- [ ] Remove the worktree: `git worktree remove .worktrees/ind-303-mcp-surface-header`
+- [ ] Delete `docs/superpowers/plans/2026-05-15-mcp-surface-header.md` and `docs/superpowers/specs/2026-05-15-mcp-surface-header-design.md` (per the finishing-a-branch checklist: delete superpowers plans/specs after the branch ships).

--- a/packages/edgeclaw/install/install_index.ts
+++ b/packages/edgeclaw/install/install_index.ts
@@ -44,7 +44,10 @@ function writeMcpServerEntry(apiKey: string): void {
   const mcpEntry = JSON.stringify({
     url: PROTOCOL_MCP_URL,
     transport: "streamable-http",
-    headers: { "x-api-key": apiKey },
+    headers: {
+      "x-api-key": apiKey,
+      "x-index-surface": "telegram",
+    },
   });
   console.log("→ writing mcp.servers.index");
   execSync(`openclaw config set mcp.servers.index '${mcpEntry}' --strict-json`, {

--- a/packages/edgeclaw/package.json
+++ b/packages/edgeclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge-city/edgeclaw",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Agent Village workspace and installer for Edge Esmeralda — on-device agent that surfaces connections and runs discovery on the Index protocol.",
   "license": "MIT",
   "type": "module",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/mcp/mcp.server.ts
+++ b/packages/protocol/src/mcp/mcp.server.ts
@@ -280,14 +280,17 @@ export function createMcpServer(
             };
           }
 
-          // Resolve authenticated identity (userId + optional agentId + optional network scope)
-          const { userId, agentId, isSessionAuth, networkScopeId } = await authResolver.resolveIdentity(httpReq);
+          // Resolve authenticated identity (userId + optional agentId + optional network scope + optional surface)
+          const { userId, agentId, isSessionAuth, networkScopeId, clientSurface } = await authResolver.resolveIdentity(httpReq);
 
           // Resolve chat context for the user (mark as MCP — no interactive UI available)
           const context = await resolveChatContext({ database: deps.database, userId });
           context.isMcp = true;
           if (agentId) {
             context.agentId = agentId;
+          }
+          if (clientSurface) {
+            context.clientSurface = clientSurface;
           }
 
           // Network-scoped agents inherit their bound network as the implicit chat

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -105,6 +105,7 @@ export async function attachActionableLinks(
     counterpartUserId: string;
     mintConnectLink: NonNullable<ToolDeps["mintConnectLink"]>;
     frontendUrl: string | undefined;
+    preferredSurface?: 'telegram' | 'web';
   },
 ): Promise<void> {
   const kind = resolveActionableLinkKind({
@@ -127,6 +128,7 @@ export async function attachActionableLinks(
       opportunityId: card.opportunityId,
       kind,
       greeting: null,
+      preferredSurface: opts.preferredSurface,
     });
     card.acceptUrl = url;
     card.feedCategory = card.viewerRole === "introducer" ? "connector-flow" : "connection";
@@ -760,6 +762,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
             counterpartUserId: firstPartyId,
             mintConnectLink: deps.mintConnectLink,
             frontendUrl: deps.frontendUrl,
+            preferredSurface: context.clientSurface,
           });
         }
 
@@ -1049,6 +1052,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
               counterpartUserId: source?.userId ?? card.userId,
               mintConnectLink,
               frontendUrl: deps.frontendUrl,
+              preferredSurface: context.clientSurface,
             });
           }),
         );
@@ -1338,6 +1342,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
               counterpartUserId,
               mintConnectLink: deps.mintConnectLink,
               frontendUrl: deps.frontendUrl,
+              preferredSurface: context.clientSurface,
             });
           }
 

--- a/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
+++ b/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
@@ -2002,9 +2002,27 @@ describe("createChatTools — MCP connect-link wiring", () => {
   }
 
   test("invokes deps.mintConnectLink and surfaces the returned URL as acceptUrl", async () => {
-    const mintCalls: Array<{ userId: string; opportunityId: string; kind: string; greeting: string | null | undefined }> = [];
-    const mintConnectLink = async (args: { userId: string; opportunityId: string; kind: string; greeting?: string | null }) => {
-      mintCalls.push({ userId: args.userId, opportunityId: args.opportunityId, kind: args.kind, greeting: args.greeting ?? null });
+    const mintCalls: Array<{
+      userId: string;
+      opportunityId: string;
+      kind: string;
+      greeting: string | null | undefined;
+      preferredSurface: 'telegram' | 'web' | undefined;
+    }> = [];
+    const mintConnectLink = async (args: {
+      userId: string;
+      opportunityId: string;
+      kind: string;
+      greeting?: string | null;
+      preferredSurface?: 'telegram' | 'web';
+    }) => {
+      mintCalls.push({
+        userId: args.userId,
+        opportunityId: args.opportunityId,
+        kind: args.kind,
+        greeting: args.greeting ?? null,
+        preferredSurface: args.preferredSurface,
+      });
       return { url: FAKE_URL };
     };
 
@@ -2044,6 +2062,63 @@ describe("createChatTools — MCP connect-link wiring", () => {
     // profileUrl is always ${frontendUrl}/u/<id>?link_preview=false (IND-289).
     // Catches frontendUrl-forwarding regressions.
     expect(parsed.data.message).toContain(`profileUrl: ${FRONTEND_URL}/u/${COUNTERPART_ID}?link_preview=false`);
+  });
+
+  test("forwards context.clientSurface as preferredSurface into deps.mintConnectLink", async () => {
+    const mintCalls: Array<{
+      userId: string;
+      opportunityId: string;
+      kind: string;
+      greeting: string | null | undefined;
+      preferredSurface: 'telegram' | 'web' | undefined;
+    }> = [];
+    const mintConnectLink = async (args: {
+      userId: string;
+      opportunityId: string;
+      kind: string;
+      greeting?: string | null;
+      preferredSurface?: 'telegram' | 'web';
+    }) => {
+      mintCalls.push({
+        userId: args.userId,
+        opportunityId: args.opportunityId,
+        kind: args.kind,
+        greeting: args.greeting ?? null,
+        preferredSurface: args.preferredSurface,
+      });
+      return { url: FAKE_URL };
+    };
+
+    const context: ToolContext = {
+      userId: VIEWER_ID,
+      database: buildMcpDb(),
+      embedder: mockEmbedder,
+      scraper: mockScraper,
+      ...mockProtocolDeps,
+      mintConnectLink,
+      apiBaseUrl: API_BASE_URL,
+      frontendUrl: FRONTEND_URL,
+    } as ToolContext;
+
+    // Reuse the standard MCP resolved context but stamp clientSurface on it.
+    const resolved = buildMcpResolvedContext();
+    resolved.clientSurface = 'telegram';
+
+    const tools = await createChatTools(context, resolved);
+    const listTool = tools.find((t: { name: string }) => t.name === "list_opportunities") as { invoke: (args: unknown) => Promise<string> };
+    expect(listTool).toBeDefined();
+
+    const raw = await listTool.invoke({});
+    const parsed = JSON.parse(raw);
+    expect(parsed.success).toBe(true);
+
+    expect(mintCalls.length).toBe(1);
+    expect(mintCalls[0]).toMatchObject({
+      userId: VIEWER_ID,
+      opportunityId: OPP_ID,
+      kind: "connect",
+      preferredSurface: 'telegram',
+    });
   });
 
   test("skips minting silently when deps.mintConnectLink is not provided", async () => {

--- a/packages/protocol/src/shared/agent/tool.helpers.ts
+++ b/packages/protocol/src/shared/agent/tool.helpers.ts
@@ -75,6 +75,14 @@ export interface ResolvedToolContext {
   isMcp?: boolean;
   /** Agent ID when the request originates from an API key linked to an agent. */
   agentId?: string;
+  /**
+   * Receiver's rendering surface declared by the MCP client via the
+   * `x-index-surface` request header. `'telegram'` means the MCP response is
+   * being rendered inside a Telegram chat (today, only EdgeClaw); anything
+   * else (including `undefined`) is treated as web. Forwarded into
+   * `mintConnectLink` so the click-time redirect can branch.
+   */
+  clientSurface?: 'telegram' | 'web';
 }
 
 /**

--- a/packages/protocol/src/shared/interfaces/auth.interface.ts
+++ b/packages/protocol/src/shared/interfaces/auth.interface.ts
@@ -6,14 +6,24 @@
 export interface McpAuthResolver {
   /**
    * Extracts and validates the authenticated identity from the request.
+   *
    * @param request - The incoming HTTP request
    * @returns The authenticated user's UUID, optional agent UUID, auth method,
-   *   and `networkScopeId` if the caller's API key is bound to a network-scoped
-   *   agent. When set, the MCP server clamps `indexScope` to that single network
-   *   plus the user's personal index — every downstream tool then operates
-   *   against that clamped scope.
-   *   `isSessionAuth` is true for OAuth/JWT bearer sessions — the agent-registration
-   *   gate in the MCP server is skipped for these callers.
+   *   `networkScopeId` if the caller's API key is bound to a network-scoped
+   *   agent, and `clientSurface` declaring which kind of UI is rendering the
+   *   MCP response (drives connect-link redirect choice at click time).
+   *
+   *   When `networkScopeId` is set, the MCP server clamps `indexScope` to that
+   *   single network plus the user's personal index — every downstream tool
+   *   then operates against that clamped scope.
+   *
+   *   `isSessionAuth` is true for OAuth/JWT bearer sessions — the agent-
+   *   registration gate in the MCP server is skipped for these callers.
+   *
+   *   `clientSurface` is read from the `x-index-surface` request header by the
+   *   backend implementation. Absent or unknown values collapse to `'web'`.
+   *   Only `'telegram'` activates the t.me redirect path on `/c/{code}` clicks.
+   *
    * @throws Error if authentication fails (no token, invalid token, etc.)
    */
   resolveIdentity(request: Request): Promise<{
@@ -21,6 +31,7 @@ export interface McpAuthResolver {
     agentId?: string;
     isSessionAuth?: boolean;
     networkScopeId?: string | null;
+    clientSurface?: 'telegram' | 'web';
   }>;
 
   /**

--- a/packages/protocol/src/shared/interfaces/connect-link.interface.ts
+++ b/packages/protocol/src/shared/interfaces/connect-link.interface.ts
@@ -7,7 +7,13 @@ export type ConnectLinkKind = 'connect' | 'approve_introduction' | 'outreach';
 
 /**
  * Mints (or reuses) a short link for the given recipient and kind, snapshotting
- * the greeting onto the link record. Returns the full public URL.
+ * the greeting and the caller's preferred surface onto the link record. Returns
+ * the full public URL.
+ *
+ * `preferredSurface` is stamped onto the row at insert time and drives the
+ * click-time redirect on `/c/{code}/go`: only `'telegram'` activates the t.me
+ * deep-link path; everything else (including `undefined`, persisted as NULL)
+ * routes to the web frontend chat URL.
  */
 export interface MintConnectLink {
   (args: {
@@ -15,5 +21,6 @@ export interface MintConnectLink {
     opportunityId: string;
     kind: ConnectLinkKind;
     greeting?: string | null;
+    preferredSurface?: 'telegram' | 'web';
   }): Promise<{ url: string }>;
 }


### PR DESCRIPTION
## Summary

- New per-request `x-index-surface: telegram | web` MCP header. Absent or unknown → `web` (the new default).
- `connect_links.preferred_surface` persisted at mint time; rotated on expired-row rotation; first mint wins for un-expired reuse.
- `/c/{code}/go` click handler branches `connect` and `outreach` kinds on the persisted surface.
- EdgeClaw declares `x-index-surface: telegram` in `install_index.ts`. No other client wired in this slice.

## Behavior change

Non-EdgeClaw callers currently receive a `t.me/...` URL whenever the target has a Telegram handle. After this ships, they receive the web frontend chat URL instead. This is the deliberate strict reading of "Telegram redirect happens only when the receiver is on Telegram." Pre-rollout `connect_links` rows have `preferred_surface = NULL` and now redirect to web. Acceptable trade-off given the 30-day TTL.

## Architecture

```
EdgeClaw MCP call (x-index-surface: telegram)
  ↓ mcp.controller.authResolver → parseClientSurface → identity.clientSurface
  ↓ protocol mcp.server.ts → context.clientSurface
  ↓ opportunity.tools.ts attachActionableLinks → mintConnectLink({ preferredSurface })
  ↓ connect-link.service.ts → connect_links.preferred_surface = 'telegram'
  ↓ /c/{code} returned in MCP response
  ↓ user clicks → GET /c/{code}/go → resolveConnectLink reads preferred_surface
  ↓ telegram + handle → t.me/{handle}?text=...
  ↓ telegram + no handle → web fallback
  ↓ web / NULL → web URL
```

## Test plan

- [x] `bun test src/controllers/tests/mcp-surface.test.ts` — 8 unit tests for `parseClientSurface`
- [x] `bun test tests/connect-link.surface.test.ts` — 3 integration tests for the three click-time matrices
- [x] `cd packages/protocol && bun test src/shared/agent/tests/tool.factory.spec.ts -t "forwards context.clientSurface"` — protocol surface forwarding
- [x] `bunx tsc --noEmit` clean in `backend/` and `packages/protocol/`

## Linear

Closes [IND-303](https://linear.app/indexnetwork/issue/IND-303/per-request-surface-header-for-mcp-connect-link-redirects-edgeclaw).

## Spec + plan

- Spec: `docs/superpowers/specs/2026-05-15-mcp-surface-header-design.md`
- Plan: `docs/superpowers/plans/2026-05-15-mcp-surface-header.md`

## Versions

- `@indexnetwork/protocol`: `0.32.0` → `0.33.0` (additive optional fields on public interfaces)
- `@edge-city/edgeclaw`: `0.1.0` → `0.1.1`
