### PR TITLE
refactor(protocol): remove profile-embedding discovery path (IND-332)

### DIFF
--- a/backend/src/adapters/embedder.adapter.ts
+++ b/backend/src/adapters/embedder.adapter.ts
@@ -26,16 +26,6 @@ export interface LensEmbedding {
   embedding: number[];
 }
 
-/** Options for searchWithProfileEmbedding (no lenses; direct profile similarity). */
-export interface ProfileEmbeddingSearchOptions {
-  indexScope: string[];
-  excludeUserId?: string;
-  limitPerStrategy?: number;
-  limit?: number;
-  minScore?: number;
-  profileMinScore?: number;
-}
-
 export interface HydeSearchOptions {
   indexScope: string[];
   excludeUserId?: string;
@@ -202,27 +192,6 @@ export class EmbedderAdapter {
     return this.mergeAndRankCandidates(flatResults, limit);
   }
 
-  async searchWithProfileEmbedding(
-    profileEmbedding: number[],
-    options: ProfileEmbeddingSearchOptions
-  ): Promise<HydeCandidate[]> {
-    const {
-      indexScope,
-      excludeUserId,
-      limitPerStrategy = 40,
-      limit = 80,
-      minScore = 0.40,
-      profileMinScore = 0.25,
-    } = options;
-    const filter = { indexScope, excludeUserId };
-    const [profileResults, intentResults] = await Promise.all([
-      this.searchProfilesByProfileEmbedding(profileEmbedding, filter, limitPerStrategy, profileMinScore),
-      this.searchIntentsByProfileEmbedding(profileEmbedding, filter, limitPerStrategy, minScore),
-    ]);
-    const flatResults = [...profileResults, ...intentResults];
-    return this.mergeAndRankCandidates(flatResults, limit);
-  }
-
   // ─────────────────────────────────────────────────────────────────────────
   // Private: profile/intent search for HyDE
   // ─────────────────────────────────────────────────────────────────────────
@@ -360,92 +329,6 @@ export class EmbedderAdapter {
       userId: r.userId,
       score: r.similarity,
       matchedVia: lens,
-      networkId: r.networkId,
-    }));
-  }
-
-  private async searchProfilesByProfileEmbedding(
-    embedding: number[],
-    filter: { indexScope: string[]; excludeUserId?: string },
-    limit: number,
-    minScore: number
-  ): Promise<HydeCandidate[]> {
-    if (filter.indexScope?.length === 0) return [];
-    const vectorStr = `[${embedding.join(',')}]`;
-    const { userProfiles, networkMembers } = schema;
-    const conditions = [
-      inArray(networkMembers.networkId, filter.indexScope),
-      isNotNull(userProfiles.embedding),
-      isNull(schema.users.deletedAt),
-      sql`1 - (${userProfiles.embedding} <=> ${vectorStr}::vector) >= ${minScore}`,
-      ...(filter.excludeUserId ? [ne(userProfiles.userId, filter.excludeUserId)] : []),
-    ];
-
-    const deduped = db
-      .selectDistinctOn([userProfiles.userId], {
-        userId: userProfiles.userId,
-        similarity: sql<number>`1 - (${userProfiles.embedding} <=> ${vectorStr}::vector)`.as('similarity'),
-        networkId: networkMembers.networkId,
-      })
-      .from(userProfiles)
-      .innerJoin(networkMembers, eq(userProfiles.userId, networkMembers.userId))
-      .innerJoin(schema.users, eq(userProfiles.userId, schema.users.id))
-      .where(and(...conditions))
-      .orderBy(userProfiles.userId, sql`${userProfiles.embedding} <=> ${vectorStr}::vector`, networkMembers.networkId)
-      .as('deduped');
-
-    const results = await db
-      .select()
-      .from(deduped)
-      .orderBy(sql`${deduped.similarity} DESC`)
-      .limit(limit);
-
-    return results.map((r) => ({
-      type: 'profile' as const,
-      id: r.userId,
-      userId: r.userId,
-      score: r.similarity,
-      matchedVia: 'profile-similarity',
-      networkId: r.networkId,
-    }));
-  }
-
-  private async searchIntentsByProfileEmbedding(
-    embedding: number[],
-    filter: { indexScope: string[]; excludeUserId?: string },
-    limit: number,
-    minScore: number
-  ): Promise<HydeCandidate[]> {
-    if (filter.indexScope?.length === 0) return [];
-    const vectorStr = `[${embedding.join(',')}]`;
-    const { intents, intentNetworks } = schema;
-    const conditions = [
-      inArray(intentNetworks.networkId, filter.indexScope),
-      isNull(intents.archivedAt),
-      isNull(schema.users.deletedAt),
-      isNotNull(intents.embedding),
-      sql`1 - (${intents.embedding} <=> ${vectorStr}::vector) >= ${minScore}`,
-      ...(filter.excludeUserId ? [ne(intents.userId, filter.excludeUserId)] : []),
-    ];
-    const results = await db
-      .select({
-        id: intents.id,
-        userId: intents.userId,
-        similarity: sql<number>`1 - (${intents.embedding} <=> ${vectorStr}::vector)`,
-        networkId: intentNetworks.networkId,
-      })
-      .from(intents)
-      .innerJoin(intentNetworks, eq(intents.id, intentNetworks.intentId))
-      .innerJoin(schema.users, eq(intents.userId, schema.users.id))
-      .where(and(...conditions))
-      .orderBy(sql`${intents.embedding} <=> ${vectorStr}::vector`)
-      .limit(limit);
-    return results.map((r) => ({
-      type: 'intent' as const,
-      id: r.id,
-      userId: r.userId,
-      score: r.similarity,
-      matchedVia: 'profile-similarity',
       networkId: r.networkId,
     }));
   }

