### PR TITLE
fix(protocol): ack confirm_user_profile immediately, async profile graph

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -136,7 +136,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "1.23.1",
+      "version": "1.24.2",
       "dependencies": {
         "@langchain/core": "^1.1.17",
         "@langchain/langgraph": "^1.1.2",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "1.24.1",
+  "version": "1.24.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/intent/intent.tools.ts
+++ b/packages/protocol/src/intent/intent.tools.ts
@@ -6,6 +6,7 @@ import { requestContext } from "../shared/observability/request-context.js";
 
 import type { DefineTool, ToolDeps } from "../shared/agent/tool.helpers.js";
 import { success, error, UUID_REGEX } from "../shared/agent/tool.helpers.js";
+import type { UserRecord } from "../shared/interfaces/database.interface.js";
 
 const logger = protocolLogger("ChatTools:Intent");
 
@@ -28,6 +29,22 @@ async function ensureScopedMembership(
     return `This chat is scoped to ${context.indexName ?? 'this index'}. You are no longer a member of this community.`;
   }
   return null;
+}
+
+function buildApprovedProfileFallback(user: UserRecord | null | undefined): string {
+  const bio = user?.intro?.trim();
+  if (!user || !bio) return "";
+
+  return JSON.stringify({
+    userId: user.id,
+    identity: {
+      name: user.name ?? "",
+      bio,
+      location: user.location?.trim() ?? "",
+    },
+    narrative: { context: bio },
+    attributes: { skills: [], interests: [] },
+  });
 }
 
 export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
@@ -223,7 +240,9 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       const profileResult = await graphs.profile.invoke({ userId: context.userId, operationMode: 'query' as const });
       const _profileGraphMs1 = Date.now() - _profileGraphStart1;
       _createIntentProfileTraceEmitter?.({ type: "graph_end", name: "profile", durationMs: _profileGraphMs1 });
-      const userProfile = profileResult.profile ? JSON.stringify(profileResult.profile) : "";
+      const latestUser = profileResult.profile ? undefined : typeof userDb.getUser === "function" ? await userDb.getUser() : context.user;
+      const approvedProfileFallback = profileResult.profile ? "" : buildApprovedProfileFallback(latestUser);
+      const userProfile = profileResult.profile ? JSON.stringify(profileResult.profile) : approvedProfileFallback;
 
       // Run inference + verification only (propose mode — no DB persistence)
       const _intentGraphStart1 = Date.now();
@@ -409,7 +428,9 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       const profileResult = await graphs.profile.invoke({ userId: context.userId, operationMode: 'query' as const });
       const _profileGraphMs2 = Date.now() - _profileGraphStart2;
       _updateIntentProfileTraceEmitter?.({ type: "graph_end", name: "profile", durationMs: _profileGraphMs2 });
-      const userProfile = profileResult.profile ? JSON.stringify(profileResult.profile) : "";
+      const latestUser = profileResult.profile ? undefined : typeof userDb.getUser === "function" ? await userDb.getUser() : context.user;
+      const approvedProfileFallback = profileResult.profile ? "" : buildApprovedProfileFallback(latestUser);
+      const userProfile = profileResult.profile ? JSON.stringify(profileResult.profile) : approvedProfileFallback;
 
       const _intentGraphStart2 = Date.now();
       const _updateIntentTraceEmitter = requestContext.getStore()?.traceEmitter;

--- a/packages/protocol/src/intent/tests/update-intent.spec.ts
+++ b/packages/protocol/src/intent/tests/update-intent.spec.ts
@@ -36,6 +36,51 @@ function captureTools(deps: ToolDeps): CapturedTool[] {
   return toolDefs;
 }
 
