### PR TITLE
fix(frontend): limit onboarding redirect to home

### DIFF
--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to the Index Network frontend are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- Limit automatic onboarding redirects to the home page so signed-in users can open app routes like `/networks` before finishing setup.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -8,8 +8,8 @@ import LandingPage from "@/app/landing/page";
  * public landing page (landing) for guests.
  *
  * AuthContext only mounts route children once auth has settled (it shows a
- * loading screen while pending) and already redirects authenticated-but-not-
- * onboarded users to /onboarding, so `isAuthenticated` is reliable here.
+ * loading screen while pending). The root route is the automatic onboarding
+ * redirect entry point for authenticated users who have not finished setup.
  */
 function RootPage() {
   const { isAuthenticated } = useAuthContext();

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -110,7 +110,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     if (authenticated && !user && !userFetchAttempted) return;
 
     const isHomePage = pathname === '/';
-    const isOnboardingPage = pathname === '/onboarding';
     const publicPrefixes = [
       '/simulation', '/l', '/index/', '/blog', '/pages', '/about',
       '/login', '/s/', '/oauth/', '/found-in-translation', '/cli-auth', '/u/',
@@ -125,12 +124,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       return;
     }
 
-    // Force redirect to /onboarding when onboarding is not complete
-    if (authenticated && user && !user.onboarding?.completedAt) {
-      if (!isOnboardingPage && !isPublicPage) {
-        navigate('/onboarding', { replace: true });
-        return;
-      }
+    // Force redirect to /onboarding only from the authenticated home page.
+    if (authenticated && user && !user.onboarding?.completedAt && isHomePage) {
+      navigate('/onboarding', { replace: true });
+      return;
     }
 
     setIsLoading(false);

--- a/frontend/tests/auth-context.test.tsx
+++ b/frontend/tests/auth-context.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { AuthProvider } from '@/contexts/AuthContext';
+
+const mocks = vi.hoisted(() => {
+  const apiClient = {
+    get: vi.fn(),
+  };
+  const authService = {
+    updateProfile: vi.fn(),
+  };
+
+  return {
+    apiClient,
+    authService,
+    clearJwtToken: vi.fn(),
+    signOut: vi.fn(),
+    useSession: vi.fn(),
+  };
+});
+
+vi.mock('@/lib/auth-client', () => ({
+  authClient: {
+    signOut: mocks.signOut,
+    useSession: () => mocks.useSession(),
+  },
+  clearJwtToken: mocks.clearJwtToken,
+}));
+
+vi.mock('@/lib/api', () => ({
+  useAuthenticatedAPI: () => mocks.apiClient,
+}));
+
+vi.mock('@/services/auth', () => ({
+  useAuthService: () => mocks.authService,
+}));
+
+vi.mock('@/components/AuthModal', () => ({
+  default: () => null,
+}));
+
+function incompleteUser() {
+  return {
+    id: 'user-1',
+    email: 'alice@example.com',
+    name: 'Alice',
+    onboarding: {},
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+  };
+}
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname}</div>;
+}
+
+function renderAuthProviderAt(route: string) {
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <AuthProvider>
+        <LocationProbe />
+      </AuthProvider>
+    </MemoryRouter>
+  );
+}
+
+describe('AuthProvider onboarding routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.useSession.mockReturnValue({
+      data: { session: { id: 'session-1' } },
+      isPending: false,
+    });
+    mocks.apiClient.get.mockResolvedValue({ user: incompleteUser() });
+    mocks.authService.updateProfile.mockResolvedValue(incompleteUser());
+  });
+
+  test('redirects an authenticated incomplete user from the home page to onboarding', async () => {
+    renderAuthProviderAt('/');
+
+    expect(await screen.findByTestId('location')).toHaveTextContent('/onboarding');
+  });
+
+  test('allows an authenticated incomplete user to stay on networks', async () => {
+    renderAuthProviderAt('/networks');
+
+    expect(await screen.findByTestId('location')).toHaveTextContent('/networks');
+  });
+
+  test('still redirects unauthenticated users away from networks', async () => {
+    mocks.useSession.mockReturnValue({ data: null, isPending: false });
+
+    renderAuthProviderAt('/networks');
+
+    expect(await screen.findByTestId('location')).toHaveTextContent('/');
+    expect(mocks.apiClient.get).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

### Bug Fixes
- Limit automatic onboarding redirects to the authenticated home page so incomplete users can open app routes like `/networks`.
- Keep unauthenticated users redirected away from authenticated app routes.

### Documentation
- Add a frontend `CHANGELOG.md` entry for the onboarding redirect hotfix.
- Update the root page comment to describe the home-page onboarding redirect behavior.

### Versioning
- Bump `frontend` from `0.11.0` to `0.11.1`.

### Tests
- Add AuthProvider routing coverage for home onboarding redirects, `/networks` access, and unauthenticated redirects.

## Verification
- `cd frontend && bun --bun vitest run tests/auth-context.test.tsx`
- `cd frontend && bun run lint` (passes with existing warnings only)