### PR TITLE
feat: add user contexts and context-to-intent discovery strategy

### DIFF
--- a/backend/drizzle/0079_add_user_contexts.sql
+++ b/backend/drizzle/0079_add_user_contexts.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "user_contexts" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"network_id" text NOT NULL,
+	"text" text NOT NULL,
+	"embedding" vector(2000),
+	"premise_hash" text,
+	"generated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "user_contexts" ADD CONSTRAINT "user_contexts_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_contexts" ADD CONSTRAINT "user_contexts_network_id_networks_id_fk" FOREIGN KEY ("network_id") REFERENCES "public"."networks"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "user_contexts_user_network_uniq" ON "user_contexts" USING btree ("user_id","network_id");--> statement-breakpoint
+CREATE INDEX "user_contexts_embedding_idx" ON "user_contexts" USING hnsw ("embedding" vector_cosine_ops);--> statement-breakpoint
+CREATE INDEX "user_contexts_user_id_idx" ON "user_contexts" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "user_contexts_network_id_idx" ON "user_contexts" USING btree ("network_id");

--- a/backend/drizzle/meta/0079_snapshot.json
+++ b/backend/drizzle/meta/0079_snapshot.json
@@ -1,0 +1,4551 @@
+{
+  "id": "7be2379c-7613-42e6-8660-10b1217169cd",
+  "prevId": "900fa2a7-a16c-4868-8de4-94b87d1a7b8d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_permissions": {
+      "name": "agent_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "permission_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actions": {
+          "name": "actions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_permissions_agent_id_idx": {
+          "name": "agent_permissions_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_permissions_user_id_idx": {
+          "name": "agent_permissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_permissions_agent_user_idx": {
+          "name": "agent_permissions_agent_user_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_agent_permissions_global": {
+          "name": "uniq_agent_permissions_global",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_permissions\".\"scope\" = 'global'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_permissions_agent_id_agents_id_fk": {
+          "name": "agent_permissions_agent_id_agents_id_fk",
+          "tableFrom": "agent_permissions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_permissions_user_id_users_id_fk": {
+          "name": "agent_permissions_user_id_users_id_fk",
+          "tableFrom": "agent_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_messages": {
+      "name": "agent_test_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_token": {
+          "name": "reservation_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reserved_at": {
+          "name": "reserved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_test_messages_agent_pending": {
+          "name": "idx_agent_test_messages_agent_pending",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reserved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_messages_agent_id_agents_id_fk": {
+          "name": "agent_test_messages_agent_id_agents_id_fk",
+          "tableFrom": "agent_test_messages",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_messages_requested_by_user_id_users_id_fk": {
+          "name": "agent_test_messages_requested_by_user_id_users_id_fk",
+          "tableFrom": "agent_test_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_transports": {
+      "name": "agent_transports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "transport_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_transports_agent_id_idx": {
+          "name": "agent_transports_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_transports_agent_id_agents_id_fk": {
+          "name": "agent_transports_agent_id_agents_id_fk",
+          "tableFrom": "agent_transports",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "agent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_on_opportunity": {
+          "name": "notify_on_opportunity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "daily_summary_enabled": {
+          "name": "daily_summary_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "handle_negotiations": {
+          "name": "handle_negotiations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_daily_summary_at": {
+          "name": "last_daily_summary_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agents_owner_id_idx": {
+          "name": "agents_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_type_idx": {
+          "name": "agents_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_last_seen_at_idx": {
+          "name": "agents_last_seen_at_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_users_id_fk": {
+          "name": "agents_owner_id_users_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apikey_user_id_users_id_fk": {
+          "name": "apikey_user_id_users_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connect_links": {
+      "name": "connect_links",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "greeting": {
+          "name": "greeting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_surface": {
+          "name": "preferred_surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connect_links_kind_recipient_uq": {
+          "name": "connect_links_kind_recipient_uq",
+          "columns": [
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connect_links_expires_at_idx": {
+          "name": "connect_links_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connect_links_user_id_users_id_fk": {
+          "name": "connect_links_user_id_users_id_fk",
+          "tableFrom": "connect_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connect_links_opportunity_id_opportunities_id_fk": {
+          "name": "connect_links_opportunity_id_opportunities_id_fk",
+          "tableFrom": "connect_links",
+          "tableTo": "opportunities",
+          "columnsFrom": [
+            "opportunity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "files_user_id_users_id_fk": {
+          "name": "files_user_id_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hyde_documents": {
+      "name": "hyde_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_text": {
+          "name": "source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_corpus": {
+          "name": "target_corpus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hyde_text": {
+          "name": "hyde_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hyde_embedding": {
+          "name": "hyde_embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "hyde_source_idx": {
+          "name": "hyde_source_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_strategy_idx": {
+          "name": "hyde_strategy_idx",
+          "columns": [
+            {
+              "expression": "strategy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_embedding_idx": {
+          "name": "hyde_embedding_idx",
+          "columns": [
+            {
+              "expression": "hyde_embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "hyde_expires_idx": {
+          "name": "hyde_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_source_strategy_unique": {
+          "name": "hyde_source_strategy_unique",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "strategy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_corpus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.intent_networks": {
+      "name": "intent_networks",
+      "schema": "",
+      "columns": {
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relevancy_score": {
+          "name": "relevancy_score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "intent_networks_network_id_idx": {
+          "name": "intent_networks_network_id_idx",
+          "columns": [
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intent_networks_intent_id_intents_id_fk": {
+          "name": "intent_networks_intent_id_intents_id_fk",
+          "tableFrom": "intent_networks",
+          "tableTo": "intents",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "intent_networks_network_id_networks_id_fk": {
+          "name": "intent_networks_network_id_networks_id_fk",
+          "tableFrom": "intent_networks",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "intent_networks_intent_id_network_id_pk": {
+          "name": "intent_networks_intent_id_network_id_pk",
+          "columns": [
+            "intent_id",
+            "network_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.intents": {
+      "name": "intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_incognito": {
+          "name": "is_incognito",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "semantic_entropy": {
+          "name": "semantic_entropy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "referential_anchor": {
+          "name": "referential_anchor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intent_mode": {
+          "name": "intent_mode",
+          "type": "intent_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ATTRIBUTIVE'"
+        },
+        "speech_act_type": {
+          "name": "speech_act_type",
+          "type": "speech_act_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "felicity_authority": {
+          "name": "felicity_authority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "felicity_sincerity": {
+          "name": "felicity_sincerity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "felicity_clarity": {
+          "name": "felicity_clarity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "intent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {
+        "embeddingIndex": {
+          "name": "embeddingIndex",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intents_user_id_users_id_fk": {
+          "name": "intents_user_id_users_id_fk",
+          "tableFrom": "intents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.links": {
+      "name": "links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "links_user_id_users_id_fk": {
+          "name": "links_user_id_users_id_fk",
+          "tableFrom": "links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.network_integrations": {
+      "name": "network_integrations",
+      "schema": "",
+      "columns": {
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolkit": {
+          "name": "toolkit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_config": {
+          "name": "sync_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "network_integrations_network_id_networks_id_fk": {
+          "name": "network_integrations_network_id_networks_id_fk",
+          "tableFrom": "network_integrations",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "network_integrations_network_id_toolkit_pk": {
+          "name": "network_integrations_network_id_toolkit_pk",
+          "columns": [
+            "network_id",
+            "toolkit"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.network_members": {
+      "name": "network_members",
+      "schema": "",
+      "columns": {
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_assign": {
+          "name": "auto_assign",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "network_members_network_id_networks_id_fk": {
+          "name": "network_members_network_id_networks_id_fk",
+          "tableFrom": "network_members",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "network_members_user_id_users_id_fk": {
+          "name": "network_members_user_id_users_id_fk",
+          "tableFrom": "network_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "network_members_network_id_user_id_pk": {
+          "name": "network_members_network_id_user_id_pk",
+          "columns": [
+            "network_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.networks": {
+      "name": "networks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_experiment": {
+          "name": "is_experiment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "experiment_master_key_hash": {
+          "name": "experiment_master_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "network_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'community'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"joinPolicy\":\"invite_only\",\"invitationLink\":null,\"allowGuestVibeCheck\":false}'::json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "indexes_key_unique": {
+          "name": "indexes_key_unique",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_access_token_client_id_idx": {
+          "name": "oauth_access_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_user_id_idx": {
+          "name": "oauth_access_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_users_id_fk": {
+          "name": "oauth_access_token_user_id_users_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_access_token_unique": {
+          "name": "oauth_access_token_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        },
+        "oauth_access_token_refresh_token_unique": {
+          "name": "oauth_access_token_refresh_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_application": {
+      "name": "oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_application_user_id_idx": {
+          "name": "oauth_application_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_application_user_id_users_id_fk": {
+          "name": "oauth_application_user_id_users_id_fk",
+          "tableFrom": "oauth_application",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_application_client_id_unique": {
+          "name": "oauth_application_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_id_idx": {
+          "name": "oauth_consent_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_user_id_idx": {
+          "name": "oauth_consent_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_users_id_fk": {
+          "name": "oauth_consent_user_id_users_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunities": {
+      "name": "opportunities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "detection": {
+          "name": "detection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actors": {
+          "name": "actors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interpretation": {
+          "name": "interpretation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "opportunity_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "opportunities_status_idx": {
+          "name": "opportunities_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunities_accepted_by_users_id_fk": {
+          "name": "opportunities_accepted_by_users_id_fk",
+          "tableFrom": "opportunities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "accepted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunity_deliveries": {
+      "name": "opportunity_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivered_at_status": {
+          "name": "delivered_at_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_token": {
+          "name": "reservation_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reserved_at": {
+          "name": "reserved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_opp_deliveries_committed": {
+          "name": "uniq_opp_deliveries_committed",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "delivered_at_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"opportunity_deliveries\".\"delivered_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_opp_deliveries_open_reservations": {
+          "name": "idx_opp_deliveries_open_reservations",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reserved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"opportunity_deliveries\".\"delivered_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunity_deliveries_opportunity_id_opportunities_id_fk": {
+          "name": "opportunity_deliveries_opportunity_id_opportunities_id_fk",
+          "tableFrom": "opportunity_deliveries",
+          "tableTo": "opportunities",
+          "columnsFrom": [
+            "opportunity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "opportunity_deliveries_user_id_users_id_fk": {
+          "name": "opportunity_deliveries_user_id_users_id_fk",
+          "tableFrom": "opportunity_deliveries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "opportunity_deliveries_agent_id_agents_id_fk": {
+          "name": "opportunity_deliveries_agent_id_agents_id_fk",
+          "tableFrom": "opportunity_deliveries",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_networks": {
+      "name": "personal_networks",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "personal_networks_network_id_unique": {
+          "name": "personal_networks_network_id_unique",
+          "columns": [
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_networks_user_id_users_id_fk": {
+          "name": "personal_networks_user_id_users_id_fk",
+          "tableFrom": "personal_networks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "personal_networks_network_id_networks_id_fk": {
+          "name": "personal_networks_network_id_networks_id_fk",
+          "tableFrom": "personal_networks",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "personal_networks_user_id_pk": {
+          "name": "personal_networks_user_id_pk",
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.premise_networks": {
+      "name": "premise_networks",
+      "schema": "",
+      "columns": {
+        "premise_id": {
+          "name": "premise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relevancy_score": {
+          "name": "relevancy_score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "premise_networks_network_id_idx": {
+          "name": "premise_networks_network_id_idx",
+          "columns": [
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "premise_networks_premise_id_premises_id_fk": {
+          "name": "premise_networks_premise_id_premises_id_fk",
+          "tableFrom": "premise_networks",
+          "tableTo": "premises",
+          "columnsFrom": [
+            "premise_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "premise_networks_network_id_networks_id_fk": {
+          "name": "premise_networks_network_id_networks_id_fk",
+          "tableFrom": "premise_networks",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "premise_networks_premise_id_network_id_pk": {
+          "name": "premise_networks_premise_id_network_id_pk",
+          "columns": [
+            "premise_id",
+            "network_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.premises": {
+      "name": "premises",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assertion": {
+          "name": "assertion",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis": {
+          "name": "analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validity": {
+          "name": "validity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "premise_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retracted_at": {
+          "name": "retracted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "premises_embedding_idx": {
+          "name": "premises_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "premises_user_id_idx": {
+          "name": "premises_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "premises_status_idx": {
+          "name": "premises_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "premises_user_id_users_id_fk": {
+          "name": "premises_user_id_users_id_fk",
+          "tableFrom": "premises",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "detection": {
+          "name": "detection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actors": {
+          "name": "actors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "question_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "answer": {
+          "name": "answer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "questions_status_idx": {
+          "name": "questions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "questions_conversation_id_idx": {
+          "name": "questions_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_contexts": {
+      "name": "user_contexts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "premise_hash": {
+          "name": "premise_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_contexts_user_network_uniq": {
+          "name": "user_contexts_user_network_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_contexts_embedding_idx": {
+          "name": "user_contexts_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "user_contexts_user_id_idx": {
+          "name": "user_contexts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_contexts_network_id_idx": {
+          "name": "user_contexts_network_id_idx",
+          "columns": [
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_contexts_user_id_users_id_fk": {
+          "name": "user_contexts_user_id_users_id_fk",
+          "tableFrom": "user_contexts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_contexts_network_id_networks_id_fk": {
+          "name": "user_contexts_network_id_networks_id_fk",
+          "tableFrom": "user_contexts",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_settings": {
+      "name": "user_notification_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"connectionUpdates\":true,\"weeklyNewsletter\":true}'::json"
+        },
+        "unsubscribe_token": {
+          "name": "unsubscribe_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_settings_user_id_users_id_fk": {
+          "name": "user_notification_settings_user_id_users_id_fk",
+          "tableFrom": "user_notification_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_notification_settings_user_id_unique": {
+          "name": "user_notification_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_notification_settings_unsubscribe_token_unique": {
+          "name": "user_notification_settings_unsubscribe_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "unsubscribe_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity": {
+          "name": "identity",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "narrative": {
+          "name": "narrative",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_profiles_user_id_unique": {
+          "name": "user_profiles_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_socials": {
+      "name": "user_socials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_socials_user_id": {
+          "name": "idx_user_socials_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_user_socials_user_label": {
+          "name": "uniq_user_socials_user_label",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_socials\".\"label\" <> 'custom'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_socials_user_id_users_id_fk": {
+          "name": "user_socials_user_id_users_id_fk",
+          "tableFrom": "user_socials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro": {
+          "name": "intro",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding": {
+          "name": "onboarding",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::json"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UTC'"
+        },
+        "last_weekly_email_sent_at": {
+          "name": "last_weekly_email_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_ghost": {
+          "name": "is_ghost",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_key_unique": {
+          "name": "users_key_unique",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artifacts": {
+      "name": "artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "artifacts_task_id_idx": {
+          "name": "artifacts_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifacts_task_id_tasks_id_fk": {
+          "name": "artifacts_task_id_tasks_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session_summaries": {
+      "name": "chat_session_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_message_id": {
+          "name": "from_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_message_id": {
+          "name": "to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "digest": {
+          "name": "digest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chat_session_summaries_session_latest_idx": {
+          "name": "chat_session_summaries_session_latest_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_session_summaries_conversation_id_conversations_id_fk": {
+          "name": "chat_session_summaries_conversation_id_conversations_id_fk",
+          "tableFrom": "chat_session_summaries",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_session_summaries_from_message_id_messages_id_fk": {
+          "name": "chat_session_summaries_from_message_id_messages_id_fk",
+          "tableFrom": "chat_session_summaries",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "from_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "chat_session_summaries_to_message_id_messages_id_fk": {
+          "name": "chat_session_summaries_to_message_id_messages_id_fk",
+          "tableFrom": "chat_session_summaries",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "to_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_metadata": {
+      "name": "conversation_metadata",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_metadata_conversation_id_conversations_id_fk": {
+          "name": "conversation_metadata_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_metadata",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_participants": {
+      "name": "conversation_participants",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_type": {
+          "name": "participant_type",
+          "type": "participant_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "hidden_at": {
+          "name": "hidden_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversation_participants_participant_id_idx": {
+          "name": "conversation_participants_participant_id_idx",
+          "columns": [
+            {
+              "expression": "participant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_participants_conversation_id_idx": {
+          "name": "conversation_participants_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_participants_conversation_id_conversations_id_fk": {
+          "name": "conversation_participants_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_participants",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_participants_conversation_id_participant_id_pk": {
+          "name": "conversation_participants_conversation_id_participant_id_pk",
+          "columns": [
+            "conversation_id",
+            "participant_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dm_pair": {
+          "name": "dm_pair",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversations_dm_pair_idx": {
+          "name": "conversations_dm_pair_idx",
+          "columns": [
+            {
+              "expression": "dm_pair",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "message_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_task_ids": {
+          "name": "reference_task_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_conversation_id_created_at_idx": {
+          "name": "messages_conversation_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_sender_id_idx": {
+          "name": "messages_sender_id_idx",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_task_id_idx": {
+          "name": "messages_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_task_id_tasks_id_fk": {
+          "name": "messages_task_id_tasks_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "task_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "status_message": {
+          "name": "status_message",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_timestamp": {
+          "name": "status_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_agent_id": {
+          "name": "claimed_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tasks_conversation_id_idx": {
+          "name": "tasks_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_state_idx": {
+          "name": "tasks_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_metadata_opportunity_id_idx": {
+          "name": "tasks_metadata_opportunity_id_idx",
+          "columns": [
+            {
+              "expression": "(\"metadata\"->>'opportunityId')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"tasks\".\"metadata\"->>'type' = 'negotiation'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_conversation_id_conversations_id_fk": {
+          "name": "tasks_conversation_id_conversations_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_status": {
+      "name": "agent_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive"
+      ]
+    },
+    "public.agent_type": {
+      "name": "agent_type",
+      "schema": "public",
+      "values": [
+        "personal",
+        "system"
+      ]
+    },
+    "public.intent_mode": {
+      "name": "intent_mode",
+      "schema": "public",
+      "values": [
+        "REFERENTIAL",
+        "ATTRIBUTIVE"
+      ]
+    },
+    "public.intent_status": {
+      "name": "intent_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "PAUSED",
+        "FULFILLED",
+        "EXPIRED"
+      ]
+    },
+    "public.network_type": {
+      "name": "network_type",
+      "schema": "public",
+      "values": [
+        "community",
+        "event"
+      ]
+    },
+    "public.opportunity_status": {
+      "name": "opportunity_status",
+      "schema": "public",
+      "values": [
+        "latent",
+        "draft",
+        "negotiating",
+        "pending",
+        "stalled",
+        "accepted",
+        "rejected",
+        "expired"
+      ]
+    },
+    "public.permission_scope": {
+      "name": "permission_scope",
+      "schema": "public",
+      "values": [
+        "global",
+        "node",
+        "network"
+      ]
+    },
+    "public.premise_status": {
+      "name": "premise_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "RETRACTED",
+        "EXPIRED"
+      ]
+    },
+    "public.question_status": {
+      "name": "question_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "answered",
+        "dismissed"
+      ]
+    },
+    "public.source_type": {
+      "name": "source_type",
+      "schema": "public",
+      "values": [
+        "file",
+        "integration",
+        "link",
+        "discovery_form",
+        "enrichment"
+      ]
+    },
+    "public.speech_act_type": {
+      "name": "speech_act_type",
+      "schema": "public",
+      "values": [
+        "COMMISSIVE",
+        "DIRECTIVE"
+      ]
+    },
+    "public.transport_channel": {
+      "name": "transport_channel",
+      "schema": "public",
+      "values": [
+        "mcp"
+      ]
+    },
+    "public.message_role": {
+      "name": "message_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "agent"
+      ]
+    },
+    "public.participant_type": {
+      "name": "participant_type",
+      "schema": "public",
+      "values": [
+        "user",
+        "agent"
+      ]
+    },
+    "public.task_state": {
+      "name": "task_state",
+      "schema": "public",
+      "values": [
+        "submitted",
+        "working",
+        "input_required",
+        "completed",
+        "failed",
+        "canceled",
+        "rejected",
+        "auth_required",
+        "waiting_for_agent",
+        "claimed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -554,6 +554,13 @@
       "when": 1779748964381,
       "tag": "0078_add_questions_conversation_id",
       "breakpoints": true
+    },
+    {
+      "idx": 79,
+      "version": "7",
+      "when": 1779869258097,
+      "tag": "0079_add_user_contexts",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -33,6 +33,7 @@
     "maintenance:rediscover-opportunities": "bun ./src/cli/rediscover-user-opportunities.ts",
     "maintenance:decompose-profiles": "bun ./src/cli/decompose-profiles.ts",
     "maintenance:backfill-premises": "bun ./src/cli/backfill-premises.ts",
+    "maintenance:compare-discovery": "bun ./src/cli/compare-discovery.ts",
     "test:opportunity-three-user": "bun ./src/cli/opportunity-three-user-test.ts",
     "test": "NODE_ENV=test bash scripts/test-safe.sh",
     "test:raw": "NODE_ENV=test bun test"

--- a/backend/package.json
+++ b/backend/package.json
@@ -34,6 +34,7 @@
     "maintenance:decompose-profiles": "bun ./src/cli/decompose-profiles.ts",
     "maintenance:backfill-premises": "bun ./src/cli/backfill-premises.ts",
     "maintenance:compare-discovery": "bun ./src/cli/compare-discovery.ts",
+    "maintenance:backfill-context-hyde": "bun ./src/cli/backfill-context-hyde.ts",
     "test:opportunity-three-user": "bun ./src/cli/opportunity-three-user-test.ts",
     "test": "NODE_ENV=test bash scripts/test-safe.sh",
     "test:raw": "NODE_ENV=test bun test"

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol",
-  "version": "0.25.1",
+  "version": "0.26.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -32,6 +32,7 @@
     "maintenance:expire-opportunities": "bun ./src/cli/expire-opportunities.ts",
     "maintenance:rediscover-opportunities": "bun ./src/cli/rediscover-user-opportunities.ts",
     "maintenance:decompose-profiles": "bun ./src/cli/decompose-profiles.ts",
+    "maintenance:backfill-premises": "bun ./src/cli/backfill-premises.ts",
     "test:opportunity-three-user": "bun ./src/cli/opportunity-three-user-test.ts",
     "test": "NODE_ENV=test bash scripts/test-safe.sh",
     "test:raw": "NODE_ENV=test bun test"

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -190,7 +190,7 @@ interface NetworkMembershipRow {
   joinedAt: Date;
 }
 
-const { intents, networks, networkMembers, intentNetworks, users, hydeDocuments, opportunities, userNotificationSettings, userProfiles, files, links, sessions, userSocials } = schema;
+const { intents, networks, networkMembers, intentNetworks, users, hydeDocuments, opportunities, userNotificationSettings, userProfiles, files, links, sessions, userSocials, userContexts } = schema;
 
 // HyDE row to document shape (embedding may come as number[] or pg vector)
 type HydeSourceTypeLocal = 'intent' | 'profile' | 'query';
@@ -4066,6 +4066,135 @@ export class ChatDatabaseAdapter {
         )
       );
     return rows.map((r) => ({ id: r.id, userId: r.userId }));
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // User Context Methods — CRUD for per-user-per-network context summaries
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Upsert a user context summary for a given user+network pair.
+   * Creates a new row or updates an existing one based on the (userId, networkId) unique constraint.
+   */
+  async upsertUserContext(params: {
+    userId: string;
+    networkId: string;
+    text: string;
+    embedding: number[];
+    premiseHash: string;
+  }): Promise<{ id: string }> {
+    const vectorStr = `[${params.embedding.join(',')}]`;
+    const rows = await db.insert(userContexts)
+      .values({
+        userId: params.userId,
+        networkId: params.networkId,
+        text: params.text,
+        embedding: sql`${vectorStr}::vector` as unknown as number[],
+        premiseHash: params.premiseHash,
+        generatedAt: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: [userContexts.userId, userContexts.networkId],
+        set: {
+          text: params.text,
+          embedding: sql`${vectorStr}::vector` as unknown as number[],
+          premiseHash: params.premiseHash,
+          generatedAt: new Date(),
+        },
+      })
+      .returning({ id: userContexts.id });
+    return { id: rows[0].id };
+  }
+
+  /**
+   * Retrieve a single user context for a user+network pair.
+   */
+  async getUserContext(userId: string, networkId: string) {
+    const rows = await db.select()
+      .from(userContexts)
+      .where(and(
+        eq(userContexts.userId, userId),
+        eq(userContexts.networkId, networkId),
+      ))
+      .limit(1);
+    if (rows.length === 0) return null;
+    const r = rows[0];
+    return {
+      id: r.id,
+      text: r.text,
+      embedding: r.embedding as unknown as number[],
+      premiseHash: r.premiseHash ?? '',
+      generatedAt: r.generatedAt,
+    };
+  }
+
+  /**
+   * Retrieve all user contexts for a given user.
+   */
+  async getUserContexts(userId: string) {
+    const rows = await db.select()
+      .from(userContexts)
+      .where(eq(userContexts.userId, userId));
+    return rows.map(r => ({
+      id: r.id,
+      networkId: r.networkId,
+      text: r.text,
+      embedding: r.embedding as unknown as number[],
+      premiseHash: r.premiseHash ?? '',
+      generatedAt: r.generatedAt,
+    }));
+  }
+
+  /**
+   * Cosine similarity search against intent embeddings using a user context embedding.
+   * Restores the profile→intent cross-search deleted when Path B was removed.
+   */
+  async searchIntentsByContextEmbedding(params: {
+    embedding: number[];
+    networkIds: string[];
+    excludeUserId: string;
+    limit: number;
+    minScore?: number;
+  }) {
+    const { embedding, networkIds, excludeUserId, limit, minScore = 0.30 } = params;
+    const vectorStr = `[${embedding.join(',')}]`;
+
+    const rows = await db.execute<{
+      intentId: string;
+      userId: string;
+      networkId: string;
+      payload: string;
+      summary: string | null;
+      similarity: number;
+    }>(sql`
+      SELECT
+        i.id AS "intentId",
+        i.user_id AS "userId",
+        ine.network_id AS "networkId",
+        i.payload,
+        i.summary,
+        1 - (i.embedding <=> ${vectorStr}::vector) AS similarity
+      FROM ${schema.intents} i
+      JOIN ${schema.intentNetworks} ine ON i.id = ine.intent_id
+      JOIN ${schema.users} u ON i.user_id = u.id
+      WHERE ine.network_id IN ${networkIds}
+        AND i.user_id != ${excludeUserId}
+        AND i.status = 'ACTIVE'
+        AND i.embedding IS NOT NULL
+        AND u.deleted_at IS NULL
+        AND 1 - (i.embedding <=> ${vectorStr}::vector) >= ${minScore}
+      ORDER BY i.embedding <=> ${vectorStr}::vector
+      LIMIT ${limit}
+    `);
+
+    return rows as Array<{
+      intentId: string;
+      userId: string;
+      networkId: string;
+      payload: string;
+      summary: string | null;
+      similarity: number;
+    }>;
   }
 
 }

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -193,7 +193,7 @@ interface NetworkMembershipRow {
 const { intents, networks, networkMembers, intentNetworks, users, hydeDocuments, opportunities, userNotificationSettings, userProfiles, files, links, sessions, userSocials, userContexts } = schema;
 
 // HyDE row to document shape (embedding may come as number[] or pg vector)
-type HydeSourceTypeLocal = 'intent' | 'profile' | 'query';
+type HydeSourceTypeLocal = 'intent' | 'profile' | 'query' | 'context';
 interface HydeDocumentRow {
   id: string;
   sourceType: HydeSourceTypeLocal;

--- a/backend/src/cli/backfill-context-hyde.ts
+++ b/backend/src/cli/backfill-context-hyde.ts
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * Backfill CLI: generate HyDE documents for existing user contexts.
+ * Finds all user_contexts rows that have no corresponding hyde_documents
+ * with sourceType='context' and generates HyDE embeddings for them.
+ *
+ * Usage: bun run maintenance:backfill-context-hyde -- --network <networkId> [--dry-run]
+ */
+import dotenv from 'dotenv';
+import path from 'path';
+
+const envFile = process.env.NODE_ENV === 'development' ? '.env.development' : '.env.production';
+dotenv.config({ path: path.resolve(process.cwd(), envFile) });
+
+import { and, eq, isNull, sql } from 'drizzle-orm';
+
+import db, { closeDb } from '../lib/drizzle/drizzle';
+import * as schema from '../schemas/database.schema';
+import { HydeGraphFactory, HydeGenerator, LensInferrer } from '@indexnetwork/protocol';
+import type { HydeGraphDatabase } from '@indexnetwork/protocol';
+import { ChatDatabaseAdapter } from '../adapters/database.adapter';
+import { EmbedderAdapter } from '../adapters/embedder.adapter';
+import { RedisCacheAdapter } from '../adapters/cache.adapter';
+
+// ---------------------------------------------------------------------------
+// Arg parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs(): { networkId: string; dryRun: boolean } {
+  const args = process.argv.slice(2);
+  const networkArg = args.find((a) => a.startsWith('--network'));
+  const dryRun = args.includes('--dry-run');
+
+  let networkId = '';
+  if (networkArg) {
+    const eqIdx = networkArg.indexOf('=');
+    if (eqIdx !== -1) {
+      networkId = networkArg.slice(eqIdx + 1);
+    } else {
+      const nextIdx = args.indexOf(networkArg) + 1;
+      if (nextIdx < args.length) networkId = args[nextIdx];
+    }
+  }
+
+  if (!networkId) {
+    console.error('Usage: bun run maintenance:backfill-context-hyde -- --network <networkId> [--dry-run]');
+    process.exit(1);
+  }
+
+  return { networkId, dryRun };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const { networkId, dryRun } = parseArgs();
+  console.log(`Backfilling context HyDE for network: ${networkId}${dryRun ? ' (dry run)' : ''}`);
+
+  // Find all contexts in this network
+  const contexts = await db
+    .select({
+      id: schema.userContexts.id,
+      userId: schema.userContexts.userId,
+      text: schema.userContexts.text,
+    })
+    .from(schema.userContexts)
+    .where(eq(schema.userContexts.networkId, networkId));
+
+  console.log(`Found ${contexts.length} contexts in network`);
+
+  if (contexts.length === 0) {
+    console.log('No contexts to process.');
+    return;
+  }
+
+  // Filter to those without HyDE docs
+  const needsHyde: typeof contexts = [];
+  for (const ctx of contexts) {
+    const existing = await db
+      .select({ id: schema.hydeDocuments.id })
+      .from(schema.hydeDocuments)
+      .where(and(
+        eq(schema.hydeDocuments.sourceType, 'context'),
+        eq(schema.hydeDocuments.sourceId, ctx.id),
+      ))
+      .limit(1);
+
+    if (existing.length === 0) {
+      needsHyde.push(ctx);
+    }
+  }
+
+  console.log(`Contexts needing HyDE: ${needsHyde.length} / ${contexts.length}`);
+
+  if (needsHyde.length === 0) {
+    console.log('All contexts already have HyDE documents.');
+    return;
+  }
+
+  if (dryRun) {
+    console.log('Dry run — no HyDE docs generated');
+    for (const ctx of needsHyde) {
+      const textPreview = ctx.text && ctx.text.length > 60 ? ctx.text.slice(0, 57) + '...' : ctx.text;
+      console.log(`  Would generate HyDE for: ${ctx.userId} — "${textPreview}"`);
+    }
+    return;
+  }
+
+  // Generate HyDE for each context
+  const chatDb = new ChatDatabaseAdapter();
+  const graphDb = chatDb as unknown as HydeGraphDatabase;
+  let success = 0;
+  let failed = 0;
+
+  for (const ctx of needsHyde) {
+    try {
+      const embedder = new EmbedderAdapter();
+      const cache = new RedisCacheAdapter();
+      const inferrer = new LensInferrer();
+      const generator = new HydeGenerator();
+      const hydeGraph = new HydeGraphFactory(graphDb, embedder, cache, inferrer, generator).createGraph();
+
+      await hydeGraph.invoke({
+        sourceType: 'context' as const,
+        sourceId: ctx.id,
+        sourceText: ctx.text ?? '',
+        forceRegenerate: false,
+        maxLenses: 3,
+      });
+
+      success++;
+      const textPreview = ctx.text && ctx.text.length > 60 ? ctx.text.slice(0, 57) + '...' : ctx.text;
+      console.log(`  ✓ ${ctx.userId} — "${textPreview}"`);
+    } catch (err) {
+      failed++;
+      const msg = err instanceof Error ? err.message : `${err}`;
+      console.error(`  ✗ ${ctx.userId} — ${msg}`);
+    }
+  }
+
+  console.log(`\nDone: ${success} generated, ${failed} failed`);
+}
+
+main()
+  .then(async () => {
+    await closeDb();
+  })
+  .catch(async (e: unknown) => {
+    const msg = e instanceof Error ? e.message : `${e}`;
+    console.error('backfill-context-hyde error:', msg);
+    await closeDb().catch(() => {});
+    process.exit(1);
+  });

--- a/backend/src/cli/backfill-premises.ts
+++ b/backend/src/cli/backfill-premises.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * Backfill CLI: enqueue enrichment jobs for all members of a network.
+ * Creates premises (via enrichment) and user contexts for members who lack them.
+ *
+ * Usage: bun run maintenance:backfill-premises -- --network <networkId> [--dry-run]
+ */
+import dotenv from 'dotenv';
+import path from 'path';
+
+const envFile = process.env.NODE_ENV === 'development' ? '.env.development' : '.env.production';
+dotenv.config({ path: path.resolve(process.cwd(), envFile) });
+
+import { and, eq, isNull } from 'drizzle-orm';
+
+import db, { closeDb } from '../lib/drizzle/drizzle';
+import { networkMembers, users } from '../schemas/database.schema';
+import { enrichmentQueue } from '../queues/enrichment.queue';
+
+// ---------------------------------------------------------------------------
+// Arg parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs(): { networkId: string; dryRun: boolean } {
+  const args = process.argv.slice(2);
+  const networkArg = args.find((a) => a.startsWith('--network'));
+  const dryRun = args.includes('--dry-run');
+
+  let networkId = '';
+  if (networkArg) {
+    const eqIdx = networkArg.indexOf('=');
+    if (eqIdx !== -1) {
+      networkId = networkArg.slice(eqIdx + 1);
+    } else {
+      const nextIdx = args.indexOf(networkArg) + 1;
+      if (nextIdx < args.length) networkId = args[nextIdx];
+    }
+  }
+
+  if (!networkId) {
+    console.error('Usage: bun run maintenance:backfill-premises -- --network <networkId> [--dry-run]');
+    process.exit(1);
+  }
+
+  return { networkId, dryRun };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const { networkId, dryRun } = parseArgs();
+  console.log(`Backfilling premises for network: ${networkId}${dryRun ? ' (dry run)' : ''}`);
+
+  const members = await db
+    .select({ userId: networkMembers.userId })
+    .from(networkMembers)
+    .innerJoin(users, eq(networkMembers.userId, users.id))
+    .where(and(
+      eq(networkMembers.networkId, networkId),
+      isNull(users.deletedAt),
+    ));
+
+  console.log(`Found ${members.length} members in network`);
+
+  if (members.length === 0) {
+    console.log('No members to process.');
+    return;
+  }
+
+  if (dryRun) {
+    console.log('Dry run -- no jobs enqueued');
+    for (const m of members) {
+      console.log(`  Would enqueue: ${m.userId}`);
+    }
+    return;
+  }
+
+  const items = members.map((m) => ({ userId: m.userId }));
+  const jobs = await enrichmentQueue.addEnrichUserJobBulk(items);
+  console.log(`Enqueued ${jobs.length} enrichment jobs`);
+}
+
+main()
+  .then(async () => {
+    await Promise.all([closeDb(), enrichmentQueue.queue.close()]);
+  })
+  .catch(async (e: unknown) => {
+    const msg = e instanceof Error ? e.message : `${e}`;
+    console.error('backfill-premises error:', msg);
+    await Promise.all([
+      closeDb().catch(() => {}),
+      enrichmentQueue.queue.close().catch(() => {}),
+    ]);
+    process.exit(1);
+  });

--- a/backend/src/cli/backfill-premises.ts
+++ b/backend/src/cli/backfill-premises.ts
@@ -59,6 +59,7 @@ async function main(): Promise<void> {
     .innerJoin(users, eq(networkMembers.userId, users.id))
     .where(and(
       eq(networkMembers.networkId, networkId),
+      isNull(networkMembers.deletedAt),
       isNull(users.deletedAt),
     ));
 

--- a/backend/src/cli/backfill-profile-hyde.ts
+++ b/backend/src/cli/backfill-profile-hyde.ts
@@ -16,7 +16,7 @@ import { and, eq, isNull } from 'drizzle-orm';
 
 import db, { closeDb } from '../lib/drizzle/drizzle';
 import { hydeDocuments, networkMembers, userProfiles } from '../schemas/database.schema';
-import { profileQueue } from '../queues/profile.queue';
+import { enrichmentQueue } from '../queues/enrichment.queue';
 
 const DEFAULT_LIMIT = 500;
 
@@ -58,7 +58,7 @@ async function main(): Promise<void> {
 
   let enqueued = 0;
   for (const { userId } of users) {
-    await profileQueue.addEnsureProfileHydeJob({ userId });
+    await enrichmentQueue.addEnsureProfileHydeJob({ userId });
     enqueued++;
   }
 
@@ -67,14 +67,14 @@ async function main(): Promise<void> {
 
 main()
   .then(async () => {
-    await Promise.all([closeDb(), profileQueue.queue.close()]);
+    await Promise.all([closeDb(), enrichmentQueue.queue.close()]);
   })
   .catch(async (e: unknown) => {
     const msg = e instanceof Error ? e.message : `${e}`;
     console.error('backfill-profile-hyde error:', msg);
     await Promise.all([
       closeDb().catch(() => {}),
-      profileQueue.queue.close().catch(() => {}),
+      enrichmentQueue.queue.close().catch(() => {}),
     ]);
     process.exit(1);
   });

--- a/backend/src/cli/compare-discovery.ts
+++ b/backend/src/cli/compare-discovery.ts
@@ -130,10 +130,11 @@ async function getProfileEmbedding(userId: string): Promise<number[] | null> {
   return Array.isArray(emb) ? emb as number[] : null;
 }
 
-/** Get context embedding for a user in a specific network. */
+/** Get context HyDE embedding for a user in a specific network (falls back to raw context embedding). */
 async function getContextEmbedding(userId: string, networkId: string): Promise<number[] | null> {
-  const rows = await db
-    .select({ embedding: schema.userContexts.embedding })
+  // First, get the context record to find its ID
+  const contextRows = await db
+    .select({ id: schema.userContexts.id, embedding: schema.userContexts.embedding })
     .from(schema.userContexts)
     .where(and(
       eq(schema.userContexts.userId, userId),
@@ -141,9 +142,27 @@ async function getContextEmbedding(userId: string, networkId: string): Promise<n
     ))
     .limit(1);
 
-  if (rows.length === 0 || !rows[0].embedding) return null;
-  const emb = rows[0].embedding;
-  return Array.isArray(emb) ? emb as number[] : null;
+  if (contextRows.length === 0) return null;
+  const contextId = contextRows[0].id;
+
+  // Try to get a HyDE embedding for this context (optimised hypothetical-document vector)
+  const hydeRows = await db
+    .select({ hydeEmbedding: schema.hydeDocuments.hydeEmbedding })
+    .from(schema.hydeDocuments)
+    .where(and(
+      eq(schema.hydeDocuments.sourceType, 'context'),
+      eq(schema.hydeDocuments.sourceId, contextId),
+    ))
+    .limit(1);
+
+  if (hydeRows.length > 0 && hydeRows[0].hydeEmbedding) {
+    const emb = hydeRows[0].hydeEmbedding;
+    return Array.isArray(emb) ? emb as number[] : null;
+  }
+
+  // Fallback to raw context embedding
+  const emb = contextRows[0].embedding;
+  return emb && Array.isArray(emb) ? emb as number[] : null;
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/src/cli/compare-discovery.ts
+++ b/backend/src/cli/compare-discovery.ts
@@ -1,0 +1,371 @@
+#!/usr/bin/env node
+/**
+ * Compare Discovery: profile-embedding vs context-embedding intent search.
+ *
+ * For each member in a network who has both a profile HyDE embedding and
+ * at least one user context embedding, runs the same cosine-similarity
+ * intent search using each vector and compares the results side-by-side.
+ *
+ * Usage:
+ *   bun run maintenance:compare-discovery -- --network <networkId> [--limit 20] [--min-score 0.30]
+ */
+import dotenv from 'dotenv';
+import path from 'path';
+
+const envFile = process.env.NODE_ENV === 'development' ? '.env.development' : '.env.production';
+dotenv.config({ path: path.resolve(process.cwd(), envFile) });
+
+import { and, eq, isNull, sql } from 'drizzle-orm';
+
+import db, { closeDb } from '../lib/drizzle/drizzle';
+import * as schema from '../schemas/database.schema';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface IntentHit {
+  intentId: string;
+  userId: string;
+  networkId: string;
+  payload: string;
+  summary: string | null;
+  similarity: number;
+}
+
+interface UserComparison {
+  userId: string;
+  userName: string;
+  profileHits: IntentHit[];
+  contextHits: IntentHit[];
+  overlap: IntentHit[];
+  profileOnly: IntentHit[];
+  contextOnly: IntentHit[];
+  avgProfileSim: number;
+  avgContextSim: number;
+}
+
+// ---------------------------------------------------------------------------
+// Arg parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs(): { networkId: string; limit: number; minScore: number } {
+  const args = process.argv.slice(2);
+
+  function getArg(name: string): string | undefined {
+    const arg = args.find((a) => a.startsWith(`--${name}`));
+    if (!arg) return undefined;
+    const eqIdx = arg.indexOf('=');
+    if (eqIdx !== -1) return arg.slice(eqIdx + 1);
+    const nextIdx = args.indexOf(arg) + 1;
+    return nextIdx < args.length ? args[nextIdx] : undefined;
+  }
+
+  const networkId = getArg('network');
+  if (!networkId) {
+    console.error('Usage: bun run maintenance:compare-discovery -- --network <networkId> [--limit 20] [--min-score 0.30]');
+    process.exit(1);
+  }
+
+  const limit = parseInt(getArg('limit') ?? '20', 10);
+  const minScore = parseFloat(getArg('min-score') ?? '0.30');
+
+  return { networkId, limit, minScore };
+}
+
+// ---------------------------------------------------------------------------
+// Intent search (shared query, different input embedding)
+// ---------------------------------------------------------------------------
+
+async function searchIntentsByEmbedding(
+  embedding: number[],
+  networkId: string,
+  excludeUserId: string,
+  limit: number,
+  minScore: number,
+): Promise<IntentHit[]> {
+  const vectorStr = `[${embedding.join(',')}]`;
+
+  const rows = await db.execute(sql`
+    SELECT
+      i.id AS "intentId",
+      i.user_id AS "userId",
+      ine.network_id AS "networkId",
+      i.payload,
+      i.summary,
+      1 - (i.embedding <=> ${vectorStr}::vector) AS similarity
+    FROM ${schema.intents} i
+    JOIN ${schema.intentNetworks} ine ON i.id = ine.intent_id
+    JOIN ${schema.users} u ON i.user_id = u.id
+    WHERE ine.network_id = ${networkId}
+      AND i.user_id != ${excludeUserId}
+      AND i.status = 'ACTIVE'
+      AND i.embedding IS NOT NULL
+      AND u.deleted_at IS NULL
+      AND 1 - (i.embedding <=> ${vectorStr}::vector) >= ${minScore}
+    ORDER BY i.embedding <=> ${vectorStr}::vector
+    LIMIT ${limit}
+  `);
+
+  return rows as unknown as IntentHit[];
+}
+
+// ---------------------------------------------------------------------------
+// Data fetchers
+// ---------------------------------------------------------------------------
+
+/** Get the first profile HyDE embedding for a user (any strategy). */
+async function getProfileEmbedding(userId: string): Promise<number[] | null> {
+  const rows = await db
+    .select({ hydeEmbedding: schema.hydeDocuments.hydeEmbedding })
+    .from(schema.hydeDocuments)
+    .where(and(
+      eq(schema.hydeDocuments.sourceType, 'profile'),
+      eq(schema.hydeDocuments.sourceId, userId),
+    ))
+    .limit(1);
+
+  if (rows.length === 0 || !rows[0].hydeEmbedding) return null;
+  const emb = rows[0].hydeEmbedding;
+  return Array.isArray(emb) ? emb as number[] : null;
+}
+
+/** Get context embedding for a user in a specific network. */
+async function getContextEmbedding(userId: string, networkId: string): Promise<number[] | null> {
+  const rows = await db
+    .select({ embedding: schema.userContexts.embedding })
+    .from(schema.userContexts)
+    .where(and(
+      eq(schema.userContexts.userId, userId),
+      eq(schema.userContexts.networkId, networkId),
+    ))
+    .limit(1);
+
+  if (rows.length === 0 || !rows[0].embedding) return null;
+  const emb = rows[0].embedding;
+  return Array.isArray(emb) ? emb as number[] : null;
+}
+
+// ---------------------------------------------------------------------------
+// Comparison logic
+// ---------------------------------------------------------------------------
+
+function compareResults(profileHits: IntentHit[], contextHits: IntentHit[]): {
+  overlap: IntentHit[];
+  profileOnly: IntentHit[];
+  contextOnly: IntentHit[];
+} {
+  const profileSet = new Set(profileHits.map(h => h.intentId));
+  const contextSet = new Set(contextHits.map(h => h.intentId));
+
+  const overlap = contextHits.filter(h => profileSet.has(h.intentId));
+  const profileOnly = profileHits.filter(h => !contextSet.has(h.intentId));
+  const contextOnly = contextHits.filter(h => !profileSet.has(h.intentId));
+
+  return { overlap, profileOnly, contextOnly };
+}
+
+function avg(nums: number[]): number {
+  if (nums.length === 0) return 0;
+  return nums.reduce((s, n) => s + n, 0) / nums.length;
+}
+
+// ---------------------------------------------------------------------------
+// Output formatting
+// ---------------------------------------------------------------------------
+
+function printHeader(networkId: string, networkTitle: string, memberCount: number, eligibleCount: number) {
+  console.log('');
+  console.log('╔══════════════════════════════════════════════════════════════════╗');
+  console.log(`║  Discovery Comparison: ${networkTitle}`);
+  console.log(`║  Network: ${networkId}`);
+  console.log(`║  Members with both embeddings: ${eligibleCount} / ${memberCount}`);
+  console.log('╠══════════════════════════════════════════════════════════════════╣');
+  console.log('');
+}
+
+function printUserComparison(comp: UserComparison) {
+  const delta = comp.avgContextSim - comp.avgProfileSim;
+  const deltaStr = delta >= 0 ? `+${delta.toFixed(3)}` : delta.toFixed(3);
+
+  console.log(`── ${comp.userName} ──────────────────────────────────────────────────`);
+  console.log(`  Profile hits: ${comp.profileHits.length}    Context hits: ${comp.contextHits.length}    Overlap: ${comp.overlap.length}`);
+  console.log(`  Context-only: ${comp.contextOnly.length}     Profile-only: ${comp.profileOnly.length}`);
+  console.log(`  Avg similarity — Profile: ${comp.avgProfileSim.toFixed(3)}   Context: ${comp.avgContextSim.toFixed(3)} (${deltaStr})`);
+
+  // Show top overlapping intents with similarity comparison
+  if (comp.overlap.length > 0) {
+    const profileMap = new Map(comp.profileHits.map(h => [h.intentId, h]));
+    const sorted = [...comp.overlap]
+      .map(ctx => {
+        const prof = profileMap.get(ctx.intentId);
+        return { ctx, profSim: prof?.similarity ?? 0, delta: ctx.similarity - (prof?.similarity ?? 0) };
+      })
+      .sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta));
+
+    console.log('  Top overlap (by delta):');
+    for (const item of sorted.slice(0, 3)) {
+      const payload = item.ctx.payload.length > 60 ? item.ctx.payload.slice(0, 57) + '...' : item.ctx.payload;
+      const d = item.delta >= 0 ? `+${item.delta.toFixed(3)}` : item.delta.toFixed(3);
+      console.log(`    "${payload}" — profile: ${item.profSim.toFixed(3)}, context: ${item.ctx.similarity.toFixed(3)} (${d})`);
+    }
+  }
+
+  // Show top context-only finds
+  if (comp.contextOnly.length > 0) {
+    console.log('  Top context-only finds:');
+    for (const hit of comp.contextOnly.slice(0, 3)) {
+      const payload = hit.payload.length > 60 ? hit.payload.slice(0, 57) + '...' : hit.payload;
+      console.log(`    "${payload}" — similarity: ${hit.similarity.toFixed(3)}`);
+    }
+  }
+
+  console.log('');
+}
+
+function printSummary(comparisons: UserComparison[]) {
+  const total = comparisons.length;
+  const contextBetter = comparisons.filter(c => c.contextHits.length > c.profileHits.length).length;
+  const profileBetter = comparisons.filter(c => c.profileHits.length > c.contextHits.length).length;
+  const tied = comparisons.filter(c => c.contextHits.length === c.profileHits.length).length;
+
+  const allOverlapCounts = comparisons.map(c => c.overlap.length);
+  const allProfileCounts = comparisons.map(c => c.profileHits.length);
+  const allContextCounts = comparisons.map(c => c.contextHits.length);
+
+  const jaccards = comparisons.map(c => {
+    const union = new Set([
+      ...c.profileHits.map(h => h.intentId),
+      ...c.contextHits.map(h => h.intentId),
+    ]);
+    return union.size === 0 ? 1 : c.overlap.length / union.size;
+  });
+
+  const simDeltas = comparisons.map(c => c.avgContextSim - c.avgProfileSim);
+  const sortedDeltas = [...simDeltas].sort((a, b) => a - b);
+  const median = sortedDeltas.length % 2 === 0
+    ? (sortedDeltas[sortedDeltas.length / 2 - 1] + sortedDeltas[sortedDeltas.length / 2]) / 2
+    : sortedDeltas[Math.floor(sortedDeltas.length / 2)];
+
+  console.log('════════════════════════════════ SUMMARY ═══════════════════════════');
+  console.log(`  Users compared:          ${total}`);
+  console.log(`  Avg profile hits:        ${avg(allProfileCounts).toFixed(1)}`);
+  console.log(`  Avg context hits:        ${avg(allContextCounts).toFixed(1)}`);
+  console.log(`  Avg overlap:             ${avg(allOverlapCounts).toFixed(1)}`);
+  console.log(`  Avg Jaccard overlap:     ${avg(jaccards).toFixed(3)}`);
+  console.log(`  Context found more:      ${contextBetter} users (${((contextBetter / total) * 100).toFixed(0)}%)`);
+  console.log(`  Profile found more:      ${profileBetter} users (${((profileBetter / total) * 100).toFixed(0)}%)`);
+  console.log(`  Tied:                    ${tied} users (${((tied / total) * 100).toFixed(0)}%)`);
+  console.log(`  Mean similarity delta:   ${avg(simDeltas) >= 0 ? '+' : ''}${avg(simDeltas).toFixed(4)} (context − profile)`);
+  console.log(`  Median similarity delta: ${median >= 0 ? '+' : ''}${median.toFixed(4)}`);
+  console.log('═══════════════════════════════════════════════════════════════════');
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const { networkId, limit, minScore } = parseArgs();
+  console.log(`Comparing discovery strategies for network: ${networkId}`);
+  console.log(`  limit=${limit}, minScore=${minScore}`);
+
+  // Get network title
+  const networkRow = await db
+    .select({ title: schema.networks.title })
+    .from(schema.networks)
+    .where(eq(schema.networks.id, networkId))
+    .limit(1);
+
+  if (networkRow.length === 0) {
+    console.error(`Network not found: ${networkId}`);
+    process.exit(1);
+  }
+  const networkTitle = networkRow[0].title;
+
+  // Get all active members of the network
+  const members = await db
+    .select({
+      userId: schema.networkMembers.userId,
+      userName: schema.users.name,
+    })
+    .from(schema.networkMembers)
+    .innerJoin(schema.users, eq(schema.networkMembers.userId, schema.users.id))
+    .where(and(
+      eq(schema.networkMembers.networkId, networkId),
+      isNull(schema.networkMembers.deletedAt),
+      isNull(schema.users.deletedAt),
+    ));
+
+  console.log(`Found ${members.length} members in network`);
+
+  // Process each member
+  const comparisons: UserComparison[] = [];
+  let skippedNoProfile = 0;
+  let skippedNoContext = 0;
+
+  for (const member of members) {
+    const [profileEmb, contextEmb] = await Promise.all([
+      getProfileEmbedding(member.userId),
+      getContextEmbedding(member.userId, networkId),
+    ]);
+
+    if (!profileEmb) { skippedNoProfile++; continue; }
+    if (!contextEmb) { skippedNoContext++; continue; }
+
+    const [profileHits, contextHits] = await Promise.all([
+      searchIntentsByEmbedding(profileEmb, networkId, member.userId, limit, minScore),
+      searchIntentsByEmbedding(contextEmb, networkId, member.userId, limit, minScore),
+    ]);
+
+    const { overlap, profileOnly, contextOnly } = compareResults(profileHits, contextHits);
+
+    comparisons.push({
+      userId: member.userId,
+      userName: member.userName ?? member.userId.slice(0, 8),
+      profileHits,
+      contextHits,
+      overlap,
+      profileOnly,
+      contextOnly,
+      avgProfileSim: avg(profileHits.map(h => h.similarity)),
+      avgContextSim: avg(contextHits.map(h => h.similarity)),
+    });
+  }
+
+  // Output
+  printHeader(networkId, networkTitle, members.length, comparisons.length);
+
+  if (skippedNoProfile > 0) console.log(`  Skipped (no profile embedding): ${skippedNoProfile}`);
+  if (skippedNoContext > 0) console.log(`  Skipped (no context embedding): ${skippedNoContext}`);
+  if (skippedNoProfile > 0 || skippedNoContext > 0) console.log('');
+
+  if (comparisons.length === 0) {
+    console.log('No users had both profile and context embeddings. Nothing to compare.');
+    return;
+  }
+
+  // Sort by largest context advantage
+  comparisons.sort((a, b) => {
+    const deltaA = a.contextHits.length - a.profileHits.length;
+    const deltaB = b.contextHits.length - b.profileHits.length;
+    return deltaB - deltaA;
+  });
+
+  for (const comp of comparisons) {
+    printUserComparison(comp);
+  }
+
+  printSummary(comparisons);
+}
+
+main()
+  .then(async () => {
+    await closeDb();
+  })
+  .catch(async (e: unknown) => {
+    const msg = e instanceof Error ? e.message : `${e}`;
+    console.error('compare-discovery error:', msg);
+    await closeDb().catch(() => {});
+    process.exit(1);
+  });

--- a/backend/src/cli/db-seed.ts
+++ b/backend/src/cli/db-seed.ts
@@ -14,7 +14,7 @@ import { agentTokenAdapter } from '../adapters/agent-token.adapter';
 import { setLevel } from '../lib/log';
 import { intentService } from '../services/intent.service';
 import { profileService } from '../services/profile.service';
-import { profileQueue } from '../queues/profile.queue';
+import { enrichmentQueue } from '../queues/enrichment.queue';
 import type { Id } from '../types/common.types';
 
 
@@ -388,7 +388,7 @@ async function seedDatabase(): Promise<{ ok: boolean; error?: string }> {
     let successfulEnqueues = 0;
     for (const user of personaUsers) {
       try {
-        await profileQueue.addEnsureProfileHydeJob({ userId: user.id });
+        await enrichmentQueue.addEnsureProfileHydeJob({ userId: user.id });
         successfulEnqueues++;
       } catch (err) {
         if (!silent) console.warn(`  Failed to enqueue ensure_profile_hyde for ${user.id}:`, err);

--- a/backend/src/controllers/queues.controller.ts
+++ b/backend/src/controllers/queues.controller.ts
@@ -17,7 +17,7 @@ import { fromIntentQueue } from '../queues/opportunity/from-intent.queue';
 import { fromIntroducerQueue } from '../queues/opportunity/from-introducer.queue';
 import { fromProfileQueue } from '../queues/opportunity/from-profile.queue';
 import { negotiationRunExistingQueue } from '../queues/negotiations/run-existing.queue';
-import { profileQueue } from '../queues/profile.queue';
+import { enrichmentQueue } from '../queues/enrichment.queue';
 import { emailQueue } from '../queues/email.queue';
 import { integrationSyncQueue } from '../queues/integration.queue';
 import { log } from '../lib/log';
@@ -39,7 +39,7 @@ createBullBoard({
     new BullMQAdapter(fromIntroducerQueue.queue),
     new BullMQAdapter(fromProfileQueue.queue),
     new BullMQAdapter(negotiationRunExistingQueue.queue),
-    new BullMQAdapter(profileQueue.queue),
+    new BullMQAdapter(enrichmentQueue.queue),
     new BullMQAdapter(emailQueue.queue),
     new BullMQAdapter(integrationSyncQueue.queue),
   ],

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -167,6 +167,7 @@ async function generateUserContexts(userId: string): Promise<void> {
     .innerJoin(networks, eq(networkMembers.networkId, networks.id))
     .where(and(
       eq(networkMembers.userId, userId),
+      isNull(networkMembers.deletedAt),
       isNull(networks.deletedAt),
       eq(networks.isPersonal, false),
     ));

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -2,6 +2,10 @@ import './startup.env';
 
 import crypto from 'crypto';
 
+import { and, eq, isNull } from 'drizzle-orm';
+
+import db from './lib/drizzle/drizzle';
+import { networkMembers, networks } from './schemas/database.schema';
 import { ChatController } from './controllers/chat.controller';
 import { DebugController } from './controllers/debug.controller';
 import { ToolController } from './controllers/tool.controller';
@@ -156,7 +160,17 @@ PremiseEvents.onExpired = (premiseId: string, userId: string) => {
 async function generateUserContexts(userId: string): Promise<void> {
   const generator = new UserContextGenerator(embedderAdapter);
 
-  const networkIds = await chatDatabaseAdapter.getUserIndexIds(userId);
+  // Fetch ALL networks (not just autoAssign) — context represents the user in every network
+  const memberRows = await db
+    .select({ networkId: networkMembers.networkId })
+    .from(networkMembers)
+    .innerJoin(networks, eq(networkMembers.networkId, networks.id))
+    .where(and(
+      eq(networkMembers.userId, userId),
+      isNull(networks.deletedAt),
+      eq(networks.isPersonal, false),
+    ));
+  const networkIds = memberRows.map(r => r.networkId);
   const allPremises = await chatDatabaseAdapter.getPremisesForUser(userId, 'ACTIVE');
   if (!allPremises?.length || networkIds.length === 0) return;
 

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,5 +1,7 @@
 import './startup.env';
 
+import crypto from 'crypto';
+
 import { ChatController } from './controllers/chat.controller';
 import { DebugController } from './controllers/debug.controller';
 import { ToolController } from './controllers/tool.controller';
@@ -68,7 +70,7 @@ import { premiseQueue } from './queues/premise.queue';
 import { init as initTelegramGateway } from './gateways/telegram.gateway';
 import { setWebhook } from './lib/telegram/bot-api';
 import { opportunityService } from './services/opportunity.service';
-import { NegotiationGraphFactory } from '@indexnetwork/protocol';
+import { NegotiationGraphFactory, UserContextGenerator } from '@indexnetwork/protocol';
 import { conversationDatabaseAdapter, chatDatabaseAdapter } from './adapters/database.adapter';
 import { embedderAdapter } from './adapters/embedder.adapter';
 import { agentService } from './services/agent.service';
@@ -112,6 +114,9 @@ NetworkMembershipEvents.onMemberAdded = (userId: string) => {
 };
 
 enrichmentQueue.onEnrichmentComplete = (userId: string) => {
+  generateUserContexts(userId)
+    .catch(err => log.job.from('UserContext').error('Failed to generate contexts after enrichment', { userId, error: err }));
+
   fromProfileQueue.addJob(
     { userId },
     { priority: 20, jobId: `profile-discovery-${userId}-${Math.floor(Date.now() / (6 * 60 * 60 * 1000))}` },
@@ -145,6 +150,54 @@ PremiseEvents.onExpired = (premiseId: string, userId: string) => {
   premiseQueue.addProfileRegenJob({ userId, trigger: 'premise_expired' })
     .catch(err => log.job.from('PremiseEvents').error('Failed to enqueue profile regen', { premiseId, userId, error: err }));
 };
+
+// ─── User context generation ────────────────────────────────────────────────
+
+async function generateUserContexts(userId: string): Promise<void> {
+  const generator = new UserContextGenerator(embedderAdapter);
+
+  const networkIds = await chatDatabaseAdapter.getUserIndexIds(userId);
+  const allPremises = await chatDatabaseAdapter.getPremisesForUser(userId, 'ACTIVE');
+  if (!allPremises?.length || networkIds.length === 0) return;
+
+  const premiseTexts = allPremises
+    .map(p => ({ text: p.assertion.text }))
+    .filter(p => p.text.length > 0);
+  if (premiseTexts.length === 0) return;
+
+  const premiseHash = crypto.createHash('sha256')
+    .update(allPremises.map(p => `${p.id}:${p.updatedAt.toISOString()}`).sort().join('|'))
+    .digest('hex')
+    .slice(0, 16);
+
+  for (const networkId of networkIds) {
+    try {
+      const existing = await chatDatabaseAdapter.getUserContext(userId, networkId);
+      if (existing && existing.premiseHash === premiseHash) continue;
+
+      const network = await chatDatabaseAdapter.getNetwork(networkId);
+      if (!network) continue;
+
+      const result = await generator.generateColdStart({
+        premises: premiseTexts,
+        networkPrompt: network.prompt ?? null,
+        networkTitle: network.title,
+      });
+
+      await chatDatabaseAdapter.upsertUserContext({
+        userId,
+        networkId,
+        text: result.text,
+        embedding: result.embedding,
+        premiseHash,
+      });
+
+      log.job.from('UserContext').verbose('Generated user context', { userId, networkId });
+    } catch (err) {
+      log.job.from('UserContext').error('Failed to generate user context', { userId, networkId, error: err });
+    }
+  }
+}
 
 // ─── Question answer reaction handlers ──────────────────────────────────────
 

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -74,9 +74,11 @@ import { premiseQueue } from './queues/premise.queue';
 import { init as initTelegramGateway } from './gateways/telegram.gateway';
 import { setWebhook } from './lib/telegram/bot-api';
 import { opportunityService } from './services/opportunity.service';
-import { NegotiationGraphFactory, UserContextGenerator } from '@indexnetwork/protocol';
+import { NegotiationGraphFactory, UserContextGenerator, HydeGraphFactory, HydeGenerator, LensInferrer } from '@indexnetwork/protocol';
+import type { HydeGraphDatabase } from '@indexnetwork/protocol';
 import { conversationDatabaseAdapter, chatDatabaseAdapter } from './adapters/database.adapter';
-import { embedderAdapter } from './adapters/embedder.adapter';
+import { EmbedderAdapter, embedderAdapter } from './adapters/embedder.adapter';
+import { RedisCacheAdapter } from './adapters/cache.adapter';
 import { agentService } from './services/agent.service';
 import { AgentDispatcherImpl } from './services/agent-dispatcher.service';
 
@@ -199,13 +201,34 @@ async function generateUserContexts(userId: string): Promise<void> {
         networkTitle: network.title,
       });
 
-      await chatDatabaseAdapter.upsertUserContext({
+      const upserted = await chatDatabaseAdapter.upsertUserContext({
         userId,
         networkId,
         text: result.text,
         embedding: result.embedding,
         premiseHash,
       });
+
+      // Generate HyDE documents for the context so context-to-intent discovery
+      // uses optimised hypothetical-document embeddings rather than raw paragraph vectors.
+      try {
+        const hydeEmbedder = new EmbedderAdapter();
+        const hydeCache = new RedisCacheAdapter();
+        const inferrer = new LensInferrer();
+        const generator = new HydeGenerator();
+        const graphDb = chatDatabaseAdapter as unknown as HydeGraphDatabase;
+        const hydeGraph = new HydeGraphFactory(graphDb, hydeEmbedder, hydeCache, inferrer, generator).createGraph();
+        await hydeGraph.invoke({
+          sourceType: 'context' as const,
+          sourceId: upserted.id,
+          sourceText: result.text,
+          forceRegenerate: false,
+          maxLenses: 3,
+        });
+        log.job.from('UserContext').verbose('Generated context HyDE documents', { userId, networkId, contextId: upserted.id });
+      } catch (hydeErr) {
+        log.job.from('UserContext').error('Failed to generate context HyDE', { userId, networkId, error: hydeErr });
+      }
 
       log.job.from('UserContext').verbose('Generated user context', { userId, networkId });
     } catch (err) {

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -50,7 +50,7 @@ import { opportunityExpirationCron } from './queues/opportunity/expiration.queue
 import { notificationQueue } from './queues/notification.queue';
 import { hydeQueue } from './queues/hyde.queue';
 import { emailQueue } from './queues/email.queue';
-import { profileQueue } from './queues/profile.queue';
+import { enrichmentQueue } from './queues/enrichment.queue';
 import { negotiationTimeoutQueue } from './queues/negotiations/timeout.queue';
 import { negotiationClaimTimeoutQueue } from './queues/negotiations/claim-timeout.queue';
 import { integrationSyncQueue } from './queues/integration.queue';
@@ -106,12 +106,12 @@ negotiationRunExistingQueue.setRuntimeDeps({
 
 // Assign callbacks before starting workers to avoid a race with jobs already in Redis.
 NetworkMembershipEvents.onMemberAdded = (userId: string) => {
-  profileQueue.addEnsureProfileHydeJob({ userId }).catch((err) => {
+  enrichmentQueue.addEnsureProfileHydeJob({ userId }).catch((err) => {
     log.job.from('NetworkMembership').error('Failed to enqueue ensure_profile_hyde', { userId, error: err });
   });
 };
 
-profileQueue.onEnrichmentComplete = (userId: string) => {
+enrichmentQueue.onEnrichmentComplete = (userId: string) => {
   fromProfileQueue.addJob(
     { userId },
     { priority: 20, jobId: `profile-discovery-${userId}-${Math.floor(Date.now() / (6 * 60 * 60 * 1000))}` },
@@ -206,7 +206,7 @@ fromProfileQueue.startWorker();
 negotiationRunExistingQueue.startWorker();
 opportunityExpirationCron.start();
 notificationQueue.startWorker();
-profileQueue.startWorker();
+enrichmentQueue.startWorker();
 hydeQueue.startCrons();
 emailQueue.startWorker();
 negotiationTimeoutQueue.startWorker();
@@ -551,7 +551,7 @@ logger.info('Server running', { port: PORT });
 const shutdown = async () => {
   logger.info('Shutting down workers...');
   await Promise.allSettled([
-    profileQueue.close(),
+    enrichmentQueue.close(),
     intentQueue.close(),
     fromIntentQueue.close(),
     fromIntroducerQueue.close(),

--- a/backend/src/queues/enrichment.queue.ts
+++ b/backend/src/queues/enrichment.queue.ts
@@ -14,48 +14,48 @@ export interface EnsureProfileHydeData {
   userId: string;
 }
 
-/** Payload for profile.enrich jobs. */
+/** Payload for enrich.user jobs. */
 export interface EnrichUserData {
   userId: string;
 }
 
-/** Union of all job payloads accepted by the profile queue. */
-export type ProfileJobPayload = EnsureProfileHydeData | EnrichUserData;
+/** Union of all job payloads accepted by the enrichment queue. */
+export type EnrichmentJobPayload = EnsureProfileHydeData | EnrichUserData;
 
 /**
  * Optional dependencies for testing.
  */
-export interface ProfileQueueDeps {
+export interface EnrichmentQueueDeps {
   invokeProfileWrite?: (userId: string) => Promise<void>;
   invokeEnrichUser?: (userId: string) => Promise<void>;
 }
 
 /**
- * Profile HyDE queue: BullMQ queue plus worker and job handlers.
+ * Enrichment queue: BullMQ queue plus worker and job handlers.
  *
  * Handles `ensure_profile_hyde`: invokes the profile graph in write mode so the user has
  * a profile and HyDE documents for discovery (index members can be found).
  *
- * Handles `profile.enrich`: enriches users (ghost or real) via Chat API enrichment
+ * Handles `enrich.user`: enriches users (ghost or real) via Chat API enrichment
  * inside the profile graph, then generates profile + HyDE documents.
  *
  * @remarks
- * Workers are started only by the protocol server via {@link ProfileQueue.startWorker}.
+ * Workers are started only by the protocol server via {@link EnrichmentQueue.startWorker}.
  */
-export class ProfileQueue {
+export class EnrichmentQueue {
   static readonly QUEUE_NAME = QUEUE_NAME;
 
-  readonly queue = QueueFactory.createQueue<ProfileJobPayload>(QUEUE_NAME);
+  readonly queue = QueueFactory.createQueue<EnrichmentJobPayload>(QUEUE_NAME);
 
-  private readonly logger = log.job.from('ProfileHydeJob');
-  private readonly queueLogger = log.queue.from('ProfileQueue');
-  private readonly deps: ProfileQueueDeps | undefined;
-  private worker: ReturnType<typeof QueueFactory.createWorker<ProfileJobPayload>> | null = null;
+  private readonly logger = log.job.from('EnrichmentJob');
+  private readonly queueLogger = log.queue.from('EnrichmentQueue');
+  private readonly deps: EnrichmentQueueDeps | undefined;
+  private worker: ReturnType<typeof QueueFactory.createWorker<EnrichmentJobPayload>> | null = null;
 
   /** Set by main.ts to trigger opportunity discovery after enrichment completes. */
   onEnrichmentComplete: ((userId: string) => void) | null = null;
 
-  constructor(deps?: ProfileQueueDeps) {
+  constructor(deps?: EnrichmentQueueDeps) {
     this.deps = deps;
   }
 
@@ -64,7 +64,7 @@ export class ProfileQueue {
    * @param data - userId
    * @returns The BullMQ job
    */
-  addEnsureProfileHydeJob(data: { userId: string }): Promise<Job<ProfileJobPayload>> {
+  addEnsureProfileHydeJob(data: { userId: string }): Promise<Job<EnrichmentJobPayload>> {
     return this.addJob('ensure_profile_hyde', data);
   }
 
@@ -74,9 +74,9 @@ export class ProfileQueue {
    * @param data - userId to enrich
    * @returns The BullMQ job
    */
-  addEnrichUserJob(data: { userId: string }): Promise<Job<ProfileJobPayload>> {
-    return this.addJob('profile.enrich', data, {
-      jobId: `profile.enrich.${data.userId}.${Date.now()}`,
+  addEnrichUserJob(data: { userId: string }): Promise<Job<EnrichmentJobPayload>> {
+    return this.addJob('enrich.user', data, {
+      jobId: `enrich.user.${data.userId}.${Date.now()}`,
     });
   }
 
@@ -85,15 +85,15 @@ export class ProfileQueue {
    * @param items - Array of { userId } to enrich
    * @returns Array of BullMQ jobs
    */
-  addEnrichUserJobBulk(items: Array<{ userId: string }>): Promise<Job<ProfileJobPayload>[]> {
+  addEnrichUserJobBulk(items: Array<{ userId: string }>): Promise<Job<EnrichmentJobPayload>[]> {
     if (items.length === 0) return Promise.resolve([]);
     const now = Date.now();
     return this.queue.addBulk(
       items.map((item, i) => ({
-        name: 'profile.enrich' as const,
+        name: 'enrich.user' as const,
         data: { userId: item.userId },
         opts: {
-          jobId: `profile.enrich.${item.userId}.${now}.${i}`,
+          jobId: `enrich.user.${item.userId}.${now}.${i}`,
           attempts: 3,
           backoff: { type: 'exponential' as const, delay: 1000 },
           removeOnComplete: { age: 24 * 60 * 60 },
@@ -104,17 +104,17 @@ export class ProfileQueue {
   }
 
   /**
-   * Add a job to the profile HyDE queue.
-   * @param name - Job type: `ensure_profile_hyde`
+   * Add a job to the enrichment queue.
+   * @param name - Job type: `ensure_profile_hyde` or `enrich.user`
    * @param data - Payload for the job
    * @param options - Optional jobId and priority
    * @returns The BullMQ job
    */
   async addJob(
-    name: 'ensure_profile_hyde' | 'profile.enrich',
-    data: ProfileJobPayload,
+    name: 'ensure_profile_hyde' | 'enrich.user',
+    data: EnrichmentJobPayload,
     options?: { jobId?: string; priority?: number }
-  ): Promise<Job<ProfileJobPayload>> {
+  ): Promise<Job<EnrichmentJobPayload>> {
     return this.queue.add(name, data, {
       jobId: options?.jobId,
       priority: options?.priority,
@@ -127,19 +127,19 @@ export class ProfileQueue {
 
   /**
    * Run the job handler for a given job name and payload. Used by the worker and by tests with injected deps.
-   * @param name - Job name (`ensure_profile_hyde`)
+   * @param name - Job name (`ensure_profile_hyde` or `enrich.user`)
    * @param data - Job payload
    */
-  async processJob(name: string, data: ProfileJobPayload): Promise<void> {
+  async processJob(name: string, data: EnrichmentJobPayload): Promise<void> {
     switch (name) {
       case 'ensure_profile_hyde':
         await this.handleEnsureProfileHyde(data);
         break;
-      case 'profile.enrich':
+      case 'enrich.user':
         await this.handleEnrichUser(data);
         break;
       default:
-        this.queueLogger.warn(`[ProfileProcessor] Unknown job name: ${name}`);
+        this.queueLogger.warn(`[EnrichmentProcessor] Unknown job name: ${name}`);
     }
   }
 
@@ -148,14 +148,14 @@ export class ProfileQueue {
    */
   startWorker(): void {
     if (this.worker) return;
-    const processor = async (job: Job<ProfileJobPayload>) => {
-      this.queueLogger.info(`[ProfileProcessor] Processing job ${job.id} (${job.name})`, {
+    const processor = async (job: Job<EnrichmentJobPayload>) => {
+      this.queueLogger.info(`[EnrichmentProcessor] Processing job ${job.id} (${job.name})`, {
         userId: (job.data as EnsureProfileHydeData).userId,
       });
       await this.processJob(job.name, job.data);
     };
     // Parallel Chat API allows 300 req/min. Rate-limit at queue level to prevent bursts.
-    this.worker = QueueFactory.createWorker<ProfileJobPayload>(QUEUE_NAME, processor, {
+    this.worker = QueueFactory.createWorker<EnrichmentJobPayload>(QUEUE_NAME, processor, {
       concurrency: 50,
       limiter: { max: 4, duration: 1000 },
     });
@@ -229,5 +229,5 @@ export class ProfileQueue {
   }
 }
 
-/** Singleton profile HyDE queue instance. Use for adding jobs and starting the worker. */
-export const profileQueue = new ProfileQueue();
+/** Singleton enrichment queue instance. Use for adding jobs and starting the worker. */
+export const enrichmentQueue = new EnrichmentQueue();

--- a/backend/src/queues/enrichment.queue.ts
+++ b/backend/src/queues/enrichment.queue.ts
@@ -3,8 +3,10 @@ import { log } from '../lib/log';
 import { QueueFactory } from '../lib/bullmq/bullmq';
 import { ProfileDatabaseAdapter } from '../adapters/database.adapter';
 import { ScraperAdapter } from '../adapters/scraper.adapter';
-import { ProfileGraphFactory } from '@indexnetwork/protocol';
+import { ProfileGraphFactory, PremiseGraphFactory } from '@indexnetwork/protocol';
+import type { PremiseGraphDatabase } from '@indexnetwork/protocol';
 import { enrichUserProfile } from '../lib/parallel/parallel';
+import { EmbedderAdapter } from '../adapters/embedder.adapter';
 
 /** BullMQ queue name for profile HyDE (ensure profile + HyDE) jobs. */
 export const QUEUE_NAME = 'profile-hyde-queue';
@@ -223,7 +225,12 @@ export class EnrichmentQueue {
   private async invokeProfileGraph(userId: string, operationMode: 'write' | 'generate') {
     const database = new ProfileDatabaseAdapter();
     const scraper = new ScraperAdapter();
-    const factory = new ProfileGraphFactory(database, scraper, { enrichUserProfile });
+    const embedder = new EmbedderAdapter();
+    const premiseGraph = new PremiseGraphFactory(
+      database as unknown as PremiseGraphDatabase,
+      embedder,
+    ).createGraph();
+    const factory = new ProfileGraphFactory(database, scraper, { enrichUserProfile }, undefined, premiseGraph);
     const graph = factory.createGraph();
     return graph.invoke({ userId, operationMode });
   }

--- a/backend/src/schemas/database.schema.ts
+++ b/backend/src/schemas/database.schema.ts
@@ -331,7 +331,7 @@ export const userContexts = pgTable('user_contexts', {
   networkIdIdx: index('user_contexts_network_id_idx').on(table.networkId),
 }));
 
-export type HydeSourceType = 'intent' | 'profile' | 'query';
+export type HydeSourceType = 'intent' | 'profile' | 'query' | 'context';
 
 export const hydeDocuments = pgTable('hyde_documents', {
   id: text('id').primaryKey().$defaultFn(() => crypto.randomUUID()),

--- a/backend/src/schemas/database.schema.ts
+++ b/backend/src/schemas/database.schema.ts
@@ -316,6 +316,21 @@ export const premiseNetworks = pgTable('premise_networks', {
   networkIdIdx: index('premise_networks_network_id_idx').on(t.networkId),
 }));
 
+export const userContexts = pgTable('user_contexts', {
+  id: text('id').primaryKey().$defaultFn(() => crypto.randomUUID()),
+  userId: text('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+  networkId: text('network_id').notNull().references(() => networks.id, { onDelete: 'cascade' }),
+  text: text('text').notNull(),
+  embedding: vector('embedding', { dimensions: 2000 }),
+  premiseHash: text('premise_hash'),
+  generatedAt: timestamp('generated_at', { withTimezone: true }).notNull().defaultNow(),
+}, (table) => ({
+  userNetworkUniq: uniqueIndex('user_contexts_user_network_uniq').on(table.userId, table.networkId),
+  embeddingIdx: index('user_contexts_embedding_idx').using('hnsw', table.embedding.op('vector_cosine_ops')),
+  userIdIdx: index('user_contexts_user_id_idx').on(table.userId),
+  networkIdIdx: index('user_contexts_network_id_idx').on(table.networkId),
+}));
+
 export type HydeSourceType = 'intent' | 'profile' | 'query';
 
 export const hydeDocuments = pgTable('hyde_documents', {
@@ -880,5 +895,7 @@ export type Premise = typeof premises.$inferSelect;
 export type NewPremise = typeof premises.$inferInsert;
 export type PremiseNetwork = typeof premiseNetworks.$inferSelect;
 export type NewPremiseNetwork = typeof premiseNetworks.$inferInsert;
+export type UserContext = typeof userContexts.$inferSelect;
+export type NewUserContext = typeof userContexts.$inferInsert;
 
 export * from './conversation.schema';

--- a/backend/src/services/contact.service.ts
+++ b/backend/src/services/contact.service.ts
@@ -1,6 +1,6 @@
 import { log } from '../lib/log';
 import { ContactDatabaseAdapter } from '../adapters/contact.database.adapter';
-import { profileQueue } from '../queues/profile.queue';
+import { enrichmentQueue } from '../queues/enrichment.queue';
 import { deduplicateContacts, getPreset } from '../lib/dedup/dedup';
 
 const logger = log.service.from('ContactService');
@@ -150,7 +150,7 @@ export class ContactService {
 
     // Enqueue enrichment for new ghosts
     if (isNew && isGhost) {
-      await profileQueue.addEnrichUserJob({ userId: user.id });
+      await enrichmentQueue.addEnrichUserJob({ userId: user.id });
       logger.info('[ContactService] Enrichment job enqueued for new ghost', { userId: user.id });
     }
 
@@ -273,7 +273,7 @@ export class ContactService {
       .filter(d => d.isNew && resolved.newGhostIds.includes(d.userId))
       .map(d => d.userId);
     if (newGhostIdsToEnrich.length > 0) {
-      await profileQueue.addEnrichUserJobBulk(newGhostIdsToEnrich.map(id => ({ userId: id })));
+      await enrichmentQueue.addEnrichUserJobBulk(newGhostIdsToEnrich.map(id => ({ userId: id })));
       logger.info('[ContactService] Enrichment jobs enqueued for new ghosts', { count: newGhostIdsToEnrich.length });
     }
 

--- a/backend/src/services/experiment.service.ts
+++ b/backend/src/services/experiment.service.ts
@@ -6,7 +6,7 @@ import { experimentImportCredentialsTemplate } from '../lib/email/templates/expe
 import { executeSendEmail } from '../lib/email/transport.helper';
 import { buildMcpServerConfig } from '../lib/mcp/mcp-config';
 import * as schema from '../schemas/database.schema';
-import { profileQueue } from '../queues/profile.queue';
+import { enrichmentQueue } from '../queues/enrichment.queue';
 
 /**
  * Experiment is a thin facade over the network-invitation flow: signup uses
@@ -93,7 +93,7 @@ class ExperimentService {
 
     // Enqueue profile enrichment so the user gets a profile + HyDE.
     try {
-      await profileQueue.addEnrichUserJob({ userId: result.user.id });
+      await enrichmentQueue.addEnrichUserJob({ userId: result.user.id });
     } catch (err) {
       logger.warn('[ExperimentService] Failed to enqueue profile enrichment (non-fatal)', { error: err });
     }
@@ -193,7 +193,7 @@ class ExperimentService {
     // above), then generates a full profile with premises and HyDE documents.
     if (importedUserIds.length > 0) {
       try {
-        await profileQueue.addEnrichUserJobBulk(importedUserIds.map(id => ({ userId: id })));
+        await enrichmentQueue.addEnrichUserJobBulk(importedUserIds.map(id => ({ userId: id })));
         logger.info('[ExperimentService] Enqueued profile enrichment', { count: importedUserIds.length });
       } catch (err) {
         logger.warn('[ExperimentService] Failed to enqueue profile enrichment (non-fatal)', { error: err });

--- a/backend/src/services/integration.service.ts
+++ b/backend/src/services/integration.service.ts
@@ -4,7 +4,7 @@ import { ChatDatabaseAdapter, userDatabaseAdapter } from '../adapters/database.a
 import { getRedisClient } from '../adapters/cache.adapter';
 
 import { deduplicateContacts, getPreset } from '../lib/dedup/dedup';
-import { profileQueue } from '../queues/profile.queue';
+import { enrichmentQueue } from '../queues/enrichment.queue';
 import type { ContactImporter, ImportResult } from '../types/integrations.types';
 import type { TelegramPrefs } from '../schemas/database.schema';
 import type { IntegrationConnection } from '../adapters/integration.adapter';
@@ -147,7 +147,7 @@ export class IntegrationService {
       .filter(d => d.isNew && resolved.newGhostIds.includes(d.userId))
       .map(d => d.userId);
     if (newGhostIdsToEnrich.length > 0) {
-      await profileQueue.addEnrichUserJobBulk(newGhostIdsToEnrich.map(id => ({ userId: id })));
+      await enrichmentQueue.addEnrichUserJobBulk(newGhostIdsToEnrich.map(id => ({ userId: id })));
       logger.info('[IntegrationService] Enrichment jobs enqueued for new ghosts', { count: newGhostIdsToEnrich.length });
     }
 

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/context/context.generator.ts
+++ b/packages/protocol/src/context/context.generator.ts
@@ -1,0 +1,127 @@
+/**
+ * User Context Generator
+ *
+ * Synthesizes network-scoped context paragraphs from user premises.
+ * Two modes: cold-start (all premises at once) and incremental
+ * (single premise change applied to an existing context).
+ * Returns { text, embedding } for storage in the user_contexts table.
+ */
+
+import { HumanMessage, SystemMessage } from '@langchain/core/messages';
+
+import { createModel } from '../shared/agent/model.config.js';
+import type { EmbeddingGenerator } from '../shared/interfaces/embedder.interface.js';
+
+/** Input for cold-start context generation from a full set of premises. */
+export interface UserContextInput {
+  premises: Array<{ text: string }>;
+  networkPrompt: string | null;
+  networkTitle: string;
+}
+
+/** Input for incremental context update from a single premise change. */
+export interface IncrementalContextInput {
+  currentContext: string;
+  changeType: 'added' | 'updated' | 'retracted' | 'expired';
+  premiseText: string;
+  previousPremiseText?: string;
+  networkPrompt: string | null;
+  networkTitle: string;
+}
+
+/** Generated context paragraph with its embedding vector. */
+export interface UserContextResult {
+  text: string;
+  embedding: number[];
+}
+
+const COLD_START_SYSTEM_PROMPT = `You synthesize user context paragraphs for community matching. Given a list of premises (atomic facts about a person) and a network description, write a focused paragraph (3-6 sentences) that captures who this person is through the lens of that network's purpose. Highlight what is most relevant to the network. Write in third person. Be specific and concrete, not generic.`;
+
+const INCREMENTAL_SYSTEM_PROMPT = `You maintain user context paragraphs for community matching. You will receive the current context paragraph, a change that occurred, and the network description. Update the context paragraph to reflect the change while preserving all other information. Keep the same style: 3-6 sentences, third person, specific and concrete. For retractions/expirations, remove the relevant information. For additions/updates, integrate the new information naturally.`;
+
+/**
+ * Generates network-scoped context paragraphs from user premises.
+ * Uses LLM synthesis to produce focused context and an embedding vector.
+ */
+export class UserContextGenerator {
+  private model = createModel('userContextGenerator');
+
+  constructor(private embeddingGenerator: EmbeddingGenerator) {}
+
+  /**
+   * Generate a context paragraph from the full set of premises (cold-start).
+   *
+   * @param input - Premises, network prompt, and network title
+   * @returns Synthesized context text with embedding vector
+   */
+  async generateColdStart(input: UserContextInput): Promise<UserContextResult> {
+    const premiseBlock = input.premises.map(p => `- ${p.text}`).join('\n');
+    const networkContext = this.formatNetworkContext(input.networkPrompt, input.networkTitle);
+
+    const response = await this.model.invoke([
+      new SystemMessage(COLD_START_SYSTEM_PROMPT),
+      new HumanMessage(
+        `${networkContext}\n\nPremises:\n${premiseBlock}\n\nWrite a focused context paragraph for this person in this network.`,
+      ),
+    ]);
+
+    const text = typeof response.content === 'string'
+      ? response.content
+      : String(response.content ?? '').trim();
+
+    const embedding = await this.embed(text);
+    return { text, embedding };
+  }
+
+  /**
+   * Update an existing context paragraph after a single premise change.
+   *
+   * @param input - Current context, change details, network metadata
+   * @returns Updated context text with embedding vector
+   */
+  async generateIncremental(input: IncrementalContextInput): Promise<UserContextResult> {
+    const networkContext = this.formatNetworkContext(input.networkPrompt, input.networkTitle);
+    const changeDescription = this.describeChange(input);
+
+    const response = await this.model.invoke([
+      new SystemMessage(INCREMENTAL_SYSTEM_PROMPT),
+      new HumanMessage(
+        `${networkContext}\n\nCurrent context:\n${input.currentContext}\n\nChange:\n${changeDescription}\n\nWrite the updated context paragraph.`,
+      ),
+    ]);
+
+    const text = typeof response.content === 'string'
+      ? response.content
+      : String(response.content ?? '').trim();
+
+    const embedding = await this.embed(text);
+    return { text, embedding };
+  }
+
+  /** Format the network context header for LLM prompts. */
+  private formatNetworkContext(prompt: string | null, title: string): string {
+    return prompt
+      ? `Network "${title}": ${prompt}`
+      : `Network: ${title}`;
+  }
+
+  /** Describe the premise change for the incremental prompt. */
+  private describeChange(input: IncrementalContextInput): string {
+    switch (input.changeType) {
+      case 'added':
+        return `A new fact was learned about this person:\n"${input.premiseText}"`;
+      case 'updated':
+        return `A fact was updated.\nOld: "${input.previousPremiseText}"\nNew: "${input.premiseText}"`;
+      case 'retracted':
+        return `A fact was retracted (no longer true):\n"${input.premiseText}"`;
+      case 'expired':
+        return `A fact has expired (time-bound, no longer current):\n"${input.premiseText}"`;
+    }
+  }
+
+  /** Generate embedding from text, normalizing the return type. */
+  private async embed(text: string): Promise<number[]> {
+    const result = await this.embeddingGenerator.generate(text);
+    return Array.isArray(result[0]) ? result[0] as number[] : result as number[];
+  }
+}

--- a/packages/protocol/src/context/context.generator.ts
+++ b/packages/protocol/src/context/context.generator.ts
@@ -7,10 +7,10 @@
  * Returns { text, embedding } for storage in the user_contexts table.
  */
 
-import { HumanMessage, SystemMessage } from '@langchain/core/messages';
+import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 
-import { createModel } from '../shared/agent/model.config.js';
-import type { EmbeddingGenerator } from '../shared/interfaces/embedder.interface.js';
+import { createModel } from "../shared/agent/model.config.js";
+import type { EmbeddingGenerator } from "../shared/interfaces/embedder.interface.js";
 
 /** Input for cold-start context generation from a full set of premises. */
 export interface UserContextInput {

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -107,6 +107,8 @@ export { PremiseGraphFactory } from "./premise/premise.graph.js";
 
 // ─── Agents ───────────────────────────────────────────────────────────────────
 
+export { UserContextGenerator } from './context/context.generator.js';
+export type { UserContextInput, IncrementalContextInput, UserContextResult } from './context/context.generator.js';
 export { ChatTitleGenerator } from "./chat/chat.title.generator.js";
 export { ChatSummarizer } from "./chat/chat.summarizer.js";
 export type { ChatSummarizerInput, ChatSummarizerMessage } from "./chat/chat.summarizer.js";

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -107,8 +107,8 @@ export { PremiseGraphFactory } from "./premise/premise.graph.js";
 
 // ─── Agents ───────────────────────────────────────────────────────────────────
 
-export { UserContextGenerator } from './context/context.generator.js';
-export type { UserContextInput, IncrementalContextInput, UserContextResult } from './context/context.generator.js';
+export { UserContextGenerator } from "./context/context.generator.js";
+export type { UserContextInput, IncrementalContextInput, UserContextResult } from "./context/context.generator.js";
 export { ChatTitleGenerator } from "./chat/chat.title.generator.js";
 export { ChatSummarizer } from "./chat/chat.summarizer.js";
 export type { ChatSummarizerInput, ChatSummarizerMessage } from "./chat/chat.summarizer.js";

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -296,7 +296,10 @@ export class OpportunityGraphFactory {
                 premiseId: p.id as Id<'premises'>,
                 embedding: p.embedding!,
               }));
-            const rawContexts = await this.database.getUserContexts(discoveryUserId);
+            const contextToIntentEnabled = process.env.DISCOVERY_CONTEXT_TO_INTENT !== '0';
+            const rawContexts = contextToIntentEnabled
+              ? await this.database.getUserContexts(discoveryUserId)
+              : [];
             const sourceContexts = rawContexts
               .filter((c: { networkId: string; embedding: number[] | null }) => c.embedding && c.embedding.length > 0 && userNetworkIds.includes(c.networkId as Id<'networks'>))
               .map((c: { networkId: string; embedding: number[] | null }) => ({

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -984,21 +984,6 @@ export class OpportunityGraphFactory {
            * Merge premise candidates into an existing candidate list.
            * Deduplicates by userId + networkId + discoverySource + entityId.
            */
-          function mergePremiseCandidates(
-            existing: CandidateMatch[],
-            premise: CandidateMatch[],
-          ): CandidateMatch[] {
-            if (premise.length === 0) return existing;
-            const merged = new Map<string, CandidateMatch>();
-            for (const c of [...existing, ...premise]) {
-              const key = `${c.candidateUserId}:${c.networkId}:${c.discoverySource}:${c.candidateIntentId ?? c.candidatePremiseId ?? 'none'}`;
-              if (!merged.has(key) || c.similarity > (merged.get(key)?.similarity ?? 0)) {
-                merged.set(key, c);
-              }
-            }
-            return Array.from(merged.values());
-          }
-
           /**
            * Context-to-intent discovery: searches intents using user context embeddings.
            * Restores the profile->intent cross-search deleted when Path B was removed.
@@ -1064,7 +1049,8 @@ export class OpportunityGraphFactory {
           /**
            * Merge candidates from multiple strategies. Deduplicates by userId + networkId + entityId,
            * keeps the highest similarity, tracks which strategies found each candidate,
-           * and applies a multi-strategy boost (+0.05 per additional strategy, capped at 1.0).
+           * and applies a multi-strategy boost (+0.05 per additional strategy, boost capped at 0.15,
+           * final similarity capped at 1.0).
            */
           function mergeStrategyCandidates(...groups: CandidateMatch[][]): CandidateMatch[] {
             const merged = new Map<string, CandidateMatch & { _strategies: Set<string> }>();

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -981,10 +981,6 @@ export class OpportunityGraphFactory {
           }
 
           /**
-           * Merge premise candidates into an existing candidate list.
-           * Deduplicates by userId + networkId + discoverySource + entityId.
-           */
-          /**
            * Context-to-intent discovery: searches intents using user context embeddings.
            * Restores the profile->intent cross-search deleted when Path B was removed.
            */

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -301,8 +301,9 @@ export class OpportunityGraphFactory {
               ? await this.database.getUserContexts(discoveryUserId)
               : [];
             const sourceContexts = rawContexts
-              .filter((c: { networkId: string; embedding: number[] | null }) => c.embedding && c.embedding.length > 0 && userNetworkIds.includes(c.networkId as Id<'networks'>))
-              .map((c: { networkId: string; embedding: number[] | null }) => ({
+              .filter((c: { id: string; networkId: string; embedding: number[] | null }) => c.embedding && c.embedding.length > 0 && userNetworkIds.includes(c.networkId as Id<'networks'>))
+              .map((c: { id: string; networkId: string; embedding: number[] | null }) => ({
+                contextId: c.id,
                 networkId: c.networkId as Id<'networks'>,
                 embedding: c.embedding!,
               }));
@@ -984,8 +985,10 @@ export class OpportunityGraphFactory {
           }
 
           /**
-           * Context-to-intent discovery: searches intents using user context embeddings.
-           * Restores the profile->intent cross-search deleted when Path B was removed.
+           * Context-to-intent discovery: searches intents using context HyDE embeddings.
+           * When HyDE documents exist for a context, uses optimised hypothetical-document
+           * embeddings via searchWithHydeEmbeddings. Falls back to raw context embedding
+           * via searchIntentsByContextEmbedding when no HyDE docs are available.
            */
           async function runContextToIntentDiscovery(): Promise<CandidateMatch[]> {
             if (!state.sourceContexts?.length) return [];
@@ -1000,33 +1003,61 @@ export class OpportunityGraphFactory {
               targetNetworks: targetNetworkIds.length,
             });
 
-            const searchResults = await Promise.all(
-              state.sourceContexts
-                .filter(ctx => targetNetworkIds.includes(ctx.networkId))
-                .map(ctx =>
-                  self.database.searchIntentsByContextEmbedding({
-                    embedding: ctx.embedding,
-                    networkIds: [ctx.networkId],
-                    excludeUserId: discoveryUserId,
-                    limit: 20,
-                    minScore: minScore,
-                  })
-                )
-            );
-
             const contextCandidates: CandidateMatch[] = [];
-            for (const results of searchResults) {
-              for (const r of results) {
-                contextCandidates.push({
-                  candidateUserId: r.userId as Id<'users'>,
-                  candidateIntentId: r.intentId as Id<'intents'>,
-                  networkId: r.networkId as Id<'networks'>,
-                  similarity: typeof r.similarity === 'number' ? r.similarity : parseFloat(String(r.similarity)),
-                  lens: 'context_match',
-                  candidatePayload: r.payload ?? '',
-                  candidateSummary: r.summary ?? undefined,
-                  discoverySource: 'context-to-intent',
+
+            for (const ctx of state.sourceContexts.filter(c => targetNetworkIds.includes(c.networkId))) {
+              // Attempt HyDE-enhanced search first
+              const hydeDocs = await self.database.getHydeDocumentsForSource('context', ctx.contextId);
+              const lensEmbeddings: LensEmbedding[] = hydeDocs
+                .filter(d => d.hydeEmbedding?.length > 0)
+                .map(d => ({
+                  lens: d.strategy,
+                  corpus: (d.targetCorpus === 'intents' ? 'intents' : d.targetCorpus === 'premises' ? 'premises' : 'intents') as 'intents' | 'premises' | 'profiles',
+                  embedding: d.hydeEmbedding,
+                }));
+
+              if (lensEmbeddings.length > 0) {
+                // HyDE-enhanced search: same path as query HyDE, scoped to this context's network
+                const results = await self.embedder.searchWithHydeEmbeddings(lensEmbeddings, {
+                  indexScope: [ctx.networkId],
+                  excludeUserId: discoveryUserId,
+                  limitPerStrategy: limitPerStrategy,
+                  limit: 20,
+                  minScore,
                 });
+                for (const r of results.filter(r => r.type === 'intent')) {
+                  contextCandidates.push({
+                    candidateUserId: r.userId as Id<'users'>,
+                    candidateIntentId: r.id as Id<'intents'>,
+                    networkId: ctx.networkId,
+                    similarity: r.score,
+                    lens: r.matchedVia,
+                    candidatePayload: '',
+                    candidateSummary: undefined,
+                    discoverySource: 'context-to-intent',
+                  });
+                }
+              } else {
+                // Fallback: raw context embedding search (no HyDE docs yet)
+                const results = await self.database.searchIntentsByContextEmbedding({
+                  embedding: ctx.embedding,
+                  networkIds: [ctx.networkId],
+                  excludeUserId: discoveryUserId,
+                  limit: 20,
+                  minScore: minScore,
+                });
+                for (const r of results) {
+                  contextCandidates.push({
+                    candidateUserId: r.userId as Id<'users'>,
+                    candidateIntentId: r.intentId as Id<'intents'>,
+                    networkId: r.networkId as Id<'networks'>,
+                    similarity: typeof r.similarity === 'number' ? r.similarity : parseFloat(String(r.similarity)),
+                    lens: 'context_match',
+                    candidatePayload: r.payload ?? '',
+                    candidateSummary: r.summary ?? undefined,
+                    discoverySource: 'context-to-intent',
+                  });
+                }
               }
             }
 

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -1099,11 +1099,15 @@ export class OpportunityGraphFactory {
           const searchText = state.searchQuery ?? resolvedIntent?.payload ?? '';
           if (!searchText) {
             logger.warn('[Graph:Discovery] No search text available for intent path');
-            const premiseCands = await runPremiseDiscovery();
-            if (premiseCands.length > 0) {
+            const [premiseCands, contextCands] = await Promise.all([
+              runPremiseDiscovery(),
+              runContextToIntentDiscovery(),
+            ]);
+            const merged = mergeStrategyCandidates(premiseCands, contextCands);
+            if (merged.length > 0) {
               return {
-                candidates: filterByTarget(premiseCands),
-                trace: [{ node: "discovery", detail: `No search text; premise search → ${premiseCands.length} candidate(s)` }],
+                candidates: filterByTarget(merged),
+                trace: [{ node: "discovery", detail: `No search text; premise → ${premiseCands.length}, context → ${contextCands.length}, merged → ${merged.length} candidate(s)` }],
               };
             }
             return { candidates: [] };
@@ -1123,12 +1127,16 @@ export class OpportunityGraphFactory {
           const hydeEmbeddings = hydeResult.hydeEmbeddings as Record<string, number[]>;
           const lenses = hydeResult.lenses ?? [];
           if (!hydeEmbeddings || Object.keys(hydeEmbeddings).length === 0) {
-            const premiseCands = await runPremiseDiscovery();
-            if (premiseCands.length > 0) {
+            const [premiseCands, contextCands] = await Promise.all([
+              runPremiseDiscovery(),
+              runContextToIntentDiscovery(),
+            ]);
+            const merged = mergeStrategyCandidates(premiseCands, contextCands);
+            if (merged.length > 0) {
               return {
                 hydeEmbeddings: {} as Record<string, number[]>,
-                candidates: filterByTarget(premiseCands),
-                trace: [{ node: "discovery", detail: `No HyDE embeddings; premise search → ${premiseCands.length} candidate(s)` }],
+                candidates: filterByTarget(merged),
+                trace: [{ node: "discovery", detail: `No HyDE embeddings; premise → ${premiseCands.length}, context → ${contextCands.length}, merged → ${merged.length} candidate(s)` }],
               };
             }
             return { hydeEmbeddings: {} as Record<string, number[]>, candidates: [] };
@@ -1267,14 +1275,20 @@ export class OpportunityGraphFactory {
             });
           }
 
-          const premiseCands = await runPremiseDiscovery();
-          const withPremises = mergePremiseCandidates(candidates, premiseCands);
-          if (premiseCands.length > 0) {
-            traceEntries.push({ node: "discovery", detail: `+ Premise search → ${premiseCands.length} candidate(s), merged to ${withPremises.length}` });
+          const [premiseCands, contextCands] = await Promise.all([
+            runPremiseDiscovery(),
+            runContextToIntentDiscovery(),
+          ]);
+          const allStrategies = mergeStrategyCandidates(candidates, premiseCands, contextCands);
+          if (premiseCands.length > 0 || contextCands.length > 0) {
+            traceEntries.push({
+              node: "discovery",
+              detail: `+ Premise → ${premiseCands.length}, Context → ${contextCands.length}, merged to ${allStrategies.length} candidate(s)`,
+            });
           }
           return {
             hydeEmbeddings: hydeEmbeddings as Record<string, number[]>,
-            candidates: filterByTarget(withPremises),
+            candidates: filterByTarget(allStrategies),
             trace: traceEntries,
           };
         } catch (error) {

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -296,14 +296,22 @@ export class OpportunityGraphFactory {
                 premiseId: p.id as Id<'premises'>,
                 embedding: p.embedding!,
               }));
+            const rawContexts = await this.database.getUserContexts(discoveryUserId);
+            const sourceContexts = rawContexts
+              .filter((c: { networkId: string; embedding: number[] | null }) => c.embedding && c.embedding.length > 0 && userNetworkIds.includes(c.networkId as Id<'networks'>))
+              .map((c: { networkId: string; embedding: number[] | null }) => ({
+                networkId: c.networkId as Id<'networks'>,
+                embedding: c.embedding!,
+              }));
             return {
               userNetworks: userNetworkIds,
               indexedIntents,
               sourceProfile,
               sourcePremises,
+              sourceContexts,
               trace: [{
                 node: "prep",
-                detail: `${userNetworkIds.length} network(s), ${intents.length} intent(s), ${sourcePremises.length} premise(s), ${profile ? 'profile loaded' : 'no profile'}`,
+                detail: `${userNetworkIds.length} network(s), ${intents.length} intent(s), ${sourcePremises.length} premise(s), ${sourceContexts.length} context(s), ${profile ? 'profile loaded' : 'no profile'}`,
               }],
             };
           },
@@ -787,21 +795,39 @@ export class OpportunityGraphFactory {
                 },
               });
 
-              const premiseCands = await runPremiseDiscovery();
-              const withPremises = mergePremiseCandidates(queryCandidates, premiseCands);
+              const [premiseCands, contextCands] = await Promise.all([
+                runPremiseDiscovery(),
+                runContextToIntentDiscovery(),
+              ]);
+              const withPremisesAndContext = mergeStrategyCandidates(queryCandidates, premiseCands, contextCands);
               if (premiseCands.length > 0) {
-                traceEntries.push({ node: "discovery", detail: `+ Premise search → ${premiseCands.length} candidate(s), merged to ${withPremises.length}` });
+                traceEntries.push({ node: "strategy", detail: `premise-to-premise → ${premiseCands.length} candidate(s)` });
               }
-              return { candidates: filterByTarget(withPremises), trace: traceEntries };
+              if (contextCands.length > 0) {
+                traceEntries.push({ node: "strategy", detail: `context-to-intent → ${contextCands.length} candidate(s)` });
+              }
+              return { candidates: filterByTarget(withPremisesAndContext), trace: traceEntries };
             }
 
-            // No search query — premise-to-premise discovery only
-            const premiseCands = await runPremiseDiscovery();
-            if (premiseCands.length > 0) {
-              return {
-                candidates: filterByTarget(premiseCands),
-                trace: [{ node: "discovery", detail: `No search query; premise search → ${premiseCands.length} candidate(s)` }],
-              };
+            // No search query — premise-to-premise + context-to-intent discovery
+            const [premiseCands, contextCands] = await Promise.all([
+              runPremiseDiscovery(),
+              runContextToIntentDiscovery(),
+            ]);
+            if (premiseCands.length > 0 || contextCands.length > 0) {
+              const merged = mergeStrategyCandidates(premiseCands, contextCands);
+              const traceEntries: Array<{ node: string; detail?: string; data?: Record<string, unknown> }> = [];
+              if (premiseCands.length > 0) {
+                traceEntries.push({ node: "strategy", detail: `premise-to-premise → ${premiseCands.length} candidate(s)` });
+              }
+              if (contextCands.length > 0) {
+                traceEntries.push({ node: "strategy", detail: `context-to-intent → ${contextCands.length} candidate(s)` });
+              }
+              traceEntries.push({
+                node: "discovery",
+                detail: `${[premiseCands.length > 0 && 'premise-to-premise', contextCands.length > 0 && 'context-to-intent'].filter(Boolean).length} strategies → ${premiseCands.length + contextCands.length} raw, ${merged.length} after dedup`,
+              });
+              return { candidates: filterByTarget(merged), trace: traceEntries };
             }
             return { candidates: [] };
           }
@@ -971,6 +997,100 @@ export class OpportunityGraphFactory {
               }
             }
             return Array.from(merged.values());
+          }
+
+          /**
+           * Context-to-intent discovery: searches intents using user context embeddings.
+           * Restores the profile->intent cross-search deleted when Path B was removed.
+           */
+          async function runContextToIntentDiscovery(): Promise<CandidateMatch[]> {
+            if (!state.sourceContexts?.length) return [];
+            const contextToIntentEnabled = process.env.DISCOVERY_CONTEXT_TO_INTENT !== '0';
+            if (!contextToIntentEnabled) return [];
+
+            const targetNetworkIds = state.targetNetworks.map(t => t.networkId);
+            if (targetNetworkIds.length === 0) return [];
+
+            logger.verbose('[Graph:Discovery] runContextToIntentDiscovery start', {
+              contextCount: state.sourceContexts.length,
+              targetNetworks: targetNetworkIds.length,
+            });
+
+            const searchResults = await Promise.all(
+              state.sourceContexts
+                .filter(ctx => targetNetworkIds.includes(ctx.networkId))
+                .map(ctx =>
+                  self.database.searchIntentsByContextEmbedding({
+                    embedding: ctx.embedding,
+                    networkIds: [ctx.networkId],
+                    excludeUserId: discoveryUserId,
+                    limit: 20,
+                    minScore: minScore,
+                  })
+                )
+            );
+
+            const contextCandidates: CandidateMatch[] = [];
+            for (const results of searchResults) {
+              for (const r of results) {
+                contextCandidates.push({
+                  candidateUserId: r.userId as Id<'users'>,
+                  candidateIntentId: r.intentId as Id<'intents'>,
+                  networkId: r.networkId as Id<'networks'>,
+                  similarity: typeof r.similarity === 'number' ? r.similarity : parseFloat(String(r.similarity)),
+                  lens: 'context_match',
+                  candidatePayload: r.payload ?? '',
+                  candidateSummary: r.summary ?? undefined,
+                  discoverySource: 'context-to-intent',
+                });
+              }
+            }
+
+            const byKey = new Map<string, CandidateMatch>();
+            for (const c of contextCandidates) {
+              const key = `${c.candidateUserId}:${c.candidateIntentId ?? 'none'}:${c.networkId}`;
+              if (!byKey.has(key) || c.similarity > (byKey.get(key)?.similarity ?? 0)) {
+                byKey.set(key, c);
+              }
+            }
+            const deduped = Array.from(byKey.values());
+            logger.verbose('[Graph:Discovery] runContextToIntentDiscovery complete', {
+              rawCount: contextCandidates.length,
+              dedupedCount: deduped.length,
+            });
+            return deduped;
+          }
+
+          /**
+           * Merge candidates from multiple strategies. Deduplicates by userId + networkId + entityId,
+           * keeps the highest similarity, tracks which strategies found each candidate,
+           * and applies a multi-strategy boost (+0.05 per additional strategy, capped at 1.0).
+           */
+          function mergeStrategyCandidates(...groups: CandidateMatch[][]): CandidateMatch[] {
+            const merged = new Map<string, CandidateMatch & { _strategies: Set<string> }>();
+            for (const group of groups) {
+              for (const c of group) {
+                const entityId = c.candidateIntentId ?? c.candidatePremiseId ?? 'none';
+                const key = `${c.candidateUserId}:${c.networkId}:${entityId}`;
+                const existing = merged.get(key);
+                if (!existing) {
+                  merged.set(key, { ...c, _strategies: new Set([c.discoverySource ?? 'unknown']) });
+                } else {
+                  existing._strategies.add(c.discoverySource ?? 'unknown');
+                  if (c.similarity > existing.similarity) {
+                    Object.assign(existing, c);
+                  }
+                }
+              }
+            }
+            return Array.from(merged.values()).map(({ _strategies, ...c }) => {
+              const boost = Math.min((_strategies.size - 1) * 0.05, 0.15);
+              return {
+                ...c,
+                similarity: Math.min(c.similarity + boost, 1.0),
+                matchedStrategies: Array.from(_strategies),
+              };
+            });
           }
 
           const resolvedIntent = state.resolvedTriggerIntentId

--- a/packages/protocol/src/opportunity/opportunity.state.ts
+++ b/packages/protocol/src/opportunity/opportunity.state.ts
@@ -354,7 +354,7 @@ export const OpportunityGraphState = Annotation.Root({
   }),
 
   /** User context embeddings per network (from prep). Used for context-to-intent discovery. */
-  sourceContexts: Annotation<Array<{ networkId: Id<'networks'>; embedding: number[] }>>({
+  sourceContexts: Annotation<Array<{ contextId: string; networkId: Id<'networks'>; embedding: number[] }>>({
     reducer: (curr, next) => next ?? curr,
     default: () => [],
   }),

--- a/packages/protocol/src/opportunity/opportunity.state.ts
+++ b/packages/protocol/src/opportunity/opportunity.state.ts
@@ -58,7 +58,7 @@ export interface CandidateMatch {
   candidateSummary?: string;
   /** How this candidate was found: 'query' (HyDE from search text), 'premise-similarity', or 'context-to-intent'. */
   discoverySource?: 'query' | 'premise-similarity' | 'context-to-intent';
-  /** All strategies that found this candidate (set during merge/dedup). */
+  /** Which discovery strategies found this candidate (set by mergeStrategyCandidates). */
   matchedStrategies?: string[];
 }
 
@@ -353,7 +353,7 @@ export const OpportunityGraphState = Annotation.Root({
     default: () => [],
   }),
 
-  /** User contexts per network (from prep). Used for context-to-intent discovery. */
+  /** User context embeddings per network (from prep). Used for context-to-intent discovery. */
   sourceContexts: Annotation<Array<{ networkId: Id<'networks'>; embedding: number[] }>>({
     reducer: (curr, next) => next ?? curr,
     default: () => [],

--- a/packages/protocol/src/opportunity/opportunity.state.ts
+++ b/packages/protocol/src/opportunity/opportunity.state.ts
@@ -56,8 +56,10 @@ export interface CandidateMatch {
   lens: string;
   candidatePayload: string;
   candidateSummary?: string;
-  /** How this candidate was found: 'query' (HyDE from search text) or 'premise-similarity'. */
-  discoverySource?: 'query' | 'premise-similarity';
+  /** How this candidate was found: 'query' (HyDE from search text), 'premise-similarity', or 'context-to-intent'. */
+  discoverySource?: 'query' | 'premise-similarity' | 'context-to-intent';
+  /** All strategies that found this candidate (set during merge/dedup). */
+  matchedStrategies?: string[];
 }
 
 /**
@@ -347,6 +349,12 @@ export const OpportunityGraphState = Annotation.Root({
 
   /** User's active premises with embeddings (from prep). Used for premise-to-premise discovery path D. */
   sourcePremises: Annotation<Array<{ premiseId: Id<'premises'>; embedding: number[] }>>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => [],
+  }),
+
+  /** User contexts per network (from prep). Used for context-to-intent discovery. */
+  sourceContexts: Annotation<Array<{ networkId: Id<'networks'>; embedding: number[] }>>({
     reducer: (curr, next) => next ?? curr,
     default: () => [],
   }),

--- a/packages/protocol/src/shared/agent/model.config.ts
+++ b/packages/protocol/src/shared/agent/model.config.ts
@@ -64,6 +64,7 @@ function getModelConfig(config?: ModelConfig) {
     premiseAnalyzer:      { model: "google/gemini-2.5-flash" },
     premiseDecomposer:    { model: "google/gemini-2.5-flash" },
     premiseIndexer:       { model: "google/gemini-2.5-flash" },
+    userContextGenerator: { model: "google/gemini-2.5-flash", temperature: 0.3, maxTokens: 512 },
     chat: {
       model: merged.chatModel ?? process.env.CHAT_MODEL ?? "google/gemini-3-pro-preview",
       maxTokens: 8192,

--- a/packages/protocol/src/shared/hyde/hyde.state.ts
+++ b/packages/protocol/src/shared/hyde/hyde.state.ts
@@ -20,8 +20,8 @@ export interface HydeDocumentState {
 export const HydeGraphState = Annotation.Root({
   // ─── Inputs ─────────────────────────────────────────────────────────────
 
-  /** Source type: intent, profile, or ad-hoc query. */
-  sourceType: Annotation<'intent' | 'profile' | 'query'>,
+  /** Source type: intent, profile, user context, or ad-hoc query. */
+  sourceType: Annotation<'intent' | 'profile' | 'query' | 'context'>,
 
   /** Source entity ID (e.g. intent ID, user ID). Omitted for ad-hoc query. */
   sourceId: Annotation<Id<'intents'> | Id<'users'> | undefined>({

--- a/packages/protocol/src/shared/interfaces/database.interface.ts
+++ b/packages/protocol/src/shared/interfaces/database.interface.ts
@@ -1991,7 +1991,7 @@ export type ChatGraphCompositeDatabase = Pick<
   | 'getPremisesForUser'
   // Premise-to-premise discovery (path D) in OpportunityGraph
   | 'searchPremisesBySimilarity'
-  // User context → intent cross-search (profile→intent path) in OpportunityGraph
+  // User context methods (context-to-intent discovery) in OpportunityGraph
   | 'getUserContext'
   | 'getUserContexts'
   | 'searchIntentsByContextEmbedding'
@@ -2037,7 +2037,7 @@ export type OpportunityGraphDatabase = Pick<
   // Premise-to-premise discovery (path D)
   | 'getPremisesForUser'
   | 'searchPremisesBySimilarity'
-  // User context → intent cross-search (profile→intent path)
+  // User context methods (context-to-intent discovery)
   | 'getUserContext'
   | 'getUserContexts'
   | 'searchIntentsByContextEmbedding'

--- a/packages/protocol/src/shared/interfaces/database.interface.ts
+++ b/packages/protocol/src/shared/interfaces/database.interface.ts
@@ -1445,6 +1445,62 @@ export interface Database {
     assertionText: string;
     similarity: number;
   }>>;
+
+  // ─── User Context Methods ───
+
+  /**
+   * Upsert a user context for a specific network.
+   * Creates or updates the synthesized context paragraph + embedding.
+   */
+  upsertUserContext(params: {
+    userId: string;
+    networkId: string;
+    text: string;
+    embedding: number[];
+    premiseHash: string;
+  }): Promise<{ id: string }>;
+
+  /**
+   * Get the user context for a specific user+network pair.
+   */
+  getUserContext(userId: string, networkId: string): Promise<{
+    id: string;
+    text: string;
+    embedding: number[];
+    premiseHash: string;
+    generatedAt: Date;
+  } | null>;
+
+  /**
+   * Get user contexts for a user across all their networks.
+   */
+  getUserContexts(userId: string): Promise<Array<{
+    id: string;
+    networkId: string;
+    text: string;
+    embedding: number[];
+    premiseHash: string;
+    generatedAt: Date;
+  }>>;
+
+  /**
+   * Cosine similarity search against intent embeddings using a context embedding.
+   * Restores the profile→intent cross-search deleted when Path B was removed.
+   */
+  searchIntentsByContextEmbedding(params: {
+    embedding: number[];
+    networkIds: string[];
+    excludeUserId: string;
+    limit: number;
+    minScore?: number;
+  }): Promise<Array<{
+    intentId: string;
+    userId: string;
+    networkId: string;
+    payload: string;
+    summary: string | null;
+    similarity: number;
+  }>>;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -1935,6 +1991,10 @@ export type ChatGraphCompositeDatabase = Pick<
   | 'getPremisesForUser'
   // Premise-to-premise discovery (path D) in OpportunityGraph
   | 'searchPremisesBySimilarity'
+  // User context → intent cross-search (profile→intent path) in OpportunityGraph
+  | 'getUserContext'
+  | 'getUserContexts'
+  | 'searchIntentsByContextEmbedding'
 > & Pick<
   NegotiationQueries,
   // Orphan heal in OpportunityGraph persist node
@@ -1977,6 +2037,10 @@ export type OpportunityGraphDatabase = Pick<
   // Premise-to-premise discovery (path D)
   | 'getPremisesForUser'
   | 'searchPremisesBySimilarity'
+  // User context → intent cross-search (profile→intent path)
+  | 'getUserContext'
+  | 'getUserContexts'
+  | 'searchIntentsByContextEmbedding'
 > & Pick<
   NegotiationQueries,
   // Orphan heal: check if a prior negotiating opportunity has a stale task

--- a/packages/protocol/src/shared/interfaces/database.interface.ts
+++ b/packages/protocol/src/shared/interfaces/database.interface.ts
@@ -415,7 +415,7 @@ export interface UpdateIndexSettingsData {
 // HYDE DOCUMENT TYPES (Opportunity Redesign)
 // ═══════════════════════════════════════════════════════════════════════════════
 
-export type HydeSourceType = 'intent' | 'profile' | 'query';
+export type HydeSourceType = 'intent' | 'profile' | 'query' | 'context';
 
 export interface HydeDocument {
   id: string;
@@ -2041,6 +2041,8 @@ export type OpportunityGraphDatabase = Pick<
   | 'getUserContext'
   | 'getUserContexts'
   | 'searchIntentsByContextEmbedding'
+  // HyDE documents for context-to-intent HyDE search
+  | 'getHydeDocumentsForSource'
 > & Pick<
   NegotiationQueries,
   // Orphan heal: check if a prior negotiating opportunity has a stale task


### PR DESCRIPTION
## New Features

- **User contexts table** — network-scoped cached representations of users (`user_contexts`), synthesized by LLM from premises + network prompt. Migration `0079` adds the table with vector embedding column, unique constraint on `(userId, networkId)`, and HNSW index.
- **UserContextGenerator** — cold-start and incremental context synthesis in `@indexnetwork/protocol`. Cold-start builds from all premises at once; incremental applies a single premise change to an existing context. Both produce text + embedding.
- **Context-to-intent discovery** — new discovery strategy in OpportunityGraph that searches intents using user context embeddings, restoring the cross-entity discovery path lost when Path B profiles were removed. Runs in parallel with premise discovery across all three discovery paths (no search text, no HyDE, main HyDE).
- **Multi-strategy candidate merging** — `mergeStrategyCandidates` deduplicates candidates across strategies (query, premise, context-to-intent), keeps the highest similarity, tracks which strategies found each candidate, and applies a +0.05 boost per additional strategy (boost capped at 0.15, similarity capped at 1.0).
- **`searchIntentsByContextEmbedding`** — cosine similarity search of context embeddings against intents table, scoped by network.
- **Backfill script** — `bun run maintenance:backfill-premises -- --network <id> [--dry-run]` enqueues enrichment jobs for all members of a given network.
- **Feature flag** — `DISCOVERY_CONTEXT_TO_INTENT=0` disables the new discovery strategy.

## Refactors

- **ProfileQueue → EnrichmentQueue** — renamed class, updated all 7 consumer files. Queue name stays `'profile-hyde-queue'` for backward compatibility with in-flight Redis jobs.
- **Premise graph injection** — `EnrichmentQueue.invokeProfileGraph` now receives `PremiseGraphFactory` via constructor injection instead of failing silently.

## Version Bumps

- `@indexnetwork/protocol`: 1.17.0 → 1.18.0

## Test Plan

- [ ] Run migration `0079_add_user_contexts` against dev database
- [ ] Verify `tsc` passes in both `packages/protocol` and `backend`
- [ ] Import users via CSV into a test network and confirm enrichment jobs complete with context generation
- [ ] Verify opportunity discovery finds context-to-intent candidates alongside intent-to-intent ones
- [ ] Run `bun run maintenance:backfill-premises -- --network <id> --dry-run` to verify backfill script lists members correctly
- [ ] Confirm context regeneration fires on enrichment completion for all non-personal networks