### PR TITLE
feat(hyde): enable premise corpus in HyDE search path

### DIFF
--- a/backend/src/adapters/embedder.adapter.ts
+++ b/backend/src/adapters/embedder.adapter.ts
@@ -46,7 +46,7 @@ export interface HydeSearchOptions {
 }
 
 export interface HydeCandidate {
-  type: 'profile' | 'intent';
+  type: 'profile' | 'intent' | 'premise';
   id: string;
   userId: string;
   score: number;
@@ -164,25 +164,33 @@ export class EmbedderAdapter {
 
     const filter = { indexScope, excludeUserId };
 
-    // Always search BOTH profiles and intents for each lens.
+    // Always search ALL corpora (profiles, intents, premises) for each lens.
     // The corpus hint from the lens inferrer is used only for limit allocation:
-    // the preferred corpus gets the full limitPerStrategy while the other gets half.
+    // the preferred corpus gets the full limitPerStrategy while others get half.
+    const halfLimit = Math.ceil(limitPerStrategy / 2);
     const searchPromises = lensEmbeddings.flatMap((le) => {
       if (!le.embedding?.length) return [];
 
-      const isProfilePreferred = le.corpus === 'profiles';
+      const preferred = le.corpus;
       return [
         this.searchProfilesForHyde(
           le.embedding,
           filter,
-          isProfilePreferred ? limitPerStrategy : Math.ceil(limitPerStrategy / 2),
+          preferred === 'profiles' ? limitPerStrategy : halfLimit,
           profileMinScore,
           le.lens
         ),
         this.searchIntentsForHyde(
           le.embedding,
           filter,
-          isProfilePreferred ? Math.ceil(limitPerStrategy / 2) : limitPerStrategy,
+          preferred === 'intents' ? limitPerStrategy : halfLimit,
+          minScore,
+          le.lens
+        ),
+        this.searchPremisesForHyde(
+          le.embedding,
+          filter,
+          preferred === 'premises' ? limitPerStrategy : halfLimit,
           minScore,
           le.lens
         ),
@@ -303,6 +311,51 @@ export class EmbedderAdapter {
 
     return results.map((r) => ({
       type: 'intent' as const,
+      id: r.id,
+      userId: r.userId,
+      score: r.similarity,
+      matchedVia: lens,
+      networkId: r.networkId,
+    }));
+  }
+
+  private async searchPremisesForHyde(
+    embedding: number[],
+    filter: { indexScope: string[]; excludeUserId?: string },
+    limit: number,
+    minScore: number,
+    lens: string
+  ): Promise<HydeCandidate[]> {
+    if (filter.indexScope?.length === 0) return [];
+    const vectorStr = `[${embedding.join(',')}]`;
+    const { premises, premiseNetworks } = schema;
+
+    const conditions = [
+      inArray(premiseNetworks.networkId, filter.indexScope),
+      ...(filter.excludeUserId ? [ne(premises.userId, filter.excludeUserId)] : []),
+      eq(premises.status, 'ACTIVE'),
+      isNull(premises.deletedAt),
+      isNull(schema.users.deletedAt),
+      isNotNull(premises.embedding),
+      sql`1 - (${premises.embedding} <=> ${vectorStr}::vector) >= ${minScore}`,
+    ];
+
+    const results = await db
+      .select({
+        id: premises.id,
+        userId: premises.userId,
+        similarity: sql<number>`1 - (${premises.embedding} <=> ${vectorStr}::vector)`,
+        networkId: premiseNetworks.networkId,
+      })
+      .from(premises)
+      .innerJoin(premiseNetworks, eq(premises.id, premiseNetworks.premiseId))
+      .innerJoin(schema.users, eq(premises.userId, schema.users.id))
+      .where(and(...conditions))
+      .orderBy(sql`${premises.embedding} <=> ${vectorStr}::vector`)
+      .limit(limit);
+
+    return results.map((r) => ({
+      type: 'premise' as const,
       id: r.id,
       userId: r.userId,
       score: r.similarity,

--- a/docs/design/protocol-deep-dive.md
+++ b/docs/design/protocol-deep-dive.md
@@ -169,10 +169,12 @@ The propose mode is a dry-run that extracts and verifies intents without persist
 
 **Flow:** `START -> prep -> scope -> resolve -> discovery -> evaluation -> ranking -> persist -> negotiate -> END`
 
-The graph supports three discovery paths:
+The graph supports three discovery paths, each searching across profiles, intents, and premises corpora:
 - **Intent-based (Path A):** Trigger intent is assigned to an index -- use its HyDE documents for search
 - **Profile-based (Path B/C):** Use profile embedding or query-generated HyDE documents for search
 - **Direct connection:** When `targetUserId` is set (user @-mentioned someone), bypass vector search and construct candidates from shared indexes
+
+Premise-based candidates carry `candidatePremiseId` in the persist node for actor tracking, regardless of discovery source.
 
 **Unified trigger model:** `OpportunityGraphState.trigger` (`'ambient' | 'orchestrator'`, default `'ambient'`) drives branches in the `persist` and `negotiate` nodes so the same graph serves both the queue-driven ambient flow and the chat-driven orchestrator flow. The tool layer passes `trigger: 'orchestrator'` whenever `context.sessionId` is set (i.e. the call comes from a chat session); all other callers inherit the ambient default.
 
@@ -415,7 +417,7 @@ Scoring bands:
 ### 4.13 Lens Inferrer
 
 **File:** `lens.inferrer.ts`
-**Role:** Analyzes source text with optional profile context and infers 1-5 search lenses, each tagged with a target corpus (profiles or intents).
+**Role:** Analyzes source text with optional profile context and infers 1-5 search lenses, each tagged with a target corpus (profiles, intents, or premises).
 **Model:** `google/gemini-2.5-flash`
 **Input:** Source text, optional profile context, optional max lenses
 **Output:** Array of lenses with label, corpus, reasoning

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -2755,7 +2755,7 @@ export class OpportunityGraphFactory {
               // When multiple premise candidates exist for the same user, keep the highest-similarity one.
               const premiseLookup = new Map<string, { premiseId: string; similarity: number }>();
               for (const c of state.candidates ?? []) {
-                if (c.discoverySource === 'premise-similarity' && c.candidatePremiseId) {
+                if (c.candidatePremiseId) {
                   const existing = premiseLookup.get(c.candidateUserId);
                   if (!existing || c.similarity > existing.similarity) {
                     premiseLookup.set(c.candidateUserId, { premiseId: c.candidatePremiseId, similarity: c.similarity });

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -1079,7 +1079,8 @@ export class OpportunityGraphFactory {
             for (const c of all) {
               // Dedup by candidateUserId + entity (intent, premise, or profile), NOT by indexId.
               // Including indexId caused the same user to appear once per index they belong to.
-              const key = `${c.candidateUserId}:${c.candidateIntentId ?? c.candidatePremiseId ?? 'profile'}`;
+              const entityKey = c.candidateIntentId ? `intent:${c.candidateIntentId}` : c.candidatePremiseId ? `premise:${c.candidatePremiseId}` : 'profile';
+              const key = `${c.candidateUserId}:${entityKey}`;
               if (!byKey.has(key) || c.similarity > (byKey.get(key)?.similarity ?? 0)) {
                 byKey.set(key, c);
               }
@@ -1260,7 +1261,8 @@ export class OpportunityGraphFactory {
           );
           const byUserAndIndex = new Map<string, CandidateMatch>();
           for (const c of allCandidates) {
-            const key = `${c.candidateUserId}:${c.networkId}:${c.candidateIntentId ?? c.candidatePremiseId ?? 'profile'}`;
+            const entityKey = c.candidateIntentId ? `intent:${c.candidateIntentId}` : c.candidatePremiseId ? `premise:${c.candidatePremiseId}` : 'profile';
+            const key = `${c.candidateUserId}:${c.networkId}:${entityKey}`;
             if (!byUserAndIndex.has(key) || c.similarity > (byUserAndIndex.get(key)?.similarity ?? 0)) {
               byUserAndIndex.set(key, c);
             }

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -1052,20 +1052,34 @@ export class OpportunityGraphFactory {
                     discoverySource: 'query' as const,
                   });
                 }
+                for (const r of results.filter((x) => x.type === 'premise')) {
+                  all.push({
+                    candidateUserId: r.userId as Id<'users'>,
+                    candidatePremiseId: r.id as Id<'premises'>,
+                    networkId: targetIndex.networkId,
+                    similarity: r.score,
+                    lens: r.matchedVia,
+                    candidatePayload: '',
+                    candidateSummary: undefined,
+                    discoverySource: 'query' as const,
+                  });
+                }
               })
             );
-            const profileCount = all.filter((c) => !c.candidateIntentId).length;
+            const profileCount = all.filter((c) => !c.candidateIntentId && !c.candidatePremiseId).length;
             const intentCount = all.filter((c) => c.candidateIntentId).length;
+            const premiseCount = all.filter((c) => c.candidatePremiseId).length;
             logger.verbose('[Graph:Discovery] searchWithHydeEmbeddings raw results', {
               total: all.length,
               fromProfile: profileCount,
               fromIntent: intentCount,
+              fromPremise: premiseCount,
             });
             const byKey = new Map<string, CandidateMatch>();
             for (const c of all) {
-              // Dedup by candidateUserId + intent (or profile), NOT by indexId.
+              // Dedup by candidateUserId + entity (intent, premise, or profile), NOT by indexId.
               // Including indexId caused the same user to appear once per index they belong to.
-              const key = `${c.candidateUserId}:${c.candidateIntentId ?? 'profile'}`;
+              const key = `${c.candidateUserId}:${c.candidateIntentId ?? c.candidatePremiseId ?? 'profile'}`;
               if (!byKey.has(key) || c.similarity > (byKey.get(key)?.similarity ?? 0)) {
                 byKey.set(key, c);
               }
@@ -1230,11 +1244,23 @@ export class OpportunityGraphFactory {
                   discoverySource: 'query' as const,
                 });
               }
+              for (const result of results.filter((r) => r.type === 'premise')) {
+                allCandidates.push({
+                  candidateUserId: result.userId as Id<'users'>,
+                  candidatePremiseId: result.id as Id<'premises'>,
+                  networkId: targetIndex.networkId,
+                  similarity: result.score,
+                  lens: result.matchedVia,
+                  candidatePayload: '',
+                  candidateSummary: undefined,
+                  discoverySource: 'query' as const,
+                });
+              }
             })
           );
           const byUserAndIndex = new Map<string, CandidateMatch>();
           for (const c of allCandidates) {
-            const key = `${c.candidateUserId}:${c.networkId}:${c.candidateIntentId ?? 'profile'}`;
+            const key = `${c.candidateUserId}:${c.networkId}:${c.candidateIntentId ?? c.candidatePremiseId ?? 'profile'}`;
             if (!byUserAndIndex.has(key) || c.similarity > (byUserAndIndex.get(key)?.similarity ?? 0)) {
               byUserAndIndex.set(key, c);
             }

--- a/packages/protocol/src/shared/hyde/lens.inferrer.ts
+++ b/packages/protocol/src/shared/hyde/lens.inferrer.ts
@@ -38,7 +38,7 @@ const SYSTEM_PROMPT = `You analyze goals and search queries to identify the most
 
 For each perspective you identify, specify:
 1. A clear, specific description of who or what to search for
-2. Whether to search "profiles" (user bios, expertise, backgrounds) or "intents" (stated goals, needs, aspirations)
+2. Whether to search "profiles" (user bios, expertise, backgrounds), "intents" (stated goals, needs, aspirations), or "premises" (identity assertions, values, worldview)
 3. A brief reason why this perspective is relevant
 
 Guidelines:

--- a/packages/protocol/src/shared/hyde/lens.inferrer.ts
+++ b/packages/protocol/src/shared/hyde/lens.inferrer.ts
@@ -46,14 +46,14 @@ Guidelines:
 - Consider both sides: who can help the person AND whose goals complement theirs.
 - When user context is provided, tailor perspectives to their domain (e.g. a DePIN founder searching for "investors" needs crypto-native infra investors specifically).
 - Generate only perspectives that add distinct search value — don't repeat similar angles.
-- Use "profiles" when looking for a type of person (expert, advisor, leader). Use "intents" when looking for a complementary goal or need (someone raising, someone hiring, someone seeking collaboration).
+- Use "profiles" when looking for a type of person (expert, advisor, leader). Use "intents" when looking for a complementary goal or need (someone raising, someone hiring, someone seeking collaboration). Use "premises" when looking for someone whose identity, values, or worldview aligns — stable traits rather than transient goals.
 - Always include at least one "profiles" perspective when the source describes a need that a specific type of professional could fulfill. Most intents benefit from profile-based discovery.
 - LOCATION AWARENESS: When the source text or user context mentions a specific location (city, region, country), incorporate it into lens descriptions. For example, "investors in San Francisco" should produce a lens like "SF-based early-stage investor" rather than just "early-stage investor". This helps the hypothetical document generator produce location-specific search documents, improving retrieval quality.`;
 
 const responseFormat = z.object({
   lenses: z.array(z.object({
     label: z.string().describe('Specific description of the search perspective'),
-    corpus: z.enum(['profiles', 'intents']).describe('Search user profiles or user intents'),
+    corpus: z.enum(['profiles', 'intents', 'premises']).describe('Search user profiles, user intents, or user premises (identity/values)'),
     reasoning: z.string().describe('Why this perspective is relevant'),
   })).min(1).max(5).describe('Inferred search lenses'),
 });

--- a/packages/protocol/src/shared/hyde/tests/hyde.generator.spec.ts
+++ b/packages/protocol/src/shared/hyde/tests/hyde.generator.spec.ts
@@ -60,6 +60,18 @@ describe('HydeGenerator', () => {
     }, 30_000);
   });
 
+  describe('premises corpus', () => {
+    it('generates an identity statement for a premise lens', async () => {
+      const input: HydeGenerateInput = {
+        sourceText: 'I believe in open-source collaboration and decentralized governance.',
+        lens: 'community-driven builder passionate about open protocols',
+        corpus: 'premises',
+      };
+      const result = await generator.generate(input);
+      expect(result.text.length).toBeGreaterThan(0);
+    }, 30_000);
+  });
+
   describe('output structure', () => {
     it('returns an object with text property', async () => {
       const input: HydeGenerateInput = {

--- a/packages/protocol/src/shared/hyde/tests/hyde.strategies.spec.ts
+++ b/packages/protocol/src/shared/hyde/tests/hyde.strategies.spec.ts
@@ -29,8 +29,16 @@ describe('HyDE Corpus Prompts', () => {
     expect(HYDE_DEFAULT_CACHE_TTL).toBe(3600);
   });
 
-  it('both corpus types have prompt templates', () => {
+  it('premises prompt embeds source text and lens with identity framing', () => {
+    const result = HYDE_CORPUS_PROMPTS.premises('Passionate about decentralized governance', 'community-first builder');
+    expect(result).toContain('Passionate about decentralized governance');
+    expect(result).toContain('community-first builder');
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('all three corpus types have prompt templates', () => {
     expect(typeof HYDE_CORPUS_PROMPTS.profiles).toBe('function');
     expect(typeof HYDE_CORPUS_PROMPTS.intents).toBe('function');
+    expect(typeof HYDE_CORPUS_PROMPTS.premises).toBe('function');
   });
 });

--- a/packages/protocol/src/shared/hyde/tests/lens.inferrer.spec.ts
+++ b/packages/protocol/src/shared/hyde/tests/lens.inferrer.spec.ts
@@ -24,7 +24,7 @@ describe('LensInferrer', () => {
       for (const lens of result.lenses) {
         expect(typeof lens.label).toBe('string');
         expect(lens.label.length).toBeGreaterThan(0);
-        expect(['profiles', 'intents']).toContain(lens.corpus);
+        expect(['profiles', 'intents', 'premises']).toContain(lens.corpus);
         expect(typeof lens.reasoning).toBe('string');
         expect(lens.reasoning.length).toBeGreaterThan(0);
       }

--- a/packages/protocol/src/shared/interfaces/embedder.interface.ts
+++ b/packages/protocol/src/shared/interfaces/embedder.interface.ts
@@ -33,9 +33,9 @@ export interface HydeSearchOptions {
 /** Options for searchWithProfileEmbedding (no lenses; direct profile similarity). */
 export type ProfileEmbeddingSearchOptions = HydeSearchOptions;
 
-/** A single candidate from HyDE search (profile or intent), with score and which lens matched. */
+/** A single candidate from HyDE search (profile, intent, or premise), with score and which lens matched. */
 export interface HydeCandidate {
-  type: 'profile' | 'intent';
+  type: 'profile' | 'intent' | 'premise';
   id: string;
   userId: string;
   score: number;


### PR DESCRIPTION
## Summary
- Widen `LensInferrer` Zod schema to accept `'premises'` corpus alongside `'profiles'` and `'intents'`
- Update system prompt with guidance on when to select premise corpus (identity, values, worldview alignment)
- Add `searchPremisesForHyde` to `EmbedderAdapter` — queries premises table joined through `premise_networks` with ACTIVE status, soft-delete filtering, and cosine similarity scoring
- Wire premise search into `searchWithHydeEmbeddings` so all three corpora are searched per lens, with preferred corpus getting full limit allocation
- Map premise HyDE results to `CandidateMatch` with `candidatePremiseId` in discovery graph (uses `discoverySource: 'query'`, same as profile/intent HyDE results)
- Broaden persist node's `premiseLookup` to check `candidatePremiseId` regardless of `discoverySource`, so premise IDs from both HyDE and direct similarity flow to opportunity actors

Closes IND-329. Part of IND-328 (profiles → presentation-only).

## Test plan
- [x] `bunx tsc --noEmit` passes for both `packages/protocol` and `backend`
- [x] `bun test src/shared/hyde/tests/hyde.strategies.spec.ts` passes (5/5)
- [ ] Verify LLM-dependent tests with API key (`lens.inferrer.spec.ts`, `hyde.generator.spec.ts`)
- [ ] Run full discovery test suite