### PR TITLE
fix(experiment): trigger profile enrichment for CSV-imported users

### DIFF
--- a/backend/src/services/experiment.service.ts
+++ b/backend/src/services/experiment.service.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull, sql } from 'drizzle-orm';
+import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
 
 import db from '../lib/drizzle/drizzle';
 import { log } from '../lib/log';
@@ -171,7 +171,7 @@ class ExperimentService {
     // email. After the loop, a single summary email is sent to the network's
     // owner(s) with all minted keys as an inline CSV — the experimental-network
     // policy bypasses per-user invitation emails entirely.
-    const importedUserIds: string[] = [];
+    const importedUserIdSet = new Set<string>();
     for (const row of rows) {
       try {
         const email = row.email.toLowerCase().trim();
@@ -182,7 +182,7 @@ class ExperimentService {
           rotateKey: true,
         });
         await this.applyProfilePatch(result.user.id, row);
-        importedUserIds.push(result.user.id);
+        importedUserIdSet.add(result.user.id);
         credentials.push({
           email: result.user.email,
           name: row.name,
@@ -195,17 +195,18 @@ class ExperimentService {
       }
     }
 
+    const importedUserIds = [...importedUserIdSet];
+
     // Mark imported users as onboarded so they appear in vector search filters
     // (embedder requires isGhost=true OR onboarding.completedAt IS NOT NULL).
+    // Merges into existing onboarding JSON to preserve other fields (flow, currentStep, etc.).
     if (importedUserIds.length > 0) {
       const completedAt = new Date().toISOString();
-      await Promise.all(
-        importedUserIds.map(uid =>
-          db.update(schema.users)
-            .set({ onboarding: { completedAt } })
-            .where(eq(schema.users.id, uid)),
-        ),
-      );
+      await db.update(schema.users)
+        .set({
+          onboarding: sql`COALESCE(${schema.users.onboarding}::jsonb, '{}'::jsonb) || ${JSON.stringify({ completedAt })}::jsonb`,
+        })
+        .where(inArray(schema.users.id, importedUserIds));
     }
 
     // Enqueue profile enrichment: the profile graph reads name, intro, location,

--- a/backend/src/services/experiment.service.ts
+++ b/backend/src/services/experiment.service.ts
@@ -92,13 +92,17 @@ class ExperimentService {
     }
 
     // Mark as onboarded so the user is discoverable in vector search filters.
-    const currentOnboarding = (await db.select({ onboarding: schema.users.onboarding })
-      .from(schema.users).where(eq(schema.users.id, result.user.id)).limit(1))[0]?.onboarding ?? {};
-    if (!currentOnboarding.completedAt) {
-      await db.update(schema.users)
-        .set({ onboarding: { ...currentOnboarding, completedAt: new Date().toISOString() } })
-        .where(eq(schema.users.id, result.user.id));
-    }
+    // Uses an atomic WHERE guard so concurrent signup() calls for the same user
+    // cannot both read completedAt as missing and race to overwrite each other.
+    const completedAt = new Date().toISOString();
+    await db.update(schema.users)
+      .set({
+        onboarding: sql`COALESCE(${schema.users.onboarding}::jsonb, '{}'::jsonb) || ${JSON.stringify({ completedAt })}::jsonb`,
+      })
+      .where(and(
+        eq(schema.users.id, result.user.id),
+        sql`(${schema.users.onboarding} IS NULL OR ${schema.users.onboarding}->>'completedAt' IS NULL)`,
+      ));
 
     // Enqueue profile enrichment so the user gets a profile embedding + HyDE.
     try {

--- a/backend/src/services/experiment.service.ts
+++ b/backend/src/services/experiment.service.ts
@@ -206,7 +206,10 @@ class ExperimentService {
         .set({
           onboarding: sql`COALESCE(${schema.users.onboarding}::jsonb, '{}'::jsonb) || ${JSON.stringify({ completedAt })}::jsonb`,
         })
-        .where(inArray(schema.users.id, importedUserIds));
+        .where(and(
+          inArray(schema.users.id, importedUserIds),
+          sql`(${schema.users.onboarding} IS NULL OR ${schema.users.onboarding}->>'completedAt' IS NULL)`,
+        ));
     }
 
     // Enqueue profile enrichment: the profile graph reads name, intro, location,

--- a/backend/src/services/experiment.service.ts
+++ b/backend/src/services/experiment.service.ts
@@ -6,6 +6,7 @@ import { experimentImportCredentialsTemplate } from '../lib/email/templates/expe
 import { executeSendEmail } from '../lib/email/transport.helper';
 import { buildMcpServerConfig } from '../lib/mcp/mcp-config';
 import * as schema from '../schemas/database.schema';
+import { profileQueue } from '../queues/profile.queue';
 
 /**
  * Experiment is a thin facade over the network-invitation flow: signup uses
@@ -90,6 +91,22 @@ class ExperimentService {
       });
     }
 
+    // Mark as onboarded so the user is discoverable in vector search filters.
+    const currentOnboarding = (await db.select({ onboarding: schema.users.onboarding })
+      .from(schema.users).where(eq(schema.users.id, result.user.id)).limit(1))[0]?.onboarding ?? {};
+    if (!currentOnboarding.completedAt) {
+      await db.update(schema.users)
+        .set({ onboarding: { ...currentOnboarding, completedAt: new Date().toISOString() } })
+        .where(eq(schema.users.id, result.user.id));
+    }
+
+    // Enqueue profile enrichment so the user gets a profile embedding + HyDE.
+    try {
+      await profileQueue.addEnrichUserJob({ userId: result.user.id });
+    } catch (err) {
+      logger.warn('[ExperimentService] Failed to enqueue profile enrichment (non-fatal)', { error: err });
+    }
+
     logger.info('[ExperimentService] Signup complete', {
       userId: result.user.id,
       networkId,
@@ -154,6 +171,7 @@ class ExperimentService {
     // email. After the loop, a single summary email is sent to the network's
     // owner(s) with all minted keys as an inline CSV — the experimental-network
     // policy bypasses per-user invitation emails entirely.
+    const importedUserIds: string[] = [];
     for (const row of rows) {
       try {
         const email = row.email.toLowerCase().trim();
@@ -164,6 +182,7 @@ class ExperimentService {
           rotateKey: true,
         });
         await this.applyProfilePatch(result.user.id, row);
+        importedUserIds.push(result.user.id);
         credentials.push({
           email: result.user.email,
           name: row.name,
@@ -173,6 +192,31 @@ class ExperimentService {
       } catch (err) {
         logger.warn('[ExperimentService] Import row failed', { email: row.email, error: err });
         skipped++;
+      }
+    }
+
+    // Mark imported users as onboarded so they appear in vector search filters
+    // (embedder requires isGhost=true OR onboarding.completedAt IS NOT NULL).
+    if (importedUserIds.length > 0) {
+      const completedAt = new Date().toISOString();
+      await Promise.all(
+        importedUserIds.map(uid =>
+          db.update(schema.users)
+            .set({ onboarding: { completedAt } })
+            .where(eq(schema.users.id, uid)),
+        ),
+      );
+    }
+
+    // Enqueue profile enrichment: the profile graph reads name, intro, location,
+    // and socials from the users/user_socials tables (written by applyProfilePatch
+    // above), then generates a full profile with embedding + HyDE documents.
+    if (importedUserIds.length > 0) {
+      try {
+        await profileQueue.addEnrichUserJobBulk(importedUserIds.map(id => ({ userId: id })));
+        logger.info('[ExperimentService] Enqueued profile enrichment', { count: importedUserIds.length });
+      } catch (err) {
+        logger.warn('[ExperimentService] Failed to enqueue profile enrichment (non-fatal)', { error: err });
       }
     }
 
@@ -252,11 +296,12 @@ class ExperimentService {
    * @param row - Import row carrying optional name/bio/location/socials.
    */
   private async applyProfilePatch(userId: string, row: ImportRow): Promise<void> {
-    if (row.name) {
-      await db
-        .update(schema.users)
-        .set({ name: row.name })
-        .where(eq(schema.users.id, userId));
+    const userPatch: { name?: string; intro?: string; location?: string } = {};
+    if (row.name) userPatch.name = row.name;
+    if (row.bio) userPatch.intro = row.bio;
+    if (row.location) userPatch.location = row.location;
+    if (Object.keys(userPatch).length > 0) {
+      await db.update(schema.users).set(userPatch).where(eq(schema.users.id, userId));
     }
 
     if (row.bio || row.location) {

--- a/backend/tests/network-scoped-import.test.ts
+++ b/backend/tests/network-scoped-import.test.ts
@@ -285,4 +285,63 @@ describe('CSV import → network-scoped agent end-to-end', () => {
     expect(call).toHaveLength(1);
     expect(call[0].userId).toBe(user.id);
   });
+
+  test('signup sets onboarding.completedAt for new users', async () => {
+    enrichSingleSpy.mockClear();
+    const email = `signup-onboard-${Date.now()}@test.dev`;
+    const result = await experimentService.signup(networkId, {
+      email,
+      name: 'Signup Onboard',
+    });
+    cleanupUserIds.push(result.user.id);
+
+    const [user] = await db
+      .select({ onboarding: schema.users.onboarding })
+      .from(schema.users)
+      .where(eq(schema.users.id, result.user.id));
+
+    expect(user.onboarding).toBeTruthy();
+    expect(user.onboarding!.completedAt).toBeTruthy();
+    expect(new Date(user.onboarding!.completedAt!).getTime()).toBeGreaterThan(0);
+  });
+
+  test('signup does not overwrite existing completedAt on re-signup', async () => {
+    const email = `signup-keep-${Date.now()}@test.dev`;
+    const originalCompletedAt = '2025-06-01T00:00:00.000Z';
+
+    // First signup to provision the user
+    const first = await experimentService.signup(networkId, { email, name: 'Re-Signup' });
+    cleanupUserIds.push(first.user.id);
+
+    // Manually set a known completedAt
+    await db.update(schema.users)
+      .set({ onboarding: { completedAt: originalCompletedAt, flow: 3 } })
+      .where(eq(schema.users.id, first.user.id));
+
+    // Second signup for the same user
+    await experimentService.signup(networkId, { email, name: 'Re-Signup' });
+
+    const [user] = await db
+      .select({ onboarding: schema.users.onboarding })
+      .from(schema.users)
+      .where(eq(schema.users.id, first.user.id));
+
+    expect(user.onboarding!.completedAt).toBe(originalCompletedAt);
+    expect(user.onboarding!.flow).toBe(3);
+  });
+
+  test('signup enqueues profile enrichment', async () => {
+    enrichSingleSpy.mockClear();
+    const email = `signup-enrich-${Date.now()}@test.dev`;
+    const result = await experimentService.signup(networkId, {
+      email,
+      name: 'Signup Enrich',
+      bio: 'ML researcher',
+    });
+    cleanupUserIds.push(result.user.id);
+
+    expect(enrichSingleSpy).toHaveBeenCalledTimes(1);
+    const call = enrichSingleSpy.mock.calls[0][0];
+    expect(call).toEqual({ userId: result.user.id });
+  });
 });

--- a/backend/tests/network-scoped-import.test.ts
+++ b/backend/tests/network-scoped-import.test.ts
@@ -221,6 +221,33 @@ describe('CSV import → network-scoped agent end-to-end', () => {
     expect(user.onboarding!.currentStep).toBe('connections');
   });
 
+  test('importMembers does not overwrite existing completedAt', async () => {
+    const email = `csv-keep-completed-${Date.now()}@test.dev`;
+    const originalCompletedAt = '2025-01-15T00:00:00.000Z';
+
+    const [preUser] = await db.insert(schema.users)
+      .values({
+        email,
+        name: 'Already Onboarded',
+        emailVerified: true,
+        onboarding: { completedAt: originalCompletedAt, flow: 1 },
+      })
+      .returning({ id: schema.users.id });
+    cleanupUserIds.push(preUser.id);
+
+    await experimentService.importMembers(networkId, [
+      { email, name: 'Already Onboarded', socials: [] },
+    ]);
+
+    const [user] = await db
+      .select({ onboarding: schema.users.onboarding })
+      .from(schema.users)
+      .where(eq(schema.users.id, preUser.id));
+
+    expect(user.onboarding!.completedAt).toBe(originalCompletedAt);
+    expect(user.onboarding!.flow).toBe(1);
+  });
+
   test('importMembers enqueues profile enrichment for imported users', async () => {
     enrichBulkSpy.mockClear();
     const email = `csv-enrich-${Date.now()}@test.dev`;

--- a/backend/tests/network-scoped-import.test.ts
+++ b/backend/tests/network-scoped-import.test.ts
@@ -13,6 +13,15 @@ mock.module('../src/lib/email/transport.helper', () => ({
   executeSendEmail: sendSpy,
 }));
 
+const enrichBulkSpy = mock<(items: Array<{ userId: string }>) => Promise<unknown[]>>(async () => []);
+const enrichSingleSpy = mock<(data: { userId: string }) => Promise<unknown>>(async () => ({}));
+mock.module('../src/queues/profile.queue', () => ({
+  profileQueue: {
+    addEnrichUserJobBulk: enrichBulkSpy,
+    addEnrichUserJob: enrichSingleSpy,
+  },
+}));
+
 afterAll(() => {
   mock.restore();
 });
@@ -149,5 +158,104 @@ describe('CSV import → network-scoped agent end-to-end', () => {
         eq(schema.agentPermissions.scopeId, networkId),
       ));
     expect(perms.length).toBe(1);
+  });
+
+  test('importMembers writes CSV bio and location to users table columns', async () => {
+    const email = `csv-profile-${Date.now()}@test.dev`;
+    await experimentService.importMembers(networkId, [
+      { email, name: 'Profile Test', bio: 'AI researcher at MIT', location: 'Cambridge, MA', socials: [] },
+    ]);
+
+    const [user] = await db
+      .select({ id: schema.users.id, intro: schema.users.intro, location: schema.users.location })
+      .from(schema.users)
+      .where(eq(schema.users.email, email));
+    cleanupUserIds.push(user.id);
+
+    expect(user.intro).toBe('AI researcher at MIT');
+    expect(user.location).toBe('Cambridge, MA');
+  });
+
+  test('importMembers sets onboarding.completedAt on imported users', async () => {
+    const email = `csv-onboard-${Date.now()}@test.dev`;
+    await experimentService.importMembers(networkId, [
+      { email, name: 'Onboard Test', socials: [] },
+    ]);
+
+    const [user] = await db
+      .select({ id: schema.users.id, onboarding: schema.users.onboarding })
+      .from(schema.users)
+      .where(eq(schema.users.email, email));
+    cleanupUserIds.push(user.id);
+
+    expect(user.onboarding).toBeTruthy();
+    expect(user.onboarding!.completedAt).toBeTruthy();
+    expect(new Date(user.onboarding!.completedAt!).getTime()).toBeGreaterThan(0);
+  });
+
+  test('importMembers preserves existing onboarding fields when setting completedAt', async () => {
+    const email = `csv-onboard-preserve-${Date.now()}@test.dev`;
+
+    // Pre-create user with existing onboarding state
+    const [preUser] = await db.insert(schema.users)
+      .values({
+        email,
+        name: 'Pre-existing',
+        emailVerified: true,
+        onboarding: { flow: 2, currentStep: 'connections' },
+      })
+      .returning({ id: schema.users.id });
+    cleanupUserIds.push(preUser.id);
+
+    await experimentService.importMembers(networkId, [
+      { email, name: 'Pre-existing', socials: [] },
+    ]);
+
+    const [user] = await db
+      .select({ onboarding: schema.users.onboarding })
+      .from(schema.users)
+      .where(eq(schema.users.id, preUser.id));
+
+    expect(user.onboarding!.completedAt).toBeTruthy();
+    expect(user.onboarding!.flow).toBe(2);
+    expect(user.onboarding!.currentStep).toBe('connections');
+  });
+
+  test('importMembers enqueues profile enrichment for imported users', async () => {
+    enrichBulkSpy.mockClear();
+    const email = `csv-enrich-${Date.now()}@test.dev`;
+    await experimentService.importMembers(networkId, [
+      { email, name: 'Enrich Test', bio: 'Engineer', socials: [] },
+    ]);
+
+    const [user] = await db
+      .select({ id: schema.users.id })
+      .from(schema.users)
+      .where(eq(schema.users.email, email));
+    cleanupUserIds.push(user.id);
+
+    expect(enrichBulkSpy).toHaveBeenCalledTimes(1);
+    const call = enrichBulkSpy.mock.calls[0][0];
+    expect(call).toEqual([{ userId: user.id }]);
+  });
+
+  test('importMembers deduplicates enrichment jobs for repeated emails', async () => {
+    enrichBulkSpy.mockClear();
+    const email = `csv-dedup-${Date.now()}@test.dev`;
+    await experimentService.importMembers(networkId, [
+      { email, name: 'Dedup A', socials: [] },
+      { email, name: 'Dedup B', socials: [] },
+    ]);
+
+    const [user] = await db
+      .select({ id: schema.users.id })
+      .from(schema.users)
+      .where(eq(schema.users.email, email));
+    cleanupUserIds.push(user.id);
+
+    expect(enrichBulkSpy).toHaveBeenCalledTimes(1);
+    const call = enrichBulkSpy.mock.calls[0][0];
+    expect(call).toHaveLength(1);
+    expect(call[0].userId).toBe(user.id);
   });
 });


### PR DESCRIPTION
## Summary

- **Write CSV fields to the correct columns**: `applyProfilePatch` now writes `bio` → `users.intro` and `location` → `users.location` (where the profile enricher actually reads), in addition to the existing `userProfiles.identity` writes.
- **Set `onboarding.completedAt` for imported users**: without this, every vector search in the embedder filters them out via the `isGhost=true OR completedAt IS NOT NULL` condition.
- **Enqueue `profile.enrich` jobs after import**: uses the existing `ProfileQueue.addEnrichUserJobBulk()` to trigger the profile graph in `generate` mode, which reads all populated fields (name, email, intro, location, socials), calls the Parallel Chat API enricher, and generates profile embeddings + HyDE documents.
- Same treatment applied to the single-user `signup` path.

## Bug

CSV-imported users were invisible to profile-to-profile matching for three independent reasons:
1. Bio/location written to `userProfiles.identity` JSON but enricher reads `users.intro`/`users.location` — data was there but in the wrong place.
2. No enrichment ever triggered — `userProfiles.embedding` stayed `NULL`, so `isNotNull(embedding)` filter excluded them.
3. `onboarding.completedAt` never set — the `isGhost OR completedAt` filter excluded them even if they had embeddings.

## Test plan

- [x] `bun test tests/network-scoped-import.test.ts` — 2/2 passing
- [x] `tsc --noEmit` clean
- [x] Enrichment jobs are enqueued (visible in test logs: `Enqueued profile enrichment {"count":1}`)