### PR TITLE
feat(queues): profile-to-profile opportunity discovery after enrichment

### DIFF
--- a/backend/src/controllers/queues.controller.ts
+++ b/backend/src/controllers/queues.controller.ts
@@ -15,6 +15,7 @@ import { notificationQueue } from '../queues/notification.queue';
 import { intentQueue } from '../queues/intent.queue';
 import { fromIntentQueue } from '../queues/opportunity/from-intent.queue';
 import { fromIntroducerQueue } from '../queues/opportunity/from-introducer.queue';
+import { fromProfileQueue } from '../queues/opportunity/from-profile.queue';
 import { negotiationRunExistingQueue } from '../queues/negotiations/run-existing.queue';
 import { profileQueue } from '../queues/profile.queue';
 import { emailQueue } from '../queues/email.queue';
@@ -35,6 +36,7 @@ createBullBoard({
     new BullMQAdapter(intentQueue.queue),
     new BullMQAdapter(fromIntentQueue.queue),
     new BullMQAdapter(fromIntroducerQueue.queue),
+    new BullMQAdapter(fromProfileQueue.queue),
     new BullMQAdapter(negotiationRunExistingQueue.queue),
     new BullMQAdapter(profileQueue.queue),
     new BullMQAdapter(emailQueue.queue),

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -93,19 +93,7 @@ negotiationRunExistingQueue.setRuntimeDeps({
   agentDispatcher: backgroundAgentDispatcher,
 });
 
-intentQueue.startWorker();
-fromIntentQueue.startWorker();
-fromIntroducerQueue.startWorker();
-fromProfileQueue.startWorker();
-negotiationRunExistingQueue.startWorker();
-opportunityExpirationCron.start();
-notificationQueue.startWorker();
-profileQueue.startWorker();
-hydeQueue.startCrons();
-emailQueue.startWorker();
-negotiationTimeoutQueue.startWorker();
-negotiationClaimTimeoutQueue.startWorker();
-
+// Assign callbacks before starting workers to avoid a race with jobs already in Redis.
 NetworkMembershipEvents.onMemberAdded = (userId: string) => {
   profileQueue.addEnsureProfileHydeJob({ userId }).catch((err) => {
     log.job.from('NetworkMembership').error('Failed to enqueue ensure_profile_hyde', { userId, error: err });
@@ -118,6 +106,19 @@ profileQueue.onEnrichmentComplete = (userId: string) => {
     { priority: 20, jobId: `profile-discovery-${userId}-${Math.floor(Date.now() / (6 * 60 * 60 * 1000))}` },
   ).catch((err) => log.job.from('ProfileEnrichment').error('Failed to enqueue profile-based discovery', { userId, error: err }));
 };
+
+intentQueue.startWorker();
+fromIntentQueue.startWorker();
+fromIntroducerQueue.startWorker();
+fromProfileQueue.startWorker();
+negotiationRunExistingQueue.startWorker();
+opportunityExpirationCron.start();
+notificationQueue.startWorker();
+profileQueue.startWorker();
+hydeQueue.startCrons();
+emailQueue.startWorker();
+negotiationTimeoutQueue.startWorker();
+negotiationClaimTimeoutQueue.startWorker();
 
 IntentEvents.onCreated = (intentId: string, userId: string) => {
   log.job.from('IntentEvents').verbose('Intent created, triggering discovery + maintenance', { intentId, userId });

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -43,6 +43,7 @@ import { getStats } from './lib/performance';
 import { intentQueue } from './queues/intent.queue';
 import { fromIntentQueue } from './queues/opportunity/from-intent.queue';
 import { fromIntroducerQueue } from './queues/opportunity/from-introducer.queue';
+import { fromProfileQueue } from './queues/opportunity/from-profile.queue';
 import { negotiationRunExistingQueue } from './queues/negotiations/run-existing.queue';
 import { opportunityExpirationCron } from './queues/opportunity/expiration.queue';
 import { notificationQueue } from './queues/notification.queue';
@@ -83,6 +84,10 @@ fromIntroducerQueue.setRuntimeDeps({
   negotiationGraph: backgroundNegotiationGraph,
   agentDispatcher: backgroundAgentDispatcher,
 });
+fromProfileQueue.setRuntimeDeps({
+  negotiationGraph: backgroundNegotiationGraph,
+  agentDispatcher: backgroundAgentDispatcher,
+});
 negotiationRunExistingQueue.setRuntimeDeps({
   negotiationGraph: backgroundNegotiationGraph,
   agentDispatcher: backgroundAgentDispatcher,
@@ -91,6 +96,7 @@ negotiationRunExistingQueue.setRuntimeDeps({
 intentQueue.startWorker();
 fromIntentQueue.startWorker();
 fromIntroducerQueue.startWorker();
+fromProfileQueue.startWorker();
 negotiationRunExistingQueue.startWorker();
 opportunityExpirationCron.start();
 notificationQueue.startWorker();
@@ -104,6 +110,13 @@ NetworkMembershipEvents.onMemberAdded = (userId: string) => {
   profileQueue.addEnsureProfileHydeJob({ userId }).catch((err) => {
     log.job.from('NetworkMembership').error('Failed to enqueue ensure_profile_hyde', { userId, error: err });
   });
+};
+
+profileQueue.onEnrichmentComplete = (userId: string) => {
+  fromProfileQueue.addJob(
+    { userId },
+    { priority: 20, jobId: `profile-discovery-${userId}-${Math.floor(Date.now() / (6 * 60 * 60 * 1000))}` },
+  ).catch((err) => log.job.from('ProfileEnrichment').error('Failed to enqueue profile-based discovery', { userId, error: err }));
 };
 
 IntentEvents.onCreated = (intentId: string, userId: string) => {
@@ -442,6 +455,7 @@ const shutdown = async () => {
     intentQueue.close(),
     fromIntentQueue.close(),
     fromIntroducerQueue.close(),
+    fromProfileQueue.close(),
     negotiationRunExistingQueue.close(),
     notificationQueue.close(),
     emailQueue.close(),

--- a/backend/src/queues/opportunity/from-profile.queue.ts
+++ b/backend/src/queues/opportunity/from-profile.queue.ts
@@ -1,0 +1,155 @@
+import { Job } from 'bullmq';
+import { log } from '../../lib/log';
+import { QueueFactory } from '../../lib/bullmq/bullmq';
+import type { Id } from '../../types/common.types';
+import { ChatDatabaseAdapter } from '../../adapters/database.adapter';
+import { EmbedderAdapter } from '../../adapters/embedder.adapter';
+import { RedisCacheAdapter } from '../../adapters/cache.adapter';
+import { OpportunityGraphFactory, HydeGraphFactory, HydeGenerator, LensInferrer } from '@indexnetwork/protocol';
+import type { OpportunityGraphDatabase, HydeGraphDatabase, Embedder, HydeCache, NegotiationGraphLike, AgentDispatcher } from '@indexnetwork/protocol';
+
+import { negotiationRunExistingQueue } from '../negotiations/run-existing.queue';
+
+export const QUEUE_NAME = 'opportunity-from-profile';
+
+export interface FromProfileJobData {
+  userId: string;
+  networkId?: string;
+}
+
+export interface FromProfileDeps {
+  invokeOpportunityGraph?: (opts: {
+    userId: string;
+    operationMode: 'create';
+    networkId?: string;
+    options: { initialStatus: 'latent' };
+  }) => Promise<void>;
+  negotiationGraph?: NegotiationGraphLike;
+  agentDispatcher?: Pick<AgentDispatcher, 'hasPersonalAgent'>;
+}
+
+/**
+ * Profile-to-profile opportunity discovery queue.
+ *
+ * Invokes OpportunityGraph with only userId (+ optional networkId), no
+ * searchQuery or triggerIntentId. The graph falls back to profile-embedding
+ * vector search, discovering connections based on profile similarity.
+ *
+ * Triggered after profile enrichment completes for experiment-network imports
+ * and headless signups.
+ */
+export class FromProfileQueue {
+  static readonly QUEUE_NAME = QUEUE_NAME;
+
+  readonly queue = QueueFactory.createQueue<FromProfileJobData>(QUEUE_NAME);
+
+  private readonly logger = log.job.from('FromProfileJob');
+  private readonly queueLogger = log.queue.from('FromProfileQueue');
+  private readonly graphDb: OpportunityGraphDatabase & HydeGraphDatabase;
+  private deps: FromProfileDeps | undefined;
+  private worker: ReturnType<typeof QueueFactory.createWorker<FromProfileJobData>> | null = null;
+
+  constructor(deps?: FromProfileDeps) {
+    this.deps = deps;
+    this.graphDb = new ChatDatabaseAdapter() as unknown as OpportunityGraphDatabase & HydeGraphDatabase;
+  }
+
+  setRuntimeDeps(runtimeDeps: Pick<FromProfileDeps, 'negotiationGraph' | 'agentDispatcher'>): void {
+    this.deps = { ...(this.deps ?? {}), ...runtimeDeps };
+  }
+
+  async addJob(
+    data: FromProfileJobData,
+    options?: { jobId?: string; priority?: number },
+  ): Promise<Job<FromProfileJobData>> {
+    return this.queue.add('discover_opportunities', data, {
+      attempts: 3,
+      backoff: { type: 'exponential', delay: 1000 },
+      removeOnComplete: { age: 24 * 60 * 60 },
+      removeOnFail: { age: 24 * 60 * 60 },
+      jobId: options?.jobId,
+      priority: options?.priority,
+    });
+  }
+
+  async processJob(name: string, data: FromProfileJobData): Promise<void> {
+    switch (name) {
+      case 'discover_opportunities':
+        await this.handleDiscover(data);
+        break;
+      default:
+        this.queueLogger.warn(`[FromProfileQueueProcessor] Unknown job name: ${name}`);
+    }
+  }
+
+  private async handleDiscover(data: FromProfileJobData): Promise<void> {
+    const { userId, networkId } = data;
+
+    this.logger.info('[FromProfile] Starting profile-based discovery', { userId, networkId });
+
+    const invokeOpts = {
+      userId: userId as Id<'users'>,
+      operationMode: 'create' as const,
+      networkId: networkId as Id<'networks'> | undefined,
+      options: { initialStatus: 'latent' as const },
+    };
+
+    if (this.deps?.invokeOpportunityGraph) {
+      await this.deps.invokeOpportunityGraph(invokeOpts);
+      return;
+    }
+
+    const embedder: Embedder = new EmbedderAdapter();
+    const cache: HydeCache = new RedisCacheAdapter();
+    const inferrer = new LensInferrer();
+    const generator = new HydeGenerator();
+    const hydeGraph = new HydeGraphFactory(this.graphDb, embedder, cache, inferrer, generator).createGraph();
+    const opportunityGraph = new OpportunityGraphFactory(
+      this.graphDb,
+      embedder,
+      hydeGraph,
+      undefined,
+      undefined,
+      this.deps?.negotiationGraph,
+      this.deps?.agentDispatcher,
+      async (opportunityId: string, userId: string) => {
+        await negotiationRunExistingQueue.addJob({ opportunityId, userId });
+      },
+    ).createGraph();
+
+    const result = await opportunityGraph.invoke(invokeOpts);
+    if (result.error) {
+      this.logger.error('[FromProfile] Graph failed', { userId, networkId, error: result.error });
+      throw new Error(typeof result.error === 'string' ? result.error : 'from-profile graph failed');
+    }
+
+    const candidates = Array.isArray(result.candidates) ? result.candidates : [];
+    const opportunitiesArr = Array.isArray(result.opportunities) ? result.opportunities : [];
+
+    this.logger.info('[FromProfile] Graph complete', {
+      userId,
+      networkId,
+      candidatesFound: candidates.length,
+      opportunitiesCreated: opportunitiesArr.length,
+    });
+  }
+
+  startWorker(): void {
+    if (this.worker) return;
+    const processor = async (job: Job<FromProfileJobData>) => {
+      this.queueLogger.info(`[FromProfileProcessor] Processing job ${job.id}`);
+      await this.processJob(job.name, job.data);
+    };
+    this.worker = QueueFactory.createWorker<FromProfileJobData>(QUEUE_NAME, processor);
+  }
+
+  async close(): Promise<void> {
+    if (this.worker) {
+      await this.worker.close();
+      this.worker = null;
+    }
+    await this.queue.close();
+  }
+}
+
+export const fromProfileQueue = new FromProfileQueue();

--- a/backend/src/queues/profile.queue.ts
+++ b/backend/src/queues/profile.queue.ts
@@ -53,6 +53,9 @@ export class ProfileQueue {
   private readonly deps: ProfileQueueDeps | undefined;
   private worker: ReturnType<typeof QueueFactory.createWorker<ProfileJobPayload>> | null = null;
 
+  /** Set by main.ts to trigger opportunity discovery after enrichment completes. */
+  onEnrichmentComplete: ((userId: string) => void) | null = null;
+
   constructor(deps?: ProfileQueueDeps) {
     this.deps = deps;
   }
@@ -190,11 +193,13 @@ export class ProfileQueue {
     const { userId } = data;
     if (this.deps?.invokeEnrichUser) {
       await this.deps.invokeEnrichUser(userId);
+      this.onEnrichmentComplete?.(userId);
       return;
     }
     try {
       await this.invokeProfileGraph(userId, 'generate');
       this.queueLogger.info('[EnrichUser] Profile enrichment completed', { userId });
+      this.onEnrichmentComplete?.(userId);
     } catch (err) {
       this.queueLogger.error('[EnrichUser] Failed to enrich user', {
         userId,

--- a/backend/src/queues/profile.queue.ts
+++ b/backend/src/queues/profile.queue.ts
@@ -193,19 +193,31 @@ export class ProfileQueue {
     const { userId } = data;
     if (this.deps?.invokeEnrichUser) {
       await this.deps.invokeEnrichUser(userId);
-      this.onEnrichmentComplete?.(userId);
+      this.fireEnrichmentComplete(userId);
       return;
     }
     try {
       await this.invokeProfileGraph(userId, 'generate');
       this.queueLogger.info('[EnrichUser] Profile enrichment completed', { userId });
-      this.onEnrichmentComplete?.(userId);
+      this.fireEnrichmentComplete(userId);
     } catch (err) {
       this.queueLogger.error('[EnrichUser] Failed to enrich user', {
         userId,
         error: err instanceof Error ? err.message : String(err),
       });
       throw err;
+    }
+  }
+
+  /** Best-effort callback invocation — never fails the enrichment job. */
+  private fireEnrichmentComplete(userId: string): void {
+    try {
+      this.onEnrichmentComplete?.(userId);
+    } catch (err) {
+      this.queueLogger.error('[EnrichUser] onEnrichmentComplete callback failed', {
+        userId,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 

--- a/backend/src/queues/tests/from-profile.queue.spec.ts
+++ b/backend/src/queues/tests/from-profile.queue.spec.ts
@@ -1,0 +1,165 @@
+/**
+ * Unit tests for FromProfileQueue. Use injected deps to avoid Redis/DB; QueueFactory is mocked.
+ */
+import { config } from 'dotenv';
+config({ path: '.env.test' });
+
+import { describe, expect, it, mock, afterAll } from 'bun:test';
+
+const mockAdd = mock(async () => ({ id: 'job-1', name: 'discover_opportunities', data: {} }));
+const mockCreateWorker = mock(() => ({}));
+
+mock.module('../../lib/bullmq/bullmq', () => ({
+  QueueFactory: {
+    createQueue: () => ({ add: mockAdd }),
+    createWorker: mockCreateWorker,
+    createQueueEvents: () => ({ on: () => {}, close: async () => {} }),
+  },
+}));
+
+mock.module('../negotiations/run-existing.queue', () => ({
+  negotiationRunExistingQueue: { addJob: async () => ({ id: 'neg-1' }) },
+}));
+
+afterAll(() => {
+  mock.restore();
+});
+
+import {
+  FromProfileQueue,
+  QUEUE_NAME,
+  type FromProfileJobData,
+} from '../opportunity/from-profile.queue';
+
+describe('FromProfileQueue', () => {
+  describe('constructor and static', () => {
+    it('exposes QUEUE_NAME on class', () => {
+      expect(FromProfileQueue.QUEUE_NAME).toBe(QUEUE_NAME);
+      expect(QUEUE_NAME).toBe('opportunity-from-profile');
+    });
+  });
+
+  describe('addJob', () => {
+    it('adds discover job with userId only', async () => {
+      const queue = new FromProfileQueue();
+      const job = await queue.addJob({ userId: 'u1' });
+      expect(job.id).toBe('job-1');
+      expect(mockAdd).toHaveBeenCalledWith(
+        'discover_opportunities',
+        { userId: 'u1' },
+        expect.objectContaining({
+          attempts: 3,
+          backoff: { type: 'exponential', delay: 1000 },
+          removeOnComplete: { age: 24 * 60 * 60 },
+          removeOnFail: { age: 24 * 60 * 60 },
+        })
+      );
+    });
+
+    it('adds discover job with userId and networkId', async () => {
+      const queue = new FromProfileQueue();
+      await queue.addJob({ userId: 'u1', networkId: 'net1' });
+      expect(mockAdd).toHaveBeenCalledWith(
+        'discover_opportunities',
+        { userId: 'u1', networkId: 'net1' },
+        expect.any(Object)
+      );
+    });
+
+    it('supports jobId and priority options', async () => {
+      const queue = new FromProfileQueue();
+      await queue.addJob({ userId: 'u1' }, { jobId: 'custom-id', priority: 20 });
+      expect(mockAdd).toHaveBeenCalledWith(
+        'discover_opportunities',
+        { userId: 'u1' },
+        expect.objectContaining({ jobId: 'custom-id', priority: 20 })
+      );
+    });
+  });
+
+  describe('processJob', () => {
+    it('unknown job name logs warning and does not throw', async () => {
+      const queue = new FromProfileQueue();
+      await expect(
+        queue.processJob('unknown_job', { userId: 'u1' })
+      ).resolves.toBeUndefined();
+    });
+
+    it('discover: invokes injected graph with userId only (no searchQuery or triggerIntentId)', async () => {
+      const invokeOpportunityGraph = mock(async () => {});
+      const queue = new FromProfileQueue({ invokeOpportunityGraph });
+      await queue.processJob('discover_opportunities', { userId: 'u1' });
+      expect(invokeOpportunityGraph).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'u1',
+          operationMode: 'create',
+          networkId: undefined,
+          options: { initialStatus: 'latent' },
+        })
+      );
+      const call = invokeOpportunityGraph.mock.calls[0][0] as Record<string, unknown>;
+      expect(call).not.toHaveProperty('searchQuery');
+      expect(call).not.toHaveProperty('triggerIntentId');
+    });
+
+    it('discover: passes networkId when provided', async () => {
+      const invokeOpportunityGraph = mock(async () => {});
+      const queue = new FromProfileQueue({ invokeOpportunityGraph });
+      await queue.processJob('discover_opportunities', { userId: 'u1', networkId: 'net1' });
+      expect(invokeOpportunityGraph).toHaveBeenCalledWith(
+        expect.objectContaining({ networkId: 'net1' })
+      );
+    });
+
+    it('discover: without invokeOpportunityGraph uses real graph (may fail without infra)', async () => {
+      const queue = new FromProfileQueue();
+      try {
+        await queue.processJob('discover_opportunities', { userId: 'u1' });
+      } catch {
+        // Real graph can fail without Redis/DB — we only verify it doesn't crash the queue class
+      }
+    });
+  });
+
+  describe('startWorker', () => {
+    it('is idempotent: second call does not create another worker', () => {
+      const queue = new FromProfileQueue();
+      queue.startWorker();
+      queue.startWorker();
+      expect(mockCreateWorker).toHaveBeenCalledTimes(1);
+    });
+
+    it('processor invokes processJob when worker runs a job', async () => {
+      let capturedProcessor: ((job: { id: string; name: string; data: FromProfileJobData }) => Promise<void>) | null = null;
+      (mockCreateWorker as import('bun:test').Mock<(n: string, p: (job: unknown) => Promise<void>) => unknown>).mockImplementation((_name: string, processor: (job: unknown) => Promise<void>) => {
+        capturedProcessor = processor as (job: { id: string; name: string; data: FromProfileJobData }) => Promise<void>;
+        return {};
+      });
+      const invokeOpportunityGraph = mock(async () => {});
+      const queue = new FromProfileQueue({ invokeOpportunityGraph });
+      queue.startWorker();
+      expect(capturedProcessor).not.toBeNull();
+      await capturedProcessor!({
+        id: 'job-1',
+        name: 'discover_opportunities',
+        data: { userId: 'u1' },
+      });
+      expect(invokeOpportunityGraph).toHaveBeenCalled();
+    });
+  });
+
+  describe('setRuntimeDeps', () => {
+    it('merges negotiationGraph and agentDispatcher into deps', async () => {
+      const invokeOpportunityGraph = mock(async () => {});
+      const queue = new FromProfileQueue({ invokeOpportunityGraph });
+      const negotiationGraph = {} as unknown;
+      const agentDispatcher = { hasPersonalAgent: async () => false };
+      queue.setRuntimeDeps({
+        negotiationGraph: negotiationGraph as FromProfileQueue extends { setRuntimeDeps(d: infer D): void } ? D extends { negotiationGraph?: infer N } ? N : never : never,
+        agentDispatcher,
+      });
+      await queue.processJob('discover_opportunities', { userId: 'u1' });
+      expect(invokeOpportunityGraph).toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/queues/tests/from-profile.queue.spec.ts
+++ b/backend/src/queues/tests/from-profile.queue.spec.ts
@@ -152,12 +152,9 @@ describe('FromProfileQueue', () => {
     it('merges negotiationGraph and agentDispatcher into deps', async () => {
       const invokeOpportunityGraph = mock(async () => {});
       const queue = new FromProfileQueue({ invokeOpportunityGraph });
-      const negotiationGraph = {} as unknown;
+      const negotiationGraph = {} as Parameters<InstanceType<typeof FromProfileQueue>['setRuntimeDeps']>[0]['negotiationGraph'];
       const agentDispatcher = { hasPersonalAgent: async () => false };
-      queue.setRuntimeDeps({
-        negotiationGraph: negotiationGraph as FromProfileQueue extends { setRuntimeDeps(d: infer D): void } ? D extends { negotiationGraph?: infer N } ? N : never : never,
-        agentDispatcher,
-      });
+      queue.setRuntimeDeps({ negotiationGraph, agentDispatcher });
       await queue.processJob('discover_opportunities', { userId: 'u1' });
       expect(invokeOpportunityGraph).toHaveBeenCalled();
     });

--- a/backend/src/queues/tests/profile.queue.spec.ts
+++ b/backend/src/queues/tests/profile.queue.spec.ts
@@ -80,6 +80,47 @@ describe('ProfileQueue', () => {
     });
   });
 
+  describe('onEnrichmentComplete callback', () => {
+    it('fires with userId after successful enrichment', async () => {
+      const onComplete = mock((_userId: string) => {});
+      const invokeEnrichUser = mock(async (_userId: string) => {});
+      const queue = new ProfileQueue({ invokeEnrichUser });
+      queue.onEnrichmentComplete = onComplete;
+      await queue.processJob('profile.enrich', { userId: 'u1' });
+      expect(onComplete).toHaveBeenCalledWith('u1');
+      expect(onComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fire when enrichment fails', async () => {
+      const onComplete = mock((_userId: string) => {});
+      const invokeEnrichUser = mock(async () => { throw new Error('enrichment failed'); });
+      const queue = new ProfileQueue({ invokeEnrichUser });
+      queue.onEnrichmentComplete = onComplete;
+      try {
+        await queue.processJob('profile.enrich', { userId: 'u1' });
+      } catch {
+        // expected
+      }
+      expect(onComplete).not.toHaveBeenCalled();
+    });
+
+    it('does not fire for ensure_profile_hyde jobs', async () => {
+      const onComplete = mock((_userId: string) => {});
+      const invokeProfileWrite = mock(async (_userId: string) => {});
+      const queue = new ProfileQueue({ invokeProfileWrite });
+      queue.onEnrichmentComplete = onComplete;
+      await queue.processJob('ensure_profile_hyde', { userId: 'u1' });
+      expect(onComplete).not.toHaveBeenCalled();
+    });
+
+    it('is null by default (no-op)', async () => {
+      const invokeEnrichUser = mock(async (_userId: string) => {});
+      const queue = new ProfileQueue({ invokeEnrichUser });
+      expect(queue.onEnrichmentComplete).toBeNull();
+      await queue.processJob('profile.enrich', { userId: 'u1' });
+    });
+  });
+
   describe('static', () => {
     it('exposes QUEUE_NAME on class', () => {
       expect(ProfileQueue.QUEUE_NAME).toBe(QUEUE_NAME);


### PR DESCRIPTION
## New Features

- `FromProfileQueue` — BullMQ queue that invokes `OpportunityGraph` with `discoverySource='profile'` for intent-free, profile-based opportunity discovery
- `ProfileQueue.onEnrichmentComplete` callback — fires after successful enrichment, triggers `FromProfileQueue.addJob` from `main.ts`

## Bug Fixes

- CSV-imported members to an experimental network completed profile enrichment but no opportunity discovery was triggered. The `OpportunityGraph` already supported a `discoverySource: 'profile'` path using profile embeddings for vector search without requiring intents — it had no caller from the enrichment pipeline.

## Refactors

- None

## Documentation

- None

## Tests

- 11 unit tests for `FromProfileQueue` (addJob variants, processJob with injected deps, unknown job handling, startWorker idempotency, setRuntimeDeps)
- 4 unit tests for `ProfileQueue.onEnrichmentComplete` (fires after enrichment, does not fire on failure, does not fire for non-enrich jobs, null by default)