### PR TITLE
fix: decouple discovery eligibility from onboarding.completedAt

### DIFF
--- a/backend/src/adapters/embedder.adapter.ts
+++ b/backend/src/adapters/embedder.adapter.ts
@@ -234,7 +234,6 @@ export class EmbedderAdapter {
       inArray(networkMembers.networkId, filter.indexScope),
       isNotNull(userProfiles.embedding),
       isNull(schema.users.deletedAt),
-      sql`(${schema.users.isGhost} = true OR ${schema.users.onboarding}->>'completedAt' IS NOT NULL)`,
       sql`1 - (${userProfiles.embedding} <=> ${vectorStr}::vector) >= ${minScore}`,
       ...(filter.excludeUserId ? [ne(userProfiles.userId, filter.excludeUserId)] : []),
     ];
@@ -284,7 +283,6 @@ export class EmbedderAdapter {
       ...(filter.excludeUserId ? [ne(intents.userId, filter.excludeUserId)] : []),
       isNull(intents.archivedAt),
       isNull(schema.users.deletedAt),
-      sql`(${schema.users.isGhost} = true OR ${schema.users.onboarding}->>'completedAt' IS NOT NULL)`,
       isNotNull(intents.embedding),
       sql`1 - (${intents.embedding} <=> ${vectorStr}::vector) >= ${minScore}`,
     ];
@@ -326,7 +324,6 @@ export class EmbedderAdapter {
       inArray(networkMembers.networkId, filter.indexScope),
       isNotNull(userProfiles.embedding),
       isNull(schema.users.deletedAt),
-      sql`(${schema.users.isGhost} = true OR ${schema.users.onboarding}->>'completedAt' IS NOT NULL)`,
       sql`1 - (${userProfiles.embedding} <=> ${vectorStr}::vector) >= ${minScore}`,
       ...(filter.excludeUserId ? [ne(userProfiles.userId, filter.excludeUserId)] : []),
     ];
@@ -373,7 +370,6 @@ export class EmbedderAdapter {
       inArray(intentNetworks.networkId, filter.indexScope),
       isNull(intents.archivedAt),
       isNull(schema.users.deletedAt),
-      sql`(${schema.users.isGhost} = true OR ${schema.users.onboarding}->>'completedAt' IS NOT NULL)`,
       isNotNull(intents.embedding),
       sql`1 - (${intents.embedding} <=> ${vectorStr}::vector) >= ${minScore}`,
       ...(filter.excludeUserId ? [ne(intents.userId, filter.excludeUserId)] : []),

--- a/backend/src/services/experiment.service.ts
+++ b/backend/src/services/experiment.service.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
+import { and, eq, isNull, sql } from 'drizzle-orm';
 
 import db from '../lib/drizzle/drizzle';
 import { log } from '../lib/log';
@@ -90,19 +90,6 @@ class ExperimentService {
         socials: payload.socials ?? [],
       });
     }
