### PR TITLE
fix(opportunity): drop stale continueFrom when fresh searchQuery is set (IND-305)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -163,7 +163,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "dependencies": {
         "@langchain/core": "^1.1.17",
         "@langchain/langgraph": "^1.1.2",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -416,7 +416,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
       continueFrom: z
         .string()
         .optional()
-        .describe("Pagination token: pass the discoveryId from a previous discover_opportunities result to evaluate the next batch of candidates. Do not combine with other mode parameters."),
+        .describe("Pagination token: pass the discoveryId from a previous discover_opportunities result to evaluate the next batch of candidates. Do not combine with searchQuery or other mode parameters — when a fresh searchQuery is also present, the server ignores continueFrom and runs a fresh discovery."),
       searchQuery: z
         .string()
         .optional()
@@ -504,8 +504,21 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
       const effectiveIndexId =
         (context.networkId || query.networkId?.trim()) ?? undefined;
 
-      // ── Continuation mode ── (must take strict precedence — it's a pagination token)
-      if (query.continueFrom) {
+      // ── Continuation mode ──
+      // `continueFrom` is a pagination token for resuming a prior discovery's
+      // cached candidates. When a caller (typically an MCP client's LLM) sends
+      // a fresh `searchQuery` alongside a stale `continueFrom`, treat it as a
+      // fresh search — the explicit search intent wins. Resuming against the
+      // stale session's exhausted cache silently produced the "No more
+      // matching opportunities found in the remaining candidates" response
+      // for users who expected fresh results (IND-305).
+      if (query.continueFrom && query.searchQuery?.trim()) {
+        logger.warn("discover_opportunities: dropping stale continueFrom in favor of fresh searchQuery", {
+          userId: context.userId,
+          continueFrom: query.continueFrom,
+        });
+      }
+      if (query.continueFrom && !query.searchQuery?.trim()) {
         const _continueTraceEmitter = requestContext.getStore()?.traceEmitter;
         const _graphStart = Date.now();
         _continueTraceEmitter?.({ type: "graph_start", name: "opportunity" });

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.continueFrom-routing.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.continueFrom-routing.spec.ts
@@ -1,0 +1,126 @@
+import { config } from 'dotenv';
+config({ path: '.env.development', override: true });
+process.env.OPENROUTER_API_KEY ??= 'test';
+
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+
+// IND-305 reproducer: the bug report shows MCP `discover_opportunities` returning
+//   { found: false, count: 0, message: "No more matching opportunities found in the remaining candidates." }
+// That exact message is produced only by `continueDiscovery` (opportunity.discover.ts:1128) —
+// `runDiscoverFromQuery` never emits it. So the failing call must have routed to the
+// continuation path. The hypothesis: an MCP client passed a stale `continueFrom` (from a
+// prior call's pagination token) alongside a fresh `searchQuery`, and the tool silently
+// preferred `continueFrom`. These tests document and exercise that routing.
+
+type ToolCallArgs = Record<string, unknown>;
+let discoverCalls: ToolCallArgs[] = [];
+let continueCalls: ToolCallArgs[] = [];
+
+mock.module('../opportunity.discover.js', () => ({
+  runDiscoverFromQuery: async (args: ToolCallArgs) => {
+    discoverCalls.push(args);
+    return { found: true, count: 0, opportunities: [], message: 'ok' };
+  },
+  continueDiscovery: async (args: ToolCallArgs) => {
+    continueCalls.push(args);
+    return {
+      found: false,
+      count: 0,
+      message: 'No more matching opportunities found in the remaining candidates.',
+    };
+  },
+}));
+
+const { createOpportunityTools } = await import('../opportunity.tools.js');
+import type { ToolDeps, ResolvedToolContext } from '../../shared/agent/tool.helpers.js';
+
+const USER_ID = 'mcp-user-1';
+
+function makeContext(overrides: Partial<ResolvedToolContext>): ResolvedToolContext {
+  return {
+    userId: USER_ID,
+    user: { id: USER_ID, name: 'M', email: 'm@test' } as never,
+    userProfile: null,
+    userNetworks: [{ networkId: 'n1' } as never],
+    isMcp: true,
+    sessionId: undefined,
+    ...overrides,
+  } as unknown as ResolvedToolContext;
+}
+
+function makeDeps(): ToolDeps {
+  return {
+    systemDb: {} as never,
+    database: {} as never,
+    cache: {} as never,
+    graphs: {
+      opportunity: { invoke: async () => ({}) },
+      index: { invoke: async () => ({ readResult: { memberOf: [{ networkId: 'n1' }] } }) },
+      networkMembership: { invoke: async () => ({}) },
+    },
+  } as unknown as ToolDeps;
+}
+
+function captureDiscoverTool(deps: ToolDeps) {
+  let captured:
+    | { handler: (i: { context: ResolvedToolContext; query: Record<string, unknown> }) => Promise<string> }
+    | undefined;
+  const defineTool = (def: { name: string; handler: typeof captured extends infer T ? T extends { handler: infer H } ? H : never : never }) => {
+    if (def.name === 'discover_opportunities') {
+      captured = def as unknown as typeof captured;
+    }
+    return def;
+  };
+  createOpportunityTools(defineTool as never, deps);
+  if (!captured) throw new Error('discover_opportunities not found');
+  return captured;
+}
+
+describe('IND-305: discover_opportunities continueFrom routing', () => {
+  beforeEach(() => {
+    discoverCalls = [];
+    continueCalls = [];
+  });
+
+  test('fresh searchQuery (no continueFrom) → runDiscoverFromQuery', async () => {
+    const tool = captureDiscoverTool(makeDeps());
+    await tool.handler({
+      context: makeContext({ isMcp: true }),
+      query: { searchQuery: 'people in San Francisco to meet, collaborate, or connect with' },
+    });
+
+    expect(discoverCalls).toHaveLength(1);
+    expect(continueCalls).toHaveLength(0);
+  });
+
+  test('continueFrom set, no searchQuery → continueDiscovery (control)', async () => {
+    const tool = captureDiscoverTool(makeDeps());
+    await tool.handler({
+      context: makeContext({ isMcp: true }),
+      query: { continueFrom: 'some-discovery-id' },
+    });
+
+    expect(continueCalls).toHaveLength(1);
+    expect(discoverCalls).toHaveLength(0);
+  });
+
+  // IND-305 regression guard. Before the fix, a caller (typically an MCP
+  // client's LLM) passing a fresh `searchQuery` alongside a stale
+  // `continueFrom` was silently routed to `continueDiscovery`, which resumed
+  // an exhausted cache and returned "No more matching opportunities found in
+  // the remaining candidates" — the user's intended fresh search never ran.
+  // The handler now drops the stale token and runs fresh discovery.
+  test('fresh searchQuery + stale continueFrom → runDiscoverFromQuery (IND-305 regression)', async () => {
+    const tool = captureDiscoverTool(makeDeps());
+    await tool.handler({
+      context: makeContext({ isMcp: true }),
+      query: {
+        searchQuery: 'people in San Francisco to meet, collaborate, or connect with',
+        continueFrom: 'stale-discovery-id-from-prior-call',
+      },
+    });
+
+    expect(discoverCalls).toHaveLength(1);
+    expect(continueCalls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Bug Fixes

- **`discover_opportunities`**: when both `searchQuery` and `continueFrom` arrive in the same call, drop `continueFrom`, log a warning, and run a fresh discovery instead of resuming against the prior session's cache (IND-305).

## Why

MCP clients (typically LLM-driven) occasionally carried a `pagination.discoveryId` from a previous tool result alongside a fresh `searchQuery`. The handler's first check was `if (query.continueFrom)`, so it routed to `continueDiscovery` against the prior session's exhausted candidate cache and returned `"No more matching opportunities found in the remaining candidates."` — the user's intended fresh search never ran. UI worked because the chat agent didn't carry pagination tokens forward.

The schema docstring already said "Do not combine with other mode parameters" — this enforces that contract gracefully (silently honor caller intent, log the conflict for visibility) rather than failing the call.

## Tests

- New: `opportunity.tools.continueFrom-routing.spec.ts` — 3 cases: fresh-search, pagination-only, and the IND-305 regression (`searchQuery` + stale `continueFrom`).
- Adjacent `opportunity.tools` test suites all pass (57/57).

## Test plan

- [ ] Manual smoke: hit `discover_opportunities` via MCP with a fresh searchQuery; confirm results match the UI's discovery for the same query.
- [ ] Tail logs during the call: look for the new `discover_opportunities: dropping stale continueFrom...` warning when an MCP client passes both fields.
- [ ] Verify pagination still works: pass `continueFrom` alone after an initial discovery; confirm continuation behaves unchanged.