### PR TITLE
fix(frontend): show experiment shared networks on profiles

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol",
-  "version": "0.26.3",
+  "version": "0.26.4",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -1393,8 +1393,8 @@ export class ChatDatabaseAdapter {
   }
 
   /**
-   * Get non-personal indexes that both users share membership in.
-   * Returns id, title, and member count for each shared index.
+   * Get non-personal networks that both users share membership in.
+   * Returns id, title, and member count for each shared network.
    */
   async getSharedNetworks(currentUserId: string, targetUserId: string): Promise<{ id: string; title: string; _count: { members: number } }[]> {
     const currentUserIndexIds = db
@@ -1419,7 +1419,6 @@ export class ChatDatabaseAdapter {
         and(
           isNull(schema.networks.deletedAt),
           eq(schema.networks.isPersonal, false),
-          or(eq(schema.networks.isExperiment, false), isNull(schema.networks.isExperiment)),
           inArray(schema.networks.id, currentUserIndexIds),
           inArray(schema.networks.id, targetUserIndexIds),
         )

--- a/backend/src/adapters/tests/database.adapter.spec.ts
+++ b/backend/src/adapters/tests/database.adapter.spec.ts
@@ -249,6 +249,31 @@ describe('ChatDatabaseAdapter', () => {
     expect(m!.networkTitle).toContain('Test Index');
   });
 
+  it('should include experiment networks in shared networks', async () => {
+    const experimentNetworkId = uuidv4();
+    await db.insert(networks).values({
+      id: experimentNetworkId,
+      title: TEST_PREFIX + 'Experiment Shared Network',
+      prompt: 'Experiment network prompt',
+      isExperiment: true,
+    });
+    await db.insert(networkMembers).values([
+      { networkId: experimentNetworkId, userId: fixture.userAId, permissions: ['member'], autoAssign: true },
+      { networkId: experimentNetworkId, userId: fixture.userBId, permissions: ['member'], autoAssign: true },
+    ]);
+
+    try {
+      const shared = await adapter.getSharedNetworks(fixture.userAId, fixture.userBId);
+      const experiment = shared.find((network) => network.id === experimentNetworkId);
+      expect(experiment).toBeDefined();
+      expect(experiment!.title).toContain('Experiment Shared Network');
+      expect(experiment!._count.members).toBe(2);
+    } finally {
+      await db.delete(networkMembers).where(eq(networkMembers.networkId, experimentNetworkId));
+      await db.delete(networks).where(eq(networks.id, experimentNetworkId));
+    }
+  });
+
   it('should get user index ids for auto-assign member', async () => {
     const indexIds = await adapter.getUserIndexIds(fixture.userBId);
     expect(indexIds).toContain(fixture.networkId);

--- a/backend/src/services/network.service.ts
+++ b/backend/src/services/network.service.ts
@@ -264,13 +264,13 @@ export class NetworkService {
   }
 
   /**
-   * Get non-personal indexes shared between the current user and a target user.
+   * Get non-personal networks shared between the current user and a target user.
    * @param currentUserId - Authenticated user ID.
    * @param targetUserId - Profile user ID to compare memberships with.
-   * @returns Shared non-personal indexes with member counts.
+   * @returns Shared non-personal networks with member counts.
    */
   async getSharedNetworks(currentUserId: string, targetUserId: string) {
-    logger.verbose('[NetworkService] Getting shared indexes', { currentUserId, targetUserId });
+    logger.verbose('[NetworkService] Getting shared networks', { currentUserId, targetUserId });
     return this.adapter.getSharedNetworks(currentUserId, targetUserId);
   }
 

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "backend": {
       "name": "protocol",
-      "version": "0.26.3",
+      "version": "0.26.4",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.939.0",
         "@aws-sdk/s3-request-presigner": "^3.983.0",
@@ -64,7 +64,7 @@
     },
     "frontend": {
       "name": "frontend",
-      "version": "0.10.0",
+      "version": "0.11.2",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.14",

--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -9,4 +9,5 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Show experiment networks such as Edge City in shared profile networks and link them to their network pages.
 - Limit automatic onboarding redirects to the home page so signed-in users can open app routes like `/networks` before finishing setup.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/frontend/src/app/u/[id]/page.tsx
+++ b/frontend/src/app/u/[id]/page.tsx
@@ -210,7 +210,7 @@ export default function UserProfilePage() {
               <h3 className="text-base font-bold text-gray-900 font-ibm-plex-mono mb-2">Shared Networks</h3>
               <div className="flex flex-wrap gap-2">
                 {sharedNetworks.map((network) => (
-                  <Link key={network.id} to={`/index/${network.id}`} className="flex items-center gap-1.5 px-3 py-1.5 border border-gray-200 rounded-full text-sm text-gray-700 hover:border-gray-400 transition-colors">
+                  <Link key={network.id} to={`/networks/${network.id}`} className="flex items-center gap-1.5 px-3 py-1.5 border border-gray-200 rounded-full text-sm text-gray-700 hover:border-gray-400 transition-colors">
                     {network.title}
                     <span className="text-xs text-gray-400">{network._count.members}</span>
                   </Link>


### PR DESCRIPTION
## Bug Fixes
- Show experiment networks like Edge City in profile Shared Networks instead of filtering them out.
- Link profile shared-network chips to `/networks/:id` instead of the broken `/index/:id` path.

## Changelog
- Updated `frontend/CHANGELOG.md` under `[Unreleased]`.

## Version Bumps
- `backend`: 0.26.3 → 0.26.4
- `frontend`: 0.11.1 → 0.11.2

## Tests
- `cd backend && bun test src/adapters/tests/database.adapter.spec.ts`
- `cd frontend && bun run lint` (passes with existing warnings)