### PR TITLE
fix(backend): fail closed for mixed scoped agents

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/backend/src/adapters/tests/database.adapter.spec.ts
+++ b/backend/src/adapters/tests/database.adapter.spec.ts
@@ -826,9 +826,10 @@ describe('OpportunityDatabaseAdapter', () => {
         const scopedToFixture = await adapter.getOpportunitiesForUser(fixture.userAId, { networkId: fixture.networkId });
         expect(scopedToFixture.some((o) => o.id === created.id)).toBe(false);
 
-        // Sanity: with the correct scope the opp is visible to userA.
+        // Even with the viewer's own actor scope, the strict gate excludes the
+        // row because the counterpart is not also anchored on that network.
         const scopedToActual = await adapter.getOpportunitiesForUser(fixture.userAId, { networkId: otherNetworkId });
-        expect(scopedToActual.some((o) => o.id === created.id)).toBe(true);
+        expect(scopedToActual.some((o) => o.id === created.id)).toBe(false);
       } finally {
         // Opp's context.networkId is otherNetworkId, so the afterAll cleanup
         // (which filters by fixture.networkId) won't touch it — clean explicitly.

--- a/backend/src/guards/agent-scope.guard.ts
+++ b/backend/src/guards/agent-scope.guard.ts
@@ -22,16 +22,18 @@ export class ScopeViolationError extends Error {
 /**
  * Resolve the network the given agent's network-level access is restricted to.
  *
- * Returns `null` (no network restriction) when any of:
- *  - the agent has any `scope='global'` permission, OR
- *  - the agent has no `scope='network'` permissions, OR
- *  - the agent doesn't exist.
+ * Returns `null` (no network restriction) when either:
+ *  - the agent has only `scope='global'` permissions, OR
+ *  - the agent has no `scope='network'` permissions / doesn't exist.
  *
  * If the agent has at least one `scope='network'` permission, returns the
- * single shared `scopeId`. Other non-global permissions (e.g. `scope='node'`)
- * are ignored here because they don't constrain network-level access. Throws
- * if the agent's network-scoped permissions disagree on `scopeId` (defensive —
- * should never happen for imported agents).
+ * single shared `scopeId` even if a stale/global permission row is also present.
+ * This intentionally fails closed for mixed-permission agents: a key that was
+ * ever bound to a network must not silently become global because an unrelated
+ * global row exists. Other non-global permissions (e.g. `scope='node'`) are
+ * ignored here because they don't constrain network-level access. Throws if the
+ * agent's network-scoped permissions disagree on `scopeId` (defensive — should
+ * never happen for imported agents).
  *
  * @param agentId - The agent UUID whose permissions are inspected
  * @returns The bound network id, or `null` if the agent has no network restriction
@@ -44,7 +46,6 @@ export const resolveAgentNetworkScopeById = async (agentId: string): Promise<str
     .where(eq(agentPermissions.agentId, agentId));
 
   if (rows.length === 0) return null;
-  if (rows.some((r) => r.scope === 'global')) return null;
 
   const networkScoped = rows.filter((r) => r.scope === 'network' && r.scopeId);
   if (networkScoped.length === 0) return null;
@@ -59,11 +60,12 @@ export const resolveAgentNetworkScopeById = async (agentId: string): Promise<str
 /**
  * Resolve the network the current request's agent is restricted to, or null
  * if the request is JWT-authenticated, has no API key, the key carries no
- * `metadata.agentId`, or the agent has any `scope='global'` permission.
+ * `metadata.agentId`, or the agent has no network-scoped permissions.
  *
- * If the agent has *only* network-scoped permissions, returns the single
- * `scopeId` they share. Throws if the agent's network-scoped permissions
- * disagree on `scopeId` (defensive — should never happen for imported agents).
+ * If the agent has any network-scoped permissions, returns the single `scopeId`
+ * they share, even when a stale/global permission row is also present. Throws if
+ * the agent's network-scoped permissions disagree on `scopeId` (defensive —
+ * should never happen for imported agents).
  *
  * @param req - The incoming request whose `x-api-key` header is inspected
  * @returns The bound network id, or `null` if the agent is not network-scoped

--- a/backend/src/guards/tests/agent-scope.guard.spec.ts
+++ b/backend/src/guards/tests/agent-scope.guard.spec.ts
@@ -95,6 +95,18 @@ describe('agent-scope.guard', () => {
     expect(await resolveAgentNetworkScopeById(scopedAgentId)).toBe(networkId);
   });
 
+  test('network scope wins when a stale global permission row also exists', async () => {
+    await agentDatabaseAdapter.grantPermission({
+      agentId: scopedAgentId,
+      userId,
+      scope: 'global',
+      actions: ['manage:profile'],
+    });
+
+    expect(await resolveAgentNetworkScopeById(scopedAgentId)).toBe(networkId);
+    expect(await resolveAgentNetworkScope(reqWithKey(scopedKey))).toBe(networkId);
+  });
+
   test('resolveAgentNetworkScopeById returns null for unknown agent id', async () => {
     expect(await resolveAgentNetworkScopeById('00000000-0000-0000-0000-000000000000')).toBeNull();
   });

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "backend": {
       "name": "protocol",
-      "version": "0.26.1",
+      "version": "0.26.2",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.939.0",
         "@aws-sdk/s3-request-presigner": "^3.983.0",


### PR DESCRIPTION
## Bug Fixes
- Treat agents with any network-scoped permission as network-scoped, even if a stale global permission row also exists.
- Keep scoped opportunity reads fail-closed so mixed-permission API keys cannot list cross-network opportunities.

## Tests
- `cd backend && bun test src/adapters/tests/database.adapter.spec.ts -t "network-scope filter"`
- `cd backend && bun test src/guards/tests/agent-scope.guard.spec.ts`