### PR TITLE
Release consent turn-boundary hotfix

### DIFF
--- a/packages/agentvillage/package.json
+++ b/packages/agentvillage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge-city/agentvillage",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Agent Village workspace and installer for Edge Esmeralda.",
   "license": "MIT",
   "type": "module",

--- a/packages/agentvillage/skills/index-network/bootstrap.md
+++ b/packages/agentvillage/skills/index-network/bootstrap.md
@@ -39,7 +39,9 @@ Then ask the first privacy question in plain language:
 
 > "I can use the profile details you already gave Edge Esmeralda to draft your village profile. Is that okay?"
 
-Call `record_onboarding_privacy_consent(edgeosImportGranted=<true|false>, source="agentvillage_onboarding")` with the user's answer.
+**Hard stop:** after sending this question, end the turn immediately. Do not call `record_onboarding_privacy_consent`, `preview_user_profile`, or any EdgeOS/profile lookup tool in the same turn as this question. Wait for the user's next message. Do not infer consent from `/start`, `hi`, silence, prior setup, the existence of staged data, or the fact that the API key is network-scoped.
+
+Only after the user's next message explicitly answers yes/no, call `record_onboarding_privacy_consent(edgeosImportGranted=<true|false>, source="agentvillage_onboarding")` with that answer.
 
 - If granted: `preview_user_profile` may use any server-staged signup/import profile seed automatically. You may also use EdgeOS recipes only for the user's own available profile/directory data. Do not use hidden values such as literal `"*"`; omit them.
 - If denied: do not fetch or use EdgeOS profile/directory data, and do not rely on staged signup/import profile data. Ask for a short self-description instead.
@@ -48,14 +50,16 @@ Then ask the second privacy question separately:
 
 > "Do you want me to also look at public profile information, like links you provide or public professional pages, to make the draft sharper? You can say no."
 
-Call `record_onboarding_privacy_consent(publicProfileLookupGranted=<true|false>, source="agentvillage_onboarding")` with the user's answer.
+**Hard stop:** after sending this second question, end the turn immediately. Do not call `record_onboarding_privacy_consent(publicProfileLookupGranted=...)`, `preview_user_profile`, `scrape_url`, or public lookup tools until the user's next message explicitly answers this second question.
+
+Only after that explicit next-message yes/no answer, call `record_onboarding_privacy_consent(publicProfileLookupGranted=<true|false>, source="agentvillage_onboarding")` with the user's answer.
 
 ## Step 2 — Draft and confirm their profile
 
-Call `preview_user_profile(...)` using only allowed inputs:
+Start this step only after both privacy questions have been asked in separate turns, both user replies have been received, and both consent-recording calls have completed successfully. Call `preview_user_profile(...)` using only allowed inputs:
 
-- Include EdgeOS/event profile text, and rely on staged signup/import profile data, only if EdgeOS import consent was granted.
-- Set `allowPublicLookup=true` only if public lookup consent was granted.
+- Include EdgeOS/event profile text, and rely on staged signup/import profile data, only if EdgeOS import consent was explicitly granted by the user's reply.
+- Set `allowPublicLookup=true` only if public lookup consent was explicitly granted by the user's reply.
 - Include social/profile URLs only if the user explicitly provided them or they came from allowed EdgeOS data.
 - If both EdgeOS import and public lookup are denied, use the user's self-description.
 
@@ -119,8 +123,10 @@ Cron-schedule preferences are not asked about — the morning digest runs at a f
 ## Rules
 
 - Do not skip steps or reorder them.
-- Do not import EdgeOS data without recorded EdgeOS import consent.
-- Do not run public lookup or scraping without recorded public-profile lookup consent.
+- Consent questions are turn boundaries: ask the question, then stop. The matching `record_onboarding_privacy_consent` call belongs only in a later turn after the user's explicit answer.
+- Do not import EdgeOS data without recorded EdgeOS import consent based on an explicit user answer.
+- Do not run public lookup or scraping without recorded public-profile lookup consent based on an explicit user answer.
+- Do not call `preview_user_profile` until both privacy questions have explicit user answers and both consent calls have succeeded.
 - Do not call `discover_opportunities`, `list_opportunities`, or any other discovery tool during onboarding. Opportunities surface on the first scheduled cron tick after onboarding completes.
 - Do not mention Gmail or email import — they are not available in this flow.
 - Call `create_intent` at most once per user response.

--- a/packages/agentvillage/skills/index-network/tools.md
+++ b/packages/agentvillage/skills/index-network/tools.md
@@ -38,7 +38,7 @@ Call `scrape_url(url, objective)` whenever the user shares a URL and you need it
 
 Always pass an `objective` describing why you're scraping — it guides extraction. Example: `scrape_url(url="linkedin.com/in/alex", objective="Update user profile from LinkedIn page")`.
 