-
-    // Mark as onboarded so the user is discoverable in vector search filters.
-    // Uses an atomic WHERE guard so concurrent signup() calls for the same user
-    // cannot both read completedAt as missing and race to overwrite each other.
-    const completedAt = new Date().toISOString();
-    await db.update(schema.users)
-      .set({
-        onboarding: sql`COALESCE(${schema.users.onboarding}::jsonb, '{}'::jsonb) || ${JSON.stringify({ completedAt })}::jsonb`,
-      })
-      .where(and(
-        eq(schema.users.id, result.user.id),
-        sql`(${schema.users.onboarding} IS NULL OR ${schema.users.onboarding}->>'completedAt' IS NULL)`,
-      ));
 
     // Enqueue profile enrichment so the user gets a profile embedding + HyDE.
     try {
@@ -200,21 +187,6 @@ class ExperimentService {
     }
 
     const importedUserIds = [...importedUserIdSet];
-
-    // Mark imported users as onboarded so they appear in vector search filters
-    // (embedder requires isGhost=true OR onboarding.completedAt IS NOT NULL).
-    // Merges into existing onboarding JSON to preserve other fields (flow, currentStep, etc.).
-    if (importedUserIds.length > 0) {
-      const completedAt = new Date().toISOString();
-      await db.update(schema.users)
-        .set({
-          onboarding: sql`COALESCE(${schema.users.onboarding}::jsonb, '{}'::jsonb) || ${JSON.stringify({ completedAt })}::jsonb`,
-        })
-        .where(and(
-          inArray(schema.users.id, importedUserIds),
-          sql`(${schema.users.onboarding} IS NULL OR ${schema.users.onboarding}->>'completedAt' IS NULL)`,
-        ));
-    }
 
     // Enqueue profile enrichment: the profile graph reads name, intro, location,
     // and socials from the users/user_socials tables (written by applyProfilePatch

--- a/backend/tests/onboarding-filter.spec.ts
+++ b/backend/tests/onboarding-filter.spec.ts
@@ -1,77 +1,46 @@
 import { describe, it, expect } from 'bun:test';
 
-describe('Non-onboarded user filtering in opportunity enrichment', () => {
-  it('should skip non-onboarded real users (onboarding.completedAt is undefined)', () => {
-    const candidateUser = {
-      id: 'test-user-1',
-      name: 'Test User',
-      isGhost: false,
-      onboarding: {},
-      deletedAt: null,
-    };
+describe('Discovery eligibility filtering in opportunity enrichment', () => {
+  it('should NOT skip candidates with a profile embedding', () => {
+    const profile = { embedding: [0.1, 0.2, 0.3] };
+    const isDirectTarget = false;
 
-    const shouldSkip = candidateUser && !candidateUser.isGhost && !candidateUser.onboarding?.completedAt;
-    expect(shouldSkip).toBe(true);
-  });
-
-  it('should NOT skip ghost users even without onboarding', () => {
-    const candidateUser = {
-      id: 'ghost-user-1',
-      name: 'Ghost',
-      isGhost: true,
-      onboarding: {},
-      deletedAt: null,
-    };
-
-    const shouldSkip = candidateUser && !candidateUser.isGhost && !candidateUser.onboarding?.completedAt;
+    const shouldSkip = !isDirectTarget && !profile?.embedding;
     expect(shouldSkip).toBe(false);
   });
 
-  it('should NOT skip onboarded real users', () => {
-    const candidateUser = {
-      id: 'real-user-1',
-      name: 'Real User',
-      isGhost: false,
-      onboarding: { completedAt: '2026-01-01T00:00:00Z' },
-      deletedAt: null,
-    };
+  it('should skip candidates without a profile embedding', () => {
+    const profile = { embedding: null };
+    const isDirectTarget = false;
 
-    const shouldSkip = candidateUser && !candidateUser.isGhost && !candidateUser.onboarding?.completedAt;
-    expect(shouldSkip).toBe(false);
-  });
-
-  it('should skip real users with null onboarding', () => {
-    const candidateUser = {
-      id: 'null-onboarding-user',
-      name: 'Null Onboarding',
-      isGhost: false,
-      onboarding: null as { completedAt?: string } | null,
-      deletedAt: null,
-    };
-
-    const shouldSkip = candidateUser && !candidateUser.isGhost && !candidateUser.onboarding?.completedAt;
+    const shouldSkip = !isDirectTarget && !profile?.embedding;
     expect(shouldSkip).toBe(true);
   });
 
-  it('should still skip soft-deleted users regardless of onboarding', () => {
+  it('should skip candidates with no profile at all', () => {
+    const profile = null as { embedding: number[] | null } | null;
+    const isDirectTarget = false;
+
+    const shouldSkip = !isDirectTarget && !profile?.embedding;
+    expect(shouldSkip).toBe(true);
+  });
+
+  it('should NOT skip direct-connection targets even without embedding', () => {
+    const profile = null as { embedding: number[] | null } | null;
+    const isDirectTarget = true;
+
+    const shouldSkip = !isDirectTarget && !profile?.embedding;
+    expect(shouldSkip).toBe(false);
+  });
+
+  it('should still skip soft-deleted users regardless of embedding (separate guard)', () => {
     const candidateUser = {
       id: 'deleted-user-1',
       name: 'Deleted',
-      isGhost: false,
-      onboarding: { completedAt: '2026-01-01T00:00:00Z' },
       deletedAt: '2026-02-01T00:00:00Z',
     };
 
     const shouldSkipDeleted = !!(candidateUser && 'deletedAt' in candidateUser && candidateUser.deletedAt);
     expect(shouldSkipDeleted).toBe(true);
-  });
-
-  it('should NOT skip when candidateUser is null (transient DB miss)', () => {
-    const candidateUser = null;
-
-    // opportunity.discover.ts: the onboarding filter guards with `candidateUser &&`
-    // so a null user should NOT be skipped by the onboarding filter
-    const shouldSkipOnboarding = candidateUser && !candidateUser.isGhost && !candidateUser.onboarding?.completedAt;
-    expect(shouldSkipOnboarding).toBeFalsy();
   });
 });

--- a/backend/tests/onboarding-filter.spec.ts
+++ b/backend/tests/onboarding-filter.spec.ts
@@ -33,6 +33,15 @@ describe('Discovery eligibility filtering in opportunity enrichment', () => {
     expect(shouldSkip).toBe(false);
   });
 
+  it('should NOT skip ghost users regardless of embedding status', () => {
+    const candidateUser = { id: 'ghost-1', name: 'Ghost', isGhost: true };
+    const profile = null as { embedding: number[] | null } | null;
+    const isDirectTarget = false;
+
+    const shouldSkip = !isDirectTarget && !candidateUser?.isGhost && !profile?.embedding;
+    expect(shouldSkip).toBe(false);
+  });
+
   it('should still skip soft-deleted users regardless of embedding (separate guard)', () => {
     const candidateUser = {
       id: 'deleted-user-1',

--- a/packages/protocol/src/opportunity/opportunity.discover.ts
+++ b/packages/protocol/src/opportunity/opportunity.discover.ts
@@ -276,7 +276,7 @@ interface EnrichOpportunitiesInput {
   debugSteps: DiscoverDebugStep[];
   /** IDs of pre-existing opportunities merged into the list; these preserve their real status. */
   existingOpportunityIds?: Set<string>;
-  /** When set, bypass the onboarding filter for this specific user (direct connection mode). */
+  /** When set, bypass the embedding filter for this specific user (direct connection mode). */
   targetUserId?: string;
 }
 
@@ -322,7 +322,7 @@ async function enrichOpportunities(
       // Skip soft-deleted users (deletedAt is set)
       if (candidateUser && 'deletedAt' in candidateUser && candidateUser.deletedAt) return null;
       const isDirectTarget = targetUserId && candidateUserId === targetUserId;
-      if (!isDirectTarget && !profile?.embedding) return null;
+      if (!isDirectTarget && !candidateUser?.isGhost && !profile?.embedding) return null;
       const confidence =
         typeof opp.interpretation?.confidence === "number"
           ? opp.interpretation.confidence

--- a/packages/protocol/src/opportunity/opportunity.discover.ts
+++ b/packages/protocol/src/opportunity/opportunity.discover.ts
@@ -321,10 +321,8 @@ async function enrichOpportunities(
         : [null, null];
       // Skip soft-deleted users (deletedAt is set)
       if (candidateUser && 'deletedAt' in candidateUser && candidateUser.deletedAt) return null;
-      // Skip non-onboarded real users (registered but haven't completed onboarding),
-      // unless this is an explicit direct-connection target (targetUserId bypass).
       const isDirectTarget = targetUserId && candidateUserId === targetUserId;
-      if (candidateUser && !candidateUser.isGhost && !candidateUser.onboarding?.completedAt && !isDirectTarget) return null;
+      if (!isDirectTarget && !profile?.embedding) return null;
       const confidence =
         typeof opp.interpretation?.confidence === "number"
           ? opp.interpretation.confidence

--- a/packages/protocol/src/opportunity/tests/opportunity.discover.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.discover.spec.ts
@@ -91,6 +91,7 @@ describe("opportunity.discover", () => {
                 identity: { name: "Jane Mentor", bio: "Experienced advisor." },
                 attributes: {},
                 narrative: {},
+                embedding: [0.1, 0.2, 0.3],
               }
             : null,
       } as unknown as ChatGraphCompositeDatabase;
@@ -221,11 +222,11 @@ describe("opportunity.discover", () => {
         ...mockDatabase,
         getProfile: async (userId: string) =>
           userId === candidateId
-            ? { identity: { bio: "Visual artist and illustrator." }, attributes: {}, narrative: {} }
+            ? { identity: { bio: "Visual artist and illustrator." }, attributes: {}, narrative: {}, embedding: [0.1, 0.2, 0.3] }
             : null,
         getUser: async (userId: string) =>
           userId === candidateId
-            ? { name: "Yuki Tanaka", avatar: "https://example.com/yuki.jpg", onboarding: { completedAt: new Date() } }
+            ? { name: "Yuki Tanaka", avatar: "https://example.com/yuki.jpg" }
             : null,
       } as unknown as ChatGraphCompositeDatabase;
 
@@ -292,15 +293,15 @@ describe("opportunity.discover", () => {
         ...mockDatabase,
         getProfile: async (userId: string) => {
           if (userId === targetId)
-            return { identity: { name: "Alice Target", bio: "Product designer." }, attributes: {}, narrative: {} };
+            return { identity: { name: "Alice Target", bio: "Product designer." }, attributes: {}, narrative: {}, embedding: [0.1, 0.2, 0.3] };
           if (userId === candidateId)
-            return { identity: { name: "Bob Candidate", bio: "UX researcher." }, attributes: {}, narrative: {} };
+            return { identity: { name: "Bob Candidate", bio: "UX researcher." }, attributes: {}, narrative: {}, embedding: [0.1, 0.2, 0.3] };
           return null;
         },
         getUser: async (userId: string) => {
-          if (userId === introducerId) return { name: "Carol Introducer", avatar: null, onboarding: { completedAt: new Date() } };
-          if (userId === targetId) return { name: "Alice Target", avatar: null, onboarding: { completedAt: new Date() } };
-          if (userId === candidateId) return { name: "Bob Candidate", avatar: null, onboarding: { completedAt: new Date() } };
+          if (userId === introducerId) return { name: "Carol Introducer", avatar: null };
+          if (userId === targetId) return { name: "Alice Target", avatar: null };
+          if (userId === candidateId) return { name: "Bob Candidate", avatar: null };
           return null;
         },
       } as unknown as ChatGraphCompositeDatabase;
@@ -362,13 +363,13 @@ describe("opportunity.discover", () => {
         ...mockDatabase,
         getProfile: async (userId: string) => {
           if (userId === candidateId)
-            return { identity: { name: "Eve Match", bio: "Engineer." }, attributes: {}, narrative: {} };
+            return { identity: { name: "Eve Match", bio: "Engineer." }, attributes: {}, narrative: {}, embedding: [0.1, 0.2, 0.3] };
           return null;
         },
         getUser: async (userId: string) => {
-          if (userId === viewerId) return { name: "Viewer User", avatar: null, onboarding: { completedAt: new Date() } };
-          if (userId === introducerThirdPartyId) return { name: "Dan Introducer", avatar: "https://example.com/dan.jpg", onboarding: { completedAt: new Date() } };
-          if (userId === candidateId) return { name: "Eve Match", avatar: null, onboarding: { completedAt: new Date() } };
+          if (userId === viewerId) return { name: "Viewer User", avatar: null };
+          if (userId === introducerThirdPartyId) return { name: "Dan Introducer", avatar: "https://example.com/dan.jpg" };
+          if (userId === candidateId) return { name: "Eve Match", avatar: null };
           return null;
         },
       } as unknown as ChatGraphCompositeDatabase;
@@ -419,13 +420,13 @@ describe("opportunity.discover", () => {
         ...mockDatabase,
         getProfile: async (userId: string) =>
           userId === candidateId
-            ? { identity: { name: "Frank Mentor", bio: "Senior dev." }, attributes: {}, narrative: {} }
+            ? { identity: { name: "Frank Mentor", bio: "Senior dev." }, attributes: {}, narrative: {}, embedding: [0.1, 0.2, 0.3] }
             : null,
         getUser: async (userId: string) =>
           userId === candidateId
-            ? { name: "Frank Mentor", avatar: null, onboarding: { completedAt: new Date() } }
+            ? { name: "Frank Mentor", avatar: null }
             : userId === "u1"
-              ? { name: "User One", avatar: null, onboarding: { completedAt: new Date() } }
+              ? { name: "User One", avatar: null }
               : null,
       } as unknown as ChatGraphCompositeDatabase;
 
@@ -479,18 +480,18 @@ describe("opportunity.discover", () => {
         ...mockDatabase,
         getProfile: async (userId: string) => {
           if (userId === deletedUserId)
-            return { identity: { name: "Deleted Person", bio: "Gone." }, attributes: {}, narrative: {} };
+            return { identity: { name: "Deleted Person", bio: "Gone." }, attributes: {}, narrative: {}, embedding: [0.1, 0.2, 0.3] };
           if (userId === activeUserId)
-            return { identity: { name: "Active Person", bio: "Here." }, attributes: {}, narrative: {} };
+            return { identity: { name: "Active Person", bio: "Here." }, attributes: {}, narrative: {}, embedding: [0.1, 0.2, 0.3] };
           return null;
         },
         getUser: async (userId: string) => {
           if (userId === deletedUserId)
-            return { id: deletedUserId, name: "Deleted Person", avatar: null, deletedAt: new Date("2026-01-01"), onboarding: { completedAt: new Date() } };
+            return { id: deletedUserId, name: "Deleted Person", avatar: null, deletedAt: new Date("2026-01-01") };
           if (userId === activeUserId)
-            return { id: activeUserId, name: "Active Person", avatar: null, deletedAt: null, onboarding: { completedAt: new Date() } };
+            return { id: activeUserId, name: "Active Person", avatar: null, deletedAt: null };
           if (userId === "u1")
-            return { id: "u1", name: "Viewer", avatar: null, deletedAt: null, onboarding: { completedAt: new Date() } };
+            return { id: "u1", name: "Viewer", avatar: null, deletedAt: null };
           return null;
         },
       } as unknown as ChatGraphCompositeDatabase;

--- a/packages/protocol/src/opportunity/tests/opportunity.discover.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.discover.spec.ts
@@ -576,12 +576,15 @@ describe("opportunity.discover", () => {
       };
       const dbWithOnboardedUser = {
         ...mockDatabase,
-        getProfile: async () => null,
+        getProfile: async (userId: string) =>
+          userId === onboardedId
+            ? { embedding: [0.1, 0.2, 0.3] }
+            : null,
         getUser: async (userId: string) =>
           userId === onboardedId
-            ? { id: onboardedId, name: "Onboarded User", avatar: null, isGhost: false, onboarding: { completedAt: new Date() } }
+            ? { id: onboardedId, name: "Onboarded User", avatar: null, isGhost: false }
             : userId === "u1"
-              ? { id: "u1", name: "Viewer", avatar: null, isGhost: false, onboarding: { completedAt: new Date() } }
+              ? { id: "u1", name: "Viewer", avatar: null, isGhost: false }
               : null,
       } as unknown as ChatGraphCompositeDatabase;
 
@@ -645,18 +648,18 @@ describe("introducer discovery cards - secondParty (Bug 1)", () => {
     ...mockDatabase,
     getProfile: async (userId: string) => {
       if (userId === candidateId)
-        return { identity: { name: "Bob Candidate", bio: "UX researcher." }, attributes: {}, narrative: {} };
+        return { embedding: [0.1, 0.2, 0.3], identity: { name: "Bob Candidate", bio: "UX researcher." }, attributes: {}, narrative: {} };
       if (userId === targetId)
-        return { identity: { name: "Alice Target", bio: "Product designer." }, attributes: {}, narrative: {} };
+        return { embedding: [0.1, 0.2, 0.3], identity: { name: "Alice Target", bio: "Product designer." }, attributes: {}, narrative: {} };
       return null;
     },
     getUser: async (userId: string) => {
       if (userId === introducerId)
-        return { name: "Carol Introducer", avatar: "https://example.com/carol.jpg", onboarding: { completedAt: new Date() } };
+        return { name: "Carol Introducer", avatar: "https://example.com/carol.jpg" };
       if (userId === targetId)
-        return { name: "Alice Target", avatar: "https://example.com/alice.jpg", onboarding: { completedAt: new Date() } };
+        return { name: "Alice Target", avatar: "https://example.com/alice.jpg" };
       if (userId === candidateId)
-        return { name: "Bob Candidate", avatar: "https://example.com/bob.jpg", onboarding: { completedAt: new Date() } };
+        return { name: "Bob Candidate", avatar: "https://example.com/bob.jpg" };
       return null;
     },
   } as unknown as ChatGraphCompositeDatabase;
@@ -734,9 +737,9 @@ describe("introducer discovery cards - secondParty (Bug 1)", () => {
         ...dbWithProfiles,
         getUser: async (userId: string) => {
           if (userId === candidateId)
-            return { name: "Bob Candidate", avatar: null, onboarding: { completedAt: new Date() } };
+            return { name: "Bob Candidate", avatar: null };
           if (userId === "u1")
-            return { name: "User One", avatar: null, onboarding: { completedAt: new Date() } };
+            return { name: "User One", avatar: null };
           return null;
         },
       } as unknown as ChatGraphCompositeDatabase,


### PR DESCRIPTION
## Summary

- **Remove onboarding gate from vector search**: Deleted the `(isGhost = true OR onboarding->>'completedAt' IS NOT NULL)` SQL filter from 4 embedder methods (`searchProfilesForHyde`, `searchIntentsForHyde`, `searchProfilesByProfileEmbedding`, `searchIntentsByProfileEmbedding`). The existing `isNotNull(embedding)` + `isNull(deletedAt)` conditions already express discovery eligibility correctly.
- **Replace enrichment filter with embedding check**: In `opportunity.discover.ts`, replaced the `isGhost/onboarding.completedAt` candidate filter with `profile?.embedding` presence. Ghost users and direct-connection targets are still bypassed.
- **Stop marking signup/import users as onboarded**: Removed the `completedAt`-setting SQL from `experiment.service.ts` `signup()` and `importMembers()`. These writes existed solely to satisfy the old vector search filter. Pre-verified users now go through the interactive EdgeClaw onboarding ritual when they first connect.

## Why

`onboarding.completedAt` served two unrelated purposes: discovery eligibility and onboarding state. The `/signup` endpoint set it for discovery, but this also satisfied EdgeClaw's onboarding gate — pre-verified Edge City users who connected via Telegram never got greeted or went through the bootstrap ritual. Now discovery gates on embedding presence (the actual signal), and onboarding state is only set by `complete_onboarding`.

## Test plan

- [x] `backend/tests/onboarding-filter.spec.ts` — 6 tests pass (embedding presence, null profile, ghost bypass, direct target, soft-delete)
- [x] `backend/tests/onboarding-has-name.spec.ts` — 9 tests pass (unaffected)
- [x] `bun run lint` — no new errors
- [x] `bunx tsc --noEmit` — no new type errors
- [x] `packages/protocol` builds cleanly
- [ ] Verify pre-verified `/signup` users get EdgeClaw onboarding ritual on first Telegram connect