### PR TITLE
feat(protocol): wire questioner userAnswers into negotiation continuation

### DIFF
--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -7482,6 +7482,26 @@ export class ConversationDatabaseAdapter {
   }
 
   /**
+   * Returns user answers collected by the questioner for a given opportunity.
+   * Reads `metadata.userAnswers` from the opportunities table.
+   */
+  async getOpportunityUserAnswers(opportunityId: string): Promise<Array<{
+    questionId: string;
+    selectedOptions: string[];
+    freeText?: string;
+    answeredAt: string;
+  }>> {
+    const [row] = await db
+      .select({ metadata: opportunities.metadata })
+      .from(opportunities)
+      .where(eq(opportunities.id, opportunityId))
+      .limit(1);
+    if (!row?.metadata) return [];
+    const meta = row.metadata as Record<string, unknown>;
+    return Array.isArray(meta.userAnswers) ? meta.userAnswers : [];
+  }
+
+  /**
    * Gets all messages for a conversation, ordered by creation time (ascending).
    * Used by negotiation tools to reconstruct turn history.
    * @param conversationId - The conversation to fetch messages for

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -7498,7 +7498,16 @@ export class ConversationDatabaseAdapter {
       .limit(1);
     if (!row?.metadata) return [];
     const meta = row.metadata as Record<string, unknown>;
-    return Array.isArray(meta.userAnswers) ? meta.userAnswers : [];
+    if (!Array.isArray(meta.userAnswers)) return [];
+    return (meta.userAnswers as Record<string, unknown>[])
+      .filter((a): a is Record<string, unknown> & { questionId: string; answeredAt: string } =>
+        typeof a?.questionId === 'string' && typeof a?.answeredAt === 'string')
+      .map((a) => ({
+        questionId: a.questionId,
+        selectedOptions: Array.isArray(a.selectedOptions) ? (a.selectedOptions as unknown[]).filter((o): o is string => typeof o === 'string') : [],
+        ...(typeof a.freeText === 'string' && { freeText: a.freeText }),
+        answeredAt: a.answeredAt,
+      }));
   }
 
   /**

--- a/backend/tests/negotiation.graph.spec.ts
+++ b/backend/tests/negotiation.graph.spec.ts
@@ -40,6 +40,7 @@ function createDeps() {
     getMessagesForConversation: mock(() => Promise.resolve([])),
     getArtifactsForTask: mock(() => Promise.resolve([])),
     getNegotiationTaskForOpportunity: mock(() => Promise.resolve(null)),
+    getOpportunityUserAnswers: mock(() => Promise.resolve([])),
     updateOpportunityStatus,
   } satisfies Partial<NegotiationGraphDatabase>;
   const database = {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "1.12.1"
+  "version": "1.12.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/negotiation/negotiation.agent.ts
+++ b/packages/protocol/src/negotiation/negotiation.agent.ts
@@ -159,6 +159,7 @@ Policy: You are continuing a prior dialogue. If this signal is materially the sa
           const opts = Array.isArray(a.selectedOptions) ? a.selectedOptions : [];
           const parts = opts.length > 0 ? opts.join(', ') : '';
           const free = a.freeText ? (parts ? ` — ${a.freeText}` : a.freeText) : '';
+          if (!parts && !free) return '';
           return `- ${parts}${free}`;
         }).filter(Boolean).join("\n")}\n`
       : '';

--- a/packages/protocol/src/negotiation/negotiation.agent.ts
+++ b/packages/protocol/src/negotiation/negotiation.agent.ts
@@ -6,6 +6,7 @@ import {
   type UserNegotiationContext,
   type SeedAssessment,
 } from "./negotiation.state.js";
+import type { NegotiationUserAnswer } from "../shared/interfaces/database.interface.js";
 
 const SYSTEM_PROMPT = `You are the Index Negotiator, an AI agent acting on behalf of {userName}. You represent their interests in a bilateral negotiation about a potential connection on a discovery network.
 
@@ -40,6 +41,8 @@ export interface NegotiationAgentInput {
   discoveryQuery?: string;
   /** Whether this negotiation is continuing a prior conversation with the same counterparty. */
   isContinuation?: boolean;
