### PR TITLE
feat: context injection into chat, MCP tools, and discovery (IND-312)

### DIFF
--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -1233,14 +1233,28 @@ export class ChatDatabaseAdapter {
     }
   }
 
-  async getNetwork(networkId: string): Promise<{ id: string; title: string } | null> {
+  async getNetwork(networkId: string): Promise<{
+    id: string;
+    title: string;
+    prompt?: string | null;
+    type?: string;
+    metadata?: Record<string, unknown> | null;
+    permissions?: Record<string, unknown> | null;
+  } | null> {
     const rows = await db
-      .select({ id: schema.networks.id, title: schema.networks.title })
+      .select({
+        id: schema.networks.id,
+        title: schema.networks.title,
+        prompt: schema.networks.prompt,
+        type: schema.networks.type,
+        metadata: schema.networks.metadata,
+        permissions: schema.networks.permissions,
+      })
       .from(schema.networks)
       .where(and(eq(schema.networks.id, networkId), isNull(schema.networks.deletedAt)))
       .limit(1);
     const row = rows[0];
-    return row ? { id: row.id, title: row.title } : null;
+    return row ?? null;
   }
 
   /**

--- a/packages/protocol/src/chat/chat.prompt.ts
+++ b/packages/protocol/src/chat/chat.prompt.ts
@@ -1,5 +1,6 @@
 import type { ResolvedToolContext } from "../shared/agent/tool.factory.js";
 
+import { renderNetworkContext } from '../shared/network/metadata.renderer.js';
 import { resolveModules } from "./chat.prompt.modules.js";
 import type { IterationContext } from "./chat.prompt.modules.js";
 
@@ -194,15 +195,13 @@ function buildCoreBody(ctx: ResolvedToolContext): string {
     2,
   );
   const scopedIndexContext = ctx.scopedIndex
-    ? JSON.stringify(
-        {
-          ...ctx.scopedIndex,
-          membershipRole: ctx.scopedMembershipRole,
-        },
-        null,
-        2,
-      )
-    : "null";
+    ? renderNetworkContext({
+        type: ctx.scopedIndex.type ?? 'community',
+        title: ctx.scopedIndex.title,
+        prompt: ctx.scopedIndex.prompt,
+        metadata: ctx.scopedIndex.metadata ?? {},
+      }) + `\n- **Your Role:** ${ctx.scopedMembershipRole ?? 'member'}`
+    : null;
 
   return `
 ### Current User (preloaded context)
@@ -221,9 +220,7 @@ ${indexesContext}
 \`\`\`
 
 ### Scoped Index (preloaded context)
-\`\`\`json
-${scopedIndexContext}
-\`\`\`
+${scopedIndexContext ?? 'No scoped index — general chat.'}
 
 ### Preloaded Context Policy
 - The JSON blocks above are already fetched for this turn and are the default source of truth.

--- a/packages/protocol/src/network/network.tools.ts
+++ b/packages/protocol/src/network/network.tools.ts
@@ -1,12 +1,24 @@
 import { z } from "zod";
 
 import { requestContext } from "../shared/observability/request-context.js";
+import { renderNetworkContext } from '../shared/network/metadata.renderer.js';
 
 import type { DefineTool, ToolDeps } from "../shared/agent/tool.helpers.js";
 import { success, error, UUID_REGEX } from "../shared/agent/tool.helpers.js";
 
 export function createNetworkTools(defineTool: DefineTool, deps: ToolDeps) {
   const { graphs, userDb, systemDb } = deps;
+
+  const enrichWithContext = (networks: Array<Record<string, unknown>>) =>
+    networks.map((n) => ({
+      ...n,
+      renderedContext: renderNetworkContext({
+        type: (n.type as string) ?? 'community',
+        title: (n.title as string) ?? '',
+        prompt: n.prompt as string | undefined,
+        metadata: (n.metadata as Record<string, unknown>) ?? {},
+      }),
+    }));
 
   const readIndexes = defineTool({
     name: "read_networks",
@@ -42,10 +54,18 @@ export function createNetworkTools(defineTool: DefineTool, deps: ToolDeps) {
         return error(result.error);
       }
       if (result.readResult) {
+        const rr = result.readResult as Record<string, unknown>;
+        const enriched = {
+          ...rr,
+          ...(Array.isArray(rr.memberOf) ? { memberOf: enrichWithContext(rr.memberOf as Array<Record<string, unknown>>) } : {}),
+          ...(Array.isArray(rr.owns) ? { owns: enrichWithContext(rr.owns as Array<Record<string, unknown>>) } : {}),
+          ...(Array.isArray(rr.publicNetworks) ? { publicNetworks: enrichWithContext(rr.publicNetworks as Array<Record<string, unknown>>) } : {}),
+        };
+
         // When scoped, add clear metadata so model knows results are limited
         if (context.networkId) {
           return success({
-            ...result.readResult,
+            ...enriched,
             scopeRestriction: {
               isScoped: true,
               scopedToIndex: context.indexName ?? context.networkId,
@@ -54,7 +74,7 @@ export function createNetworkTools(defineTool: DefineTool, deps: ToolDeps) {
             _graphTimings: [{ name: 'index', durationMs: _readIndexGraphMs, agents: result.agentTimings ?? [] }],
           });
         }
-        return success({ ...result.readResult, _graphTimings: [{ name: 'index', durationMs: _readIndexGraphMs, agents: result.agentTimings ?? [] }] });
+        return success({ ...enriched, _graphTimings: [{ name: 'index', durationMs: _readIndexGraphMs, agents: result.agentTimings ?? [] }] });
       }
       return error("Failed to fetch index information.");
     },

--- a/packages/protocol/src/opportunity/opportunity.evaluator.ts
+++ b/packages/protocol/src/opportunity/opportunity.evaluator.ts
@@ -476,7 +476,7 @@ CRITICAL SCORING RULES FOR DISCOVERY REQUESTS:
   MATCHED VIA: ${e.matchedVia ?? '—'}`;
     }).join('\n');
     const networkContextPart = input.networkContexts && Object.keys(input.networkContexts).length > 0
-      ? `\n\nNETWORK CONTEXTS:\n${Object.values(input.networkContexts).join('\n\n')}`
+      ? `\n\nNETWORK CONTEXTS:\n${Object.entries(input.networkContexts).map(([nid, ctx]) => `[INDEX: ${nid}]\n${ctx}`).join('\n\n')}`
       : '';
     const humanContent = `DISCOVERER: ${input.discovererId}${introModePart}${discoveryQueryPart}${networkContextPart}\n\nENTITIES:\n${entitiesBlock}${existingPart}`;
     const messages = [

--- a/packages/protocol/src/opportunity/opportunity.evaluator.ts
+++ b/packages/protocol/src/opportunity/opportunity.evaluator.ts
@@ -206,6 +206,8 @@ export interface EvaluatorInput {
   introductionHint?: string;
   /** Optional discovery query (e.g. from chat). When set, only suggest opportunities where candidates clearly match this request. */
   discoveryQuery?: string;
+  /** Pre-rendered network context markdown, keyed by networkId. */
+  networkContexts?: Record<string, string>;
 }
 
 const ActorSchema = z.object({
@@ -473,7 +475,10 @@ CRITICAL SCORING RULES FOR DISCOVERY REQUESTS:
   RAG SCORE: ${e.ragScore ?? '—'}
   MATCHED VIA: ${e.matchedVia ?? '—'}`;
     }).join('\n');
-    const humanContent = `DISCOVERER: ${input.discovererId}${introModePart}${discoveryQueryPart}\n\nENTITIES:\n${entitiesBlock}${existingPart}`;
+    const networkContextPart = input.networkContexts && Object.keys(input.networkContexts).length > 0
+      ? `\n\nNETWORK CONTEXTS:\n${Object.values(input.networkContexts).join('\n\n')}`
+      : '';
+    const humanContent = `DISCOVERER: ${input.discovererId}${introModePart}${discoveryQueryPart}${networkContextPart}\n\nENTITIES:\n${entitiesBlock}${existingPart}`;
     const messages = [
       new SystemMessage(entityBundleSystemPrompt),
       new HumanMessage(humanContent),

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -77,6 +77,7 @@ import type { NegotiationGraphLike } from "../negotiation/negotiation.state.js";
 import type { AgentDispatcher } from "../shared/interfaces/agent-dispatcher.interface.js";
 import { protocolLogger, withCallLogging } from '../shared/observability/protocol.logger.js';
 import { timed } from '../shared/observability/performance.js';
+import { renderNetworkContext } from '../shared/network/metadata.renderer.js';
 import { requestContext } from "../shared/observability/request-context.js";
 
 const logger = protocolLogger('OpportunityGraph');
@@ -141,6 +142,33 @@ export function buildDiscovererContext(
   }
 
   return lines.length > 0 ? lines.join('\n') : undefined;
+}
+
+/**
+ * Build a networkContexts map for the evaluator from a set of entities.
+ * Fetches network data, checks permissions.contextInjection.discovery,
+ * and renders context for eligible networks.
+ */
+async function buildNetworkContexts(
+  entities: EvaluatorEntity[],
+  database: Pick<OpportunityGraphDatabase, 'getNetwork'>,
+): Promise<Record<string, string>> {
+  const networkIds = [...new Set(entities.map((e) => e.networkId))];
+  const contexts: Record<string, string> = {};
+  for (const nid of networkIds) {
+    const network = await database.getNetwork(nid);
+    if (!network) continue;
+    const perms = (network.permissions ?? {}) as Record<string, unknown>;
+    const injection = perms.contextInjection as { discovery?: boolean } | undefined;
+    if (injection?.discovery === false) continue;
+    contexts[nid] = renderNetworkContext({
+      type: network.type ?? 'community',
+      title: network.title,
+      prompt: network.prompt,
+      metadata: network.metadata ?? {},
+    });
+  }
+  return contexts;
 }
 
 /**
@@ -1349,6 +1377,7 @@ export class OpportunityGraphFactory {
             : new OpportunityEvaluator();
 
           const runParallel = process.env.RUN_OPPORTUNITY_EVAL_IN_PARALLEL === 'true';
+          const networkContexts = await buildNetworkContexts([sourceEntity, ...candidateEntities], this.database);
 
           // Declare trace entries early so both parallel and serial paths can push error entries
           const traceEntries: Array<{ node: string; detail?: string; data?: Record<string, unknown> }> = [];
@@ -1366,6 +1395,7 @@ export class OpportunityGraphFactory {
                   entities: [sourceEntity, candidateEntity],
                   existingOpportunities: state.options.existingOpportunities,
                   ...(state.searchQuery?.trim() ? { discoveryQuery: state.searchQuery.trim() } : {}),
+                  networkContexts,
                 };
                 const _evalStart = Date.now();
                 const _traceEmitter = requestContext.getStore()?.traceEmitter;
@@ -1427,6 +1457,7 @@ export class OpportunityGraphFactory {
               entities,
               existingOpportunities: state.options.existingOpportunities,
               ...(state.searchQuery?.trim() ? { discoveryQuery: state.searchQuery.trim() } : {}),
+              networkContexts,
             };
             // Get ALL scored results for tracing (returnAll: true), filter for persistence later
             const _evalStart = Date.now();
@@ -2235,12 +2266,14 @@ export class OpportunityGraphFactory {
         try {
           const introducerUser = await this.database.getUser(state.userId);
           introducerName = introducerUser?.name ?? undefined;
+          const networkContexts = await buildNetworkContexts(entities, this.database);
           const input: EvaluatorInput = {
             discovererId: state.userId,
             entities,
             introductionMode: true,
             introducerName,
             introductionHint: state.introductionHint ?? undefined,
+            networkContexts,
           };
 
           _evalStart = Date.now();

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -154,9 +154,9 @@ async function buildNetworkContexts(
   database: Pick<OpportunityGraphDatabase, 'getNetwork'>,
 ): Promise<Record<string, string>> {
   const networkIds = [...new Set(entities.map((e) => e.networkId))];
+  const networks = await Promise.all(networkIds.map((nid) => database.getNetwork(nid).then((n) => ({ nid, n }))));
   const contexts: Record<string, string> = {};
-  for (const nid of networkIds) {
-    const network = await database.getNetwork(nid);
+  for (const { nid, n: network } of networks) {
     if (!network) continue;
     const perms = (network.permissions ?? {}) as Record<string, unknown>;
     const injection = perms.contextInjection as { discovery?: boolean } | undefined;

--- a/packages/protocol/src/shared/agent/tool.helpers.ts
+++ b/packages/protocol/src/shared/agent/tool.helpers.ts
@@ -74,6 +74,9 @@ export interface ResolvedToolContext {
     id: string;
     title: string;
     prompt: string | null;
+    type?: string;
+    metadata?: Record<string, unknown>;
+    permissions?: Record<string, unknown>;
   };
   scopedMembershipRole?: "owner" | "member";
   /** True when user has not completed onboarding (onboarding.completedAt is null). */
@@ -287,6 +290,9 @@ export async function resolveChatContext(params: {
       id: index.id,
       title: index.title,
       prompt: membership?.indexPrompt ?? null,
+      type: index.type ?? 'community',
+      metadata: index.metadata ?? {},
+      permissions: index.permissions ?? {},
     };
     isOwner = owner;
     indexName = index.title;

--- a/packages/protocol/src/shared/interfaces/database.interface.ts
+++ b/packages/protocol/src/shared/interfaces/database.interface.ts
@@ -697,7 +697,14 @@ export interface Database {
   /**
    * Get index by ID (id and title only). Used for opportunity presentation.
    */
-  getNetwork(networkId: string): Promise<{ id: string; title: string } | null>;
+  getNetwork(networkId: string): Promise<{
+    id: string;
+    title: string;
+    prompt?: string | null;
+    type?: string;
+    metadata?: Record<string, unknown> | null;
+    permissions?: Record<string, unknown> | null;
+  } | null>;
 
   /**
    * Get index by ID with permissions (e.g. joinPolicy). Used by chat tools for create_index_membership.
@@ -1629,7 +1636,14 @@ export interface SystemDatabase {
   // ─────────────────────────────────────────────────────────────────────────────
 
   /** Get index info by ID (requires scope). */
-  getNetwork(networkId: string): Promise<{ id: string; title: string } | null>;
+  getNetwork(networkId: string): Promise<{
+    id: string;
+    title: string;
+    prompt?: string | null;
+    type?: string;
+    metadata?: Record<string, unknown> | null;
+    permissions?: Record<string, unknown> | null;
+  } | null>;
 
   /** Get index with permissions (requires scope). */
   getNetworkWithPermissions(networkId: string): Promise<{ id: string; title: string; permissions: { joinPolicy: 'anyone' | 'invite_only' } } | null>;

--- a/packages/protocol/src/shared/interfaces/database.interface.ts
+++ b/packages/protocol/src/shared/interfaces/database.interface.ts
@@ -695,7 +695,7 @@ export interface Database {
   getNetworkMembership(networkId: string, userId: string): Promise<NetworkMembership | null>;
 
   /**
-   * Get index by ID (id and title only). Used for opportunity presentation.
+   * Get index by ID with core fields. Used for opportunity presentation and context rendering.
    */
   getNetwork(networkId: string): Promise<{
     id: string;
@@ -1635,7 +1635,7 @@ export interface SystemDatabase {
   // Index Operations (any index in scope)
   // ─────────────────────────────────────────────────────────────────────────────
 
-  /** Get index info by ID (requires scope). */
+  /** Get index info by ID with core fields (requires scope). */
   getNetwork(networkId: string): Promise<{
     id: string;
     title: string;


### PR DESCRIPTION
## Summary
- **Extended `getNetwork`** interface and adapter to return `prompt`, `type`, `metadata`, and `permissions` — the protocol layer now has full network data when resolving chat context
- **Replaced JSON serialization** of scoped index in chat system prompt with `renderNetworkContext()` markdown, including membership role — LLM now receives structured event metadata (dates, themes, schedule) instead of raw JSON
- **Added `renderedContext`** field to each network entry in the `read_networks` MCP tool response — MCP clients get pre-rendered markdown alongside raw data
- **Injected network context** into the opportunity evaluator's input, gated by `permissions.contextInjection.discovery` (default: true) — event network metadata enriches opportunity scoring

Closes IND-312

## Test plan
- [x] Protocol `tsc --noEmit` passes
- [x] Backend `tsc --noEmit` passes
- [x] Protocol build succeeds
- [x] Existing renderer tests pass (7/7)
- [ ] Copilot review