### PR TITLE
Release 2026-05-23

### DIFF
--- a/backend/drizzle/0070_add_network_type_and_metadata.sql
+++ b/backend/drizzle/0070_add_network_type_and_metadata.sql
@@ -1,0 +1,8 @@
+CREATE TYPE "public"."network_type" AS ENUM('community', 'event');--> statement-breakpoint
+ALTER TABLE "network_members" ALTER COLUMN "metadata" SET DATA TYPE jsonb;--> statement-breakpoint
+ALTER TABLE "network_members" ALTER COLUMN "metadata" SET DEFAULT '{}'::jsonb;--> statement-breakpoint
+UPDATE "network_members" SET "metadata" = '{}'::jsonb WHERE "metadata" IS NULL;--> statement-breakpoint
+ALTER TABLE "network_members" ALTER COLUMN "metadata" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "network_integrations" ADD COLUMN "sync_config" jsonb DEFAULT '{}'::jsonb NOT NULL;--> statement-breakpoint
+ALTER TABLE "networks" ADD COLUMN "type" "network_type" DEFAULT 'community' NOT NULL;--> statement-breakpoint
+ALTER TABLE "networks" ADD COLUMN "metadata" jsonb DEFAULT '{}'::jsonb NOT NULL;

--- a/backend/drizzle/meta/0070_snapshot.json
+++ b/backend/drizzle/meta/0070_snapshot.json
@@ -1,0 +1,4064 @@
+{
+  "id": "8c4e2318-317f-415e-bbf7-cedebd89ac29",
+  "prevId": "fc3ecc77-c885-45ea-bf6c-bc741b534e57",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_permissions": {
+      "name": "agent_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "permission_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actions": {
+          "name": "actions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_permissions_agent_id_idx": {
+          "name": "agent_permissions_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_permissions_user_id_idx": {
+          "name": "agent_permissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_permissions_agent_user_idx": {
+          "name": "agent_permissions_agent_user_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_agent_permissions_global": {
+          "name": "uniq_agent_permissions_global",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_permissions\".\"scope\" = 'global'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_permissions_agent_id_agents_id_fk": {
+          "name": "agent_permissions_agent_id_agents_id_fk",
+          "tableFrom": "agent_permissions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_permissions_user_id_users_id_fk": {
+          "name": "agent_permissions_user_id_users_id_fk",
+          "tableFrom": "agent_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_messages": {
+      "name": "agent_test_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_token": {
+          "name": "reservation_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reserved_at": {
+          "name": "reserved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_test_messages_agent_pending": {
+          "name": "idx_agent_test_messages_agent_pending",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reserved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_messages_agent_id_agents_id_fk": {
+          "name": "agent_test_messages_agent_id_agents_id_fk",
+          "tableFrom": "agent_test_messages",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_messages_requested_by_user_id_users_id_fk": {
+          "name": "agent_test_messages_requested_by_user_id_users_id_fk",
+          "tableFrom": "agent_test_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_transports": {
+      "name": "agent_transports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "transport_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_transports_agent_id_idx": {
+          "name": "agent_transports_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_transports_agent_id_agents_id_fk": {
+          "name": "agent_transports_agent_id_agents_id_fk",
+          "tableFrom": "agent_transports",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "agent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_on_opportunity": {
+          "name": "notify_on_opportunity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "daily_summary_enabled": {
+          "name": "daily_summary_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "handle_negotiations": {
+          "name": "handle_negotiations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_daily_summary_at": {
+          "name": "last_daily_summary_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agents_owner_id_idx": {
+          "name": "agents_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_type_idx": {
+          "name": "agents_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_last_seen_at_idx": {
+          "name": "agents_last_seen_at_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_users_id_fk": {
+          "name": "agents_owner_id_users_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apikey_user_id_users_id_fk": {
+          "name": "apikey_user_id_users_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connect_links": {
+      "name": "connect_links",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "greeting": {
+          "name": "greeting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_surface": {
+          "name": "preferred_surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connect_links_kind_recipient_uq": {
+          "name": "connect_links_kind_recipient_uq",
+          "columns": [
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connect_links_expires_at_idx": {
+          "name": "connect_links_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connect_links_user_id_users_id_fk": {
+          "name": "connect_links_user_id_users_id_fk",
+          "tableFrom": "connect_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connect_links_opportunity_id_opportunities_id_fk": {
+          "name": "connect_links_opportunity_id_opportunities_id_fk",
+          "tableFrom": "connect_links",
+          "tableTo": "opportunities",
+          "columnsFrom": [
+            "opportunity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "files_user_id_users_id_fk": {
+          "name": "files_user_id_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hyde_documents": {
+      "name": "hyde_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_text": {
+          "name": "source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_corpus": {
+          "name": "target_corpus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hyde_text": {
+          "name": "hyde_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hyde_embedding": {
+          "name": "hyde_embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "hyde_source_idx": {
+          "name": "hyde_source_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_strategy_idx": {
+          "name": "hyde_strategy_idx",
+          "columns": [
+            {
+              "expression": "strategy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_embedding_idx": {
+          "name": "hyde_embedding_idx",
+          "columns": [
+            {
+              "expression": "hyde_embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "hyde_expires_idx": {
+          "name": "hyde_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_source_strategy_unique": {
+          "name": "hyde_source_strategy_unique",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "strategy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_corpus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.intent_networks": {
+      "name": "intent_networks",
+      "schema": "",
+      "columns": {
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relevancy_score": {
+          "name": "relevancy_score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "intent_networks_network_id_idx": {
+          "name": "intent_networks_network_id_idx",
+          "columns": [
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intent_networks_intent_id_intents_id_fk": {
+          "name": "intent_networks_intent_id_intents_id_fk",
+          "tableFrom": "intent_networks",
+          "tableTo": "intents",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "intent_networks_network_id_networks_id_fk": {
+          "name": "intent_networks_network_id_networks_id_fk",
+          "tableFrom": "intent_networks",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "intent_networks_intent_id_network_id_pk": {
+          "name": "intent_networks_intent_id_network_id_pk",
+          "columns": [
+            "intent_id",
+            "network_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.intents": {
+      "name": "intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_incognito": {
+          "name": "is_incognito",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "semantic_entropy": {
+          "name": "semantic_entropy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "referential_anchor": {
+          "name": "referential_anchor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intent_mode": {
+          "name": "intent_mode",
+          "type": "intent_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ATTRIBUTIVE'"
+        },
+        "speech_act_type": {
+          "name": "speech_act_type",
+          "type": "speech_act_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "felicity_authority": {
+          "name": "felicity_authority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "felicity_sincerity": {
+          "name": "felicity_sincerity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "felicity_clarity": {
+          "name": "felicity_clarity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "intent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {
+        "embeddingIndex": {
+          "name": "embeddingIndex",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intents_user_id_users_id_fk": {
+          "name": "intents_user_id_users_id_fk",
+          "tableFrom": "intents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.links": {
+      "name": "links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "links_user_id_users_id_fk": {
+          "name": "links_user_id_users_id_fk",
+          "tableFrom": "links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.network_integrations": {
+      "name": "network_integrations",
+      "schema": "",
+      "columns": {
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolkit": {
+          "name": "toolkit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_config": {
+          "name": "sync_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "network_integrations_network_id_networks_id_fk": {
+          "name": "network_integrations_network_id_networks_id_fk",
+          "tableFrom": "network_integrations",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "network_integrations_network_id_toolkit_pk": {
+          "name": "network_integrations_network_id_toolkit_pk",
+          "columns": [
+            "network_id",
+            "toolkit"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.network_members": {
+      "name": "network_members",
+      "schema": "",
+      "columns": {
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_assign": {
+          "name": "auto_assign",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "network_members_network_id_networks_id_fk": {
+          "name": "network_members_network_id_networks_id_fk",
+          "tableFrom": "network_members",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "network_members_user_id_users_id_fk": {
+          "name": "network_members_user_id_users_id_fk",
+          "tableFrom": "network_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "network_members_network_id_user_id_pk": {
+          "name": "network_members_network_id_user_id_pk",
+          "columns": [
+            "network_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.networks": {
+      "name": "networks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_experiment": {
+          "name": "is_experiment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "experiment_master_key_hash": {
+          "name": "experiment_master_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "network_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'community'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"joinPolicy\":\"invite_only\",\"invitationLink\":null,\"allowGuestVibeCheck\":false}'::json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "indexes_key_unique": {
+          "name": "indexes_key_unique",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_access_token_client_id_idx": {
+          "name": "oauth_access_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_user_id_idx": {
+          "name": "oauth_access_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_users_id_fk": {
+          "name": "oauth_access_token_user_id_users_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_access_token_unique": {
+          "name": "oauth_access_token_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        },
+        "oauth_access_token_refresh_token_unique": {
+          "name": "oauth_access_token_refresh_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_application": {
+      "name": "oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_application_user_id_idx": {
+          "name": "oauth_application_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_application_user_id_users_id_fk": {
+          "name": "oauth_application_user_id_users_id_fk",
+          "tableFrom": "oauth_application",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_application_client_id_unique": {
+          "name": "oauth_application_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_id_idx": {
+          "name": "oauth_consent_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_user_id_idx": {
+          "name": "oauth_consent_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_users_id_fk": {
+          "name": "oauth_consent_user_id_users_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunities": {
+      "name": "opportunities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "detection": {
+          "name": "detection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actors": {
+          "name": "actors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interpretation": {
+          "name": "interpretation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "opportunity_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "opportunities_status_idx": {
+          "name": "opportunities_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunities_accepted_by_users_id_fk": {
+          "name": "opportunities_accepted_by_users_id_fk",
+          "tableFrom": "opportunities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "accepted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunity_deliveries": {
+      "name": "opportunity_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivered_at_status": {
+          "name": "delivered_at_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_token": {
+          "name": "reservation_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reserved_at": {
+          "name": "reserved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_opp_deliveries_committed": {
+          "name": "uniq_opp_deliveries_committed",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "delivered_at_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"opportunity_deliveries\".\"delivered_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_opp_deliveries_open_reservations": {
+          "name": "idx_opp_deliveries_open_reservations",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reserved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"opportunity_deliveries\".\"delivered_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunity_deliveries_opportunity_id_opportunities_id_fk": {
+          "name": "opportunity_deliveries_opportunity_id_opportunities_id_fk",
+          "tableFrom": "opportunity_deliveries",
+          "tableTo": "opportunities",
+          "columnsFrom": [
+            "opportunity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "opportunity_deliveries_user_id_users_id_fk": {
+          "name": "opportunity_deliveries_user_id_users_id_fk",
+          "tableFrom": "opportunity_deliveries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "opportunity_deliveries_agent_id_agents_id_fk": {
+          "name": "opportunity_deliveries_agent_id_agents_id_fk",
+          "tableFrom": "opportunity_deliveries",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_networks": {
+      "name": "personal_networks",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "personal_networks_network_id_unique": {
+          "name": "personal_networks_network_id_unique",
+          "columns": [
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_networks_user_id_users_id_fk": {
+          "name": "personal_networks_user_id_users_id_fk",
+          "tableFrom": "personal_networks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "personal_networks_network_id_networks_id_fk": {
+          "name": "personal_networks_network_id_networks_id_fk",
+          "tableFrom": "personal_networks",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "personal_networks_user_id_pk": {
+          "name": "personal_networks_user_id_pk",
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_settings": {
+      "name": "user_notification_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"connectionUpdates\":true,\"weeklyNewsletter\":true}'::json"
+        },
+        "unsubscribe_token": {
+          "name": "unsubscribe_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_settings_user_id_users_id_fk": {
+          "name": "user_notification_settings_user_id_users_id_fk",
+          "tableFrom": "user_notification_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_notification_settings_user_id_unique": {
+          "name": "user_notification_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_notification_settings_unsubscribe_token_unique": {
+          "name": "user_notification_settings_unsubscribe_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "unsubscribe_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity": {
+          "name": "identity",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "narrative": {
+          "name": "narrative",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "implicit_intents": {
+          "name": "implicit_intents",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_profiles_embedding_idx": {
+          "name": "user_profiles_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_profiles_user_id_unique": {
+          "name": "user_profiles_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_socials": {
+      "name": "user_socials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_socials_user_id": {
+          "name": "idx_user_socials_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_user_socials_user_label": {
+          "name": "uniq_user_socials_user_label",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_socials\".\"label\" <> 'custom'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_socials_user_id_users_id_fk": {
+          "name": "user_socials_user_id_users_id_fk",
+          "tableFrom": "user_socials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro": {
+          "name": "intro",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding": {
+          "name": "onboarding",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::json"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UTC'"
+        },
+        "last_weekly_email_sent_at": {
+          "name": "last_weekly_email_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_ghost": {
+          "name": "is_ghost",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_key_unique": {
+          "name": "users_key_unique",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artifacts": {
+      "name": "artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "artifacts_task_id_idx": {
+          "name": "artifacts_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifacts_task_id_tasks_id_fk": {
+          "name": "artifacts_task_id_tasks_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session_summaries": {
+      "name": "chat_session_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_message_id": {
+          "name": "from_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_message_id": {
+          "name": "to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "digest": {
+          "name": "digest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chat_session_summaries_session_latest_idx": {
+          "name": "chat_session_summaries_session_latest_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_session_summaries_conversation_id_conversations_id_fk": {
+          "name": "chat_session_summaries_conversation_id_conversations_id_fk",
+          "tableFrom": "chat_session_summaries",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_session_summaries_from_message_id_messages_id_fk": {
+          "name": "chat_session_summaries_from_message_id_messages_id_fk",
+          "tableFrom": "chat_session_summaries",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "from_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "chat_session_summaries_to_message_id_messages_id_fk": {
+          "name": "chat_session_summaries_to_message_id_messages_id_fk",
+          "tableFrom": "chat_session_summaries",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "to_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_metadata": {
+      "name": "conversation_metadata",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_metadata_conversation_id_conversations_id_fk": {
+          "name": "conversation_metadata_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_metadata",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_participants": {
+      "name": "conversation_participants",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_type": {
+          "name": "participant_type",
+          "type": "participant_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "hidden_at": {
+          "name": "hidden_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversation_participants_participant_id_idx": {
+          "name": "conversation_participants_participant_id_idx",
+          "columns": [
+            {
+              "expression": "participant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_participants_conversation_id_idx": {
+          "name": "conversation_participants_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_participants_conversation_id_conversations_id_fk": {
+          "name": "conversation_participants_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_participants",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_participants_conversation_id_participant_id_pk": {
+          "name": "conversation_participants_conversation_id_participant_id_pk",
+          "columns": [
+            "conversation_id",
+            "participant_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dm_pair": {
+          "name": "dm_pair",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversations_dm_pair_idx": {
+          "name": "conversations_dm_pair_idx",
+          "columns": [
+            {
+              "expression": "dm_pair",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "message_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_task_ids": {
+          "name": "reference_task_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_conversation_id_created_at_idx": {
+          "name": "messages_conversation_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_sender_id_idx": {
+          "name": "messages_sender_id_idx",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_task_id_idx": {
+          "name": "messages_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_task_id_tasks_id_fk": {
+          "name": "messages_task_id_tasks_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "task_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "status_message": {
+          "name": "status_message",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_timestamp": {
+          "name": "status_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_agent_id": {
+          "name": "claimed_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tasks_conversation_id_idx": {
+          "name": "tasks_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_state_idx": {
+          "name": "tasks_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_metadata_opportunity_id_idx": {
+          "name": "tasks_metadata_opportunity_id_idx",
+          "columns": [
+            {
+              "expression": "(\"metadata\"->>'opportunityId')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"tasks\".\"metadata\"->>'type' = 'negotiation'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_conversation_id_conversations_id_fk": {
+          "name": "tasks_conversation_id_conversations_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_status": {
+      "name": "agent_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive"
+      ]
+    },
+    "public.agent_type": {
+      "name": "agent_type",
+      "schema": "public",
+      "values": [
+        "personal",
+        "system"
+      ]
+    },
+    "public.intent_mode": {
+      "name": "intent_mode",
+      "schema": "public",
+      "values": [
+        "REFERENTIAL",
+        "ATTRIBUTIVE"
+      ]
+    },
+    "public.intent_status": {
+      "name": "intent_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "PAUSED",
+        "FULFILLED",
+        "EXPIRED"
+      ]
+    },
+    "public.network_type": {
+      "name": "network_type",
+      "schema": "public",
+      "values": [
+        "community",
+        "event"
+      ]
+    },
+    "public.opportunity_status": {
+      "name": "opportunity_status",
+      "schema": "public",
+      "values": [
+        "latent",
+        "draft",
+        "negotiating",
+        "pending",
+        "stalled",
+        "accepted",
+        "rejected",
+        "expired"
+      ]
+    },
+    "public.permission_scope": {
+      "name": "permission_scope",
+      "schema": "public",
+      "values": [
+        "global",
+        "node",
+        "network"
+      ]
+    },
+    "public.source_type": {
+      "name": "source_type",
+      "schema": "public",
+      "values": [
+        "file",
+        "integration",
+        "link",
+        "discovery_form",
+        "enrichment"
+      ]
+    },
+    "public.speech_act_type": {
+      "name": "speech_act_type",
+      "schema": "public",
+      "values": [
+        "COMMISSIVE",
+        "DIRECTIVE"
+      ]
+    },
+    "public.transport_channel": {
+      "name": "transport_channel",
+      "schema": "public",
+      "values": [
+        "mcp"
+      ]
+    },
+    "public.message_role": {
+      "name": "message_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "agent"
+      ]
+    },
+    "public.participant_type": {
+      "name": "participant_type",
+      "schema": "public",
+      "values": [
+        "user",
+        "agent"
+      ]
+    },
+    "public.task_state": {
+      "name": "task_state",
+      "schema": "public",
+      "values": [
+        "submitted",
+        "working",
+        "input_required",
+        "completed",
+        "failed",
+        "canceled",
+        "rejected",
+        "auth_required",
+        "waiting_for_agent",
+        "claimed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -491,6 +491,13 @@
       "when": 1778852025988,
       "tag": "0069_add_connect_link_preferred_surface",
       "breakpoints": true
+    },
+    {
+      "idx": 70,
+      "version": "7",
+      "when": 1779472341802,
+      "tag": "0070_add_network_type_and_metadata",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -2158,7 +2158,7 @@ export class ChatDatabaseAdapter {
       db.select({ count: count() }).from(networkMembers).where(and(eq(networkMembers.networkId, networkId), isNull(networkMembers.deletedAt))),
       db.select({ count: count() }).from(intentNetworks).where(eq(intentNetworks.networkId, networkId)),
     ]);
-    const perms = (updatedRow.permissions as { joinPolicy: string; invitationLink: { code: string } | null; allowGuestVibeCheck: boolean }) ?? {};
+    const perms = (updatedRow.permissions as { joinPolicy: string; invitationLink: { code: string } | null; allowGuestVibeCheck: boolean; contextInjection?: { discovery: boolean } }) ?? {};
     const memberCount = Number(memberCountResult[0]?.count ?? 0);
     return {
       id: updatedRow.id,
@@ -2171,6 +2171,7 @@ export class ChatDatabaseAdapter {
         joinPolicy: (perms.joinPolicy ?? 'invite_only') as 'anyone' | 'invite_only',
         allowGuestVibeCheck: perms.allowGuestVibeCheck ?? false,
         invitationLink: perms.invitationLink ?? null,
+        ...(perms.contextInjection !== undefined && { contextInjection: perms.contextInjection }),
       },
       isPersonal: updatedRow.isPersonal,
       createdAt: updatedRow.createdAt,

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -1318,6 +1318,8 @@ export class ChatDatabaseAdapter {
         updatedAt: schema.networks.updatedAt,
         ownerName: schema.users.name,
         ownerAvatar: schema.users.avatar,
+        type: schema.networks.type,
+        metadata: schema.networks.metadata,
       })
       .from(schema.networks)
       .leftJoin(ownerMembers, eq(schema.networks.id, ownerMembers.networkId))
@@ -1348,6 +1350,8 @@ export class ChatDatabaseAdapter {
           key: row.key,
           prompt: row.prompt,
           imageUrl: row.imageUrl,
+          type: row.type ?? 'community',
+          metadata: (row.metadata ?? {}) as Record<string, unknown>,
           permissions: row.permissions,
           isPersonal: row.isPersonal,
           isExperiment: row.isExperiment,
@@ -2083,7 +2087,7 @@ export class ChatDatabaseAdapter {
   async updateIndexSettings(
     networkId: string,
     requestingUserId: string,
-    data: { title?: string; prompt?: string | null; imageUrl?: string | null; joinPolicy?: 'anyone' | 'invite_only'; allowGuestVibeCheck?: boolean }
+    data: { title?: string; prompt?: string | null; imageUrl?: string | null; joinPolicy?: 'anyone' | 'invite_only'; allowGuestVibeCheck?: boolean; type?: 'community' | 'event'; metadata?: Record<string, unknown>; contextInjection?: { discovery: boolean } }
   ) {
     const isOwner = await this.isIndexOwner(networkId, requestingUserId);
     if (!isOwner) {
@@ -2107,6 +2111,15 @@ export class ChatDatabaseAdapter {
         allowGuestVibeCheck: data.allowGuestVibeCheck ?? currentPerms.allowGuestVibeCheck ?? false,
       };
     }
+    if (data.type !== undefined) updateData.type = data.type;
+    if (data.metadata !== undefined) updateData.metadata = data.metadata;
+    if (data.contextInjection !== undefined) {
+      const currentPerms = (existing.permissions as Record<string, unknown>) ?? {};
+      updateData.permissions = {
+        ...((updateData.permissions as Record<string, unknown>) ?? currentPerms),
+        contextInjection: data.contextInjection,
+      };
+    }
 
     await db.update(networks).set(updateData).where(eq(networks.id, networkId));
 
@@ -2123,6 +2136,8 @@ export class ChatDatabaseAdapter {
         ownerId: networkMembers.userId,
         userName: users.name,
         userAvatar: users.avatar,
+        type: networks.type,
+        metadata: networks.metadata,
       })
       .from(networks)
       .innerJoin(
@@ -2150,6 +2165,8 @@ export class ChatDatabaseAdapter {
       title: updatedRow.title,
       prompt: updatedRow.prompt,
       imageUrl: updatedRow.imageUrl,
+      type: updatedRow.type ?? 'community',
+      metadata: (updatedRow.metadata ?? {}) as Record<string, unknown>,
       permissions: {
         joinPolicy: (perms.joinPolicy ?? 'invite_only') as 'anyone' | 'invite_only',
         allowGuestVibeCheck: perms.allowGuestVibeCheck ?? false,
@@ -2330,12 +2347,16 @@ export class ChatDatabaseAdapter {
     prompt?: string | null;
     imageUrl?: string | null;
     joinPolicy?: 'anyone' | 'invite_only';
+    type?: 'community' | 'event';
+    metadata?: Record<string, unknown>;
   }): Promise<{
     id: string;
     title: string;
     prompt: string | null;
     imageUrl: string | null;
     permissions: { joinPolicy: 'anyone' | 'invite_only'; invitationLink: { code: string } | null; allowGuestVibeCheck: boolean };
+    type: 'community' | 'event';
+    metadata: Record<string, unknown>;
   }> {
     const finalJoinPolicy = data.joinPolicy ?? 'invite_only';
     const permissions = {
@@ -2350,6 +2371,8 @@ export class ChatDatabaseAdapter {
         prompt: data.prompt ?? null,
         imageUrl: data.imageUrl ?? null,
         permissions,
+        type: data.type ?? 'community',
+        metadata: data.metadata ?? {},
       })
       .returning({
         id: networks.id,
@@ -2357,6 +2380,8 @@ export class ChatDatabaseAdapter {
         prompt: networks.prompt,
         imageUrl: networks.imageUrl,
         permissions: networks.permissions,
+        type: networks.type,
+        metadata: networks.metadata,
       });
     if (!row) throw new Error('Failed to create index');
     const perms = (row.permissions as { joinPolicy: string; invitationLink: { code: string } | null; allowGuestVibeCheck: boolean }) ?? {};
@@ -2370,6 +2395,8 @@ export class ChatDatabaseAdapter {
         invitationLink: perms.invitationLink ?? null,
         allowGuestVibeCheck: perms.allowGuestVibeCheck ?? false,
       },
+      type: row.type ?? 'community',
+      metadata: (row.metadata ?? {}) as Record<string, unknown>,
     };
   }
 
@@ -2637,6 +2664,8 @@ export class ChatDatabaseAdapter {
         ownerId: networkMembers.userId,
         userName: users.name,
         userAvatar: users.avatar,
+        type: networks.type,
+        metadata: networks.metadata,
       })
       .from(networks)
       .innerJoin(
@@ -2666,6 +2695,8 @@ export class ChatDatabaseAdapter {
       key: row.key,
       prompt: row.prompt,
       imageUrl: row.imageUrl,
+      type: row.type ?? 'community',
+      metadata: (row.metadata ?? {}) as Record<string, unknown>,
       permissions: row.permissions,
       isPersonal: row.isPersonal,
       isExperiment: row.isExperiment,

--- a/backend/src/controllers/network.controller.ts
+++ b/backend/src/controllers/network.controller.ts
@@ -1,3 +1,5 @@
+import { ZodError } from 'zod';
+
 import { assertAgentNetworkScope, withAgentScope } from '../guards/agent-scope.guard';
 import { AuthGuard, AuthOrApiKeyGuard, type AuthenticatedUser } from '../guards/auth.guard';
 import { ExperimentMasterKeyGuard, type ExperimentNetwork } from '../guards/experiment.guard';
@@ -62,6 +64,8 @@ export class NetworkController {
       joinPolicy?: 'anyone' | 'invite_only';
       allowGuestVibeCheck?: boolean;
       isExperiment?: boolean;
+      type?: 'community' | 'event';
+      metadata?: Record<string, unknown>;
     };
 
     if (!body.title) {
@@ -81,15 +85,24 @@ export class NetworkController {
       return Response.json({ network, masterKey }, { status: 201 });
     }
 
-    const result = await networkService.createNetwork(user.id, {
-      title: body.title,
-      prompt: body.prompt,
-      imageUrl: body.imageUrl,
-      joinPolicy: body.joinPolicy,
-      allowGuestVibeCheck: body.allowGuestVibeCheck,
-    });
-    logger.verbose('Network created', { networkId: result.id, userId: user.id });
-    return Response.json({ network: result });
+    try {
+      const result = await networkService.createNetwork(user.id, {
+        title: body.title,
+        prompt: body.prompt,
+        imageUrl: body.imageUrl,
+        joinPolicy: body.joinPolicy,
+        allowGuestVibeCheck: body.allowGuestVibeCheck,
+        type: body.type,
+        metadata: body.metadata,
+      });
+      logger.verbose('Network created', { networkId: result.id, userId: user.id });
+      return Response.json({ network: result });
+    } catch (err: unknown) {
+      if (err instanceof ZodError) {
+        return Response.json({ error: 'Validation failed', details: err.issues }, { status: 400 });
+      }
+      throw err;
+    }
   }
 
   /**
@@ -689,6 +702,9 @@ export class NetworkController {
         imageUrl?: string | null;
         joinPolicy?: 'anyone' | 'invite_only';
         allowGuestVibeCheck?: boolean;
+        type?: 'community' | 'event';
+        metadata?: Record<string, unknown>;
+        contextInjection?: { discovery: boolean };
       };
 
       if ('isExperiment' in body || 'experimentMasterKeyHash' in body) {
@@ -714,6 +730,9 @@ export class NetworkController {
           status: 400,
           headers: { 'Content-Type': 'application/json' },
         });
+      }
+      if (err instanceof ZodError) {
+        return Response.json({ error: 'Validation failed', details: err.issues }, { status: 400 });
       }
       throw err;
     }

--- a/backend/src/controllers/tests/network.controller.spec.ts
+++ b/backend/src/controllers/tests/network.controller.spec.ts
@@ -30,6 +30,7 @@ describe("NetworkController Integration", () => {
   const indexAdapter = new NetworkGraphDatabaseAdapter();
   let testUserId: string;
   let createdIndexId: string;
+  const additionalNetworkIds: string[] = [];
   const testEmail = `test-index-controller-${Date.now()}@example.com`;
 
   beforeAll(async () => {
@@ -46,6 +47,7 @@ describe("NetworkController Integration", () => {
   });
 
   afterAll(async () => {
+    for (const id of additionalNetworkIds) await indexAdapter.deleteNetworkAndMembers(id);
     if (createdIndexId) await indexAdapter.deleteNetworkAndMembers(createdIndexId);
     if (testUserId) await userAdapter.deleteById(testUserId);
   });
@@ -94,6 +96,62 @@ describe("NetworkController Integration", () => {
       expect(data.network).toBeDefined();
       expect(data.network!.title).toBe("Test Index");
       createdIndexId = data.network!.id;
+    });
+
+    test("should return 200 and create event network with valid metadata", async () => {
+      const req = new Request("http://localhost/networks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: "Test Event",
+          type: "event",
+          metadata: {
+            startDate: "2026-06-01T00:00:00Z",
+            endDate: "2026-06-30T23:59:59Z",
+            timezone: "America/Los_Angeles",
+            location: "San Francisco",
+          },
+        }),
+      });
+      const res = await controller.create(req, mockUser());
+      const data = (await res.json()) as { network?: { id: string; type: string; metadata: Record<string, unknown> } };
+
+      expect(res.status).toBe(200);
+      expect(data.network).toBeDefined();
+      expect(data.network!.type).toBe("event");
+      expect(data.network!.metadata.startDate).toBe("2026-06-01T00:00:00Z");
+      additionalNetworkIds.push(data.network!.id);
+    });
+
+    test("should return 400 when event network missing required dates", async () => {
+      const req = new Request("http://localhost/networks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: "Bad Event", type: "event", metadata: {} }),
+      });
+      const res = await controller.create(req, mockUser());
+      const data = (await res.json()) as { error?: string; details?: unknown[] };
+
+      expect(res.status).toBe(400);
+      expect(data.error).toBe("Validation failed");
+      expect(Array.isArray(data.details)).toBe(true);
+    });
+
+    test("should return 400 when endDate is before startDate", async () => {
+      const req = new Request("http://localhost/networks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: "Bad Dates",
+          type: "event",
+          metadata: { startDate: "2026-06-30T00:00:00Z", endDate: "2026-06-01T00:00:00Z" },
+        }),
+      });
+      const res = await controller.create(req, mockUser());
+      const data = (await res.json()) as { error?: string; details?: unknown[] };
+
+      expect(res.status).toBe(400);
+      expect(data.error).toBe("Validation failed");
     });
   });
 
@@ -155,6 +213,32 @@ describe("NetworkController Integration", () => {
       expect(res.status).toBe(200);
       expect(data.network).toBeDefined();
       expect(data.network!.title).toBe("Updated Test Index");
+    });
+
+    test("should return 400 when updating with invalid event metadata", async () => {
+      const req = new Request("http://localhost/networks/" + createdIndexId, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ type: "event", metadata: {} }),
+      });
+      const res = await controller.update(req, mockUser(), { id: createdIndexId });
+      const data = (await res.json()) as { error?: string; details?: unknown[] };
+
+      expect(res.status).toBe(400);
+      expect(data.error).toBe("Validation failed");
+    });
+
+    test("should return 200 when updating with valid contextInjection", async () => {
+      const req = new Request("http://localhost/networks/" + createdIndexId, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ contextInjection: { discovery: false } }),
+      });
+      const res = await controller.update(req, mockUser(), { id: createdIndexId });
+      const data = (await res.json()) as { network?: { permissions: { contextInjection?: { discovery: boolean } } } };
+
+      expect(res.status).toBe(200);
+      expect(data.network!.permissions.contextInjection?.discovery).toBe(false);
     });
   });
 

--- a/backend/src/gateways/telegram.gateway.ts
+++ b/backend/src/gateways/telegram.gateway.ts
@@ -245,7 +245,27 @@ export async function handleInbound(
     content: responseText,
   }).catch((err) => logger.warn('Failed to write assistant message to conversation', { error: err }));
 
-  await deps.sendTelegramMessage(chatId, responseText);
+  // Send final response. sendMessage defaults to plain text (no parse_mode)
+  // so LLM output containing <, >, & won't trigger Telegram's HTML parser.
+  try {
+    await deps.sendTelegramMessage(chatId, responseText);
+  } catch (err) {
+    logger.error('Failed to deliver final response via Telegram', { chatId, error: err });
+    // Last-resort fallback
+    await deps.sendTelegramMessage(chatId, 'I generated a response but couldn\'t deliver it. Please try again.').catch(() => {});
+  }
+}
+
+/**
+ * Send a status message during streaming — best-effort.
+ * Telegram API errors (rate limits, network) must not kill the stream.
+ */
+async function trySendStatus(chatId: string, text: string, deps: GatewayDeps): Promise<void> {
+  try {
+    await deps.sendTelegramMessage(chatId, text);
+  } catch (err) {
+    logger.warn('Failed to send Telegram status message', { chatId, text, error: err });
+  }
 }
 
 /**
@@ -262,6 +282,9 @@ async function handleInboundStreaming(
 ): Promise<string> {
   const stopTyping = startTypingIndicator(chatId, deps);
 
+  // Timeout timer — must be cleaned up to avoid unhandled rejections
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+
   try {
     let responseText = '';
     let lastStatusSentAt = 0;
@@ -270,9 +293,9 @@ async function handleInboundStreaming(
     const stream = deps.streamMessage!(userId, text, sessionId);
 
     // Race the stream against a hard timeout
-    const timeoutPromise = new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error('streamMessage timed out')), PROCESS_TIMEOUT_MS),
-    );
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutHandle = setTimeout(() => reject(new Error('streamMessage timed out')), PROCESS_TIMEOUT_MS);
+    });
 
     // Wrap the async iteration in a promise so we can race it
     const streamPromise = (async () => {
@@ -282,7 +305,7 @@ async function handleInboundStreaming(
           const status = toolStatusText(event.toolName);
           const now = Date.now();
           if (status && status !== lastStatusText && now - lastStatusSentAt >= STATUS_THROTTLE_MS) {
-            await deps.sendTelegramMessage(chatId, status);
+            await trySendStatus(chatId, status, deps);
             lastStatusText = status;
             lastStatusSentAt = now;
           }
@@ -293,7 +316,7 @@ async function handleInboundStreaming(
           const agentStatus = agentStatusText(event.name);
           const now = Date.now();
           if (agentStatus && agentStatus !== lastStatusText && now - lastStatusSentAt >= STATUS_THROTTLE_MS) {
-            await deps.sendTelegramMessage(chatId, agentStatus);
+            await trySendStatus(chatId, agentStatus, deps);
             lastStatusText = agentStatus;
             lastStatusSentAt = now;
           }
@@ -309,9 +332,20 @@ async function handleInboundStreaming(
     await Promise.race([streamPromise, timeoutPromise]);
     return responseText || 'Sorry, I could not process your message.';
   } catch (err) {
-    logger.error('Streaming processMessage failed for Telegram user', { userId, chatId, error: err });
-    return 'Sorry, something went wrong. Please try again.';
+    const errorMsg = err instanceof Error ? err.message : String(err);
+    const isTimeout = errorMsg.includes('timed out');
+    logger.error('Streaming processMessage failed for Telegram user', {
+      userId,
+      chatId,
+      errorType: isTimeout ? 'timeout' : 'stream_error',
+      errorMessage: errorMsg,
+      error: err,
+    });
+    return isTimeout
+      ? 'This is taking longer than expected. Please try a simpler question, or try again in a moment.'
+      : 'Sorry, something went wrong. Please try again.';
   } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
     stopTyping();
   }
 }

--- a/backend/src/gateways/telegram.gateway.ts
+++ b/backend/src/gateways/telegram.gateway.ts
@@ -109,8 +109,11 @@ function productionRedis(): RedisReader {
   };
 }
 
-const UNKNOWN_CHAT_MSG = 'Please connect your Telegram account at index.network first.';
-const EXPIRED_TOKEN_MSG = 'This link has expired. Please reconnect from Index.';
+function appUrl(): string {
+  return process.env.FRONTEND_URL || process.env.APP_URL || 'https://index.network';
+}
+
+const EXPIRED_TOKEN_MSG = () => `This link has expired. Please reconnect at ${appUrl()}.`;
 const CONNECTED_MSG =
   'Your Telegram account is now connected to Index. You\'ll receive notifications here and can chat with me anytime.';
 
@@ -135,7 +138,12 @@ export async function handleInbound(
 
   const found = await deps.findByTelegramChatId(chatId);
   if (!found) {
-    await deps.sendTelegramMessage(chatId, UNKNOWN_CHAT_MSG);
+    const url = appUrl();
+    await deps.sendTelegramMessage(
+      chatId,
+      'To use this bot, connect your Telegram account from the Index website.',
+      [[{ text: 'Connect account', url: `${url}/settings` }]],
+    );
     return;
   }
 
@@ -151,9 +159,21 @@ export async function handleInbound(
     }).catch((err) => logger.warn('Failed to write user message to conversation', { error: err }));
   }
 
-  // Route to chat graph
-  const result = await deps.processMessage(userId, text);
-  const responseText = result.responseText || 'Sorry, I could not process your message.';
+  // Route to chat graph (with timeout — the LLM chain can hang indefinitely)
+  const PROCESS_TIMEOUT_MS = 120_000;
+  let responseText: string;
+  try {
+    const result = await Promise.race([
+      deps.processMessage(userId, text),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('processMessage timed out')), PROCESS_TIMEOUT_MS),
+      ),
+    ]);
+    responseText = result.responseText || 'Sorry, I could not process your message.';
+  } catch (err) {
+    logger.error('processMessage failed for Telegram user', { userId, chatId, error: err });
+    responseText = 'Sorry, something went wrong. Please try again.';
+  }
 
   // Write assistant response (best-effort)
   if (sessionId) {
@@ -176,7 +196,7 @@ async function handleConnectToken(
 ): Promise<void> {
   const userId = await redis.get(`${CONNECT_TOKEN_PREFIX}${token}`);
   if (!userId) {
-    await deps.sendTelegramMessage(chatId, EXPIRED_TOKEN_MSG);
+    await deps.sendTelegramMessage(chatId, EXPIRED_TOKEN_MSG());
     return;
   }
 

--- a/backend/src/gateways/telegram.gateway.ts
+++ b/backend/src/gateways/telegram.gateway.ts
@@ -1,6 +1,12 @@
 import { log } from '../lib/log';
 import { onTelegramNotification, type TelegramNotificationPayload } from '../lib/notification-events';
 import type { TelegramPrefs } from '../schemas/database.schema';
+import {
+  parseResponseSegments,
+  hasStructuredBlocks,
+  formatOpportunityCardHtml,
+  formatOpportunityCardPlainText,
+} from '../lib/telegram/formatter';
 
 const logger = log.lib.from('telegram.gateway');
 
@@ -28,7 +34,7 @@ export interface GatewayDeps {
   createChatSession(data: { id: string; userId: string; title?: string }): Promise<void>;
   createChatMessage(data: { id: string; sessionId: string; role: 'user' | 'assistant' | 'system'; content: string }): Promise<void>;
   processMessage(userId: string, text: string): Promise<{ responseText: string; error?: string }>;
-  sendTelegramMessage(chatId: string, text: string, keyboard?: Array<Array<{ text: string; url: string }>>): Promise<void>;
+  sendTelegramMessage(chatId: string, text: string, keyboard?: Array<Array<{ text: string; url: string }>>, parseMode?: 'HTML' | 'MarkdownV2'): Promise<void>;
   sendChatAction(chatId: string): Promise<void>;
   streamMessage?(userId: string, text: string, sessionId: string): AsyncGenerator<GatewayStreamEvent>;
 }
@@ -180,6 +186,46 @@ const STATUS_THROTTLE_MS = 5_000;
 
 const PROCESS_TIMEOUT_MS = 120_000;
 
+// ── Structured-block formatting ────────────────────────────────────────────────
+
+/**
+ * Parse the LLM response for structured blocks (opportunity cards, intent
+ * proposals) and render them as individual HTML-formatted messages with inline
+ * keyboards. Plain-text responses pass through unchanged.
+ *
+ * Each opportunity card is sent as a separate message with:
+ * - HTML formatting: bold name, italic headline, body, metadata
+ * - An inline keyboard button linking to the web app
+ * - A plain-text fallback if Telegram rejects the HTML
+ */
+async function sendFormattedResponse(
+  chatId: string,
+  responseText: string,
+  deps: GatewayDeps,
+): Promise<void> {
+  const segments = parseResponseSegments(responseText);
+
+  if (!hasStructuredBlocks(segments)) {
+    await deps.sendTelegramMessage(chatId, responseText);
+    return;
+  }
+
+  for (const segment of segments) {
+    if (segment.type === 'text') {
+      await deps.sendTelegramMessage(chatId, segment.content);
+    } else if (segment.type === 'opportunity') {
+      const { text, keyboard } = formatOpportunityCardHtml(segment.card, appUrl());
+      try {
+        await deps.sendTelegramMessage(chatId, text, keyboard, 'HTML');
+      } catch {
+        // HTML rejected by Telegram — fall back to plain text without keyboard
+        const plain = formatOpportunityCardPlainText(segment.card);
+        await deps.sendTelegramMessage(chatId, plain).catch(() => {});
+      }
+    }
+  }
+}
+
 /**
  * Handle an update received from Telegram (text message or /start command).
  * Uses the streaming graph interface when available, falling back to
@@ -245,10 +291,10 @@ export async function handleInbound(
     content: responseText,
   }).catch((err) => logger.warn('Failed to write assistant message to conversation', { error: err }));
 
-  // Send final response. sendMessage defaults to plain text (no parse_mode)
-  // so LLM output containing <, >, & won't trigger Telegram's HTML parser.
+  // Format structured blocks (opportunity cards, etc.) as styled Telegram
+  // messages; plain-text responses are sent as-is.
   try {
-    await deps.sendTelegramMessage(chatId, responseText);
+    await sendFormattedResponse(chatId, responseText, deps);
   } catch (err) {
     logger.error('Failed to deliver final response via Telegram', { chatId, error: err });
     // Last-resort fallback

--- a/backend/src/gateways/telegram.gateway.ts
+++ b/backend/src/gateways/telegram.gateway.ts
@@ -7,6 +7,18 @@ const logger = log.lib.from('telegram.gateway');
 export const CONNECT_TOKEN_PREFIX = 'telegram:connect:';
 export const CONNECT_TOKEN_TTL_SEC = 15 * 60;
 
+// ── Stream event subset (gateway only cares about a few event types) ────────
+
+/** Minimal event shape the gateway consumes from the chat graph stream. */
+export interface GatewayStreamEvent {
+  type: string;
+  toolName?: string;
+  description?: string;
+  phase?: string;
+  response?: string;
+  name?: string;
+}
+
 // ── Dependency interface (injected in tests, resolved from singletons in prod) ─
 
 export interface GatewayDeps {
@@ -17,6 +29,8 @@ export interface GatewayDeps {
   createChatMessage(data: { id: string; sessionId: string; role: 'user' | 'assistant' | 'system'; content: string }): Promise<void>;
   processMessage(userId: string, text: string): Promise<{ responseText: string; error?: string }>;
   sendTelegramMessage(chatId: string, text: string, keyboard?: Array<Array<{ text: string; url: string }>>): Promise<void>;
+  sendChatAction(chatId: string): Promise<void>;
+  streamMessage?(userId: string, text: string, sessionId: string): AsyncGenerator<GatewayStreamEvent>;
 }
 
 /**
@@ -29,7 +43,7 @@ function productionDeps(): GatewayDeps {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { chatSessionService } = require('../services/chat.service') as typeof import('../services/chat.service');
   // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { sendMessage } = require('../lib/telegram/bot-api') as typeof import('../lib/telegram/bot-api');
+  const { sendMessage, sendChatAction } = require('../lib/telegram/bot-api') as typeof import('../lib/telegram/bot-api');
   return {
     getTelegramPrefs: (userId) => userDatabaseAdapter.getTelegramPrefs(userId),
     updateTelegramPrefs: (userId, prefs) => userDatabaseAdapter.updateTelegramPrefs(userId, prefs),
@@ -38,6 +52,11 @@ function productionDeps(): GatewayDeps {
     createChatMessage: (data) => conversationDatabaseAdapter.createChatMessage(data),
     processMessage: (userId, text) => chatSessionService.processMessage(userId, text),
     sendTelegramMessage: sendMessage,
+    sendChatAction: (chatId) => sendChatAction(chatId),
+    streamMessage: async function* (userId, text, sessionId) {
+      const factory = chatSessionService.getGraphFactory();
+      yield* factory.streamChatEventsWithContext({ userId, message: text, sessionId });
+    },
   };
 }
 
@@ -117,8 +136,58 @@ const EXPIRED_TOKEN_MSG = () => `This link has expired. Please reconnect at ${ap
 const CONNECTED_MSG =
   'Your Telegram account is now connected to Index. You\'ll receive notifications here and can chat with me anytime.';
 
+// ── Typing indicator helper ─────────────────────────────────────────────────
+
+/** Telegram typing indicator expires after ~5 s; re-send every 4 s. */
+const TYPING_INTERVAL_MS = 4_000;
+
+/**
+ * Start a recurring typing indicator for a Telegram chat.
+ * Returns a cleanup function that stops the interval.
+ */
+function startTypingIndicator(chatId: string, deps: GatewayDeps): () => void {
+  deps.sendChatAction(chatId).catch(() => {});
+  const timer = setInterval(() => {
+    deps.sendChatAction(chatId).catch(() => {});
+  }, TYPING_INTERVAL_MS);
+  return () => clearInterval(timer);
+}
+
+// ── Tool-activity → user-friendly status mapping ────────────────────────────
+
+/**
+ * Map internal tool names to short, user-friendly status messages.
+ * Returns undefined for tools that shouldn't produce a visible status.
+ */
+function toolStatusText(toolName: string): string | undefined {
+  // Normalize: tools may arrive as camelCase or snake_case
+  const normalized = toolName.toLowerCase().replace(/[_-]/g, '');
+
+  if (normalized.includes('searchintent') || normalized.includes('readintent')) return 'Looking at your signals...';
+  if (normalized.includes('discoveropportunit')) return 'Discovering opportunities...';
+  if (normalized.includes('listopportunit') || normalized.includes('readopportunit')) return 'Checking your opportunities...';
+  if (normalized.includes('userprofile') || normalized.includes('readuser')) return 'Loading profile info...';
+  if (normalized.includes('searchcontact') || normalized.includes('listcontact')) return 'Looking through contacts...';
+  if (normalized.includes('readnetwork') || normalized.includes('listnetwork')) return 'Checking communities...';
+  if (normalized.includes('scrape')) return 'Reading linked content...';
+  return undefined;
+}
+
+/** Minimum gap between status messages to avoid spam. */
+const STATUS_THROTTLE_MS = 5_000;
+
+// ── Inbound message handling ────────────────────────────────────────────────
+
+const PROCESS_TIMEOUT_MS = 120_000;
+
 /**
  * Handle an update received from Telegram (text message or /start command).
+ * Uses the streaming graph interface when available, falling back to
+ * the blocking `processMessage` path otherwise.
+ *
+ * While the graph runs the user sees a typing indicator and short
+ * status messages as tools execute (e.g. "Looking at your signals...").
+ *
  * @param chatId - Sender's Telegram chat ID
  * @param text - Message text
  * @param deps - Injectable deps (defaults to production singletons)
@@ -147,21 +216,127 @@ export async function handleInbound(
     return;
   }
 
-  const { userId, sessionId } = found;
+  const { userId } = found;
+  let { sessionId } = found;
 
-  // Write user message to conversation (best-effort)
-  if (sessionId) {
-    await deps.createChatMessage({
-      id: crypto.randomUUID(),
-      sessionId,
-      role: 'user',
-      content: text,
-    }).catch((err) => logger.warn('Failed to write user message to conversation', { error: err }));
+  // Ensure a chat session exists (may not if the user messages before any outbound notification)
+  if (!sessionId) {
+    sessionId = await ensureSession(userId, deps);
   }
 
-  // Route to chat graph (with timeout — the LLM chain can hang indefinitely)
-  const PROCESS_TIMEOUT_MS = 120_000;
-  let responseText: string;
+  // Write user message to conversation (best-effort)
+  await deps.createChatMessage({
+    id: crypto.randomUUID(),
+    sessionId,
+    role: 'user',
+    content: text,
+  }).catch((err) => logger.warn('Failed to write user message to conversation', { error: err }));
+
+  // Choose streaming or blocking path
+  const responseText = deps.streamMessage
+    ? await handleInboundStreaming(chatId, userId, text, sessionId, deps)
+    : await handleInboundBlocking(chatId, userId, text, deps);
+
+  // Write assistant response (best-effort)
+  await deps.createChatMessage({
+    id: crypto.randomUUID(),
+    sessionId,
+    role: 'assistant',
+    content: responseText,
+  }).catch((err) => logger.warn('Failed to write assistant message to conversation', { error: err }));
+
+  await deps.sendTelegramMessage(chatId, responseText);
+}
+
+/**
+ * Streaming path: consumes the graph event stream, sends typing indicators
+ * and stage-notification messages as tools run, then returns the final
+ * response text.
+ */
+async function handleInboundStreaming(
+  chatId: string,
+  userId: string,
+  text: string,
+  sessionId: string,
+  deps: GatewayDeps,
+): Promise<string> {
+  const stopTyping = startTypingIndicator(chatId, deps);
+
+  try {
+    let responseText = '';
+    let lastStatusSentAt = 0;
+    let lastStatusText: string | null = null;
+
+    const stream = deps.streamMessage!(userId, text, sessionId);
+
+    // Race the stream against a hard timeout
+    const timeoutPromise = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('streamMessage timed out')), PROCESS_TIMEOUT_MS),
+    );
+
+    // Wrap the async iteration in a promise so we can race it
+    const streamPromise = (async () => {
+      for await (const event of stream) {
+        // Tool-activity status notifications
+        if (event.type === 'tool_activity' && event.phase === 'start' && event.toolName) {
+          const status = toolStatusText(event.toolName);
+          const now = Date.now();
+          if (status && status !== lastStatusText && now - lastStatusSentAt >= STATUS_THROTTLE_MS) {
+            await deps.sendTelegramMessage(chatId, status);
+            lastStatusText = status;
+            lastStatusSentAt = now;
+          }
+        }
+
+        // Agent-level status (e.g. negotiator starting)
+        if (event.type === 'agent_start' && event.name) {
+          const agentStatus = agentStatusText(event.name);
+          const now = Date.now();
+          if (agentStatus && agentStatus !== lastStatusText && now - lastStatusSentAt >= STATUS_THROTTLE_MS) {
+            await deps.sendTelegramMessage(chatId, agentStatus);
+            lastStatusText = agentStatus;
+            lastStatusSentAt = now;
+          }
+        }
+
+        // Authoritative final response
+        if (event.type === 'response_complete' && typeof event.response === 'string') {
+          responseText = event.response;
+        }
+      }
+    })();
+
+    await Promise.race([streamPromise, timeoutPromise]);
+    return responseText || 'Sorry, I could not process your message.';
+  } catch (err) {
+    logger.error('Streaming processMessage failed for Telegram user', { userId, chatId, error: err });
+    return 'Sorry, something went wrong. Please try again.';
+  } finally {
+    stopTyping();
+  }
+}
+
+/**
+ * Map agent names to user-friendly status messages.
+ */
+function agentStatusText(agentName: string): string | undefined {
+  const lower = agentName.toLowerCase();
+  if (lower.includes('negotiat')) return 'Evaluating a potential connection...';
+  return undefined;
+}
+
+/**
+ * Blocking fallback path: calls processMessage with a timeout.
+ * Used when streamMessage is not available (e.g. in tests without streaming deps).
+ */
+async function handleInboundBlocking(
+  chatId: string,
+  userId: string,
+  text: string,
+  deps: GatewayDeps,
+): Promise<string> {
+  const stopTyping = startTypingIndicator(chatId, deps);
+
   try {
     const result = await Promise.race([
       deps.processMessage(userId, text),
@@ -169,23 +344,30 @@ export async function handleInbound(
         setTimeout(() => reject(new Error('processMessage timed out')), PROCESS_TIMEOUT_MS),
       ),
     ]);
-    responseText = result.responseText || 'Sorry, I could not process your message.';
+    return result.responseText || 'Sorry, I could not process your message.';
   } catch (err) {
     logger.error('processMessage failed for Telegram user', { userId, chatId, error: err });
-    responseText = 'Sorry, something went wrong. Please try again.';
+    return 'Sorry, something went wrong. Please try again.';
+  } finally {
+    stopTyping();
+  }
+}
+
+/**
+ * Create a chat session for a Telegram user who doesn't have one yet.
+ * Updates the user's Telegram prefs with the new sessionId.
+ */
+async function ensureSession(userId: string, deps: GatewayDeps): Promise<string> {
+  const sessionId = crypto.randomUUID();
+  await deps.createChatSession({ id: sessionId, userId, title: 'Telegram' });
+
+  // Persist sessionId in prefs so future messages reuse it
+  const prefs = await deps.getTelegramPrefs(userId);
+  if (prefs) {
+    await deps.updateTelegramPrefs(userId, { ...prefs, sessionId });
   }
 
-  // Write assistant response (best-effort)
-  if (sessionId) {
-    await deps.createChatMessage({
-      id: crypto.randomUUID(),
-      sessionId,
-      role: 'assistant',
-      content: responseText,
-    }).catch((err) => logger.warn('Failed to write assistant message to conversation', { error: err }));
-  }
-
-  await deps.sendTelegramMessage(chatId, responseText);
+  return sessionId;
 }
 
 async function handleConnectToken(

--- a/backend/src/gateways/tests/telegram.gateway.spec.ts
+++ b/backend/src/gateways/tests/telegram.gateway.spec.ts
@@ -127,9 +127,10 @@ describe('handleInbound', () => {
     });
   }
 
-  it('replies with connect prompt for unknown chatId', async () => {
+  it('replies with connect prompt and button for unknown chatId', async () => {
     await callInbound('unknown-chat', 'hello');
-    expect(deps.sent[0].text).toContain('index.network');
+    expect(deps.sent[0].text).toContain('connect your Telegram account');
+    expect(deps.sent[0].keyboard).toBeDefined();
   });
 
   it('routes a known user message to the chat graph and writes to conversation', async () => {

--- a/backend/src/gateways/tests/telegram.gateway.spec.ts
+++ b/backend/src/gateways/tests/telegram.gateway.spec.ts
@@ -3,6 +3,7 @@ config({ path: '.env.test' });
 
 import { describe, it, expect, beforeEach } from 'bun:test';
 import type { TelegramPrefs } from '../../schemas/database.schema';
+import type { GatewayStreamEvent } from '../telegram.gateway';
 
 // ── Fakes ────────────────────────────────────────────────────────────────────
 
@@ -18,6 +19,7 @@ function defaultDeps() {
   const sent: SentMessage[] = [];
   const telegramPrefs = new Map<string, TelegramPrefs>();
   const chatIdIndex = new Map<string, { userId: string; sessionId?: string }>();
+  const chatActions: string[] = [];
 
   return {
     sent,
@@ -25,6 +27,7 @@ function defaultDeps() {
     sessions,
     telegramPrefs,
     chatIdIndex,
+    chatActions,
     getTelegramPrefs: async (userId: string) => telegramPrefs.get(userId) ?? null,
     updateTelegramPrefs: async (userId: string, prefs: TelegramPrefs) => { telegramPrefs.set(userId, prefs); },
     findByTelegramChatId: async (chatId: string) => chatIdIndex.get(chatId) ?? null,
@@ -32,10 +35,18 @@ function defaultDeps() {
     createChatMessage: async (data: { id: string; sessionId: string; role: string; content: string }) => { messages.push(data); },
     processMessage: async (_userId: string, _text: string) => ({ responseText: 'Hello from Index!' }),
     sendTelegramMessage: async (chatId: string, text: string, keyboard?: unknown) => { sent.push({ chatId, text, keyboard }); },
+    sendChatAction: async (chatId: string) => { chatActions.push(chatId); },
     seedTelegramUser: (userId: string, prefs: TelegramPrefs) => {
       telegramPrefs.set(userId, prefs);
       chatIdIndex.set(prefs.chatId, { userId, sessionId: prefs.sessionId });
     },
+  };
+}
+
+/** Helper: create a fake stream that yields the given events. */
+function fakeStream(...events: GatewayStreamEvent[]): () => AsyncGenerator<GatewayStreamEvent> {
+  return async function* () {
+    for (const e of events) yield e;
   };
 }
 
@@ -108,9 +119,9 @@ describe('handleOutbound', () => {
   });
 });
 
-// ── Tests: handleInbound ─────────────────────────────────────────────────────
+// ── Tests: handleInbound (blocking fallback) ────────────────────────────────
 
-describe('handleInbound', () => {
+describe('handleInbound (blocking)', () => {
   let deps: ReturnType<typeof makeDeps>;
   let redisFake: Map<string, string>;
 
@@ -119,9 +130,10 @@ describe('handleInbound', () => {
     redisFake = new Map();
   });
 
-  async function callInbound(chatId: string, text: string) {
+  async function callInbound(chatId: string, text: string, overrides?: Partial<ReturnType<typeof defaultDeps>>) {
+    const d = overrides ? { ...deps, ...overrides } : deps;
     const { handleInbound } = await import('../telegram.gateway');
-    await handleInbound(chatId, text, deps, {
+    await handleInbound(chatId, text, d, {
       get: async (key: string) => redisFake.get(key) ?? null,
       del: async (key: string) => { redisFake.delete(key); },
     });
@@ -144,13 +156,46 @@ describe('handleInbound', () => {
 
     await callInbound('chat-known', 'What are my intents?');
 
-    // Sends graph response back
-    expect(deps.sent[0]).toMatchObject({ chatId: 'chat-known', text: 'Hello from Index!' });
+    // Final message is the response
+    const responseMsgs = deps.sent.filter((m) => m.chatId === 'chat-known');
+    expect(responseMsgs[responseMsgs.length - 1].text).toBe('Hello from Index!');
     // Writes user + assistant messages to conversation
     const userMsg = deps.messages.find((m) => m.role === 'user');
     const assistantMsg = deps.messages.find((m) => m.role === 'assistant');
     expect(userMsg?.content).toBe('What are my intents?');
     expect(assistantMsg?.content).toBe('Hello from Index!');
+  });
+
+  it('sends typing indicator while processing', async () => {
+    const prefs: TelegramPrefs = {
+      chatId: 'chat-typing',
+      sessionId: 'sess-typing',
+      connectedAt: '2026-04-14T00:00:00Z',
+      notifications: { opportunityAccepted: true },
+    };
+    deps.seedTelegramUser('user-typing', prefs);
+
+    await callInbound('chat-typing', 'hello');
+
+    // At least one typing action should have been sent
+    expect(deps.chatActions.length).toBeGreaterThanOrEqual(1);
+    expect(deps.chatActions[0]).toBe('chat-typing');
+  });
+
+  it('creates a session when user has none', async () => {
+    const prefs: TelegramPrefs = {
+      chatId: 'chat-nosess',
+      connectedAt: '2026-04-14T00:00:00Z',
+      notifications: { opportunityAccepted: true },
+    };
+    deps.seedTelegramUser('user-nosess', prefs);
+
+    await callInbound('chat-nosess', 'hi');
+
+    // A session should have been created
+    expect(deps.sessions.size).toBe(1);
+    // Prefs should be updated with the session ID
+    expect(deps.telegramPrefs.get('user-nosess')?.sessionId).toBeDefined();
   });
 
   it('completes /start <token> flow: stores chatId and confirms', async () => {
@@ -169,5 +214,140 @@ describe('handleInbound', () => {
   it('replies with expired-token message for unknown token', async () => {
     await callInbound('chat-x', '/start bad-token');
     expect(deps.sent[0].text).toContain('expired');
+  });
+});
+
+// ── Tests: handleInbound (streaming) ────────────────────────────────────────
+
+describe('handleInbound (streaming)', () => {
+  let deps: ReturnType<typeof makeDeps>;
+  let redisFake: Map<string, string>;
+
+  beforeEach(() => {
+    deps = makeDeps();
+    redisFake = new Map();
+  });
+
+  function seedUser(userId: string, chatId: string, sessionId?: string) {
+    const prefs: TelegramPrefs = {
+      chatId,
+      sessionId,
+      connectedAt: '2026-04-14T00:00:00Z',
+      notifications: { opportunityAccepted: true },
+    };
+    deps.seedTelegramUser(userId, prefs);
+  }
+
+  async function callInbound(chatId: string, text: string, streamFn: ReturnType<typeof fakeStream>) {
+    const d = { ...deps, streamMessage: streamFn };
+    const { handleInbound } = await import('../telegram.gateway');
+    await handleInbound(chatId, text, d, {
+      get: async (key: string) => redisFake.get(key) ?? null,
+      del: async (key: string) => { redisFake.delete(key); },
+    });
+  }
+
+  it('sends final response from response_complete event', async () => {
+    seedUser('user-s1', 'chat-s1', 'sess-s1');
+
+    const stream = fakeStream(
+      { type: 'status' },
+      { type: 'response_complete', response: 'Here are your signals.' },
+    );
+
+    await callInbound('chat-s1', 'Show my signals', stream);
+
+    const responseMsgs = deps.sent.filter((m) => m.chatId === 'chat-s1');
+    expect(responseMsgs[responseMsgs.length - 1].text).toBe('Here are your signals.');
+  });
+
+  it('sends typing indicator during streaming', async () => {
+    seedUser('user-s2', 'chat-s2', 'sess-s2');
+
+    const stream = fakeStream(
+      { type: 'response_complete', response: 'Done.' },
+    );
+
+    await callInbound('chat-s2', 'hi', stream);
+
+    expect(deps.chatActions.length).toBeGreaterThanOrEqual(1);
+    expect(deps.chatActions[0]).toBe('chat-s2');
+  });
+
+  it('sends tool-activity status messages', async () => {
+    seedUser('user-s3', 'chat-s3', 'sess-s3');
+
+    const stream = fakeStream(
+      { type: 'tool_activity', toolName: 'search_intents', phase: 'start' },
+      { type: 'tool_activity', toolName: 'search_intents', phase: 'end' },
+      { type: 'response_complete', response: 'Found 3 signals.' },
+    );
+
+    await callInbound('chat-s3', 'What are my signals?', stream);
+
+    // Should have sent a status message for the tool activity
+    const statusMsg = deps.sent.find((m) => m.text.includes('signals'));
+    expect(statusMsg).toBeDefined();
+
+    // Final message should be the response
+    expect(deps.sent[deps.sent.length - 1].text).toBe('Found 3 signals.');
+  });
+
+  it('deduplicates consecutive identical status messages', async () => {
+    seedUser('user-s4', 'chat-s4', 'sess-s4');
+
+    const stream = fakeStream(
+      { type: 'tool_activity', toolName: 'search_intents', phase: 'start' },
+      { type: 'tool_activity', toolName: 'search_intents', phase: 'start' }, // duplicate
+      { type: 'response_complete', response: 'Done.' },
+    );
+
+    await callInbound('chat-s4', 'test', stream);
+
+    // Only one status message (plus the final response)
+    const statusMsgs = deps.sent.filter((m) => m.text.includes('signals'));
+    expect(statusMsgs).toHaveLength(1);
+  });
+
+  it('falls back to error message when stream yields no response_complete', async () => {
+    seedUser('user-s5', 'chat-s5', 'sess-s5');
+
+    const stream = fakeStream(
+      { type: 'status' },
+      // No response_complete event
+    );
+
+    await callInbound('chat-s5', 'hello', stream);
+
+    expect(deps.sent[deps.sent.length - 1].text).toContain('could not process');
+  });
+
+  it('writes user and assistant messages to conversation', async () => {
+    seedUser('user-s6', 'chat-s6', 'sess-s6');
+
+    const stream = fakeStream(
+      { type: 'response_complete', response: 'Streamed response!' },
+    );
+
+    await callInbound('chat-s6', 'hi there', stream);
+
+    const userMsg = deps.messages.find((m) => m.role === 'user');
+    const assistantMsg = deps.messages.find((m) => m.role === 'assistant');
+    expect(userMsg?.content).toBe('hi there');
+    expect(assistantMsg?.content).toBe('Streamed response!');
+  });
+
+  it('sends agent-start status for negotiator', async () => {
+    seedUser('user-s7', 'chat-s7', 'sess-s7');
+
+    const stream = fakeStream(
+      { type: 'agent_start', name: 'negotiation-agent' },
+      { type: 'response_complete', response: 'Connection found.' },
+    );
+
+    await callInbound('chat-s7', 'find connections', stream);
+
+    const statusMsg = deps.sent.find((m) => m.text.includes('connection'));
+    expect(statusMsg).toBeDefined();
   });
 });

--- a/backend/src/gateways/tests/telegram.gateway.spec.ts
+++ b/backend/src/gateways/tests/telegram.gateway.spec.ts
@@ -350,4 +350,82 @@ describe('handleInbound (streaming)', () => {
     const statusMsg = deps.sent.find((m) => m.text.includes('connection'));
     expect(statusMsg).toBeDefined();
   });
+
+  it('sends LLM response with special chars as-is (no HTML parse mode)', async () => {
+    seedUser('user-html', 'chat-html', 'sess-html');
+
+    const stream = fakeStream(
+      { type: 'response_complete', response: 'Use <code>x & y</code> to compare' },
+    );
+
+    await callInbound('chat-html', 'test', stream);
+
+    // sendMessage defaults to plain text — no escaping, chars sent verbatim
+    const finalMsg = deps.sent[deps.sent.length - 1];
+    expect(finalMsg.text).toBe('Use <code>x & y</code> to compare');
+
+    // Conversation record matches
+    const assistantMsg = deps.messages.find((m) => m.role === 'assistant');
+    expect(assistantMsg?.content).toBe('Use <code>x & y</code> to compare');
+  });
+
+  it('continues streaming when a status send fails', async () => {
+    seedUser('user-sfail', 'chat-sfail', 'sess-sfail');
+
+    const deliveredMsgs: SentMessage[] = [];
+    const streamFn = fakeStream(
+      { type: 'tool_activity', toolName: 'search_intents', phase: 'start' },
+      { type: 'response_complete', response: 'Here are results.' },
+    );
+
+    const d = {
+      ...deps,
+      sendTelegramMessage: async (chatId: string, text: string, keyboard?: Array<Array<{ text: string; url: string }>>) => {
+        if (text.includes('signals')) throw new Error('Telegram 429');
+        deliveredMsgs.push({ chatId, text, keyboard });
+      },
+      streamMessage: streamFn,
+    };
+
+    const { handleInbound } = await import('../telegram.gateway');
+    await handleInbound('chat-sfail', 'test', d, {
+      get: async () => null,
+      del: async () => {},
+    });
+
+    // Final response delivered despite status send failure
+    expect(deliveredMsgs.some((m) => m.text === 'Here are results.')).toBe(true);
+  });
+
+  it('delivers fallback when final send throws', async () => {
+    seedUser('user-fallback', 'chat-fallback', 'sess-fallback');
+
+    const deliveredMsgs: SentMessage[] = [];
+    let finalSendAttempted = false;
+    const streamFn = fakeStream(
+      { type: 'response_complete', response: 'Normal response text' },
+    );
+
+    const d = {
+      ...deps,
+      sendTelegramMessage: async (chatId: string, text: string, keyboard?: Array<Array<{ text: string; url: string }>>) => {
+        // Simulate Telegram network error on the first final-send attempt
+        if (text === 'Normal response text' && !finalSendAttempted) {
+          finalSendAttempted = true;
+          throw new Error('Telegram network error');
+        }
+        deliveredMsgs.push({ chatId, text, keyboard });
+      },
+      streamMessage: streamFn,
+    };
+
+    const { handleInbound } = await import('../telegram.gateway');
+    await handleInbound('chat-fallback', 'test', d, {
+      get: async () => null,
+      del: async () => {},
+    });
+
+    // Fallback message was delivered
+    expect(deliveredMsgs.some((m) => m.text.includes('couldn\'t deliver'))).toBe(true);
+  });
 });

--- a/backend/src/gateways/tests/telegram.gateway.spec.ts
+++ b/backend/src/gateways/tests/telegram.gateway.spec.ts
@@ -7,7 +7,7 @@ import type { GatewayStreamEvent } from '../telegram.gateway';
 
 // ── Fakes ────────────────────────────────────────────────────────────────────
 
-interface SentMessage { chatId: string; text: string; keyboard?: unknown }
+interface SentMessage { chatId: string; text: string; keyboard?: unknown; parseMode?: string }
 
 function makeDeps(overrides: Partial<ReturnType<typeof defaultDeps>> = {}) {
   return { ...defaultDeps(), ...overrides };
@@ -34,7 +34,7 @@ function defaultDeps() {
     createChatSession: async (data: { id: string; userId: string; title?: string }) => { sessions.set(data.id, data); },
     createChatMessage: async (data: { id: string; sessionId: string; role: string; content: string }) => { messages.push(data); },
     processMessage: async (_userId: string, _text: string) => ({ responseText: 'Hello from Index!' }),
-    sendTelegramMessage: async (chatId: string, text: string, keyboard?: unknown) => { sent.push({ chatId, text, keyboard }); },
+    sendTelegramMessage: async (chatId: string, text: string, keyboard?: unknown, parseMode?: string) => { sent.push({ chatId, text, keyboard, parseMode }); },
     sendChatAction: async (chatId: string) => { chatActions.push(chatId); },
     seedTelegramUser: (userId: string, prefs: TelegramPrefs) => {
       telegramPrefs.set(userId, prefs);
@@ -380,9 +380,9 @@ describe('handleInbound (streaming)', () => {
 
     const d = {
       ...deps,
-      sendTelegramMessage: async (chatId: string, text: string, keyboard?: Array<Array<{ text: string; url: string }>>) => {
+      sendTelegramMessage: async (chatId: string, text: string, keyboard?: Array<Array<{ text: string; url: string }>>, parseMode?: string) => {
         if (text.includes('signals')) throw new Error('Telegram 429');
-        deliveredMsgs.push({ chatId, text, keyboard });
+        deliveredMsgs.push({ chatId, text, keyboard, parseMode });
       },
       streamMessage: streamFn,
     };
@@ -408,13 +408,13 @@ describe('handleInbound (streaming)', () => {
 
     const d = {
       ...deps,
-      sendTelegramMessage: async (chatId: string, text: string, keyboard?: Array<Array<{ text: string; url: string }>>) => {
+      sendTelegramMessage: async (chatId: string, text: string, keyboard?: Array<Array<{ text: string; url: string }>>, parseMode?: string) => {
         // Simulate Telegram network error on the first final-send attempt
         if (text === 'Normal response text' && !finalSendAttempted) {
           finalSendAttempted = true;
           throw new Error('Telegram network error');
         }
-        deliveredMsgs.push({ chatId, text, keyboard });
+        deliveredMsgs.push({ chatId, text, keyboard, parseMode });
       },
       streamMessage: streamFn,
     };
@@ -427,5 +427,99 @@ describe('handleInbound (streaming)', () => {
 
     // Fallback message was delivered
     expect(deliveredMsgs.some((m) => m.text.includes('couldn\'t deliver'))).toBe(true);
+  });
+
+  it('renders opportunity blocks as formatted HTML cards', async () => {
+    seedUser('user-opp', 'chat-opp', 'sess-opp');
+
+    const responseWithBlocks = [
+      'I found some connections for you.',
+      '',
+      '```opportunity',
+      JSON.stringify({
+        opportunityId: 'opp-1',
+        name: 'Alice',
+        headline: 'Potential collaborator',
+        mainText: 'Alice works in AI research.',
+        mutualIntentsLabel: 'Aligned goals',
+        narratorChip: { name: 'Index', text: 'Strong overlap in interests' },
+        primaryActionLabel: 'Start Chat',
+      }),
+      '```',
+      '',
+      'Want to see more?',
+    ].join('\n');
+
+    const stream = fakeStream(
+      { type: 'response_complete', response: responseWithBlocks },
+    );
+
+    await callInbound('chat-opp', 'find me connections', stream);
+
+    // Filter to messages sent to this chat (excludes typing actions)
+    const oppMsgs = deps.sent.filter((m) => m.chatId === 'chat-opp');
+
+    // First: framing text (plain, no parseMode)
+    expect(oppMsgs[0].text).toContain('I found some connections');
+    expect(oppMsgs[0].parseMode).toBeUndefined();
+
+    // Second: HTML card with inline keyboard
+    expect(oppMsgs[1].text).toContain('<b>Alice</b>');
+    expect(oppMsgs[1].text).toContain('AI research');
+    expect(oppMsgs[1].text).toContain('💡');
+    expect(oppMsgs[1].parseMode).toBe('HTML');
+    expect(oppMsgs[1].keyboard).toBeDefined();
+
+    // Third: trailing text (plain)
+    expect(oppMsgs[2].text).toContain('Want to see more');
+    expect(oppMsgs[2].parseMode).toBeUndefined();
+
+    // Conversation record stores the original response with JSON blocks intact
+    const assistantMsg = deps.messages.find((m) => m.role === 'assistant');
+    expect(assistantMsg?.content).toContain('```opportunity');
+  });
+
+  it('falls back to plain text when HTML card send fails', async () => {
+    seedUser('user-oppfail', 'chat-oppfail', 'sess-oppfail');
+
+    const responseWithBlock = [
+      'Found a connection.',
+      '',
+      '```opportunity',
+      JSON.stringify({
+        opportunityId: 'opp-fail',
+        name: 'Bob',
+        headline: 'Developer',
+        mainText: 'Bob builds apps.',
+      }),
+      '```',
+    ].join('\n');
+
+    const deliveredMsgs: SentMessage[] = [];
+    const streamFn = fakeStream(
+      { type: 'response_complete', response: responseWithBlock },
+    );
+
+    const d = {
+      ...deps,
+      sendTelegramMessage: async (chatId: string, text: string, keyboard?: unknown, parseMode?: string) => {
+        if (parseMode === 'HTML') throw new Error('Telegram HTML parse error');
+        deliveredMsgs.push({ chatId, text, keyboard, parseMode });
+      },
+      streamMessage: streamFn,
+    };
+
+    const { handleInbound } = await import('../telegram.gateway');
+    await handleInbound('chat-oppfail', 'test', d, {
+      get: async () => null,
+      del: async () => {},
+    });
+
+    // Plain-text fallback should have been sent (no HTML tags)
+    const cardMsg = deliveredMsgs.find((m) => m.text.includes('Bob'));
+    expect(cardMsg).toBeDefined();
+    expect(cardMsg!.text).toContain('Developer');
+    expect(cardMsg!.text).not.toContain('<b>');
+    expect(cardMsg!.text).not.toContain('<i>');
   });
 });

--- a/backend/src/lib/telegram/bot-api.ts
+++ b/backend/src/lib/telegram/bot-api.ts
@@ -5,17 +5,36 @@ function botUrl(method: string): string {
 }
 
 /**
+ * Escape HTML special characters so text can be safely sent with parse_mode=HTML.
+ * Handles the five characters that Telegram's HTML parser requires escaped:
+ * `<`, `>`, `&`, `"`, and `'`.
+ */
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+/**
  * Send a text message to a Telegram chat.
  * @param chatId - Telegram chat ID (string form of the integer ID)
- * @param text - Message text (HTML parse mode enabled)
+ * @param text - Message text
  * @param inlineKeyboard - Optional URL-button rows: [[{ text, url }], ...]
+ * @param parseMode - Parse mode for text formatting (default: none / plain text)
  */
 export async function sendMessage(
   chatId: string,
   text: string,
   inlineKeyboard?: Array<Array<{ text: string; url: string }>>,
+  parseMode?: 'HTML' | 'MarkdownV2',
 ): Promise<void> {
-  const body: Record<string, unknown> = { chat_id: chatId, text, parse_mode: 'HTML' };
+  const body: Record<string, unknown> = { chat_id: chatId, text };
+  if (parseMode) {
+    body.parse_mode = parseMode;
+  }
   if (inlineKeyboard) {
     body.reply_markup = { inline_keyboard: inlineKeyboard };
   }

--- a/backend/src/lib/telegram/bot-api.ts
+++ b/backend/src/lib/telegram/bot-api.ts
@@ -31,6 +31,24 @@ export async function sendMessage(
 }
 
 /**
+ * Signal that the bot is "typing" (or performing another action).
+ * The indicator auto-expires after 5 seconds; call repeatedly for longer operations.
+ * Best-effort — failures are silently ignored.
+ * @param chatId - Telegram chat ID
+ * @param action - Chat action (default: 'typing')
+ */
+export async function sendChatAction(
+  chatId: string,
+  action: 'typing' | 'upload_document' = 'typing',
+): Promise<void> {
+  await fetch(botUrl('sendChatAction'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ chat_id: chatId, action }),
+  }).catch(() => {});
+}
+
+/**
  * Register a webhook URL with Telegram so the bot receives updates via HTTP POST.
  * @param url - The full HTTPS webhook URL
  * @param secretToken - Sent as X-Telegram-Bot-Api-Secret-Token header with each update

--- a/backend/src/lib/telegram/formatter.ts
+++ b/backend/src/lib/telegram/formatter.ts
@@ -1,0 +1,170 @@
+import { escapeHtml } from './bot-api';
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Parsed opportunity card from a ```opportunity code block.
+ * Mirrors the card shape emitted by `buildOpportunityPresentation` in the
+ * protocol layer's opportunity tools.
+ */
+export interface OpportunityCard {
+  opportunityId: string;
+  userId?: string;
+  name?: string;
+  avatar?: string;
+  mainText?: string;
+  headline?: string;
+  cta?: string;
+  primaryActionLabel?: string;
+  secondaryActionLabel?: string;
+  mutualIntentsLabel?: string;
+  narratorChip?: { name: string; text: string };
+  viewerRole?: string;
+  isGhost?: boolean;
+  score?: number;
+  status?: string;
+}
+
+/** A segment of the LLM response: either prose or a structured block. */
+export type ResponseSegment =
+  | { type: 'text'; content: string }
+  | { type: 'opportunity'; card: OpportunityCard };
+
+// ── Parsing ────────────────────────────────────────────────────────────────────
+
+/**
+ * Matches ```opportunity and ```intent_proposal code fences.
+ * The `sanitizeJsonForCodeFence` helper in the protocol layer escapes any
+ * backticks inside the JSON payload, so the non-greedy `[\s\S]*?` always
+ * stops at the closing triple-backtick that belongs to the fence.
+ */
+const BLOCK_RE = /```(?:opportunity|intent_proposal)\n([\s\S]*?)```/g;
+
+/**
+ * Parse an LLM response into an ordered list of prose and structured-block
+ * segments, preserving the interleaving so the gateway can send messages in
+ * the same order the LLM intended.
+ *
+ * - `opportunity` blocks are parsed into typed card segments.
+ * - `intent_proposal` blocks have their `description` extracted as plain text.
+ * - Malformed JSON is silently dropped.
+ */
+export function parseResponseSegments(text: string): ResponseSegment[] {
+  const segments: ResponseSegment[] = [];
+  let lastIndex = 0;
+
+  for (const match of text.matchAll(BLOCK_RE)) {
+    const before = text.slice(lastIndex, match.index);
+    if (before.trim()) {
+      segments.push({ type: 'text', content: before.trim() });
+    }
+
+    const isOpportunity = match[0].startsWith('```opportunity');
+    if (isOpportunity) {
+      try {
+        const card = JSON.parse(match[1]) as OpportunityCard;
+        segments.push({ type: 'opportunity', card });
+      } catch {
+        // Malformed JSON — drop the block silently
+      }
+    } else {
+      // intent_proposal or other block type — extract description if possible
+      try {
+        const data = JSON.parse(match[1]) as Record<string, unknown>;
+        const desc = String(data.description ?? data.summary ?? '');
+        if (desc.trim()) {
+          segments.push({ type: 'text', content: desc.trim() });
+        }
+      } catch {
+        // Malformed — drop
+      }
+    }
+
+    lastIndex = (match.index ?? 0) + match[0].length;
+  }
+
+  const trailing = text.slice(lastIndex);
+  if (trailing.trim()) {
+    segments.push({ type: 'text', content: trailing.trim() });
+  }
+
+  return segments;
+}
+
+/** True when the response contains at least one structured block. */
+export function hasStructuredBlocks(segments: ResponseSegment[]): boolean {
+  return segments.some((s) => s.type !== 'text');
+}
+
+// ── Card formatting ────────────────────────────────────────────────────────────
+
+/**
+ * Render an opportunity card as an HTML-formatted Telegram message with an
+ * inline-keyboard action button.
+ *
+ * Layout:
+ * ```
+ * <b>Name</b>
+ * <i>Headline</i>
+ *
+ * Main body text...
+ *
+ * 🎯 Mutual intents label
+ *
+ * 💡 Narrator editorial note
+ *
+ * [💬 Start Chat]  ← inline keyboard
+ * ```
+ */
+export function formatOpportunityCardHtml(
+  card: OpportunityCard,
+  webAppUrl: string,
+): { text: string; keyboard: Array<Array<{ text: string; url: string }>> } {
+  const lines: string[] = [];
+
+  // ── Name ──
+  lines.push(`<b>${escapeHtml(card.name ?? 'Someone')}</b>`);
+
+  // ── Headline ──
+  if (card.headline) {
+    lines.push(`<i>${escapeHtml(card.headline)}</i>`);
+  }
+
+  // ── Body ──
+  if (card.mainText) {
+    lines.push('');
+    lines.push(escapeHtml(card.mainText));
+  }
+
+  // ── Mutual-intents label ──
+  if (card.mutualIntentsLabel) {
+    lines.push('');
+    lines.push(`🎯 ${escapeHtml(card.mutualIntentsLabel)}`);
+  }
+
+  // ── Narrator chip (editorial note from the system) ──
+  if (card.narratorChip?.text) {
+    lines.push('');
+    lines.push(`💡 <i>${escapeHtml(card.narratorChip.text)}</i>`);
+  }
+
+  const keyboard: Array<Array<{ text: string; url: string }>> = [
+    [{ text: `💬 ${card.primaryActionLabel ?? 'View'}`, url: `${webAppUrl}/opportunities` }],
+  ];
+
+  return { text: lines.join('\n'), keyboard };
+}
+
+/**
+ * Plain-text fallback for when HTML send fails (e.g. Telegram rejects markup).
+ * No HTML tags, no inline keyboard — just the essential card content.
+ */
+export function formatOpportunityCardPlainText(card: OpportunityCard): string {
+  const lines: string[] = [];
+  if (card.name) lines.push(card.name);
+  if (card.headline) lines.push(card.headline);
+  if (card.mainText) lines.push('', card.mainText);
+  if (card.mutualIntentsLabel) lines.push('', `🎯 ${card.mutualIntentsLabel}`);
+  if (card.narratorChip?.text) lines.push('', `💡 ${card.narratorChip.text}`);
+  return lines.join('\n');
+}

--- a/backend/src/lib/telegram/tests/formatter.spec.ts
+++ b/backend/src/lib/telegram/tests/formatter.spec.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  parseResponseSegments,
+  hasStructuredBlocks,
+  formatOpportunityCardHtml,
+  formatOpportunityCardPlainText,
+  type ResponseSegment,
+} from '../formatter';
+
+// ── parseResponseSegments ──────────────────────────────────────────────────────
+
+describe('parseResponseSegments', () => {
+  it('returns a single text segment for plain responses', () => {
+    const segments = parseResponseSegments('Hello, how are you?');
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toEqual({ type: 'text', content: 'Hello, how are you?' });
+  });
+
+  it('parses opportunity blocks into typed card segments', () => {
+    const response = [
+      'Found connections.',
+      '',
+      '```opportunity',
+      '{"opportunityId":"opp-1","name":"Alice","headline":"AI researcher"}',
+      '```',
+      '',
+      'Want more?',
+    ].join('\n');
+
+    const segments = parseResponseSegments(response);
+    expect(segments).toHaveLength(3);
+    expect(segments[0]).toEqual({ type: 'text', content: 'Found connections.' });
+    expect(segments[1].type).toBe('opportunity');
+    if (segments[1].type === 'opportunity') {
+      expect(segments[1].card.name).toBe('Alice');
+      expect(segments[1].card.opportunityId).toBe('opp-1');
+    }
+    expect(segments[2]).toEqual({ type: 'text', content: 'Want more?' });
+  });
+
+  it('handles multiple consecutive opportunity blocks', () => {
+    const response = [
+      '```opportunity',
+      '{"opportunityId":"opp-1","name":"Alice"}',
+      '```',
+      '',
+      '```opportunity',
+      '{"opportunityId":"opp-2","name":"Bob"}',
+      '```',
+    ].join('\n');
+
+    const segments = parseResponseSegments(response);
+    const oppSegments = segments.filter((s) => s.type === 'opportunity');
+    expect(oppSegments).toHaveLength(2);
+  });
+
+  it('drops malformed JSON in opportunity blocks silently', () => {
+    const response = [
+      'Text before.',
+      '',
+      '```opportunity',
+      '{invalid json}',
+      '```',
+      '',
+      'Text after.',
+    ].join('\n');
+
+    const segments = parseResponseSegments(response);
+    expect(segments).toHaveLength(2);
+    expect(segments[0]).toEqual({ type: 'text', content: 'Text before.' });
+    expect(segments[1]).toEqual({ type: 'text', content: 'Text after.' });
+  });
+
+  it('extracts description from intent_proposal blocks as text', () => {
+    const response = [
+      '```intent_proposal',
+      '{"proposalId":"p-1","description":"Looking for AI researchers"}',
+      '```',
+    ].join('\n');
+
+    const segments = parseResponseSegments(response);
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toEqual({ type: 'text', content: 'Looking for AI researchers' });
+  });
+
+  it('falls back to summary field for intent_proposal without description', () => {
+    const response = [
+      '```intent_proposal',
+      '{"proposalId":"p-2","summary":"Web3 enthusiast"}',
+      '```',
+    ].join('\n');
+
+    const segments = parseResponseSegments(response);
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toEqual({ type: 'text', content: 'Web3 enthusiast' });
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(parseResponseSegments('')).toHaveLength(0);
+    expect(parseResponseSegments('   ')).toHaveLength(0);
+  });
+
+  it('preserves interleaving order of prose and blocks', () => {
+    const response = [
+      'Intro text.',
+      '',
+      '```opportunity',
+      '{"opportunityId":"1","name":"Alice"}',
+      '```',
+      '',
+      'Middle text.',
+      '',
+      '```opportunity',
+      '{"opportunityId":"2","name":"Bob"}',
+      '```',
+      '',
+      'Trailing text.',
+    ].join('\n');
+
+    const segments = parseResponseSegments(response);
+    const types = segments.map((s) => s.type);
+    expect(types).toEqual(['text', 'opportunity', 'text', 'opportunity', 'text']);
+  });
+});
+
+// ── hasStructuredBlocks ────────────────────────────────────────────────────────
+
+describe('hasStructuredBlocks', () => {
+  it('returns false for text-only segments', () => {
+    const segments: ResponseSegment[] = [{ type: 'text', content: 'hello' }];
+    expect(hasStructuredBlocks(segments)).toBe(false);
+  });
+
+  it('returns true when opportunity segments exist', () => {
+    const segments: ResponseSegment[] = [
+      { type: 'text', content: 'intro' },
+      { type: 'opportunity', card: { opportunityId: '1' } },
+    ];
+    expect(hasStructuredBlocks(segments)).toBe(true);
+  });
+
+  it('returns false for empty segments', () => {
+    expect(hasStructuredBlocks([])).toBe(false);
+  });
+});
+
+// ── formatOpportunityCardHtml ──────────────────────────────────────────────────
+
+describe('formatOpportunityCardHtml', () => {
+  it('renders name as bold and headline as italic', () => {
+    const { text } = formatOpportunityCardHtml(
+      { opportunityId: '1', name: 'Alice', headline: 'Great collaborator' },
+      'https://index.network',
+    );
+    expect(text).toContain('<b>Alice</b>');
+    expect(text).toContain('<i>Great collaborator</i>');
+  });
+
+  it('escapes HTML special characters in all fields', () => {
+    const { text } = formatOpportunityCardHtml(
+      {
+        opportunityId: '1',
+        name: 'Bob & Carol',
+        headline: 'Uses <React>',
+        mainText: 'Builds apps with "TypeScript" & more',
+      },
+      'https://index.network',
+    );
+    expect(text).toContain('Bob &amp; Carol');
+    expect(text).toContain('&lt;React&gt;');
+    expect(text).toContain('&quot;TypeScript&quot;');
+  });
+
+  it('includes main text body', () => {
+    const { text } = formatOpportunityCardHtml(
+      { opportunityId: '1', name: 'Eve', mainText: 'Eve is an expert in cryptography.' },
+      'https://index.network',
+    );
+    expect(text).toContain('Eve is an expert in cryptography.');
+  });
+
+  it('includes mutual intents label with emoji', () => {
+    const { text } = formatOpportunityCardHtml(
+      { opportunityId: '1', name: 'Dave', mutualIntentsLabel: 'Aligned goals' },
+      'https://index.network',
+    );
+    expect(text).toContain('🎯 Aligned goals');
+  });
+
+  it('includes narrator chip as italic editorial note', () => {
+    const { text } = formatOpportunityCardHtml(
+      { opportunityId: '1', name: 'Eve', narratorChip: { name: 'Index', text: 'Strong overlap in AI' } },
+      'https://index.network',
+    );
+    expect(text).toContain('💡 <i>Strong overlap in AI</i>');
+  });
+
+  it('generates inline keyboard with action button', () => {
+    const { keyboard } = formatOpportunityCardHtml(
+      { opportunityId: '1', name: 'Frank', primaryActionLabel: 'Start Chat' },
+      'https://index.network',
+    );
+    expect(keyboard).toHaveLength(1);
+    expect(keyboard[0]).toHaveLength(1);
+    expect(keyboard[0][0].text).toContain('Start Chat');
+    expect(keyboard[0][0].url).toBe('https://index.network/opportunities');
+  });
+
+  it('uses "View" as default button label when primaryActionLabel is absent', () => {
+    const { keyboard } = formatOpportunityCardHtml(
+      { opportunityId: '1', name: 'Grace' },
+      'https://app.example.com',
+    );
+    expect(keyboard[0][0].text).toContain('View');
+    expect(keyboard[0][0].url).toBe('https://app.example.com/opportunities');
+  });
+
+  it('handles minimal card with only name', () => {
+    const { text } = formatOpportunityCardHtml(
+      { opportunityId: '1', name: 'Zoe' },
+      'https://index.network',
+    );
+    expect(text).toContain('<b>Zoe</b>');
+    // Should not contain undefined or null
+    expect(text).not.toContain('undefined');
+    expect(text).not.toContain('null');
+  });
+
+  it('defaults name to "Someone" when missing', () => {
+    const { text } = formatOpportunityCardHtml(
+      { opportunityId: '1' },
+      'https://index.network',
+    );
+    expect(text).toContain('<b>Someone</b>');
+  });
+});
+
+// ── formatOpportunityCardPlainText ─────────────────────────────────────────────
+
+describe('formatOpportunityCardPlainText', () => {
+  it('renders card without HTML tags', () => {
+    const text = formatOpportunityCardPlainText({
+      opportunityId: '1',
+      name: 'Alice',
+      headline: 'AI researcher',
+      mainText: 'Alice works in AI.',
+      mutualIntentsLabel: 'Aligned goals',
+      narratorChip: { name: 'Index', text: 'Strong fit' },
+    });
+    expect(text).toContain('Alice');
+    expect(text).toContain('AI researcher');
+    expect(text).toContain('Alice works in AI.');
+    expect(text).toContain('🎯 Aligned goals');
+    expect(text).toContain('💡 Strong fit');
+    expect(text).not.toContain('<b>');
+    expect(text).not.toContain('<i>');
+  });
+
+  it('handles card with only name', () => {
+    const text = formatOpportunityCardPlainText({ opportunityId: '1', name: 'Bob' });
+    expect(text).toBe('Bob');
+  });
+});

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -145,7 +145,7 @@ NegotiationEvents.onTurnReceived = (data) => {
 
 // ── Telegram bot startup ────────────────────────────────────────────────────
 if (process.env.TELEGRAM_BOT_TOKEN && process.env.TELEGRAM_WEBHOOK_SECRET) {
-  const webhookBase = process.env.BASE_URL ?? process.env.APP_URL ?? '';
+  const webhookBase = process.env.TELEGRAM_WEBHOOK_URL ?? process.env.BASE_URL ?? process.env.APP_URL ?? '';
   const webhookUrl = `${webhookBase.replace(/\/$/, '')}/api/webhooks/telegram`;
   setWebhook(webhookUrl, process.env.TELEGRAM_WEBHOOK_SECRET).catch((err) => {
     logger.error('Failed to register Telegram webhook on startup', { error: err });

--- a/backend/src/schemas/database.schema.ts
+++ b/backend/src/schemas/database.schema.ts
@@ -13,6 +13,7 @@ export const agentTypeEnum = pgEnum('agent_type', ['personal', 'system']);
 export const agentStatusEnum = pgEnum('agent_status', ['active', 'inactive']);
 export const transportChannelEnum = pgEnum('transport_channel', ['mcp']);
 export const permissionScopeEnum = pgEnum('permission_scope', ['global', 'node', 'network']);
+export const networkTypeEnum = pgEnum('network_type', ['community', 'event']);
 
 export interface OnboardingState {
   completedAt?: string;
@@ -376,14 +377,17 @@ export const networks = pgTable('networks', {
   isPersonal: boolean('is_personal').default(false).notNull(),
   isExperiment: boolean('is_experiment').default(false).notNull(),
   experimentMasterKeyHash: text('experiment_master_key_hash'),
+  type: networkTypeEnum('type').default('community').notNull(),
+  metadata: jsonb('metadata').$type<Record<string, unknown>>().default({}).notNull(),
   permissions: json('permissions').$type<{
     joinPolicy: 'anyone' | 'invite_only';
     invitationLink: { code: string } | null;
     allowGuestVibeCheck: boolean;
+    contextInjection?: { discovery: boolean };
   }>().default({
     joinPolicy: 'invite_only',
     invitationLink: null,
-    allowGuestVibeCheck: false
+    allowGuestVibeCheck: false,
   }),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
@@ -398,7 +402,7 @@ export const networkMembers = pgTable('network_members', {
   permissions: text('permissions').array().notNull().default([]),
   prompt: text('prompt'),
   autoAssign: boolean('auto_assign').notNull().default(false),
-  metadata: json('metadata').$type<Record<string, string | string[]>>(),
+  metadata: jsonb('metadata').$type<Record<string, unknown>>().default({}).notNull(),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
   deletedAt: timestamp('deleted_at'),
@@ -418,6 +422,12 @@ export const networkIntegrations = pgTable('network_integrations', {
   networkId: text('network_id').notNull().references(() => networks.id),
   toolkit: text('toolkit').notNull(),
   connectedAccountId: text('connected_account_id').notNull(),
+  syncConfig: jsonb('sync_config').$type<{
+    intervalMs?: number;
+    lastSyncAt?: string;
+    calendarId?: string;
+    status?: 'active' | 'paused' | 'error';
+  }>().default({}).notNull(),
   createdAt: timestamp('created_at').defaultNow().notNull(),
 }, (table) => ({
   pk: primaryKey({ columns: [table.networkId, table.toolkit] }),

--- a/backend/src/schemas/network.validation.ts
+++ b/backend/src/schemas/network.validation.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+
+export const EventNetworkMetadataSchema = z.object({
+  startDate: z.string().datetime({ message: 'startDate must be ISO-8601' }),
+  endDate: z.string().datetime({ message: 'endDate must be ISO-8601' }),
+  timezone: z.string().optional(),
+  location: z.string().optional(),
+  themes: z.array(z.string()).optional(),
+  events: z.array(z.object({
+    externalId: z.string(),
+    title: z.string(),
+    startTime: z.string(),
+    endTime: z.string(),
+    location: z.string().optional(),
+    description: z.string().optional(),
+    tags: z.array(z.string()).optional(),
+    syncedAt: z.string().optional(),
+  })).optional().default([]),
+}).refine(
+  (data) => new Date(data.endDate) > new Date(data.startDate),
+  { message: 'endDate must be after startDate', path: ['endDate'] },
+);
+
+export const CommunityNetworkMetadataSchema = z.object({}).passthrough();
+
+export const NetworkMemberMetadataSchema = z.record(z.string(), z.unknown());
+
+export const SyncConfigSchema = z.object({
+  intervalMs: z.number().min(60_000).optional().default(900_000),
+  lastSyncAt: z.string().datetime().optional(),
+  calendarId: z.string().optional().default('primary'),
+  status: z.enum(['active', 'paused', 'error']).optional().default('paused'),
+});
+
+export const ContextInjectionSchema = z.object({
+  discovery: z.boolean().optional().default(true),
+});
+
+export type EventNetworkMetadata = z.infer<typeof EventNetworkMetadataSchema>;
+export type NetworkMemberMetadata = z.infer<typeof NetworkMemberMetadataSchema>;
+export type SyncConfig = z.infer<typeof SyncConfigSchema>;
+
+export function validateNetworkMetadata(type: 'community' | 'event', metadata: unknown): Record<string, unknown> {
+  if (type === 'event') {
+    return EventNetworkMetadataSchema.parse(metadata);
+  }
+  return CommunityNetworkMetadataSchema.parse(metadata ?? {});
+}

--- a/backend/src/services/experiment.service.ts
+++ b/backend/src/services/experiment.service.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull, sql } from 'drizzle-orm';
+import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
 
 import db from '../lib/drizzle/drizzle';
 import { log } from '../lib/log';
@@ -171,7 +171,7 @@ class ExperimentService {
     // email. After the loop, a single summary email is sent to the network's
     // owner(s) with all minted keys as an inline CSV — the experimental-network
     // policy bypasses per-user invitation emails entirely.
-    const importedUserIds: string[] = [];
+    const importedUserIdSet = new Set<string>();
     for (const row of rows) {
       try {
         const email = row.email.toLowerCase().trim();
@@ -182,7 +182,7 @@ class ExperimentService {
           rotateKey: true,
         });
         await this.applyProfilePatch(result.user.id, row);
-        importedUserIds.push(result.user.id);
+        importedUserIdSet.add(result.user.id);
         credentials.push({
           email: result.user.email,
           name: row.name,
@@ -195,17 +195,18 @@ class ExperimentService {
       }
     }
 
+    const importedUserIds = [...importedUserIdSet];
+
     // Mark imported users as onboarded so they appear in vector search filters
     // (embedder requires isGhost=true OR onboarding.completedAt IS NOT NULL).
+    // Merges into existing onboarding JSON to preserve other fields (flow, currentStep, etc.).
     if (importedUserIds.length > 0) {
       const completedAt = new Date().toISOString();
-      await Promise.all(
-        importedUserIds.map(uid =>
-          db.update(schema.users)
-            .set({ onboarding: { completedAt } })
-            .where(eq(schema.users.id, uid)),
-        ),
-      );
+      await db.update(schema.users)
+        .set({
+          onboarding: sql`COALESCE(${schema.users.onboarding}::jsonb, '{}'::jsonb) || ${JSON.stringify({ completedAt })}::jsonb`,
+        })
+        .where(inArray(schema.users.id, importedUserIds));
     }
 
     // Enqueue profile enrichment: the profile graph reads name, intro, location,

--- a/backend/src/services/experiment.service.ts
+++ b/backend/src/services/experiment.service.ts
@@ -92,13 +92,17 @@ class ExperimentService {
     }
 
     // Mark as onboarded so the user is discoverable in vector search filters.
-    const currentOnboarding = (await db.select({ onboarding: schema.users.onboarding })
-      .from(schema.users).where(eq(schema.users.id, result.user.id)).limit(1))[0]?.onboarding ?? {};
-    if (!currentOnboarding.completedAt) {
-      await db.update(schema.users)
-        .set({ onboarding: { ...currentOnboarding, completedAt: new Date().toISOString() } })
-        .where(eq(schema.users.id, result.user.id));
-    }
+    // Uses an atomic WHERE guard so concurrent signup() calls for the same user
+    // cannot both read completedAt as missing and race to overwrite each other.
+    const completedAt = new Date().toISOString();
+    await db.update(schema.users)
+      .set({
+        onboarding: sql`COALESCE(${schema.users.onboarding}::jsonb, '{}'::jsonb) || ${JSON.stringify({ completedAt })}::jsonb`,
+      })
+      .where(and(
+        eq(schema.users.id, result.user.id),
+        sql`(${schema.users.onboarding} IS NULL OR ${schema.users.onboarding}->>'completedAt' IS NULL)`,
+      ));
 
     // Enqueue profile enrichment so the user gets a profile embedding + HyDE.
     try {

--- a/backend/src/services/experiment.service.ts
+++ b/backend/src/services/experiment.service.ts
@@ -206,7 +206,10 @@ class ExperimentService {
         .set({
           onboarding: sql`COALESCE(${schema.users.onboarding}::jsonb, '{}'::jsonb) || ${JSON.stringify({ completedAt })}::jsonb`,
         })
-        .where(inArray(schema.users.id, importedUserIds));
+        .where(and(
+          inArray(schema.users.id, importedUserIds),
+          sql`(${schema.users.onboarding} IS NULL OR ${schema.users.onboarding}->>'completedAt' IS NULL)`,
+        ));
     }
 
     // Enqueue profile enrichment: the profile graph reads name, intro, location,

--- a/backend/src/services/experiment.service.ts
+++ b/backend/src/services/experiment.service.ts
@@ -6,6 +6,7 @@ import { experimentImportCredentialsTemplate } from '../lib/email/templates/expe
 import { executeSendEmail } from '../lib/email/transport.helper';
 import { buildMcpServerConfig } from '../lib/mcp/mcp-config';
 import * as schema from '../schemas/database.schema';
+import { profileQueue } from '../queues/profile.queue';
 
 /**
  * Experiment is a thin facade over the network-invitation flow: signup uses
@@ -90,6 +91,22 @@ class ExperimentService {
       });
     }
 
+    // Mark as onboarded so the user is discoverable in vector search filters.
+    const currentOnboarding = (await db.select({ onboarding: schema.users.onboarding })
+      .from(schema.users).where(eq(schema.users.id, result.user.id)).limit(1))[0]?.onboarding ?? {};
+    if (!currentOnboarding.completedAt) {
+      await db.update(schema.users)
+        .set({ onboarding: { ...currentOnboarding, completedAt: new Date().toISOString() } })
+        .where(eq(schema.users.id, result.user.id));
+    }
+
+    // Enqueue profile enrichment so the user gets a profile embedding + HyDE.
+    try {
+      await profileQueue.addEnrichUserJob({ userId: result.user.id });
+    } catch (err) {
+      logger.warn('[ExperimentService] Failed to enqueue profile enrichment (non-fatal)', { error: err });
+    }
+
     logger.info('[ExperimentService] Signup complete', {
       userId: result.user.id,
       networkId,
@@ -154,6 +171,7 @@ class ExperimentService {
     // email. After the loop, a single summary email is sent to the network's
     // owner(s) with all minted keys as an inline CSV — the experimental-network
     // policy bypasses per-user invitation emails entirely.
+    const importedUserIds: string[] = [];
     for (const row of rows) {
       try {
         const email = row.email.toLowerCase().trim();
@@ -164,6 +182,7 @@ class ExperimentService {
           rotateKey: true,
         });
         await this.applyProfilePatch(result.user.id, row);
+        importedUserIds.push(result.user.id);
         credentials.push({
           email: result.user.email,
           name: row.name,
@@ -173,6 +192,31 @@ class ExperimentService {
       } catch (err) {
         logger.warn('[ExperimentService] Import row failed', { email: row.email, error: err });
         skipped++;
+      }
+    }
+
+    // Mark imported users as onboarded so they appear in vector search filters
+    // (embedder requires isGhost=true OR onboarding.completedAt IS NOT NULL).
+    if (importedUserIds.length > 0) {
+      const completedAt = new Date().toISOString();
+      await Promise.all(
+        importedUserIds.map(uid =>
+          db.update(schema.users)
+            .set({ onboarding: { completedAt } })
+            .where(eq(schema.users.id, uid)),
+        ),
+      );
+    }
+
+    // Enqueue profile enrichment: the profile graph reads name, intro, location,
+    // and socials from the users/user_socials tables (written by applyProfilePatch
+    // above), then generates a full profile with embedding + HyDE documents.
+    if (importedUserIds.length > 0) {
+      try {
+        await profileQueue.addEnrichUserJobBulk(importedUserIds.map(id => ({ userId: id })));
+        logger.info('[ExperimentService] Enqueued profile enrichment', { count: importedUserIds.length });
+      } catch (err) {
+        logger.warn('[ExperimentService] Failed to enqueue profile enrichment (non-fatal)', { error: err });
       }
     }
 
@@ -252,11 +296,12 @@ class ExperimentService {
    * @param row - Import row carrying optional name/bio/location/socials.
    */
   private async applyProfilePatch(userId: string, row: ImportRow): Promise<void> {
-    if (row.name) {
-      await db
-        .update(schema.users)
-        .set({ name: row.name })
-        .where(eq(schema.users.id, userId));
+    const userPatch: { name?: string; intro?: string; location?: string } = {};
+    if (row.name) userPatch.name = row.name;
+    if (row.bio) userPatch.intro = row.bio;
+    if (row.location) userPatch.location = row.location;
+    if (Object.keys(userPatch).length > 0) {
+      await db.update(schema.users).set(userPatch).where(eq(schema.users.id, userId));
     }
 
     if (row.bio || row.location) {

--- a/backend/src/services/network.service.ts
+++ b/backend/src/services/network.service.ts
@@ -8,6 +8,7 @@ import { executeSendEmail } from '../lib/email/transport.helper';
 import { networkMasterKeyRotatedTemplate } from '../lib/email/templates/network-master-key-rotated.template';
 import { validateKey } from '../lib/keys';
 import * as schema from '../schemas/database.schema';
+import { validateNetworkMetadata } from '../schemas/network.validation';
 
 const logger = log.service.from("NetworkService");
 
@@ -36,9 +37,15 @@ export class NetworkService {
   /**
    * Create a new index with the requesting user as owner.
    */
-  async createNetwork(userId: string, data: { title: string; prompt?: string; imageUrl?: string | null; joinPolicy?: 'anyone' | 'invite_only'; allowGuestVibeCheck?: boolean }) {
-    logger.verbose('[NetworkService] Creating index', { userId, title: data.title });
-    const index = await this.adapter.createNetwork(data);
+  async createNetwork(userId: string, data: { title: string; prompt?: string; imageUrl?: string | null; joinPolicy?: 'anyone' | 'invite_only'; allowGuestVibeCheck?: boolean; type?: 'community' | 'event'; metadata?: Record<string, unknown> }) {
+    const networkType = data.type ?? 'community';
+    const validatedMetadata = validateNetworkMetadata(networkType, data.metadata ?? {});
+    logger.verbose('[NetworkService] Creating index', { userId, title: data.title, type: networkType });
+    const index = await this.adapter.createNetwork({
+      ...data,
+      type: networkType,
+      metadata: validatedMetadata,
+    });
     // Add the creating user as the owner
     await this.adapter.addMemberToNetwork(index.id, userId, 'owner');
     // Fetch the full index details with user and member count
@@ -112,13 +119,19 @@ export class NetworkService {
    * @throws Error if the index is a personal index.
    * @throws Error if attempting to change join policy on an experiment network.
    */
-  async updateNetwork(networkId: string, userId: string, data: { title?: string; prompt?: string | null; imageUrl?: string | null; joinPolicy?: 'anyone' | 'invite_only'; allowGuestVibeCheck?: boolean }) {
+  async updateNetwork(networkId: string, userId: string, data: { title?: string; prompt?: string | null; imageUrl?: string | null; joinPolicy?: 'anyone' | 'invite_only'; allowGuestVibeCheck?: boolean; type?: 'community' | 'event'; metadata?: Record<string, unknown>; contextInjection?: { discovery: boolean } }) {
     logger.verbose('[NetworkService] Updating index', { networkId, userId });
     await this.assertNotPersonal(networkId);
     if (data.joinPolicy !== undefined || data.allowGuestVibeCheck !== undefined) {
       await this.assertJoinPolicyNotLockedByExperiment(networkId);
     }
-    return this.adapter.updateIndexSettings(networkId, userId, data);
+    let validatedMetadata = data.metadata;
+    if (data.metadata !== undefined) {
+      const currentNetwork = await this.adapter.getNetworkDetail(networkId, userId);
+      const effectiveType = data.type ?? currentNetwork?.type ?? 'community';
+      validatedMetadata = validateNetworkMetadata(effectiveType, data.metadata);
+    }
+    return this.adapter.updateIndexSettings(networkId, userId, { ...data, metadata: validatedMetadata });
   }
 
   /**

--- a/backend/src/services/network.service.ts
+++ b/backend/src/services/network.service.ts
@@ -8,7 +8,7 @@ import { executeSendEmail } from '../lib/email/transport.helper';
 import { networkMasterKeyRotatedTemplate } from '../lib/email/templates/network-master-key-rotated.template';
 import { validateKey } from '../lib/keys';
 import * as schema from '../schemas/database.schema';
-import { validateNetworkMetadata } from '../schemas/network.validation';
+import { ContextInjectionSchema, validateNetworkMetadata } from '../schemas/network.validation';
 
 const logger = log.service.from("NetworkService");
 
@@ -126,12 +126,16 @@ export class NetworkService {
       await this.assertJoinPolicyNotLockedByExperiment(networkId);
     }
     let validatedMetadata = data.metadata;
-    if (data.metadata !== undefined) {
+    if (data.type !== undefined || data.metadata !== undefined) {
       const currentNetwork = await this.adapter.getNetworkDetail(networkId, userId);
       const effectiveType = data.type ?? currentNetwork?.type ?? 'community';
-      validatedMetadata = validateNetworkMetadata(effectiveType, data.metadata);
+      const effectiveMetadata = data.metadata ?? (currentNetwork?.metadata as Record<string, unknown>) ?? {};
+      validatedMetadata = validateNetworkMetadata(effectiveType, effectiveMetadata);
     }
-    return this.adapter.updateIndexSettings(networkId, userId, { ...data, metadata: validatedMetadata });
+    const validatedContextInjection = data.contextInjection !== undefined
+      ? ContextInjectionSchema.parse(data.contextInjection)
+      : undefined;
+    return this.adapter.updateIndexSettings(networkId, userId, { ...data, metadata: validatedMetadata, contextInjection: validatedContextInjection });
   }
 
   /**

--- a/backend/tests/network-scoped-import.test.ts
+++ b/backend/tests/network-scoped-import.test.ts
@@ -285,4 +285,63 @@ describe('CSV import → network-scoped agent end-to-end', () => {
     expect(call).toHaveLength(1);
     expect(call[0].userId).toBe(user.id);
   });
+
+  test('signup sets onboarding.completedAt for new users', async () => {
+    enrichSingleSpy.mockClear();
+    const email = `signup-onboard-${Date.now()}@test.dev`;
+    const result = await experimentService.signup(networkId, {
+      email,
+      name: 'Signup Onboard',
+    });
+    cleanupUserIds.push(result.user.id);
+
+    const [user] = await db
+      .select({ onboarding: schema.users.onboarding })
+      .from(schema.users)
+      .where(eq(schema.users.id, result.user.id));
+
+    expect(user.onboarding).toBeTruthy();
+    expect(user.onboarding!.completedAt).toBeTruthy();
+    expect(new Date(user.onboarding!.completedAt!).getTime()).toBeGreaterThan(0);
+  });
+
+  test('signup does not overwrite existing completedAt on re-signup', async () => {
+    const email = `signup-keep-${Date.now()}@test.dev`;
+    const originalCompletedAt = '2025-06-01T00:00:00.000Z';
+
+    // First signup to provision the user
+    const first = await experimentService.signup(networkId, { email, name: 'Re-Signup' });
+    cleanupUserIds.push(first.user.id);
+
+    // Manually set a known completedAt
+    await db.update(schema.users)
+      .set({ onboarding: { completedAt: originalCompletedAt, flow: 3 } })
+      .where(eq(schema.users.id, first.user.id));
+
+    // Second signup for the same user
+    await experimentService.signup(networkId, { email, name: 'Re-Signup' });
+
+    const [user] = await db
+      .select({ onboarding: schema.users.onboarding })
+      .from(schema.users)
+      .where(eq(schema.users.id, first.user.id));
+
+    expect(user.onboarding!.completedAt).toBe(originalCompletedAt);
+    expect(user.onboarding!.flow).toBe(3);
+  });
+
+  test('signup enqueues profile enrichment', async () => {
+    enrichSingleSpy.mockClear();
+    const email = `signup-enrich-${Date.now()}@test.dev`;
+    const result = await experimentService.signup(networkId, {
+      email,
+      name: 'Signup Enrich',
+      bio: 'ML researcher',
+    });
+    cleanupUserIds.push(result.user.id);
+
+    expect(enrichSingleSpy).toHaveBeenCalledTimes(1);
+    const call = enrichSingleSpy.mock.calls[0][0];
+    expect(call).toEqual({ userId: result.user.id });
+  });
 });

--- a/backend/tests/network-scoped-import.test.ts
+++ b/backend/tests/network-scoped-import.test.ts
@@ -221,6 +221,33 @@ describe('CSV import → network-scoped agent end-to-end', () => {
     expect(user.onboarding!.currentStep).toBe('connections');
   });
 
+  test('importMembers does not overwrite existing completedAt', async () => {
+    const email = `csv-keep-completed-${Date.now()}@test.dev`;
+    const originalCompletedAt = '2025-01-15T00:00:00.000Z';
+
+    const [preUser] = await db.insert(schema.users)
+      .values({
+        email,
+        name: 'Already Onboarded',
+        emailVerified: true,
+        onboarding: { completedAt: originalCompletedAt, flow: 1 },
+      })
+      .returning({ id: schema.users.id });
+    cleanupUserIds.push(preUser.id);
+
+    await experimentService.importMembers(networkId, [
+      { email, name: 'Already Onboarded', socials: [] },
+    ]);
+
+    const [user] = await db
+      .select({ onboarding: schema.users.onboarding })
+      .from(schema.users)
+      .where(eq(schema.users.id, preUser.id));
+
+    expect(user.onboarding!.completedAt).toBe(originalCompletedAt);
+    expect(user.onboarding!.flow).toBe(1);
+  });
+
   test('importMembers enqueues profile enrichment for imported users', async () => {
     enrichBulkSpy.mockClear();
     const email = `csv-enrich-${Date.now()}@test.dev`;

--- a/backend/tests/network-scoped-import.test.ts
+++ b/backend/tests/network-scoped-import.test.ts
@@ -13,6 +13,15 @@ mock.module('../src/lib/email/transport.helper', () => ({
   executeSendEmail: sendSpy,
 }));
 
+const enrichBulkSpy = mock<(items: Array<{ userId: string }>) => Promise<unknown[]>>(async () => []);
+const enrichSingleSpy = mock<(data: { userId: string }) => Promise<unknown>>(async () => ({}));
+mock.module('../src/queues/profile.queue', () => ({
+  profileQueue: {
+    addEnrichUserJobBulk: enrichBulkSpy,
+    addEnrichUserJob: enrichSingleSpy,
+  },
+}));
+
 afterAll(() => {
   mock.restore();
 });
@@ -149,5 +158,104 @@ describe('CSV import → network-scoped agent end-to-end', () => {
         eq(schema.agentPermissions.scopeId, networkId),
       ));
     expect(perms.length).toBe(1);
+  });
+
+  test('importMembers writes CSV bio and location to users table columns', async () => {
+    const email = `csv-profile-${Date.now()}@test.dev`;
+    await experimentService.importMembers(networkId, [
+      { email, name: 'Profile Test', bio: 'AI researcher at MIT', location: 'Cambridge, MA', socials: [] },
+    ]);
+
+    const [user] = await db
+      .select({ id: schema.users.id, intro: schema.users.intro, location: schema.users.location })
+      .from(schema.users)
+      .where(eq(schema.users.email, email));
+    cleanupUserIds.push(user.id);
+
+    expect(user.intro).toBe('AI researcher at MIT');
+    expect(user.location).toBe('Cambridge, MA');
+  });
+
+  test('importMembers sets onboarding.completedAt on imported users', async () => {
+    const email = `csv-onboard-${Date.now()}@test.dev`;
+    await experimentService.importMembers(networkId, [
+      { email, name: 'Onboard Test', socials: [] },
+    ]);
+
+    const [user] = await db
+      .select({ id: schema.users.id, onboarding: schema.users.onboarding })
+      .from(schema.users)
+      .where(eq(schema.users.email, email));
+    cleanupUserIds.push(user.id);
+
+    expect(user.onboarding).toBeTruthy();
+    expect(user.onboarding!.completedAt).toBeTruthy();
+    expect(new Date(user.onboarding!.completedAt!).getTime()).toBeGreaterThan(0);
+  });
+
+  test('importMembers preserves existing onboarding fields when setting completedAt', async () => {
+    const email = `csv-onboard-preserve-${Date.now()}@test.dev`;
+
+    // Pre-create user with existing onboarding state
+    const [preUser] = await db.insert(schema.users)
+      .values({
+        email,
+        name: 'Pre-existing',
+        emailVerified: true,
+        onboarding: { flow: 2, currentStep: 'connections' },
+      })
+      .returning({ id: schema.users.id });
+    cleanupUserIds.push(preUser.id);
+
+    await experimentService.importMembers(networkId, [
+      { email, name: 'Pre-existing', socials: [] },
+    ]);
+
+    const [user] = await db
+      .select({ onboarding: schema.users.onboarding })
+      .from(schema.users)
+      .where(eq(schema.users.id, preUser.id));
+
+    expect(user.onboarding!.completedAt).toBeTruthy();
+    expect(user.onboarding!.flow).toBe(2);
+    expect(user.onboarding!.currentStep).toBe('connections');
+  });
+
+  test('importMembers enqueues profile enrichment for imported users', async () => {
+    enrichBulkSpy.mockClear();
+    const email = `csv-enrich-${Date.now()}@test.dev`;
+    await experimentService.importMembers(networkId, [
+      { email, name: 'Enrich Test', bio: 'Engineer', socials: [] },
+    ]);
+
+    const [user] = await db
+      .select({ id: schema.users.id })
+      .from(schema.users)
+      .where(eq(schema.users.email, email));
+    cleanupUserIds.push(user.id);
+
+    expect(enrichBulkSpy).toHaveBeenCalledTimes(1);
+    const call = enrichBulkSpy.mock.calls[0][0];
+    expect(call).toEqual([{ userId: user.id }]);
+  });
+
+  test('importMembers deduplicates enrichment jobs for repeated emails', async () => {
+    enrichBulkSpy.mockClear();
+    const email = `csv-dedup-${Date.now()}@test.dev`;
+    await experimentService.importMembers(networkId, [
+      { email, name: 'Dedup A', socials: [] },
+      { email, name: 'Dedup B', socials: [] },
+    ]);
+
+    const [user] = await db
+      .select({ id: schema.users.id })
+      .from(schema.users)
+      .where(eq(schema.users.email, email));
+    cleanupUserIds.push(user.id);
+
+    expect(enrichBulkSpy).toHaveBeenCalledTimes(1);
+    const call = enrichBulkSpy.mock.calls[0][0];
+    expect(call).toHaveLength(1);
+    expect(call[0].userId).toBe(user.id);
   });
 });

--- a/docs/superpowers/specs/2026-05-22-polymorphic-network-types-design.md
+++ b/docs/superpowers/specs/2026-05-22-polymorphic-network-types-design.md
@@ -1,0 +1,264 @@
+# Polymorphic Network Types & Network-Level Integrations
+
+**Date:** 2026-05-22
+**Status:** Draft
+**Scope:** Schema extension, integration sync worker, LLM context injection
+
+## Motivation
+
+Index Network depends on EdgeOS for event-network features (schedule, attendee directory, venues, RSVPs) via the EdgeClaw skills. EdgeOS readiness is uncertain. This design absorbs the core value — temporal community context and calendar-aware discovery — into Index Network's own model, without building a full event platform. Index stays focused on discovery and matching; calendar and venue infrastructure remain external via integrations.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| `isExperiment` relationship to `type` | Orthogonal | `isExperiment` gates auth/isolation (headless signup, master keys). Any network type can be experimental. |
+| Core protocol entities | Unchanged | No modifications to intents, opportunities, or the discovery pipeline. MVP scope. |
+| Network type values | `community`, `event` | Explicit type on every network. Existing rows backfill to `community`. |
+| Sync model | Periodic BullMQ worker | Repeatable job polls Google Calendar on a configurable interval. No webhooks. |
+| Event storage | `networks.metadata` JSONB | Synced calendar events stored in the network's own metadata. No new tables. |
+| Per-member extra fields | `network_members.metadata` JSONB | Flat bag for network-specific attendee data (participation weeks, dietary, etc.). |
+| Discovery injection toggle | `networks.permissions` JSONB | Policy/config lives in `permissions`; content/data lives in `metadata`. |
+| Auto-archive | Manual only | `endDate` is informational. Network owner archives explicitly. |
+| Context renderer | Type-aware, per-type functions | Curated markdown per network type. Event networks get date ranges, event tables, tag lists. |
+
+## Schema Changes
+
+### `networks` table — two new columns
+
+```sql
+-- New enum
+CREATE TYPE network_type AS ENUM ('community', 'event');
+
+-- New columns
+ALTER TABLE networks
+  ADD COLUMN type network_type NOT NULL DEFAULT 'community',
+  ADD COLUMN metadata jsonb NOT NULL DEFAULT '{}';
+```
+
+Existing rows automatically receive `type = 'community'` and `metadata = '{}'` via the defaults.
+
+### `network_members` table — one new column
+
+```sql
+ALTER TABLE network_members
+  ADD COLUMN metadata jsonb NOT NULL DEFAULT '{}';
+```
+
+### `network_integrations` table — one new column
+
+```sql
+ALTER TABLE network_integrations
+  ADD COLUMN sync_config jsonb NOT NULL DEFAULT '{}';
+```
+
+### Metadata shapes
+
+**`networks.metadata` for `type = 'community'`:**
+
+```json
+{}
+```
+
+Communities have no required metadata today. The JSONB is available for future extensions.
+
+**`networks.metadata` for `type = 'event'`:**
+
+```json
+{
+  "startDate": "2026-05-30T00:00:00Z",
+  "endDate": "2026-06-27T23:59:59Z",
+  "timezone": "America/Los_Angeles",
+  "location": "Healdsburg, California",
+  "themes": ["AI", "Governance & Coordination", "Health & Longevity"],
+  "events": [
+    {
+      "externalId": "google-cal-event-abc123",
+      "title": "AI Governance Panel",
+      "startTime": "2026-06-10T14:00:00-07:00",
+      "endTime": "2026-06-10T15:30:00-07:00",
+      "location": "Main Hall",
+      "description": "Panel discussion on AI governance frameworks",
+      "tags": ["AI", "Governance"],
+      "syncedAt": "2026-06-09T10:00:00Z"
+    }
+  ]
+}
+```
+
+Service-layer validation: if `type === 'event'`, then `metadata.startDate` and `metadata.endDate` are required. All other fields are optional.
+
+**`network_members.metadata` (any network type):**
+
+```json
+{
+  "participationWeeks": [1, 2],
+  "dietaryPreferences": "vegetarian",
+  "builderDescription": "Working on decentralized identity",
+  "personalGoals": "Connect with governance researchers"
+}
+```
+
+Flat bag — no formal schema. Content varies by network. The network owner or import process defines what goes here.
+
+**`networks.permissions` — extended shape:**
+
+```json
+{
+  "joinPolicy": "invite_only",
+  "invitationLink": true,
+  "allowGuestVibeCheck": false,
+  "contextInjection": {
+    "discovery": true
+  }
+}
+```
+
+`contextInjection.discovery` (default `true`) controls whether the network's rendered metadata is included in the opportunity discovery evaluator's context.
+
+**`network_integrations.sync_config`:**
+
+```json
+{
+  "intervalMs": 900000,
+  "lastSyncAt": "2026-06-09T10:00:00Z",
+  "calendarId": "primary",
+  "status": "active"
+}
+```
+
+`status`: `'active' | 'paused' | 'error'`. The sync worker reads this to decide what to pull and when.
+
+### Zod validation schemas
+
+Service-layer validation uses Zod schemas for metadata shapes. Define in the network service (or a shared validation module):
+
+- `EventNetworkMetadataSchema` — validates `startDate` (required), `endDate` (required), `timezone`, `location`, `themes`, `events[]`
+- `NetworkMemberMetadataSchema` — passthrough (no required fields, accepts any JSON object)
+- `SyncConfigSchema` — validates `intervalMs`, `lastSyncAt`, `calendarId`, `status`
+
+On network create/update: if `type === 'event'`, parse `metadata` through `EventNetworkMetadataSchema`. If `type === 'community'`, no metadata validation (empty object accepted).
+
+## Integration Sync Worker
+
+### New toolkit
+
+Extend the `Toolkit` type to include `'google_calendar'`:
+
+```typescript
+type Toolkit = 'gmail' | 'slack' | 'google_calendar';
+```
+
+The Composio action slug is `GOOGLESUPER_GOOGLE_CALENDAR_LIST_EVENTS` (from the `googlesuper` toolkit). The Index Network toolkit identifier stays `'google_calendar'`.
+
+### Connection flow
+
+1. Network owner calls the existing `linkToIndex(userId, 'google_calendar', networkId)` flow
+2. Composio OAuth resolves the user's Google account; `connectedAccountId` is stored in `network_integrations`
+3. The owner (or an API call) sets `sync_config` with `calendarId`, `intervalMs`, and `status: 'active'`
+4. The sync worker picks it up on next tick
+
+### Sync worker (new BullMQ repeatable job)
+
+Job name: `integration-sync`. A single BullMQ repeatable job that ticks on a fixed global interval (default 5 min). Each tick scans for integrations whose per-row `intervalMs` has elapsed:
+
+1. Query `network_integrations` rows where `sync_config->>'status' = 'active'` and the time since `sync_config->>'lastSyncAt'` exceeds the row's `sync_config->'intervalMs'` (default 900000 ms / 15 min)
+2. For each row, read the parent network's `metadata.startDate` and `metadata.endDate` to scope the time window
+3. Execute `composio.tools.execute('GOOGLESUPER_GOOGLE_CALENDAR_LIST_EVENTS', { connectedAccountId, arguments: { time_min: startDate, time_max: endDate, single_events: true, calendar_id: calendarId } })`
+4. Paginate via `nextPageToken` until all events are fetched
+5. Map response items to the `metadata.events[]` shape:
+   - `externalId` ← Google event `id`
+   - `title` ← `summary`
+   - `startTime` ← `start.dateTime`
+   - `endTime` ← `end.dateTime`
+   - `location` ← `location`
+   - `description` ← `description` (truncated to 500 chars)
+   - `tags` ← empty (no Google Calendar equivalent; can be enriched later)
+   - `syncedAt` ← current timestamp
+6. Upsert into `networks.metadata.events[]` by `externalId`: add new, update changed, remove events no longer in the calendar response
+7. Update `sync_config.lastSyncAt`
+8. On error: set `sync_config.status = 'error'`, log the error. The owner can re-activate manually.
+
+### What stays the same
+
+User-level integrations (Gmail contacts, Slack contacts) are unchanged. The sync worker only processes `network_integrations` rows that have a non-empty `sync_config` with `status = 'active'`.
+
+## LLM Context Injection
+
+### Renderer
+
+A type-aware utility in the protocol package:
+
+**Location:** `packages/protocol/src/shared/network/metadata.renderer.ts`
+
+**Interface:**
+
+```typescript
+function renderNetworkContext(network: {
+  type: string;
+  title: string;
+  prompt?: string;
+  metadata: Record<string, unknown>;
+}): string
+```
+
+Dispatches by `type` to type-specific renderers. Returns a markdown string.
+
+**`community` renderer:** Returns `title` + `prompt` (existing behavior, no metadata rendering).
+
+**`event` renderer:** Produces structured markdown:
+
+```markdown
+## Edge Esmeralda 2026
+
+A month-long popup village exploring AI, consciousness, governance, and emerging technology.
+
+- **Type:** Event
+- **Dates:** May 30 – June 27, 2026
+- **Location:** Healdsburg, California
+- **Timezone:** America/Los_Angeles
+- **Themes:** AI, Governance & Coordination, Health & Longevity, Privacy, d/acc
+
+### Upcoming Events (next 7 days)
+| Time | Event | Location |
+|------|-------|----------|
+| Jun 10, 2:00 PM | AI Governance Panel | Main Hall |
+| Jun 10, 4:00 PM | Cold Plunge & Conversations | River Deck |
+| Jun 11, 10:00 AM | Builder Demo Day | Workshop Room |
+```
+
+The event table is time-windowed: "next 7 days" relative to the current time. This keeps token count manageable. The full `metadata.events[]` array is available for direct queries.
+
+### Injection points
+
+**1. Chat orchestrator**
+
+The chat graph assembles network context before the LLM call. Add `renderNetworkContext(network)` to that assembly step. The agent sees the rendered markdown as part of its system context when a user asks about a specific network.
+
+**2. MCP tool responses**
+
+When `read_networks` returns network data, include a `renderedContext` field with the markdown alongside the raw data. Agents consuming MCP tool responses get human-readable context without parsing JSON.
+
+**3. Opportunity discovery**
+
+The opportunity evaluator receives network context when scoring cross-network connections. Append `renderNetworkContext(network)` to the evaluator's network context string. Gated by `permissions.contextInjection.discovery` — if `false`, the evaluator receives only `title` + `prompt` (existing behavior).
+
+## Migration Plan
+
+1. Add `network_type` pgEnum
+2. Add `type` column to `networks` (default `'community'`)
+3. Add `metadata` JSONB column to `networks` (default `'{}'`)
+4. Add `metadata` JSONB column to `network_members` (default `'{}'`)
+5. Add `sync_config` JSONB column to `network_integrations` (default `'{}'`)
+
+All additive. No data migration beyond the defaults. Existing networks become `type = 'community'` with empty metadata automatically.
+
+## Out of Scope
+
+- **Venue management** — physical venue CRUD, capacity, booking modes stay external (EdgeOS or future integration)
+- **RSVP system** — formal event registration/cancellation is not part of this design
+- **iCal export** — calendar export lives in Google Calendar; Index mirrors, not replaces
+- **Auto-archive** — no lifecycle jobs; `endDate` is informational, archive is manual
+- **Intent/opportunity schema changes** — the core discovery pipeline is unchanged
+- **Webhook-driven sync** — periodic polling only; webhooks are a future optimization
+- **Additional network types** — `project`, `cohort`, etc. can be added later by extending the enum and adding type-specific renderers

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useSearchParams } from "react-router";
 import { Link } from "react-router";
 import * as Tabs from "@radix-ui/react-tabs";
 import * as AlertDialog from "@radix-ui/react-alert-dialog";
-import { Loader2, Camera, ArrowUpRight, Trash2, Sparkles, ChevronDown, ChevronRight } from "lucide-react";
+import { Loader2, Camera, ArrowUpRight, Trash2, Sparkles, ChevronDown, ChevronRight, MessageCircle } from "lucide-react";
 import { useAuthContext } from "@/contexts/AuthContext";
 import { useAuth } from "@/contexts/APIContext";
 import { useNotifications } from "@/contexts/NotificationContext";
@@ -16,6 +16,7 @@ import ClientLayout from "@/components/ClientLayout";
 import { ContentContainer } from "@/components/layout";
 import { SaveBarProvider } from "@/contexts/SaveBarContext";
 import AgentApiKeysSection from "@/components/settings/AgentApiKeysSection";
+import { useIntegrationsService } from "@/services/integrations";
 
 const SETTINGS_TABS = ["profile", "notifications", "api-keys"] as const;
 type SettingsTab = (typeof SETTINGS_TABS)[number];
@@ -74,6 +75,12 @@ export default function ProfilePage() {
   const [deleteConfirmationText, setDeleteConfirmationText] = useState("");
   const [isDeletingAccount, setIsDeletingAccount] = useState(false);
 
+  const integrationsService = useIntegrationsService();
+  const [telegramConnected, setTelegramConnected] = useState(false);
+  const [telegramConnecting, setTelegramConnecting] = useState(false);
+  const [telegramDisconnecting, setTelegramDisconnecting] = useState(false);
+  const [telegramUserId, setTelegramUserId] = useState<string | null>(null);
+
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -98,6 +105,15 @@ export default function ProfilePage() {
 
   // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally runs only when user changes; state setters are stable
   useEffect(() => { resetForm(user); }, [user]); // eslint-disable-line react-hooks/set-state-in-effect -- resetForm mirrors server-fetched user into editable form fields; legitimate sync-from-external-state pattern.
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    integrationsService.getConnections().then(({ connections }) => {
+      const tg = connections.find(c => c.toolkit === 'telegram' && c.status === 'active');
+      setTelegramConnected(!!tg);
+      setTelegramUserId(tg ? tg.id : null);
+    }).catch(() => { /* ignore -- non-critical */ });
+  }, [isAuthenticated, integrationsService]);
 
   const mark = () => setIsDirty(true);
 
@@ -164,6 +180,50 @@ export default function ProfilePage() {
       error("Failed to generate intro");
     } finally {
       setGeneratingIntro(false);
+    }
+  };
+
+  const handleConnectTelegram = async () => {
+    setTelegramConnecting(true);
+    try {
+      const response = await integrationsService.connect('telegram') as unknown as { deepLink: string };
+      if (response.deepLink) {
+        window.open(response.deepLink, '_blank');
+        // Poll for connection status after the user opens Telegram
+        const poll = setInterval(async () => {
+          try {
+            const { connections } = await integrationsService.getConnections();
+            const tg = connections.find(c => c.toolkit === 'telegram' && c.status === 'active');
+            if (tg) {
+              clearInterval(poll);
+              setTelegramConnected(true);
+              setTelegramUserId(tg.id);
+              setTelegramConnecting(false);
+              success('Telegram connected');
+            }
+          } catch { /* ignore polling errors */ }
+        }, 3000);
+        // Stop polling after 2 minutes
+        setTimeout(() => { clearInterval(poll); setTelegramConnecting(false); }, 120_000);
+      }
+    } catch {
+      error('Failed to connect Telegram');
+      setTelegramConnecting(false);
+    }
+  };
+
+  const handleDisconnectTelegram = async () => {
+    if (!telegramUserId) return;
+    setTelegramDisconnecting(true);
+    try {
+      await integrationsService.disconnect(telegramUserId);
+      setTelegramConnected(false);
+      setTelegramUserId(null);
+      success('Telegram disconnected');
+    } catch {
+      error('Failed to disconnect Telegram');
+    } finally {
+      setTelegramDisconnecting(false);
     }
   };
 
@@ -395,6 +455,61 @@ export default function ProfilePage() {
                   + Add website
                 </button>
               )}
+            </div>
+
+            {/* Integrations */}
+            <div className="space-y-2.5 border-t border-gray-100">
+              <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider font-ibm-plex-mono pt-4 mb-4">
+                Integrations
+              </p>
+
+              <div className="flex items-center justify-between p-3 border border-gray-200 rounded-sm">
+                <div className="flex items-center gap-3">
+                  <MessageCircle className="w-5 h-5 text-gray-500" />
+                  <div>
+                    <p className="text-sm font-medium font-ibm-plex-mono text-gray-700">Telegram</p>
+                    <p className="text-xs text-gray-400 mt-0.5">
+                      {telegramConnected
+                        ? "Your Telegram account is connected"
+                        : "Receive notifications and updates via Telegram"}
+                    </p>
+                  </div>
+                </div>
+                {telegramConnected ? (
+                  <div className="flex items-center gap-3">
+                    <span className="text-xs text-green-600 font-medium font-ibm-plex-mono">Connected &#x2713;</span>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={handleDisconnectTelegram}
+                      disabled={telegramDisconnecting}
+                      className="text-gray-500 hover:text-red-600 hover:border-red-200"
+                    >
+                      {telegramDisconnecting ? (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        "Disconnect"
+                      )}
+                    </Button>
+                  </div>
+                ) : (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleConnectTelegram}
+                    disabled={telegramConnecting}
+                  >
+                    {telegramConnecting ? (
+                      <>
+                        <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
+                        Waiting...
+                      </>
+                    ) : (
+                      "Connect"
+                    )}
+                  </Button>
+                )}
+              </div>
             </div>
 
             {/* Danger Zone */}

--- a/packages/edgeclaw/README.md
+++ b/packages/edgeclaw/README.md
@@ -132,9 +132,31 @@ Every call with the same email returns the same user but a **fresh API key** —
 1. Runs the EdgeClaw installer with the returned `apiKey`: `bun install/install.ts --index-api-key <apiKey>` (or equivalent in the hosted runtime). If InstaClaw has also fetched an EdgeOS personal access token for the attendee, it passes that on the same line: `bun install/install.ts --index-api-key <apiKey> --edgeos-api-key <eos_live_…> --edgeos-bearer-token <jwt>`.
 2. In a follow-up step, captures the attendee's Telegram handle and binds it to their agent transport — this is entirely InstaClaw-owned and happens outside this endpoint.
 
-### What EdgeOS does after signup
+### What EdgeOS does after signup (BYOA flow)
 
-Displays the returned `mcpServer` object to the attendee as a copyable config snippet. The attendee pastes it into their agent's MCP servers config (or runs `bun install/install.ts --index-api-key <apiKey>` from a clone of this repo).
+Displays per-host install commands with the attendee's credentials pre-filled. The attendee copies and runs them in their terminal. EdgeOS also completes the email-OTP flow to obtain `EDGEOS_BEARER_TOKEN` and `EDGEOS_API_KEY`, which are included in the install commands.
+
+**Claude Code:**
+```bash
+export INDEX_API_KEY=<apiKey>
+export EDGEOS_BEARER_TOKEN=<jwt>
+export EDGEOS_API_KEY=<eos_live_…>
+claude plugin marketplace add Edge-City/edgeclaw-skills
+claude plugin install edgeclaw@edgeclaw-skills
+```
+
+**OpenClaw:**
+```bash
+openclaw plugins install edgeclaw --marketplace Edge-City/edgeclaw-skills
+openclaw config set mcp.servers.index '{"url":"https://protocol.index.network/mcp","transport":"streamable-http","headers":{"x-api-key":"<apiKey>"}}'
+openclaw config set env.vars.EDGEOS_BEARER_TOKEN '<jwt>'
+openclaw config set env.vars.EDGEOS_API_KEY '<eos_live_…>'
+openclaw gateway restart
+```
+
+**Claude Desktop / other MCP clients:** displays the `mcpServer` JSON with the API key baked in.
+
+See `skills/README.md` for the full per-host reference.
 
 ## Prerequisites
 

--- a/packages/edgeclaw/README.md
+++ b/packages/edgeclaw/README.md
@@ -154,6 +154,17 @@ openclaw config set env.vars.EDGEOS_API_KEY '<eos_live_…>'
 openclaw gateway restart
 ```
 
+**Hermes:**
+```bash
+hermes skills install Edge-City/edgeclaw/skills/edge-esmeralda --force
+hermes skills install Edge-City/edgeclaw/skills/edgeos --force
+hermes skills install Edge-City/edgeclaw/skills/index-network --force
+hermes config set mcp_servers.index.url 'https://protocol.index.network/mcp'
+hermes config set mcp_servers.index.headers.x-api-key '<apiKey>'
+hermes config set EDGEOS_BEARER_TOKEN '<jwt>'
+hermes config set EDGEOS_API_KEY '<eos_live_…>'
+```
+
 **Claude Desktop / other MCP clients:** displays the `mcpServer` JSON with the API key baked in.
 
 See `skills/README.md` for the full per-host reference.

--- a/packages/edgeclaw/skills/.claude-plugin/marketplace.json
+++ b/packages/edgeclaw/skills/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "edgeclaw",
       "description": "Edge Esmeralda 2026 — popup knowledge, EdgeOS calendar & directory, and Index Network discovery.",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "author": {
         "name": "Edge City",
         "url": "https://edgecity.live"

--- a/packages/edgeclaw/skills/.claude-plugin/plugin.json
+++ b/packages/edgeclaw/skills/.claude-plugin/plugin.json
@@ -1,26 +1,18 @@
 {
   "name": "edgeclaw",
   "description": "Edge Esmeralda 2026 — popup knowledge, EdgeOS calendar & directory, and Index Network discovery skills for the Agent Village.",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "skills": "./",
   "author": {
     "name": "Edge City",
     "url": "https://edgecity.live"
-  },
-  "userConfig": {
-    "apiKey": {
-      "type": "string",
-      "title": "Index Network API Key",
-      "description": "API key for Index Network. Obtain one at edgecity.live/agentvillage or from your community admin.",
-      "sensitive": true
-    }
   },
   "mcpServers": {
     "index": {
       "type": "http",
       "url": "https://protocol.index.network/mcp",
       "headers": {
-        "x-api-key": "${user_config.apiKey}"
+        "x-api-key": "${INDEX_API_KEY}"
       }
     }
   }

--- a/packages/edgeclaw/skills/.codex-plugin/plugin.json
+++ b/packages/edgeclaw/skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "edgeclaw",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Edge Esmeralda 2026 — popup knowledge, EdgeOS calendar & directory, and Index Network discovery.",
   "author": {
     "name": "Edge City",

--- a/packages/edgeclaw/skills/README.md
+++ b/packages/edgeclaw/skills/README.md
@@ -14,46 +14,83 @@ The skills cross-reference each other. `edge-esmeralda` supplies the popup id th
 
 ## Install
 
+### Environment variables
+
+All hosts read credentials from environment variables. Set these before installing or add them to your shell profile (`~/.zshrc`, `~/.bashrc`) to persist across sessions:
+
+| Variable | Source | Required |
+|---|---|---|
+| `INDEX_API_KEY` | Index Network signup (BYOA page or [edgecity.live/agentvillage](https://edgecity.live/agentvillage)) | Yes |
+| `EDGEOS_BEARER_TOKEN` | EdgeOS email-OTP onboarding flow | Optional |
+| `EDGEOS_API_KEY` | EdgeOS email-OTP onboarding flow (`eos_live_...` key) | Optional |
+
+`INDEX_API_KEY` is required for the Index Network MCP server. The EdgeOS tokens are optional — without them the agent still loads; EdgeOS recipes will prompt for the missing token on first use.
+
+### BYOA flow
+
+If you authenticated through the EdgeOS portal (edgecity.live/agentvillage), the page provides your credentials and per-host install commands with the keys pre-filled. Copy and run them in your terminal.
+
 ### Claude Code
 
 ```bash
+export INDEX_API_KEY=<YOUR_API_KEY>
+export EDGEOS_BEARER_TOKEN=<YOUR_TOKEN>
+export EDGEOS_API_KEY=<YOUR_KEY>
 claude plugin marketplace add Edge-City/edgeclaw-skills
 claude plugin install edgeclaw@edgeclaw-skills
 ```
+
+The plugin manifest declares the Index Network MCP endpoint and resolves `INDEX_API_KEY` from the environment at runtime. No interactive prompt.
 
 ### OpenClaw
 
 ```bash
 openclaw plugins install edgeclaw --marketplace Edge-City/edgeclaw-skills
+openclaw config set mcp.servers.index '{"url":"https://protocol.index.network/mcp","transport":"streamable-http","headers":{"x-api-key":"<YOUR_API_KEY>"}}'
+openclaw config set env.vars.EDGEOS_BEARER_TOKEN '<YOUR_TOKEN>'
+openclaw config set env.vars.EDGEOS_API_KEY '<YOUR_KEY>'
+openclaw gateway restart
 ```
+
+OpenClaw persists credentials in `~/.openclaw/openclaw.json` — no shell profile changes needed.
+
+### Claude Desktop
+
+Add the MCP server to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "index": {
+      "url": "https://protocol.index.network/mcp",
+      "headers": {
+        "x-api-key": "<YOUR_API_KEY>"
+      }
+    }
+  }
+}
+```
+
+Claude Desktop provides MCP tools only (no skills).
 
 ### Codex
 
 Not yet supported. Codex requires plugins in a `plugins/<name>/` subdirectory layout, which this repo doesn't use.
 
-For the batteries-included OpenClaw experience (workspace, installer, cron jobs, onboarding), use the full [EdgeClaw](https://github.com/Edge-City/edgeclaw) package instead.
+### Other MCP-compatible agents
 
-## API keys
+Configure an HTTP MCP server with the following settings:
 
-### Index Network
-
-The `index-network` skill requires an Index Network MCP server connection. On Claude Code, the plugin manifest declares the MCP endpoint automatically and prompts for the API key on install. On OpenClaw, register the MCP server manually after installing the plugin:
-
-```bash
-openclaw config set mcp.servers.index '{"url":"https://protocol.index.network/mcp","transport":"streamable-http","headers":{"x-api-key":"YOUR_API_KEY"}}'
-openclaw gateway restart
+```json
+{
+  "url": "https://protocol.index.network/mcp",
+  "headers": { "x-api-key": "<YOUR_API_KEY>" }
+}
 ```
 
-Obtain your API key at [edgecity.live/agentvillage](https://edgecity.live/agentvillage) or from your community admin.
+Set `EDGEOS_BEARER_TOKEN` and `EDGEOS_API_KEY` in your agent's environment if it supports EdgeOS recipes.
 
-### EdgeOS
-
-The `edgeos` skill requires two environment variables:
-
-- `EDGEOS_BEARER_TOKEN` — human session JWT, obtained via the EdgeOS email-OTP onboarding flow.
-- `EDGEOS_API_KEY` — long-lived `eos_live_...` automation key, obtained via the same flow.
-
-Both are optional. Without them the agent still loads; EdgeOS recipes will prompt for the missing token on first use. See the `edge-esmeralda` skill's section 2 for the full onboarding flow.
+For the batteries-included OpenClaw experience (workspace, installer, cron jobs, onboarding), use the full [EdgeClaw](https://github.com/Edge-City/edgeclaw) package instead.
 
 ## Contributing
 

--- a/packages/edgeclaw/skills/README.md
+++ b/packages/edgeclaw/skills/README.md
@@ -1,6 +1,6 @@
 # EdgeClaw Skills
 
-Agent skills for **Edge Esmeralda 2026** (May 30 – Jun 27, Healdsburg, CA). Installable as a standalone plugin on Claude Code, Codex, and OpenClaw.
+Agent skills for **Edge Esmeralda 2026** (May 30 – Jun 27, Healdsburg, CA). Installable as a standalone plugin on Claude Code, Hermes, OpenClaw, and other MCP-compatible agents.
 
 ## What you get
 
@@ -53,6 +53,20 @@ openclaw gateway restart
 ```
 
 OpenClaw persists credentials in `~/.openclaw/openclaw.json` — no shell profile changes needed.
+
+### Hermes
+
+```bash
+hermes skills install Edge-City/edgeclaw/skills/edge-esmeralda --force
+hermes skills install Edge-City/edgeclaw/skills/edgeos --force
+hermes skills install Edge-City/edgeclaw/skills/index-network --force
+hermes config set mcp_servers.index.url 'https://protocol.index.network/mcp'
+hermes config set mcp_servers.index.headers.x-api-key '<YOUR_API_KEY>'
+hermes config set EDGEOS_BEARER_TOKEN '<YOUR_TOKEN>'
+hermes config set EDGEOS_API_KEY '<YOUR_KEY>'
+```
+
+`hermes config set` routes UPPERCASE keys to `~/.hermes/.env` and dot-notation keys to `~/.hermes/config.yaml`. The `--force` flag is required because the security scanner flags community-sourced skills.
 
 ### Claude Desktop
 

--- a/packages/edgeclaw/skills/edgeos/SKILL.md
+++ b/packages/edgeclaw/skills/edgeos/SKILL.md
@@ -4,6 +4,15 @@ description: Talk to the EdgeOS popup-village platform — read the event schedu
 version: 1.1.0
 author: Edge City
 tags: [edgeos, events, directory, popup-village]
+required_environment_variables:
+  - name: EDGEOS_BEARER_TOKEN
+    prompt: EdgeOS bearer token (JWT from email-OTP flow)
+    help: Obtain from the EdgeOS onboarding flow at edgecity.live/agentvillage
+    required_for: directory, own profile, OpenAPI spec
+  - name: EDGEOS_API_KEY
+    prompt: EdgeOS API key (eos_live_...)
+    help: Obtain from the EdgeOS onboarding flow at edgecity.live/agentvillage
+    required_for: events, RSVPs, venues
 metadata:
   openclaw:
     requires:

--- a/packages/edgeclaw/skills/marketplace.json
+++ b/packages/edgeclaw/skills/marketplace.json
@@ -12,7 +12,7 @@
       },
       "policy": {
         "installation": "AVAILABLE",
-        "authentication": "ON_INSTALL"
+        "authentication": "ENVIRONMENT"
       },
       "category": "Productivity"
     }

--- a/packages/edgeclaw/skills/mcp.json
+++ b/packages/edgeclaw/skills/mcp.json
@@ -1,6 +1,9 @@
 {
   "index": {
     "type": "http",
-    "url": "https://protocol.index.network/mcp"
+    "url": "https://protocol.index.network/mcp",
+    "headers": {
+      "x-api-key": "${INDEX_API_KEY}"
+    }
   }
 }

--- a/packages/edgeclaw/skills/openclaw.plugin.json
+++ b/packages/edgeclaw/skills/openclaw.plugin.json
@@ -2,17 +2,6 @@
   "id": "edgeclaw-skills",
   "name": "EdgeClaw Skills",
   "description": "Edge Esmeralda 2026 skills — popup knowledge, EdgeOS calendar & directory, and Index Network discovery.",
-  "version": "1.0.2",
-  "skills": ["."],
-  "configSchema": {
-    "type": "object",
-    "properties": {
-      "apiKey": {
-        "type": "string",
-        "description": "Index Network API key for MCP authentication."
-      }
-    },
-    "required": [],
-    "additionalProperties": false
-  }
+  "version": "1.1.0",
+  "skills": ["."]
 }

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -125,6 +125,7 @@ export type {
 
 // ─── Support utilities ────────────────────────────────────────────────────────
 
+export { renderNetworkContext } from './shared/network/metadata.renderer.js';
 export {
   canUserSeeOpportunity,
   isActionableForViewer,

--- a/packages/protocol/src/shared/network/metadata.renderer.ts
+++ b/packages/protocol/src/shared/network/metadata.renderer.ts
@@ -52,8 +52,8 @@ function renderEventNetwork(network: NetworkForRendering): string {
   const endDate = typeof meta.endDate === 'string' ? meta.endDate : undefined;
   const location = typeof meta.location === 'string' ? meta.location : undefined;
   const timezone = typeof meta.timezone === 'string' ? meta.timezone : undefined;
-  const themes = Array.isArray(meta.themes) ? meta.themes as string[] : [];
-  const events = Array.isArray(meta.events) ? meta.events as NonNullable<EventMetadata['events']> : [];
+  const themes = Array.isArray(meta.themes) ? meta.themes.filter((t: unknown): t is string => typeof t === 'string') : [];
+  const events = Array.isArray(meta.events) ? normalizeEvents(meta.events) : [];
   const lines: string[] = [`## ${network.title}`];
 
   if (network.prompt) {
@@ -63,8 +63,9 @@ function renderEventNetwork(network: NetworkForRendering): string {
   lines.push('');
   lines.push('- **Type:** Event');
 
-  if (startDate && endDate) {
-    lines.push(`- **Dates:** ${formatDateRange(startDate, endDate)}`);
+  const dateRange = startDate && endDate ? formatDateRange(startDate, endDate) : undefined;
+  if (dateRange) {
+    lines.push(`- **Dates:** ${dateRange}`);
   }
   if (location) {
     lines.push(`- **Location:** ${location}`);
@@ -86,26 +87,41 @@ function renderEventNetwork(network: NetworkForRendering): string {
     lines.push('|------|-------|----------|');
     for (const evt of upcoming) {
       const time = formatEventTime(evt.startTime);
-      const loc = evt.location ?? '';
-      lines.push(`| ${time} | ${evt.title} | ${loc} |`);
+      const loc = escapeTableCell(evt.location ?? '');
+      const title = escapeTableCell(evt.title);
+      lines.push(`| ${time} | ${title} | ${loc} |`);
     }
   }
 
   return lines.join('\n');
 }
 
-function formatDateRange(start: string, end: string): string {
+function formatDateRange(start: string, end: string): string | undefined {
   const s = new Date(start);
   const e = new Date(end);
-  const opts: Intl.DateTimeFormatOptions = { month: 'long', day: 'numeric', year: 'numeric' };
+  if (isNaN(s.getTime()) || isNaN(e.getTime())) return undefined;
+  const opts: Intl.DateTimeFormatOptions = { month: 'long', day: 'numeric', year: 'numeric', timeZone: 'UTC' };
   return `${s.toLocaleDateString('en-US', opts)} – ${e.toLocaleDateString('en-US', opts)}`;
 }
 
 function formatEventTime(iso: string): string {
   const d = new Date(iso);
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) +
+  if (isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' }) +
     ', ' +
-    d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+    d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', timeZone: 'UTC' });
+}
+
+function escapeTableCell(value: string): string {
+  return value.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+function normalizeEvents(raw: unknown[]): NonNullable<EventMetadata['events']> {
+  return raw.filter((e): e is NonNullable<EventMetadata['events']>[number] => {
+    if (typeof e !== 'object' || e === null) return false;
+    const obj = e as Record<string, unknown>;
+    return typeof obj.title === 'string' && typeof obj.startTime === 'string' && typeof obj.endTime === 'string';
+  });
 }
 
 function getUpcomingEvents(

--- a/packages/protocol/src/shared/network/metadata.renderer.ts
+++ b/packages/protocol/src/shared/network/metadata.renderer.ts
@@ -1,0 +1,122 @@
+interface NetworkForRendering {
+  type: string;
+  title: string;
+  prompt?: string | null;
+  metadata: Record<string, unknown>;
+}
+
+interface EventMetadata {
+  startDate?: string;
+  endDate?: string;
+  timezone?: string;
+  location?: string;
+  themes?: string[];
+  events?: Array<{
+    externalId: string;
+    title: string;
+    startTime: string;
+    endTime: string;
+    location?: string;
+    description?: string;
+    tags?: string[];
+  }>;
+}
+
+/**
+ * Render a network's metadata as structured markdown for LLM context.
+ *
+ * @param network - The network to render, with type, title, optional prompt, and metadata.
+ * @returns Markdown string suitable for injection into an LLM prompt.
+ */
+export function renderNetworkContext(network: NetworkForRendering): string {
+  switch (network.type) {
+    case 'event':
+      return renderEventNetwork(network);
+    case 'community':
+    default:
+      return renderCommunityNetwork(network);
+  }
+}
+
+function renderCommunityNetwork(network: NetworkForRendering): string {
+  const lines: string[] = [`## ${network.title}`];
+  if (network.prompt) {
+    lines.push('', network.prompt);
+  }
+  return lines.join('\n');
+}
+
+function renderEventNetwork(network: NetworkForRendering): string {
+  const meta = network.metadata;
+  const startDate = typeof meta.startDate === 'string' ? meta.startDate : undefined;
+  const endDate = typeof meta.endDate === 'string' ? meta.endDate : undefined;
+  const location = typeof meta.location === 'string' ? meta.location : undefined;
+  const timezone = typeof meta.timezone === 'string' ? meta.timezone : undefined;
+  const themes = Array.isArray(meta.themes) ? meta.themes as string[] : [];
+  const events = Array.isArray(meta.events) ? meta.events as NonNullable<EventMetadata['events']> : [];
+  const lines: string[] = [`## ${network.title}`];
+
+  if (network.prompt) {
+    lines.push('', network.prompt);
+  }
+
+  lines.push('');
+  lines.push('- **Type:** Event');
+
+  if (startDate && endDate) {
+    lines.push(`- **Dates:** ${formatDateRange(startDate, endDate)}`);
+  }
+  if (location) {
+    lines.push(`- **Location:** ${location}`);
+  }
+  if (timezone) {
+    lines.push(`- **Timezone:** ${timezone}`);
+  }
+  if (themes.length > 0) {
+    lines.push(`- **Themes:** ${themes.join(', ')}`);
+  }
+
+  lines.push('');
+  const upcoming = getUpcomingEvents(events, 7);
+  if (upcoming.length === 0) {
+    lines.push('No upcoming events in the next 7 days.');
+  } else {
+    lines.push('### Upcoming Events (next 7 days)');
+    lines.push('| Time | Event | Location |');
+    lines.push('|------|-------|----------|');
+    for (const evt of upcoming) {
+      const time = formatEventTime(evt.startTime);
+      const loc = evt.location ?? '';
+      lines.push(`| ${time} | ${evt.title} | ${loc} |`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function formatDateRange(start: string, end: string): string {
+  const s = new Date(start);
+  const e = new Date(end);
+  const opts: Intl.DateTimeFormatOptions = { month: 'long', day: 'numeric', year: 'numeric' };
+  return `${s.toLocaleDateString('en-US', opts)} – ${e.toLocaleDateString('en-US', opts)}`;
+}
+
+function formatEventTime(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) +
+    ', ' +
+    d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+}
+
+function getUpcomingEvents(
+  events: NonNullable<EventMetadata['events']>,
+  windowDays: number,
+): NonNullable<EventMetadata['events']> {
+  const now = Date.now();
+  const windowEnd = now + windowDays * 24 * 60 * 60 * 1000;
+  return events
+    .map((e) => ({ e, t: new Date(e.startTime).getTime() }))
+    .filter(({ t }) => !isNaN(t) && t >= now && t <= windowEnd)
+    .sort((a, b) => a.t - b.t)
+    .map(({ e }) => e);
+}

--- a/packages/protocol/src/shared/network/tests/metadata.renderer.test.ts
+++ b/packages/protocol/src/shared/network/tests/metadata.renderer.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'bun:test';
+import { renderNetworkContext } from '../metadata.renderer.js';
+
+describe('renderNetworkContext', () => {
+  describe('community type', () => {
+    it('renders title and prompt', () => {
+      const result = renderNetworkContext({
+        type: 'community',
+        title: 'AI Builders',
+        prompt: 'A community for AI practitioners to share knowledge.',
+        metadata: {},
+      });
+      expect(result).toContain('## AI Builders');
+      expect(result).toContain('A community for AI practitioners');
+      expect(result).not.toContain('**Dates:**');
+    });
+
+    it('renders title only when prompt is absent', () => {
+      const result = renderNetworkContext({
+        type: 'community',
+        title: 'No Prompt Community',
+        metadata: {},
+      });
+      expect(result).toContain('## No Prompt Community');
+      expect(result).not.toContain('undefined');
+      expect(result).not.toContain('null');
+    });
+  });
+
+  describe('event type', () => {
+    const baseEvent = {
+      type: 'event' as const,
+      title: 'Edge Esmeralda 2026',
+      prompt: 'A month-long popup village.',
+      metadata: {
+        startDate: '2026-05-30T00:00:00Z',
+        endDate: '2026-06-27T23:59:59Z',
+        timezone: 'America/Los_Angeles',
+        location: 'Healdsburg, California',
+        themes: ['AI', 'Governance', 'Health & Longevity'],
+        events: [],
+      },
+    };
+
+    it('renders all metadata fields', () => {
+      const result = renderNetworkContext(baseEvent);
+      expect(result).toContain('## Edge Esmeralda 2026');
+      expect(result).toContain('A month-long popup village.');
+      expect(result).toContain('**Type:** Event');
+      expect(result).toContain('May 30');
+      expect(result).toContain('June 27');
+      expect(result).toContain('Healdsburg, California');
+      expect(result).toContain('America/Los_Angeles');
+      expect(result).toContain('AI');
+      expect(result).toContain('Governance');
+    });
+
+    it('omits missing optional fields gracefully', () => {
+      const result = renderNetworkContext({
+        type: 'event',
+        title: 'Minimal Event',
+        metadata: {
+          startDate: '2026-06-01T00:00:00Z',
+          endDate: '2026-06-15T23:59:59Z',
+          events: [],
+        },
+      });
+      expect(result).toContain('## Minimal Event');
+      expect(result).not.toContain('**Location:**');
+      expect(result).not.toContain('**Timezone:**');
+      expect(result).not.toContain('**Themes:**');
+      expect(result).not.toContain('undefined');
+    });
+
+    it('renders "No upcoming events" when events array is empty', () => {
+      const result = renderNetworkContext(baseEvent);
+      expect(result).toContain('No upcoming events');
+    });
+
+    it('renders upcoming events table for events within 7 days of now', () => {
+      const now = new Date();
+      const tomorrow = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+      const nextWeekPlus = new Date(now.getTime() + 8 * 24 * 60 * 60 * 1000);
+
+      const result = renderNetworkContext({
+        ...baseEvent,
+        metadata: {
+          ...baseEvent.metadata,
+          startDate: new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString(),
+          endDate: new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+          events: [
+            {
+              externalId: 'e1',
+              title: 'Tomorrow Talk',
+              startTime: tomorrow.toISOString(),
+              endTime: new Date(tomorrow.getTime() + 60 * 60 * 1000).toISOString(),
+              location: 'Main Hall',
+            },
+            {
+              externalId: 'e2',
+              title: 'Far Future Talk',
+              startTime: nextWeekPlus.toISOString(),
+              endTime: new Date(nextWeekPlus.getTime() + 60 * 60 * 1000).toISOString(),
+            },
+          ],
+        },
+      });
+      expect(result).toContain('Tomorrow Talk');
+      expect(result).toContain('Main Hall');
+      expect(result).not.toContain('Far Future Talk');
+    });
+  });
+
+  describe('unknown type fallback', () => {
+    it('renders title and prompt for unknown types', () => {
+      const result = renderNetworkContext({
+        type: 'project' as string,
+        title: 'Unknown Type',
+        prompt: 'Some prompt.',
+        metadata: {},
+      });
+      expect(result).toContain('## Unknown Type');
+      expect(result).toContain('Some prompt.');
+    });
+  });
+});


### PR DESCRIPTION
## Changelog

### New Features
- **Network types**: polymorphic network type system with enum (`community`, `event`, `project`, etc.), metadata columns, validation on type change, and CRUD support (`b16df9169`, `4da35a0ba`, `cb6f4f6fa`)
- **Network context renderer**: type-aware renderer that produces structured context for agents, exported from `@indexnetwork/protocol` (`07e7426f4`, `1f8154824`)
- **Telegram gateway**: streaming responses with typing indicator and stage notifications, styled HTML opportunity cards (`b5703576f`, `521a0445d`, `77056e12a`)
- **EdgeClaw Hermes agent**: BYOA install flow support for Hermes agents (`cdcb77321`)
- **EdgeClaw plugin auth**: switched from interactive `userConfig` prompt to `INDEX_API_KEY` env var (`cb0971778`)

### Bug Fixes
- **Telegram gateway**: hardened against HTML parse errors and status-send failures (`bb089a4a6`)
- **Network context renderer**: hardened against malformed input and timezone variance (`d1de58359`)
- **Experiment network**: trigger profile enrichment for CSV-imported users, make signup `completedAt` update atomic, skip update for already-onboarded users, dedup and JSON merge fixes (`69ce412ad`, `0b2b8186e`, `aa08d6ece`, `de61d5b62`)

### Tests
- Network type validation integration tests (`760a15d68`)
- Profile enrichment coverage for CSV import (`23d3d8117`)
- Signup `completedAt` atomicity tests (`de61d5b62`)

### Documentation
- Polymorphic network types design spec (`f21ee703d`)

## Packages touched
- `backend/`
- `packages/protocol/`
- `packages/edgeclaw/`