### PR TITLE
feat(edgeclaw): cross-pass dedup for digest + ambient prompts

### DIFF
--- a/docs/superpowers/plans/2026-05-15-edgeclaw-cross-pass-dedup.md
+++ b/docs/superpowers/plans/2026-05-15-edgeclaw-cross-pass-dedup.md
@@ -22,7 +22,7 @@ Files modified by this plan:
 - `packages/edgeclaw/README.md` — one-line update to the row describing `ambient.md`'s dedup.
 - `packages/edgeclaw/package.json` — version bump.
 
-No new files. No deletions.
+This plan's implementation tasks neither add nor delete files — only the five files above are modified. (The spec and plan markdown under `docs/superpowers/` were committed earlier in the workflow and are not in scope here.)
 
 ---
 
@@ -377,4 +377,4 @@ No commit — the verification is the deliverable. If any scenario fails, return
 - [x] Version bump → Task 4.
 - [x] Manual scenario verification → Task 5.
 
-No spec requirements left unaddressed. No tasks reference undefined symbols. Step counts in `ambient.md` (12 = 1 onboarding + 1 read + 1 list + 1 filter + 1 hash + 1 cap + 1 quality + 1 nothing-qualifies + 1 surface + 1 confirm + 1 write — wait, that's 11) — recount in Task 1: steps 1–11, matching the spec. Step counts in `digest.md`: 1–12. Both consistent with the body of each task.
+No spec requirements left unaddressed. No tasks reference undefined symbols. Step counts: `ambient.md` has steps 1–11; `digest.md` has steps 1–12. Both match the bodies of Tasks 1 and 2 respectively.

--- a/packages/edgeclaw/README.md
+++ b/packages/edgeclaw/README.md
@@ -205,8 +205,8 @@ The remaining ambient/accepted/freshness/memory work stays on the heartbeat tick
 | `TOOLS.md` | MCP endpoint, full tool family list, output translation table, channel formatting, URL preservation rule. |
 | `HEARTBEAT.md` | Background tasks that run on the OpenClaw heartbeat tick: accepted opportunities, signal freshness, memory curation. |
 | `prompts/welcome.md` | Self-contained prompt for the welcome pass — used by `BOOTSTRAP.md` Step 6. Self-dedupes via `memory/welcome-state.json` and gates on server-side `onboardingComplete`. |
-| `prompts/digest.md` | Self-contained prompt for the daily 08:00 digest cron. |
-| `prompts/ambient.md` | Self-contained prompt for the 14:00 + 20:00 ambient discovery crons. Selective: max 3 direct + 3 introducer per dispatch, dedup via `memory/heartbeat-state.json:lastAmbientHash`. |
+| `prompts/digest.md` | Self-contained prompt for the daily 08:00 digest cron. Filters against `memory/heartbeat-state.json:deliveredToday` so opportunities already surfaced earlier today are skipped. |
+| `prompts/ambient.md` | Self-contained prompt for the 14:00 + 20:00 ambient discovery crons. Selective: max 3 direct + 3 introducer per dispatch. Dedup: `memory/heartbeat-state.json:lastAmbientHash` (skip pass when the fetched set is unchanged) + `deliveredToday` (drop opportunities already surfaced earlier today by digest or ambient). |
 
 ## Auth
 

--- a/packages/edgeclaw/package.json
+++ b/packages/edgeclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge-city/edgeclaw",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Agent Village workspace and installer for Edge Esmeralda — on-device agent that surfaces connections and runs discovery on the Index protocol.",
   "license": "MIT",
   "type": "module",

--- a/packages/edgeclaw/workspace/TOOLS.md
+++ b/packages/edgeclaw/workspace/TOOLS.md
@@ -48,7 +48,7 @@ Never expose internal IDs unless the ID is actionable (e.g. a `conversationId` t
 ## Local files
 
 - `COMMUNITY.md` — Edge Esmeralda context (dates, attendee count, programming format, design principles). Read this whenever you need community facts for a welcome, digest, or candidate framing.
-- `memory/heartbeat-state.json` — last-run timestamps for heartbeat tasks (so intervals survive restarts) and dedup hashes (e.g. `lastAmbientHash`).
+- `memory/heartbeat-state.json` — last-run timestamps for heartbeat tasks (so intervals survive restarts) and dedup state: `lastAmbientHash` (ambient pass short-circuit) and `deliveredToday` (cross-pass surfaced-IDs list, resets daily; shared by `digest.md` and `ambient.md`).
 - `memory/welcome-state.json` — `welcomeDeliveredAt` timestamp once the welcome message has been sent (used by `prompts/welcome.md` for dedup).
 - `memory/YYYY-MM-DD.md` — daily memory log.
 - `MEMORY.md` — curated long-term memory; **main session only**.

--- a/packages/edgeclaw/workspace/prompts/ambient.md
+++ b/packages/edgeclaw/workspace/prompts/ambient.md
@@ -13,7 +13,7 @@ Calm, direct, analytical, concise. Vocabulary: opportunity, overlap, signal, pat
 
 4. **Filter against dedup state.** Drop any opportunity whose `id` is in the dedup set from step 2. Use this filtered set for every subsequent step (caps, quality bar, hashing, surfacing). If the filtered set is empty, jump to step 11 (write state) and then end your turn.
 
-5. Hash the filtered set's opportunity IDs (the result of step 4, not the raw `list_opportunities` return). Compare against `lastAmbientHash` from step 2. If the hash matches, jump to step 11 (write state, with `lastAmbientHash` unchanged) and end your turn — no new signal since the previous pass.
+5. **Sort the filtered set's opportunity IDs lexicographically, then hash that sorted list** (the result of step 4, not the raw `list_opportunities` return). Sorting is required — without it, the same set of IDs returned in a different order would produce a different hash and bypass this early-exit. Compare against `lastAmbientHash` from step 2. If the hash matches, jump to step 11 (write state, with `lastAmbientHash` unchanged) and end your turn — no new signal since the previous pass.
 
 6. **Per-dispatch cap (the routing rule):**
    - At most **3 direct opportunities** — `feedCategory: "connection"`. The receiver is a party of the opportunity. The opportunity may or may not have an introducer; the only constraint is that the receiver is NOT the introducer. These are people the user might want to reach out to directly.

--- a/packages/edgeclaw/workspace/prompts/ambient.md
+++ b/packages/edgeclaw/workspace/prompts/ambient.md
@@ -7,22 +7,24 @@ Calm, direct, analytical, concise. Vocabulary: opportunity, overlap, signal, pat
 
 1. Call `read_user_profiles()` (no args). If `onboardingComplete` is `false`, end your turn — ambient passes don't run while the user is still onboarding.
 
-2. Call `list_opportunities(status="pending", limit=10)`.
+2. **Read dedup state.** Read `memory/heartbeat-state.json`. Treat a missing file or malformed JSON as `{}`. Resolve `deliveredToday`: if it exists and `deliveredToday.date` equals today's host-local date (`YYYY-MM-DD`), keep `deliveredToday.ids` as the dedup set; otherwise treat the dedup set as empty (the date will roll forward when you write the file back at the end). Also remember `lastAmbientHash` if present — you'll compare against it in step 5.
 
-3. If the response is empty, end your turn.
+3. Call `list_opportunities(status="pending", limit=10)`.
 
-4. Hash the set of returned opportunity IDs. Read `memory/heartbeat-state.json` and compare against `lastAmbientHash`. If the hash matches, end your turn — no new signal since the previous pass.
+4. **Filter against dedup state.** Drop any opportunity whose `id` is in the dedup set from step 2. Use this filtered set for every subsequent step (caps, quality bar, hashing, surfacing). If the filtered set is empty, jump to step 11 (write state) and then end your turn.
 
-5. **Per-dispatch cap (the routing rule):**
+5. Hash the filtered set's opportunity IDs (the result of step 4, not the raw `list_opportunities` return). Compare against `lastAmbientHash` from step 2. If the hash matches, jump to step 11 (write state, with `lastAmbientHash` unchanged) and end your turn — no new signal since the previous pass.
+
+6. **Per-dispatch cap (the routing rule):**
    - At most **3 direct opportunities** — `feedCategory: "connection"`. The receiver is a party of the opportunity. The opportunity may or may not have an introducer; the only constraint is that the receiver is NOT the introducer. These are people the user might want to reach out to directly.
    - At most **3 introducer opportunities** — `feedCategory: "connector-flow"`. The receiver IS the introducer between other parties. These are NOT surfaced as "people to message" — they are surfaced as **community intents the user might know someone for**.
    - If more than 3 of either type qualify, surface the highest-signal ones and let the rest fall to the morning digest.
 
-6. **Quality bar:** a candidate qualifies only when you can write a one-sentence reason that is specific to *this* user's situation and would not read identically for any other user. Generic framings ("interesting profile", "might be useful", "works in a related space") do not qualify; drop them.
+7. **Quality bar:** a candidate qualifies only when you can write a one-sentence reason that is specific to *this* user's situation and would not read identically for any other user. Generic framings ("interesting profile", "might be useful", "works in a related space") do not qualify; drop them.
 
-7. **If nothing qualifies after the bar:** end your turn without calling the `message` tool. Telling the user there's nothing worth interrupting them for is itself an interruption. The morning digest will sweep what's still pending.
+8. **If nothing qualifies after the bar:** jump to step 11 (write state) and end your turn without calling the `message` tool. Telling the user there's nothing worth interrupting them for is itself an interruption. The morning digest will sweep what's still pending.
 
-8. **If at least one qualifies:** send the message via the `message` tool. Compose one or both of the following sections (skip a section that has zero qualifying candidates), mimicking the *Ambient update* exemplar in `AGENTS.md`. Flat prose, inline links — no bullet-list-of-links, no pipe rows, no tables, no link strips.
+9. **If at least one qualifies:** send the message via the `message` tool. Compose one or both of the following sections (skip a section that has zero qualifying candidates), mimicking the *Ambient update* exemplar in `AGENTS.md`. Flat prose, inline links — no bullet-list-of-links, no pipe rows, no tables, no link strips.
 
    **Section A — direct candidates** (only if any direct candidates qualified)
 
@@ -50,9 +52,14 @@ Calm, direct, analytical, concise. Vocabulary: opportunity, overlap, signal, pat
 
    If `totalPending` exceeds the candidates you surfaced, end with: `There are N more conversations waiting for you, let me know if you want to see them.`
 
-9. For every opportunity you mention in the message, call `confirm_opportunity_delivery(opportunityId, trigger="ambient")`. Do NOT confirm for opportunities you skipped.
+10. For every opportunity you mention in the message, call `confirm_opportunity_delivery(opportunityId, trigger="ambient")`. Do NOT confirm for opportunities you skipped.
 
-10. Update `memory/heartbeat-state.json` with the new `lastAmbientHash`. Then end your turn.
+11. **Write dedup state.** Update `memory/heartbeat-state.json` so that:
+    - `deliveredToday.date` = today's host-local `YYYY-MM-DD`.
+    - `deliveredToday.ids` = the dedup set from step 2 ∪ the IDs of every opportunity you surfaced in step 9 (treat as a set; preserve order is not required, no duplicates). If you didn't surface anything (early-exit branches from steps 4, 5, or 8), `ids` is the dedup set from step 2 unchanged.
+    - `lastAmbientHash` = the hash from step 5 if you surfaced a message in step 9; otherwise leave it at whatever value step 2 read (do not overwrite with a stale hash).
+
+    Preserve any other top-level keys in the file. Then end your turn.
 
 # Hard rules
 

--- a/packages/edgeclaw/workspace/prompts/ambient.md
+++ b/packages/edgeclaw/workspace/prompts/ambient.md
@@ -7,7 +7,7 @@ Calm, direct, analytical, concise. Vocabulary: opportunity, overlap, signal, pat
 
 1. Call `read_user_profiles()` (no args). If `onboardingComplete` is `false`, end your turn — ambient passes don't run while the user is still onboarding.
 
-2. **Read dedup state.** Read `memory/heartbeat-state.json`. Treat a missing file or malformed JSON as `{}`. Resolve `deliveredToday`: if it exists and `deliveredToday.date` equals today's host-local date (`YYYY-MM-DD`), keep `deliveredToday.ids` as the dedup set; otherwise treat the dedup set as empty (the date will roll forward when you write the file back at the end). Also remember `lastAmbientHash` if present — you'll compare against it in step 5.
+2. **Read dedup state.** Read `memory/heartbeat-state.json`. Treat a missing file or malformed JSON as `{}`. Resolve the dedup set: if `deliveredToday.date` equals today's host-local date (`YYYY-MM-DD`) AND `deliveredToday.ids` is an array, use that array as the dedup set; in every other case (no `deliveredToday`, date mismatch, missing `ids`, `ids` not an array, any other unexpected shape) treat the dedup set as empty (the date will roll forward when you write the file back at the end). Also remember `lastAmbientHash` if present — you'll compare against it in step 5.
 
 3. Call `list_opportunities(status="pending", limit=10)`.
 

--- a/packages/edgeclaw/workspace/prompts/digest.md
+++ b/packages/edgeclaw/workspace/prompts/digest.md
@@ -6,9 +6,15 @@ Calm, direct, analytical, concise. Vocabulary: opportunity, overlap, signal, pat
 # Job
 Send a morning brief to the user via the `message` tool.
 
-1. Call `list_opportunities(status="pending", limit=10)`.
-2. **If empty:** send via `message` tool: "Quiet night — I'll keep listening." Then end your turn.
-3. **Otherwise** compose the brief in this exact structure (mimic the exemplar):
+1. **Read dedup state.** Read `memory/heartbeat-state.json`. Treat a missing file or malformed JSON as `{}`. Resolve `deliveredToday`: if it exists and `deliveredToday.date` equals today's host-local date (`YYYY-MM-DD`), keep `deliveredToday.ids` as the dedup set; otherwise treat the dedup set as empty (the date will roll forward when you write the file back at the end).
+
+2. Call `list_opportunities(status="pending", limit=10)`.
+
+3. **Filter against dedup state.** Drop any returned opportunity whose `id` is in the dedup set from step 1. Use the filtered set for everything that follows. (Filtering happens before the quality bar so the LLM does not waste evaluation budget on candidates that will be dropped.)
+
+4. **If the filtered set is empty:** send via the `message` tool: "Quiet night — I'll keep listening." Then write `memory/heartbeat-state.json` so that `deliveredToday.date` = today's host-local `YYYY-MM-DD` and `deliveredToday.ids` = the dedup set from step 1 unchanged (preserve `lastAmbientHash` and any other top-level keys). End your turn.
+
+5. **Otherwise** compose the brief in this exact structure (mimic the exemplar):
 
    ```
    🌞 Good morning from Edge Esmeralda
@@ -31,17 +37,23 @@ Send a morning brief to the user via the `message` tool.
    - DO link the person's name to their `profileUrl` (the Index web profile URL — same shape as the direct section).
    - Do NOT link the opportunity — no `acceptUrl`. The trailing `make intro` is plain text, not a hyperlink. The connect/accept link belongs only in the direct (`connection`) section. If the user wants to act on an introducer item, they reply to the agent and the agent handles it next turn.
 
-4. **Quality bar (apply per candidate):** a candidate qualifies only if you can write a one-sentence reason that is specific to *this* user's situation and would not read identically for any other user. Drop generic framings.
+6. **Quality bar (apply per candidate):** a candidate qualifies only if you can write a one-sentence reason that is specific to *this* user's situation and would not read identically for any other user. Drop generic framings.
 
-5. **URL rules:** weave links into prose. The strip-the-URLs test is the rule — if a reader removes every link, the prose still reads coherently. NO bullet-list-of-links, NO link tables, NO action strips, NO blockquote whose body is link labels.
+7. **URL rules:** weave links into prose. The strip-the-URLs test is the rule — if a reader removes every link, the prose still reads coherently. NO bullet-list-of-links, NO link tables, NO action strips, NO blockquote whose body is link labels.
 
-6. **acceptUrl handling (connection candidates only):** Embed `acceptUrl` verbatim on a short verb phrase. The URL is opaque — do not append, encode, or modify any part of it. The backend has already prepared the greeting that will pre-fill the conversation when the user clicks. **`connector-flow` candidates carry no `acceptUrl`** — those trigger an introduction approval, not a direct conversation.
+8. **acceptUrl handling (connection candidates only):** Embed `acceptUrl` verbatim on a short verb phrase. The URL is opaque — do not append, encode, or modify any part of it. The backend has already prepared the greeting that will pre-fill the conversation when the user clicks. **`connector-flow` candidates carry no `acceptUrl`** — those trigger an introduction approval, not a direct conversation.
 
-7. For every opportunity you mention in the brief, call `confirm_opportunity_delivery(opportunityId, trigger="digest")`. Do NOT confirm for opportunities you skipped.
+9. For every opportunity you mention in the brief, call `confirm_opportunity_delivery(opportunityId, trigger="digest")`. Do NOT confirm for opportunities you skipped.
 
-8. If `totalPending` exceeds the candidates you surfaced, end with: `There are N more conversations waiting — let me know if you want to see them.`
+10. If `totalPending` exceeds the candidates you surfaced, end with: `There are N more conversations waiting — let me know if you want to see them.`
 
-9. Send the brief via the `message` tool. After delivery, end your turn.
+11. **Write dedup state.** Update `memory/heartbeat-state.json` so that:
+    - `deliveredToday.date` = today's host-local `YYYY-MM-DD`.
+    - `deliveredToday.ids` = the dedup set from step 1 ∪ the IDs of every opportunity you mentioned in the brief (treat as a set; no duplicates).
+
+    Preserve any other top-level keys (e.g. `lastAmbientHash`).
+
+12. Send the brief via the `message` tool. After delivery, end your turn.
 
 # Hard rules
 - Never invent candidates. If `list_opportunities` returns nothing, the brief is the "Quiet night" line; don't pad.

--- a/packages/edgeclaw/workspace/prompts/digest.md
+++ b/packages/edgeclaw/workspace/prompts/digest.md
@@ -6,13 +6,13 @@ Calm, direct, analytical, concise. Vocabulary: opportunity, overlap, signal, pat
 # Job
 Send a morning brief to the user via the `message` tool.
 
-1. **Read dedup state.** Read `memory/heartbeat-state.json`. Treat a missing file or malformed JSON as `{}`. Resolve `deliveredToday`: if it exists and `deliveredToday.date` equals today's host-local date (`YYYY-MM-DD`), keep `deliveredToday.ids` as the dedup set; otherwise treat the dedup set as empty (the date will roll forward when you write the file back at the end).
+1. **Read dedup state.** Read `memory/heartbeat-state.json`. Treat a missing file or malformed JSON as `{}`. Resolve the dedup set: if `deliveredToday.date` equals today's host-local date (`YYYY-MM-DD`) AND `deliveredToday.ids` is an array, use that array as the dedup set; in every other case (no `deliveredToday`, date mismatch, missing `ids`, `ids` not an array, any other unexpected shape) treat the dedup set as empty (the date will roll forward when you write the file back at the end).
 
 2. Call `list_opportunities(status="pending", limit=10)`.
 
 3. **Filter against dedup state.** Drop any returned opportunity whose `id` is in the dedup set from step 1. Use the filtered set for everything that follows. (Filtering happens before the quality bar so the LLM does not waste evaluation budget on candidates that will be dropped.)
 
-4. **If the filtered set is empty:** send via the `message` tool: "Quiet night — I'll keep listening." Then write `memory/heartbeat-state.json` so that `deliveredToday.date` = today's host-local `YYYY-MM-DD` and `deliveredToday.ids` = the dedup set from step 1 unchanged (preserve `lastAmbientHash` and any other top-level keys). End your turn.
+4. **If the filtered set is empty:** first write `memory/heartbeat-state.json` so that `deliveredToday.date` = today's host-local `YYYY-MM-DD` and `deliveredToday.ids` = the dedup set from step 1 unchanged (preserve `lastAmbientHash` and any other top-level keys). Then send via the `message` tool: "Quiet night — I'll keep listening." End your turn. Writing state before the final `message` call matches the main path (step 11 → step 12) so a `message` tool failure can't lose the date roll-forward.
 
 5. **Otherwise** compose the brief in this exact structure (mimic the exemplar):
 


### PR DESCRIPTION
## Summary

EdgeClaw's morning digest (08:00) and ambient passes (14:00, 20:00) each call `list_opportunities(status="pending")` independently, so the same opportunity gets surfaced multiple times in one host-local day. This PR extends `memory/heartbeat-state.json` with a `deliveredToday` block shared by both prompts. Each `(user, opportunityId)` pair is surfaced at most once per host-local day; next morning's digest starts fresh.

Closes IND-304.

## New Features

- `prompts/ambient.md` and `prompts/digest.md` read `deliveredToday` near the top of every run, filter the `list_opportunities` result against it, and write surfaced IDs back before ending the turn. Daily rolling window via a host-local date stamp — no explicit cleanup.
- Filter step runs **before** per-pass caps / quality bar so LLM budget isn't spent on candidates that will be dropped.
- `lastAmbientHash` retained as an orthogonal early-exit; it now hashes the *filtered* set so subsequent passes correctly recognize "already shown today" vs "no change in raw results."
- No backend changes. `confirm_opportunity_delivery` calls preserved (the backend ledger still serves audit and accepted-opportunity lookups).

## Documentation

- `packages/edgeclaw/workspace/TOOLS.md` and `packages/edgeclaw/README.md` describe the new `deliveredToday` field and updated dedup behavior of each prompt.

## Version

- `@edge-city/edgeclaw` 0.1.1 → 0.2.0 (additive prompt behavior).

## Spec / Plan

- Spec: `docs/superpowers/specs/2026-05-15-edgeclaw-cross-pass-dedup-design.md`
- Plan: `docs/superpowers/plans/2026-05-15-edgeclaw-cross-pass-dedup.md`

## Test plan

EdgeClaw is prompt-driven; verification is via scenario walks against a running EdgeClaw on a non-production Index Network backend.

- [ ] **Same-day cross-pass dedup.** Trigger morning digest with at least 3 pending opportunities; confirm `heartbeat-state.json` records `deliveredToday.date = today` with the surfaced IDs. Trigger an afternoon and evening ambient pass with no new opportunities; both must skip the morning IDs.
- [ ] **Day rollover.** Manually set `deliveredToday.date` to yesterday with a non-empty `ids` array. Next pass surfaces those opportunities and resets `date` to today.
- [ ] **Missing / malformed state file.** Delete or corrupt `heartbeat-state.json`. Next pass proceeds with an empty dedup set and writes a fresh file.
- [ ] **Empty result path.** With no pending opportunities, digest delivers "Quiet night" and rolls `deliveredToday.date` forward to today with empty `ids`.
- [ ] **`confirm_opportunity_delivery` side-effect.** For each surfaced opportunity, a new row appears in `opportunity_deliveries` with `trigger='digest'` or `'ambient'`. The local-state fix did not regress the backend ledger writes.