### PR TITLE
feat(protocol): add type-aware network context renderer

### DIFF
--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -125,6 +125,7 @@ export type {
 
 // ─── Support utilities ────────────────────────────────────────────────────────
 
+export { renderNetworkContext } from './shared/network/metadata.renderer.js';
 export {
   canUserSeeOpportunity,
   isActionableForViewer,

--- a/packages/protocol/src/shared/network/metadata.renderer.ts
+++ b/packages/protocol/src/shared/network/metadata.renderer.ts
@@ -52,8 +52,8 @@ function renderEventNetwork(network: NetworkForRendering): string {
   const endDate = typeof meta.endDate === 'string' ? meta.endDate : undefined;
   const location = typeof meta.location === 'string' ? meta.location : undefined;
   const timezone = typeof meta.timezone === 'string' ? meta.timezone : undefined;
-  const themes = Array.isArray(meta.themes) ? meta.themes as string[] : [];
-  const events = Array.isArray(meta.events) ? meta.events as NonNullable<EventMetadata['events']> : [];
+  const themes = Array.isArray(meta.themes) ? meta.themes.filter((t: unknown): t is string => typeof t === 'string') : [];
+  const events = Array.isArray(meta.events) ? normalizeEvents(meta.events) : [];
   const lines: string[] = [`## ${network.title}`];
 
   if (network.prompt) {
@@ -63,8 +63,9 @@ function renderEventNetwork(network: NetworkForRendering): string {
   lines.push('');
   lines.push('- **Type:** Event');
 
-  if (startDate && endDate) {
-    lines.push(`- **Dates:** ${formatDateRange(startDate, endDate)}`);
+  const dateRange = startDate && endDate ? formatDateRange(startDate, endDate) : undefined;
+  if (dateRange) {
+    lines.push(`- **Dates:** ${dateRange}`);
   }
   if (location) {
     lines.push(`- **Location:** ${location}`);
@@ -86,26 +87,41 @@ function renderEventNetwork(network: NetworkForRendering): string {
     lines.push('|------|-------|----------|');
     for (const evt of upcoming) {
       const time = formatEventTime(evt.startTime);
-      const loc = evt.location ?? '';
-      lines.push(`| ${time} | ${evt.title} | ${loc} |`);
+      const loc = escapeTableCell(evt.location ?? '');
+      const title = escapeTableCell(evt.title);
+      lines.push(`| ${time} | ${title} | ${loc} |`);
     }
   }
 
   return lines.join('\n');
 }
 
-function formatDateRange(start: string, end: string): string {
+function formatDateRange(start: string, end: string): string | undefined {
   const s = new Date(start);
   const e = new Date(end);
-  const opts: Intl.DateTimeFormatOptions = { month: 'long', day: 'numeric', year: 'numeric' };
+  if (isNaN(s.getTime()) || isNaN(e.getTime())) return undefined;
+  const opts: Intl.DateTimeFormatOptions = { month: 'long', day: 'numeric', year: 'numeric', timeZone: 'UTC' };
   return `${s.toLocaleDateString('en-US', opts)} – ${e.toLocaleDateString('en-US', opts)}`;
 }
 
 function formatEventTime(iso: string): string {
   const d = new Date(iso);
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) +
+  if (isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' }) +
     ', ' +
-    d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+    d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', timeZone: 'UTC' });
+}
+
+function escapeTableCell(value: string): string {
+  return value.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+function normalizeEvents(raw: unknown[]): NonNullable<EventMetadata['events']> {
+  return raw.filter((e): e is NonNullable<EventMetadata['events']>[number] => {
+    if (typeof e !== 'object' || e === null) return false;
+    const obj = e as Record<string, unknown>;
+    return typeof obj.title === 'string' && typeof obj.startTime === 'string' && typeof obj.endTime === 'string';
+  });
 }
 
 function getUpcomingEvents(

--- a/packages/protocol/src/shared/network/metadata.renderer.ts
+++ b/packages/protocol/src/shared/network/metadata.renderer.ts
@@ -1,0 +1,122 @@
+interface NetworkForRendering {
+  type: string;
+  title: string;
+  prompt?: string | null;
+  metadata: Record<string, unknown>;
+}
+
+interface EventMetadata {
+  startDate?: string;
+  endDate?: string;
+  timezone?: string;
+  location?: string;
+  themes?: string[];
+  events?: Array<{
+    externalId: string;
+    title: string;
+    startTime: string;
+    endTime: string;
+    location?: string;
+    description?: string;
+    tags?: string[];
+  }>;
+}
+
+/**
+ * Render a network's metadata as structured markdown for LLM context.
+ *
+ * @param network - The network to render, with type, title, optional prompt, and metadata.
+ * @returns Markdown string suitable for injection into an LLM prompt.
+ */
+export function renderNetworkContext(network: NetworkForRendering): string {
+  switch (network.type) {
+    case 'event':
+      return renderEventNetwork(network);
+    case 'community':
+    default:
+      return renderCommunityNetwork(network);
+  }
+}
+
+function renderCommunityNetwork(network: NetworkForRendering): string {
+  const lines: string[] = [`## ${network.title}`];
+  if (network.prompt) {
+    lines.push('', network.prompt);
+  }
+  return lines.join('\n');
+}
+
+function renderEventNetwork(network: NetworkForRendering): string {
+  const meta = network.metadata;
+  const startDate = typeof meta.startDate === 'string' ? meta.startDate : undefined;
+  const endDate = typeof meta.endDate === 'string' ? meta.endDate : undefined;
+  const location = typeof meta.location === 'string' ? meta.location : undefined;
+  const timezone = typeof meta.timezone === 'string' ? meta.timezone : undefined;
+  const themes = Array.isArray(meta.themes) ? meta.themes as string[] : [];
+  const events = Array.isArray(meta.events) ? meta.events as NonNullable<EventMetadata['events']> : [];
+  const lines: string[] = [`## ${network.title}`];
+
+  if (network.prompt) {
+    lines.push('', network.prompt);
+  }
+
+  lines.push('');
+  lines.push('- **Type:** Event');
+
+  if (startDate && endDate) {
+    lines.push(`- **Dates:** ${formatDateRange(startDate, endDate)}`);
+  }
+  if (location) {
+    lines.push(`- **Location:** ${location}`);
+  }
+  if (timezone) {
+    lines.push(`- **Timezone:** ${timezone}`);
+  }
+  if (themes.length > 0) {
+    lines.push(`- **Themes:** ${themes.join(', ')}`);
+  }
+
+  lines.push('');
+  const upcoming = getUpcomingEvents(events, 7);
+  if (upcoming.length === 0) {
+    lines.push('No upcoming events in the next 7 days.');
+  } else {
+    lines.push('### Upcoming Events (next 7 days)');
+    lines.push('| Time | Event | Location |');
+    lines.push('|------|-------|----------|');
+    for (const evt of upcoming) {
+      const time = formatEventTime(evt.startTime);
+      const loc = evt.location ?? '';
+      lines.push(`| ${time} | ${evt.title} | ${loc} |`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function formatDateRange(start: string, end: string): string {
+  const s = new Date(start);
+  const e = new Date(end);
+  const opts: Intl.DateTimeFormatOptions = { month: 'long', day: 'numeric', year: 'numeric' };
+  return `${s.toLocaleDateString('en-US', opts)} – ${e.toLocaleDateString('en-US', opts)}`;
+}
+
+function formatEventTime(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) +
+    ', ' +
+    d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+}
+
+function getUpcomingEvents(
+  events: NonNullable<EventMetadata['events']>,
+  windowDays: number,
+): NonNullable<EventMetadata['events']> {
+  const now = Date.now();
+  const windowEnd = now + windowDays * 24 * 60 * 60 * 1000;
+  return events
+    .map((e) => ({ e, t: new Date(e.startTime).getTime() }))
+    .filter(({ t }) => !isNaN(t) && t >= now && t <= windowEnd)
+    .sort((a, b) => a.t - b.t)
+    .map(({ e }) => e);
+}

--- a/packages/protocol/src/shared/network/tests/metadata.renderer.test.ts
+++ b/packages/protocol/src/shared/network/tests/metadata.renderer.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'bun:test';
+import { renderNetworkContext } from '../metadata.renderer.js';
+
+describe('renderNetworkContext', () => {
+  describe('community type', () => {
+    it('renders title and prompt', () => {
+      const result = renderNetworkContext({
+        type: 'community',
+        title: 'AI Builders',
+        prompt: 'A community for AI practitioners to share knowledge.',
+        metadata: {},
+      });
+      expect(result).toContain('## AI Builders');
+      expect(result).toContain('A community for AI practitioners');
+      expect(result).not.toContain('**Dates:**');
+    });
+
+    it('renders title only when prompt is absent', () => {
+      const result = renderNetworkContext({
+        type: 'community',
+        title: 'No Prompt Community',
+        metadata: {},
+      });
+      expect(result).toContain('## No Prompt Community');
+      expect(result).not.toContain('undefined');
+      expect(result).not.toContain('null');
+    });
+  });
+
+  describe('event type', () => {
+    const baseEvent = {
+      type: 'event' as const,
+      title: 'Edge Esmeralda 2026',
+      prompt: 'A month-long popup village.',
+      metadata: {
+        startDate: '2026-05-30T00:00:00Z',
+        endDate: '2026-06-27T23:59:59Z',
+        timezone: 'America/Los_Angeles',
+        location: 'Healdsburg, California',
+        themes: ['AI', 'Governance', 'Health & Longevity'],
+        events: [],
+      },
+    };
+
+    it('renders all metadata fields', () => {
+      const result = renderNetworkContext(baseEvent);
+      expect(result).toContain('## Edge Esmeralda 2026');
+      expect(result).toContain('A month-long popup village.');
+      expect(result).toContain('**Type:** Event');
+      expect(result).toContain('May 30');
+      expect(result).toContain('June 27');
+      expect(result).toContain('Healdsburg, California');
+      expect(result).toContain('America/Los_Angeles');
+      expect(result).toContain('AI');
+      expect(result).toContain('Governance');
+    });
+
+    it('omits missing optional fields gracefully', () => {
+      const result = renderNetworkContext({
+        type: 'event',
+        title: 'Minimal Event',
+        metadata: {
+          startDate: '2026-06-01T00:00:00Z',
+          endDate: '2026-06-15T23:59:59Z',
+          events: [],
+        },
+      });
+      expect(result).toContain('## Minimal Event');
+      expect(result).not.toContain('**Location:**');
+      expect(result).not.toContain('**Timezone:**');
+      expect(result).not.toContain('**Themes:**');
+      expect(result).not.toContain('undefined');
+    });
+
+    it('renders "No upcoming events" when events array is empty', () => {
+      const result = renderNetworkContext(baseEvent);
+      expect(result).toContain('No upcoming events');
+    });
+
+    it('renders upcoming events table for events within 7 days of now', () => {
+      const now = new Date();
+      const tomorrow = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+      const nextWeekPlus = new Date(now.getTime() + 8 * 24 * 60 * 60 * 1000);
+
+      const result = renderNetworkContext({
+        ...baseEvent,
+        metadata: {
+          ...baseEvent.metadata,
+          startDate: new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString(),
+          endDate: new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+          events: [
+            {
+              externalId: 'e1',
+              title: 'Tomorrow Talk',
+              startTime: tomorrow.toISOString(),
+              endTime: new Date(tomorrow.getTime() + 60 * 60 * 1000).toISOString(),
+              location: 'Main Hall',
+            },
+            {
+              externalId: 'e2',
+              title: 'Far Future Talk',
+              startTime: nextWeekPlus.toISOString(),
+              endTime: new Date(nextWeekPlus.getTime() + 60 * 60 * 1000).toISOString(),
+            },
+          ],
+        },
+      });
+      expect(result).toContain('Tomorrow Talk');
+      expect(result).toContain('Main Hall');
+      expect(result).not.toContain('Far Future Talk');
+    });
+  });
+
+  describe('unknown type fallback', () => {
+    it('renders title and prompt for unknown types', () => {
+      const result = renderNetworkContext({
+        type: 'project' as string,
+        title: 'Unknown Type',
+        prompt: 'Some prompt.',
+        metadata: {},
+      });
+      expect(result).toContain('## Unknown Type');
+      expect(result).toContain('Some prompt.');
+    });
+  });
+});


### PR DESCRIPTION
## New Features
- Add `renderNetworkContext()` to `@indexnetwork/protocol` — type-aware markdown renderer for LLM context injection
- **Community** networks render title + prompt
- **Event** networks render title, prompt, dates, location, timezone, themes, and a 7-day windowed upcoming events table

## Refactors
- Defensive field-level type guards on all metadata access (no unsafe casts)
- Element-level validation: themes filtered to strings, events validated for required fields
- UTC-locked `Intl` formatting for deterministic output across environments
- Invalid date guards with graceful fallback
- Pipe/newline escaping in markdown table cells

## Tests
- 7 unit tests: community (with/without prompt), event (full/minimal metadata, empty events, upcoming events filtering), unknown type fallback

Part of IND-311 / IND-308 (Polymorphic Network Types).