### PR TITLE
feat: QuestionerAgent Slice 3 — REST endpoints, events, discovery migration

### DIFF
--- a/backend/src/adapters/questioner.adapter.ts
+++ b/backend/src/adapters/questioner.adapter.ts
@@ -152,48 +152,75 @@ export class QuestionerAdapter {
   /**
    * Record an answer for a question, setting its status to `answered`.
    * Emits `QuestionEvents.onAnswered` after persisting the answer.
+   * Only updates the question if the user is listed as an actor.
    *
    * @param questionId - ID of the question to answer.
+   * @param userId     - Authenticated user; must be an actor on the question.
    * @param answer     - The user's response data.
+   * @returns `true` if a row was updated, `false` if no matching question found.
    */
-  async answer(questionId: string, answer: AdapterQuestionAnswer): Promise<void> {
+  async answer(questionId: string, userId: string, answer: AdapterQuestionAnswer): Promise<boolean> {
+    const ownershipCheck = and(
+      eq(questions.id, questionId),
+      sql`${questions.actors}::jsonb @> ${JSON.stringify([{ userId }])}::jsonb`,
+    );
+
     const [existing] = await this.db
       .select()
       .from(questions)
-      .where(eq(questions.id, questionId));
+      .where(ownershipCheck);
+
+    if (!existing) return false;
 
     await this.db
       .update(questions)
       .set({ status: 'answered', answer })
-      .where(eq(questions.id, questionId));
+      .where(ownershipCheck);
 
-    if (existing) {
-      const detection = existing.detection as AdapterQuestionDetection;
-      const actors = existing.actors as AdapterQuestionActor[];
-      const firstActor = actors[0];
-      if (firstActor) {
-        QuestionEvents.onAnswered({
-          questionId,
-          userId: firstActor.userId,
-          mode: detection.mode,
-          sourceType: detection.sourceType,
-          sourceId: detection.sourceId,
-          answer,
-        });
-      }
+    const detection = existing.detection as AdapterQuestionDetection;
+    const actors = existing.actors as AdapterQuestionActor[];
+    const firstActor = actors[0];
+    if (firstActor) {
+      QuestionEvents.onAnswered({
+        questionId,
+        userId: firstActor.userId,
+        mode: detection.mode,
+        sourceType: detection.sourceType,
+        sourceId: detection.sourceId,
+        answer,
+      });
     }
+
+    return true;
   }
 
   /**
    * Dismiss a question, setting its status to `dismissed`.
+   * Only updates the question if the user is listed as an actor.
    *
    * @param questionId - ID of the question to dismiss.
+   * @param userId     - Authenticated user; must be an actor on the question.
+   * @returns `true` if a row was updated, `false` if no matching question found.
    */
-  async dismiss(questionId: string): Promise<void> {
+  async dismiss(questionId: string, userId: string): Promise<boolean> {
+    const ownershipCheck = and(
+      eq(questions.id, questionId),
+      sql`${questions.actors}::jsonb @> ${JSON.stringify([{ userId }])}::jsonb`,
+    );
+
+    const [existing] = await this.db
+      .select({ id: questions.id })
+      .from(questions)
+      .where(ownershipCheck);
+
+    if (!existing) return false;
+
     await this.db
       .update(questions)
       .set({ status: 'dismissed' })
-      .where(eq(questions.id, questionId));
+      .where(ownershipCheck);
+
+    return true;
   }
 }
 

--- a/backend/src/adapters/questioner.adapter.ts
+++ b/backend/src/adapters/questioner.adapter.ts
@@ -16,6 +16,7 @@ import { eq, and, sql } from 'drizzle-orm';
 import { questions } from '../schemas/database.schema';
 import type { QuestionDetection, QuestionActor } from '../schemas/database.schema';
 import type { DrizzleDB } from '../lib/drizzle/drizzle';
+import { QuestionEvents } from '../events/question.event';
 
 // ─── Local adapter types (structurally aligned with protocol contracts) ───────
 
@@ -94,9 +95,10 @@ export class QuestionerAdapter {
    * Persist a batch of generated questions.
    *
    * @param batch - Questions to insert (up to 3 per generation).
+   * @returns The IDs of the inserted rows.
    */
-  async persist(batch: AdapterPersistableQuestion[]): Promise<void> {
-    if (batch.length === 0) return;
+  async persist(batch: AdapterPersistableQuestion[]): Promise<string[]> {
+    if (batch.length === 0) return [];
     const rows = batch.map((q) => ({
       detection: { ...q.detection, strategy: q.strategy } satisfies QuestionDetection,
       actors: q.actors as QuestionActor[],
@@ -104,7 +106,8 @@ export class QuestionerAdapter {
       status: 'pending' as const,
     }));
 
-    await this.db.insert(questions).values(rows);
+    const inserted = await this.db.insert(questions).values(rows).returning({ id: questions.id });
+    return inserted.map((r) => r.id);
   }
 
   /**
@@ -148,15 +151,37 @@ export class QuestionerAdapter {
 
   /**
    * Record an answer for a question, setting its status to `answered`.
+   * Emits `QuestionEvents.onAnswered` after persisting the answer.
    *
    * @param questionId - ID of the question to answer.
    * @param answer     - The user's response data.
    */
   async answer(questionId: string, answer: AdapterQuestionAnswer): Promise<void> {
+    const [existing] = await this.db
+      .select()
+      .from(questions)
+      .where(eq(questions.id, questionId));
+
     await this.db
       .update(questions)
       .set({ status: 'answered', answer })
       .where(eq(questions.id, questionId));
+
+    if (existing) {
+      const detection = existing.detection as AdapterQuestionDetection;
+      const actors = existing.actors as AdapterQuestionActor[];
+      const firstActor = actors[0];
+      if (firstActor) {
+        QuestionEvents.onAnswered({
+          questionId,
+          userId: firstActor.userId,
+          mode: detection.mode,
+          sourceType: detection.sourceType,
+          sourceId: detection.sourceId,
+          answer,
+        });
+      }
+    }
   }
 
   /**

--- a/backend/src/adapters/questioner.adapter.ts
+++ b/backend/src/adapters/questioner.adapter.ts
@@ -160,25 +160,21 @@ export class QuestionerAdapter {
    * @returns `true` if a row was updated, `false` if no matching question found.
    */
   async answer(questionId: string, userId: string, answer: AdapterQuestionAnswer): Promise<boolean> {
-    const ownershipCheck = and(
-      eq(questions.id, questionId),
-      eq(questions.status, 'pending'),
-      sql`${questions.actors}::jsonb @> ${JSON.stringify([{ userId }])}::jsonb`,
-    );
-
-    const [existing] = await this.db
-      .select()
-      .from(questions)
-      .where(ownershipCheck);
-
-    if (!existing) return false;
-
-    await this.db
+    const [updated] = await this.db
       .update(questions)
       .set({ status: 'answered', answer })
-      .where(ownershipCheck);
+      .where(
+        and(
+          eq(questions.id, questionId),
+          eq(questions.status, 'pending'),
+          sql`${questions.actors}::jsonb @> ${JSON.stringify([{ userId }])}::jsonb`,
+        ),
+      )
+      .returning({ id: questions.id, detection: questions.detection });
 
-    const detection = existing.detection as AdapterQuestionDetection;
+    if (!updated) return false;
+
+    const detection = updated.detection as AdapterQuestionDetection;
     QuestionEvents.onAnswered({
       questionId,
       userId,
@@ -200,25 +196,19 @@ export class QuestionerAdapter {
    * @returns `true` if a row was updated, `false` if no matching question found.
    */
   async dismiss(questionId: string, userId: string): Promise<boolean> {
-    const ownershipCheck = and(
-      eq(questions.id, questionId),
-      eq(questions.status, 'pending'),
-      sql`${questions.actors}::jsonb @> ${JSON.stringify([{ userId }])}::jsonb`,
-    );
-
-    const [existing] = await this.db
-      .select({ id: questions.id })
-      .from(questions)
-      .where(ownershipCheck);
-
-    if (!existing) return false;
-
-    await this.db
+    const [updated] = await this.db
       .update(questions)
       .set({ status: 'dismissed' })
-      .where(ownershipCheck);
+      .where(
+        and(
+          eq(questions.id, questionId),
+          eq(questions.status, 'pending'),
+          sql`${questions.actors}::jsonb @> ${JSON.stringify([{ userId }])}::jsonb`,
+        ),
+      )
+      .returning({ id: questions.id });
 
-    return true;
+    return !!updated;
   }
 }
 

--- a/backend/src/adapters/questioner.adapter.ts
+++ b/backend/src/adapters/questioner.adapter.ts
@@ -178,18 +178,14 @@ export class QuestionerAdapter {
       .where(ownershipCheck);
 
     const detection = existing.detection as AdapterQuestionDetection;
-    const actors = existing.actors as AdapterQuestionActor[];
-    const firstActor = actors[0];
-    if (firstActor) {
-      QuestionEvents.onAnswered({
-        questionId,
-        userId: firstActor.userId,
-        mode: detection.mode,
-        sourceType: detection.sourceType,
-        sourceId: detection.sourceId,
-        answer,
-      });
-    }
+    QuestionEvents.onAnswered({
+      questionId,
+      userId,
+      mode: detection.mode,
+      sourceType: detection.sourceType,
+      sourceId: detection.sourceId,
+      answer,
+    });
 
     return true;
   }

--- a/backend/src/adapters/questioner.adapter.ts
+++ b/backend/src/adapters/questioner.adapter.ts
@@ -162,6 +162,7 @@ export class QuestionerAdapter {
   async answer(questionId: string, userId: string, answer: AdapterQuestionAnswer): Promise<boolean> {
     const ownershipCheck = and(
       eq(questions.id, questionId),
+      eq(questions.status, 'pending'),
       sql`${questions.actors}::jsonb @> ${JSON.stringify([{ userId }])}::jsonb`,
     );
 
@@ -201,6 +202,7 @@ export class QuestionerAdapter {
   async dismiss(questionId: string, userId: string): Promise<boolean> {
     const ownershipCheck = and(
       eq(questions.id, questionId),
+      eq(questions.status, 'pending'),
       sql`${questions.actors}::jsonb @> ${JSON.stringify([{ userId }])}::jsonb`,
     );
 

--- a/backend/src/controllers/mcp.controller.ts
+++ b/backend/src/controllers/mcp.controller.ts
@@ -45,7 +45,7 @@ import type { ConnectLinkKind } from '../services/connect-link.service';
 import { mintConnectLink as mintConnectLinkSvc, buildConnectShortUrl } from '../services/connect-link.service';
 
 import { IntentGraphFactory, ProfileGraphFactory, OpportunityGraphFactory, HydeGraphFactory, NetworkGraphFactory, NetworkMembershipGraphFactory, IntentNetworkGraphFactory, NegotiationGraphFactory, HydeGenerator, LensInferrer, IntentIndexer, createMcpServer, ChatGraphFactory, PremiseGraphFactory } from '@indexnetwork/protocol';
-import type { HydeGraphDatabase, PremiseGraphDatabase, ToolDeps, McpAuthResolver, ScopedDepsFactory, Embedder, ChatGraphCompositeDatabase } from '@indexnetwork/protocol';
+import type { HydeGraphDatabase, PremiseGraphDatabase, ToolDeps, McpAuthResolver, ScopedDepsFactory, Embedder, ChatGraphCompositeDatabase, QuestionerEnqueuePayload } from '@indexnetwork/protocol';
 
 import { BASE_URL, JWT_AUDIENCE } from '../lib/betterauth/betterauth';
 import { log } from '../lib/log';
@@ -120,20 +120,7 @@ const protocolDeps = {
   apiBaseUrl,
   questionerDatabase: questionerAdapter,
   ...(process.env.QUESTIONER_ENABLED === 'true' && {
-    questionerEnqueue: async (input: {
-      mode: 'discovery';
-      userId: string;
-      sourceType: string;
-      sourceId: string;
-      context: {
-        query: string;
-        sourceProfile: unknown;
-        negotiationDigests: unknown[];
-        summary: unknown;
-        chatContext?: unknown;
-        now: string;
-      };
-    }) => {
+    questionerEnqueue: async (input: QuestionerEnqueuePayload) => {
       await questionerQueue.addGenerateJob(input as Parameters<typeof questionerQueue.addGenerateJob>[0]);
     },
   }),

--- a/backend/src/controllers/mcp.controller.ts
+++ b/backend/src/controllers/mcp.controller.ts
@@ -28,6 +28,7 @@ import { ChatSummaryDatabaseAdapter } from '../adapters/chat-summary.database.ad
 import { ChatMessageWriterAdapter } from '../adapters/chat-message-writer.adapter';
 import { enricherAdapter } from '../adapters/enricher.adapter';
 import { QuestionerAdapter } from '../adapters/questioner.adapter';
+import { questionerQueue } from '../queues/questioner.queue';
 import db from '../lib/drizzle/drizzle';
 import { agentService } from '../services/agent.service';
 import { chatSessionService } from '../services/chat.service';
@@ -118,6 +119,24 @@ const protocolDeps = {
   frontendUrl: process.env.FRONTEND_URL ?? process.env.APP_URL ?? 'https://index.network',
   apiBaseUrl,
   questionerDatabase: questionerAdapter,
+  ...(process.env.QUESTIONER_ENABLED === 'true' && {
+    questionerEnqueue: async (input: {
+      mode: 'discovery';
+      userId: string;
+      sourceType: string;
+      sourceId: string;
+      context: {
+        query: string;
+        sourceProfile: unknown;
+        negotiationDigests: unknown[];
+        summary: unknown;
+        chatContext?: unknown;
+        now: string;
+      };
+    }) => {
+      await questionerQueue.addGenerateJob(input as Parameters<typeof questionerQueue.addGenerateJob>[0]);
+    },
+  }),
 };
 
 const chatSessionReader = {

--- a/backend/src/controllers/mcp.controller.ts
+++ b/backend/src/controllers/mcp.controller.ts
@@ -418,6 +418,7 @@ function getOrCreateMcpServer(): McpServer {
     mintConnectLink: protocolDeps.mintConnectLink,
     frontendUrl: protocolDeps.frontendUrl,
     apiBaseUrl: protocolDeps.apiBaseUrl,
+    ...(protocolDeps.questionerEnqueue && { questionerEnqueue: protocolDeps.questionerEnqueue }),
     graphs,
   };
 

--- a/backend/src/controllers/question.controller.ts
+++ b/backend/src/controllers/question.controller.ts
@@ -58,9 +58,11 @@ export class QuestionController {
     }
     const status = statusResult.data;
 
-    // Currently only pending queries are supported via the adapter
     if (status !== 'pending') {
-      return Response.json({ questions: [] });
+      return Response.json(
+        { error: 'Only status=pending is currently supported' },
+        { status: 400 },
+      );
     }
 
     const filters: AdapterQuestionFilters = {};

--- a/backend/src/controllers/question.controller.ts
+++ b/backend/src/controllers/question.controller.ts
@@ -116,11 +116,15 @@ export class QuestionController {
       );
     }
 
-    await questionService.answer(questionId, {
+    const updated = await questionService.answer(questionId, user.id, {
       ...parsed.data,
       answeredBy: user.id,
       answeredAt: new Date().toISOString(),
     });
+
+    if (!updated) {
+      return Response.json({ error: 'Question not found' }, { status: 404 });
+    }
 
     logger.info('Question answered', { questionId, userId: user.id });
     return Response.json({ success: true });
@@ -142,7 +146,11 @@ export class QuestionController {
       return Response.json({ error: 'Question ID is required' }, { status: 400 });
     }
 
-    await questionService.dismiss(questionId);
+    const updated = await questionService.dismiss(questionId, user.id);
+
+    if (!updated) {
+      return Response.json({ error: 'Question not found' }, { status: 404 });
+    }
 
     logger.info('Question dismissed', { questionId, userId: user.id });
     return Response.json({ success: true });

--- a/backend/src/controllers/question.controller.ts
+++ b/backend/src/controllers/question.controller.ts
@@ -1,0 +1,150 @@
+import { z } from 'zod';
+
+import { questionService } from '../services/question.service';
+import type { AdapterQuestionFilters } from '../services/question.service';
+
+import { Controller, Get, Post, UseGuards } from '../lib/router/router.decorators';
+import { AuthGuard } from '../guards/auth.guard';
+import { RateLimit } from '../guards/limiter.guard';
+import type { AuthenticatedUser } from '../guards/auth.guard';
+import { log } from '../lib/log';
+
+const logger = log.controller.from('question');
+
+type RouteParams = Record<string, string>;
+
+const answerBodySchema = z.object({
+  selectedOptions: z.array(z.string()),
+  freeText: z.string().optional(),
+});
+
+const statusQuerySchema = z.enum(['pending', 'answered', 'dismissed']).default('pending');
+const modeQuerySchema = z.enum(['discovery', 'intent', 'profile', 'negotiation']);
+
+/**
+ * QuestionController: REST API for question delivery and lifecycle.
+ *
+ * Endpoints:
+ * - GET /questions — list questions for the authenticated user
+ * - POST /questions/:id/answer — submit an answer
+ * - POST /questions/:id/dismiss — dismiss a question
+ */
+@Controller('/questions')
+export class QuestionController {
+  /**
+   * GET /questions — list questions for the authenticated user.
+   *
+   * Query params: status (default: pending), mode, sourceType, sourceId.
+   *
+   * @param req  - Incoming request with optional query params.
+   * @param user - Authenticated user from AuthGuard.
+   * @returns JSON with `{ questions }` array.
+   */
+  @Get('')
+  @UseGuards(RateLimit('read'), AuthGuard)
+  async list(req: Request, user: AuthenticatedUser, _params?: RouteParams) {
+    const url = new URL(req.url, `http://${req.headers.get('host') || 'localhost'}`);
+    const rawStatus = url.searchParams.get('status');
+    const rawMode = url.searchParams.get('mode');
+    const sourceType = url.searchParams.get('sourceType');
+    const sourceId = url.searchParams.get('sourceId');
+
+    const statusResult = statusQuerySchema.safeParse(rawStatus ?? 'pending');
+    if (!statusResult.success) {
+      return Response.json(
+        { error: 'Invalid status; use one of: pending, answered, dismissed' },
+        { status: 400 },
+      );
+    }
+    const status = statusResult.data;
+
+    // Currently only pending queries are supported via the adapter
+    if (status !== 'pending') {
+      return Response.json({ questions: [] });
+    }
+
+    const filters: AdapterQuestionFilters = {};
+
+    if (rawMode) {
+      const modeResult = modeQuerySchema.safeParse(rawMode);
+      if (!modeResult.success) {
+        return Response.json(
+          { error: 'Invalid mode; use one of: discovery, intent, profile, negotiation' },
+          { status: 400 },
+        );
+      }
+      filters.mode = modeResult.data;
+    }
+    if (sourceType) filters.sourceType = sourceType;
+    if (sourceId) filters.sourceId = sourceId;
+
+    const hasFilters = Object.keys(filters).length > 0;
+    const questions = await questionService.findPending(user.id, hasFilters ? filters : undefined);
+
+    logger.verbose('Questions listed', { userId: user.id, count: questions.length });
+    return Response.json({ questions });
+  }
+
+  /**
+   * POST /questions/:id/answer — submit an answer for a question.
+   *
+   * @param req    - Request with JSON body `{ selectedOptions, freeText? }`.
+   * @param user   - Authenticated user from AuthGuard.
+   * @param params - Route params; `id` is the question ID.
+   * @returns JSON `{ success: true }` on success.
+   */
+  @Post('/:id/answer')
+  @UseGuards(RateLimit('write'), AuthGuard)
+  async answer(req: Request, user: AuthenticatedUser, params?: RouteParams) {
+    const questionId = params?.id;
+    if (!questionId) {
+      return Response.json({ error: 'Question ID is required' }, { status: 400 });
+    }
+
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return Response.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
+
+    const parsed = answerBodySchema.safeParse(body);
+    if (!parsed.success) {
+      return Response.json(
+        { error: 'Invalid body', details: parsed.error.flatten() },
+        { status: 400 },
+      );
+    }
+
+    await questionService.answer(questionId, {
+      ...parsed.data,
+      answeredBy: user.id,
+      answeredAt: new Date().toISOString(),
+    });
+
+    logger.info('Question answered', { questionId, userId: user.id });
+    return Response.json({ success: true });
+  }
+
+  /**
+   * POST /questions/:id/dismiss — dismiss a question.
+   *
+   * @param _req   - Incoming request (body is ignored).
+   * @param user   - Authenticated user from AuthGuard.
+   * @param params - Route params; `id` is the question ID.
+   * @returns JSON `{ success: true }` on success.
+   */
+  @Post('/:id/dismiss')
+  @UseGuards(RateLimit('write'), AuthGuard)
+  async dismiss(_req: Request, user: AuthenticatedUser, params?: RouteParams) {
+    const questionId = params?.id;
+    if (!questionId) {
+      return Response.json({ error: 'Question ID is required' }, { status: 400 });
+    }
+
+    await questionService.dismiss(questionId);
+
+    logger.info('Question dismissed', { questionId, userId: user.id });
+    return Response.json({ success: true });
+  }
+}

--- a/backend/src/events/question.event.ts
+++ b/backend/src/events/question.event.ts
@@ -1,0 +1,32 @@
+interface QuestionAnswer {
+  selectedOptions: string[];
+  freeText?: string;
+  answeredBy: string;
+  answeredAt: string;
+}
+
+interface QuestionCreatedPayload {
+  questionId: string;
+  userId: string;
+  mode: string;
+  sourceType: string;
+  sourceId: string;
+}
+
+interface QuestionAnsweredPayload {
+  questionId: string;
+  userId: string;
+  mode: string;
+  sourceType: string;
+  sourceId: string;
+  answer: QuestionAnswer;
+}
+
+/**
+ * Hooks called on question lifecycle events.
+ * Set by main.ts to trigger downstream processing via queues or services.
+ */
+export const QuestionEvents = {
+  onCreated: (_payload: QuestionCreatedPayload): void => {},
+  onAnswered: (_payload: QuestionAnsweredPayload): void => {},
+};

--- a/backend/src/events/question.event.ts
+++ b/backend/src/events/question.event.ts
@@ -5,10 +5,12 @@ interface QuestionAnswer {
   answeredAt: string;
 }
 
+type QuestionMode = 'discovery' | 'intent' | 'profile' | 'negotiation';
+
 interface QuestionCreatedPayload {
   questionId: string;
   userId: string;
-  mode: string;
+  mode: QuestionMode;
   sourceType: string;
   sourceId: string;
 }
@@ -16,7 +18,7 @@ interface QuestionCreatedPayload {
 interface QuestionAnsweredPayload {
   questionId: string;
   userId: string;
-  mode: string;
+  mode: QuestionMode;
   sourceType: string;
   sourceId: string;
   answer: QuestionAnswer;

--- a/backend/src/events/question.event.ts
+++ b/backend/src/events/question.event.ts
@@ -24,7 +24,8 @@ interface QuestionAnsweredPayload {
 
 /**
  * Hooks called on question lifecycle events.
- * Set by main.ts to trigger downstream processing via queues or services.
+ * No-ops by default — assign handlers in main.ts when downstream processing
+ * is needed (e.g. feeding answered questions back into intent refinement).
  */
 export const QuestionEvents = {
   onCreated: (_payload: QuestionCreatedPayload): void => {},

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -470,6 +470,7 @@ const shutdown = async () => {
     emailQueue.close(),
     negotiationTimeoutQueue.close(),
     negotiationClaimTimeoutQueue.close(),
+    questionerQueue.close(),
   ]);
   logger.info('Workers closed');
   process.exit(0);

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -24,6 +24,7 @@ import { ConversationService } from './services/conversation.service';
 import { TaskService } from './services/task.service';
 import { IntegrationController } from './controllers/integration.controller';
 import { WebhooksController } from './controllers/webhooks.controller';
+import { QuestionController } from './controllers/question.controller';
 import { ComposioIntegrationAdapter } from './adapters/integration.adapter';
 import { IntegrationService } from './services/integration.service';
 import { contactService } from './services/contact.service';
@@ -237,6 +238,7 @@ controllerInstances.set(WebhooksController, new WebhooksController());
 controllerInstances.set(DebugController, new DebugController());
 const toolService = new ToolService(contactService, integrationService, integrationAdapter);
 controllerInstances.set(ToolController, new ToolController(toolService));
+controllerInstances.set(QuestionController, new QuestionController());
 
 logger.info('Routes registered', { prefix: GLOBAL_PREFIX });
 

--- a/backend/src/queues/questioner.queue.ts
+++ b/backend/src/queues/questioner.queue.ts
@@ -7,6 +7,7 @@ import { log } from '../lib/log';
 import { QueueFactory } from '../lib/bullmq/bullmq';
 import db from '../lib/drizzle/drizzle';
 import { QuestionerAdapter } from '../adapters/questioner.adapter';
+import { QuestionEvents } from '../events/question.event';
 
 /** BullMQ queue name for question generation jobs. */
 export const QUEUE_NAME = 'questioner-queue';
@@ -159,13 +160,23 @@ export class QuestionerQueue {
       strategy: result.strategies[i],
     }));
 
-    await this.adapter.persist(batch);
+    const ids = await this.adapter.persist(batch);
 
     this.logger.info('[QuestionerJob] Persisted questions', {
       mode: data.mode,
       sourceId: data.sourceId,
       count: batch.length,
     });
+
+    for (let i = 0; i < ids.length; i++) {
+      QuestionEvents.onCreated({
+        questionId: ids[i],
+        userId: data.userId,
+        mode: data.mode,
+        sourceType: data.sourceType,
+        sourceId: data.sourceId,
+      });
+    }
   }
 }
 

--- a/backend/src/services/question.service.ts
+++ b/backend/src/services/question.service.ts
@@ -1,0 +1,69 @@
+import { log } from '../lib/log';
+
+import { QuestionerAdapter } from '../adapters/questioner.adapter';
+import type {
+  AdapterQuestionAnswer,
+  AdapterQuestionFilters,
+  AdapterPersistedQuestion,
+} from '../adapters/questioner.adapter';
+import db from '../lib/drizzle/drizzle';
+
+// Re-export adapter types so the controller layer can reference them without
+// importing from the adapters directory directly (enforced by layer boundaries).
+export type { AdapterQuestionFilters, AdapterPersistedQuestion, AdapterQuestionAnswer };
+
+const logger = log.service.from('QuestionService');
+
+/**
+ * QuestionService — business logic layer for the question lifecycle.
+ *
+ * Wraps QuestionerAdapter to expose pending-question retrieval and
+ * answer/dismiss mutations through a service boundary, keeping
+ * controllers free of adapter dependencies.
+ */
+export class QuestionService {
+  private readonly adapter: QuestionerAdapter;
+
+  constructor(adapter?: QuestionerAdapter) {
+    this.adapter = adapter ?? new QuestionerAdapter(db);
+  }
+
+  /**
+   * Find pending questions for a given user, optionally filtered by
+   * detection mode, source type, or source id.
+   *
+   * @param userId  - The user to find pending questions for.
+   * @param filters - Optional narrowing filters.
+   * @returns Pending questions ordered by creation time (oldest first).
+   */
+  async findPending(
+    userId: string,
+    filters?: AdapterQuestionFilters,
+  ): Promise<AdapterPersistedQuestion[]> {
+    logger.verbose('Finding pending questions', { userId, filters });
+    return this.adapter.findPending(userId, filters);
+  }
+
+  /**
+   * Record an answer for a question, setting its status to `answered`.
+   *
+   * @param questionId - ID of the question to answer.
+   * @param answer     - The user's response data.
+   */
+  async answer(questionId: string, answer: AdapterQuestionAnswer): Promise<void> {
+    logger.verbose('Answering question', { questionId, answeredBy: answer.answeredBy });
+    return this.adapter.answer(questionId, answer);
+  }
+
+  /**
+   * Dismiss a question, setting its status to `dismissed`.
+   *
+   * @param questionId - ID of the question to dismiss.
+   */
+  async dismiss(questionId: string): Promise<void> {
+    logger.verbose('Dismissing question', { questionId });
+    return this.adapter.dismiss(questionId);
+  }
+}
+
+export const questionService = new QuestionService();

--- a/backend/src/services/question.service.ts
+++ b/backend/src/services/question.service.ts
@@ -46,23 +46,29 @@ export class QuestionService {
 
   /**
    * Record an answer for a question, setting its status to `answered`.
+   * Only succeeds if the user is an actor on the question.
    *
    * @param questionId - ID of the question to answer.
+   * @param userId     - Authenticated user; must be an actor on the question.
    * @param answer     - The user's response data.
+   * @returns `true` if the question was answered, `false` if not found or unauthorized.
    */
-  async answer(questionId: string, answer: AdapterQuestionAnswer): Promise<void> {
+  async answer(questionId: string, userId: string, answer: AdapterQuestionAnswer): Promise<boolean> {
     logger.verbose('Answering question', { questionId, answeredBy: answer.answeredBy });
-    return this.adapter.answer(questionId, answer);
+    return this.adapter.answer(questionId, userId, answer);
   }
 
   /**
    * Dismiss a question, setting its status to `dismissed`.
+   * Only succeeds if the user is an actor on the question.
    *
    * @param questionId - ID of the question to dismiss.
+   * @param userId     - Authenticated user; must be an actor on the question.
+   * @returns `true` if the question was dismissed, `false` if not found or unauthorized.
    */
-  async dismiss(questionId: string): Promise<void> {
-    logger.verbose('Dismissing question', { questionId });
-    return this.adapter.dismiss(questionId);
+  async dismiss(questionId: string, userId: string): Promise<boolean> {
+    logger.verbose('Dismissing question', { questionId, userId });
+    return this.adapter.dismiss(questionId, userId);
   }
 }
 

--- a/backend/src/services/question.service.ts
+++ b/backend/src/services/question.service.ts
@@ -51,7 +51,7 @@ export class QuestionService {
    * @param questionId - ID of the question to answer.
    * @param userId     - Authenticated user; must be an actor on the question.
    * @param answer     - The user's response data.
-   * @returns `true` if the question was answered, `false` if not found or unauthorized.
+   * @returns `true` if the question was answered, `false` if not found, not pending, or unauthorized.
    */
   async answer(questionId: string, userId: string, answer: AdapterQuestionAnswer): Promise<boolean> {
     logger.verbose('Answering question', { questionId, answeredBy: answer.answeredBy });
@@ -64,7 +64,7 @@ export class QuestionService {
    *
    * @param questionId - ID of the question to dismiss.
    * @param userId     - Authenticated user; must be an actor on the question.
-   * @returns `true` if the question was dismissed, `false` if not found or unauthorized.
+   * @returns `true` if the question was dismissed, `false` if not found, not pending, or unauthorized.
    */
   async dismiss(questionId: string, userId: string): Promise<boolean> {
     logger.verbose('Dismissing question', { questionId, userId });

--- a/backend/tests/questioner.adapter.test.ts
+++ b/backend/tests/questioner.adapter.test.ts
@@ -85,7 +85,7 @@ describe('QuestionerAdapter', () => {
     const pending = await adapter.findPending('test-user-1');
     expect(pending.length).toBeGreaterThan(0);
     const questionId = pending[0].id;
-    await adapter.answer(questionId, {
+    await adapter.answer(questionId, 'test-user-1', {
       selectedOptions: ['Early'],
       answeredBy: 'test-user-1',
       answeredAt: new Date().toISOString(),
@@ -100,7 +100,7 @@ describe('QuestionerAdapter', () => {
     const pending = await adapter.findPending('test-user-1');
     expect(pending.length).toBeGreaterThan(0);
     const questionId = pending[0].id;
-    await adapter.dismiss(questionId);
+    await adapter.dismiss(questionId, 'test-user-1');
     const after = await adapter.findPending('test-user-1');
     const dismissed = after.find((q) => q.id === questionId);
     expect(dismissed).toBeUndefined();

--- a/backend/tests/questioner.adapter.test.ts
+++ b/backend/tests/questioner.adapter.test.ts
@@ -105,4 +105,43 @@ describe('QuestionerAdapter', () => {
     const dismissed = after.find((q) => q.id === questionId);
     expect(dismissed).toBeUndefined();
   });
+
+  it('answer returns false for wrong userId', async () => {
+    // Persist a fresh question for this test
+    const ids = await adapter.persist([makePersistable()]);
+    const result = await adapter.answer(ids[0], 'wrong-user', {
+      selectedOptions: ['Early'],
+      answeredBy: 'wrong-user',
+      answeredAt: new Date().toISOString(),
+    });
+    expect(result).toBe(false);
+  });
+
+  it('dismiss returns false for wrong userId', async () => {
+    const ids = await adapter.persist([makePersistable()]);
+    const result = await adapter.dismiss(ids[0], 'wrong-user');
+    expect(result).toBe(false);
+  });
+
+  it('answer returns false for already-answered question', async () => {
+    const ids = await adapter.persist([makePersistable()]);
+    const answer = {
+      selectedOptions: ['Early'],
+      answeredBy: 'test-user-1',
+      answeredAt: new Date().toISOString(),
+    };
+    const first = await adapter.answer(ids[0], 'test-user-1', answer);
+    expect(first).toBe(true);
+    // Second answer attempt should fail (status is no longer pending)
+    const second = await adapter.answer(ids[0], 'test-user-1', answer);
+    expect(second).toBe(false);
+  });
+
+  it('dismiss returns false for already-dismissed question', async () => {
+    const ids = await adapter.persist([makePersistable()]);
+    const first = await adapter.dismiss(ids[0], 'test-user-1');
+    expect(first).toBe(true);
+    const second = await adapter.dismiss(ids[0], 'test-user-1');
+    expect(second).toBe(false);
+  });
 });

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -129,6 +129,8 @@ export type { QuestionerAgentConfig } from "./questioner/questioner.agent.js";
 export type {
   QuestionerInput,
   QuestionerContext,
+  QuestionerEnqueuePayload,
+  QuestionerEnqueueFn,
   DiscoveryContext,
   IntentContext,
   ProfileContext,

--- a/packages/protocol/src/opportunity/discovery-question.helper.ts
+++ b/packages/protocol/src/opportunity/discovery-question.helper.ts
@@ -2,6 +2,7 @@
  * Pure mapper from opportunity-graph outputs + optional chat digest to a
  * `DiscoveryQuestionInput`. No I/O. Side-effect-free.
  */
+
 import type { ChatContextDigest } from "../shared/schemas/chat-context.schema.js";
 import type { DiscoveryNegotiationDigest } from "../shared/schemas/negotiation-digest.schema.js";
 import type { SourceProfileData } from "./opportunity.state.js";
@@ -20,6 +21,7 @@ export interface BuildDiscoveryQuestionInputArgs {
   now: string;
 }
 
+/** @deprecated Use QuestionerAgent discovery preset instead. Will be removed in a future version. */
 export function buildDiscoveryQuestionInput(args: BuildDiscoveryQuestionInputArgs): DiscoveryQuestionInput {
   return {
     query: args.query,

--- a/packages/protocol/src/opportunity/opportunity.discover.ts
+++ b/packages/protocol/src/opportunity/opportunity.discover.ts
@@ -150,6 +150,27 @@ export interface DiscoverInput {
    * `process.env.ENABLE_DISCOVERY_QUESTIONS === "true"`.
    */
   enableQuestions?: boolean;
+  /**
+   * Optional async question enqueue callback. When provided, question generation
+   * is dispatched asynchronously to the QuestionerQueue instead of running inline
+   * via the `questionGenerator`. The callback receives an enqueue payload and
+   * returns a promise that resolves when the job is enqueued (not when generation
+   * completes).
+   */
+  questionerEnqueue?: (input: {
+    mode: 'discovery';
+    userId: string;
+    sourceType: string;
+    sourceId: string;
+    context: {
+      query: string;
+      sourceProfile: unknown;
+      negotiationDigests: unknown[];
+      summary: unknown;
+      chatContext?: unknown;
+      now: string;
+    };
+  }) => Promise<void>;
 }
 
 /** Context used by the minimal (no-LLM) path; only introducerName is needed for narrator chip. */
@@ -776,6 +797,8 @@ export async function runDiscoverFromQuery(
           graphResult: result,
           negotiationDigests,
           query: queryOrEmpty,
+          questionerEnqueue: input.questionerEnqueue,
+          userId: input.userId,
         });
         return { negotiationDigests, questionPayload };
       });
@@ -966,6 +989,10 @@ interface MaybeBuildQuestionsInput {
   /** Pre-built per-negotiation digests. Pass [] when summarization is unavailable or disabled. */
   negotiationDigests: DiscoveryNegotiationDigest[];
   query: string;
+  /** Optional async enqueue callback for background question generation. */
+  questionerEnqueue?: DiscoverInput['questionerEnqueue'];
+  /** User ID needed for the enqueue payload. */
+  userId?: string;
 }
 
 /**
@@ -1029,7 +1056,6 @@ async function maybeBuildQuestions(args: MaybeBuildQuestionsInput): Promise<{
 }> {
   if (!args.enableQuestions) return {};
   if (args.trigger !== 'orchestrator') return {};
-  if (!args.questionGenerator) return {};
 
   // Hardcoded — `insights` mode is planned for a later slice. Warn if the env
   // var is set so operators aren't surprised when reporting still says
@@ -1059,6 +1085,52 @@ async function maybeBuildQuestions(args: MaybeBuildQuestionsInput): Promise<{
       (digest) => (digest ? "loaded" : "empty"),
     );
   }
+
+  // ── Async enqueue path ──────────────────────────────────────────────────
+  // When questionerEnqueue is provided, dispatch question generation
+  // asynchronously to the background QuestionerQueue. This replaces the
+  // inline generator path. Questions will be persisted to DB by the queue
+  // worker and served via GET /api/questions.
+  if (args.questionerEnqueue && args.userId) {
+    const summary = args.graphResult.discoverySummary ?? {
+      totalCandidates: 0,
+      opportunitiesFound: 0,
+      noOpportunityCount: 0,
+      timeoutCount: 0,
+      roleDistribution: {},
+    };
+
+    const enqueueInput = buildDiscoveryQuestionInput({
+      query: args.query,
+      sourceProfile: args.graphResult.sourceProfile ?? null,
+      negotiationDigests: args.negotiationDigests,
+      summary,
+      chatContext,
+      now: new Date().toISOString(),
+    });
+
+    try {
+      await args.questionerEnqueue({
+        mode: 'discovery',
+        userId: args.userId,
+        sourceType: 'discovery',
+        sourceId: args.chatSessionId ?? 'unknown',
+        context: enqueueInput,
+      });
+      logger.info("Question generation enqueued to QuestionerQueue", {
+        userId: args.userId,
+        trigger: args.trigger,
+      });
+    } catch (err) {
+      logger.warn("Failed to enqueue question generation", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    return {};
+  }
+
+  // ── Inline generator path (backward compat) ────────────────────────────
+  if (!args.questionGenerator) return {};
 
   const negotiationDigests = args.negotiationDigests;
   const summary = args.graphResult.discoverySummary ?? {

--- a/packages/protocol/src/opportunity/opportunity.discover.ts
+++ b/packages/protocol/src/opportunity/opportunity.discover.ts
@@ -13,6 +13,7 @@ import type { Opportunity, ChatGraphCompositeDatabase, UserRecord } from "../sha
 import type { Cache } from "../shared/interfaces/cache.interface.js";
 import type { OpportunityGraphOptions, CandidateMatch, SourceProfileData } from "./opportunity.state.js";
 import type { DiscoveryNegotiation, DiscoverySummary } from "./question.prompt.js";
+import type { QuestionerEnqueueFn } from "../questioner/questioner.types.js";
 import {
   OpportunityPresenter,
   gatherPresenterContext,
@@ -157,20 +158,7 @@ export interface DiscoverInput {
    * returns a promise that resolves when the job is enqueued (not when generation
    * completes).
    */
-  questionerEnqueue?: (input: {
-    mode: 'discovery';
-    userId: string;
-    sourceType: string;
-    sourceId: string;
-    context: {
-      query: string;
-      sourceProfile: unknown;
-      negotiationDigests: unknown[];
-      summary: unknown;
-      chatContext?: unknown;
-      now: string;
-    };
-  }) => Promise<void>;
+  questionerEnqueue?: QuestionerEnqueueFn;
 }
 
 /** Context used by the minimal (no-LLM) path; only introducerName is needed for narrator chip. */

--- a/packages/protocol/src/opportunity/opportunity.discover.ts
+++ b/packages/protocol/src/opportunity/opportunity.discover.ts
@@ -1114,7 +1114,7 @@ async function maybeBuildQuestions(args: MaybeBuildQuestionsInput): Promise<{
         mode: 'discovery',
         userId: args.userId,
         sourceType: 'discovery',
-        sourceId: args.chatSessionId ?? 'unknown',
+        sourceId: args.chatSessionId ?? crypto.randomUUID(),
         context: enqueueInput,
       });
       logger.info("Question generation enqueued to QuestionerQueue", {

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -919,6 +919,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         ...(runDiscoveryOrchestrator && { trigger: 'orchestrator' as const }),
         ...(deps.chatSummary && { chatSummary: deps.chatSummary }),
         ...(deps.questionGenerator && { questionGenerator: deps.questionGenerator }),
+        ...(deps.questionerEnqueue && { questionerEnqueue: deps.questionerEnqueue }),
         ...(deps.negotiationSummary && { negotiationSummary: deps.negotiationSummary }),
         // Decision questions add an LLM call after the negotiation phase.
         // Capped at DISCOVERY_QUESTIONS_TIMEOUT_MS (12 s default,

--- a/packages/protocol/src/opportunity/question.generator.ts
+++ b/packages/protocol/src/opportunity/question.generator.ts
@@ -1,4 +1,6 @@
 /**
+ * @deprecated Use QuestionerAgent instead. Will be removed in a future version.
+ *
  * QuestionGenerator — pure LLM pass that turns a structured DiscoveryQuestionInput
  * into 0–3 decision questions. No DB, no events, no caller wired here; Slice 3
  * (opportunity.discover.ts) is the first consumer.
@@ -35,6 +37,7 @@ const logger = protocolLogger("QuestionGenerator");
 /** Maximum same-strategy questions allowed in a single emission. */
 const MAX_SAME_STRATEGY = 2;
 
+/** @deprecated Use QuestionerAgent instead. Will be removed in a future version. */
 export class QuestionGenerator {
   private model: ReturnType<ChatOpenAI["withStructuredOutput"]>;
 

--- a/packages/protocol/src/opportunity/question.prompt.ts
+++ b/packages/protocol/src/opportunity/question.prompt.ts
@@ -1,4 +1,6 @@
 /**
+ * @deprecated Use QuestionerAgent and questioner presets instead. Will be removed in a future version.
+ *
  * Prompt module for the decision-question generator: the system prompt
  * constant, the `DiscoveryQuestionInput` contract, and a pure string-building
  * `buildQuestionPrompt` that assembles the user message.
@@ -86,6 +88,7 @@ export interface DiscoveryQuestionInput {
   now: string;
 }
 
+/** @deprecated Use QuestionerAgent and questioner presets instead. Will be removed in a future version. */
 export const SYSTEM_PROMPT = `You sit between a human and a discovery protocol that just ran negotiations on their behalf. Your job: surface the minimum set of structured decision questions the human must answer to make the next discovery turn sharper, or improve their outlook on the intent.
 
 You may pick from five strategies. Choose contextually; mix when multiple questions genuinely complement.
@@ -118,7 +121,11 @@ Anti-patterns — never do these.
 
 Output. Return at most 3 entries in the "questions" array. Each entry must include a "strategy" field (one of the five values). If nothing is worth asking, return "questions": [].`;
 
-/** Pure builder: assembles the user message string from a structured input. */
+/**
+ * @deprecated Use QuestionerAgent and questioner presets instead. Will be removed in a future version.
+ *
+ * Pure builder: assembles the user message string from a structured input.
+ */
 export function buildQuestionPrompt(input: DiscoveryQuestionInput): string {
   const profileSummary = renderProfile(input.sourceProfile);
   const negotiationBlocks = renderDiscoveryNegotiationDigests(input.negotiationDigests);

--- a/packages/protocol/src/questioner/questioner.types.ts
+++ b/packages/protocol/src/questioner/questioner.types.ts
@@ -47,6 +47,30 @@ export type QuestionerContext =
   | ProfileContext
   | NegotiationContext;
 
+/**
+ * Payload shape accepted by the questionerEnqueue callback at the
+ * composition-root boundary. Context fields are typed as `unknown` because the
+ * protocol layer is agnostic of the concrete queue input types — the backend
+ * composition root casts them to `QuestionerInput` when bridging.
+ */
+export interface QuestionerEnqueuePayload {
+  mode: 'discovery';
+  userId: string;
+  sourceType: string;
+  sourceId: string;
+  context: {
+    query: string;
+    sourceProfile: unknown;
+    negotiationDigests: unknown[];
+    summary: unknown;
+    chatContext?: unknown;
+    now: string;
+  };
+}
+
+/** Callback signature for async question generation enqueue. */
+export type QuestionerEnqueueFn = (input: QuestionerEnqueuePayload) => Promise<void>;
+
 /** Top-level input envelope for QuestionerAgent.invoke(). */
 export interface QuestionerInput {
   /** Selects the preset (system prompt + builder). */

--- a/packages/protocol/src/shared/agent/tool.factory.ts
+++ b/packages/protocol/src/shared/agent/tool.factory.ts
@@ -187,6 +187,7 @@ export async function createChatTools(
     apiBaseUrl: deps.apiBaseUrl,
     ...(deps.chatSummary && { chatSummary: deps.chatSummary }),
     ...(deps.questionGenerator && { questionGenerator: deps.questionGenerator }),
+    ...(deps.questionerEnqueue && { questionerEnqueue: deps.questionerEnqueue }),
     ...(deps.negotiationSummary && { negotiationSummary: deps.negotiationSummary }),
     graphs: {
       profile: profileGraph,

--- a/packages/protocol/src/shared/agent/tool.helpers.ts
+++ b/packages/protocol/src/shared/agent/tool.helpers.ts
@@ -28,6 +28,7 @@ import type { AgentDispatcher } from "../interfaces/agent-dispatcher.interface.j
 import type { DeliveryLedger } from "../interfaces/delivery-ledger.interface.js";
 import type { MintConnectLink } from "../interfaces/connect-link.interface.js";
 import type { QuestionerDatabase } from "../interfaces/questioner.interface.js";
+import type { QuestionerEnqueueFn } from "../../questioner/questioner.types.js";
 
 /** Profile without embedding — used in resolved context to avoid bloating prompts and memory. */
 export type ProfileContext = Omit<ProfileDocument, "embedding"> | null;
@@ -158,20 +159,7 @@ export interface ToolContext {
    * is dispatched asynchronously to the QuestionerQueue instead of running inline.
    * Injected by the composition root when QUESTIONER_ENABLED=true.
    */
-  questionerEnqueue?: (input: {
-    mode: 'discovery';
-    userId: string;
-    sourceType: string;
-    sourceId: string;
-    context: {
-      query: string;
-      sourceProfile: unknown;
-      negotiationDigests: unknown[];
-      summary: unknown;
-      chatContext?: unknown;
-      now: string;
-    };
-  }) => Promise<void>;
+  questionerEnqueue?: QuestionerEnqueueFn;
   /** Negotiation-digest summarizer. Optional; consumers fall back to deterministic digests. */
   negotiationSummary?: NegotiationSummaryReader;
   /** Profile enrichment from external data sources. */
@@ -433,20 +421,7 @@ export interface ToolDeps {
    * via the `questionGenerator`. Injected by the composition root when
    * QUESTIONER_ENABLED=true.
    */
-  questionerEnqueue?: (input: {
-    mode: 'discovery';
-    userId: string;
-    sourceType: string;
-    sourceId: string;
-    context: {
-      query: string;
-      sourceProfile: unknown;
-      negotiationDigests: unknown[];
-      summary: unknown;
-      chatContext?: unknown;
-      now: string;
-    };
-  }) => Promise<void>;
+  questionerEnqueue?: QuestionerEnqueueFn;
   /** Negotiation-digest summarizer. Optional; consumers fall back to deterministic digests. */
   negotiationSummary?: NegotiationSummaryReader;
   /** Manages negotiation timeout jobs (optional — enables AI fallback on external agent timeout). */

--- a/packages/protocol/src/shared/agent/tool.helpers.ts
+++ b/packages/protocol/src/shared/agent/tool.helpers.ts
@@ -153,6 +153,25 @@ export interface ToolContext {
   chatMessageWriter?: ChatMessageWriter;
   /** Decision-question generator. Optional; consumers fall back to no `questions`. */
   questionGenerator?: QuestionGeneratorReader;
+  /**
+   * Optional async question enqueue callback. When provided, question generation
+   * is dispatched asynchronously to the QuestionerQueue instead of running inline.
+   * Injected by the composition root when QUESTIONER_ENABLED=true.
+   */
+  questionerEnqueue?: (input: {
+    mode: 'discovery';
+    userId: string;
+    sourceType: string;
+    sourceId: string;
+    context: {
+      query: string;
+      sourceProfile: unknown;
+      negotiationDigests: unknown[];
+      summary: unknown;
+      chatContext?: unknown;
+      now: string;
+    };
+  }) => Promise<void>;
   /** Negotiation-digest summarizer. Optional; consumers fall back to deterministic digests. */
   negotiationSummary?: NegotiationSummaryReader;
   /** Profile enrichment from external data sources. */
@@ -408,6 +427,26 @@ export interface ToolDeps {
   chatMessageWriter?: ChatMessageWriter;
   /** Decision-question generator. Optional; consumers fall back to no `questions`. */
   questionGenerator?: QuestionGeneratorReader;
+  /**
+   * Optional async question enqueue callback. When provided, question generation
+   * is dispatched asynchronously to the QuestionerQueue instead of running inline
+   * via the `questionGenerator`. Injected by the composition root when
+   * QUESTIONER_ENABLED=true.
+   */
+  questionerEnqueue?: (input: {
+    mode: 'discovery';
+    userId: string;
+    sourceType: string;
+    sourceId: string;
+    context: {
+      query: string;
+      sourceProfile: unknown;
+      negotiationDigests: unknown[];
+      summary: unknown;
+      chatContext?: unknown;
+      now: string;
+    };
+  }) => Promise<void>;
   /** Negotiation-digest summarizer. Optional; consumers fall back to deterministic digests. */
   negotiationSummary?: NegotiationSummaryReader;
   /** Manages negotiation timeout jobs (optional — enables AI fallback on external agent timeout). */

--- a/packages/protocol/src/shared/interfaces/question-generator.interface.ts
+++ b/packages/protocol/src/shared/interfaces/question-generator.interface.ts
@@ -1,4 +1,6 @@
 /**
+ * @deprecated Use QuestionerAgent instead. Will be removed in a future version.
+ *
  * Protocol-level read contract for decision-question generation. Implementations
  * live in the backend (see `QuestionGeneratorService`) and are injected into the
  * protocol via `ProtocolDeps`/`ToolContext`. The protocol module never constructs

--- a/packages/protocol/src/shared/interfaces/questioner.interface.ts
+++ b/packages/protocol/src/shared/interfaces/questioner.interface.ts
@@ -39,8 +39,9 @@ export interface QuestionFilters {
 }
 
 export interface QuestionerDatabase {
-  /** Persist a batch of generated questions (up to 3 per generation). */
-  persist(questions: PersistableQuestion[]): Promise<void>;
+  /** Persist a batch of generated questions (up to 3 per generation).
+   *  @returns The IDs of the inserted rows. */
+  persist(questions: PersistableQuestion[]): Promise<string[]>;
 
   /** Find pending questions for a user, optionally filtered by mode/source. */
   findPending(userId: string, filters?: QuestionFilters): Promise<PersistedQuestion[]>;

--- a/packages/protocol/src/shared/interfaces/questioner.interface.ts
+++ b/packages/protocol/src/shared/interfaces/questioner.interface.ts
@@ -46,9 +46,13 @@ export interface QuestionerDatabase {
   /** Find pending questions for a user, optionally filtered by mode/source. */
   findPending(userId: string, filters?: QuestionFilters): Promise<PersistedQuestion[]>;
 
-  /** Record an answer for a question. Sets status to "answered". */
-  answer(questionId: string, answer: QuestionAnswer): Promise<void>;
+  /** Record an answer for a question. Sets status to "answered".
+   *  Only succeeds if the user is an actor on the question.
+   *  @returns `true` if updated, `false` if not found or unauthorized. */
+  answer(questionId: string, userId: string, answer: QuestionAnswer): Promise<boolean>;
 
-  /** Dismiss a question. Sets status to "dismissed". */
-  dismiss(questionId: string): Promise<void>;
+  /** Dismiss a question. Sets status to "dismissed".
+   *  Only succeeds if the user is an actor on the question.
+   *  @returns `true` if updated, `false` if not found or unauthorized. */
+  dismiss(questionId: string, userId: string): Promise<boolean>;
 }

--- a/packages/protocol/src/shared/interfaces/questioner.interface.ts
+++ b/packages/protocol/src/shared/interfaces/questioner.interface.ts
@@ -47,12 +47,12 @@ export interface QuestionerDatabase {
   findPending(userId: string, filters?: QuestionFilters): Promise<PersistedQuestion[]>;
 
   /** Record an answer for a question. Sets status to "answered".
-   *  Only succeeds if the user is an actor on the question.
-   *  @returns `true` if updated, `false` if not found or unauthorized. */
+   *  Only succeeds if the user is an actor on a pending question.
+   *  @returns `true` if updated, `false` if not found, not pending, or unauthorized. */
   answer(questionId: string, userId: string, answer: QuestionAnswer): Promise<boolean>;
 
   /** Dismiss a question. Sets status to "dismissed".
-   *  Only succeeds if the user is an actor on the question.
-   *  @returns `true` if updated, `false` if not found or unauthorized. */
+   *  Only succeeds if the user is an actor on a pending question.
+   *  @returns `true` if updated, `false` if not found, not pending, or unauthorized. */
   dismiss(questionId: string, userId: string): Promise<boolean>;
 }

--- a/packages/protocol/src/shared/interfaces/tests/questioner.interface.spec.ts
+++ b/packages/protocol/src/shared/interfaces/tests/questioner.interface.spec.ts
@@ -13,10 +13,10 @@ import type { QuestionAnswer } from "../../schemas/question.schema.js";
 describe("QuestionerDatabase interface", () => {
   it("is satisfiable by a mock implementation", () => {
     const mock: QuestionerDatabase = {
-      persist: async (_questions: PersistableQuestion[]): Promise<void> => {},
+      persist: async (_questions: PersistableQuestion[]): Promise<string[]> => [],
       findPending: async (_userId: string): Promise<PersistedQuestion[]> => [],
-      answer: async (_questionId: string, _answer: QuestionAnswer): Promise<void> => {},
-      dismiss: async (_questionId: string): Promise<void> => {},
+      answer: async (_questionId: string, _userId: string, _answer: QuestionAnswer): Promise<boolean> => false,
+      dismiss: async (_questionId: string, _userId: string): Promise<boolean> => false,
     };
     expect(mock).toBeDefined();
     expect(typeof mock.persist).toBe("function");


### PR DESCRIPTION
## Summary

- Add `QuestionEvents` emitter (`onCreated`, `onAnswered`) following the existing `IntentEvents` pattern
- Wire events into `QuestionerQueue` worker (emit after persist) and `QuestionerAdapter` (emit after answer)
- Create `QuestionService` + `QuestionController` with three REST endpoints: `GET /questions`, `POST /questions/:id/answer`, `POST /questions/:id/dismiss` — controller uses services only (no adapter imports)
- Add async `questionerEnqueue` callback to the protocol's discovery flow; when `QUESTIONER_ENABLED=true`, question generation is dispatched to the background `QuestionerQueue` instead of running inline. The old inline `questionGenerator` path remains as backward compat
- Deprecate old `QuestionGenerator`, `buildQuestionPrompt`, `buildDiscoveryQuestionInput`, and `QuestionGeneratorReader` with `@deprecated` JSDoc tags
- Update `QuestionerDatabase.persist` return type from `void` to `string[]` for event emission

## Test Plan

- [ ] `bun test src/questioner/tests/` — 13 tests pass
- [ ] `bun test src/opportunity/tests/` — 528 pass (16 pre-existing failures unchanged)
- [ ] `npx tsc --noEmit` — protocol and backend both compile clean
- [ ] Verify `GET /api/questions` returns pending questions for authenticated user
- [ ] Verify `POST /api/questions/:id/answer` records answer and emits `onAnswered`
- [ ] Verify `POST /api/questions/:id/dismiss` sets status to dismissed
- [ ] Verify discovery with `QUESTIONER_ENABLED=true` enqueues to QuestionerQueue instead of inline generation