### PR TITLE
feat: self-heal expired connect links

### DIFF
--- a/backend/src/controllers/connect-link.controller.ts
+++ b/backend/src/controllers/connect-link.controller.ts
@@ -6,10 +6,10 @@ import { opportunityService } from '../services/opportunity.service';
 /** Route params when path has :code */
 type RouteParams = Record<string, string>;
 
-const EXPIRED_HTML = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Link Expired</title></head>
+const EXPIRED_HTML = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Unavailable</title></head>
 <body style="font-family:system-ui;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0">
-<div style="text-align:center"><h1 style="font-size:1.5rem">This link has expired</h1>
-<p style="color:#666">Connect links are valid for 30 days. Check your latest notification for a fresh link.</p>
+<div style="text-align:center"><h1 style="font-size:1.5rem">This opportunity is no longer available</h1>
+<p style="color:#666">The opportunity behind this link has expired or been closed.</p>
 </div></body></html>`;
 
 const APPROVED_HTML = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Introduction Approved</title></head>

--- a/backend/src/services/connect-link.service.ts
+++ b/backend/src/services/connect-link.service.ts
@@ -1,13 +1,15 @@
 import { and, eq, gt } from 'drizzle-orm';
 
 import db from '../lib/drizzle/drizzle';
-import { connectLinks } from '../schemas/database.schema';
+import { connectLinks, opportunities } from '../schemas/database.schema';
 
 export type ConnectLinkKind = 'connect' | 'approve_introduction' | 'outreach' | 'send_direct';
 
 const CODE_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 const CODE_LENGTH = 10;
 const TTL_DAYS = 30;
+
+const TERMINAL_STATUSES = new Set(['expired', 'rejected']);
 
 function generateCode(): string {
   const bytes = new Uint8Array(CODE_LENGTH);
@@ -155,33 +157,58 @@ export interface ResolvedLink {
   preferredSurface: 'telegram' | 'web' | null;
 }
 
-/**
- * Resolve a short code to its row, only if the row hasn't expired.
- *
- * @param code - The 10-char base62 short code.
- * @returns The resolved link row, or `null` for unknown or expired codes.
- */
-export async function resolveConnectLink(code: string): Promise<ResolvedLink | null> {
-  const [row] = await db
-    .select()
-    .from(connectLinks)
-    .where(and(eq(connectLinks.code, code), gt(connectLinks.expiresAt, new Date())))
-    .limit(1);
-  if (!row) return null;
+function toResolvedLink(row: typeof connectLinks.$inferSelect): ResolvedLink {
   return {
     code: row.code,
     userId: row.userId,
     opportunityId: row.opportunityId,
     kind: row.kind as ConnectLinkKind,
     greeting: row.greeting,
-    // The DB column is unconstrained text — narrow defensively so any non-
-    // canonical value (a new surface added without normalization, a hand-edited
-    // row, a typo) collapses to null rather than silently passing through the
-    // type-cast and being interpreted later as `'telegram' | 'web'`.
     preferredSurface:
       row.preferredSurface === 'telegram' || row.preferredSurface === 'web'
         ? row.preferredSurface
         : null,
   };
+}
+
+/**
+ * Resolve a short code to its row. Self-heals expired codes by extending
+ * TTL when the underlying opportunity is still actionable.
+ *
+ * @param code - The 10-char base62 short code.
+ * @returns The resolved link row, or `null` for unknown codes or codes
+ *   whose opportunity has reached a terminal status.
+ */
+export async function resolveConnectLink(code: string): Promise<ResolvedLink | null> {
+  const [row] = await db
+    .select()
+    .from(connectLinks)
+    .where(eq(connectLinks.code, code))
+    .limit(1);
+  if (!row) return null;
+
+  const now = new Date();
+
+  if (row.expiresAt > now) {
+    return toResolvedLink(row);
+  }
+
+  // Expired — check if the opportunity is still actionable.
+  const [opp] = await db
+    .select({ status: opportunities.status })
+    .from(opportunities)
+    .where(eq(opportunities.id, row.opportunityId))
+    .limit(1);
+
+  if (!opp || TERMINAL_STATUSES.has(opp.status)) return null;
+
+  // Extend TTL.
+  const expiresAt = new Date(now.getTime() + TTL_DAYS * 24 * 60 * 60 * 1000);
+  await db
+    .update(connectLinks)
+    .set({ expiresAt })
+    .where(eq(connectLinks.code, code));
+
+  return toResolvedLink(row);
 }
 

--- a/backend/src/services/tests/connect-link.service.spec.ts
+++ b/backend/src/services/tests/connect-link.service.spec.ts
@@ -97,11 +97,6 @@ describe('connect-link service', () => {
       .set({ expiresAt: past })
       .where(eq(connectLinks.code, a.code));
 
-    // Expired code self-heals since the opportunity is actionable.
-    const healed = await resolveConnectLink(a.code);
-    expect(healed).not.toBeNull();
-    expect(healed!.code).toBe(a.code);
-
     // Re-minting must succeed (rotates code + expiresAt + greeting in place)
     // — without this, the unique index on (opp,user,kind) would deadlock the
     // insert and the retry loop would throw after 3 attempts.

--- a/backend/src/services/tests/connect-link.service.spec.ts
+++ b/backend/src/services/tests/connect-link.service.spec.ts
@@ -11,6 +11,7 @@ import { mintConnectLink, resolveConnectLink, buildConnectShortUrl } from '../co
 
 const USER_ID = `cl-svc-user-${Date.now()}`;
 const OPP_ID = `cl-svc-opp-${Date.now()}`;
+const EXPIRED_OPP_ID = `cl-svc-expired-opp-${Date.now()}`;
 
 describe('connect-link service', () => {
   beforeAll(async () => {
@@ -28,11 +29,21 @@ describe('connect-link service', () => {
       confidence: '0.9',
       status: 'pending',
     });
+    await db.insert(opportunities).values({
+      id: EXPIRED_OPP_ID,
+      actors: [{ userId: USER_ID, networkId: 'n/a', role: 'seeker' }],
+      detection: { source: 'test', timestamp: new Date().toISOString(), createdBy: USER_ID },
+      interpretation: { category: 'test', reasoning: 'test', confidence: 0.9 },
+      context: { networkId: 'n/a' },
+      confidence: '0.9',
+      status: 'expired',
+    });
   });
 
   afterAll(async () => {
     await db.delete(connectLinks).where(eq(connectLinks.userId, USER_ID));
     await db.delete(opportunities).where(eq(opportunities.id, OPP_ID));
+    await db.delete(opportunities).where(eq(opportunities.id, EXPIRED_OPP_ID));
     await db.delete(users).where(eq(users.id, USER_ID));
   });
 
@@ -86,8 +97,10 @@ describe('connect-link service', () => {
       .set({ expiresAt: past })
       .where(eq(connectLinks.code, a.code));
 
-    // Resolver must reject the expired code.
-    expect(await resolveConnectLink(a.code)).toBeNull();
+    // Expired code self-heals since the opportunity is actionable.
+    const healed = await resolveConnectLink(a.code);
+    expect(healed).not.toBeNull();
+    expect(healed!.code).toBe(a.code);
 
     // Re-minting must succeed (rotates code + expiresAt + greeting in place)
     // — without this, the unique index on (opp,user,kind) would deadlock the
@@ -107,7 +120,59 @@ describe('connect-link service', () => {
     const resolved = await resolveConnectLink(b.code);
     expect(resolved?.userId).toBe(USER_ID);
     expect(resolved?.greeting).toBe('second greeting');
+    // The old code was rotated away by re-mint — it no longer exists in the DB,
+    // so resolve returns null (unknown code, not expired code).
     expect(await resolveConnectLink(a.code)).toBeNull();
+  });
+
+  test('resolve self-heals an expired code when opportunity is actionable', async () => {
+    const r = await mintConnectLink({
+      userId: USER_ID,
+      opportunityId: OPP_ID,
+      kind: 'send_direct',
+      greeting: 'heal me',
+    });
+
+    // Expire the link.
+    const past = new Date(Date.now() - 60 * 1000);
+    await db
+      .update(connectLinks)
+      .set({ expiresAt: past })
+      .where(eq(connectLinks.code, r.code));
+
+    // Should self-heal: resolve returns the row and extends TTL.
+    const resolved = await resolveConnectLink(r.code);
+    expect(resolved).not.toBeNull();
+    expect(resolved!.code).toBe(r.code);
+    expect(resolved!.greeting).toBe('heal me');
+    expect(resolved!.kind).toBe('send_direct');
+
+    // Verify TTL was extended in the DB.
+    const [row] = await db
+      .select()
+      .from(connectLinks)
+      .where(eq(connectLinks.code, r.code))
+      .limit(1);
+    expect(row.expiresAt.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  test('resolve returns null for expired code when opportunity is terminal', async () => {
+    const r = await mintConnectLink({
+      userId: USER_ID,
+      opportunityId: EXPIRED_OPP_ID,
+      kind: 'connect',
+      greeting: 'should not heal',
+    });
+
+    // Expire the link.
+    const past = new Date(Date.now() - 60 * 1000);
+    await db
+      .update(connectLinks)
+      .set({ expiresAt: past })
+      .where(eq(connectLinks.code, r.code));
+
+    // Terminal opportunity — should NOT self-heal.
+    expect(await resolveConnectLink(r.code)).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

- `resolveConnectLink` now extends TTL by 30 days when an expired code's opportunity is still actionable (not `expired` or `rejected`), instead of returning a dead-end 404
- Updated the 404 HTML to say "This opportunity is no longer available" since only truly terminal opportunities reach it now
- Extracted `toResolvedLink` helper to deduplicate row-to-interface mapping

## Bug Fixes

- Expired connect links embedded in Telegram messages / emails no longer show a dead-end page when the opportunity is still live

## Tests

- `resolve self-heals an expired code when opportunity is actionable` — verifies TTL extension and row return
- `resolve returns null for expired code when opportunity is terminal` — verifies terminal gate
- Updated existing re-mint test to avoid interference with self-healing path

## Test plan

- [x] All 10 connect-link service tests pass
- [x] `tsc --noEmit` clean
- [x] ESLint clean (lint-staged on commit)