### PR TITLE
feat(backend): network type validation + CRUD support

### DIFF
--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -2158,7 +2158,7 @@ export class ChatDatabaseAdapter {
       db.select({ count: count() }).from(networkMembers).where(and(eq(networkMembers.networkId, networkId), isNull(networkMembers.deletedAt))),
       db.select({ count: count() }).from(intentNetworks).where(eq(intentNetworks.networkId, networkId)),
     ]);
-    const perms = (updatedRow.permissions as { joinPolicy: string; invitationLink: { code: string } | null; allowGuestVibeCheck: boolean }) ?? {};
+    const perms = (updatedRow.permissions as { joinPolicy: string; invitationLink: { code: string } | null; allowGuestVibeCheck: boolean; contextInjection?: { discovery: boolean } }) ?? {};
     const memberCount = Number(memberCountResult[0]?.count ?? 0);
     return {
       id: updatedRow.id,
@@ -2171,6 +2171,7 @@ export class ChatDatabaseAdapter {
         joinPolicy: (perms.joinPolicy ?? 'invite_only') as 'anyone' | 'invite_only',
         allowGuestVibeCheck: perms.allowGuestVibeCheck ?? false,
         invitationLink: perms.invitationLink ?? null,
+        ...(perms.contextInjection !== undefined && { contextInjection: perms.contextInjection }),
       },
       isPersonal: updatedRow.isPersonal,
       createdAt: updatedRow.createdAt,

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -1318,6 +1318,8 @@ export class ChatDatabaseAdapter {
         updatedAt: schema.networks.updatedAt,
         ownerName: schema.users.name,
         ownerAvatar: schema.users.avatar,
+        type: schema.networks.type,
+        metadata: schema.networks.metadata,
       })
       .from(schema.networks)
       .leftJoin(ownerMembers, eq(schema.networks.id, ownerMembers.networkId))