+describe("create_intent", () => {
+  test("falls back to approved user intro when structured profile is still pending", async () => {
+    const capturedProfiles: string[] = [];
+    const tools = captureTools({
+      userDb: {
+        getUser: async () => ({
+          id: "alice",
+          name: "Alice",
+          email: "alice@example.com",
+          intro: "I build agent tools.",
+          location: "Healdsburg",
+          socials: [],
+        }),
+      },
+      systemDb: {},
+      graphs: {
+        profile: { invoke: async () => ({ profile: null, agentTimings: [] }) },
+        intent: {
+          invoke: async (input: { userProfile?: string; operationMode?: string }) => {
+            capturedProfiles.push(input.userProfile ?? "");
+            if (input.operationMode === "propose") {
+              return {
+                verifiedIntents: [{ description: "Find agent builders", score: 0.91, verification: { classification: "request" } }],
+                agentTimings: [],
+                trace: [],
+              };
+            }
+            return { executionResults: [{ success: true }], agentTimings: [] };
+          },
+        },
+      },
+    } as unknown as ToolDeps);
+    const tool = tools.find((t) => t.name === "create_intent")!;
+
+    const result = JSON.parse(await tool.handler({
+      context: makeContext("alice"),
+      query: { description: "Find agent builders", autoApprove: true },
+    }));
+
+    expect(result.success).toBe(true);
+    expect(capturedProfiles[0]).toContain("I build agent tools.");
+    expect(capturedProfiles[0]).toContain("Healdsburg");
+  });
+});
+
 describe("update_intent", () => {
   test("accepts description and rejects legacy newDescription", () => {
     const tools = captureTools({

--- a/packages/protocol/src/profile/profile.tools.ts
+++ b/packages/protocol/src/profile/profile.tools.ts
@@ -517,25 +517,46 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
         location: query.location?.trim(),
         bioOrDescription: description,
       });
-      const _confirmGraphStart = Date.now();
+      const rawProfile = {
+        identity: {
+          name: query.name?.trim() ?? user?.name ?? '',
+          bio: description,
+          location: query.location?.trim() ?? '',
+        },
+      };
+      await persistApprovedProfileContext(rawProfile, user, context.networkId);
+
       const _confirmTraceEmitter = requestContext.getStore()?.traceEmitter;
+      const _confirmGraphStart = Date.now();
       _confirmTraceEmitter?.({ type: "graph_start", name: "profile" });
-      const result = await graphs.profile.invoke({
+      graphs.profile.invoke({
         userId: context.userId,
         operationMode: 'write' as const,
         input,
         forceUpdate: true,
-      });
-      const _confirmGraphMs = Date.now() - _confirmGraphStart;
-      _confirmTraceEmitter?.({ type: "graph_end", name: "profile", durationMs: _confirmGraphMs });
-      if (result.error) return error(result.error);
-      if (!result.profile) return error("Failed to save profile from approved text.");
-      await persistApprovedProfileContext(result.profile, user, context.networkId);
+      }).then((result) => {
+        const _confirmGraphMs = Date.now() - _confirmGraphStart;
+        _confirmTraceEmitter?.({ type: "graph_end", name: "profile", durationMs: _confirmGraphMs });
+        if (result.error || !result.profile) {
+          logger.error('Background profile generation failed', {
+            userId: context.userId,
+            error: result.error ?? 'No profile returned',
+          });
+        }
+      }).catch((err: unknown) =>
+        logger.error('Background profile generation failed', {
+          userId: context.userId,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      );
+
       return success({
         created: true,
-        message: "Profile saved from approved text.",
-        profile: toProfileSummary(result.profile),
-        _graphTimings: [{ name: 'profile', durationMs: _confirmGraphMs, agents: result.agentTimings ?? [] }],
+        message: "Profile text accepted. Your profile is being structured in the background.",
+        profile: toProfileSummary({
+          identity: rawProfile.identity,
+          attributes: { skills: [], interests: [] },
+        }),
       });
     },
   });

--- a/packages/protocol/src/profile/profile.tools.ts
+++ b/packages/protocol/src/profile/profile.tools.ts
@@ -512,16 +512,18 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
       if (!description) {
         return error("Pass the approved structured draft or explicit approved profile text.");
       }
+      const approvedName = query.name?.trim();
+      const approvedLocation = query.location?.trim();
       const input = buildProfileInput({
-        name: query.name?.trim(),
-        location: query.location?.trim(),
+        name: approvedName,
+        location: approvedLocation,
         bioOrDescription: description,
       });
       const rawProfile = {
         identity: {
-          name: query.name?.trim() ?? user?.name ?? '',
+          name: approvedName && approvedName.length > 0 ? approvedName : user?.name ?? '',
           bio: description,
-          location: query.location?.trim() ?? '',
+          location: approvedLocation && approvedLocation.length > 0 ? approvedLocation : user?.location ?? '',
         },
       };
       await persistApprovedProfileContext(rawProfile, user, context.networkId);
@@ -535,8 +537,6 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
         input,
         forceUpdate: true,
       }).then((result) => {
-        const _confirmGraphMs = Date.now() - _confirmGraphStart;
-        _confirmTraceEmitter?.({ type: "graph_end", name: "profile", durationMs: _confirmGraphMs });
         if (result.error || !result.profile) {
           logger.error('Background profile generation failed', {
             userId: context.userId,
@@ -548,7 +548,10 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
           userId: context.userId,
           error: err instanceof Error ? err.message : String(err),
         })
-      );
+      ).finally(() => {
+        const _confirmGraphMs = Date.now() - _confirmGraphStart;
+        _confirmTraceEmitter?.({ type: "graph_end", name: "profile", durationMs: _confirmGraphMs });
+      });
 
       return success({
         created: true,

--- a/packages/protocol/src/profile/tests/profile.privacy-tools.spec.ts
+++ b/packages/protocol/src/profile/tests/profile.privacy-tools.spec.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach, mock } from "bun:test";
 import { z } from "zod";
 
+import { requestContext } from "../../shared/observability/request-context.js";
+
 import type { ToolDeps, ResolvedToolContext } from "../../shared/agent/tool.helpers.js";
 
 let generatedInputs: string[] = [];
@@ -48,6 +50,7 @@ describe("onboarding privacy profile tools", () => {
   let saveProfile: ReturnType<typeof mock>;
   let setUserSocials: ReturnType<typeof mock>;
   let enricher: ReturnType<typeof mock>;
+  let profileGraphInvoke: ReturnType<typeof mock>;
   let tools: CapturedTool[];
   let onboarding: ResolvedToolContext["user"]["onboarding"];
 
@@ -73,10 +76,11 @@ describe("onboarding privacy profile tools", () => {
       attributes: { skills: ["AI"], interests: ["coordination"] },
       socials: {},
     }));
+    profileGraphInvoke = mock(async () => ({}));
 
     tools = captureTools({
       userDb: {
-        getUser: async () => ({ id: "u1", name: "Alice", email: "alice@example.com", location: null, intro: null, socials: [], onboarding }),
+        getUser: async () => ({ id: "u1", name: "Alice", email: "alice@example.com", location: "Healdsburg", intro: null, socials: [], onboarding }),
         updateUser,
         getProfile: async () => null,
         saveProfile,
@@ -85,7 +89,7 @@ describe("onboarding privacy profile tools", () => {
       },
       systemDb: {},
       database: {},
-      graphs: { profile: { invoke: async () => ({}) } },
+      graphs: { profile: { invoke: profileGraphInvoke } },
       enricher: { enrichUserProfile: enricher },
       grantDefaultSystemPermissions: async () => undefined,
     } as unknown as ToolDeps);
@@ -222,5 +226,40 @@ describe("onboarding privacy profile tools", () => {
     expect(result.success).toBe(true);
     expect(saveProfile).toHaveBeenCalledWith({ ...draft, userId: "u1" });
     expect(enricher).not.toHaveBeenCalled();
+  });
+
+  it("confirming approved text preserves existing location when no correction is supplied", async () => {
+    const tool = tools.find((t) => t.name === "confirm_user_profile")!;
+    const result = parseToolResult(await tool.handler({
+      context: context(),
+      query: { bioOrDescription: "I build agent tools.", name: "Alice" },
+    }));
+
+    expect(result.success).toBe(true);
+    expect(updateUser).toHaveBeenCalledWith({
+      name: "Alice",
+      intro: "I build agent tools.",
+      location: "Healdsburg",
+    });
+  });
+
+  it("emits graph_end when background profile generation rejects", async () => {
+    const tool = tools.find((t) => t.name === "confirm_user_profile")!;
+    const events: Array<{ type: string; name: string }> = [];
+    profileGraphInvoke.mockImplementation(async () => {
+      throw new Error("profile timeout");
+    });
+
+    const result = parseToolResult(await requestContext.run(
+      { traceEmitter: (event) => events.push({ type: event.type, name: event.name }) },
+      () => tool.handler({ context: context(), query: { bioOrDescription: "I build agent tools." } }),
+    ));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(result.success).toBe(true);
+    expect(events).toEqual([
+      { type: "graph_start", name: "profile" },
+      { type: "graph_end", name: "profile" },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- **`confirm_user_profile(bioOrDescription)`** now persists approved name/bio/location synchronously and returns immediately instead of blocking on the full profile write graph.
- Profile structuring (premise decompose → generate → save) runs **fire-and-forget** in the background; failures are logged server-side.
- Bumps `@indexnetwork/protocol` to **1.24.2**.

## Cause

During Edge Esmeralda onboarding (Eric Lacosse, session `20260531_121411_9c82e5a7`), `confirm_user_profile` timed out **3× at 120s** on the MCP client. The handler awaited `graphs.profile.invoke({ operationMode: 'write' })`, which routes through:

```
decompose_premises (1 LLM) → N × premise graph (N LLMs) → aggregate → generate_profile (1 LLM) → save
```

Each LLM call uses OpenRouter with **60s timeout × 1 retry = 120s worst case** — exactly matching the MCP transport limit. When the first call hung, the tool never returned and **`users.intro` was never saved** even though the user had approved their bio.

**Railway main protocol logs (19:43–20:00 UTC):** server was healthy (intent/opportunity graphs completing for the same userId), but **no profile graph activity** during the confirm window. The `TimeoutError: MCP call timed out after 120.0s` error is client-side only — it does not appear in protocol server logs.

## What changes for onboarding

| Before | After |
|--------|-------|
| Tool blocks up to 120s | Returns in ~100–500ms after DB write |
| MCP timeout → agent thinks profile failed | Immediate success; onboarding continues |
| Raw bio lost if LLM hangs | `intro`/`name`/`location` durable immediately |
| Skills/interests in response from LLM | Empty until background graph completes |

`complete_onboarding` auto-join still fires `ensure_profile_hyde` as a retry safety net.

## Test plan

- [x] `bun test packages/protocol/src/profile/tests/profile.privacy-tools.spec.ts`
- [ ] Deploy to dev; run AgentVillage onboarding with `bioOrDescription` confirm path
- [ ] Verify Railway logs show immediate tool return + later `ProfileGraph` / `PremiseDecomposer` activity
- [ ] Confirm `users.intro` is set before Step 3 even if background graph is slow