+  /** User answers collected by the questioner between negotiation sessions. */
+  userAnswers?: NegotiationUserAnswer[];
 }
 
 export interface IndexNegotiatorConfig {
@@ -151,6 +154,14 @@ ${input.discoveryQuery
 Policy: You are continuing a prior dialogue. If this signal is materially the same as one you previously evaluated, you may resolve quickly. If materially different, evaluate on its own merits.`
       : '';
 
+    const userAnswersContext = input.userAnswers && input.userAnswers.length > 0
+      ? `\n\n--- ${userName}'s additional context (provided between sessions) ---\n${input.userAnswers.map((a) => {
+          const parts = a.selectedOptions.length > 0 ? a.selectedOptions.join(', ') : '';
+          const free = a.freeText ? (parts ? ` — ${a.freeText}` : a.freeText) : '';
+          return `- ${parts}${free}`;
+        }).join("\n")}\n`
+      : '';
+
     const discoveryQueryReminder = input.discoveryQuery
       ? `\nREMINDER: ${userName} searched for "${input.discoveryQuery}". Evaluate ${otherName} against this query FIRST. If ${otherName} is not a "${input.discoveryQuery}", reject.\n`
       : '';
@@ -169,7 +180,7 @@ Skills: ${input.otherUser.profile.skills?.join(", ") ?? "N/A"}
 Intents:
 ${input.otherUser.intents.map((i) => `- ${i.title}: ${i.description}`).join("\n")}
 
-Why this match was suggested: ${input.seedAssessment.reasoning}${input.isContinuation ? continuationContext : historyText}
+Why this match was suggested: ${input.seedAssessment.reasoning}${input.isContinuation ? continuationContext : historyText}${userAnswersContext}
 ${discoveryQueryReminder}
 ${input.history.length === 0 && !input.isContinuation ? "This is the opening turn. Propose the connection case." : "Evaluate the latest arguments and respond."}`;
 

