### PR TITLE
feat(profile): route chat/scraping input through premises first

### DIFF
--- a/backend/src/controllers/mcp.controller.ts
+++ b/backend/src/controllers/mcp.controller.ts
@@ -150,7 +150,8 @@ function getOrCompileGraphs(): ToolDeps['graphs'] {
   const { database, embedder, scraper } = protocolDeps;
   const qEnqueue = protocolDeps.questionerEnqueue;
   const intentGraph = new IntentGraphFactory(database, embedder, protocolDeps.intentQueue, qEnqueue).createGraph();
-  const profileGraph = new ProfileGraphFactory(database, embedder, scraper, protocolDeps.enricher, qEnqueue).createGraph();
+  const premiseGraph = new PremiseGraphFactory(database as unknown as PremiseGraphDatabase, embedder).createGraph();
+  const profileGraph = new ProfileGraphFactory(database, embedder, scraper, protocolDeps.enricher, qEnqueue, premiseGraph).createGraph();
   const compiledHydeGraph = new HydeGraphFactory(
     database as unknown as HydeGraphDatabase,
     embedder,
@@ -173,7 +174,6 @@ function getOrCompileGraphs(): ToolDeps['graphs'] {
   const indexGraph = new NetworkGraphFactory(database).createGraph();
   const networkMembershipGraph = new NetworkMembershipGraphFactory(database).createGraph();
   const intentIndexGraph = new IntentNetworkGraphFactory(database, new IntentIndexer()).createGraph();
-  const premiseGraph = new PremiseGraphFactory(database as unknown as PremiseGraphDatabase, embedder).createGraph();
 
   compiledGraphs = {
     profile: profileGraph,

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -117,6 +117,8 @@ export type { InviteInput, InviteOutput } from "./contact/contact.inviter.js";
 export { IntentIndexer } from "./intent/intent.indexer.js";
 export { PremiseAnalyzer } from "./premise/premise.analyzer.js";
 export type { PremiseAnalyzerOutput } from "./premise/premise.analyzer.js";
+export { PremiseDecomposer } from "./premise/premise.decomposer.js";
+export type { PremiseDecomposerOutput, DecomposedPremise } from "./premise/premise.decomposer.js";
 export { PremiseIndexer } from "./premise/premise.indexer.js";
 export type { PremiseIndexerOutput } from "./premise/premise.indexer.js";
 export { LensInferrer } from "./shared/hyde/lens.inferrer.js";

--- a/packages/protocol/src/premise/premise.decomposer.ts
+++ b/packages/protocol/src/premise/premise.decomposer.ts
@@ -1,0 +1,118 @@
+import { HumanMessage, SystemMessage } from "@langchain/core/messages";
+import { z } from "zod";
+import { protocolLogger } from "../shared/observability/protocol.logger.js";
+import { Timed } from "../shared/observability/performance.js";
+import { createModel } from "../shared/agent/model.config.js";
+
+const logger = protocolLogger("PremiseDecomposer");
+
+const systemPrompt = `
+You are the Premise Decomposer for the Index Network — an intent-driven discovery protocol.
+
+Your job: decompose free-text input about a person into individual, atomic premises.
+
+A premise is a single self-descriptive proposition — a fact someone asserts about themselves.
+Each premise should be:
+1. **Atomic** — one fact per premise, not compound statements
+2. **First-person** — phrased as "I am...", "I work at...", "I specialize in..."
+3. **Self-descriptive** — about the person's identity, role, skills, interests, location, or context
+4. **Non-redundant** — do not repeat the same information in multiple premises
+
+═══════════════════════════════════════════════════
+INPUT TYPES
+═══════════════════════════════════════════════════
+
+You may receive:
+- **Chat messages**: "I'm a software engineer at Google, based in SF. I'm interested in AI safety."
+- **Bio text**: A paragraph describing someone's background
+- **Scraped content**: LinkedIn/GitHub/Twitter data about someone
+- **Mixed input**: Name, location, and free-text combined
+
+═══════════════════════════════════════════════════
+DECOMPOSITION RULES
+═══════════════════════════════════════════════════
+
+1. Extract every distinct factual claim about the person
+2. Convert third-person ("She works at...") to first-person ("I work at...")
+3. Separate compound statements: "I know Python and Rust" → two premises
+4. Classify each premise:
+   - \`assertive\` — stable identity facts (role, skills, education, location)
+   - \`contextual\` — temporal/situational (current projects, events, fundraising status)
+5. Skip vague or uninformative statements ("I like stuff", "I'm a person")
+6. Skip desires, requests, or intents ("I'm looking for...", "I want to...") — those are intents, not premises
+7. If the input contains NO extractable premises (e.g. just "Yes" or "Hello"), return an empty array
+
+═══════════════════════════════════════════════════
+EXAMPLES
+═══════════════════════════════════════════════════
+
+Input: "I'm a climate tech founder based in Berlin. I have a PhD in renewable energy systems and I'm currently raising Series A."
+Output:
+  1. "I am a climate tech founder" (assertive)
+  2. "I am based in Berlin" (assertive)
+  3. "I hold a PhD in renewable energy systems" (assertive)
+  4. "I am currently raising Series A" (contextual)
+
+Input: "John Doe is a senior ML engineer at Meta in Menlo Park. He has 8 years of experience in NLP and computer vision."
+Output:
+  1. "I am a senior ML engineer" (assertive)
+  2. "I work at Meta" (assertive)
+  3. "I am based in Menlo Park" (assertive)
+  4. "I have 8 years of experience in NLP" (assertive)
+  5. "I have experience in computer vision" (assertive)
+
+Input: "Yes, create my profile"
+Output: [] (empty — no premises)
+`;
+
+const premiseItemSchema = z.object({
+  text: z.string().describe("The premise text in first person (e.g. 'I am a software engineer at Google')"),
+  tier: z.enum(["assertive", "contextual"]).describe(
+    "assertive = stable identity fact; contextual = temporal/situational"
+  ),
+});
+
+const responseFormat = z.object({
+  reasoning: z.string().describe(
+    "Brief analysis of what factual claims can be extracted from the input"
+  ),
+  premises: z.array(premiseItemSchema).describe(
+    "Array of extracted premises. Empty if input contains no self-descriptive facts."
+  ),
+});
+
+export type PremiseDecomposerOutput = z.infer<typeof responseFormat>;
+export type DecomposedPremise = z.infer<typeof premiseItemSchema>;
+
+/**
+ * Decomposes free-text input (chat messages, bios, scraped content) into
+ * individual atomic premises suitable for the premise graph.
+ */
+export class PremiseDecomposer {
+  private model: ReturnType<ReturnType<typeof createModel>["withStructuredOutput"]>;
+
+  constructor() {
+    const model = createModel("premiseDecomposer");
+    this.model = model.withStructuredOutput(responseFormat, {
+      name: "premise_decomposer",
+    });
+  }
+
+  @Timed()
+  public async invoke(input: string): Promise<PremiseDecomposerOutput> {
+    logger.verbose(`[PremiseDecomposer.invoke] Decomposing input (${input.length} chars)`);
+
+    const prompt = `Decompose the following text into individual premises:\n\n${input}`;
+
+    const messages = [
+      new SystemMessage(systemPrompt),
+      new HumanMessage(prompt),
+    ];
+
+    const result = await this.model.invoke(messages);
+    const output = responseFormat.parse(result);
+
+    logger.verbose(`[PremiseDecomposer.invoke] Extracted ${output.premises.length} premise(s)`);
+    return output;
+  }
+}

--- a/packages/protocol/src/premise/tests/premise.decomposer.spec.ts
+++ b/packages/protocol/src/premise/tests/premise.decomposer.spec.ts
@@ -1,7 +1,6 @@
 // Env must be set before any imports that transitively call createModel
 import { config } from "dotenv";
-config({ path: "backend/.env.test" });
-config({ path: ".env.test" });
+config({ path: ".env.test", override: true });
 
 import { describe, it, expect, beforeAll } from 'bun:test';
 import { PremiseDecomposer } from '../premise.decomposer.js';

--- a/packages/protocol/src/premise/tests/premise.decomposer.spec.ts
+++ b/packages/protocol/src/premise/tests/premise.decomposer.spec.ts
@@ -6,7 +6,9 @@ config({ path: ".env.test" });
 import { describe, it, expect, beforeAll } from 'bun:test';
 import { PremiseDecomposer } from '../premise.decomposer.js';
 
-describe('PremiseDecomposer', () => {
+const HAS_OPENROUTER_KEY = !!process.env.OPENROUTER_API_KEY;
+
+describe.skipIf(!HAS_OPENROUTER_KEY)('PremiseDecomposer', () => {
   let decomposer: PremiseDecomposer;
 
   beforeAll(() => {

--- a/packages/protocol/src/premise/tests/premise.decomposer.spec.ts
+++ b/packages/protocol/src/premise/tests/premise.decomposer.spec.ts
@@ -1,0 +1,105 @@
+// Env must be set before any imports that transitively call createModel
+import { config } from "dotenv";
+config({ path: "backend/.env.test" });
+config({ path: ".env.test" });
+
+import { describe, it, expect, beforeAll } from 'bun:test';
+import { PremiseDecomposer } from '../premise.decomposer.js';
+
+describe('PremiseDecomposer', () => {
+  let decomposer: PremiseDecomposer;
+
+  beforeAll(() => {
+    decomposer = new PremiseDecomposer();
+  });
+
+  it('should decompose a multi-fact bio into individual premises', async () => {
+    const input = "I'm a software engineer at Google based in Mountain View. I specialize in distributed systems and have 5 years of experience in Go and Rust.";
+
+    const result = await decomposer.invoke(input);
+
+    expect(result.premises.length).toBeGreaterThanOrEqual(3);
+    expect(result.reasoning).toBeTruthy();
+
+    // All premises should be first-person
+    for (const p of result.premises) {
+      expect(p.text.toLowerCase()).toMatch(/^i\s/);
+      expect(['assertive', 'contextual']).toContain(p.tier);
+    }
+
+    // Should contain core facts
+    const allText = result.premises.map(p => p.text.toLowerCase()).join(' | ');
+    expect(allText).toContain('google');
+    expect(allText).toMatch(/mountain view|mv/i);
+  }, 30_000);
+
+  it('should convert third-person input to first-person premises', async () => {
+    const input = "Jane Doe is a product designer at Figma. She lives in San Francisco and is passionate about accessibility.";
+
+    const result = await decomposer.invoke(input);
+
+    expect(result.premises.length).toBeGreaterThanOrEqual(2);
+
+    // All should be first-person
+    for (const p of result.premises) {
+      expect(p.text.toLowerCase()).toMatch(/^i\s/);
+    }
+  }, 30_000);
+
+  it('should classify temporal facts as contextual', async () => {
+    const input = "I am attending ETHDenver this week and am currently fundraising for my seed round.";
+
+    const result = await decomposer.invoke(input);
+
+    expect(result.premises.length).toBeGreaterThanOrEqual(2);
+
+    const contextual = result.premises.filter(p => p.tier === 'contextual');
+    expect(contextual.length).toBeGreaterThanOrEqual(1);
+  }, 30_000);
+
+  it('should return empty array for confirmation-only input', async () => {
+    const result = await decomposer.invoke("Yes, create my profile");
+
+    expect(result.premises).toEqual([]);
+  }, 30_000);
+
+  it('should return empty array for non-descriptive input', async () => {
+    const result = await decomposer.invoke("Hello, how are you?");
+
+    expect(result.premises).toEqual([]);
+  }, 30_000);
+
+  it('should handle scraped LinkedIn-style content', async () => {
+    const input = `Name: Alex Chen
+Location: Berlin, Germany
+Current Role: Senior Backend Engineer at Stripe
+Previous: Software Engineer at Amazon (3 years)
+Skills: Python, Kotlin, PostgreSQL, AWS, microservices architecture
+Education: MS Computer Science, Stanford University
+Interests: fintech, open-source tooling, developer experience`;
+
+    const result = await decomposer.invoke(input);
+
+    expect(result.premises.length).toBeGreaterThanOrEqual(5);
+
+    const allText = result.premises.map(p => p.text.toLowerCase()).join(' | ');
+    expect(allText).toContain('berlin');
+    expect(allText).toContain('stripe');
+    expect(allText).toContain('stanford');
+  }, 30_000);
+
+  it('should skip intents and desires', async () => {
+    const input = "I am a designer based in NYC. I'm looking for a co-founder for my startup. I want to find investors.";
+
+    const result = await decomposer.invoke(input);
+
+    // Should extract the factual premises
+    const allText = result.premises.map(p => p.text.toLowerCase()).join(' | ');
+    expect(allText).toContain('designer');
+    expect(allText).toContain('nyc');
+
+    // Should NOT include desires/intents
+    expect(allText).not.toContain('looking for');
+    expect(allText).not.toContain('want to find');
+  }, 30_000);
+});

--- a/packages/protocol/src/premise/tests/premise.decomposer.spec.ts
+++ b/packages/protocol/src/premise/tests/premise.decomposer.spec.ts
@@ -24,7 +24,7 @@ describe.skipIf(!HAS_OPENROUTER_KEY)('PremiseDecomposer', () => {
 
     // All premises should be first-person
     for (const p of result.premises) {
-      expect(p.text.toLowerCase()).toMatch(/^i\s/);
+      expect(p.text.toLowerCase()).toMatch(/^i\b/);
       expect(['assertive', 'contextual']).toContain(p.tier);
     }
 
@@ -43,7 +43,7 @@ describe.skipIf(!HAS_OPENROUTER_KEY)('PremiseDecomposer', () => {
 
     // All should be first-person
     for (const p of result.premises) {
-      expect(p.text.toLowerCase()).toMatch(/^i\s/);
+      expect(p.text.toLowerCase()).toMatch(/^i\b/);
     }
   }, 30_000);
 

--- a/packages/protocol/src/profile/profile.graph.ts
+++ b/packages/protocol/src/profile/profile.graph.ts
@@ -120,6 +120,7 @@ export class ProfileGraphFactory {
   public createGraph() {
     const profileGenerator = new ProfileGenerator();
     const hydeGenerator = new HydeGenerator();
+    const premiseDecomposer = new PremiseDecomposer();
 
     // ─────────────────────────────────────────────────────────
     // NODE: Check State
@@ -911,12 +912,11 @@ export class ProfileGraphFactory {
         const agentTimingsAccum: DebugMetaAgent[] = [];
 
         try {
-          const decomposer = new PremiseDecomposer();
           const _traceEmitter = requestContext.getStore()?.traceEmitter;
 
           const decomposeStart = Date.now();
           _traceEmitter?.({ type: "agent_start", name: "premise-decomposer" });
-          const result = await decomposer.invoke(state.input);
+          const result = await premiseDecomposer.invoke(state.input);
           const decomposeMs = Date.now() - decomposeStart;
           agentTimingsAccum.push({ name: "premise.decomposer", durationMs: decomposeMs });
           _traceEmitter?.({

--- a/packages/protocol/src/profile/profile.graph.ts
+++ b/packages/protocol/src/profile/profile.graph.ts
@@ -13,6 +13,23 @@ import type { QuestionerEnqueueFn } from "../questioner/questioner.types.js";
 import { timed } from "../shared/observability/performance.js";
 import { requestContext } from "../shared/observability/request-context.js";
 import type { DebugMetaAgent } from "../chat/chat-streaming.types.js";
+import { PremiseDecomposer } from "../premise/premise.decomposer.js";
+
+/**
+ * Compiled premise graph interface. Matches the invoke signature of a compiled LangGraph.
+ * Accepted as an optional dependency so write-mode input can be decomposed into premises.
+ */
+export interface CompiledPremiseGraph {
+  invoke(input: {
+    userId: string;
+    assertionText: string;
+    tier: 'assertive' | 'contextual';
+    operationMode: 'create';
+  }): Promise<{
+    premise?: { id: string } | undefined;
+    error?: string | undefined;
+  }>;
+}
 
 const logger = protocolLogger("ProfileGraphFactory");
 
@@ -97,6 +114,7 @@ export class ProfileGraphFactory {
     private scraper: Scraper,
     private enricher?: ProfileEnricher,
     private questionerEnqueue?: QuestionerEnqueueFn,
+    private premiseGraph?: CompiledPremiseGraph,
   ) { }
 
   public createGraph() {
@@ -863,6 +881,116 @@ export class ProfileGraphFactory {
     };
 
     // ─────────────────────────────────────────────────────────
+    // NODE: Decompose Premises
+    // Decomposes free-text input (chat or scraped) into individual premises,
+    // creates each via the premise graph, then routes to aggregate_profile
+    // to synthesize the profile from all active premises.
+    // ─────────────────────────────────────────────────────────
+    const decomposePremisesNode = async (state: typeof ProfileGraphState.State) => {
+      return timed("ProfileGraph.decomposePremises", async () => {
+        if (!state.input) {
+          logger.error("No input for premise decomposition");
+          return { error: "Input required for premise decomposition" };
+        }
+
+        if (!this.premiseGraph) {
+          // Fallback: if no premise graph is available, skip decomposition
+          // and route directly to profile generation (legacy behavior)
+          logger.warn("No premise graph injected — falling back to direct profile generation");
+          return {
+            needsProfileGeneration: true,
+            forceUpdate: true,
+          };
+        }
+
+        logger.verbose("Decomposing input into premises...", {
+          userId: state.userId,
+          inputLength: state.input.length,
+        });
+
+        const agentTimingsAccum: DebugMetaAgent[] = [];
+
+        try {
+          const decomposer = new PremiseDecomposer();
+          const _traceEmitter = requestContext.getStore()?.traceEmitter;
+
+          const decomposeStart = Date.now();
+          _traceEmitter?.({ type: "agent_start", name: "premise-decomposer" });
+          const result = await decomposer.invoke(state.input);
+          const decomposeMs = Date.now() - decomposeStart;
+          agentTimingsAccum.push({ name: "premise.decomposer", durationMs: decomposeMs });
+          _traceEmitter?.({
+            type: "agent_end",
+            name: "premise-decomposer",
+            durationMs: decomposeMs,
+            summary: `Decomposed into ${result.premises.length} premise(s)`,
+          });
+
+          if (result.premises.length === 0) {
+            logger.verbose("No premises extracted — skipping decomposition");
+            // No premises found; fall through to aggregate which will use
+            // whatever premises already exist (or end if none)
+            return {
+              operationMode: 'aggregate' as const,
+              agentTimings: agentTimingsAccum,
+            };
+          }
+
+          logger.verbose(`Creating ${result.premises.length} premise(s) via premise graph`, {
+            userId: state.userId,
+          });
+
+          let created = 0;
+          for (const p of result.premises) {
+            try {
+              const premiseResult = await this.premiseGraph.invoke({
+                userId: state.userId,
+                assertionText: p.text,
+                tier: p.tier,
+                operationMode: 'create',
+              });
+
+              if (premiseResult.premise) {
+                created++;
+              } else if (premiseResult.error) {
+                logger.warn("Premise creation failed", {
+                  text: p.text.substring(0, 60),
+                  error: premiseResult.error,
+                });
+              }
+            } catch (err) {
+              logger.warn("Premise creation threw", {
+                text: p.text.substring(0, 60),
+                error: err instanceof Error ? err.message : String(err),
+              });
+            }
+          }
+
+          logger.verbose(`Created ${created}/${result.premises.length} premise(s)`, {
+            userId: state.userId,
+          });
+
+          // Route to aggregate mode to rebuild the profile from all active premises
+          return {
+            operationMode: 'aggregate' as const,
+            agentTimings: agentTimingsAccum,
+            operationsPerformed: { decomposedPremises: true },
+          };
+        } catch (err) {
+          logger.error("Premise decomposition failed", {
+            error: err instanceof Error ? err.message : String(err),
+          });
+          // Fallback: route to direct profile generation
+          return {
+            needsProfileGeneration: true,
+            forceUpdate: true,
+            agentTimings: agentTimingsAccum,
+          };
+        }
+      });
+    };
+
+    // ─────────────────────────────────────────────────────────
     // ROUTING CONDITIONS
     // Smart conditional routing based on operation mode and missing components
     // ─────────────────────────────────────────────────────────
@@ -909,6 +1037,13 @@ export class ProfileGraphFactory {
       if (state.needsProfileGeneration) {
         // Only use provided input if it's meaningful (not just "Yes" / confirmation)
         if (state.input && isMeaningfulProfileInput(state.input)) {
+          // Route through premise decomposition when a premise graph is available.
+          // The decompose node extracts atomic premises, creates them, then
+          // routes to aggregate_profile for profile synthesis.
+          if (this.premiseGraph) {
+            logger.verbose("Profile generation needed — decomposing input into premises");
+            return "decompose_premises";
+          }
           logger.verbose("Profile generation needed with meaningful input provided");
           return "generate_profile";
         } else {
@@ -979,6 +1114,7 @@ export class ProfileGraphFactory {
       // Add all nodes
       .addNode("check_state", checkStateNode)
       .addNode("scrape", scrapeNode)
+      .addNode("decompose_premises", decomposePremisesNode)
       .addNode("auto_generate", autoGenerateNode)
       .addNode("use_prepopulated_profile", usePrePopulatedProfileNode)
       .addNode("aggregate_profile", aggregateProfileNode)
@@ -998,8 +1134,9 @@ export class ProfileGraphFactory {
           use_prepopulated_profile: "use_prepopulated_profile", // Pre-populated profile -> skip generation
           auto_generate: "auto_generate",       // Generate mode -> Chat API enrichment
           aggregate_profile: "aggregate_profile", // Aggregate mode -> synthesize from premises
+          decompose_premises: "decompose_premises", // Write mode + input + premise graph -> decompose first
           scrape: "scrape",                     // Need profile, no input -> scrape first
-          generate_profile: "generate_profile", // Need profile, have input -> generate
+          generate_profile: "generate_profile", // Need profile, have input -> generate (legacy, no premise graph)
           embed_save_profile: "embed_save_profile", // Have profile, need embedding
           generate_hyde: "generate_hyde",       // Have profile+embedding, need hyde
           embed_save_hyde: "embed_save_hyde",   // Have hyde, need embedding
@@ -1009,6 +1146,21 @@ export class ProfileGraphFactory {
 
       // Pre-populated profile feeds into embedding (skips generation)
       .addEdge("use_prepopulated_profile", "embed_save_profile")
+
+      // Decompose premises routes to aggregate (normal) or generate_profile (fallback)
+      .addConditionalEdges(
+        "decompose_premises",
+        (state: typeof ProfileGraphState.State) => {
+          if (state.operationMode === 'aggregate') return "aggregate_profile";
+          // Fallback when decomposition failed (no premise graph or error)
+          if (state.needsProfileGeneration) return "generate_profile";
+          return "aggregate_profile";
+        },
+        {
+          aggregate_profile: "aggregate_profile",
+          generate_profile: "generate_profile",
+        },
+      )
 
       // Aggregate profile: generate if premises found, END if none
       .addConditionalEdges(
@@ -1043,9 +1195,19 @@ export class ProfileGraphFactory {
         }
       )
 
-      // Scrape -> Generate profile (linear)
-      .addEdge("scrape", "generate_profile")
-      
+      // Scrape -> decompose_premises (when premise graph available) or generate_profile (legacy)
+      .addConditionalEdges(
+        "scrape",
+        (_state: typeof ProfileGraphState.State) => {
+          if (this.premiseGraph) return "decompose_premises";
+          return "generate_profile";
+        },
+        {
+          decompose_premises: "decompose_premises",
+          generate_profile: "generate_profile",
+        },
+      )
+
       // Generate profile -> Embed profile (linear)
       .addEdge("generate_profile", "embed_save_profile")
 

--- a/packages/protocol/src/profile/profile.graph.ts
+++ b/packages/protocol/src/profile/profile.graph.ts
@@ -928,8 +928,9 @@ export class ProfileGraphFactory {
 
           if (result.premises.length === 0) {
             logger.verbose("No premises extracted — skipping decomposition");
-            // No premises found; fall through to aggregate which will use
-            // whatever premises already exist (or end if none)
+            // No premises found; fall through to aggregate which will
+            // synthesize from any existing premises, or to generate_profile
+            // if needsProfileGeneration is still set from check_state
             return {
               operationMode: 'aggregate' as const,
               agentTimings: agentTimingsAccum,

--- a/packages/protocol/src/profile/profile.state.ts
+++ b/packages/protocol/src/profile/profile.state.ts
@@ -151,6 +151,7 @@ export const ProfileGraphState = Annotation.Root({
    */
   operationsPerformed: Annotation<{
     scraped?: boolean;
+    decomposedPremises?: boolean;
     generatedProfile?: boolean;
     embeddedProfile?: boolean;
     generatedHyde?: boolean;

--- a/packages/protocol/src/profile/tests/profile.decompose.spec.ts
+++ b/packages/protocol/src/profile/tests/profile.decompose.spec.ts
@@ -195,6 +195,7 @@ describe('ProfileGraph - Premise Decomposition', () => {
       mockEmbedder,
       mockScraper,
       undefined, // no enricher
+      undefined, // no questionerEnqueue
       mockPremiseGraph,
     ).createGraph();
   }
@@ -374,7 +375,8 @@ describe('ProfileGraph - Premise Decomposition', () => {
         mockDatabase,
         mockEmbedder,
         mockScraper,
-        undefined,
+        undefined, // no enricher
+        undefined, // no questionerEnqueue
         failingPremiseGraph,
       ).createGraph();
 

--- a/packages/protocol/src/profile/tests/profile.decompose.spec.ts
+++ b/packages/protocol/src/profile/tests/profile.decompose.spec.ts
@@ -1,15 +1,11 @@
 /**
  * Unit tests for the decompose_premises node in ProfileGraph.
  *
- * Run with: OPENROUTER_API_KEY=test bun test profile.decompose.spec.ts
- * The env var must be set BEFORE Bun loads this file because ESM static imports
- * are resolved before the module body runs, and ProfileGenerator calls
- * createModel() at module load time.
+ * All LLM calls are mocked — no real API key needed. The dummy key
+ * prevents createModel() from throwing at module load time.
  */
 import { config } from "dotenv";
-import { resolve } from "path";
-config({ path: resolve(import.meta.dir, "../../../../../backend/.env.test") });
-config({ path: resolve(import.meta.dir, "../../../../../backend/.env") });
+config({ path: ".env.test", override: true });
 process.env.OPENROUTER_API_KEY ??= 'test';
 
 import { describe, it, expect, beforeEach, mock } from 'bun:test';

--- a/packages/protocol/src/profile/tests/profile.decompose.spec.ts
+++ b/packages/protocol/src/profile/tests/profile.decompose.spec.ts
@@ -1,0 +1,393 @@
+/**
+ * Unit tests for the decompose_premises node in ProfileGraph.
+ *
+ * Run with: OPENROUTER_API_KEY=test bun test profile.decompose.spec.ts
+ * The env var must be set BEFORE Bun loads this file because ESM static imports
+ * are resolved before the module body runs, and ProfileGenerator calls
+ * createModel() at module load time.
+ */
+import { config } from "dotenv";
+import { resolve } from "path";
+config({ path: resolve(import.meta.dir, "../../../../../backend/.env.test") });
+config({ path: resolve(import.meta.dir, "../../../../../backend/.env") });
+process.env.OPENROUTER_API_KEY ??= 'test';
+
+import { describe, it, expect, beforeEach, mock } from 'bun:test';
+
+// ─── Mock LLM-calling modules ──────────────────────────────────────────────
+// ProfileGenerator and HydeGenerator create models at MODULE SCOPE, so they
+// call createModel() before mock.module on model.config can intercept it.
+// Instead, we mock the entire module that exports these classes.
+
+const mockProfileOutput = {
+  identity: {
+    name: 'Test User',
+    bio: 'A software engineer based in Berlin',
+    location: 'Berlin',
+  },
+  narrative: { context: 'Test user context' },
+  attributes: {
+    interests: ['distributed systems'],
+    skills: ['TypeScript', 'software engineering'],
+  },
+};
+
+mock.module("../profile.generator.js", () => ({
+  ProfileGenerator: class MockProfileGenerator {
+    async invoke(input: string) {
+      return {
+        output: mockProfileOutput,
+        textToEmbed: 'mock text to embed',
+      };
+    }
+  },
+}));
+
+mock.module("../profile.hyde.generator.js", () => ({
+  HydeGenerator: class MockHydeGenerator {
+    async invoke(_input: string) {
+      return {
+        textToEmbed: 'Mock HyDE text for test user profile',
+      };
+    }
+  },
+}));
+
+const mockDecomposeOutput = {
+  reasoning: 'Decomposed input into premises',
+  premises: [
+    { text: 'I am a software engineer', tier: 'assertive' as const },
+    { text: 'I am based in Berlin', tier: 'assertive' as const },
+  ],
+};
+
+mock.module("../../premise/premise.decomposer.js", () => ({
+  PremiseDecomposer: class MockPremiseDecomposer {
+    async invoke(_input: string) {
+      return mockDecomposeOutput;
+    }
+  },
+}));
+
+import { ProfileGraphFactory } from '../profile.graph.js';
+import type { ProfileGraphDatabase, PremiseRecord } from '../../shared/interfaces/database.interface.js';
+import type { Embedder } from '../../shared/interfaces/embedder.interface.js';
+import type { Scraper } from '../../shared/interfaces/scraper.interface.js';
+import type { CompiledPremiseGraph } from '../profile.graph.js';
+
+interface ProfileDocument {
+  userId: string;
+  identity: {
+    name: string;
+    bio: string;
+    location: string;
+  };
+  narrative: { context: string };
+  attributes: {
+    interests: string[];
+    skills: string[];
+  };
+  embedding: number[] | number[][] | null;
+}
+
+describe('ProfileGraph - Premise Decomposition', () => {
+  let mockDatabase: ProfileGraphDatabase;
+  let mockEmbedder: Embedder;
+  let mockScraper: Scraper;
+  let mockPremiseGraph: CompiledPremiseGraph;
+
+  const mockProfile: ProfileDocument = {
+    userId: 'test-user-id',
+    identity: {
+      name: 'Test User',
+      bio: 'A test user bio',
+      location: 'Test City',
+    },
+    narrative: { context: 'Test user context' },
+    attributes: {
+      interests: ['testing'],
+      skills: ['TypeScript'],
+    },
+    embedding: [0.1, 0.2, 0.3],
+  };
+
+  const mockActivePremises: PremiseRecord[] = [
+    {
+      id: 'premise-1',
+      userId: 'test-user-id',
+      assertion: { text: 'I am a software engineer', tier: 'assertive' },
+      provenance: { source: 'explicit', confidence: 1.0, timestamp: new Date().toISOString() },
+      analysis: null,
+      validity: { volatile: false },
+      status: 'ACTIVE',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      retractedAt: null,
+    },
+    {
+      id: 'premise-2',
+      userId: 'test-user-id',
+      assertion: { text: 'I am based in Berlin', tier: 'assertive' },
+      provenance: { source: 'explicit', confidence: 1.0, timestamp: new Date().toISOString() },
+      analysis: null,
+      validity: { volatile: false },
+      status: 'ACTIVE',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      retractedAt: null,
+    },
+  ];
+
+  let premiseCreateCalls: Array<{ userId: string; assertionText: string; tier: string }>;
+
+  beforeEach(() => {
+    premiseCreateCalls = [];
+
+    mockDatabase = {
+      getProfile: mock(async () => null),
+      getProfileByUserId: mock(async () => null),
+      getUser: mock(async (userId: string) => ({
+        id: userId,
+        name: 'Test User',
+        email: 'test@example.com',
+        socials: [],
+      })),
+      getUserSocials: mock(async () => []),
+      setUserSocials: mock(async () => {}),
+      updateUser: mock(async (userId: string, data: unknown) => ({
+        id: userId,
+        name: 'Test User',
+        email: 'test@example.com',
+        ...(data as object),
+      })),
+      saveProfile: mock(async () => {}),
+      getHydeDocument: mock(async () => null),
+      saveHydeDocument: mock(async () => ({ id: 'mock-hyde-id' })),
+      softDeleteGhost: mock(async () => true),
+      getPremisesForUser: mock(async () => mockActivePremises),
+    } as unknown as ProfileGraphDatabase;
+
+    mockEmbedder = {
+      generate: mock(async () => [0.1, 0.2, 0.3]),
+    } as unknown as Embedder;
+
+    mockScraper = {
+      scrape: mock(async () => 'Scraped content about the user: software engineer in Berlin'),
+    } as unknown as Scraper;
+
+    mockPremiseGraph = {
+      invoke: mock(async (input: { userId: string; assertionText: string; tier: string; operationMode: string }) => {
+        premiseCreateCalls.push({
+          userId: input.userId,
+          assertionText: input.assertionText,
+          tier: input.tier,
+        });
+        return {
+          premise: { id: `premise-${premiseCreateCalls.length}` },
+        };
+      }),
+    } as unknown as CompiledPremiseGraph;
+  });
+
+  function buildGraph() {
+    return new ProfileGraphFactory(
+      mockDatabase,
+      mockEmbedder,
+      mockScraper,
+      undefined, // no enricher
+      mockPremiseGraph,
+    ).createGraph();
+  }
+
+  function buildGraphWithoutPremise() {
+    return new ProfileGraphFactory(
+      mockDatabase,
+      mockEmbedder,
+      mockScraper,
+    ).createGraph();
+  }
+
+  // ─── Write mode with input: routes through decompose_premises ───────────
+
+  describe('write mode with meaningful input and premise graph', () => {
+    it('should decompose input into premises and route to aggregate', async () => {
+      const graph = buildGraph();
+      const result = await graph.invoke({
+        userId: 'test-user-id',
+        operationMode: 'write',
+        input: 'I am a software engineer based in Berlin. I specialize in distributed systems.',
+        forceUpdate: true,
+      });
+
+      // Premise graph should have been called to create premises
+      expect(premiseCreateCalls.length).toBeGreaterThanOrEqual(1);
+
+      // All created premises should be for the correct user
+      for (const call of premiseCreateCalls) {
+        expect(call.userId).toBe('test-user-id');
+      }
+
+      // Should have fetched active premises for aggregation
+      expect(mockDatabase.getPremisesForUser).toHaveBeenCalledWith('test-user-id', 'ACTIVE');
+
+      // Should have generated a profile (via aggregate -> generate_profile)
+      expect(result.profile).toBeDefined();
+      expect(mockDatabase.saveProfile).toHaveBeenCalled();
+    }, 60_000);
+
+    it('should create premises with correct tiers', async () => {
+      const graph = buildGraph();
+      await graph.invoke({
+        userId: 'test-user-id',
+        operationMode: 'write',
+        input: 'I am a climate tech founder. I am attending ETHDenver this week.',
+        forceUpdate: true,
+      });
+
+      // At least one premise should have been created
+      expect(premiseCreateCalls.length).toBeGreaterThanOrEqual(1);
+
+      // Each premise should have a valid tier
+      for (const call of premiseCreateCalls) {
+        expect(['assertive', 'contextual']).toContain(call.tier);
+      }
+    }, 60_000);
+  });
+
+  // ─── Legacy fallback: no premise graph ────────────────────────────────────
+
+  describe('write mode without premise graph (legacy)', () => {
+    it('should route directly to generate_profile when no premise graph is injected', async () => {
+      const graph = buildGraphWithoutPremise();
+      const result = await graph.invoke({
+        userId: 'test-user-id',
+        operationMode: 'write',
+        input: 'I am a software engineer based in Berlin.',
+        forceUpdate: true,
+      });
+
+      // Should have generated profile directly (no decomposition)
+      expect(result.profile).toBeDefined();
+      expect(mockDatabase.saveProfile).toHaveBeenCalled();
+
+      // Premise graph should NOT have been called
+      expect(premiseCreateCalls.length).toBe(0);
+    }, 60_000);
+  });
+
+  // ─── Scrape then decompose ───────────────────────────────────────────────
+
+  describe('scrape followed by decomposition', () => {
+    it('should scrape first, then decompose scraped content into premises', async () => {
+      const graph = buildGraph();
+      const result = await graph.invoke({
+        userId: 'test-user-id',
+        operationMode: 'write',
+        // No input — will trigger scraping first
+      });
+
+      // Scraper should have been called
+      expect(mockScraper.scrape).toHaveBeenCalled();
+
+      // Premise graph should have been called with scraped content
+      expect(premiseCreateCalls.length).toBeGreaterThanOrEqual(1);
+
+      // Should have generated profile via aggregate
+      expect(result.profile).toBeDefined();
+      expect(mockDatabase.saveProfile).toHaveBeenCalled();
+    }, 60_000);
+
+    it('should skip scraping and decomposition when scraping is not needed', async () => {
+      // Profile already exists, no forceUpdate
+      (mockDatabase.getProfile as ReturnType<typeof mock>).mockResolvedValue(mockProfile);
+      (mockDatabase.getHydeDocument as ReturnType<typeof mock>).mockResolvedValue({
+        hydeText: 'Existing HyDE',
+        hydeEmbedding: [0.4, 0.5, 0.6],
+      });
+
+      const graph = buildGraph();
+      const result = await graph.invoke({
+        userId: 'test-user-id',
+        operationMode: 'write',
+      });
+
+      // No scraping, no decomposition
+      expect(mockScraper.scrape).not.toHaveBeenCalled();
+      expect(premiseCreateCalls.length).toBe(0);
+
+      // Profile returned as-is
+      expect(result.profile).toEqual(mockProfile);
+    }, 30_000);
+  });
+
+  // ─── Aggregate mode still works directly ─────────────────────────────────
+
+  describe('aggregate mode', () => {
+    it('should still work directly without going through decomposition', async () => {
+      const graph = buildGraph();
+      const result = await graph.invoke({
+        userId: 'test-user-id',
+        operationMode: 'aggregate',
+      });
+
+      // Should fetch active premises
+      expect(mockDatabase.getPremisesForUser).toHaveBeenCalledWith('test-user-id', 'ACTIVE');
+
+      // Should generate profile
+      expect(result.profile).toBeDefined();
+      expect(mockDatabase.saveProfile).toHaveBeenCalled();
+
+      // Should NOT call premise graph (aggregate uses existing premises)
+      expect(premiseCreateCalls.length).toBe(0);
+    }, 60_000);
+  });
+
+  // ─── Query mode unaffected ───────────────────────────────────────────────
+
+  describe('query mode', () => {
+    it('should return profile without decomposition', async () => {
+      (mockDatabase.getProfile as ReturnType<typeof mock>).mockResolvedValue(mockProfile);
+
+      const graph = buildGraph();
+      const result = await graph.invoke({
+        userId: 'test-user-id',
+        operationMode: 'query',
+      });
+
+      expect(result.profile).toEqual(mockProfile);
+      expect(premiseCreateCalls.length).toBe(0);
+      expect(mockScraper.scrape).not.toHaveBeenCalled();
+    }, 30_000);
+  });
+
+  // ─── Error handling ──────────────────────────────────────────────────────
+
+  describe('error handling', () => {
+    it('should fall back to direct generation if premise graph throws', async () => {
+      const failingPremiseGraph: CompiledPremiseGraph = {
+        invoke: mock(async () => {
+          throw new Error('Premise graph crashed');
+        }),
+      } as unknown as CompiledPremiseGraph;
+
+      const graph = new ProfileGraphFactory(
+        mockDatabase,
+        mockEmbedder,
+        mockScraper,
+        undefined,
+        failingPremiseGraph,
+      ).createGraph();
+
+      const result = await graph.invoke({
+        userId: 'test-user-id',
+        operationMode: 'write',
+        input: 'I am a software engineer in Berlin.',
+        forceUpdate: true,
+      });
+
+      // Should still generate a profile (fallback to direct generation)
+      expect(result.profile).toBeDefined();
+      expect(mockDatabase.saveProfile).toHaveBeenCalled();
+    }, 60_000);
+  });
+});

--- a/packages/protocol/src/shared/agent/model.config.ts
+++ b/packages/protocol/src/shared/agent/model.config.ts
@@ -63,6 +63,7 @@ function getModelConfig(config?: ModelConfig) {
     negotiationSummarizer:      { model: "google/gemini-2.5-flash", temperature: 0.2, maxTokens: 256 },
     inviteGenerator:      { model: "google/gemini-2.5-flash", temperature: 0.3, maxTokens: 512 },
     premiseAnalyzer:      { model: "google/gemini-2.5-flash" },
+    premiseDecomposer:    { model: "google/gemini-2.5-flash" },
     premiseIndexer:       { model: "google/gemini-2.5-flash" },
     chat: {
       model: merged.chatModel ?? process.env.CHAT_MODEL ?? "google/gemini-3-pro-preview",

--- a/packages/protocol/src/shared/agent/tool.factory.ts
+++ b/packages/protocol/src/shared/agent/tool.factory.ts
@@ -114,7 +114,8 @@ export async function createChatTools(
 
   // ─── Compile subgraphs ─────────────────────────────────────────────────────
   const intentGraph = new IntentGraphFactory(database, embedder, deps.intentQueue).createGraph();
-  const profileGraph = new ProfileGraphFactory(database, embedder, scraper, deps.enricher).createGraph();
+  const premiseGraph = new PremiseGraphFactory(database as unknown as PremiseGraphDatabase, embedder).createGraph();
+  const profileGraph = new ProfileGraphFactory(database, embedder, scraper, deps.enricher, deps.questionerEnqueue, premiseGraph).createGraph();
   const hydeCache = deps.hydeCache;
   const lensInferrer = new LensInferrer();
   const hydeGenerator = new HydeGenerator();
@@ -145,7 +146,6 @@ export async function createChatTools(
   const networkGraph = new NetworkGraphFactory(database).createGraph();
   const networkMembershipGraph = new NetworkMembershipGraphFactory(database).createGraph();
   const intentNetworkGraph = new IntentNetworkGraphFactory(database, new IntentIndexer()).createGraph();
-  const premiseGraph = new PremiseGraphFactory(database as unknown as PremiseGraphDatabase, embedder).createGraph();
 
   // ─── Create context-bound databases ────────────────────────────────────────
   // Use injected instances when provided (e.g. tests). Otherwise create from the same

--- a/packages/protocol/src/shared/agent/tool.factory.ts
+++ b/packages/protocol/src/shared/agent/tool.factory.ts
@@ -113,7 +113,7 @@ export async function createChatTools(
   }
 
   // ─── Compile subgraphs ─────────────────────────────────────────────────────
-  const intentGraph = new IntentGraphFactory(database, embedder, deps.intentQueue).createGraph();
+  const intentGraph = new IntentGraphFactory(database, embedder, deps.intentQueue, deps.questionerEnqueue).createGraph();
   const premiseGraph = new PremiseGraphFactory(database as unknown as PremiseGraphDatabase, embedder).createGraph();
   const profileGraph = new ProfileGraphFactory(database, embedder, scraper, deps.enricher, deps.questionerEnqueue, premiseGraph).createGraph();
   const hydeCache = deps.hydeCache;


### PR DESCRIPTION
## Summary
- Add `PremiseDecomposer` agent — structured output LLM (gemini-2.5-flash) that extracts atomic first-person premises from free text (bios, chat, scraped content)
- Add `decompose_premises` node to profile graph with error fallback to legacy generation
- Route write-mode input through premise decomposition when `premiseGraph` is available: extract claims → create premises → aggregate into profile
- Route scrape output through decomposition (same path)
- `ProfileGraphFactory` constructor accepts optional `CompiledPremiseGraph` — backward compatible (no premiseGraph = legacy behavior)
- Wire premiseGraph into factory in `mcp.controller.ts` and `tool.factory.ts`

Closes IND-330. Part of IND-328 (profiles → presentation-only).

## Test plan
- [x] `bunx tsc --noEmit` passes for both `packages/protocol` and `backend`
- [x] 8 unit tests covering all decomposition paths (write+input, write+scrape, legacy fallback, aggregate, query, error handling)
- [ ] Run `PremiseDecomposer` integration test with API key
- [ ] Run full profile graph test suite