-During AgentVillage onboarding, do not scrape or run public profile lookup until `record_onboarding_privacy_consent(publicProfileLookupGranted=true)` has succeeded. Use `preview_user_profile` for drafts and `confirm_user_profile` only after the user has seen and approved/corrected the draft. Do not use legacy `create_user_profile` for the AgentVillage onboarding ritual.
+During AgentVillage onboarding, privacy questions are hard turn boundaries. After asking a consent question, stop and wait for the user's next message; do not record consent in the same turn as the question. Do not scrape or run public profile lookup until the user explicitly answers yes and `record_onboarding_privacy_consent(publicProfileLookupGranted=true)` has succeeded. Do not use EdgeOS/import data until the user explicitly answers yes and `record_onboarding_privacy_consent(edgeosImportGranted=true)` has succeeded. Use `preview_user_profile` for drafts only after both consent questions have explicit answers, and use `confirm_user_profile` only after the user has seen and approved/corrected the draft. Do not use legacy `create_user_profile` for the AgentVillage onboarding ritual.
 
 ## Output translation
 

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/profile/profile.tools.ts
+++ b/packages/protocol/src/profile/profile.tools.ts
@@ -360,7 +360,8 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
   const recordOnboardingPrivacyConsent = defineTool({
     name: "record_onboarding_privacy_consent",
     description:
-      "Records the authenticated user's onboarding privacy choices. Use this during AgentVillage/Hermes onboarding before using event-provided EdgeOS profile data or public web/profile lookup. " +
+      "Records exactly one authenticated-user onboarding privacy choice. Use this during AgentVillage/Hermes onboarding only after the user explicitly answers the matching consent question in a prior message. " +
+      "Do not call this in the same assistant turn as the consent question, and do not combine EdgeOS import and public lookup decisions in one call. " +
       "This only records consent; it does not mark onboarding complete and does not create or update a profile.",
     querySchema: z.object({
       edgeosImportGranted: z.boolean().optional().describe("Whether the user grants permission to use EdgeOS/event-provided profile data for onboarding."),
@@ -372,8 +373,13 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
       if (user?.isGhost) {
         return error("Ghost users cannot record onboarding consent. The user must authenticate as a real account first.");
       }
-      if (query.edgeosImportGranted === undefined && query.publicProfileLookupGranted === undefined) {
-        return error("Provide at least one consent decision to record.");
+      const hasEdgeosDecision = query.edgeosImportGranted !== undefined;
+      const hasPublicLookupDecision = query.publicProfileLookupGranted !== undefined;
+      if (!hasEdgeosDecision && !hasPublicLookupDecision) {
+        return error("Provide exactly one consent decision to record.");
+      }
+      if (hasEdgeosDecision && hasPublicLookupDecision) {
+        return error("Record EdgeOS import consent and public-profile lookup consent separately, after each explicit user answer. Do not combine them in one call.");
       }
 
       const currentOnboarding = user?.onboarding ?? context.user.onboarding ?? {};

--- a/packages/protocol/src/profile/tests/profile.privacy-tools.spec.ts
+++ b/packages/protocol/src/profile/tests/profile.privacy-tools.spec.ts
@@ -91,15 +91,24 @@ describe("onboarding privacy profile tools", () => {
     } as unknown as ToolDeps);
   });
 
-  it("records onboarding privacy consent without completing onboarding", async () => {
+  it("records one onboarding privacy consent decision without completing onboarding", async () => {
     const tool = tools.find((t) => t.name === "record_onboarding_privacy_consent")!;
-    const result = parseToolResult(await tool.handler({ context: context(), query: { edgeosImportGranted: true, publicProfileLookupGranted: false, source: "agentvillage_onboarding" } }));
+    const result = parseToolResult(await tool.handler({ context: context(), query: { edgeosImportGranted: true, source: "agentvillage_onboarding" } }));
 
     expect(result.success).toBe(true);
     expect(updateUser).toHaveBeenCalledTimes(1);
     expect(onboarding?.completedAt).toBeUndefined();
     expect(onboarding?.privacy?.edgeosImport?.granted).toBe(true);
-    expect(onboarding?.privacy?.publicProfileLookup?.granted).toBe(false);
+    expect(onboarding?.privacy?.publicProfileLookup).toBeUndefined();
+  });
+
+  it("rejects combined EdgeOS and public lookup consent decisions", async () => {
+    const tool = tools.find((t) => t.name === "record_onboarding_privacy_consent")!;
+    const result = parseToolResult(await tool.handler({ context: context(), query: { edgeosImportGranted: true, publicProfileLookupGranted: false, source: "agentvillage_onboarding" } }));
+
+    expect(result.success).toBe(false);
+    expect(String(result.error)).toContain("separately");
+    expect(updateUser).not.toHaveBeenCalled();
   });
 
   it("records onboarding privacy consent without dropping persisted onboarding fields", async () => {


### PR DESCRIPTION
## Changelog

### Fixed
- AgentVillage onboarding consent questions are now hard turn boundaries: ask the question, stop, and wait for the explicit next-message answer before recording consent.
- `record_onboarding_privacy_consent` now rejects combined EdgeOS import + public-profile lookup decisions, forcing one explicit consent answer per call.
- Profile previews now have stronger guidance to wait until both privacy questions have explicit answers.

### Changed
- `@indexnetwork/protocol` `1.24.1`
- `@edge-city/agentvillage` `0.3.1`

## Verification

- PR #866 checks passed on dev: generated skills, lint, typecheck.
- Local verification:
  - `git diff --check`
  - `cd packages/protocol && OPENROUTER_API_KEY=test-key bun test src/profile/tests/profile.privacy-tools.spec.ts`
  - `cd packages/protocol && bun run build`
