### PR TITLE
release: 2026-05-21b — edgeclaw 0.9.0 (flag-based installer CLI)

### DIFF
--- a/packages/edgeclaw/README.md
+++ b/packages/edgeclaw/README.md
@@ -122,12 +122,12 @@ Every call with the same email returns the same user but a **fresh API key** —
 
 ### What InstaClaw does after signup
 
-1. Runs the EdgeClaw installer with the returned `apiKey`: `bun install/install.ts <apiKey>` (or equivalent in the hosted runtime).
+1. Runs the EdgeClaw installer with the returned `apiKey`: `bun install/install.ts --index-api-key <apiKey>` (or equivalent in the hosted runtime). If InstaClaw has also fetched an EdgeOS personal access token for the attendee, it passes that on the same line: `bun install/install.ts --index-api-key <apiKey> --edgeos-api-key <eos_live_…> --edgeos-bearer-token <jwt>`.
 2. In a follow-up step, captures the attendee's Telegram handle and binds it to their agent transport — this is entirely InstaClaw-owned and happens outside this endpoint.
 
 ### What EdgeOS does after signup
 
-Displays the returned `mcpServer` object to the attendee as a copyable config snippet. The attendee pastes it into their agent's MCP servers config (or runs `bun install/install.ts <apiKey>` from a clone of this repo).
+Displays the returned `mcpServer` object to the attendee as a copyable config snippet. The attendee pastes it into their agent's MCP servers config (or runs `bun install/install.ts --index-api-key <apiKey>` from a clone of this repo).
 
 ## Prerequisites
 
@@ -145,25 +145,24 @@ Displays the returned `mcpServer` object to the attendee as a copyable config sn
 From a clone of this repo:
 
 ```bash
-bun install/install.ts <YOUR_API_KEY>
-# or
-API_KEY=<YOUR_API_KEY> bun install/install.ts
+bun install/install.ts --index-api-key <YOUR_API_KEY>
 ```
 
 To target the dev environment (keys generated on `dev.index.network`), pass `--dev`:
 
 ```bash
-bun install/install.ts <YOUR_DEV_API_KEY> --dev
+bun install/install.ts --index-api-key <YOUR_DEV_API_KEY> --dev
 ```
 
 Or override the MCP URL explicitly via `INDEX_MCP_URL=…`. Without either, the installer points at `https://protocol.index.network/mcp` (production).
 
-To wire the optional EdgeOS tokens at the same time, supply them in env:
+To wire the optional EdgeOS tokens at the same time, pass them as flags:
 
 ```bash
-EDGEOS_API_KEY=eos_live_… \
-EDGEOS_BEARER_TOKEN=eyJ… \
-bun install/install.ts <YOUR_API_KEY>
+bun install/install.ts \
+  --index-api-key <YOUR_API_KEY> \
+  --edgeos-api-key eos_live_… \
+  --edgeos-bearer-token eyJ…
 ```
 
 The installer writes any tokens it finds into `env.vars.*` in `~/.openclaw/openclaw.json`; on the next gateway start they become process-env on the gateway and inherit into the agent's shell tool, so `curl -H "Authorization: Bearer $EDGEOS_API_KEY"` recipes work without further plumbing.
@@ -171,7 +170,7 @@ The installer writes any tokens it finds into `env.vars.*` in `~/.openclaw/openc
 The installer:
 
 1. Writes `mcp.servers.index` in `~/.openclaw/openclaw.json`, pointed at `https://protocol.index.network/mcp` with your API key in `x-api-key`.
-2. If `EDGEOS_API_KEY` and/or `EDGEOS_BEARER_TOKEN` are set in env, writes each to `env.vars.<NAME>` so the gateway exposes them to the agent's subprocesses on its next start.
+2. If `--edgeos-api-key` and/or `--edgeos-bearer-token` are passed, writes each to `env.vars.<NAME>` so the gateway exposes them to the agent's subprocesses on its next start.
 3. Sets `channels.telegram.streaming.mode = off` so OpenClaw doesn't dump per-tool status drafts into your chat.
 4. Copies the workspace markdown bundle into `~/.openclaw/workspace/`. `USER.md` is preserved on re-install (it holds the lived notes the active skill's bootstrap ritual populated for you); pass `--wipe-user` to overwrite `USER.md` and delete the agent-curated `MEMORY.md`, OpenClaw's `workspace-state.json` first-run marker, and the local onboarding/welcome/cron-preference markers under `memory/` so the next session re-onboards from scratch.
 5. Copies backend skill bundles from `skills/` into `~/.openclaw/workspace/skills/` so OpenClaw registers them as workspace skills.
@@ -196,7 +195,7 @@ bun install/reset.ts
 Then re-install:
 
 ```bash
-bun install/install.ts <YOUR_API_KEY>
+bun install/install.ts --index-api-key <YOUR_API_KEY>
 ```
 
 Pass `--wipe-user` to also remove `USER.md`, `MEMORY.md`, the `.openclaw/` first-run marker, the entire `memory/` directory (including `edgeclaw-state.json`, `welcome-state.json`, and daily notes), and all agent sessions under `~/.openclaw/agents/main/sessions/` — so the next message spawns a brand new session against a freshly-bootstrapped workspace:

--- a/packages/edgeclaw/install/args.ts
+++ b/packages/edgeclaw/install/args.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared CLI flag reader for the EdgeClaw installer.
+ *
+ * Supports both `--name value` and `--name=value` forms. Returns `undefined`
+ * when the flag is absent so each backend installer can decide whether the
+ * flag is required (Index) or optional (EdgeOS).
+ */
+
+export function readFlag(name: string): string | undefined {
+  const args = process.argv.slice(2);
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === name && i + 1 < args.length) return args[i + 1];
+    if (arg.startsWith(`${name}=`)) return arg.slice(name.length + 1);
+  }
+  return undefined;
+}

