### PR TITLE
fix(protocol): clamp negotiation digest strings instead of rejecting

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -162,7 +162,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "1.3.0",
+      "version": "1.3.2",
       "dependencies": {
         "@langchain/core": "^1.1.17",
         "@langchain/langgraph": "^1.1.2",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/negotiation/tests/negotiation.summarizer.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.summarizer.spec.ts
@@ -1,0 +1,102 @@
+/** Config */
+import { config } from "dotenv";
+config({ path: '.env.test' });
+
+import { describe, it, expect } from "bun:test";
+
+import { NegotiationSummarizer } from "../negotiation.summarizer.js";
+import type { DiscoveryNegotiation } from "../../opportunity/question.prompt.js";
+
+const summarizer = new NegotiationSummarizer();
+
+const richNegotiation: DiscoveryNegotiation = {
+  counterpartyId: "user-bob",
+  // Intentionally verbose: nudges the LLM toward an over-length counterpartyHint
+  // if it didn't faithfully truncate the input. The fix slices on parse, so the
+  // returned digest must still satisfy `.max(120)` regardless.
+  counterpartyHint:
+    "Senior staff engineer who has spent fourteen years building distributed databases, real-time analytics platforms, and high-throughput streaming infrastructure across both startups and FAANG; previously led a 30-person platform team responsible for the global write path of a top-five social network.",
+  indexContext:
+    "A focused community of AI infrastructure builders, founding engineers, and ML platform leads who are actively looking for collaborators on agentic systems, LLM eval pipelines, and retrieval architectures.",
+  turns: [
+    {
+      action: "propose",
+      reasoning:
+        "Source operates an AI startup and is hiring a founding ML engineer with production LLM experience; counterparty has shipped retrieval pipelines and vector index systems at scale, so the seed assessment is strong. Proposing the connection with both as peers initially.",
+      suggestedRoles: { ownUser: "peer", otherUser: "peer" },
+    },
+    {
+      action: "counter",
+      reasoning:
+        "Counterparty pushes back on the peer framing — wants to clarify whether the role is hands-on IC or eng-management, because that materially changes the fit. Suggests reframing as patient (source needs help) / agent (counterparty provides it).",
+      suggestedRoles: { ownUser: "patient", otherUser: "agent" },
+    },
+    {
+      action: "accept",
+      reasoning:
+        "Source confirms an IC-heavy founding role with optional tech-lead progression — that aligns with what the counterparty wants right now. Roles agreed.",
+      suggestedRoles: { ownUser: "patient", otherUser: "agent" },
+    },
+  ],
+  outcome: {
+    hasOpportunity: true,
+    reasoning:
+      "Strong technical fit; the candidate's retrieval-infra background maps directly onto what source needs to ship. The role-framing pivot from peer → patient/agent was the decisive moment — without it the negotiation would have stalled on ambiguity about seniority and scope.",
+    agreedRoles: [
+      { userId: "user-alice", role: "patient" },
+      { userId: "user-bob", role: "agent" },
+    ],
+  },
+};
+
+describe("NegotiationSummarizer", () => {
+  it("returns a digest with clamped fields when the LLM call succeeds", async () => {
+    const result = await summarizer.summarize(richNegotiation);
+    expect(result).not.toBeNull();
+    if (!result) return;
+
+    // Schema guarantees these (the fix clamps on parse), but assert explicitly
+    // so a regression in the schema-side clamp would fail here, not silently.
+    expect(result.counterpartyHint.length).toBeLessThanOrEqual(120);
+    expect(result.counterpartyHint.length).toBeGreaterThan(0);
+    expect(result.indexContext.length).toBeLessThanOrEqual(120);
+    expect(result.indexContext.length).toBeGreaterThan(0);
+    expect(result.keyTake.length).toBeLessThanOrEqual(180);
+    expect(result.keyTake.length).toBeGreaterThan(0);
+    expect(result.outcomeRole).toBe("opportunity");
+    expect(result.outcomeReason).toBeNull();
+  }, 60_000);
+
+  it("emits a no-opportunity digest for a stalled negotiation", async () => {
+    const stalled: DiscoveryNegotiation = {
+      ...richNegotiation,
+      counterpartyId: "user-cara",
+      turns: [
+        {
+          action: "propose",
+          reasoning: "Source proposes connection on AI infra collaboration.",
+          suggestedRoles: { ownUser: "peer", otherUser: "peer" },
+        },
+        {
+          action: "counter",
+          reasoning:
+            "Counterparty's stated focus is consumer mobile UX, which doesn't overlap with source's infra work. Asks for clarification but signals low intent.",
+          suggestedRoles: { ownUser: "peer", otherUser: "peer" },
+        },
+      ],
+      outcome: {
+        hasOpportunity: false,
+        reasoning:
+          "Domain mismatch — infra vs. consumer mobile. No concrete overlap surfaced in either turn; counterparty's signals trend disengaged.",
+        reason: "turn_cap",
+      },
+    };
+
+    const result = await summarizer.summarize(stalled);
+    expect(result).not.toBeNull();
+    if (!result) return;
+    expect(result.outcomeRole).toBe("no-opportunity");
+    expect(result.outcomeReason).not.toBeNull();
+    expect(result.keyTake.length).toBeLessThanOrEqual(180);
+  }, 60_000);
+});

--- a/packages/protocol/src/shared/schemas/negotiation-digest.schema.ts
+++ b/packages/protocol/src/shared/schemas/negotiation-digest.schema.ts
@@ -9,11 +9,21 @@
  */
 import { z } from "zod";
 
+// LLMs ignore .max() length constraints often enough that strict validation
+// throws every call and forces a fallback. Slice strings down before validating
+// so JSON schema still advertises the limit but a small overshoot doesn't drop
+// the whole digest.
+const clampedString = (maxLen: number) =>
+  z.preprocess(
+    (v) => (typeof v === "string" ? v.slice(0, maxLen) : v),
+    z.string().min(1).max(maxLen),
+  );
+
 export const DiscoveryNegotiationDigestSchema = z.object({
   /** Abstract counterparty descriptor (no PII, no IDs). E.g. "AI infra founder, Berlin". */
-  counterpartyHint: z.string().min(1).max(120),
+  counterpartyHint: clampedString(120),
   /** The network the negotiation ran under (community prompt). */
-  indexContext: z.string().min(1).max(120),
+  indexContext: clampedString(120),
   /** Whether the negotiation produced an opportunity. */
   outcomeRole: z.enum(["opportunity", "no-opportunity"]),
   /** When `outcomeRole === "no-opportunity"`, why the negotiation didn't yield one. Null otherwise. */
@@ -23,7 +33,7 @@ export const DiscoveryNegotiationDigestSchema = z.object({
    * this negotiation. Written for the downstream question generator — should
    * highlight a fact or tension that could inform a clarifying question.
    */
-  keyTake: z.string().min(1).max(180),
+  keyTake: clampedString(180),
   /** Suggested roles agreed by both parties. Null when no agreement reached. */
   suggestedRoles: z
     .object({

--- a/packages/protocol/src/shared/schemas/tests/negotiation-digest.schema.spec.ts
+++ b/packages/protocol/src/shared/schemas/tests/negotiation-digest.schema.spec.ts
@@ -1,0 +1,76 @@
+/** Config */
+import { config } from "dotenv";
+config({ path: '.env.test' });
+
+import { describe, it, expect } from "bun:test";
+
+import { DiscoveryNegotiationDigestSchema } from "../negotiation-digest.schema.js";
+
+const baseDigest = {
+  counterpartyHint: "AI infra founder, Berlin",
+  indexContext: "AI founders and engineers",
+  outcomeRole: "opportunity" as const,
+  outcomeReason: null,
+  keyTake: "Aligned on roles after one counter.",
+  suggestedRoles: { ownUser: "agent" as const, otherUser: "patient" as const },
+};
+
+describe("DiscoveryNegotiationDigestSchema", () => {
+  it("clamps counterpartyHint > 120 chars instead of rejecting", () => {
+    const parsed = DiscoveryNegotiationDigestSchema.safeParse({
+      ...baseDigest,
+      counterpartyHint: "x".repeat(200),
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.counterpartyHint.length).toBe(120);
+    }
+  });
+
+  it("clamps keyTake > 180 chars instead of rejecting", () => {
+    const parsed = DiscoveryNegotiationDigestSchema.safeParse({
+      ...baseDigest,
+      keyTake: "y".repeat(250),
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.keyTake.length).toBe(180);
+    }
+  });
+
+  it("clamps indexContext > 120 chars instead of rejecting", () => {
+    const parsed = DiscoveryNegotiationDigestSchema.safeParse({
+      ...baseDigest,
+      indexContext: "z".repeat(200),
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.indexContext.length).toBe(120);
+    }
+  });
+
+  it("preserves short strings unchanged", () => {
+    const parsed = DiscoveryNegotiationDigestSchema.parse(baseDigest);
+    expect(parsed.counterpartyHint).toBe(baseDigest.counterpartyHint);
+    expect(parsed.indexContext).toBe(baseDigest.indexContext);
+    expect(parsed.keyTake).toBe(baseDigest.keyTake);
+  });
+
+  it("still rejects empty strings (preserves min(1))", () => {
+    expect(
+      DiscoveryNegotiationDigestSchema.safeParse({ ...baseDigest, counterpartyHint: "" }).success,
+    ).toBe(false);
+    expect(
+      DiscoveryNegotiationDigestSchema.safeParse({ ...baseDigest, keyTake: "" }).success,
+    ).toBe(false);
+    expect(
+      DiscoveryNegotiationDigestSchema.safeParse({ ...baseDigest, indexContext: "" }).success,
+    ).toBe(false);
+  });
+
+  it("rejects non-string input for the clamped fields", () => {
+    expect(
+      DiscoveryNegotiationDigestSchema.safeParse({ ...baseDigest, counterpartyHint: 42 }).success,
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Bug Fixes

- **`NegotiationSummarizer` no longer throws on every call.** The Zod schema enforced `.max(120)` on `counterpartyHint`/`indexContext` and `.max(180)` on `keyTake`; Gemini 2.5 Flash routinely emits strings slightly over those limits, so every `summarize()` call threw and was caught into `null`, forcing the graph to use `buildFallbackDigest`. Each failed call burned a ~5 s LLM round-trip producing a result that was discarded, and the question generator saw the deterministic fallback instead of the LLM digest. Wrapping each length-bounded field in `z.preprocess(slice, inner)` clamps overshoot on receipt; JSON schema sent to the LLM still advertises `maxLength` (so the model keeps the hint), `min(1)` is preserved.

  *Evidence:* Railway runtime logs for `protocol` service on dev, 2026-05-19 ~18:52 UTC during a `discover_opportunities` call. `[NegotiationSummarizer] NegotiationSummarizer LLM call failed` fired twice with Zod errors `counterpartyHint > 120` and `keyTake > 180` for two separate candidates. Same shape has been firing across many recent calls.

## Tests

- 6 new unit tests in `packages/protocol/src/shared/schemas/tests/negotiation-digest.schema.spec.ts` — over-length clamp on all three string fields, short-string preservation, empty-string rejection, non-string rejection.
- 2 new LLM integration tests in `packages/protocol/src/negotiation/tests/negotiation.summarizer.spec.ts` — `summarize()` returns a valid digest end-to-end (no throw, all length constraints hold) on both opportunity and no-opportunity paths.
- `tsc` clean in `packages/protocol` and `backend`.

## Versions

- `@indexnetwork/protocol` 1.3.1 → 1.3.2
- `bun.lock` synced to match