### PR TITLE
fix(backend): keep experiment signup keys stable

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/backend/src/services/experiment.service.ts
+++ b/backend/src/services/experiment.service.ts
@@ -74,10 +74,13 @@ class ExperimentService {
     const result = await networkInvitationService.ensureMembership({
       networkId,
       email: normalizedEmail,
-      rotateKey: true,
+      mintKey: true,
     });
 
-    // rotateKey=true guarantees apiKey is non-null
+    // New users get their first key; existing users get an additional key.
+    // We deliberately do not revoke prior keys here: signup may be retried by
+    // portals/installers, and invalidating a just-installed Hermes key creates
+    // a setup race. Explicit rotation paths remain responsible for revocation.
     const apiKey = result.apiKey!;
 
     await this.stageProfileSeed(result.user.id, networkId, {

--- a/backend/src/services/network-invitation.service.ts
+++ b/backend/src/services/network-invitation.service.ts
@@ -63,17 +63,23 @@ class NetworkInvitationService {
    * Used by the headless signup path. invite() wraps this and adds email delivery.
    *
    * @param params.rotateKey - When true and a scoped agent already exists, revokes
-   *   its tokens and mints a fresh one (returns new key). When false, returns
-   *   apiKey=null for users who already have a scoped agent.
+   *   its tokens and mints a fresh one (returns new key).
+   * @param params.mintKey - When true and a scoped agent already exists, mints
+   *   an additional key without revoking existing tokens. Use for headless
+   *   self-serve signup where retries must not break already-running agents.
+   *   When both flags are false, returns apiKey=null for users who already have
+   *   a scoped agent.
    */
   async ensureMembership(params: {
     networkId: string;
     email: string;
     name?: string;
     rotateKey?: boolean;
+    mintKey?: boolean;
   }): Promise<EnsureMembershipResult> {
     const email = params.email.toLowerCase().trim();
     const rotateKey = params.rotateKey ?? false;
+    const mintKey = params.mintKey ?? false;
 
     const { user, created } = await this.findOrCreateUser(email, params.name);
     await ensurePersonalNetwork(user.id);
@@ -83,6 +89,13 @@ class NetworkInvitationService {
     if (agentId) {
       if (rotateKey) {
         await agentTokenAdapter.revokeAllForAgent(agentId);
+        const token = await agentTokenAdapter.create(user.id, {
+          name: 'Personal Agent API Key',
+          agentId,
+        });
+        return { user, apiKey: token.key, created, alreadyMember };
+      }
+      if (mintKey) {
         const token = await agentTokenAdapter.create(user.id, {
           name: 'Personal Agent API Key',
           agentId,

--- a/backend/tests/experiment-signup.spec.ts
+++ b/backend/tests/experiment-signup.spec.ts
@@ -5,6 +5,7 @@ import { randomUUID } from 'node:crypto';
 import { and, eq, isNull } from 'drizzle-orm';
 
 import { experimentService } from '../src/services/experiment.service';
+import { AuthOrApiKeyGuard } from '../src/guards/auth.guard';
 import db from '../src/lib/drizzle/drizzle';
 import {
   agentPermissions,
@@ -80,7 +81,7 @@ describe('experimentService.signup', () => {
     expect(result.created).toBe(true);
   }, 15_000);
 
-  it('stores name, bio, location, and socials from rich payload', async () => {
+  it('stages name, bio, location, and socials from rich payload for consented onboarding', async () => {
     const { networkId } = await setupExperimentNetwork();
     const email = `rich-${randomUUID()}@example.com`;
 
@@ -98,27 +99,26 @@ describe('experimentService.signup', () => {
     cleanup.push(() => cleanupUser(result.user.id));
 
     const [u] = await db
-      .select({ name: users.name })
+      .select({ name: users.name, onboarding: users.onboarding })
       .from(users)
       .where(eq(users.id, result.user.id));
-    expect(u.name).toBe('Alice Test');
+    expect(u.name).not.toBe('Alice Test');
 
-    const [profile] = await db
-      .select({ identity: userProfiles.identity })
-      .from(userProfiles)
-      .where(eq(userProfiles.userId, result.user.id));
-    expect((profile.identity as { bio?: string }).bio).toBe('Independent researcher.');
-    expect((profile.identity as { location?: string }).location).toBe('Healdsburg, CA');
-
-    const socials = await db
-      .select({ label: userSocials.label, value: userSocials.value })
-      .from(userSocials)
-      .where(eq(userSocials.userId, result.user.id));
-    expect(socials).toContainEqual({ label: 'telegram', value: '@alice_test' });
-    expect(socials).toContainEqual({ label: 'twitter',  value: 'alice_test' });
+    const seed = u.onboarding.profileSeeds?.find(
+      (item) => item.networkId === networkId && item.source === 'experiment_signup',
+    );
+    expect(seed).toMatchObject({
+      name: 'Alice Test',
+      bio: 'Independent researcher.',
+      location: 'Healdsburg, CA',
+      socials: [
+        { label: 'telegram', value: '@alice_test' },
+        { label: 'twitter', value: 'alice_test' },
+      ],
+    });
   }, 15_000);
 
-  it('re-signup rotates the key on the SAME agent — no orphan agent records', async () => {
+  it('re-signup mints a new key on the SAME agent without revoking the old key', async () => {
     const { networkId } = await setupExperimentNetwork();
     const email = `resig-${randomUUID()}@example.com`;
 
@@ -143,11 +143,14 @@ describe('experimentService.signup', () => {
       );
     expect(scopedAgents.length).toBe(1);
 
-    const oldKeyRow = await db
-      .select({ id: apikeys.id })
-      .from(apikeys)
-      .where(and(eq(apikeys.userId, first.user.id), eq(apikeys.start, first.apiKey.slice(0, 4))));
-    expect(oldKeyRow.length).toBe(0);
+    const firstAuth = await AuthOrApiKeyGuard(new Request('http://localhost/test', {
+      headers: { 'x-api-key': first.apiKey },
+    }));
+    const secondAuth = await AuthOrApiKeyGuard(new Request('http://localhost/test', {
+      headers: { 'x-api-key': second.apiKey },
+    }));
+    expect(firstAuth.id).toBe(first.user.id);
+    expect(secondAuth.id).toBe(first.user.id);
   }, 15_000);
 
   it('returns created=false for an existing user', async () => {

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "backend": {
       "name": "protocol",
-      "version": "0.26.2",
+      "version": "0.26.3",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.939.0",
         "@aws-sdk/s3-request-presigner": "^3.983.0",


### PR DESCRIPTION
## Bug Fixes
- Make experiment-network /signup retries non-destructive by minting an additional scoped agent key instead of revoking existing keys.
- Preserve explicit rotation semantics for paths that intentionally pass rotateKey.
- Update signup coverage to prove repeated signup keeps both the old and newly returned API keys valid.
- Bump backend package version to 0.26.3.

## Tests
- `cd backend && bun test tests/experiment-signup.spec.ts`