### PR TITLE
feat: member role management (promote/demote)

### DIFF
--- a/backend/drizzle/0074_promote_admins_to_owners.sql
+++ b/backend/drizzle/0074_promote_admins_to_owners.sql
@@ -1,0 +1,5 @@
+-- Promote all admin members to owners (dropping the admin tier)
+UPDATE "network_members"
+SET "permissions" = ARRAY['owner'],
+    "updated_at" = NOW()
+WHERE 'admin' = ANY("permissions");

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -519,6 +519,13 @@
       "when": 1779648000000,
       "tag": "0073_add_questions_table",
       "breakpoints": true
+    },
+    {
+      "idx": 74,
+      "version": "7",
+      "when": 1779820800000,
+      "tag": "0074_promote_admins_to_owners",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -2767,8 +2767,8 @@ export class ChatDatabaseAdapter {
   }
 
   /**
-   * Add a member to an index. Checks that the requesting user has owner or admin permissions.
-   * Throws "Access denied" if not authorized.
+   * Add a member to an index. Owner-only.
+   * Throws "Access denied" if the requesting user is not an owner.
    */
   async addMemberForOwner(
     networkId: string,
@@ -2813,11 +2813,20 @@ export class ChatDatabaseAdapter {
       throw new Error('Access denied: Only owners can change member roles');
     }
 
-    // Get existing membership
+    // Cannot change your own role
+    if (targetUserId === requestingUserId) {
+      throw new Error('Cannot change your own role');
+    }
+
+    // Get existing membership (exclude soft-deleted)
     const [existing] = await db
       .select({ permissions: networkMembers.permissions })
       .from(networkMembers)
-      .where(and(eq(networkMembers.networkId, networkId), eq(networkMembers.userId, targetUserId)))
+      .where(and(
+        eq(networkMembers.networkId, networkId),
+        eq(networkMembers.userId, targetUserId),
+        isNull(networkMembers.deletedAt)
+      ))
       .limit(1);
 
     if (!existing) {
@@ -2829,27 +2838,35 @@ export class ChatDatabaseAdapter {
       throw new Error('Cannot change role of a contact');
     }
 
-    // If demoting from owner, ensure they're not the last owner
-    if (role === 'member' && existing.permissions?.includes('owner')) {
-      const ownerCount = await db
-        .select({ count: sql<number>`count(*)` })
-        .from(networkMembers)
-        .where(and(
-          eq(networkMembers.networkId, networkId),
-          sql`'owner' = ANY(${networkMembers.permissions})`,
-          isNull(networkMembers.deletedAt)
-        ));
-      if (Number(ownerCount[0]?.count ?? 0) <= 1) {
-        throw new Error('Cannot demote the last owner');
-      }
-    }
-
     const newPermissions = role === 'owner' ? ['owner'] : ['member'];
 
-    await db
-      .update(networkMembers)
-      .set({ permissions: newPermissions, updatedAt: new Date() })
-      .where(and(eq(networkMembers.networkId, networkId), eq(networkMembers.userId, targetUserId)));
+    // Atomic demotion guard: only demote if more than one owner remains.
+    // Uses a conditional UPDATE to avoid TOCTOU races.
+    if (role === 'member' && existing.permissions?.includes('owner')) {
+      const result = await db
+        .update(networkMembers)
+        .set({ permissions: newPermissions, updatedAt: new Date() })
+        .where(and(
+          eq(networkMembers.networkId, networkId),
+          eq(networkMembers.userId, targetUserId),
+          isNull(networkMembers.deletedAt),
+          sql`(SELECT count(*) FROM ${networkMembers} WHERE ${networkMembers.networkId} = ${networkId} AND 'owner' = ANY(${networkMembers.permissions}) AND ${networkMembers.deletedAt} IS NULL) > 1`
+        ))
+        .returning({ userId: networkMembers.userId });
+
+      if (result.length === 0) {
+        throw new Error('Cannot demote the last owner');
+      }
+    } else {
+      await db
+        .update(networkMembers)
+        .set({ permissions: newPermissions, updatedAt: new Date() })
+        .where(and(
+          eq(networkMembers.networkId, networkId),
+          eq(networkMembers.userId, targetUserId),
+          isNull(networkMembers.deletedAt)
+        ));
+    }
 
     const user = await this.getUser(targetUserId);
     return {

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -2423,13 +2423,13 @@ export class ChatDatabaseAdapter {
   async addMemberToNetwork(
     networkId: string,
     userId: string,
-    role: 'owner' | 'admin' | 'member'
+    role: 'owner' | 'member'
   ): Promise<{ success: boolean; alreadyMember?: boolean }> {
     let memberPrompt: string | null = null;
     const [indexRow] = await db.select({ prompt: networks.prompt }).from(networks).where(eq(networks.id, networkId)).limit(1);
     if (indexRow) memberPrompt = indexRow.prompt;
 
-    const finalPermissions = role === 'owner' ? ['owner'] : role === 'admin' ? ['admin', 'member'] : ['member'];
+    const finalPermissions = role === 'owner' ? ['owner'] : ['member'];
     const result = await db.insert(networkMembers).values({
       networkId,
       userId,
@@ -2770,20 +2770,15 @@ export class ChatDatabaseAdapter {
    * Add a member to an index. Checks that the requesting user has owner or admin permissions.
    * Throws "Access denied" if not authorized.
    */
-  async addMemberForOwnerOrAdmin(
+  async addMemberForOwner(
     networkId: string,
     userId: string,
     requestingUserId: string,
-    role: 'admin' | 'member' = 'member'
+    role: 'owner' | 'member' = 'member'
   ) {
-    const [membership] = await db
-      .select({ permissions: networkMembers.permissions })
-      .from(networkMembers)
-      .where(and(eq(networkMembers.networkId, networkId), eq(networkMembers.userId, requestingUserId)))
-      .limit(1);
-
-    if (!membership || (!membership.permissions?.includes('owner') && !membership.permissions?.includes('admin'))) {
-      throw new Error('Access denied: Only owners or admins can add members');
+    const isOwner = await this.isIndexOwner(networkId, requestingUserId);
+    if (!isOwner) {
+      throw new Error('Access denied: Only owners can add members');
     }
 
     const result = await this.addMemberToNetwork(networkId, userId, role);
@@ -2791,9 +2786,76 @@ export class ChatDatabaseAdapter {
 
     return {
       member: user
-        ? { id: user.id, name: user.name, email: user.email, avatar: user.avatar, permissions: role === 'admin' ? ['admin', 'member'] : ['member'] }
+        ? { id: user.id, name: user.name, email: user.email, avatar: user.avatar, permissions: role === 'owner' ? ['owner'] : ['member'] }
         : null,
       alreadyMember: result.alreadyMember,
+    };
+  }
+
+  /**
+   * Update an existing member's role. Owner-only.
+   * Cannot demote the last owner. Cannot change contacts.
+   * @param networkId - The network ID
+   * @param targetUserId - The member whose role is being changed
+   * @param requestingUserId - The user making the change (must be owner)
+   * @param role - The new role ('owner' | 'member')
+   * @returns The updated member with new permissions
+   * @throws Error if not authorized, last owner, or member not found
+   */
+  async updateMemberRole(
+    networkId: string,
+    targetUserId: string,
+    requestingUserId: string,
+    role: 'owner' | 'member'
+  ) {
+    const isOwner = await this.isIndexOwner(networkId, requestingUserId);
+    if (!isOwner) {
+      throw new Error('Access denied: Only owners can change member roles');
+    }
+
+    // Get existing membership
+    const [existing] = await db
+      .select({ permissions: networkMembers.permissions })
+      .from(networkMembers)
+      .where(and(eq(networkMembers.networkId, networkId), eq(networkMembers.userId, targetUserId)))
+      .limit(1);
+
+    if (!existing) {
+      throw new Error('Member not found');
+    }
+
+    // Don't allow changing contacts
+    if (existing.permissions?.includes('contact')) {
+      throw new Error('Cannot change role of a contact');
+    }
+
+    // If demoting from owner, ensure they're not the last owner
+    if (role === 'member' && existing.permissions?.includes('owner')) {
+      const ownerCount = await db
+        .select({ count: sql<number>`count(*)` })
+        .from(networkMembers)
+        .where(and(
+          eq(networkMembers.networkId, networkId),
+          sql`'owner' = ANY(${networkMembers.permissions})`,
+          isNull(networkMembers.deletedAt)
+        ));
+      if (Number(ownerCount[0]?.count ?? 0) <= 1) {
+        throw new Error('Cannot demote the last owner');
+      }
+    }
+
+    const newPermissions = role === 'owner' ? ['owner'] : ['member'];
+
+    await db
+      .update(networkMembers)
+      .set({ permissions: newPermissions, updatedAt: new Date() })
+      .where(and(eq(networkMembers.networkId, networkId), eq(networkMembers.userId, targetUserId)));
+
+    const user = await this.getUser(targetUserId);
+    return {
+      member: user
+        ? { id: user.id, name: user.name, email: user.email, avatar: user.avatar, permissions: newPermissions }
+        : null,
     };
   }
 
@@ -6205,7 +6267,7 @@ export function createSystemDatabase(
      * @remarks Intentionally unscoped -- used by join flows, invitation acceptance, and
      * contact addition that operate outside the caller's current index scope.
      */
-    addMemberToNetwork: (networkId: string, userId: string, role: 'owner' | 'admin' | 'member') => db.addMemberToNetwork(networkId, userId, role),
+    addMemberToNetwork: (networkId: string, userId: string, role: 'owner' | 'member') => db.addMemberToNetwork(networkId, userId, role),
     /**
      * Removes a member from an index without scope check.
      * @remarks Intentionally unscoped -- used by leave/kick flows and member removal

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -2840,23 +2840,34 @@ export class ChatDatabaseAdapter {
 
     const newPermissions = role === 'owner' ? ['owner'] : ['member'];
 
-    // Atomic demotion guard: only demote if more than one owner remains.
-    // Uses a conditional UPDATE to avoid TOCTOU races.
+    // Demotion guard: prevent demoting the last owner.
+    // Uses a transaction with SELECT ... FOR UPDATE to lock all owner rows,
+    // preventing concurrent write-skew under READ COMMITTED.
     if (role === 'member' && existing.permissions?.includes('owner')) {
-      const result = await db
-        .update(networkMembers)
-        .set({ permissions: newPermissions, updatedAt: new Date() })
-        .where(and(
-          eq(networkMembers.networkId, networkId),
-          eq(networkMembers.userId, targetUserId),
-          isNull(networkMembers.deletedAt),
-          sql`(SELECT count(*) FROM ${networkMembers} WHERE ${networkMembers.networkId} = ${networkId} AND 'owner' = ANY(${networkMembers.permissions}) AND ${networkMembers.deletedAt} IS NULL) > 1`
-        ))
-        .returning({ userId: networkMembers.userId });
+      await db.transaction(async (tx) => {
+        const owners = await tx
+          .select({ userId: networkMembers.userId })
+          .from(networkMembers)
+          .where(and(
+            eq(networkMembers.networkId, networkId),
+            sql`'owner' = ANY(${networkMembers.permissions})`,
+            isNull(networkMembers.deletedAt)
+          ))
+          .for('update');
 
-      if (result.length === 0) {
-        throw new Error('Cannot demote the last owner');
-      }
+        if (owners.length <= 1) {
+          throw new Error('Cannot demote the last owner');
+        }
+
+        await tx
+          .update(networkMembers)
+          .set({ permissions: newPermissions, updatedAt: new Date() })
+          .where(and(
+            eq(networkMembers.networkId, networkId),
+            eq(networkMembers.userId, targetUserId),
+            isNull(networkMembers.deletedAt)
+          ));
+      });
     } else {
       await db
         .update(networkMembers)

--- a/backend/src/adapters/tests/database.adapter.spec.ts
+++ b/backend/src/adapters/tests/database.adapter.spec.ts
@@ -343,19 +343,26 @@ describe('ChatDatabaseAdapter', () => {
   });
 
   describe('updateMemberRole', () => {
+    // Reset A=owner, B=member before each test to prevent cascading state corruption
+    const resetRoles = async () => {
+      await db.update(networkMembers).set({ permissions: ['owner'] }).where(
+        sql`${networkMembers.networkId} = ${fixture.networkId} AND ${networkMembers.userId} = ${fixture.userAId}`
+      );
+      await db.update(networkMembers).set({ permissions: ['member'] }).where(
+        sql`${networkMembers.networkId} = ${fixture.networkId} AND ${networkMembers.userId} = ${fixture.userBId}`
+      );
+    };
+
     it('should promote a member to owner', async () => {
-      expect(await adapter.isIndexOwner(fixture.networkId, fixture.userBId)).toBe(false);
+      await resetRoles();
       const result = await adapter.updateMemberRole(fixture.networkId, fixture.userBId, fixture.userAId, 'owner');
       expect(result.member).toBeDefined();
       expect(result.member!.permissions).toEqual(['owner']);
       expect(await adapter.isIndexOwner(fixture.networkId, fixture.userBId)).toBe(true);
-      // Restore: B back to member
-      await db.update(networkMembers).set({ permissions: ['member'] }).where(
-        sql`${networkMembers.networkId} = ${fixture.networkId} AND ${networkMembers.userId} = ${fixture.userBId}`
-      );
-    });
+    }, 15000);
 
     it('should demote an owner to member when multiple owners exist', async () => {
+      await resetRoles();
       // Setup: make B an owner so there are two
       await db.update(networkMembers).set({ permissions: ['owner'] }).where(
         sql`${networkMembers.networkId} = ${fixture.networkId} AND ${networkMembers.userId} = ${fixture.userBId}`
@@ -364,9 +371,10 @@ describe('ChatDatabaseAdapter', () => {
       const result = await adapter.updateMemberRole(fixture.networkId, fixture.userBId, fixture.userAId, 'member');
       expect(result.member!.permissions).toEqual(['member']);
       expect(await adapter.isIndexOwner(fixture.networkId, fixture.userBId)).toBe(false);
-    });
+    }, 15000);
 
     it('should reject demoting the last owner (atomic guard)', async () => {
+      await resetRoles();
       // A is sole owner. The atomic conditional UPDATE has a subquery that checks
       // ownerCount > 1. With serial access, other guards (self, access-denied) fire
       // before the atomic path. Test the conditional UPDATE directly at the SQL level
@@ -389,20 +397,48 @@ describe('ChatDatabaseAdapter', () => {
       expect(directResult.length).toBe(0);
       // Confirm A is still owner
       expect(await adapter.isIndexOwner(fixture.networkId, fixture.userAId)).toBe(true);
-    });
+    }, 15000);
 
     it('should reject self role change', async () => {
+      await resetRoles();
       await expect(
         adapter.updateMemberRole(fixture.networkId, fixture.userAId, fixture.userAId, 'owner')
       ).rejects.toThrow('Cannot change your own role');
-    });
+    }, 15000);
 
     it('should reject role change by non-owner', async () => {
+      await resetRoles();
       expect(await adapter.isIndexOwner(fixture.networkId, fixture.userBId)).toBe(false);
       await expect(
         adapter.updateMemberRole(fixture.networkId, fixture.userAId, fixture.userBId, 'member')
       ).rejects.toThrow('Access denied');
-    });
+    }, 15000);
+
+    it('should reject role change on a contact', async () => {
+      await resetRoles();
+      const contactUserId = uuidv4();
+      await db.insert(users).values({
+        id: contactUserId,
+        email: TEST_PREFIX + contactUserId + '@test.com',
+        name: TEST_PREFIX + 'ContactUser',
+      });
+      await db.insert(networkMembers).values({
+        networkId: fixture.networkId,
+        userId: contactUserId,
+        permissions: ['contact'],
+        autoAssign: false,
+      });
+      try {
+        await expect(
+          adapter.updateMemberRole(fixture.networkId, contactUserId, fixture.userAId, 'owner')
+        ).rejects.toThrow('Cannot change role of a contact');
+      } finally {
+        await db.delete(networkMembers).where(
+          sql`${networkMembers.networkId} = ${fixture.networkId} AND ${networkMembers.userId} = ${contactUserId}`
+        );
+        await db.delete(users).where(eq(users.id, contactUserId));
+      }
+    }, 15000);
   });
 
   describe('getUserByEmail (IND-166)', () => {

--- a/backend/src/adapters/tests/database.adapter.spec.ts
+++ b/backend/src/adapters/tests/database.adapter.spec.ts
@@ -7,7 +7,7 @@ import { config } from "dotenv";
 config({ path: '.env.test' });
 
 import { describe, expect, it, beforeAll, afterAll } from 'bun:test';
-import { eq, inArray, sql } from 'drizzle-orm';
+import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
 import db from '../../lib/drizzle/drizzle';
 import {
@@ -373,29 +373,45 @@ describe('ChatDatabaseAdapter', () => {
       expect(await adapter.isIndexOwner(fixture.networkId, fixture.userBId)).toBe(false);
     }, 15000);
 
-    it('should reject demoting the last owner (atomic guard)', async () => {
+    it('should reject demoting the last owner (transactional guard)', async () => {
       await resetRoles();
-      // A is sole owner. The atomic conditional UPDATE has a subquery that checks
-      // ownerCount > 1. With serial access, other guards (self, access-denied) fire
-      // before the atomic path. Test the conditional UPDATE directly at the SQL level
-      // to verify the subquery prevents demotion when ownerCount = 1.
+      // A is sole owner. The transactional guard locks owner rows with FOR UPDATE,
+      // counts them, and throws if <= 1. In serial access, application guards (self,
+      // access-denied) fire before this path, so test the guard directly via transaction.
       expect(await adapter.isIndexOwner(fixture.networkId, fixture.userAId)).toBe(true);
-      const directResult = await db
-        .update(networkMembers)
-        .set({ permissions: ['member'], updatedAt: new Date() })
-        .where(sql`
-          ${networkMembers.networkId} = ${fixture.networkId}
-          AND ${networkMembers.userId} = ${fixture.userAId}
-          AND ${networkMembers.deletedAt} IS NULL
-          AND (SELECT count(*) FROM ${networkMembers}
-               WHERE ${networkMembers.networkId} = ${fixture.networkId}
-               AND 'owner' = ANY(${networkMembers.permissions})
-               AND ${networkMembers.deletedAt} IS NULL) > 1
-        `)
-        .returning({ userId: networkMembers.userId });
-      // 0 rows returned — sole owner not demoted
-      expect(directResult.length).toBe(0);
-      // Confirm A is still owner
+      let threw = false;
+      try {
+        await db.transaction(async (tx) => {
+          const owners = await tx
+            .select({ userId: networkMembers.userId })
+            .from(networkMembers)
+            .where(and(
+              eq(networkMembers.networkId, fixture.networkId),
+              sql`'owner' = ANY(${networkMembers.permissions})`,
+              isNull(networkMembers.deletedAt)
+            ))
+            .for('update');
+          if (owners.length <= 1) {
+            throw new Error('Cannot demote the last owner');
+          }
+          await tx
+            .update(networkMembers)
+            .set({ permissions: ['member'], updatedAt: new Date() })
+            .where(and(
+              eq(networkMembers.networkId, fixture.networkId),
+              eq(networkMembers.userId, fixture.userAId),
+              isNull(networkMembers.deletedAt)
+            ));
+        });
+      } catch (err: unknown) {
+        if (err instanceof Error && err.message === 'Cannot demote the last owner') {
+          threw = true;
+        } else {
+          throw err;
+        }
+      }
+      expect(threw).toBe(true);
+      // Confirm A is still owner (transaction rolled back)
       expect(await adapter.isIndexOwner(fixture.networkId, fixture.userAId)).toBe(true);
     }, 15000);
 

--- a/backend/src/adapters/tests/database.adapter.spec.ts
+++ b/backend/src/adapters/tests/database.adapter.spec.ts
@@ -373,47 +373,44 @@ describe('ChatDatabaseAdapter', () => {
       expect(await adapter.isIndexOwner(fixture.networkId, fixture.userBId)).toBe(false);
     }, 15000);
 
-    it('should reject demoting the last owner (transactional guard)', async () => {
+    it('should reject demoting the last owner under concurrent demotions', async () => {
       await resetRoles();
-      // A is sole owner. The transactional guard locks owner rows with FOR UPDATE,
-      // counts them, and throws if <= 1. In serial access, application guards (self,
-      // access-denied) fire before this path, so test the guard directly via transaction.
-      expect(await adapter.isIndexOwner(fixture.networkId, fixture.userAId)).toBe(true);
-      let threw = false;
-      try {
-        await db.transaction(async (tx) => {
-          const owners = await tx
-            .select({ userId: networkMembers.userId })
-            .from(networkMembers)
-            .where(and(
-              eq(networkMembers.networkId, fixture.networkId),
-              sql`'owner' = ANY(${networkMembers.permissions})`,
-              isNull(networkMembers.deletedAt)
-            ))
-            .for('update');
-          if (owners.length <= 1) {
-            throw new Error('Cannot demote the last owner');
-          }
-          await tx
-            .update(networkMembers)
-            .set({ permissions: ['member'], updatedAt: new Date() })
-            .where(and(
-              eq(networkMembers.networkId, fixture.networkId),
-              eq(networkMembers.userId, fixture.userAId),
-              isNull(networkMembers.deletedAt)
-            ));
-        });
-      } catch (err: unknown) {
-        if (err instanceof Error && err.message === 'Cannot demote the last owner') {
-          threw = true;
-        } else {
-          throw err;
-        }
-      }
-      expect(threw).toBe(true);
-      // Confirm A is still owner (transaction rolled back)
-      expect(await adapter.isIndexOwner(fixture.networkId, fixture.userAId)).toBe(true);
-    }, 15000);
+      // Make both A and B owners (2 total)
+      await db.update(networkMembers).set({ permissions: ['owner'] }).where(
+        sql`${networkMembers.networkId} = ${fixture.networkId} AND ${networkMembers.userId} = ${fixture.userBId}`
+      );
+
+      // Concurrently: A demotes B, B demotes A.
+      // FOR UPDATE lock serializes the transactions — the second sees ownerCount = 1
+      // after the first commits and rejects the demotion.
+      const results = await Promise.allSettled([
+        adapter.updateMemberRole(fixture.networkId, fixture.userBId, fixture.userAId, 'member'),
+        adapter.updateMemberRole(fixture.networkId, fixture.userAId, fixture.userBId, 'member'),
+      ]);
+
+      const fulfilled = results.filter(r => r.status === 'fulfilled');
+      const rejected = results.filter(r => r.status === 'rejected');
+      expect(fulfilled.length).toBe(1);
+      expect(rejected.length).toBe(1);
+      // The rejected call hits either the demotion guard ("Cannot demote the last owner")
+      // or the access check ("Access denied") depending on timing — both prevent 0 owners.
+      const errorMsg = (rejected[0] as PromiseRejectedResult).reason.message;
+      expect(
+        errorMsg === 'Cannot demote the last owner' ||
+        errorMsg === 'Access denied: Only owners can change member roles'
+      ).toBe(true);
+
+      // Exactly one owner remains
+      const owners = await db
+        .select({ userId: networkMembers.userId })
+        .from(networkMembers)
+        .where(and(
+          eq(networkMembers.networkId, fixture.networkId),
+          sql`'owner' = ANY(${networkMembers.permissions})`,
+          isNull(networkMembers.deletedAt)
+        ));
+      expect(owners.length).toBe(1);
+    }, 30000);
 
     it('should reject self role change', async () => {
       await resetRoles();

--- a/backend/src/adapters/tests/database.adapter.spec.ts
+++ b/backend/src/adapters/tests/database.adapter.spec.ts
@@ -342,6 +342,43 @@ describe('ChatDatabaseAdapter', () => {
     expect(await adapter.isNetworkMember(fixture.networkId, uuidv4())).toBe(false);
   });
 
+  describe('updateMemberRole', () => {
+    it('should promote a member to owner', async () => {
+      // userB starts as a member
+      expect(await adapter.isIndexOwner(fixture.networkId, fixture.userBId)).toBe(false);
+      const result = await adapter.updateMemberRole(fixture.networkId, fixture.userBId, fixture.userAId, 'owner');
+      expect(result.member).toBeDefined();
+      expect(result.member!.permissions).toEqual(['owner']);
+      expect(await adapter.isIndexOwner(fixture.networkId, fixture.userBId)).toBe(true);
+    });
+
+    it('should demote an owner to member when multiple owners exist', async () => {
+      // userB is now an owner from the previous test; demote them
+      const result = await adapter.updateMemberRole(fixture.networkId, fixture.userBId, fixture.userAId, 'member');
+      expect(result.member!.permissions).toEqual(['member']);
+      expect(await adapter.isIndexOwner(fixture.networkId, fixture.userBId)).toBe(false);
+    });
+
+    it('should reject demoting the last owner', async () => {
+      // userA is the sole owner
+      await expect(
+        adapter.updateMemberRole(fixture.networkId, fixture.userAId, fixture.userAId, 'member')
+      ).rejects.toThrow('Cannot change your own role');
+    });
+
+    it('should reject self role change', async () => {
+      await expect(
+        adapter.updateMemberRole(fixture.networkId, fixture.userAId, fixture.userAId, 'owner')
+      ).rejects.toThrow('Cannot change your own role');
+    });
+
+    it('should reject role change by non-owner', async () => {
+      await expect(
+        adapter.updateMemberRole(fixture.networkId, fixture.userAId, fixture.userBId, 'member')
+      ).rejects.toThrow('Access denied');
+    });
+  });
+
   describe('getUserByEmail (IND-166)', () => {
     const caseTestUserId = uuidv4();
     const caseTestEmail = TEST_PREFIX + 'CaseSensitive@Test.COM';

--- a/backend/src/adapters/tests/database.adapter.spec.ts
+++ b/backend/src/adapters/tests/database.adapter.spec.ts
@@ -344,26 +344,51 @@ describe('ChatDatabaseAdapter', () => {
 
   describe('updateMemberRole', () => {
     it('should promote a member to owner', async () => {
-      // userB starts as a member
       expect(await adapter.isIndexOwner(fixture.networkId, fixture.userBId)).toBe(false);
       const result = await adapter.updateMemberRole(fixture.networkId, fixture.userBId, fixture.userAId, 'owner');
       expect(result.member).toBeDefined();
       expect(result.member!.permissions).toEqual(['owner']);
       expect(await adapter.isIndexOwner(fixture.networkId, fixture.userBId)).toBe(true);
+      // Restore: B back to member
+      await db.update(networkMembers).set({ permissions: ['member'] }).where(
+        sql`${networkMembers.networkId} = ${fixture.networkId} AND ${networkMembers.userId} = ${fixture.userBId}`
+      );
     });
 
     it('should demote an owner to member when multiple owners exist', async () => {
-      // userB is now an owner from the previous test; demote them
+      // Setup: make B an owner so there are two
+      await db.update(networkMembers).set({ permissions: ['owner'] }).where(
+        sql`${networkMembers.networkId} = ${fixture.networkId} AND ${networkMembers.userId} = ${fixture.userBId}`
+      );
+      // Act: A demotes B (two owners → one is fine)
       const result = await adapter.updateMemberRole(fixture.networkId, fixture.userBId, fixture.userAId, 'member');
       expect(result.member!.permissions).toEqual(['member']);
       expect(await adapter.isIndexOwner(fixture.networkId, fixture.userBId)).toBe(false);
     });
 
-    it('should reject demoting the last owner', async () => {
-      // userA is the sole owner
-      await expect(
-        adapter.updateMemberRole(fixture.networkId, fixture.userAId, fixture.userAId, 'member')
-      ).rejects.toThrow('Cannot change your own role');
+    it('should reject demoting the last owner (atomic guard)', async () => {
+      // A is sole owner. The atomic conditional UPDATE has a subquery that checks
+      // ownerCount > 1. With serial access, other guards (self, access-denied) fire
+      // before the atomic path. Test the conditional UPDATE directly at the SQL level
+      // to verify the subquery prevents demotion when ownerCount = 1.
+      expect(await adapter.isIndexOwner(fixture.networkId, fixture.userAId)).toBe(true);
+      const directResult = await db
+        .update(networkMembers)
+        .set({ permissions: ['member'], updatedAt: new Date() })
+        .where(sql`
+          ${networkMembers.networkId} = ${fixture.networkId}
+          AND ${networkMembers.userId} = ${fixture.userAId}
+          AND ${networkMembers.deletedAt} IS NULL
+          AND (SELECT count(*) FROM ${networkMembers}
+               WHERE ${networkMembers.networkId} = ${fixture.networkId}
+               AND 'owner' = ANY(${networkMembers.permissions})
+               AND ${networkMembers.deletedAt} IS NULL) > 1
+        `)
+        .returning({ userId: networkMembers.userId });
+      // 0 rows returned — sole owner not demoted
+      expect(directResult.length).toBe(0);
+      // Confirm A is still owner
+      expect(await adapter.isIndexOwner(fixture.networkId, fixture.userAId)).toBe(true);
     });
 
     it('should reject self role change', async () => {
@@ -373,6 +398,7 @@ describe('ChatDatabaseAdapter', () => {
     });
 
     it('should reject role change by non-owner', async () => {
+      expect(await adapter.isIndexOwner(fixture.networkId, fixture.userBId)).toBe(false);
       await expect(
         adapter.updateMemberRole(fixture.networkId, fixture.userAId, fixture.userBId, 'member')
       ).rejects.toThrow('Access denied');

--- a/backend/src/controllers/network.controller.ts
+++ b/backend/src/controllers/network.controller.ts
@@ -403,7 +403,16 @@ export class NetworkController {
         headers: { 'Content-Type': 'application/json' },
       });
     }
-    const role = body.permissions.includes('owner') ? 'owner' as const : 'member' as const;
+    // Strict validation: only ['owner'] or ['member'] are accepted
+    const isOwnerRole = body.permissions.length === 1 && body.permissions[0] === 'owner';
+    const isMemberRole = body.permissions.length === 1 && body.permissions[0] === 'member';
+    if (!isOwnerRole && !isMemberRole) {
+      return new Response(JSON.stringify({ error: "permissions must be exactly ['owner'] or ['member']" }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    const role = isOwnerRole ? 'owner' as const : 'member' as const;
     try {
       await assertAgentNetworkScope(req, params.id);
       const result = await networkService.updateMemberRole(params.id, params.memberId, user.id, role);

--- a/backend/src/controllers/network.controller.ts
+++ b/backend/src/controllers/network.controller.ts
@@ -375,7 +375,13 @@ export class NetworkController {
     try {
       await assertAgentNetworkScope(req, params.id);
       let role: 'owner' | 'member' = 'member';
-      if (body.permissions) {
+      if (body.permissions !== undefined) {
+        if (!Array.isArray(body.permissions)) {
+          return new Response(JSON.stringify({ error: "permissions must be an array" }), {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
         const isOwnerRole = body.permissions.length === 1 && body.permissions[0] === 'owner';
         const isMemberRole = body.permissions.length === 1 && body.permissions[0] === 'member';
         if (!isOwnerRole && !isMemberRole) {

--- a/backend/src/controllers/network.controller.ts
+++ b/backend/src/controllers/network.controller.ts
@@ -423,7 +423,7 @@ export class NetworkController {
           headers: { 'Content-Type': 'application/json' },
         });
       }
-      if (msg === 'Cannot demote the last owner' || msg === 'Cannot change role of a contact') {
+      if (msg === 'Cannot demote the last owner' || msg === 'Cannot change role of a contact' || msg === 'Cannot change your own role') {
         return new Response(JSON.stringify({ error: msg }), {
           status: 400,
           headers: { 'Content-Type': 'application/json' },

--- a/backend/src/controllers/network.controller.ts
+++ b/backend/src/controllers/network.controller.ts
@@ -374,7 +374,18 @@ export class NetworkController {
     }
     try {
       await assertAgentNetworkScope(req, params.id);
-      const role = body.permissions?.includes('owner') ? 'owner' as const : 'member' as const;
+      let role: 'owner' | 'member' = 'member';
+      if (body.permissions) {
+        const isOwnerRole = body.permissions.length === 1 && body.permissions[0] === 'owner';
+        const isMemberRole = body.permissions.length === 1 && body.permissions[0] === 'member';
+        if (!isOwnerRole && !isMemberRole) {
+          return new Response(JSON.stringify({ error: "permissions must be exactly ['owner'] or ['member']" }), {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        role = isOwnerRole ? 'owner' : 'member';
+      }
       const result = await networkService.addMember(params.id, body.userId, user.id, role);
       return Response.json({ member: result.member, message: result.alreadyMember ? 'Already a member' : 'Member added' });
     } catch (err: unknown) {

--- a/backend/src/controllers/network.controller.ts
+++ b/backend/src/controllers/network.controller.ts
@@ -360,7 +360,7 @@ export class NetworkController {
   }
 
   /**
-   * Add a member to a network. Owner/admin-only.
+   * Add a member to a network. Owner-only.
    */
   @Post('/:id/members')
   @UseGuards(RateLimit('write'), AuthOrApiKeyGuard)
@@ -374,7 +374,7 @@ export class NetworkController {
     }
     try {
       await assertAgentNetworkScope(req, params.id);
-      const role = body.permissions?.includes('admin') ? 'admin' as const : 'member' as const;
+      const role = body.permissions?.includes('owner') ? 'owner' as const : 'member' as const;
       const result = await networkService.addMember(params.id, body.userId, user.id, role);
       return Response.json({ member: result.member, message: result.alreadyMember ? 'Already a member' : 'Member added' });
     } catch (err: unknown) {
@@ -382,6 +382,50 @@ export class NetworkController {
       if (msg.includes('Access denied')) {
         return new Response(JSON.stringify({ error: msg }), {
           status: 403,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Update a member's role. Owner-only.
+   * Accepts { permissions: ['owner'] } or { permissions: ['member'] }.
+   */
+  @Patch('/:id/members/:memberId')
+  @UseGuards(RateLimit('write'), AuthOrApiKeyGuard)
+  async updateMemberRole(req: Request, user: AuthenticatedUser, params: Record<string, string>) {
+    const body = await req.json().catch(() => ({})) as { permissions?: string[] };
+    if (!body.permissions || !Array.isArray(body.permissions)) {
+      return new Response(JSON.stringify({ error: 'permissions array is required' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    const role = body.permissions.includes('owner') ? 'owner' as const : 'member' as const;
+    try {
+      await assertAgentNetworkScope(req, params.id);
+      const result = await networkService.updateMemberRole(params.id, params.memberId, user.id, role);
+      logger.verbose('Member role updated', { networkId: params.id, memberId: params.memberId, role });
+      return Response.json({ member: result.member, message: 'Role updated' });
+    } catch (err: unknown) {
+      const msg = errorMessage(err);
+      if (msg.includes('Access denied')) {
+        return new Response(JSON.stringify({ error: msg }), {
+          status: 403,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (msg === 'Member not found') {
+        return new Response(JSON.stringify({ error: msg }), {
+          status: 404,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (msg === 'Cannot demote the last owner' || msg === 'Cannot change role of a contact') {
+        return new Response(JSON.stringify({ error: msg }), {
+          status: 400,
           headers: { 'Content-Type': 'application/json' },
         });
       }

--- a/backend/src/services/network.service.ts
+++ b/backend/src/services/network.service.ts
@@ -160,13 +160,23 @@ export class NetworkService {
   }
 
   /**
-   * Add a member to an index. Only owners/admins can add members.
+   * Add a member to an index. Owner-only.
    * @throws Error if the index is a personal index.
    */
-  async addMember(networkId: string, userId: string, requestingUserId: string, role: 'admin' | 'member' = 'member') {
+  async addMember(networkId: string, userId: string, requestingUserId: string, role: 'owner' | 'member' = 'member') {
     logger.verbose('[NetworkService] Adding member', { networkId, userId, role });
     await this.assertNotPersonal(networkId);
-    return this.adapter.addMemberForOwnerOrAdmin(networkId, userId, requestingUserId, role);
+    return this.adapter.addMemberForOwner(networkId, userId, requestingUserId, role);
+  }
+
+  /**
+   * Update a member's role (owner ↔ member). Owner-only.
+   * @throws Error if the index is personal, member not found, or last owner.
+   */
+  async updateMemberRole(networkId: string, targetUserId: string, requestingUserId: string, role: 'owner' | 'member') {
+    logger.verbose('[NetworkService] Updating member role', { networkId, targetUserId, role });
+    await this.assertNotPersonal(networkId);
+    return this.adapter.updateMemberRole(networkId, targetUserId, requestingUserId, role);
   }
 
   /**

--- a/bun.lock
+++ b/bun.lock
@@ -133,7 +133,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "dependencies": {
         "@langchain/core": "^1.1.17",
         "@langchain/langgraph": "^1.1.2",

--- a/frontend/src/components/settings/AccessTab.tsx
+++ b/frontend/src/components/settings/AccessTab.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import * as AlertDialog from '@radix-ui/react-alert-dialog';
 import * as Dialog from '@radix-ui/react-dialog';
-import { Copy, Globe, Lock, Trash2, Plus, Check, ChevronRight, ChevronLeft, Upload, Download, X, RotateCw } from 'lucide-react';
+import { Copy, Globe, Lock, Trash2, Plus, Check, ChevronRight, ChevronLeft, Upload, Download, X, RotateCw, Shield, ShieldOff } from 'lucide-react';
 
 import { Network } from '@/lib/types';
 import { Button } from '@/components/ui/button';
@@ -57,6 +57,7 @@ export default function AccessTab({
 
   const [resendTarget, setResendTarget] = useState<Member | null>(null);
   const [isResendInFlight, setIsResendInFlight] = useState(false);
+  const [roleChangeTarget, setRoleChangeTarget] = useState<{ member: Member; newRole: 'owner' | 'member' } | null>(null);
 
   const csvInputRef = useRef<HTMLInputElement>(null);
   const [csvPreview, setCsvPreview] = useState<ParsedCsvResult | null>(null);
@@ -190,6 +191,18 @@ export default function AccessTab({
       setMembers(prev => prev.filter(m => m.id !== memberId));
     } catch (err) {
       console.error('Error removing member:', err);
+    }
+  };
+
+  const handleUpdateMemberRole = async (memberId: string, newRole: 'owner' | 'member') => {
+    try {
+      const permissions = newRole === 'owner' ? ['owner'] : ['member'];
+      const updated = await networkService.updateMemberPermissions(networkId, memberId, permissions);
+      setMembers(prev => prev.map(m => m.id === memberId ? { ...m, permissions: updated.permissions } : m));
+      success(`Role updated to ${newRole}`);
+    } catch (err) {
+      console.error('Error updating member role:', err);
+      error(err instanceof Error ? err.message : 'Failed to update role');
     }
   };
 
@@ -481,6 +494,28 @@ export default function AccessTab({
                     {member.permissions.includes('member') ? 'Member' : 'Contact'}
                   </span>
                 )}
+                {/* Role change: promote member → owner */}
+                {!member.permissions.includes('owner') && member.permissions.includes('member') && member.id !== currentUser?.id && (
+                  <Tooltip content="Promote to owner">
+                    <button
+                      onClick={() => setRoleChangeTarget({ member, newRole: 'owner' })}
+                      className="hidden group-hover:block p-1 text-gray-300 hover:text-gray-900 transition-colors flex-shrink-0"
+                    >
+                      <Shield className="h-3.5 w-3.5" />
+                    </button>
+                  </Tooltip>
+                )}
+                {/* Role change: demote owner → member */}
+                {member.permissions.includes('owner') && member.id !== currentUser?.id && (
+                  <Tooltip content="Demote to member">
+                    <button
+                      onClick={() => setRoleChangeTarget({ member, newRole: 'member' })}
+                      className="hidden group-hover:block p-1 text-gray-300 hover:text-gray-900 transition-colors flex-shrink-0"
+                    >
+                      <ShieldOff className="h-3.5 w-3.5" />
+                    </button>
+                  </Tooltip>
+                )}
                 {network.isExperiment && (
                   <Tooltip content="Resend invitation · expires old key">
                     <button
@@ -553,6 +588,35 @@ export default function AccessTab({
               </AlertDialog.Cancel>
               <Button onClick={handleConfirmResend} disabled={isResendInFlight}>
                 {isResendInFlight ? 'Sending...' : 'Resend'}
+              </Button>
+            </div>
+          </AlertDialog.Content>
+        </AlertDialog.Portal>
+      </AlertDialog.Root>
+
+      {/* Role change dialog */}
+      <AlertDialog.Root open={roleChangeTarget !== null} onOpenChange={(open) => { if (!open) setRoleChangeTarget(null); }}>
+        <AlertDialog.Portal>
+          <AlertDialog.Overlay className="fixed inset-0 bg-black/50 z-[100]" />
+          <AlertDialog.Content className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-white rounded-sm shadow-lg p-6 w-full max-w-md z-[100] focus:outline-none">
+            <AlertDialog.Title className="text-lg font-bold text-gray-900 mb-4">
+              {roleChangeTarget?.newRole === 'owner' ? 'Promote' : 'Demote'} {roleChangeTarget?.member.name || 'this member'}?
+            </AlertDialog.Title>
+            <AlertDialog.Description className="text-sm text-gray-600 mb-4">
+              {roleChangeTarget?.newRole === 'owner'
+                ? 'This will give them full control of this community — they can manage settings, members, and integrations.'
+                : 'This will remove their owner privileges. They will remain a member but won\'t be able to manage settings or members.'}
+            </AlertDialog.Description>
+            <div className="flex justify-end gap-2">
+              <AlertDialog.Cancel asChild>
+                <Button variant="outline">Cancel</Button>
+              </AlertDialog.Cancel>
+              <Button onClick={async () => {
+                if (!roleChangeTarget) return;
+                await handleUpdateMemberRole(roleChangeTarget.member.id, roleChangeTarget.newRole);
+                setRoleChangeTarget(null);
+              }}>
+                {roleChangeTarget?.newRole === 'owner' ? 'Promote to Owner' : 'Demote to Member'}
               </Button>
             </div>
           </AlertDialog.Content>

--- a/frontend/src/components/settings/AccessTab.tsx
+++ b/frontend/src/components/settings/AccessTab.tsx
@@ -498,6 +498,8 @@ export default function AccessTab({
                 {!member.permissions.includes('owner') && member.permissions.includes('member') && member.id !== currentUser?.id && (
                   <Tooltip content="Promote to owner">
                     <button
+                      type="button"
+                      aria-label="Promote to owner"
                       onClick={() => setRoleChangeTarget({ member, newRole: 'owner' })}
                       className="hidden group-hover:block p-1 text-gray-300 hover:text-gray-900 transition-colors flex-shrink-0"
                     >
@@ -509,6 +511,8 @@ export default function AccessTab({
                 {member.permissions.includes('owner') && member.id !== currentUser?.id && (
                   <Tooltip content="Demote to member">
                     <button
+                      type="button"
+                      aria-label="Demote to member"
                       onClick={() => setRoleChangeTarget({ member, newRole: 'member' })}
                       className="hidden group-hover:block p-1 text-gray-300 hover:text-gray-900 transition-colors flex-shrink-0"
                     >

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-"version": "1.8.0",
+  "version": "1.8.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/shared/interfaces/database.interface.ts
+++ b/packages/protocol/src/shared/interfaces/database.interface.ts
@@ -1067,7 +1067,7 @@ export interface Database {
   addMemberToNetwork(
     networkId: string,
     userId: string,
-    role: 'owner' | 'admin' | 'member'
+    role: 'owner' | 'member'
   ): Promise<{ success: boolean; alreadyMember?: boolean }>;
 
   /**
@@ -1699,7 +1699,7 @@ export interface SystemDatabase {
   getMembersFromScope(): Promise<{ userId: Id<'users'>; name: string; avatar: string | null }[]>;
 
   /** Add a user to an index (requires ownership or 'anyone' policy). */
-  addMemberToNetwork(networkId: string, userId: string, role: 'owner' | 'admin' | 'member'): Promise<{ success: boolean; alreadyMember?: boolean }>;
+  addMemberToNetwork(networkId: string, userId: string, role: 'owner' | 'member'): Promise<{ success: boolean; alreadyMember?: boolean }>;
 
   /** Remove a user from an index (requires ownership). Cannot remove the owner. */
   removeMemberFromIndex(networkId: string, userId: string): Promise<{ success: boolean; wasOwner?: boolean; notMember?: boolean }>;

--- a/packages/protocol/src/shared/interfaces/database.interface.ts
+++ b/packages/protocol/src/shared/interfaces/database.interface.ts
@@ -1061,7 +1061,7 @@ export interface Database {
    *
    * @param networkId - The network to add to
    * @param userId - The user to add
-   * @param role - owner | admin | member
+   * @param role - owner | member
    * @returns success and optionally alreadyMember if they were already in the network
    */
   addMemberToNetwork(


### PR DESCRIPTION
## New Features
- `PATCH /networks/:id/members/:memberId` endpoint for promoting/demoting members (owner ↔ member)
- Frontend: shield/shield-off hover actions on member rows with confirmation dialog in AccessTab
- Server-side guards: last-owner protection (atomic), contact exclusion, self-exclusion

## Refactors
- Drop the admin permission tier — migration 0074 promotes all existing admins to owners
- Rename `addMemberForOwnerOrAdmin` → `addMemberForOwner`, remove `'admin'` from role union types

## Tests
- Add `updateMemberRole` integration tests to `database.adapter.spec.ts`: promote, demote, last-owner rejection, self-exclusion, non-owner rejection

## Test plan
- [ ] Verify migration 0074 runs cleanly on dev DB
- [ ] Promote a member to owner via the UI — confirm they see settings tab
- [ ] Demote an owner to member — confirm settings tab disappears for them
- [ ] Attempt to demote the last owner — should get "Cannot demote the last owner" error
- [ ] Verify contacts cannot be promoted (no shield icon shown)
- [ ] Verify self cannot be promoted/demoted (no shield icon shown for own row)