### PR TITLE
fix: use registered network tool names

### DIFF
--- a/packages/cli/src/network.command.ts
+++ b/packages/cli/src/network.command.ts
@@ -188,7 +188,7 @@ async function networkUpdate(
     return;
   }
 
-  const result = await client.callTool("update_index", { networkId: id, settings });
+  const result = await client.callTool("update_network", { networkId: id, settings });
   if (json) { console.log(JSON.stringify(result)); return; }
   if (!result.success) {
     output.error(result.error ?? "Network update failed", 1);
@@ -206,7 +206,7 @@ async function networkDelete(client: ApiClient, id: string | undefined, json?: b
     return;
   }
 
-  const result = await client.callTool("delete_index", { networkId: id });
+  const result = await client.callTool("delete_network", { networkId: id });
   if (json) { console.log(JSON.stringify(result)); return; }
   if (!result.success) {
     output.error(result.error ?? "Network deletion failed", 1);

--- a/packages/cli/src/opportunity.command.ts
+++ b/packages/cli/src/opportunity.command.ts
@@ -185,8 +185,8 @@ async function discoverIntroduction(
 
   // Step 1: Find shared indexes between the two users
   const [membershipsA, membershipsB] = await Promise.all([
-    client.callTool("read_index_memberships", { userId: userA }),
-    client.callTool("read_index_memberships", { userId: userB }),
+    client.callTool("read_network_memberships", { userId: userA }),
+    client.callTool("read_network_memberships", { userId: userB }),
   ]);
 
   if (!membershipsA.success || !membershipsB.success) {

--- a/packages/cli/tests/opportunity.command.test.ts
+++ b/packages/cli/tests/opportunity.command.test.ts
@@ -236,7 +236,7 @@ describe("opportunity command behavior", () => {
       async callTool(toolName: string) {
         calls.push(toolName);
 
-        if (toolName === "read_index_memberships") {
+        if (toolName === "read_network_memberships") {
           return {
             success: true,
             data: { memberships: [{ networkId: "shared-network" }] },
@@ -296,7 +296,7 @@ describe("opportunity command behavior", () => {
   it("keeps --json output clean during introduction discovery", async () => {
     const client = {
       async callTool(toolName: string) {
-        if (toolName === "read_index_memberships") {
+        if (toolName === "read_network_memberships") {
           return {
             success: true,
             data: { memberships: [{ networkId: "shared-network" }] },

--- a/packages/cli/tests/tool-calls.test.ts
+++ b/packages/cli/tests/tool-calls.test.ts
@@ -337,7 +337,7 @@ describe("CLI tool call contracts", () => {
         json: true,
       });
 
-      // Should have called: read_index_memberships x2, read_user_profiles x2, read_intents x2, discover_opportunities x1
+      // Should have called: read_network_memberships x2, read_user_profiles x2, read_intents x2, discover_opportunities x1
       const toolNames = mock.toolCalls.map((c) => c.toolName);
       expect(toolNames.filter((n) => n === "read_network_memberships")).toHaveLength(2);
       expect(toolNames.filter((n) => n === "read_user_profiles")).toHaveLength(2);

--- a/packages/cli/tests/tool-calls.test.ts
+++ b/packages/cli/tests/tool-calls.test.ts
@@ -311,7 +311,7 @@ describe("CLI tool call contracts", () => {
 
     it("discover --introduce gathers entities then calls discover_opportunities with partyUserIds + entities", async () => {
       // Mock the prerequisite tool responses
-      mock.setToolResponse("read_index_memberships", {
+      mock.setToolResponse("read_network_memberships", {
         success: true,
         data: {
           memberships: [{ networkId: "shared-index-1", indexTitle: "AI Network" }],
@@ -339,7 +339,7 @@ describe("CLI tool call contracts", () => {
 
       // Should have called: read_index_memberships x2, read_user_profiles x2, read_intents x2, discover_opportunities x1
       const toolNames = mock.toolCalls.map((c) => c.toolName);
-      expect(toolNames.filter((n) => n === "read_index_memberships")).toHaveLength(2);
+      expect(toolNames.filter((n) => n === "read_network_memberships")).toHaveLength(2);
       expect(toolNames.filter((n) => n === "read_user_profiles")).toHaveLength(2);
       expect(toolNames.filter((n) => n === "read_intents")).toHaveLength(2);
       expect(toolNames.filter((n) => n === "discover_opportunities")).toHaveLength(1);
@@ -361,7 +361,7 @@ describe("CLI tool call contracts", () => {
     });
 
     it("discover --introduce without hint omits hint field", async () => {
-      mock.setToolResponse("read_index_memberships", {
+      mock.setToolResponse("read_network_memberships", {
         success: true,
         data: { memberships: [{ networkId: "idx-1" }] },
       });
@@ -381,7 +381,7 @@ describe("CLI tool call contracts", () => {
     });
 
     it("discover --introduce fails gracefully when no shared indexes", async () => {
-      mock.setToolResponse("read_index_memberships", {
+      mock.setToolResponse("read_network_memberships", {
         success: true,
         data: { memberships: [] },
       });
@@ -396,7 +396,7 @@ describe("CLI tool call contracts", () => {
       expect(mock.toolCalls.filter((c) => c.toolName === "discover_opportunities")).toHaveLength(0);
       // Should only have the 2 membership lookups
       expect(mock.toolCalls).toHaveLength(2);
-      expect(mock.toolCalls.every((c) => c.toolName === "read_index_memberships")).toBe(true);
+      expect(mock.toolCalls.every((c) => c.toolName === "read_network_memberships")).toBe(true);
     });
 
     it("accept calls update_opportunity with status accepted (CLI: opportunity accept)", async () => {
@@ -441,8 +441,8 @@ describe("CLI tool call contracts", () => {
   // ── Network ──────────────────────────────────────────────────────
 
   describe("network", () => {
-    it("update calls update_index with networkId and settings", async () => {
-      mock.setToolResponse("update_index", { success: true, data: {} });
+    it("update calls update_network with networkId and settings", async () => {
+      mock.setToolResponse("update_network", { success: true, data: {} });
 
       await handleNetwork(client, "update", ["index-123"], {
         title: "New Name",
@@ -450,20 +450,20 @@ describe("CLI tool call contracts", () => {
       });
 
       expect(mock.toolCalls).toHaveLength(1);
-      expect(mock.toolCalls[0].toolName).toBe("update_index");
+      expect(mock.toolCalls[0].toolName).toBe("update_network");
       expect(mock.toolCalls[0].query).toEqual({
         networkId: "index-123",
         settings: { title: "New Name", prompt: "Updated description" },
       });
     });
 
-    it("delete calls delete_index with networkId", async () => {
-      mock.setToolResponse("delete_index", { success: true, data: {} });
+    it("delete calls delete_network with networkId", async () => {
+      mock.setToolResponse("delete_network", { success: true, data: {} });
 
       await handleNetwork(client, "delete", ["index-456"], {});
 
       expect(mock.toolCalls).toHaveLength(1);
-      expect(mock.toolCalls[0].toolName).toBe("delete_index");
+      expect(mock.toolCalls[0].toolName).toBe("delete_network");
       expect(mock.toolCalls[0].query).toEqual({ networkId: "index-456" });
     });
   });


### PR DESCRIPTION
## Summary

- Update `network update` to call the registered `update_network` MCP tool.
- Update `network delete` to call the registered `delete_network` MCP tool.
- Update introduction discovery to call `read_network_memberships` instead of the unregistered `read_index_memberships` tool.
- Refresh the related CLI tool-call tests to assert the registered tool names.

Closes #719.

## Verification

- `bun install --ignore-scripts` in `packages/cli`
- `bun test tests/tool-calls.test.ts tests/opportunity.command.test.ts` in `packages/cli`
- `git diff --check`
