### PR TITLE
fix: dedup user_socials by label before insert

### DIFF
--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -4185,11 +4185,15 @@ export class ProfileDatabaseAdapter {
       if (socials.length > 0) {
         const classified = socials
           .filter(s => s.value.trim() !== '')
-          .map(s => ({
-            userId,
-            label: detectSocialLabel(s.value) === 'custom' ? s.label : detectSocialLabel(s.value),
-            value: s.value.trim(),
-          }));
+          .map(s => {
+            const value = s.value.trim();
+            const detected = detectSocialLabel(value);
+            return {
+              userId,
+              label: detected === 'custom' ? s.label : detected,
+              value,
+            };
+          });
 
         // Dedup: for non-custom labels the unique index allows only one row per label.
         // Keep the first occurrence (explicit field) and drop later duplicates.

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -4183,15 +4183,26 @@ export class ProfileDatabaseAdapter {
     await db.transaction(async (tx) => {
       await tx.delete(schema.userSocials).where(eq(schema.userSocials.userId, userId));
       if (socials.length > 0) {
-        const filtered = socials.filter(s => s.value.trim() !== '');
-        if (filtered.length > 0) {
-          await tx.insert(schema.userSocials).values(
-            filtered.map(s => ({
-              userId,
-              label: detectSocialLabel(s.value) === 'custom' ? s.label : detectSocialLabel(s.value),
-              value: s.value.trim(),
-            })),
-          );
+        const classified = socials
+          .filter(s => s.value.trim() !== '')
+          .map(s => ({
+            userId,
+            label: detectSocialLabel(s.value) === 'custom' ? s.label : detectSocialLabel(s.value),
+            value: s.value.trim(),
+          }));
+
+        // Dedup: for non-custom labels the unique index allows only one row per label.
+        // Keep the first occurrence (explicit field) and drop later duplicates.
+        const seen = new Set<string>();
+        const deduped = classified.filter(s => {
+          if (s.label === 'custom') return true;
+          if (seen.has(s.label)) return false;
+          seen.add(s.label);
+          return true;
+        });
+
+        if (deduped.length > 0) {
+          await tx.insert(schema.userSocials).values(deduped);
         }
       }
     });

--- a/backend/src/adapters/tests/database.adapter.spec.ts
+++ b/backend/src/adapters/tests/database.adapter.spec.ts
@@ -13,6 +13,7 @@ import db from '../../lib/drizzle/drizzle';
 import {
   users,
   userProfiles,
+  userSocials,
   networks,
   networkMembers,
   intents,
@@ -571,6 +572,23 @@ describe('ProfileDatabaseAdapter', () => {
     const user = await adapter.getUser(fixture.userAId);
     expect(user).not.toBeNull();
     expect(user!.id).toBe(fixture.userAId);
+  });
+
+  it('should dedup socials when detectSocialLabel reclassifies a website as linkedin', async () => {
+    await adapter.setUserSocials(fixture.userAId, [
+      { label: 'linkedin', value: 'some-slug' },
+      { label: 'custom', value: 'https://www.linkedin.com/in/some-slug' },
+      { label: 'custom', value: 'http://example.org' },
+    ]);
+    const rows = await adapter.getUserSocials(fixture.userAId);
+    const linkedinRows = rows.filter(r => r.label === 'linkedin');
+    const customRows = rows.filter(r => r.label === 'custom');
+    expect(linkedinRows).toHaveLength(1);
+    expect(linkedinRows[0].value).toBe('some-slug');
+    expect(customRows).toHaveLength(1);
+    expect(customRows[0].value).toBe('http://example.org');
+
+    await db.delete(userSocials).where(eq(userSocials.userId, fixture.userAId));
   });
 });
 


### PR DESCRIPTION
## Bug Fixes
- Dedup `user_socials` rows by label after `detectSocialLabel` reclassification to prevent unique constraint violations. Chat API enrichment can return the same social link in multiple fields (e.g. LinkedIn slug in `socials.linkedin` and full URL in `socials.websites[]`), both classified as `linkedin`.

## Tests
- Added regression test in `database.adapter.spec.ts` covering the duplicate-label scenario (LinkedIn slug + LinkedIn URL in websites array).

## Test plan
- [ ] Re-run profile enrichment for affected users and confirm no `user_socials` insert errors
- [ ] Verify enriched profiles use Chat API data instead of falling back to basic info
- [ ] Confirm existing socials are preserved correctly for users with single-value social fields