--- a/backend/src/adapters/tests/adapter-interface-alignment.spec.ts
+++ b/backend/src/adapters/tests/adapter-interface-alignment.spec.ts
@@ -25,7 +25,6 @@ import type {
 import type {
   LensEmbedding as ProtocolLensEmbedding,
   HydeSearchOptions as ProtocolHydeSearchOptions,
-  ProfileEmbeddingSearchOptions as ProtocolProfileEmbeddingSearchOptions,
   HydeCandidate as ProtocolHydeCandidate,
   VectorSearchResult as ProtocolVectorSearchResult,
   VectorStoreOption as ProtocolVectorStoreOption,
@@ -61,7 +60,6 @@ import type {
 
 import type {
   LensEmbedding as AdapterLensEmbedding,
-  ProfileEmbeddingSearchOptions as AdapterProfileEmbeddingSearchOptions,
   HydeSearchOptions as AdapterHydeSearchOptions,
   HydeCandidate as AdapterHydeCandidate,
   VectorSearchResult as AdapterVectorSearchResult,
@@ -136,16 +134,6 @@ describe('Embedder adapter ↔ protocol interface alignment', () => {
 
   it('HydeSearchOptions: protocol → adapter', () => {
     const check: (_: ProtocolHydeSearchOptions) => AdapterHydeSearchOptions = (v) => v;
-    expect(check).toBeDefined();
-  });
-
-  it('ProfileEmbeddingSearchOptions: adapter → protocol', () => {
-    const check: (_: AdapterProfileEmbeddingSearchOptions) => ProtocolProfileEmbeddingSearchOptions = (v) => v;
-    expect(check).toBeDefined();
-  });
-
-  it('ProfileEmbeddingSearchOptions: protocol → adapter', () => {
-    const check: (_: ProtocolProfileEmbeddingSearchOptions) => AdapterProfileEmbeddingSearchOptions = (v) => v;
     expect(check).toBeDefined();
   });
 

--- a/backend/src/adapters/tests/embedder.adapter.spec.ts
+++ b/backend/src/adapters/tests/embedder.adapter.spec.ts
@@ -37,7 +37,6 @@ let fixture: {
   deletedUserId: string;
   networkId: string;
   intentId: string;
-  profileEmbeddingIntentId: string;
   /** Intent owned by the soft-deleted user. */
   deletedUserIntentId: string;
 };
@@ -48,7 +47,6 @@ beforeAll(async () => {
   const deletedUserId = uuidv4();
   const networkId = uuidv4();
   const intentId = uuidv4();
-  const profileEmbeddingIntentId = uuidv4();
   const deletedUserIntentId = uuidv4();
 
   await db.insert(users).values([
@@ -97,7 +95,7 @@ beforeAll(async () => {
   });
   await db.insert(intentNetworks).values({ intentId: deletedUserIntentId, networkId });
 
-  fixture = { userAId, userBId, deletedUserId, networkId, intentId, profileEmbeddingIntentId, deletedUserIntentId };
+  fixture = { userAId, userBId, deletedUserId, networkId, intentId, deletedUserIntentId };
 });
 
 afterAll(async () => {
@@ -235,62 +233,6 @@ describe('EmbedderAdapter', () => {
     });
   });
 
-  describe('searchWithProfileEmbedding', () => {
-    beforeAll(async () => {
-      await db.insert(intents).values({
-        id: fixture.profileEmbeddingIntentId,
-        userId: fixture.userAId,
-        payload: TEST_PREFIX + 'Intent for profile-embedding search',
-        summary: 'Summary',
-        embedding: makeTestVector(42),
-      });
-      await db.insert(intentNetworks).values({
-        intentId: fixture.profileEmbeddingIntentId,
-        networkId: fixture.networkId,
-      });
-    });
-
-    it('should return candidates (profiles and/or intents) in index scope with correct shape', async () => {
-      const profileEmbedding = makeTestVector(42);
-      const results = await adapter.searchWithProfileEmbedding(profileEmbedding, {
-        indexScope: [fixture.networkId],
-        limit: 10,
-        limitPerStrategy: 5,
-        minScore: 0,
-      });
-
-      expect(Array.isArray(results)).toBe(true);
-      for (const c of results) {
-        expect(['profile', 'intent']).toContain(c.type);
-        expect(c.id).toBeDefined();
-        expect(c.userId).toBeDefined();
-        expect(c.score).toBeGreaterThanOrEqual(0);
-        expect(c.matchedVia).toBeDefined();
-        expect(c.networkId).toBe(fixture.networkId);
-      }
-      const intentMatch = results.find(
-        (r) => r.type === 'intent' && r.id === fixture.profileEmbeddingIntentId
-      );
-      expect(intentMatch).toBeDefined();
-      expect(intentMatch!.score).toBeGreaterThanOrEqual(0.99);
-    });
-
-    it('should respect indexScope and excludeUserId', async () => {
-      const profileEmbedding = makeTestVector(100);
-      const results = await adapter.searchWithProfileEmbedding(profileEmbedding, {
-        indexScope: [fixture.networkId],
-        excludeUserId: fixture.userAId,
-        limit: 5,
-        minScore: 0,
-      });
-
-      for (const c of results) {
-        expect(c.userId).not.toBe(fixture.userAId);
-        expect(c.networkId).toBe(fixture.networkId);
-      }
-    });
-  });
-
   describe('soft-deleted user exclusion', () => {
     it('should not return soft-deleted users from searchWithHydeEmbeddings (profiles)', async () => {
       const vec = makeTestVector(42); // same as deleted user's profile embedding
@@ -309,19 +251,6 @@ describe('EmbedderAdapter', () => {
         [{ lens: 'test lens', corpus: 'intents' as const, embedding: vec }],
         { indexScope: [fixture.networkId], limit: 20, minScore: 0 },
       );
-
-      const deletedMatch = results.find((c) => c.userId === fixture.deletedUserId);
-      expect(deletedMatch).toBeUndefined();
-    });
-
-    it('should not return soft-deleted users from searchWithProfileEmbedding', async () => {
-      const vec = makeTestVector(42);
-      const results = await adapter.searchWithProfileEmbedding(vec, {
-        indexScope: [fixture.networkId],
-        limit: 20,
-        minScore: 0,
-        profileMinScore: 0,
-      });
 
       const deletedMatch = results.find((c) => c.userId === fixture.deletedUserId);
       expect(deletedMatch).toBeUndefined();

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "1.12.5",
+  "version": "1.12.6",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -724,23 +724,17 @@ export class OpportunityGraphFactory {
           const minScore = 0.3;
 
           if (state.discoverySource === 'profile') {
-            const embedding = state.sourceProfile?.embedding ?? null;
-            const vector = Array.isArray(embedding) && embedding.length > 0 && typeof embedding[0] === 'number'
-              ? (embedding as number[])
-              : Array.isArray(embedding) && Array.isArray(embedding[0])
-                ? (embedding[0] as number[])
-                : null;
+            // Profile-context discovery: HyDE (when search query exists) + premise-to-premise.
+            // Profile-embedding direct search (Path B) has been removed — all semantic
+            // matching goes through HyDE embeddings or premise-to-premise similarity.
 
-            // ALWAYS run query-based HyDE when we have a search query (e.g., "looking for investors")
-            // This ensures we use the right strategies (investor, mentor, etc.) not just mirror
             if (state.searchQuery?.trim()) {
-              logger.verbose('[Graph:Discovery] Profile source with searchQuery → running query HyDE path for broader search', {
+              logger.verbose('[Graph:Discovery] Profile source with searchQuery → running query HyDE + premise paths', {
                 searchQuery: state.searchQuery.trim().substring(0, 80),
-                hasProfileVector: !!vector,
               });
               const queryCandidates = await runQueryHydeDiscovery();
               logger.verbose('[Graph:Discovery] Query HyDE path complete', { candidatesFound: queryCandidates.length });
-              
+
               // Build trace entries for this path
               const traceEntries: Array<{ node: string; detail?: string; data?: Record<string, unknown> }> = [];
 
@@ -796,62 +790,6 @@ export class OpportunityGraphFactory {
                   model: getModelName("hydeGenerator"),
                 },
               });
-              
-              // If we also have a profile vector, merge with profile-based results
-              if (vector && vector.length > 0) {
-                const profileCandidates: CandidateMatch[] = [];
-                for (const targetIndex of state.targetNetworks) {
-                  const results = await this.embedder.searchWithProfileEmbedding(vector, {
-                    indexScope: [targetIndex.networkId],
-                    excludeUserId: discoveryUserId,
-                    limitPerStrategy: Math.floor(limitPerStrategy / 2),
-                    limit: Math.floor(perIndexLimit / 2),
-                    minScore,
-                  });
-                  for (const result of results) {
-                    profileCandidates.push({
-                      candidateUserId: result.userId as Id<'users'>,
-                      candidateIntentId: result.type === 'intent' ? result.id as Id<'intents'> : undefined,
-                      networkId: targetIndex.networkId,
-                      similarity: result.score,
-                      lens: result.matchedVia,
-                      candidatePayload: '',
-                      candidateSummary: undefined,
-                      discoverySource: 'profile-similarity' as const,
-                    });
-                  }
-                }
-                // Merge and dedupe - keep both intent and profile candidates per user
-                const byKey = new Map<string, CandidateMatch>();
-                for (const c of [...queryCandidates, ...profileCandidates]) {
-                  const key = `${c.candidateUserId}:${c.networkId}:${c.candidateIntentId ?? 'profile'}:${c.discoverySource ?? 'unknown'}`;
-                  if (!byKey.has(key) || c.similarity > (byKey.get(key)?.similarity ?? 0)) {
-                    byKey.set(key, c);
-                  }
-                }
-                const merged = Array.from(byKey.values());
-                logger.verbose('[Graph:Discovery] Merged HyDE + profile candidates', { 
-                  hydeCandidates: queryCandidates.length, 
-                  profileCandidates: profileCandidates.length,
-                  merged: merged.length 
-                });
-                
-                traceEntries.push({
-                  node: "discovery",
-                  detail: `+ Profile search → ${profileCandidates.length} additional, merged to ${merged.length}`,
-                  data: {
-                    profileCandidates: profileCandidates.length,
-                    merged: merged.length,
-                  },
-                });
-                
-                const premiseCands = await runPremiseDiscovery();
-                const withPremises = mergePremiseCandidates(merged, premiseCands);
-                if (premiseCands.length > 0) {
-                  traceEntries.push({ node: "discovery", detail: `+ Premise search → ${premiseCands.length} candidate(s), merged to ${withPremises.length}` });
-                }
-                return { candidates: filterByTarget(withPremises), trace: traceEntries };
-              }
 
               const premiseCands = await runPremiseDiscovery();
               const withPremises = mergePremiseCandidates(queryCandidates, premiseCands);
@@ -861,127 +799,15 @@ export class OpportunityGraphFactory {
               return { candidates: filterByTarget(withPremises), trace: traceEntries };
             }
 
-            // No search query - use profile embedding directly (mirror-only)
-            if (!vector || vector.length === 0) {
-              // Still attempt premise-based discovery even without a profile vector
-              const premiseCands = await runPremiseDiscovery();
-              if (premiseCands.length > 0) {
-                return {
-                  candidates: filterByTarget(premiseCands),
-                  trace: [{ node: "discovery", detail: `No profile vector; premise search → ${premiseCands.length} candidate(s)` }],
-                };
-              }
-              return { candidates: [] };
-            }
-            const allCandidates: CandidateMatch[] = [];
-            for (const targetIndex of state.targetNetworks) {
-              const results = await this.embedder.searchWithProfileEmbedding(vector, {
-                indexScope: [targetIndex.networkId],
-                excludeUserId: discoveryUserId,
-                limitPerStrategy,
-                limit: perIndexLimit,
-                minScore,
-              });
-              for (const result of results) {
-                if (result.type === 'intent') {
-                  allCandidates.push({
-                    candidateUserId: result.userId as Id<'users'>,
-                    candidateIntentId: result.id as Id<'intents'>,
-                    networkId: targetIndex.networkId,
-                    similarity: result.score,
-                    lens: result.matchedVia,
-                    candidatePayload: '',
-                    candidateSummary: undefined,
-                    discoverySource: 'profile-similarity' as const,
-                  });
-                } else {
-                  allCandidates.push({
-                    candidateUserId: result.userId as Id<'users'>,
-                    networkId: targetIndex.networkId,
-                    similarity: result.score,
-                    lens: result.matchedVia,
-                    candidatePayload: '',
-                    candidateSummary: undefined,
-                    discoverySource: 'profile-similarity' as const,
-                  });
-                }
-              }
-            }
-            const byUserAndIndex = new Map<string, CandidateMatch>();
-            for (const c of allCandidates) {
-              const key = `${c.candidateUserId}:${c.networkId}:${c.candidateIntentId ?? 'profile'}`;
-              if (!byUserAndIndex.has(key) || c.similarity > (byUserAndIndex.get(key)?.similarity ?? 0)) {
-                byUserAndIndex.set(key, c);
-              }
-            }
-            const candidates = Array.from(byUserAndIndex.values());
-            logger.verbose('[Graph:Discovery] Profile-as-source discovery complete', { candidatesFound: candidates.length });
-
-            // Build trace with individual candidate similarity scores
-            const traceEntries: Array<{ node: string; detail?: string; data?: Record<string, unknown> }> = [];
-
-            // Show what the profile search is based on
-            const profileBio = state.sourceProfile?.identity?.bio;
-            const profileContext = state.sourceProfile?.narrative?.context;
-            const profileSummary = profileBio || profileContext || '(profile embedding)';
-
-            // Compute per-lens stats from deduped candidates
-            const lensStats: Record<string, { count: number; avgSimilarity: number }> = {};
-            for (const c of candidates) {
-              const s = c.lens || 'unknown';
-              if (!lensStats[s]) lensStats[s] = { count: 0, avgSimilarity: 0 };
-              lensStats[s].count++;
-              lensStats[s].avgSimilarity += c.similarity;
-            }
-            for (const s of Object.values(lensStats)) {
-              s.avgSimilarity = s.count > 0 ? Math.round((s.avgSimilarity / s.count) * 1000) / 1000 : 0;
-            }
-
-            traceEntries.push({
-              node: "discovery",
-              detail: `Profile-based search → ${candidates.length} candidate(s)`,
-              data: {
-                source: "profile",
-                candidateCount: candidates.length,
-                byLens: lensStats,
-                durationMs: Date.now() - startTime,
-              },
-            });
-
-            traceEntries.push({
-              node: "search_query",
-              detail: `Searching for matches to: "${profileSummary.slice(0, 150)}${profileSummary.length > 150 ? '...' : ''}"`,
-              data: {
-                type: "profile_embedding",
-                bio: profileBio,
-                context: profileContext,
-              },
-            });
-
-            // Add top candidates with similarity scores
-            const sortedCandidates = [...candidates].sort((a, b) => b.similarity - a.similarity).slice(0, 10);
-            for (const c of sortedCandidates) {
-              traceEntries.push({
-                node: "match",
-                detail: `Similarity ${Math.round(c.similarity * 100)}% via ${c.lens}`,
-                data: {
-                  userId: c.candidateUserId,
-                  similarity: Math.round(c.similarity * 100),
-                  lens: c.lens,
-                  hasIntent: !!c.candidateIntentId,
-                },
-              });
-            }
-
+            // No search query — premise-to-premise discovery only
             const premiseCands = await runPremiseDiscovery();
-            const withPremises = mergePremiseCandidates(candidates, premiseCands);
             if (premiseCands.length > 0) {
-              traceEntries.push({ node: "discovery", detail: `+ Premise search → ${premiseCands.length} candidate(s), merged to ${withPremises.length}` });
+              return {
+                candidates: filterByTarget(premiseCands),
+                trace: [{ node: "discovery", detail: `No search query; premise search → ${premiseCands.length} candidate(s)` }],
+              };
             }
-            return {
-              candidates: filterByTarget(withPremises),
-              trace: traceEntries,
-            };
+            return { candidates: [] };
           }
 
           async function runQueryHydeDiscovery(): Promise<CandidateMatch[]> {
@@ -1436,7 +1262,7 @@ export class OpportunityGraphFactory {
         const remaining = dedupedCandidates.slice(EVAL_BATCH_SIZE);
 
         // Early termination: if search was query-driven and no query-sourced candidates remain,
-        // clear remaining to prevent pointless pagination through profile-similarity leftovers
+        // clear remaining to prevent pointless pagination through non-query leftovers
         const isQueryDriven = !!state.searchQuery?.trim();
         const queryRemaining = remaining.filter(
           (c) => c.discoverySource === 'query' || c.discoverySource == null,

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -1274,7 +1274,7 @@ export class OpportunityGraphFactory {
           logger.info(
             "[Graph:Evaluation] Early termination: no query-sourced candidates remain",
             {
-              droppedProfileCandidates: remaining.length,
+              droppedCandidates: remaining.length,
             },
           );
         }

--- a/packages/protocol/src/opportunity/opportunity.state.ts
+++ b/packages/protocol/src/opportunity/opportunity.state.ts
@@ -45,7 +45,6 @@ export interface TargetNetwork {
 
 /**
  * Candidate match from discovery (semantic search).
- * candidateIntentId is set for intent matches; omitted for profile-only matches.
  */
 export interface CandidateMatch {
   candidateUserId: Id<'users'>;
@@ -58,8 +57,8 @@ export interface CandidateMatch {
   lens: string;
   candidatePayload: string;
   candidateSummary?: string;
-  /** How this candidate was found: 'query' (HyDE from search text), 'profile-similarity', or 'premise-similarity'. */
-  discoverySource?: 'query' | 'profile-similarity' | 'premise-similarity';
+  /** How this candidate was found: 'query' (HyDE from search text) or 'premise-similarity'. */
+  discoverySource?: 'query' | 'premise-similarity';
 }
 
 /**

--- a/packages/protocol/src/opportunity/tests/opportunity.graph.dedup.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.graph.dedup.spec.ts
@@ -52,13 +52,12 @@ const mockEvaluator: OpportunityEvaluatorLike = {
   ],
 };
 
-// Embedder that returns USER_B as a profile-based candidate so the graph
+// Embedder that returns USER_B as a query-based candidate so the graph
 // produces evaluated opportunities and reaches the Persist node.
 const dummyEmbedder: Embedder = {
   generate: async () => DUMMY_EMBEDDING,
   search: async () => [],
-  searchWithHydeEmbeddings: async () => [],
-  searchWithProfileEmbedding: async () => [
+  searchWithHydeEmbeddings: async () => [
     {
       type: 'intent' as const,
       id: 'intent-bob' as Id<'intents'>,
@@ -171,6 +170,7 @@ function buildGraph(db: OpportunityGraphDatabase) {
 const discoveryInput = {
   userId: USER_A,
   operationMode: 'discover' as const,
+  searchQuery: 'co-founder',
   options: { initialStatus: 'latent' as const },
 };
 

--- a/packages/protocol/src/opportunity/tests/opportunity.graph.negotiate-timeout.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.graph.negotiate-timeout.spec.ts
@@ -87,7 +87,6 @@ function makeFactory(opts: { hangNegotiationForever: boolean }) {
       matchedVia: 'mirror' as const,
       networkId: 'idx-1',
     }]),
-    searchWithProfileEmbedding: async () => [],
   } as unknown as Embedder;
 
   const mockHyde = {

--- a/packages/protocol/src/opportunity/tests/opportunity.graph.self-accept-guard.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.graph.self-accept-guard.spec.ts
@@ -17,7 +17,6 @@ const dummyEmbedder = {
   generate: async () => [],
   search: async () => [],
   searchWithHydeEmbeddings: async () => [],
-  searchWithProfileEmbedding: async () => [],
 } as unknown as Embedder;
 const dummyHyde = { invoke: async () => ({ hydeEmbeddings: { mirror: [], reciprocal: [] } }) };
 

--- a/packages/protocol/src/opportunity/tests/opportunity.graph.send-actedAt.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.graph.send-actedAt.spec.ts
@@ -15,7 +15,7 @@ import type { OpportunityEvaluatorLike } from '../opportunity.graph.js';
 const mockEvaluator: OpportunityEvaluatorLike = { invokeEntityBundle: async () => [] };
 const dummyEmbedder = {
   generate: async () => [], search: async () => [],
-  searchWithHydeEmbeddings: async () => [], searchWithProfileEmbedding: async () => [],
+  searchWithHydeEmbeddings: async () => [],
 } as unknown as Embedder;
 const dummyHyde = { invoke: async () => ({ hydeEmbeddings: { mirror: [], reciprocal: [] } }) };
 

--- a/packages/protocol/src/opportunity/tests/opportunity.graph.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.graph.spec.ts
@@ -122,7 +122,6 @@ function createMockGraph(deps?: {
           networkId: 'idx-1',
         },
       ]),
-    searchWithProfileEmbedding: () => Promise.resolve([]),
   } as unknown as Embedder;
 
   const mockHydeGenerator = {
@@ -218,7 +217,6 @@ function createMockGraphWithFnOverrides(deps?: {
           networkId: 'idx-1',
         },
       ]),
-    searchWithProfileEmbedding: () => Promise.resolve([]),
   } as unknown as Embedder;
 
   const mockHyde = {
@@ -441,10 +439,7 @@ describe('Opportunity Graph', () => {
   describe('Evaluation node: early termination', () => {
     test('when search is query-driven and remaining candidates have no query-sourced entries, remainingCandidates is empty', async () => {
       // 5 query candidates come through HyDE search → tagged 'query'
-      // 25 profile candidates come through profile search → tagged 'profile-similarity'
-      // With EVAL_BATCH_SIZE=25, batch 1 gets all 5 query + 20 profile
-      // Remaining 5 are all profile-similarity → should be cleared
-      const dummyProfileEmbedding = new Array(2000).fill(0.1);
+      // With EVAL_BATCH_SIZE=25, all 5 fit in one batch → remaining = 0
       const queryCandidates = Array.from({ length: 5 }, (_, i) => ({
         type: 'intent' as const,
         id: `intent-query-${i}`,
@@ -453,30 +448,13 @@ describe('Opportunity Graph', () => {
         matchedVia: 'Painters' as const,
         networkId: 'idx-1',
       }));
-      const profileCandidates = Array.from({ length: 25 }, (_, i) => ({
-        type: 'profile' as const,
-        id: `user-profile-${i}`,
-        userId: `${String(i + 1).padStart(8, '0')}-0000-4000-8000-0000000000b0`,
-        score: 0.6 - i * 0.005,
-        matchedVia: 'profile-similarity' as const,
-        networkId: 'idx-1',
-      }));
 
       const { compiledGraph, mockEmbedder } = createMockGraph({
         evaluatorResult: [],
-        getProfile: {
-          userId: 'a0000000-0000-4000-8000-000000000001',
-          embedding: dummyProfileEmbedding,
-          identity: { name: 'Test User', bio: 'Test bio', location: 'Remote' },
-          narrative: { context: 'Test narrative' },
-          attributes: { interests: ['painting'], skills: ['art'] },
-        } satisfies ProfileDocument,
       });
 
       // HyDE search returns query candidates (tagged 'query' in discovery node)
       spyOn(mockEmbedder, 'searchWithHydeEmbeddings').mockResolvedValue(queryCandidates);
-      // Profile search returns profile candidates (tagged 'profile-similarity' in discovery node)
-      spyOn(mockEmbedder, 'searchWithProfileEmbedding').mockResolvedValue(profileCandidates);
 
       const result = (await compiledGraph.invoke({
         userId: 'a0000000-0000-4000-8000-000000000001' as Id<'users'>,
@@ -484,8 +462,7 @@ describe('Opportunity Graph', () => {
         options: { minScore: 50 },
       } as OpportunityGraphInvokeInput)) as OpportunityGraphInvokeResult;
 
-      // All query candidates consumed in batch 1, remaining are profile-only
-      // Early termination should clear remainingCandidates
+      // All query candidates consumed in one batch → remainingCandidates is empty
       expect(result.remainingCandidates.length).toBe(0);
     });
 
@@ -1485,7 +1462,6 @@ describe('Opportunity Graph', () => {
               networkId: 'idx-1',
             },
           ]),
-        searchWithProfileEmbedding: () => Promise.resolve([]),
       } as unknown as Embedder;
 
       const mockHyde = {
@@ -1883,7 +1859,6 @@ describe('Opportunity Graph', () => {
         generate: () => Promise.resolve(dummyEmbedding),
         search: () => Promise.resolve([]),
         searchWithHydeEmbeddings: () => Promise.resolve([]),
-        searchWithProfileEmbedding: () => Promise.resolve([]),
       } as unknown as Embedder;
 
       const mockHyde = { invoke: () => Promise.resolve({ hydeEmbeddings: { mirror: dummyEmbedding } }) };
@@ -2016,7 +1991,6 @@ describe('Opportunity Graph', () => {
               networkId: 'idx-1',
             },
           ]),
-        searchWithProfileEmbedding: () => Promise.resolve([]),
       } as unknown as Embedder;
 
       const mockHydeGenerator = {
@@ -2141,7 +2115,6 @@ describe('Opportunity Graph', () => {
               networkId: 'idx-1',
             },
           ]),
-        searchWithProfileEmbedding: () => Promise.resolve([]),
       } as unknown as Embedder;
 
       const mockHydeGenerator = {
@@ -2292,7 +2265,6 @@ describe('Opportunity Graph', () => {
         generate: () => Promise.resolve(dummyEmbedding),
         search: () => Promise.resolve([]),
         searchWithHydeEmbeddings: () => Promise.resolve([]),
-        searchWithProfileEmbedding: () => Promise.resolve([]),
       } as unknown as Embedder;
 
       const mockHydeGenerator = {
@@ -2631,7 +2603,6 @@ function createTraceMockGraph() {
           networkId: 'idx-1',
         },
       ]),
-    searchWithProfileEmbedding: () => Promise.resolve([]),
   } as unknown as Embedder;
 
   const mockHydeGenerator = {

--- a/packages/protocol/src/opportunity/tests/opportunity.graph.update.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.graph.update.spec.ts
@@ -19,7 +19,6 @@ const dummyEmbedder = {
   generate: async () => [],
   search: async () => [],
   searchWithHydeEmbeddings: async () => [],
-  searchWithProfileEmbedding: async () => [],
 } as unknown as Embedder;
 
 const dummyHyde = {

--- a/packages/protocol/src/premise/tests/premise.discovery.spec.ts
+++ b/packages/protocol/src/premise/tests/premise.discovery.spec.ts
@@ -49,7 +49,7 @@ describe('Premise Discovery', () => {
         similarity: 0.72,
         lens: 'profile_match',
         candidatePayload: 'Product manager at a climate startup',
-        discoverySource: 'profile-similarity',
+        discoverySource: 'query',
       };
       expect(candidate.candidatePremiseId).toBeUndefined();
     });

--- a/packages/protocol/src/premise/tests/premise.graph.spec.ts
+++ b/packages/protocol/src/premise/tests/premise.graph.spec.ts
@@ -53,7 +53,6 @@ function createMockEmbedder(): Embedder {
     generate: async (_text: string | string[]) => new Array(2000).fill(0.01),
     search: async () => [],
     searchWithHydeEmbeddings: async () => [],
-    searchWithProfileEmbedding: async () => [],
   } as Embedder;
 }
 

--- a/packages/protocol/src/shared/interfaces/embedder.interface.ts
+++ b/packages/protocol/src/shared/interfaces/embedder.interface.ts
@@ -30,9 +30,6 @@ export interface HydeSearchOptions {
   profileMinScore?: number;
 }
 
-/** Options for searchWithProfileEmbedding (no lenses; direct profile similarity). */
-export type ProfileEmbeddingSearchOptions = HydeSearchOptions;
-
 /** A single candidate from HyDE search (profile, intent, or premise), with score and which lens matched. */
 export interface HydeCandidate {
   type: 'profile' | 'intent' | 'premise';
@@ -102,12 +99,4 @@ export interface Embedder extends EmbeddingGenerator, VectorStore {
     options: HydeSearchOptions
   ): Promise<HydeCandidate[]>;
 
-  /**
-   * Profile-as-source search: run vector search with the asker's profile embedding
-   * against profiles and intents in the given index scope. Returns same shape as HyDE search.
-   */
-  searchWithProfileEmbedding(
-    profileEmbedding: number[],
-    options: ProfileEmbeddingSearchOptions
-  ): Promise<HydeCandidate[]>;
 }


### PR DESCRIPTION
## Summary

- Remove `searchWithProfileEmbedding` from the `Embedder` interface and its backend adapter implementation (3 methods deleted)
- Narrow `CandidateMatch.discoverySource` from `'query' | 'profile-similarity' | 'premise-similarity'` to `'query' | 'premise-similarity'`
- Rewrite the `discoverySource === 'profile'` branch in the discovery graph to use HyDE + premise search only (no more direct profile-embedding similarity)
- Update 10 test files across protocol and backend to remove profile-search mocks and expectations
- Bump `@indexnetwork/protocol` to 1.12.4

Profile candidates remain discoverable via HyDE (Path A) when the LensInferrer selects `corpus: 'profiles'`. Only the direct profile-embedding similarity search (Path B) is removed.

## Test plan

- [ ] `bun test` in `packages/protocol` — all opportunity, premise, and dedup tests pass
- [ ] `bun test` in `backend` — embedder adapter and alignment tests pass
- [ ] `tsc --noEmit` in both protocol and backend — no type errors