--- a/packages/edgeclaw/install/install.ts
+++ b/packages/edgeclaw/install/install.ts
@@ -37,13 +37,16 @@
  * `reset.ts --wipe-user`.)
  *
  * Usage:
- *   bun install.ts <API_KEY>
- *   bun install.ts <API_KEY> --wipe-user
- *   API_KEY=... bun install.ts
+ *   bun install.ts --index-api-key <KEY>
+ *   bun install.ts --index-api-key <KEY> --dev
+ *   bun install.ts --index-api-key <KEY> --wipe-user
  *
  * Optional EdgeOS tokens (consumed by install_edgeos.ts and written into
  * `env.vars.*` so the agent's curl/HTTP recipes can read them):
- *   EDGEOS_API_KEY=eos_live_... EDGEOS_BEARER_TOKEN=... bun install.ts <API_KEY>
+ *   bun install.ts \
+ *     --index-api-key <KEY> \
+ *     --edgeos-api-key eos_live_... \
+ *     --edgeos-bearer-token <jwt>
  */
 
 import {
@@ -308,7 +311,7 @@ function main(): void {
   } else {
     console.log("next:");
     console.log("  1. send any message to your agent on Telegram");
-    console.log("  2. re-run `bun install.ts <key>` to bind cron deliveries to that chat");
+    console.log("  2. re-run `bun install.ts --index-api-key <key>` to bind cron deliveries to that chat");
   }
 }
 

--- a/packages/edgeclaw/install/install_edgeos.ts
+++ b/packages/edgeclaw/install/install_edgeos.ts
@@ -15,18 +15,23 @@
  * just fail at first use and the SKILL.md instructs the agent to ask the
  * user for the missing token inline at that point.
  *
- * Invoked only by the orchestrator (`install.ts`). Reads from env:
+ * Invoked only by the orchestrator (`install.ts`). Reads two optional flags:
  *
- *   - `EDGEOS_API_KEY` (`eos_live_...`) — personal access token issued at
+ *   - `--edgeos-api-key <eos_live_...>` — personal access token issued at
  *     `/portal/api-keys` in the EdgeOS portal. Required for events, RSVPs,
- *     venues.
- *   - `EDGEOS_BEARER_TOKEN` — citizen-portal JWT. Required for the
- *     attendee directory.
+ *     venues. Lands in `env.vars.EDGEOS_API_KEY`.
+ *   - `--edgeos-bearer-token <jwt>` — citizen-portal JWT. Required for the
+ *     attendee directory. Lands in `env.vars.EDGEOS_BEARER_TOKEN`.
  */
 
 import { execFileSync } from "node:child_process";
 
-const ENV_KEYS = ["EDGEOS_API_KEY", "EDGEOS_BEARER_TOKEN"] as const;
+import { readFlag } from "./args";
+
+const FLAG_TO_ENV_VAR: ReadonlyArray<readonly [string, string]> = [
+  ["--edgeos-api-key", "EDGEOS_API_KEY"],
+  ["--edgeos-bearer-token", "EDGEOS_BEARER_TOKEN"],
+];
 
 function setEnvVar(name: string, value: string): void {
   // `openclaw config set env.vars.<NAME> <value>` — writes a literal into
@@ -46,19 +51,19 @@ export function installEdgeos(): void {
   const present: string[] = [];
   const missing: string[] = [];
 
-  for (const key of ENV_KEYS) {
-    const value = process.env[key]?.trim();
+  for (const [flag, envName] of FLAG_TO_ENV_VAR) {
+    const value = readFlag(flag)?.trim();
     if (value) {
-      setEnvVar(key, value);
-      present.push(key);
+      setEnvVar(envName, value);
+      present.push(envName);
     } else {
-      missing.push(key);
+      missing.push(envName);
     }
   }
 
   if (present.length === 0) {
     console.log(
-      "→ edgeos: no tokens provided in env; live EdgeOS recipes will prompt the user at first use",
+      "→ edgeos: no tokens provided; live EdgeOS recipes will prompt the user at first use",
     );
     return;
   }

--- a/packages/edgeclaw/install/install_index.ts
+++ b/packages/edgeclaw/install/install_index.ts
@@ -10,31 +10,28 @@
  *     dispatch, gated on the same quality bar.
  *
  * Invoked only by the orchestrator (`install.ts`) — not a standalone
- * entrypoint. The orchestrator reads `<API_KEY>` and `--dev` from
- * `process.argv` and this module reads the same args.
+ * entrypoint. Reads `--index-api-key <value>` and `--dev` from
+ * `process.argv` and `INDEX_MCP_URL` from env for the MCP URL override.
  */
 
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
 
+import { readFlag } from "./args";
+
 const PROD_MCP_URL = "https://protocol.index.network/mcp";
 const DEV_MCP_URL = "https://protocol.dev.index.network/mcp";
 
-const FLAGS = process.argv.slice(2).filter((a) => a.startsWith("--"));
-const POSITIONALS = process.argv.slice(2).filter((a) => !a.startsWith("--"));
-const IS_DEV = FLAGS.includes("--dev");
+const IS_DEV = process.argv.slice(2).includes("--dev");
 const PROTOCOL_MCP_URL =
   process.env.INDEX_MCP_URL?.trim() || (IS_DEV ? DEV_MCP_URL : PROD_MCP_URL);
 
 function readApiKey(): string {
-  const fromArg = POSITIONALS[0]?.trim();
-  const fromEnv = process.env.API_KEY?.trim() ?? process.env.INDEX_API_KEY?.trim();
-  const key = fromArg || fromEnv;
+  const key = readFlag("--index-api-key")?.trim();
   if (!key) {
-    console.error("error: API_KEY required");
-    console.error("usage: bun install.ts <API_KEY> [--dev]");
-    console.error("       API_KEY=<key> bun install.ts [--dev]");
+    console.error("error: --index-api-key required");
+    console.error("usage: bun install.ts --index-api-key <KEY> [--dev]");
     process.exit(1);
   }
   return key;

--- a/packages/edgeclaw/install/reset.ts
+++ b/packages/edgeclaw/install/reset.ts
@@ -4,7 +4,7 @@
  *
  * Tears down everything EdgeClaw installed, leaving the underlying OpenClaw
  * setup (Telegram bot token, OpenRouter key, gateway config) untouched.
- * After this runs, re-install with `bun install.ts <API_KEY>`.
+ * After this runs, re-install with `bun install.ts --index-api-key <KEY>`.
  *
  * What gets removed:
  *   - All cron jobs whose name starts with "EdgeClaw"
@@ -206,7 +206,7 @@ function main(): void {
   console.log("✓ reset complete");
   console.log("");
   console.log("next:");
-  console.log("  re-install: bun install.ts <API_KEY>");
+  console.log("  re-install: bun install.ts --index-api-key <KEY>");
 }
 
 main();

--- a/packages/edgeclaw/package.json
+++ b/packages/edgeclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge-city/edgeclaw",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Agent Village workspace and installer for Edge Esmeralda — on-device agent that surfaces connections and runs discovery on the Index protocol.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Follow-up to PR #795. Single-feature release that propagates the EdgeClaw installer's new flag-based CLI to `main`, which then syncs to the `indexnetwork/edgeclaw` fork and updates the cross-network PR Edge-City/edgeclaw#5.

## Package versions

| Package | main | dev (this PR) |
|---|---|---|
| `@edge-city/edgeclaw` (`packages/edgeclaw/`) | 0.8.0 | **0.9.0** |

Nothing npm-published changes in this release — `@edge-city/edgeclaw` is not on npm.

## What changed

`feat(edgeclaw)!: switch installer to flag-based CLI` (`d368e1c7`).

The installer's three credentials — Index API key, EdgeOS personal access token, EdgeOS bearer JWT — now come in through symmetric flags:

```bash
bun install.ts \
  --index-api-key <ix_...> \
  --edgeos-api-key <eos_live_...> \
  --edgeos-bearer-token <jwt>
```

Previously: Index API key was a raw positional or `API_KEY`/`INDEX_API_KEY` env var; EdgeOS tokens were env-only (`EDGEOS_API_KEY`, `EDGEOS_BEARER_TOKEN`). InstaClaw VMs provisioning agents need a uniform way to pass all three; flags give it.

- New shared `packages/edgeclaw/install/args.ts` reader supporting `--name value` and `--name=value`.
- `install_index.ts` reads `--index-api-key` (required, exits with the new usage message when missing).
- `install_edgeos.ts` reads `--edgeos-api-key` and `--edgeos-bearer-token` (both optional, same behaviour as before — when either is missing, the relevant recipe asks the user at first use).
- README's Install + Integration API sections + `reset.ts` re-install hint updated.

**BREAKING:** Callers passing the Index API key positionally or via env, or EdgeOS tokens via env, must switch to flags.

## Release notes

- The cross-network PR Edge-City/edgeclaw#5 will pick this up automatically on merge — the subtree-sync workflow force-pushes `packages/edgeclaw/` to `indexnetwork/edgeclaw:main` whose tip is that PR's head.

## Post-merge

- Subtree sync auto-pushes `packages/edgeclaw/` to `indexnetwork/edgeclaw`.
- No npm publish step (EdgeClaw isn't on npm).