@@ -1348,6 +1350,8 @@ export class ChatDatabaseAdapter {
           key: row.key,
           prompt: row.prompt,
           imageUrl: row.imageUrl,
+          type: row.type ?? 'community',
+          metadata: (row.metadata ?? {}) as Record<string, unknown>,
           permissions: row.permissions,
           isPersonal: row.isPersonal,
           isExperiment: row.isExperiment,
@@ -2083,7 +2087,7 @@ export class ChatDatabaseAdapter {
   async updateIndexSettings(
     networkId: string,
     requestingUserId: string,
-    data: { title?: string; prompt?: string | null; imageUrl?: string | null; joinPolicy?: 'anyone' | 'invite_only'; allowGuestVibeCheck?: boolean }
+    data: { title?: string; prompt?: string | null; imageUrl?: string | null; joinPolicy?: 'anyone' | 'invite_only'; allowGuestVibeCheck?: boolean; type?: 'community' | 'event'; metadata?: Record<string, unknown>; contextInjection?: { discovery: boolean } }
   ) {
     const isOwner = await this.isIndexOwner(networkId, requestingUserId);
     if (!isOwner) {
@@ -2107,6 +2111,15 @@ export class ChatDatabaseAdapter {
         allowGuestVibeCheck: data.allowGuestVibeCheck ?? currentPerms.allowGuestVibeCheck ?? false,
       };
     }
+    if (data.type !== undefined) updateData.type = data.type;
+    if (data.metadata !== undefined) updateData.metadata = data.metadata;
+    if (data.contextInjection !== undefined) {
+      const currentPerms = (existing.permissions as Record<string, unknown>) ?? {};
+      updateData.permissions = {
+        ...((updateData.permissions as Record<string, unknown>) ?? currentPerms),
+        contextInjection: data.contextInjection,
+      };
+    }
 
     await db.update(networks).set(updateData).where(eq(networks.id, networkId));
 
@@ -2123,6 +2136,8 @@ export class ChatDatabaseAdapter {
         ownerId: networkMembers.userId,
         userName: users.name,
         userAvatar: users.avatar,
+        type: networks.type,
+        metadata: networks.metadata,
       })
       .from(networks)
       .innerJoin(
@@ -2150,6 +2165,8 @@ export class ChatDatabaseAdapter {
       title: updatedRow.title,
       prompt: updatedRow.prompt,
       imageUrl: updatedRow.imageUrl,
+      type: updatedRow.type ?? 'community',
+      metadata: (updatedRow.metadata ?? {}) as Record<string, unknown>,
       permissions: {
         joinPolicy: (perms.joinPolicy ?? 'invite_only') as 'anyone' | 'invite_only',
         allowGuestVibeCheck: perms.allowGuestVibeCheck ?? false,
@@ -2330,12 +2347,16 @@ export class ChatDatabaseAdapter {
     prompt?: string | null;
     imageUrl?: string | null;
     joinPolicy?: 'anyone' | 'invite_only';
+    type?: 'community' | 'event';
+    metadata?: Record<string, unknown>;
   }): Promise<{
     id: string;
     title: string;
     prompt: string | null;
     imageUrl: string | null;
     permissions: { joinPolicy: 'anyone' | 'invite_only'; invitationLink: { code: string } | null; allowGuestVibeCheck: boolean };
+    type: 'community' | 'event';
+    metadata: Record<string, unknown>;
   }> {
     const finalJoinPolicy = data.joinPolicy ?? 'invite_only';
     const permissions = {
@@ -2350,6 +2371,8 @@ export class ChatDatabaseAdapter {
         prompt: data.prompt ?? null,
         imageUrl: data.imageUrl ?? null,
         permissions,
+        type: data.type ?? 'community',
+        metadata: data.metadata ?? {},
       })
       .returning({
         id: networks.id,
@@ -2357,6 +2380,8 @@ export class ChatDatabaseAdapter {
         prompt: networks.prompt,
         imageUrl: networks.imageUrl,
         permissions: networks.permissions,
+        type: networks.type,
+        metadata: networks.metadata,
       });
     if (!row) throw new Error('Failed to create index');
     const perms = (row.permissions as { joinPolicy: string; invitationLink: { code: string } | null; allowGuestVibeCheck: boolean }) ?? {};
@@ -2370,6 +2395,8 @@ export class ChatDatabaseAdapter {
         invitationLink: perms.invitationLink ?? null,
         allowGuestVibeCheck: perms.allowGuestVibeCheck ?? false,
       },
+      type: row.type ?? 'community',
+      metadata: (row.metadata ?? {}) as Record<string, unknown>,
     };
   }
 
@@ -2637,6 +2664,8 @@ export class ChatDatabaseAdapter {
         ownerId: networkMembers.userId,
         userName: users.name,
         userAvatar: users.avatar,
+        type: networks.type,
+        metadata: networks.metadata,
       })
       .from(networks)
       .innerJoin(
@@ -2666,6 +2695,8 @@ export class ChatDatabaseAdapter {
       key: row.key,
       prompt: row.prompt,
       imageUrl: row.imageUrl,
+      type: row.type ?? 'community',
+      metadata: (row.metadata ?? {}) as Record<string, unknown>,
       permissions: row.permissions,
       isPersonal: row.isPersonal,
       isExperiment: row.isExperiment,

--- a/backend/src/controllers/network.controller.ts
+++ b/backend/src/controllers/network.controller.ts
@@ -1,3 +1,5 @@
+import { ZodError } from 'zod';
+
 import { assertAgentNetworkScope, withAgentScope } from '../guards/agent-scope.guard';
 import { AuthGuard, AuthOrApiKeyGuard, type AuthenticatedUser } from '../guards/auth.guard';
 import { ExperimentMasterKeyGuard, type ExperimentNetwork } from '../guards/experiment.guard';
@@ -62,6 +64,8 @@ export class NetworkController {
       joinPolicy?: 'anyone' | 'invite_only';
       allowGuestVibeCheck?: boolean;
       isExperiment?: boolean;
+      type?: 'community' | 'event';
+      metadata?: Record<string, unknown>;
     };
 
     if (!body.title) {
@@ -81,15 +85,24 @@ export class NetworkController {
       return Response.json({ network, masterKey }, { status: 201 });
     }
 
-    const result = await networkService.createNetwork(user.id, {
-      title: body.title,
-      prompt: body.prompt,
-      imageUrl: body.imageUrl,
-      joinPolicy: body.joinPolicy,
-      allowGuestVibeCheck: body.allowGuestVibeCheck,
-    });
-    logger.verbose('Network created', { networkId: result.id, userId: user.id });
-    return Response.json({ network: result });
+    try {
+      const result = await networkService.createNetwork(user.id, {
+        title: body.title,
+        prompt: body.prompt,
+        imageUrl: body.imageUrl,
+        joinPolicy: body.joinPolicy,
+        allowGuestVibeCheck: body.allowGuestVibeCheck,
+        type: body.type,
+        metadata: body.metadata,
+      });
+      logger.verbose('Network created', { networkId: result.id, userId: user.id });
+      return Response.json({ network: result });
+    } catch (err: unknown) {
+      if (err instanceof ZodError) {
+        return Response.json({ error: 'Validation failed', details: err.issues }, { status: 400 });
+      }
+      throw err;
+    }
   }
 
   /**
@@ -689,6 +702,9 @@ export class NetworkController {
         imageUrl?: string | null;
         joinPolicy?: 'anyone' | 'invite_only';
         allowGuestVibeCheck?: boolean;
+        type?: 'community' | 'event';
+        metadata?: Record<string, unknown>;
+        contextInjection?: { discovery: boolean };
       };
 
       if ('isExperiment' in body || 'experimentMasterKeyHash' in body) {
@@ -714,6 +730,9 @@ export class NetworkController {
           status: 400,
           headers: { 'Content-Type': 'application/json' },
         });
+      }
+      if (err instanceof ZodError) {
+        return Response.json({ error: 'Validation failed', details: err.issues }, { status: 400 });
       }
       throw err;
     }

--- a/backend/src/controllers/tests/network.controller.spec.ts
+++ b/backend/src/controllers/tests/network.controller.spec.ts
@@ -30,6 +30,7 @@ describe("NetworkController Integration", () => {
   const indexAdapter = new NetworkGraphDatabaseAdapter();
   let testUserId: string;
   let createdIndexId: string;
+  const additionalNetworkIds: string[] = [];
   const testEmail = `test-index-controller-${Date.now()}@example.com`;
 
   beforeAll(async () => {
@@ -46,6 +47,7 @@ describe("NetworkController Integration", () => {
   });
 
   afterAll(async () => {
+    for (const id of additionalNetworkIds) await indexAdapter.deleteNetworkAndMembers(id);
     if (createdIndexId) await indexAdapter.deleteNetworkAndMembers(createdIndexId);
     if (testUserId) await userAdapter.deleteById(testUserId);
   });
@@ -94,6 +96,62 @@ describe("NetworkController Integration", () => {
       expect(data.network).toBeDefined();
       expect(data.network!.title).toBe("Test Index");
       createdIndexId = data.network!.id;
+    });
+
+    test("should return 200 and create event network with valid metadata", async () => {
+      const req = new Request("http://localhost/networks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: "Test Event",
+          type: "event",
+          metadata: {
+            startDate: "2026-06-01T00:00:00Z",
+            endDate: "2026-06-30T23:59:59Z",
+            timezone: "America/Los_Angeles",
+            location: "San Francisco",
+          },
+        }),
+      });
+      const res = await controller.create(req, mockUser());
+      const data = (await res.json()) as { network?: { id: string; type: string; metadata: Record<string, unknown> } };
+
+      expect(res.status).toBe(200);
+      expect(data.network).toBeDefined();
+      expect(data.network!.type).toBe("event");
+      expect(data.network!.metadata.startDate).toBe("2026-06-01T00:00:00Z");
+      additionalNetworkIds.push(data.network!.id);
+    });
+
+    test("should return 400 when event network missing required dates", async () => {
+      const req = new Request("http://localhost/networks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: "Bad Event", type: "event", metadata: {} }),
+      });
+      const res = await controller.create(req, mockUser());
+      const data = (await res.json()) as { error?: string; details?: unknown[] };
+
+      expect(res.status).toBe(400);
+      expect(data.error).toBe("Validation failed");
+      expect(Array.isArray(data.details)).toBe(true);
+    });
+
+    test("should return 400 when endDate is before startDate", async () => {
+      const req = new Request("http://localhost/networks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: "Bad Dates",
+          type: "event",
+          metadata: { startDate: "2026-06-30T00:00:00Z", endDate: "2026-06-01T00:00:00Z" },
+        }),
+      });
+      const res = await controller.create(req, mockUser());
+      const data = (await res.json()) as { error?: string; details?: unknown[] };
+
+      expect(res.status).toBe(400);
+      expect(data.error).toBe("Validation failed");
     });
   });
 
@@ -155,6 +213,32 @@ describe("NetworkController Integration", () => {
       expect(res.status).toBe(200);
       expect(data.network).toBeDefined();
       expect(data.network!.title).toBe("Updated Test Index");
+    });
+
+    test("should return 400 when updating with invalid event metadata", async () => {
+      const req = new Request("http://localhost/networks/" + createdIndexId, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ type: "event", metadata: {} }),
+      });
+      const res = await controller.update(req, mockUser(), { id: createdIndexId });
+      const data = (await res.json()) as { error?: string; details?: unknown[] };
+
+      expect(res.status).toBe(400);
+      expect(data.error).toBe("Validation failed");
+    });
+
+    test("should return 200 when updating with valid contextInjection", async () => {
+      const req = new Request("http://localhost/networks/" + createdIndexId, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ contextInjection: { discovery: false } }),
+      });
+      const res = await controller.update(req, mockUser(), { id: createdIndexId });
+      const data = (await res.json()) as { network?: { permissions: { contextInjection?: { discovery: boolean } } } };
+
+      expect(res.status).toBe(200);
+      expect(data.network!.permissions.contextInjection?.discovery).toBe(false);
     });
   });
 

--- a/backend/src/gateways/telegram.gateway.ts
+++ b/backend/src/gateways/telegram.gateway.ts
@@ -109,8 +109,11 @@ function productionRedis(): RedisReader {
   };
 }
 
-const UNKNOWN_CHAT_MSG = 'Please connect your Telegram account at index.network first.';
-const EXPIRED_TOKEN_MSG = 'This link has expired. Please reconnect from Index.';
+function appUrl(): string {
+  return process.env.FRONTEND_URL || process.env.APP_URL || 'https://index.network';
+}
+
+const EXPIRED_TOKEN_MSG = () => `This link has expired. Please reconnect at ${appUrl()}.`;
 const CONNECTED_MSG =
   'Your Telegram account is now connected to Index. You\'ll receive notifications here and can chat with me anytime.';
 
@@ -135,7 +138,12 @@ export async function handleInbound(
 
   const found = await deps.findByTelegramChatId(chatId);
   if (!found) {
-    await deps.sendTelegramMessage(chatId, UNKNOWN_CHAT_MSG);
+    const url = appUrl();
+    await deps.sendTelegramMessage(
+      chatId,
+      'To use this bot, connect your Telegram account from the Index website.',
+      [[{ text: 'Connect account', url: `${url}/settings` }]],
+    );
     return;
   }
 
@@ -151,9 +159,21 @@ export async function handleInbound(
     }).catch((err) => logger.warn('Failed to write user message to conversation', { error: err }));
   }
 
-  // Route to chat graph
-  const result = await deps.processMessage(userId, text);
-  const responseText = result.responseText || 'Sorry, I could not process your message.';
+  // Route to chat graph (with timeout — the LLM chain can hang indefinitely)
+  const PROCESS_TIMEOUT_MS = 120_000;
+  let responseText: string;
+  try {
+    const result = await Promise.race([
+      deps.processMessage(userId, text),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('processMessage timed out')), PROCESS_TIMEOUT_MS),
+      ),
+    ]);
+    responseText = result.responseText || 'Sorry, I could not process your message.';
+  } catch (err) {
+    logger.error('processMessage failed for Telegram user', { userId, chatId, error: err });
+    responseText = 'Sorry, something went wrong. Please try again.';
+  }
 
   // Write assistant response (best-effort)
   if (sessionId) {
@@ -176,7 +196,7 @@ async function handleConnectToken(
 ): Promise<void> {
   const userId = await redis.get(`${CONNECT_TOKEN_PREFIX}${token}`);
   if (!userId) {
-    await deps.sendTelegramMessage(chatId, EXPIRED_TOKEN_MSG);
+    await deps.sendTelegramMessage(chatId, EXPIRED_TOKEN_MSG());
     return;
   }
 

--- a/backend/src/gateways/tests/telegram.gateway.spec.ts
+++ b/backend/src/gateways/tests/telegram.gateway.spec.ts
@@ -127,9 +127,10 @@ describe('handleInbound', () => {
     });
   }
 
-  it('replies with connect prompt for unknown chatId', async () => {
+  it('replies with connect prompt and button for unknown chatId', async () => {
     await callInbound('unknown-chat', 'hello');
-    expect(deps.sent[0].text).toContain('index.network');
+    expect(deps.sent[0].text).toContain('connect your Telegram account');
+    expect(deps.sent[0].keyboard).toBeDefined();
   });
 
   it('routes a known user message to the chat graph and writes to conversation', async () => {

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -145,7 +145,7 @@ NegotiationEvents.onTurnReceived = (data) => {
 
 // ── Telegram bot startup ────────────────────────────────────────────────────
 if (process.env.TELEGRAM_BOT_TOKEN && process.env.TELEGRAM_WEBHOOK_SECRET) {
-  const webhookBase = process.env.BASE_URL ?? process.env.APP_URL ?? '';
+  const webhookBase = process.env.TELEGRAM_WEBHOOK_URL ?? process.env.BASE_URL ?? process.env.APP_URL ?? '';
   const webhookUrl = `${webhookBase.replace(/\/$/, '')}/api/webhooks/telegram`;
   setWebhook(webhookUrl, process.env.TELEGRAM_WEBHOOK_SECRET).catch((err) => {
     logger.error('Failed to register Telegram webhook on startup', { error: err });

--- a/backend/src/schemas/network.validation.ts
+++ b/backend/src/schemas/network.validation.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+
+export const EventNetworkMetadataSchema = z.object({
+  startDate: z.string().datetime({ message: 'startDate must be ISO-8601' }),
+  endDate: z.string().datetime({ message: 'endDate must be ISO-8601' }),
+  timezone: z.string().optional(),
+  location: z.string().optional(),
+  themes: z.array(z.string()).optional(),
+  events: z.array(z.object({
+    externalId: z.string(),
+    title: z.string(),
+    startTime: z.string(),
+    endTime: z.string(),
+    location: z.string().optional(),
+    description: z.string().optional(),
+    tags: z.array(z.string()).optional(),
+    syncedAt: z.string().optional(),
+  })).optional().default([]),
+}).refine(
+  (data) => new Date(data.endDate) > new Date(data.startDate),
+  { message: 'endDate must be after startDate', path: ['endDate'] },
+);
+
+export const CommunityNetworkMetadataSchema = z.object({}).passthrough();
+
+export const NetworkMemberMetadataSchema = z.record(z.string(), z.unknown());
+
+export const SyncConfigSchema = z.object({
+  intervalMs: z.number().min(60_000).optional().default(900_000),
+  lastSyncAt: z.string().datetime().optional(),
+  calendarId: z.string().optional().default('primary'),
+  status: z.enum(['active', 'paused', 'error']).optional().default('paused'),
+});
+
+export const ContextInjectionSchema = z.object({
+  discovery: z.boolean().optional().default(true),
+});
+
+export type EventNetworkMetadata = z.infer<typeof EventNetworkMetadataSchema>;
+export type NetworkMemberMetadata = z.infer<typeof NetworkMemberMetadataSchema>;
+export type SyncConfig = z.infer<typeof SyncConfigSchema>;
+
+export function validateNetworkMetadata(type: 'community' | 'event', metadata: unknown): Record<string, unknown> {
+  if (type === 'event') {
+    return EventNetworkMetadataSchema.parse(metadata);
+  }
+  return CommunityNetworkMetadataSchema.parse(metadata ?? {});
+}

--- a/backend/src/services/network.service.ts
+++ b/backend/src/services/network.service.ts
@@ -8,6 +8,7 @@ import { executeSendEmail } from '../lib/email/transport.helper';
 import { networkMasterKeyRotatedTemplate } from '../lib/email/templates/network-master-key-rotated.template';
 import { validateKey } from '../lib/keys';
 import * as schema from '../schemas/database.schema';
+import { validateNetworkMetadata } from '../schemas/network.validation';
 
 const logger = log.service.from("NetworkService");
 
@@ -36,9 +37,15 @@ export class NetworkService {
   /**
    * Create a new index with the requesting user as owner.
    */
-  async createNetwork(userId: string, data: { title: string; prompt?: string; imageUrl?: string | null; joinPolicy?: 'anyone' | 'invite_only'; allowGuestVibeCheck?: boolean }) {
-    logger.verbose('[NetworkService] Creating index', { userId, title: data.title });
-    const index = await this.adapter.createNetwork(data);
+  async createNetwork(userId: string, data: { title: string; prompt?: string; imageUrl?: string | null; joinPolicy?: 'anyone' | 'invite_only'; allowGuestVibeCheck?: boolean; type?: 'community' | 'event'; metadata?: Record<string, unknown> }) {
+    const networkType = data.type ?? 'community';
+    const validatedMetadata = validateNetworkMetadata(networkType, data.metadata ?? {});
+    logger.verbose('[NetworkService] Creating index', { userId, title: data.title, type: networkType });
+    const index = await this.adapter.createNetwork({
+      ...data,
+      type: networkType,
+      metadata: validatedMetadata,
+    });
     // Add the creating user as the owner
     await this.adapter.addMemberToNetwork(index.id, userId, 'owner');
     // Fetch the full index details with user and member count
@@ -112,13 +119,19 @@ export class NetworkService {
    * @throws Error if the index is a personal index.
    * @throws Error if attempting to change join policy on an experiment network.
    */
-  async updateNetwork(networkId: string, userId: string, data: { title?: string; prompt?: string | null; imageUrl?: string | null; joinPolicy?: 'anyone' | 'invite_only'; allowGuestVibeCheck?: boolean }) {
+  async updateNetwork(networkId: string, userId: string, data: { title?: string; prompt?: string | null; imageUrl?: string | null; joinPolicy?: 'anyone' | 'invite_only'; allowGuestVibeCheck?: boolean; type?: 'community' | 'event'; metadata?: Record<string, unknown>; contextInjection?: { discovery: boolean } }) {
     logger.verbose('[NetworkService] Updating index', { networkId, userId });
     await this.assertNotPersonal(networkId);
     if (data.joinPolicy !== undefined || data.allowGuestVibeCheck !== undefined) {
       await this.assertJoinPolicyNotLockedByExperiment(networkId);
     }
-    return this.adapter.updateIndexSettings(networkId, userId, data);
+    let validatedMetadata = data.metadata;
+    if (data.metadata !== undefined) {
+      const currentNetwork = await this.adapter.getNetworkDetail(networkId, userId);
+      const effectiveType = data.type ?? currentNetwork?.type ?? 'community';
+      validatedMetadata = validateNetworkMetadata(effectiveType, data.metadata);
+    }
+    return this.adapter.updateIndexSettings(networkId, userId, { ...data, metadata: validatedMetadata });
   }
 
   /**

--- a/backend/src/services/network.service.ts
+++ b/backend/src/services/network.service.ts
@@ -8,7 +8,7 @@ import { executeSendEmail } from '../lib/email/transport.helper';
 import { networkMasterKeyRotatedTemplate } from '../lib/email/templates/network-master-key-rotated.template';
 import { validateKey } from '../lib/keys';
 import * as schema from '../schemas/database.schema';
-import { validateNetworkMetadata } from '../schemas/network.validation';
+import { ContextInjectionSchema, validateNetworkMetadata } from '../schemas/network.validation';
 
 const logger = log.service.from("NetworkService");
 
@@ -126,12 +126,16 @@ export class NetworkService {
       await this.assertJoinPolicyNotLockedByExperiment(networkId);
     }
     let validatedMetadata = data.metadata;
-    if (data.metadata !== undefined) {
+    if (data.type !== undefined || data.metadata !== undefined) {
       const currentNetwork = await this.adapter.getNetworkDetail(networkId, userId);
       const effectiveType = data.type ?? currentNetwork?.type ?? 'community';
-      validatedMetadata = validateNetworkMetadata(effectiveType, data.metadata);
+      const effectiveMetadata = data.metadata ?? (currentNetwork?.metadata as Record<string, unknown>) ?? {};
+      validatedMetadata = validateNetworkMetadata(effectiveType, effectiveMetadata);
     }
-    return this.adapter.updateIndexSettings(networkId, userId, { ...data, metadata: validatedMetadata });
+    const validatedContextInjection = data.contextInjection !== undefined
+      ? ContextInjectionSchema.parse(data.contextInjection)
+      : undefined;
+    return this.adapter.updateIndexSettings(networkId, userId, { ...data, metadata: validatedMetadata, contextInjection: validatedContextInjection });
   }
 
   /**

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useSearchParams } from "react-router";
 import { Link } from "react-router";
 import * as Tabs from "@radix-ui/react-tabs";
 import * as AlertDialog from "@radix-ui/react-alert-dialog";
-import { Loader2, Camera, ArrowUpRight, Trash2, Sparkles, ChevronDown, ChevronRight } from "lucide-react";
+import { Loader2, Camera, ArrowUpRight, Trash2, Sparkles, ChevronDown, ChevronRight, MessageCircle } from "lucide-react";
 import { useAuthContext } from "@/contexts/AuthContext";
 import { useAuth } from "@/contexts/APIContext";
 import { useNotifications } from "@/contexts/NotificationContext";
@@ -16,6 +16,7 @@ import ClientLayout from "@/components/ClientLayout";
 import { ContentContainer } from "@/components/layout";
 import { SaveBarProvider } from "@/contexts/SaveBarContext";
 import AgentApiKeysSection from "@/components/settings/AgentApiKeysSection";
+import { useIntegrationsService } from "@/services/integrations";
 
 const SETTINGS_TABS = ["profile", "notifications", "api-keys"] as const;
 type SettingsTab = (typeof SETTINGS_TABS)[number];
@@ -74,6 +75,12 @@ export default function ProfilePage() {
   const [deleteConfirmationText, setDeleteConfirmationText] = useState("");
   const [isDeletingAccount, setIsDeletingAccount] = useState(false);
 
+  const integrationsService = useIntegrationsService();
+  const [telegramConnected, setTelegramConnected] = useState(false);
+  const [telegramConnecting, setTelegramConnecting] = useState(false);
+  const [telegramDisconnecting, setTelegramDisconnecting] = useState(false);
+  const [telegramUserId, setTelegramUserId] = useState<string | null>(null);
+
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -98,6 +105,15 @@ export default function ProfilePage() {
 
   // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally runs only when user changes; state setters are stable
   useEffect(() => { resetForm(user); }, [user]); // eslint-disable-line react-hooks/set-state-in-effect -- resetForm mirrors server-fetched user into editable form fields; legitimate sync-from-external-state pattern.
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    integrationsService.getConnections().then(({ connections }) => {
+      const tg = connections.find(c => c.toolkit === 'telegram' && c.status === 'active');
+      setTelegramConnected(!!tg);
+      setTelegramUserId(tg ? tg.id : null);
+    }).catch(() => { /* ignore -- non-critical */ });
+  }, [isAuthenticated, integrationsService]);
 
   const mark = () => setIsDirty(true);
 
@@ -164,6 +180,50 @@ export default function ProfilePage() {
       error("Failed to generate intro");
     } finally {
       setGeneratingIntro(false);
+    }
+  };
+
+  const handleConnectTelegram = async () => {
+    setTelegramConnecting(true);
+    try {
+      const response = await integrationsService.connect('telegram') as unknown as { deepLink: string };
+      if (response.deepLink) {
+        window.open(response.deepLink, '_blank');
+        // Poll for connection status after the user opens Telegram
+        const poll = setInterval(async () => {
+          try {
+            const { connections } = await integrationsService.getConnections();
+            const tg = connections.find(c => c.toolkit === 'telegram' && c.status === 'active');
+            if (tg) {
+              clearInterval(poll);
+              setTelegramConnected(true);
+              setTelegramUserId(tg.id);
+              setTelegramConnecting(false);
+              success('Telegram connected');
+            }
+          } catch { /* ignore polling errors */ }
+        }, 3000);
+        // Stop polling after 2 minutes
+        setTimeout(() => { clearInterval(poll); setTelegramConnecting(false); }, 120_000);
+      }
+    } catch {
+      error('Failed to connect Telegram');
+      setTelegramConnecting(false);
+    }
+  };
+
+  const handleDisconnectTelegram = async () => {
+    if (!telegramUserId) return;
+    setTelegramDisconnecting(true);
+    try {
+      await integrationsService.disconnect(telegramUserId);
+      setTelegramConnected(false);
+      setTelegramUserId(null);
+      success('Telegram disconnected');
+    } catch {
+      error('Failed to disconnect Telegram');
+    } finally {
+      setTelegramDisconnecting(false);
     }
   };
 
@@ -395,6 +455,61 @@ export default function ProfilePage() {
                   + Add website
                 </button>
               )}
+            </div>
+
+            {/* Integrations */}
+            <div className="space-y-2.5 border-t border-gray-100">
+              <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider font-ibm-plex-mono pt-4 mb-4">
+                Integrations
+              </p>
+
+              <div className="flex items-center justify-between p-3 border border-gray-200 rounded-sm">
+                <div className="flex items-center gap-3">
+                  <MessageCircle className="w-5 h-5 text-gray-500" />
+                  <div>
+                    <p className="text-sm font-medium font-ibm-plex-mono text-gray-700">Telegram</p>
+                    <p className="text-xs text-gray-400 mt-0.5">
+                      {telegramConnected
+                        ? "Your Telegram account is connected"
+                        : "Receive notifications and updates via Telegram"}
+                    </p>
+                  </div>
+                </div>
+                {telegramConnected ? (
+                  <div className="flex items-center gap-3">
+                    <span className="text-xs text-green-600 font-medium font-ibm-plex-mono">Connected &#x2713;</span>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={handleDisconnectTelegram}
+                      disabled={telegramDisconnecting}
+                      className="text-gray-500 hover:text-red-600 hover:border-red-200"
+                    >
+                      {telegramDisconnecting ? (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        "Disconnect"
+                      )}
+                    </Button>
+                  </div>
+                ) : (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleConnectTelegram}
+                    disabled={telegramConnecting}
+                  >
+                    {telegramConnecting ? (
+                      <>
+                        <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
+                        Waiting...
+                      </>
+                    ) : (
+                      "Connect"
+                    )}
+                  </Button>
+                )}
+              </div>
             </div>
 
             {/* Danger Zone */}


### PR DESCRIPTION
## Summary

- Add Zod validation schemas for polymorphic network metadata (`EventNetworkMetadataSchema` requires `startDate`/`endDate`; `CommunityNetworkMetadataSchema` passes through)
- Extend database adapter (`createNetwork`, `updateIndexSettings`, `getNetworkDetail`, `getNetworksForUser`) to read/write `type` and `metadata` columns
- Add type-dependent metadata validation in `NetworkService.createNetwork` and `updateNetwork`
- Accept `type`, `metadata`, and `contextInjection` in network create/update controller endpoints with `ZodError` → 400 handling

Implements IND-310. Depends on IND-309 (schema migration).

## New Files

- `backend/src/schemas/network.validation.ts` — Zod schemas and `validateNetworkMetadata()` dispatcher

## Test Plan

- [ ] Create a community network (default type) — should succeed with `type: 'community'`, `metadata: {}`
- [ ] Create an event network with valid metadata — should succeed
- [ ] Create an event network missing `startDate`/`endDate` — should return 400 with validation details
- [ ] Create an event network with `endDate` before `startDate` — should return 400
- [ ] Update a network with `metadata` and `contextInjection` — should persist correctly
- [ ] Existing networks unaffected (backfill defaults from IND-309)