--- a/packages/protocol/src/negotiation/negotiation.agent.ts
+++ b/packages/protocol/src/negotiation/negotiation.agent.ts
@@ -156,10 +156,11 @@ Policy: You are continuing a prior dialogue. If this signal is materially the sa
 
     const userAnswersContext = input.userAnswers && input.userAnswers.length > 0
       ? `\n\n--- ${userName}'s additional context (provided between sessions) ---\n${input.userAnswers.map((a) => {
-          const parts = a.selectedOptions.length > 0 ? a.selectedOptions.join(', ') : '';
+          const opts = Array.isArray(a.selectedOptions) ? a.selectedOptions : [];
+          const parts = opts.length > 0 ? opts.join(', ') : '';
           const free = a.freeText ? (parts ? ` — ${a.freeText}` : a.freeText) : '';
           return `- ${parts}${free}`;
-        }).join("\n")}\n`
+        }).filter(Boolean).join("\n")}\n`
       : '';
 
     const discoveryQueryReminder = input.discoveryQuery

--- a/packages/protocol/src/negotiation/negotiation.graph.ts
+++ b/packages/protocol/src/negotiation/negotiation.graph.ts
@@ -104,6 +104,14 @@ export class NegotiationGraphFactory {
           });
         }
 
+        // Load user answers collected by the questioner between sessions
+        const userAnswers = (isContinuation && state.opportunityId)
+          ? await database.getOpportunityUserAnswers(state.opportunityId).catch((err) => {
+              logger.error('[Graph:Init] Failed to load user answers', { opportunityId: state.opportunityId, error: err });
+              return [];
+            })
+          : [];
+
         // Seed messages with prior turns (additive reducer appends new turns on top)
         const seedMessages = isContinuation ? priorMessages.map((m) => ({
           id: m.id,
@@ -121,6 +129,7 @@ export class NegotiationGraphFactory {
           maxTurns,
           isContinuation,
           priorTurnCount: priorTurns.length,
+          ...(userAnswers.length > 0 && { userAnswers }),
           ...(seedMessages.length > 0 && { messages: seedMessages }),
         };
       } catch (err) {
@@ -206,6 +215,7 @@ export class NegotiationGraphFactory {
             isDiscoverer: isSource,
             ...(state.discoveryQuery && isSource && { discoveryQuery: state.discoveryQuery }),
             isContinuation: state.isContinuation,
+            ...(state.userAnswers.length > 0 && { userAnswers: state.userAnswers }),
           });
         }
 

--- a/packages/protocol/src/negotiation/negotiation.state.ts
+++ b/packages/protocol/src/negotiation/negotiation.state.ts
@@ -1,5 +1,6 @@
 import { Annotation } from "@langchain/langgraph";
 import { z } from "zod";
+import type { NegotiationUserAnswer } from "../shared/interfaces/database.interface.js";
 
 /** Zod schema for a single negotiation turn (DataPart payload in A2A message). */
 export const NegotiationTurnSchema = z.object({
@@ -188,6 +189,12 @@ export const NegotiationGraphState = Annotation.Root({
   priorTurnCount: Annotation<number>({
     reducer: (curr, next) => next ?? curr,
     default: () => 0,
+  }),
+
+  /** User answers collected by the questioner between negotiation sessions. */
+  userAnswers: Annotation<NegotiationUserAnswer[]>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => [],
   }),
 
   outcome: Annotation<NegotiationOutcome | null>({

--- a/packages/protocol/src/negotiation/tests/negotiation.continuation.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.continuation.spec.ts
@@ -22,6 +22,7 @@ function createMockDatabase(overrides: Partial<Record<string, unknown>> = {}) {
     createArtifact: async () => ({ id: "art-1" }),
     setTaskTurnContext: async () => {},
     getNegotiationTaskForOpportunity: async () => null,
+    getOpportunityUserAnswers: async () => [],
     getTasksForUser: async () => [],
     getTask: async () => null,
     getMessagesForConversation: async () => [],
@@ -294,6 +295,83 @@ describe("Negotiation continuation telemetry", () => {
     expect(result.isContinuation).toBe(true);
     expect(result.priorTurnCount).toBe(1);
     expect(result.outcome).not.toBeNull();
+
+    IndexNegotiator.prototype.invoke = origInvoke;
+  }, 30_000);
+
+  it("continuation with userAnswers: passes answers to agent prompt", async () => {
+    const priorTurn = {
+      action: "propose",
+      assessment: { reasoning: "Good fit", suggestedRoles: { ownUser: "peer", otherUser: "peer" } },
+    };
+    const priorMessages = [{
+      id: "msg-prior-1",
+      senderId: `agent:${sourceUser.id}`,
+      role: "agent" as const,
+      parts: [{ kind: "data" as const, data: priorTurn }],
+      createdAt: new Date(Date.now() - 60_000),
+    }];
+
+    const mockAnswers = [
+      { questionId: "q1", selectedOptions: ["ML infrastructure"], freeText: "Specifically PyTorch", answeredAt: "2026-05-25T12:00:00Z" },
+      { questionId: "q2", selectedOptions: ["Co-founder"], answeredAt: "2026-05-25T12:01:00Z" },
+    ];
+
+    let capturedInput: Record<string, unknown> | null = null;
+    IndexNegotiator.prototype.invoke = async function (input) {
+      capturedInput = input as unknown as Record<string, unknown>;
+      return { action: "accept", assessment: { reasoning: "r", suggestedRoles: { ownUser: "peer", otherUser: "peer" } } } as never;
+    };
+
+    const db = createMockDatabase({
+      getMessagesForConversation: async () => priorMessages,
+      getOpportunityUserAnswers: async () => mockAnswers,
+    });
+    const dispatcher = createMockDispatcher();
+    const graph = new NegotiationGraphFactory(db, dispatcher).createGraph();
+
+    const result = await graph.invoke({
+      sourceUser,
+      candidateUser,
+      indexContext,
+      seedAssessment: seed,
+      opportunityId: "opp-answers",
+      maxTurns: 4,
+    } as Partial<typeof NegotiationGraphState.State>);
+
+    expect(result.isContinuation).toBe(true);
+    expect(result.userAnswers).toHaveLength(2);
+    expect(capturedInput).not.toBeNull();
+    expect((capturedInput as Record<string, unknown>).userAnswers).toHaveLength(2);
+
+    IndexNegotiator.prototype.invoke = origInvoke;
+  }, 30_000);
+
+  it("fresh flow: userAnswers not loaded when not a continuation", async () => {
+    let getAnswersCalled = false;
+    const scripted = [
+      { action: "propose", assessment: { reasoning: "r1", suggestedRoles: { ownUser: "peer", otherUser: "peer" } } },
+      { action: "accept", assessment: { reasoning: "r2", suggestedRoles: { ownUser: "peer", otherUser: "peer" } } },
+    ];
+    let call = 0;
+    IndexNegotiator.prototype.invoke = async function () { return scripted[Math.min(call++, scripted.length - 1)] as never; };
+
+    const db = createMockDatabase({
+      getOpportunityUserAnswers: async () => { getAnswersCalled = true; return []; },
+    });
+    const dispatcher = createMockDispatcher();
+    const graph = new NegotiationGraphFactory(db, dispatcher).createGraph();
+
+    await graph.invoke({
+      sourceUser,
+      candidateUser,
+      indexContext,
+      seedAssessment: seed,
+      opportunityId: "opp-fresh-no-answers",
+      maxTurns: 4,
+    } as Partial<typeof NegotiationGraphState.State>);
+
+    expect(getAnswersCalled).toBe(false);
 
     IndexNegotiator.prototype.invoke = origInvoke;
   }, 30_000);

--- a/packages/protocol/src/shared/interfaces/database.interface.ts
+++ b/packages/protocol/src/shared/interfaces/database.interface.ts
@@ -1987,6 +1987,14 @@ export type OpportunityGraphDatabase = Pick<
  * Negotiation-specific query operations not covered by generic
  * conversation/task primitives.
  */
+/** A user's answer to a questioner-generated question, stored on opportunity metadata. */
+export interface NegotiationUserAnswer {
+  questionId: string;
+  selectedOptions: string[];
+  freeText?: string;
+  answeredAt: string;
+}
+
 export interface NegotiationQueries {
   /**
    * Persists the full negotiation turn context (source/candidate user contexts,
@@ -2011,6 +2019,14 @@ export interface NegotiationQueries {
     createdAt: Date;
     updatedAt: Date;
   } | null>;
+
+  /**
+   * Returns user answers collected by the questioner system for a given
+   * opportunity. Reads `metadata.userAnswers` from the opportunities table.
+   * Used by the negotiation graph to inject between-session context into
+   * continuation prompts.
+   */
+  getOpportunityUserAnswers(opportunityId: string): Promise<NegotiationUserAnswer[]>;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Closes the gap where negotiation-mode question answers (stored on `opportunity.metadata.userAnswers` by the questioner system) were never read back during conversation continuation
- Adds `getOpportunityUserAnswers()` to `NegotiationQueries` interface and implements it in `ConversationDatabaseAdapter`
- Init node loads answers when resuming a prior conversation (`isContinuation && opportunityId`), passes them through graph state to the system agent
- Agent prompt renders answers as a "additional context (provided between sessions)" section, positioned after the continuation dialogue context

## Test plan

- [x] `bun test src/negotiation/tests/negotiation.continuation.spec.ts` — 10/10 pass (2 new: answer flow-through on continuation, no-load on fresh flow)
- [x] `bun test tests/negotiation.graph.spec.ts` — 2/2 pass (mock updated)
- [x] `tsc --noEmit` clean on both `packages/protocol` and `backend`