### PR TITLE
Release 2026-06-01: dev → main

### DIFF
--- a/backend/drizzle/0080_add_opportunity_discovery_runs.sql
+++ b/backend/drizzle/0080_add_opportunity_discovery_runs.sql
@@ -1,0 +1,28 @@
+CREATE TYPE "public"."discovery_run_status" AS ENUM('queued', 'running', 'succeeded', 'failed', 'cancelled');
+--> statement-breakpoint
+CREATE TABLE "opportunity_discovery_runs" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"agent_id" text,
+	"status" "discovery_run_status" DEFAULT 'queued' NOT NULL,
+	"input" jsonb NOT NULL,
+	"context" jsonb NOT NULL,
+	"progress" jsonb,
+	"result" jsonb,
+	"error" text,
+	"cancel_requested_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"started_at" timestamp with time zone,
+	"completed_at" timestamp with time zone,
+	"expires_at" timestamp with time zone
+);
+--> statement-breakpoint
+ALTER TABLE "opportunity_discovery_runs" ADD CONSTRAINT "opportunity_discovery_runs_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "opportunity_discovery_runs" ADD CONSTRAINT "opportunity_discovery_runs_agent_id_agents_id_fk" FOREIGN KEY ("agent_id") REFERENCES "public"."agents"("id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX "opportunity_discovery_runs_user_created_idx" ON "opportunity_discovery_runs" USING btree ("user_id","created_at");
+--> statement-breakpoint
+CREATE INDEX "opportunity_discovery_runs_status_created_idx" ON "opportunity_discovery_runs" USING btree ("status","created_at");
+--> statement-breakpoint
+CREATE INDEX "opportunity_discovery_runs_expires_at_idx" ON "opportunity_discovery_runs" USING btree ("expires_at");

--- a/backend/drizzle/meta/0080_snapshot.json
+++ b/backend/drizzle/meta/0080_snapshot.json
@@ -1,0 +1,4747 @@
+{
+  "id": "f93aa6b4-a9ef-42d7-8c56-7cdf01cb85ea",
+  "prevId": "7be2379c-7613-42e6-8660-10b1217169cd",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_permissions": {
+      "name": "agent_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "permission_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actions": {
+          "name": "actions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_permissions_agent_id_idx": {
+          "name": "agent_permissions_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_permissions_user_id_idx": {
+          "name": "agent_permissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_permissions_agent_user_idx": {
+          "name": "agent_permissions_agent_user_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_agent_permissions_global": {
+          "name": "uniq_agent_permissions_global",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_permissions\".\"scope\" = 'global'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_permissions_agent_id_agents_id_fk": {
+          "name": "agent_permissions_agent_id_agents_id_fk",
+          "tableFrom": "agent_permissions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_permissions_user_id_users_id_fk": {
+          "name": "agent_permissions_user_id_users_id_fk",
+          "tableFrom": "agent_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_messages": {
+      "name": "agent_test_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_token": {
+          "name": "reservation_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reserved_at": {
+          "name": "reserved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_test_messages_agent_pending": {
+          "name": "idx_agent_test_messages_agent_pending",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reserved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_messages_agent_id_agents_id_fk": {
+          "name": "agent_test_messages_agent_id_agents_id_fk",
+          "tableFrom": "agent_test_messages",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_messages_requested_by_user_id_users_id_fk": {
+          "name": "agent_test_messages_requested_by_user_id_users_id_fk",
+          "tableFrom": "agent_test_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_transports": {
+      "name": "agent_transports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "transport_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_transports_agent_id_idx": {
+          "name": "agent_transports_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_transports_agent_id_agents_id_fk": {
+          "name": "agent_transports_agent_id_agents_id_fk",
+          "tableFrom": "agent_transports",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "agent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_on_opportunity": {
+          "name": "notify_on_opportunity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "daily_summary_enabled": {
+          "name": "daily_summary_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "handle_negotiations": {
+          "name": "handle_negotiations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_daily_summary_at": {
+          "name": "last_daily_summary_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agents_owner_id_idx": {
+          "name": "agents_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_type_idx": {
+          "name": "agents_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_last_seen_at_idx": {
+          "name": "agents_last_seen_at_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_users_id_fk": {
+          "name": "agents_owner_id_users_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apikey_user_id_users_id_fk": {
+          "name": "apikey_user_id_users_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connect_links": {
+      "name": "connect_links",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "greeting": {
+          "name": "greeting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_surface": {
+          "name": "preferred_surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connect_links_kind_recipient_uq": {
+          "name": "connect_links_kind_recipient_uq",
+          "columns": [
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connect_links_expires_at_idx": {
+          "name": "connect_links_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connect_links_user_id_users_id_fk": {
+          "name": "connect_links_user_id_users_id_fk",
+          "tableFrom": "connect_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connect_links_opportunity_id_opportunities_id_fk": {
+          "name": "connect_links_opportunity_id_opportunities_id_fk",
+          "tableFrom": "connect_links",
+          "tableTo": "opportunities",
+          "columnsFrom": [
+            "opportunity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "files_user_id_users_id_fk": {
+          "name": "files_user_id_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hyde_documents": {
+      "name": "hyde_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_text": {
+          "name": "source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_corpus": {
+          "name": "target_corpus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hyde_text": {
+          "name": "hyde_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hyde_embedding": {
+          "name": "hyde_embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "hyde_source_idx": {
+          "name": "hyde_source_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_strategy_idx": {
+          "name": "hyde_strategy_idx",
+          "columns": [
+            {
+              "expression": "strategy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_embedding_idx": {
+          "name": "hyde_embedding_idx",
+          "columns": [
+            {
+              "expression": "hyde_embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "hyde_expires_idx": {
+          "name": "hyde_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_source_strategy_unique": {
+          "name": "hyde_source_strategy_unique",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "strategy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_corpus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.intent_networks": {
+      "name": "intent_networks",
+      "schema": "",
+      "columns": {
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relevancy_score": {
+          "name": "relevancy_score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "intent_networks_network_id_idx": {
+          "name": "intent_networks_network_id_idx",
+          "columns": [
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intent_networks_intent_id_intents_id_fk": {
+          "name": "intent_networks_intent_id_intents_id_fk",
+          "tableFrom": "intent_networks",
+          "tableTo": "intents",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "intent_networks_network_id_networks_id_fk": {
+          "name": "intent_networks_network_id_networks_id_fk",
+          "tableFrom": "intent_networks",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "intent_networks_intent_id_network_id_pk": {
+          "name": "intent_networks_intent_id_network_id_pk",
+          "columns": [
+            "intent_id",
+            "network_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.intents": {
+      "name": "intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_incognito": {
+          "name": "is_incognito",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "semantic_entropy": {
+          "name": "semantic_entropy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "referential_anchor": {
+          "name": "referential_anchor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intent_mode": {
+          "name": "intent_mode",
+          "type": "intent_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ATTRIBUTIVE'"
+        },
+        "speech_act_type": {
+          "name": "speech_act_type",
+          "type": "speech_act_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "felicity_authority": {
+          "name": "felicity_authority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "felicity_sincerity": {
+          "name": "felicity_sincerity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "felicity_clarity": {
+          "name": "felicity_clarity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "intent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {
+        "embeddingIndex": {
+          "name": "embeddingIndex",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intents_user_id_users_id_fk": {
+          "name": "intents_user_id_users_id_fk",
+          "tableFrom": "intents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.links": {
+      "name": "links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "links_user_id_users_id_fk": {
+          "name": "links_user_id_users_id_fk",
+          "tableFrom": "links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.network_integrations": {
+      "name": "network_integrations",
+      "schema": "",
+      "columns": {
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolkit": {
+          "name": "toolkit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_config": {
+          "name": "sync_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "network_integrations_network_id_networks_id_fk": {
+          "name": "network_integrations_network_id_networks_id_fk",
+          "tableFrom": "network_integrations",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "network_integrations_network_id_toolkit_pk": {
+          "name": "network_integrations_network_id_toolkit_pk",
+          "columns": [
+            "network_id",
+            "toolkit"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.network_members": {
+      "name": "network_members",
+      "schema": "",
+      "columns": {
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_assign": {
+          "name": "auto_assign",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "network_members_network_id_networks_id_fk": {
+          "name": "network_members_network_id_networks_id_fk",
+          "tableFrom": "network_members",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "network_members_user_id_users_id_fk": {
+          "name": "network_members_user_id_users_id_fk",
+          "tableFrom": "network_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "network_members_network_id_user_id_pk": {
+          "name": "network_members_network_id_user_id_pk",
+          "columns": [
+            "network_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.networks": {
+      "name": "networks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_experiment": {
+          "name": "is_experiment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "experiment_master_key_hash": {
+          "name": "experiment_master_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "network_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'community'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"joinPolicy\":\"invite_only\",\"invitationLink\":null,\"allowGuestVibeCheck\":false}'::json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "indexes_key_unique": {
+          "name": "indexes_key_unique",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_access_token_client_id_idx": {
+          "name": "oauth_access_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_user_id_idx": {
+          "name": "oauth_access_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_users_id_fk": {
+          "name": "oauth_access_token_user_id_users_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_access_token_unique": {
+          "name": "oauth_access_token_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        },
+        "oauth_access_token_refresh_token_unique": {
+          "name": "oauth_access_token_refresh_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_application": {
+      "name": "oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_application_user_id_idx": {
+          "name": "oauth_application_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_application_user_id_users_id_fk": {
+          "name": "oauth_application_user_id_users_id_fk",
+          "tableFrom": "oauth_application",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_application_client_id_unique": {
+          "name": "oauth_application_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_id_idx": {
+          "name": "oauth_consent_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_user_id_idx": {
+          "name": "oauth_consent_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_users_id_fk": {
+          "name": "oauth_consent_user_id_users_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunities": {
+      "name": "opportunities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "detection": {
+          "name": "detection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actors": {
+          "name": "actors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interpretation": {
+          "name": "interpretation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "opportunity_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "opportunities_status_idx": {
+          "name": "opportunities_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunities_accepted_by_users_id_fk": {
+          "name": "opportunities_accepted_by_users_id_fk",
+          "tableFrom": "opportunities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "accepted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunity_deliveries": {
+      "name": "opportunity_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivered_at_status": {
+          "name": "delivered_at_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_token": {
+          "name": "reservation_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reserved_at": {
+          "name": "reserved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_opp_deliveries_committed": {
+          "name": "uniq_opp_deliveries_committed",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "delivered_at_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"opportunity_deliveries\".\"delivered_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_opp_deliveries_open_reservations": {
+          "name": "idx_opp_deliveries_open_reservations",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reserved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"opportunity_deliveries\".\"delivered_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunity_deliveries_opportunity_id_opportunities_id_fk": {
+          "name": "opportunity_deliveries_opportunity_id_opportunities_id_fk",
+          "tableFrom": "opportunity_deliveries",
+          "tableTo": "opportunities",
+          "columnsFrom": [
+            "opportunity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "opportunity_deliveries_user_id_users_id_fk": {
+          "name": "opportunity_deliveries_user_id_users_id_fk",
+          "tableFrom": "opportunity_deliveries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "opportunity_deliveries_agent_id_agents_id_fk": {
+          "name": "opportunity_deliveries_agent_id_agents_id_fk",
+          "tableFrom": "opportunity_deliveries",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunity_discovery_runs": {
+      "name": "opportunity_discovery_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "discovery_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "opportunity_discovery_runs_user_created_idx": {
+          "name": "opportunity_discovery_runs_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opportunity_discovery_runs_status_created_idx": {
+          "name": "opportunity_discovery_runs_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opportunity_discovery_runs_expires_at_idx": {
+          "name": "opportunity_discovery_runs_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunity_discovery_runs_user_id_users_id_fk": {
+          "name": "opportunity_discovery_runs_user_id_users_id_fk",
+          "tableFrom": "opportunity_discovery_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "opportunity_discovery_runs_agent_id_agents_id_fk": {
+          "name": "opportunity_discovery_runs_agent_id_agents_id_fk",
+          "tableFrom": "opportunity_discovery_runs",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_networks": {
+      "name": "personal_networks",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "personal_networks_network_id_unique": {
+          "name": "personal_networks_network_id_unique",
+          "columns": [
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_networks_user_id_users_id_fk": {
+          "name": "personal_networks_user_id_users_id_fk",
+          "tableFrom": "personal_networks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "personal_networks_network_id_networks_id_fk": {
+          "name": "personal_networks_network_id_networks_id_fk",
+          "tableFrom": "personal_networks",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "personal_networks_user_id_pk": {
+          "name": "personal_networks_user_id_pk",
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.premise_networks": {
+      "name": "premise_networks",
+      "schema": "",
+      "columns": {
+        "premise_id": {
+          "name": "premise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relevancy_score": {
+          "name": "relevancy_score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "premise_networks_network_id_idx": {
+          "name": "premise_networks_network_id_idx",
+          "columns": [
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "premise_networks_premise_id_premises_id_fk": {
+          "name": "premise_networks_premise_id_premises_id_fk",
+          "tableFrom": "premise_networks",
+          "tableTo": "premises",
+          "columnsFrom": [
+            "premise_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "premise_networks_network_id_networks_id_fk": {
+          "name": "premise_networks_network_id_networks_id_fk",
+          "tableFrom": "premise_networks",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "premise_networks_premise_id_network_id_pk": {
+          "name": "premise_networks_premise_id_network_id_pk",
+          "columns": [
+            "premise_id",
+            "network_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.premises": {
+      "name": "premises",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assertion": {
+          "name": "assertion",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis": {
+          "name": "analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validity": {
+          "name": "validity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "premise_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retracted_at": {
+          "name": "retracted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "premises_embedding_idx": {
+          "name": "premises_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "premises_user_id_idx": {
+          "name": "premises_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "premises_status_idx": {
+          "name": "premises_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "premises_user_id_users_id_fk": {
+          "name": "premises_user_id_users_id_fk",
+          "tableFrom": "premises",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "detection": {
+          "name": "detection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actors": {
+          "name": "actors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "question_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "answer": {
+          "name": "answer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "questions_status_idx": {
+          "name": "questions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "questions_conversation_id_idx": {
+          "name": "questions_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_contexts": {
+      "name": "user_contexts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "premise_hash": {
+          "name": "premise_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_contexts_user_network_uniq": {
+          "name": "user_contexts_user_network_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_contexts_embedding_idx": {
+          "name": "user_contexts_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "user_contexts_user_id_idx": {
+          "name": "user_contexts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_contexts_network_id_idx": {
+          "name": "user_contexts_network_id_idx",
+          "columns": [
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_contexts_user_id_users_id_fk": {
+          "name": "user_contexts_user_id_users_id_fk",
+          "tableFrom": "user_contexts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_contexts_network_id_networks_id_fk": {
+          "name": "user_contexts_network_id_networks_id_fk",
+          "tableFrom": "user_contexts",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_settings": {
+      "name": "user_notification_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"connectionUpdates\":true,\"weeklyNewsletter\":true}'::json"
+        },
+        "unsubscribe_token": {
+          "name": "unsubscribe_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_settings_user_id_users_id_fk": {
+          "name": "user_notification_settings_user_id_users_id_fk",
+          "tableFrom": "user_notification_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_notification_settings_user_id_unique": {
+          "name": "user_notification_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_notification_settings_unsubscribe_token_unique": {
+          "name": "user_notification_settings_unsubscribe_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "unsubscribe_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity": {
+          "name": "identity",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "narrative": {
+          "name": "narrative",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_profiles_user_id_unique": {
+          "name": "user_profiles_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_socials": {
+      "name": "user_socials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_socials_user_id": {
+          "name": "idx_user_socials_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_user_socials_user_label": {
+          "name": "uniq_user_socials_user_label",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_socials\".\"label\" <> 'custom'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_socials_user_id_users_id_fk": {
+          "name": "user_socials_user_id_users_id_fk",
+          "tableFrom": "user_socials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro": {
+          "name": "intro",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding": {
+          "name": "onboarding",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::json"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UTC'"
+        },
+        "last_weekly_email_sent_at": {
+          "name": "last_weekly_email_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_ghost": {
+          "name": "is_ghost",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_key_unique": {
+          "name": "users_key_unique",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artifacts": {
+      "name": "artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "artifacts_task_id_idx": {
+          "name": "artifacts_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifacts_task_id_tasks_id_fk": {
+          "name": "artifacts_task_id_tasks_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session_summaries": {
+      "name": "chat_session_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_message_id": {
+          "name": "from_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_message_id": {
+          "name": "to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "digest": {
+          "name": "digest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chat_session_summaries_session_latest_idx": {
+          "name": "chat_session_summaries_session_latest_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_session_summaries_conversation_id_conversations_id_fk": {
+          "name": "chat_session_summaries_conversation_id_conversations_id_fk",
+          "tableFrom": "chat_session_summaries",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_session_summaries_from_message_id_messages_id_fk": {
+          "name": "chat_session_summaries_from_message_id_messages_id_fk",
+          "tableFrom": "chat_session_summaries",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "from_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "chat_session_summaries_to_message_id_messages_id_fk": {
+          "name": "chat_session_summaries_to_message_id_messages_id_fk",
+          "tableFrom": "chat_session_summaries",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "to_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_metadata": {
+      "name": "conversation_metadata",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_metadata_conversation_id_conversations_id_fk": {
+          "name": "conversation_metadata_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_metadata",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_participants": {
+      "name": "conversation_participants",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_type": {
+          "name": "participant_type",
+          "type": "participant_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "hidden_at": {
+          "name": "hidden_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversation_participants_participant_id_idx": {
+          "name": "conversation_participants_participant_id_idx",
+          "columns": [
+            {
+              "expression": "participant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_participants_conversation_id_idx": {
+          "name": "conversation_participants_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_participants_conversation_id_conversations_id_fk": {
+          "name": "conversation_participants_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_participants",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_participants_conversation_id_participant_id_pk": {
+          "name": "conversation_participants_conversation_id_participant_id_pk",
+          "columns": [
+            "conversation_id",
+            "participant_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dm_pair": {
+          "name": "dm_pair",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversations_dm_pair_idx": {
+          "name": "conversations_dm_pair_idx",
+          "columns": [
+            {
+              "expression": "dm_pair",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "message_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_task_ids": {
+          "name": "reference_task_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_conversation_id_created_at_idx": {
+          "name": "messages_conversation_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_sender_id_idx": {
+          "name": "messages_sender_id_idx",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_task_id_idx": {
+          "name": "messages_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_task_id_tasks_id_fk": {
+          "name": "messages_task_id_tasks_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "task_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "status_message": {
+          "name": "status_message",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_timestamp": {
+          "name": "status_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_agent_id": {
+          "name": "claimed_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tasks_conversation_id_idx": {
+          "name": "tasks_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_state_idx": {
+          "name": "tasks_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_metadata_opportunity_id_idx": {
+          "name": "tasks_metadata_opportunity_id_idx",
+          "columns": [
+            {
+              "expression": "(\"metadata\"->>'opportunityId')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"tasks\".\"metadata\"->>'type' = 'negotiation'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_conversation_id_conversations_id_fk": {
+          "name": "tasks_conversation_id_conversations_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_status": {
+      "name": "agent_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive"
+      ]
+    },
+    "public.agent_type": {
+      "name": "agent_type",
+      "schema": "public",
+      "values": [
+        "personal",
+        "system"
+      ]
+    },
+    "public.discovery_run_status": {
+      "name": "discovery_run_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "succeeded",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.intent_mode": {
+      "name": "intent_mode",
+      "schema": "public",
+      "values": [
+        "REFERENTIAL",
+        "ATTRIBUTIVE"
+      ]
+    },
+    "public.intent_status": {
+      "name": "intent_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "PAUSED",
+        "FULFILLED",
+        "EXPIRED"
+      ]
+    },
+    "public.network_type": {
+      "name": "network_type",
+      "schema": "public",
+      "values": [
+        "community",
+        "event"
+      ]
+    },
+    "public.opportunity_status": {
+      "name": "opportunity_status",
+      "schema": "public",
+      "values": [
+        "latent",
+        "draft",
+        "negotiating",
+        "pending",
+        "stalled",
+        "accepted",
+        "rejected",
+        "expired"
+      ]
+    },
+    "public.permission_scope": {
+      "name": "permission_scope",
+      "schema": "public",
+      "values": [
+        "global",
+        "node",
+        "network"
+      ]
+    },
+    "public.premise_status": {
+      "name": "premise_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "RETRACTED",
+        "EXPIRED"
+      ]
+    },
+    "public.question_status": {
+      "name": "question_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "answered",
+        "dismissed"
+      ]
+    },
+    "public.source_type": {
+      "name": "source_type",
+      "schema": "public",
+      "values": [
+        "file",
+        "integration",
+        "link",
+        "discovery_form",
+        "enrichment"
+      ]
+    },
+    "public.speech_act_type": {
+      "name": "speech_act_type",
+      "schema": "public",
+      "values": [
+        "COMMISSIVE",
+        "DIRECTIVE"
+      ]
+    },
+    "public.transport_channel": {
+      "name": "transport_channel",
+      "schema": "public",
+      "values": [
+        "mcp"
+      ]
+    },
+    "public.message_role": {
+      "name": "message_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "agent"
+      ]
+    },
+    "public.participant_type": {
+      "name": "participant_type",
+      "schema": "public",
+      "values": [
+        "user",
+        "agent"
+      ]
+    },
+    "public.task_state": {
+      "name": "task_state",
+      "schema": "public",
+      "values": [
+        "submitted",
+        "working",
+        "input_required",
+        "completed",
+        "failed",
+        "canceled",
+        "rejected",
+        "auth_required",
+        "waiting_for_agent",
+        "claimed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -561,6 +561,13 @@
       "when": 1779869258097,
       "tag": "0079_add_user_contexts",
       "breakpoints": true
+    },
+    {
+      "idx": 80,
+      "version": "7",
+      "when": 1780324801407,
+      "tag": "0080_add_opportunity_discovery_runs",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol",
-  "version": "0.26.3",
+  "version": "0.26.4",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -1393,8 +1393,8 @@ export class ChatDatabaseAdapter {
   }
 
   /**
-   * Get non-personal indexes that both users share membership in.
-   * Returns id, title, and member count for each shared index.
+   * Get non-personal networks that both users share membership in.
+   * Returns id, title, and member count for each shared network.
    */
   async getSharedNetworks(currentUserId: string, targetUserId: string): Promise<{ id: string; title: string; _count: { members: number } }[]> {
     const currentUserIndexIds = db
@@ -1419,7 +1419,6 @@ export class ChatDatabaseAdapter {
         and(
           isNull(schema.networks.deletedAt),
           eq(schema.networks.isPersonal, false),
-          or(eq(schema.networks.isExperiment, false), isNull(schema.networks.isExperiment)),
           inArray(schema.networks.id, currentUserIndexIds),
           inArray(schema.networks.id, targetUserIndexIds),
         )

--- a/backend/src/adapters/discovery-run.adapter.ts
+++ b/backend/src/adapters/discovery-run.adapter.ts
@@ -1,0 +1,202 @@
+import { and, desc, eq, inArray } from 'drizzle-orm';
+
+import db from '../lib/drizzle/drizzle';
+import { opportunityDiscoveryRuns } from '../schemas/database.schema';
+
+const DEFAULT_DISCOVERY_RUN_TTL_MS = 24 * 60 * 60 * 1000;
+
+type DiscoveryRunStatus = 'queued' | 'running' | 'succeeded' | 'failed' | 'cancelled';
+
+interface DiscoveryRunInput {
+  continueFrom?: string;
+  searchQuery?: string;
+  networkId?: string;
+  intentId?: string;
+  targetUserId?: string;
+  introTargetUserId?: string;
+  partyUserIds?: string[];
+  entities?: Array<{
+    userId: string;
+    profile?: {
+      name?: string;
+      bio?: string;
+      location?: string;
+      interests?: string[];
+      skills?: string[];
+      context?: string;
+    };
+    intents?: Array<{
+      intentId: string;
+      payload: string;
+      summary?: string;
+    }>;
+    networkId: string;
+  }>;
+  hint?: string;
+}
+
+interface DiscoveryRunContext {
+  userId: string;
+  userName: string;
+  userEmail: string;
+  networkId?: string;
+  indexName?: string;
+  indexScope: string[];
+  sessionId?: string;
+  agentId?: string;
+  clientSurface?: 'telegram' | 'web';
+}
+
+interface DiscoveryRunRecord {
+  id: string;
+  userId: string;
+  agentId?: string | null;
+  status: DiscoveryRunStatus;
+  input: DiscoveryRunInput;
+  context: DiscoveryRunContext;
+  progress?: Record<string, unknown> | null;
+  result?: unknown;
+  error?: string | null;
+  cancelRequestedAt?: Date | null;
+  createdAt: Date;
+  startedAt?: Date | null;
+  completedAt?: Date | null;
+  expiresAt?: Date | null;
+}
+
+interface CreateDiscoveryRunInput {
+  userId: string;
+  agentId?: string | null;
+  input: DiscoveryRunInput;
+  context: DiscoveryRunContext;
+  expiresAt?: Date;
+}
+
+interface DiscoveryRunStore {
+  create(input: CreateDiscoveryRunInput): Promise<DiscoveryRunRecord>;
+  get(runId: string, userId: string): Promise<DiscoveryRunRecord | null>;
+  markRunning(runId: string): Promise<DiscoveryRunRecord | null>;
+  updateProgress(runId: string, progress: Record<string, unknown>): Promise<void>;
+  markSucceeded(runId: string, result: unknown): Promise<void>;
+  markFailed(runId: string, error: string): Promise<void>;
+  requestCancel(runId: string, userId: string): Promise<DiscoveryRunRecord | null>;
+  markCancelled(runId: string, reason?: string): Promise<void>;
+  isCancelRequested(runId: string): Promise<boolean>;
+  listActive(userId: string, limit?: number): Promise<DiscoveryRunRecord[]>;
+}
+
+function mapRow(row: typeof opportunityDiscoveryRuns.$inferSelect): DiscoveryRunRecord {
+  return {
+    id: row.id,
+    userId: row.userId,
+    agentId: row.agentId,
+    status: row.status as DiscoveryRunStatus,
+    input: row.input as unknown as DiscoveryRunRecord['input'],
+    context: row.context as unknown as DiscoveryRunRecord['context'],
+    progress: row.progress,
+    result: row.result,
+    error: row.error,
+    cancelRequestedAt: row.cancelRequestedAt,
+    createdAt: row.createdAt,
+    startedAt: row.startedAt,
+    completedAt: row.completedAt,
+    expiresAt: row.expiresAt,
+  };
+}
+
+export class DiscoveryRunAdapter implements DiscoveryRunStore {
+  async create(input: CreateDiscoveryRunInput): Promise<DiscoveryRunRecord> {
+    const expiresAt = input.expiresAt ?? new Date(Date.now() + DEFAULT_DISCOVERY_RUN_TTL_MS);
+    const [row] = await db.insert(opportunityDiscoveryRuns).values({
+      userId: input.userId,
+      agentId: input.agentId ?? null,
+      input: input.input as unknown as Record<string, unknown>,
+      context: input.context as unknown as Record<string, unknown>,
+      status: 'queued',
+      progress: { stage: 'queued' },
+      expiresAt,
+    }).returning();
+    return mapRow(row);
+  }
+
+  async get(runId: string, userId: string): Promise<DiscoveryRunRecord | null> {
+    const [row] = await db.select().from(opportunityDiscoveryRuns).where(and(
+      eq(opportunityDiscoveryRuns.id, runId),
+      eq(opportunityDiscoveryRuns.userId, userId),
+    )).limit(1);
+    return row ? mapRow(row) : null;
+  }
+
+  async markRunning(runId: string): Promise<DiscoveryRunRecord | null> {
+    const [row] = await db.update(opportunityDiscoveryRuns).set({
+      status: 'running',
+      startedAt: new Date(),
+      progress: { stage: 'running' },
+    }).where(and(
+      eq(opportunityDiscoveryRuns.id, runId),
+      inArray(opportunityDiscoveryRuns.status, ['queued', 'running']),
+    )).returning();
+    return row ? mapRow(row) : null;
+  }
+
+  async updateProgress(runId: string, progress: Record<string, unknown>): Promise<void> {
+    await db.update(opportunityDiscoveryRuns).set({ progress }).where(eq(opportunityDiscoveryRuns.id, runId));
+  }
+
+  async markSucceeded(runId: string, result: unknown): Promise<void> {
+    await db.update(opportunityDiscoveryRuns).set({
+      status: 'succeeded',
+      result,
+      progress: { stage: 'succeeded' },
+      completedAt: new Date(),
+    }).where(eq(opportunityDiscoveryRuns.id, runId));
+  }
+
+  async markFailed(runId: string, error: string): Promise<void> {
+    await db.update(opportunityDiscoveryRuns).set({
+      status: 'failed',
+      error,
+      progress: { stage: 'failed' },
+      completedAt: new Date(),
+    }).where(eq(opportunityDiscoveryRuns.id, runId));
+  }
+
+  async requestCancel(runId: string, userId: string): Promise<DiscoveryRunRecord | null> {
+    const [row] = await db.update(opportunityDiscoveryRuns).set({
+      cancelRequestedAt: new Date(),
+      progress: { stage: 'cancellation_requested' },
+    }).where(and(
+      eq(opportunityDiscoveryRuns.id, runId),
+      eq(opportunityDiscoveryRuns.userId, userId),
+      inArray(opportunityDiscoveryRuns.status, ['queued', 'running']),
+    )).returning();
+    return row ? mapRow(row) : null;
+  }
+
+  async markCancelled(runId: string, reason?: string): Promise<void> {
+    await db.update(opportunityDiscoveryRuns).set({
+      status: 'cancelled',
+      error: reason ?? null,
+      progress: { stage: 'cancelled' },
+      completedAt: new Date(),
+    }).where(eq(opportunityDiscoveryRuns.id, runId));
+  }
+
+  async isCancelRequested(runId: string): Promise<boolean> {
+    const [row] = await db.select({ cancelRequestedAt: opportunityDiscoveryRuns.cancelRequestedAt, status: opportunityDiscoveryRuns.status })
+      .from(opportunityDiscoveryRuns)
+      .where(eq(opportunityDiscoveryRuns.id, runId))
+      .limit(1);
+    return !!row?.cancelRequestedAt || row?.status === 'cancelled';
+  }
+
+  async listActive(userId: string, limit = 20): Promise<DiscoveryRunRecord[]> {
+    const rows = await db.select().from(opportunityDiscoveryRuns).where(and(
+      eq(opportunityDiscoveryRuns.userId, userId),
+      inArray(opportunityDiscoveryRuns.status, ['queued', 'running']),
+    )).orderBy(desc(opportunityDiscoveryRuns.createdAt)).limit(limit);
+    return rows.map(mapRow);
+  }
+}
+
+export const discoveryRunAdapter = new DiscoveryRunAdapter();

--- a/backend/src/adapters/embedder.adapter.ts
+++ b/backend/src/adapters/embedder.adapter.ts
@@ -84,7 +84,8 @@ export class EmbedderAdapter {
 
   async generate(
     text: string | string[],
-    dimensions?: number
+    dimensions?: number,
+    options?: { signal?: AbortSignal }
   ): Promise<number[] | number[][]> {
     const texts = Array.isArray(text) ? text : [text];
     const cleanTexts = texts.map((t) => t.replace(/\n/g, ' ').trim()).filter(Boolean);
@@ -98,7 +99,7 @@ export class EmbedderAdapter {
       input: cleanTexts,
       dimensions: dim,
       encoding_format: 'float',
-    });
+    }, options?.signal ? { signal: options.signal } : undefined);
 
     if (!response.data?.length) {
       throw new Error('No embedding data returned');

--- a/backend/src/adapters/scraper.adapter.ts
+++ b/backend/src/adapters/scraper.adapter.ts
@@ -93,7 +93,7 @@ export class ScraperAdapter {
    * @param options - Optional. objective: natural-language reason (intent/profile/general).
    * @returns The extracted content as a string, or null if extraction failed
    */
-  async extractUrlContent(url: string, options?: { objective?: string }): Promise<string | null> {
+  async extractUrlContent(url: string, options?: { objective?: string; signal?: AbortSignal }): Promise<string | null> {
     const useSearch =
       isProfileSearchUrl(url) ||
       (isProfileObjective(options?.objective) && url.startsWith('http'));
@@ -102,7 +102,10 @@ export class ScraperAdapter {
         const objective =
           options?.objective?.trim() ||
           `Find information about the person from this profile page: ${url}`;
-        const response = await searchUser({ objective: `${objective}\nURL: ${url}` });
+        const searchRequest = { objective: `${objective}\nURL: ${url}` };
+        const response = options?.signal
+          ? await searchUser(searchRequest, { signal: options.signal })
+          : await searchUser(searchRequest);
         if (response.results?.length) {
           return formatSearchResultsForContent(response.results, true);
         }

--- a/backend/src/adapters/tests/database.adapter.spec.ts
+++ b/backend/src/adapters/tests/database.adapter.spec.ts
@@ -249,6 +249,31 @@ describe('ChatDatabaseAdapter', () => {
     expect(m!.networkTitle).toContain('Test Index');
   });
 
+  it('should include experiment networks in shared networks', async () => {
+    const experimentNetworkId = uuidv4();
+    await db.insert(networks).values({
+      id: experimentNetworkId,
+      title: TEST_PREFIX + 'Experiment Shared Network',
+      prompt: 'Experiment network prompt',
+      isExperiment: true,
+    });
+    await db.insert(networkMembers).values([
+      { networkId: experimentNetworkId, userId: fixture.userAId, permissions: ['member'], autoAssign: true },
+      { networkId: experimentNetworkId, userId: fixture.userBId, permissions: ['member'], autoAssign: true },
+    ]);
+
+    try {
+      const shared = await adapter.getSharedNetworks(fixture.userAId, fixture.userBId);
+      const experiment = shared.find((network) => network.id === experimentNetworkId);
+      expect(experiment).toBeDefined();
+      expect(experiment!.title).toContain('Experiment Shared Network');
+      expect(experiment!._count.members).toBe(2);
+    } finally {
+      await db.delete(networkMembers).where(eq(networkMembers.networkId, experimentNetworkId));
+      await db.delete(networks).where(eq(networks.id, experimentNetworkId));
+    }
+  });
+
   it('should get user index ids for auto-assign member', async () => {
     const indexIds = await adapter.getUserIndexIds(fixture.userBId);
     expect(indexIds).toContain(fixture.networkId);

--- a/backend/src/controllers/mcp.controller.ts
+++ b/backend/src/controllers/mcp.controller.ts
@@ -486,6 +486,54 @@ function getMcpMaxRequestBytes(): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_MCP_MAX_REQUEST_BYTES;
 }
 
+function requestTooLargeResponse(maxRequestBytes: number, corsHeaders: Record<string, string>): Response {
+  return new Response(
+    JSON.stringify({ error: `MCP request too large. Max ${maxRequestBytes} bytes.` }),
+    { status: 413, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+  );
+}
+
+async function enforceMcpRequestSize(
+  req: Request,
+  maxRequestBytes: number,
+  corsHeaders: Record<string, string>,
+): Promise<Request | Response> {
+  const contentLength = req.headers.get('content-length');
+  if (contentLength && Number.parseInt(contentLength, 10) > maxRequestBytes) {
+    return requestTooLargeResponse(maxRequestBytes, corsHeaders);
+  }
+
+  if (!req.body) return req;
+
+  const reader = req.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    totalBytes += value.byteLength;
+    if (totalBytes > maxRequestBytes) {
+      await reader.cancel().catch(() => undefined);
+      return requestTooLargeResponse(maxRequestBytes, corsHeaders);
+    }
+    chunks.push(value);
+  }
+
+  const body = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return new Request(req.url, {
+    method: req.method,
+    headers: req.headers,
+    body,
+    signal: req.signal,
+  });
+}
+
 /**
  * Handles an incoming MCP HTTP request.
  *
@@ -497,14 +545,10 @@ export async function mcpHandler(
   req: Request,
   corsHeaders: Record<string, string>,
 ): Promise<Response> {
-  const contentLength = req.headers.get('content-length');
   const maxRequestBytes = getMcpMaxRequestBytes();
-  if (contentLength && Number.parseInt(contentLength, 10) > maxRequestBytes) {
-    return new Response(
-      JSON.stringify({ error: `MCP request too large. Max ${maxRequestBytes} bytes.` }),
-      { status: 413, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
-    );
-  }
+  const sizeCheckedRequest = await enforceMcpRequestSize(req, maxRequestBytes, corsHeaders);
+  if (sizeCheckedRequest instanceof Response) return sizeCheckedRequest;
+  req = sizeCheckedRequest;
 
   // Reject unauthenticated requests at the HTTP level before they reach the MCP transport.
   // The transport catches errors and wraps them as HTTP 200 isError responses, which means

--- a/backend/src/controllers/mcp.controller.ts
+++ b/backend/src/controllers/mcp.controller.ts
@@ -29,6 +29,8 @@ import { ChatMessageWriterAdapter } from '../adapters/chat-message-writer.adapte
 import { enricherAdapter } from '../adapters/enricher.adapter';
 import { QuestionerAdapter } from '../adapters/questioner.adapter';
 import { questionerQueue } from '../queues/questioner.queue';
+import { discoveryRunAdapter } from '../adapters/discovery-run.adapter';
+import { discoveryRunQueue } from '../queues/opportunity/discovery-run.queue';
 import db from '../lib/drizzle/drizzle';
 import { agentService } from '../services/agent.service';
 import { chatSessionService } from '../services/chat.service';
@@ -111,6 +113,8 @@ const protocolDeps = {
   agentDispatcher,
   chatMessageWriter: new ChatMessageWriterAdapter(chatSessionService),
   deliveryLedger: opportunityDeliveryService,
+  discoveryRuns: discoveryRunAdapter,
+  discoveryRunQueue,
   negotiationTimeoutQueue,
   queueNegotiateExisting: async (opportunityId: string, userId: string): Promise<void> => {
     await negotiationRunExistingQueue.addJob({ opportunityId, userId });
@@ -404,6 +408,8 @@ function getOrCreateMcpServer(): McpServer {
     questionGenerator: protocolDeps.questionGenerator,
     chatMessageWriter: protocolDeps.chatMessageWriter,
     deliveryLedger: protocolDeps.deliveryLedger,
+    discoveryRuns: protocolDeps.discoveryRuns,
+    discoveryRunQueue: protocolDeps.discoveryRunQueue,
     mintConnectToken: protocolDeps.mintConnectToken,
     mintConnectLink: protocolDeps.mintConnectLink,
     frontendUrl: protocolDeps.frontendUrl,

--- a/backend/src/controllers/mcp.controller.ts
+++ b/backend/src/controllers/mcp.controller.ts
@@ -473,6 +473,13 @@ function getOrCreateTransport(): Promise<WebStandardStreamableHTTPServerTranspor
 // HTTP HANDLER
 // ═══════════════════════════════════════════════════════════════════════════════
 
+const DEFAULT_MCP_MAX_REQUEST_BYTES = 1_000_000;
+
+function getMcpMaxRequestBytes(): number {
+  const parsed = Number.parseInt(process.env.MCP_MAX_REQUEST_BYTES ?? '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_MCP_MAX_REQUEST_BYTES;
+}
+
 /**
  * Handles an incoming MCP HTTP request.
  *
@@ -484,6 +491,15 @@ export async function mcpHandler(
   req: Request,
   corsHeaders: Record<string, string>,
 ): Promise<Response> {
+  const contentLength = req.headers.get('content-length');
+  const maxRequestBytes = getMcpMaxRequestBytes();
+  if (contentLength && Number.parseInt(contentLength, 10) > maxRequestBytes) {
+    return new Response(
+      JSON.stringify({ error: `MCP request too large. Max ${maxRequestBytes} bytes.` }),
+      { status: 413, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    );
+  }
+
   // Reject unauthenticated requests at the HTTP level before they reach the MCP transport.
   // The transport catches errors and wraps them as HTTP 200 isError responses, which means
   // Claude Code never sees a 401 and never triggers OAuth. By checking here, we return a

--- a/backend/src/controllers/queues.controller.ts
+++ b/backend/src/controllers/queues.controller.ts
@@ -16,6 +16,7 @@ import { intentQueue } from '../queues/intent.queue';
 import { fromIntentQueue } from '../queues/opportunity/from-intent.queue';
 import { fromIntroducerQueue } from '../queues/opportunity/from-introducer.queue';
 import { fromProfileQueue } from '../queues/opportunity/from-profile.queue';
+import { discoveryRunQueue } from '../queues/opportunity/discovery-run.queue';
 import { negotiationRunExistingQueue } from '../queues/negotiations/run-existing.queue';
 import { enrichmentQueue } from '../queues/enrichment.queue';
 import { emailQueue } from '../queues/email.queue';
@@ -38,6 +39,7 @@ createBullBoard({
     new BullMQAdapter(fromIntentQueue.queue),
     new BullMQAdapter(fromIntroducerQueue.queue),
     new BullMQAdapter(fromProfileQueue.queue),
+    new BullMQAdapter(discoveryRunQueue.queue),
     new BullMQAdapter(negotiationRunExistingQueue.queue),
     new BullMQAdapter(enrichmentQueue.queue),
     new BullMQAdapter(emailQueue.queue),

--- a/backend/src/lib/embedder/embedder.generator.ts
+++ b/backend/src/lib/embedder/embedder.generator.ts
@@ -30,7 +30,8 @@ export class OpenRouterGenerator implements EmbeddingGenerator {
 
   async generate(
     text: string | string[],
-    dimensions: number = OPENROUTER_EMBEDDING_DIMENSIONS
+    dimensions: number = OPENROUTER_EMBEDDING_DIMENSIONS,
+    options?: { signal?: AbortSignal }
   ): Promise<number[] | number[][]> {
     const texts = Array.isArray(text) ? text : [text];
 
@@ -47,7 +48,7 @@ export class OpenRouterGenerator implements EmbeddingGenerator {
         input: cleanTexts,
         dimensions,
         encoding_format: 'float',
-      });
+      }, options?.signal ? { signal: options.signal } : undefined);
 
       if (!response.data || response.data.length === 0) {
         throw new Error('No embedding data returned from OpenRouter');

--- a/backend/src/lib/embedder/embedder.types.ts
+++ b/backend/src/lib/embedder/embedder.types.ts
@@ -1,6 +1,10 @@
 
+export interface EmbeddingGenerateOptions {
+  signal?: AbortSignal;
+}
+
 export interface EmbeddingGenerator {
-  generate(text: string | string[], dimensions?: number): Promise<number[] | number[][]>;
+  generate(text: string | string[], dimensions?: number, options?: EmbeddingGenerateOptions): Promise<number[] | number[][]>;
 }
 
 export interface VectorSearchResult<T> {

--- a/backend/src/lib/embedder/index.ts
+++ b/backend/src/lib/embedder/index.ts
@@ -30,8 +30,8 @@ export class IndexEmbedder implements Embedder {
   /**
    * Generates embeddings using the internal generator.
    */
-  async generate(text: string | string[], dimensions: number = 2000): Promise<number[] | number[][]> {
-    return this.generator.generate(text, dimensions);
+  async generate(text: string | string[], dimensions: number = 2000, options?: { signal?: AbortSignal }): Promise<number[] | number[][]> {
+    return this.generator.generate(text, dimensions, options);
   }
 
   /**

--- a/backend/src/lib/parallel/parallel.ts
+++ b/backend/src/lib/parallel/parallel.ts
@@ -23,8 +23,39 @@ function getRateLimitDelayMs(response: Response): number {
   return RATE_LIMIT_DEFAULT_DELAY_MS;
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.reject(createAbortError(signal));
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(resolve, ms);
+    const onAbort = () => {
+      clearTimeout(timeout);
+      reject(createAbortError(signal));
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+function createAbortError(signal?: AbortSignal): Error {
+  const reason = signal?.reason;
+  if (reason instanceof Error) return reason;
+  const err = new Error('Operation aborted');
+  err.name = 'AbortError';
+  return err;
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw createAbortError(signal);
+}
+
+async function withAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  throwIfAborted(signal);
+  if (!signal) return promise;
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) => {
+      signal.addEventListener('abort', () => reject(createAbortError(signal)), { once: true });
+    }),
+  ]);
 }
 
 function isRateLimitError(error: unknown): boolean {
@@ -71,7 +102,7 @@ export interface ParallelSearchRequestStruct {
  * Searches for a user using Parallel.ai API.
  * @param objective The specific query, e.g. 'seren sandikci, "seren@index.network"'
  */
-export async function searchUser(request: ParallelSearchRequest): Promise<ParallelSearchResponse> {
+export async function searchUser(request: ParallelSearchRequest, options?: { signal?: AbortSignal }): Promise<ParallelSearchResponse> {
   const apiKey = process.env.PARALLELS_API_KEY;
   if (!apiKey) {
     throw new Error('PARALLELS_API_KEY is not defined');
@@ -111,6 +142,7 @@ export async function searchUser(request: ParallelSearchRequest): Promise<Parall
   logger.info('Parallel Search request', { url: PARALLEL_API_URL, body: requestBody });
 
   for (let attempt = 1; attempt <= RATE_LIMIT_MAX_RETRIES; attempt++) {
+    throwIfAborted(options?.signal);
     const response = await fetch(PARALLEL_API_URL, {
       method: 'POST',
       headers: {
@@ -118,7 +150,8 @@ export async function searchUser(request: ParallelSearchRequest): Promise<Parall
         'x-api-key': apiKey,
         'parallel-beta': 'search-extract-2025-10-10'
       },
-      body: JSON.stringify(requestBody)
+      body: JSON.stringify(requestBody),
+      signal: options?.signal,
     });
 
     if (response.status === 429) {
@@ -132,7 +165,7 @@ export async function searchUser(request: ParallelSearchRequest): Promise<Parall
         maxRetries: RATE_LIMIT_MAX_RETRIES,
         delayMs,
       });
-      await sleep(delayMs);
+      await sleep(delayMs, options?.signal);
       continue;
     }
 
@@ -156,6 +189,8 @@ export interface ExtractUrlContentOptions {
    * "update my profile from this page"). When provided, the extract API may tailor content.
    */
   objective?: string;
+  /** Optional cancellation signal for caller/client disconnect or runtime deadline. */
+  signal?: AbortSignal;
 }
 
 /**
@@ -175,8 +210,9 @@ export async function extractUrlContent(url: string, options?: ExtractUrlContent
     logger.verbose('Extracting URL content', { url, hasObjective: !!options?.objective });
 
     for (let attempt = 1; attempt <= RATE_LIMIT_MAX_RETRIES; attempt++) {
+      throwIfAborted(options?.signal);
       try {
-        const extract = await parallelClient.beta.extract({
+        const extract = await withAbort(parallelClient.beta.extract({
           urls: [url],
           excerpts: true,
           full_content: true,
@@ -186,7 +222,7 @@ export async function extractUrlContent(url: string, options?: ExtractUrlContent
             max_age_seconds: 5184000, // 60 days
             timeout_seconds: 30,
           },
-        });
+        }), options?.signal);
 
         logger.verbose('Parallel extract response received', { url, resultsCount: extract.results?.length || 0 });
 
@@ -210,7 +246,7 @@ export async function extractUrlContent(url: string, options?: ExtractUrlContent
             maxRetries: RATE_LIMIT_MAX_RETRIES,
             delayMs,
           });
-          await sleep(delayMs);
+          await sleep(delayMs, options?.signal);
           continue;
         }
         throw extractError;

--- a/backend/src/lib/parallel/parallel.ts
+++ b/backend/src/lib/parallel/parallel.ts
@@ -26,12 +26,20 @@ function getRateLimitDelayMs(response: Response): number {
 function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   if (signal?.aborted) return Promise.reject(createAbortError(signal));
   return new Promise((resolve, reject) => {
-    const timeout = setTimeout(resolve, ms);
+    let removeAbortListener = () => {};
+    const timeout = setTimeout(() => {
+      removeAbortListener();
+      resolve();
+    }, ms);
     const onAbort = () => {
       clearTimeout(timeout);
+      removeAbortListener();
       reject(createAbortError(signal));
     };
-    signal?.addEventListener('abort', onAbort, { once: true });
+    if (signal) {
+      signal.addEventListener('abort', onAbort, { once: true });
+      removeAbortListener = () => signal.removeEventListener('abort', onAbort);
+    }
   });
 }
 
@@ -50,12 +58,19 @@ function throwIfAborted(signal?: AbortSignal): void {
 async function withAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
   throwIfAborted(signal);
   if (!signal) return promise;
-  return Promise.race([
-    promise,
-    new Promise<never>((_, reject) => {
-      signal.addEventListener('abort', () => reject(createAbortError(signal)), { once: true });
-    }),
-  ]);
+
+  let removeAbortListener = () => {};
+  const abortPromise = new Promise<never>((_, reject) => {
+    const onAbort = () => reject(createAbortError(signal));
+    signal.addEventListener('abort', onAbort, { once: true });
+    removeAbortListener = () => signal.removeEventListener('abort', onAbort);
+  });
+
+  try {
+    return await Promise.race([promise, abortPromise]);
+  } finally {
+    removeAbortListener();
+  }
 }
 
 function isRateLimitError(error: unknown): boolean {

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -51,6 +51,7 @@ import { intentQueue } from './queues/intent.queue';
 import { fromIntentQueue } from './queues/opportunity/from-intent.queue';
 import { fromIntroducerQueue } from './queues/opportunity/from-introducer.queue';
 import { fromProfileQueue } from './queues/opportunity/from-profile.queue';
+import { discoveryRunQueue } from './queues/opportunity/discovery-run.queue';
 import { negotiationRunExistingQueue } from './queues/negotiations/run-existing.queue';
 import { opportunityExpirationCron } from './queues/opportunity/expiration.queue';
 import { notificationQueue } from './queues/notification.queue';
@@ -104,6 +105,10 @@ fromIntroducerQueue.setRuntimeDeps({
   agentDispatcher: backgroundAgentDispatcher,
 });
 fromProfileQueue.setRuntimeDeps({
+  negotiationGraph: backgroundNegotiationGraph,
+  agentDispatcher: backgroundAgentDispatcher,
+});
+discoveryRunQueue.setRuntimeDeps({
   negotiationGraph: backgroundNegotiationGraph,
   agentDispatcher: backgroundAgentDispatcher,
 });
@@ -300,6 +305,7 @@ intentQueue.startWorker();
 fromIntentQueue.startWorker();
 fromIntroducerQueue.startWorker();
 fromProfileQueue.startWorker();
+discoveryRunQueue.startWorker();
 negotiationRunExistingQueue.startWorker();
 opportunityExpirationCron.start();
 notificationQueue.startWorker();

--- a/backend/src/queues/opportunity/discovery-run.queue.ts
+++ b/backend/src/queues/opportunity/discovery-run.queue.ts
@@ -1,0 +1,274 @@
+import { Job } from 'bullmq';
+
+import {
+  HydeGenerator,
+  HydeGraphFactory,
+  LensInferrer,
+  OpportunityGraphFactory,
+  createOpportunityTools,
+  getToolTimeoutPolicy,
+  requestContext,
+  resolveChatContext,
+} from '@indexnetwork/protocol';
+import type {
+  AgentDispatcher,
+  CompiledGraph,
+  DiscoveryRunInput,
+  DiscoveryRunRecord,
+  HydeGraphDatabase,
+  NegotiationGraphLike,
+  OpportunityGraphDatabase,
+  RawToolDefinition,
+  ResolvedToolContext,
+  ToolDeps,
+} from '@indexnetwork/protocol';
+
+import { log } from '../../lib/log';
+import { QueueFactory } from '../../lib/bullmq/bullmq';
+import { chatDatabaseAdapter, createSystemDatabase, createUserDatabase } from '../../adapters/database.adapter';
+import { embedderAdapter } from '../../adapters/embedder.adapter';
+import { cacheAdapter, hydeCacheAdapter, RedisCacheAdapter } from '../../adapters/cache.adapter';
+import { scraperAdapter } from '../../adapters/scraper.adapter';
+import { discoveryRunAdapter } from '../../adapters/discovery-run.adapter';
+import { mintConnectLink as mintConnectLinkSvc, buildConnectShortUrl } from '../../services/connect-link.service';
+import type { ConnectLinkKind } from '../../services/connect-link.service';
+import { negotiationRunExistingQueue } from '../negotiations/run-existing.queue';
+
+export const QUEUE_NAME = 'opportunity-discovery-run';
+
+export interface DiscoveryRunJobData {
+  runId: string;
+}
+
+export interface DiscoveryRunQueueDeps {
+  negotiationGraph?: NegotiationGraphLike;
+  agentDispatcher?: Pick<AgentDispatcher, 'hasPersonalAgent'>;
+}
+
+const apiBaseUrl = (
+  process.env.BASE_URL ||
+  process.env.API_BASE_URL ||
+  process.env.APP_URL ||
+  'http://localhost:3001'
+).replace(/\/+$/, '');
+
+const mintConnectLink = async ({ userId, opportunityId, kind, greeting, preferredSurface }: {
+  userId: string;
+  opportunityId: string;
+  kind: ConnectLinkKind;
+  greeting?: string | null;
+  preferredSurface?: 'telegram' | 'web';
+}): Promise<{ url: string }> => {
+  const { code } = await mintConnectLinkSvc({ userId, opportunityId, kind, greeting, preferredSurface });
+  return { url: buildConnectShortUrl(apiBaseUrl, code) };
+};
+
+function assertDiscoveryRunOutputFits(raw: string): void {
+  const policy = getToolTimeoutPolicy('discover_opportunities');
+  const outputBytes = new TextEncoder().encode(raw).byteLength;
+  if (outputBytes > policy.maxOutputBytes) {
+    throw new Error(
+      `Discovery run result exceeded MCP output cap: ${outputBytes} bytes > ${policy.maxOutputBytes} bytes`,
+    );
+  }
+}
+
+export class DiscoveryRunQueue {
+  static readonly QUEUE_NAME = QUEUE_NAME;
+
+  readonly queue = QueueFactory.createQueue<DiscoveryRunJobData>(QUEUE_NAME);
+
+  private readonly logger = log.job.from('DiscoveryRunJob');
+  private readonly queueLogger = log.queue.from('DiscoveryRunQueue');
+  private worker: ReturnType<typeof QueueFactory.createWorker<DiscoveryRunJobData>> | null = null;
+  private deps: DiscoveryRunQueueDeps | undefined;
+
+  setRuntimeDeps(deps: DiscoveryRunQueueDeps): void {
+    this.deps = { ...(this.deps ?? {}), ...deps };
+  }
+
+  async enqueue(runId: string): Promise<{ jobId?: string | number }> {
+    const job = await this.queue.add('run_discovery', { runId }, {
+      attempts: 1,
+      removeOnComplete: { age: 24 * 60 * 60 },
+      removeOnFail: { age: 24 * 60 * 60 },
+      jobId: runId,
+      priority: 10,
+    });
+    return { jobId: job.id };
+  }
+
+  async cancel(runId: string): Promise<boolean> {
+    const job = await this.queue.getJob(runId);
+    if (!job) return false;
+    const state = await job.getState();
+    if (state === 'waiting' || state === 'delayed' || state === 'prioritized') {
+      await job.remove();
+      return true;
+    }
+    return false;
+  }
+
+  async processJob(name: string, data: DiscoveryRunJobData): Promise<void> {
+    switch (name) {
+      case 'run_discovery':
+        await this.handleRun(data.runId);
+        break;
+      default:
+        this.queueLogger.warn(`[DiscoveryRunProcessor] Unknown job name: ${name}`);
+    }
+  }
+
+  startWorker(): void {
+    if (this.worker) return;
+    const processor = async (job: Job<DiscoveryRunJobData>) => {
+      this.queueLogger.info(`[DiscoveryRunProcessor] Processing job ${job.id}`);
+      await this.processJob(job.name, job.data);
+    };
+    this.worker = QueueFactory.createWorker<DiscoveryRunJobData>(QUEUE_NAME, processor);
+  }
+
+  async close(): Promise<void> {
+    if (this.worker) {
+      await this.worker.close();
+      this.worker = null;
+    }
+    await this.queue.close();
+  }
+
+  private async handleRun(runId: string): Promise<void> {
+    const run = await discoveryRunAdapter.markRunning(runId);
+    if (!run) return;
+    if (await discoveryRunAdapter.isCancelRequested(runId)) {
+      await discoveryRunAdapter.markCancelled(runId, 'cancelled before start');
+      return;
+    }
+
+    const abortController = new AbortController();
+    const cancelPoll = setInterval(() => {
+      discoveryRunAdapter.isCancelRequested(runId)
+        .then((cancelled) => {
+          if (cancelled && !abortController.signal.aborted) {
+            abortController.abort(new Error('Discovery run cancelled'));
+          }
+        })
+        .catch((err) => this.logger.warn('[DiscoveryRun] cancel poll failed', {
+          runId,
+          error: err instanceof Error ? err.message : String(err),
+        }));
+    }, 1000);
+
+    try {
+      await discoveryRunAdapter.updateProgress(runId, { stage: 'discovering' });
+      const result = await requestContext.run({ abortSignal: abortController.signal }, () => this.executeRun(run));
+      if (abortController.signal.aborted || await discoveryRunAdapter.isCancelRequested(runId)) {
+        await discoveryRunAdapter.markCancelled(runId, 'cancelled');
+        return;
+      }
+      await discoveryRunAdapter.markSucceeded(runId, result);
+      this.logger.info('[DiscoveryRun] Completed', { runId, userId: run.userId });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (abortController.signal.aborted || await discoveryRunAdapter.isCancelRequested(runId)) {
+        await discoveryRunAdapter.markCancelled(runId, message);
+        return;
+      }
+      await discoveryRunAdapter.markFailed(runId, message);
+      this.logger.error('[DiscoveryRun] Failed', { runId, userId: run.userId, error: message });
+      throw err;
+    } finally {
+      clearInterval(cancelPoll);
+    }
+  }
+
+  private async executeRun(run: DiscoveryRunRecord): Promise<unknown> {
+    const resolved = await resolveChatContext({
+      database: chatDatabaseAdapter,
+      userId: run.userId,
+      networkId: run.context.networkId,
+      sessionId: run.context.sessionId,
+    });
+    const context: ResolvedToolContext = {
+      ...resolved,
+      indexScope: run.context.indexScope ?? resolved.indexScope,
+      isMcp: true,
+      ...(run.agentId ? { agentId: run.agentId } : {}),
+      ...(run.context.clientSurface ? { clientSurface: run.context.clientSurface } : {}),
+    };
+
+    const userDb = createUserDatabase(chatDatabaseAdapter, run.userId);
+    const systemDb = createSystemDatabase(chatDatabaseAdapter, run.userId, context.indexScope, embedderAdapter);
+    const graphDb = chatDatabaseAdapter as unknown as OpportunityGraphDatabase & HydeGraphDatabase;
+    const hydeGraph = new HydeGraphFactory(
+      graphDb,
+      embedderAdapter,
+      hydeCacheAdapter ?? new RedisCacheAdapter(),
+      new LensInferrer(),
+      new HydeGenerator(),
+    ).createGraph();
+    const opportunityGraph = new OpportunityGraphFactory(
+      graphDb,
+      embedderAdapter,
+      hydeGraph,
+      undefined,
+      undefined,
+      this.deps?.negotiationGraph,
+      this.deps?.agentDispatcher,
+      async (opportunityId: string, userId: string) => {
+        await negotiationRunExistingQueue.addJob({ opportunityId, userId });
+      },
+    ).createGraph();
+
+    const rawTools = new Map<string, RawToolDefinition>();
+    createOpportunityTools(((opts: {
+      name: string;
+      description: string;
+      querySchema: RawToolDefinition['schema'];
+      handler: RawToolDefinition['handler'];
+    }) => {
+      rawTools.set(opts.name, {
+        name: opts.name,
+        description: opts.description,
+        schema: opts.querySchema,
+        handler: opts.handler,
+      });
+      return null;
+    }) as never, {
+      database: chatDatabaseAdapter,
+      userDb,
+      systemDb,
+      scraper: scraperAdapter,
+      embedder: embedderAdapter,
+      cache: cacheAdapter,
+      integration: {} as ToolDeps['integration'],
+      contactService: {} as ToolDeps['contactService'],
+      integrationImporter: {} as ToolDeps['integrationImporter'],
+      enricher: {} as ToolDeps['enricher'],
+      negotiationDatabase: {} as ToolDeps['negotiationDatabase'],
+      mintConnectLink,
+      frontendUrl: process.env.FRONTEND_URL ?? process.env.APP_URL ?? 'https://index.network',
+      apiBaseUrl,
+      graphs: {
+        profile: { invoke: async () => ({}) } as CompiledGraph,
+        intent: { invoke: async () => ({}) } as CompiledGraph,
+        index: { invoke: async () => ({}) } as CompiledGraph,
+        networkMembership: { invoke: async () => ({}) } as CompiledGraph,
+        intentIndex: { invoke: async () => ({}) } as CompiledGraph,
+        opportunity: opportunityGraph,
+        premise: { invoke: async () => ({}) } as CompiledGraph,
+      },
+    });
+
+    const discover = rawTools.get('discover_opportunities');
+    if (!discover) throw new Error('discover_opportunities handler not available');
+    const raw = await discover.handler({ context, query: run.input as DiscoveryRunInput });
+    assertDiscoveryRunOutputFits(raw);
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return raw;
+    }
+  }
+}
+
+export const discoveryRunQueue = new DiscoveryRunQueue();

--- a/backend/src/schemas/database.schema.ts
+++ b/backend/src/schemas/database.schema.ts
@@ -16,6 +16,7 @@ export const permissionScopeEnum = pgEnum('permission_scope', ['global', 'node',
 export const networkTypeEnum = pgEnum('network_type', ['community', 'event']);
 export const premiseStatusEnum = pgEnum('premise_status', ['ACTIVE', 'RETRACTED', 'EXPIRED']);
 export const questionStatusEnum = pgEnum('question_status', ['pending', 'answered', 'dismissed']);
+export const discoveryRunStatusEnum = pgEnum('discovery_run_status', ['queued', 'running', 'succeeded', 'failed', 'cancelled']);
 
 export type PrivacyConsentSource = 'agentvillage_onboarding' | 'hermes_setup' | 'web_onboarding' | 'api';
 
@@ -449,6 +450,27 @@ export const opportunities = pgTable('opportunities', {
   metadata: jsonb('metadata').$type<Record<string, unknown>>().default({}),
 }, (table) => ({
   statusIdx: index('opportunities_status_idx').on(table.status),
+}));
+
+export const opportunityDiscoveryRuns = pgTable('opportunity_discovery_runs', {
+  id: text('id').primaryKey().$defaultFn(() => crypto.randomUUID()),
+  userId: text('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+  agentId: text('agent_id').references(() => agents.id, { onDelete: 'set null' }),
+  status: discoveryRunStatusEnum('status').notNull().default('queued'),
+  input: jsonb('input').$type<Record<string, unknown>>().notNull(),
+  context: jsonb('context').$type<Record<string, unknown>>().notNull(),
+  progress: jsonb('progress').$type<Record<string, unknown>>(),
+  result: jsonb('result').$type<unknown>(),
+  error: text('error'),
+  cancelRequestedAt: timestamp('cancel_requested_at', { withTimezone: true }),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  startedAt: timestamp('started_at', { withTimezone: true }),
+  completedAt: timestamp('completed_at', { withTimezone: true }),
+  expiresAt: timestamp('expires_at', { withTimezone: true }),
+}, (table) => ({
+  userCreatedIdx: index('opportunity_discovery_runs_user_created_idx').on(table.userId, table.createdAt),
+  statusCreatedIdx: index('opportunity_discovery_runs_status_created_idx').on(table.status, table.createdAt),
+  expiresAtIdx: index('opportunity_discovery_runs_expires_at_idx').on(table.expiresAt),
 }));
 
 export interface QuestionDetection {

--- a/backend/src/services/network.service.ts
+++ b/backend/src/services/network.service.ts
@@ -264,13 +264,13 @@ export class NetworkService {
   }
 
   /**
-   * Get non-personal indexes shared between the current user and a target user.
+   * Get non-personal networks shared between the current user and a target user.
    * @param currentUserId - Authenticated user ID.
    * @param targetUserId - Profile user ID to compare memberships with.
-   * @returns Shared non-personal indexes with member counts.
+   * @returns Shared non-personal networks with member counts.
    */
   async getSharedNetworks(currentUserId: string, targetUserId: string) {
-    logger.verbose('[NetworkService] Getting shared indexes', { currentUserId, targetUserId });
+    logger.verbose('[NetworkService] Getting shared networks', { currentUserId, targetUserId });
     return this.adapter.getSharedNetworks(currentUserId, targetUserId);
   }
 

--- a/backend/src/services/tool.service.ts
+++ b/backend/src/services/tool.service.ts
@@ -14,7 +14,7 @@ import {
 import { EmbedderAdapter } from '../adapters/embedder.adapter';
 import { ScraperAdapter } from '../adapters/scraper.adapter';
 import { RedisCacheAdapter } from '../adapters/cache.adapter';
-import { IntentGraphFactory, ProfileGraphFactory, OpportunityGraphFactory, HydeGraphFactory, NetworkGraphFactory, NetworkMembershipGraphFactory, IntentNetworkGraphFactory, NegotiationGraphFactory, PremiseGraphFactory, HydeGenerator, LensInferrer, IntentIndexer, resolveChatContext, createToolRegistry, invokeToolRuntime } from '@indexnetwork/protocol';
+import { IntentGraphFactory, ProfileGraphFactory, OpportunityGraphFactory, HydeGraphFactory, NetworkGraphFactory, NetworkMembershipGraphFactory, IntentNetworkGraphFactory, NegotiationGraphFactory, PremiseGraphFactory, HydeGenerator, LensInferrer, IntentIndexer, resolveChatContext, createToolRegistry, invokeToolRuntime, toolRuntimeErrorToResult } from '@indexnetwork/protocol';
 import type { AgentDispatcher } from '@indexnetwork/protocol';
 import type { HydeGraphDatabase, PremiseGraphDatabase, ToolDeps, ContactServiceAdapter, IntegrationAdapter, PendingQuestionSummary } from '@indexnetwork/protocol';
 import { intentQueue } from '../queues/intent.queue';
@@ -125,12 +125,19 @@ export class ToolService {
 
     // Execute handler through the shared runtime so direct REST tool calls use
     // the same timeout and requestContext cancellation plumbing as MCP.
-    const rawResult = await invokeToolRuntime({
-      toolName,
-      tool,
-      context,
-      query: parseResult.data,
-    });
+    let rawResult: string;
+    try {
+      rawResult = await invokeToolRuntime({
+        toolName,
+        tool,
+        context,
+        query: parseResult.data,
+      });
+    } catch (err) {
+      const runtimeResult = toolRuntimeErrorToResult(err);
+      if (!runtimeResult) throw err;
+      rawResult = runtimeResult;
+    }
 
     // Parse JSON result
     try {

--- a/backend/src/services/tool.service.ts
+++ b/backend/src/services/tool.service.ts
@@ -14,7 +14,7 @@ import {
 import { EmbedderAdapter } from '../adapters/embedder.adapter';
 import { ScraperAdapter } from '../adapters/scraper.adapter';
 import { RedisCacheAdapter } from '../adapters/cache.adapter';
-import { IntentGraphFactory, ProfileGraphFactory, OpportunityGraphFactory, HydeGraphFactory, NetworkGraphFactory, NetworkMembershipGraphFactory, IntentNetworkGraphFactory, NegotiationGraphFactory, PremiseGraphFactory, HydeGenerator, LensInferrer, IntentIndexer, resolveChatContext, createToolRegistry } from '@indexnetwork/protocol';
+import { IntentGraphFactory, ProfileGraphFactory, OpportunityGraphFactory, HydeGraphFactory, NetworkGraphFactory, NetworkMembershipGraphFactory, IntentNetworkGraphFactory, NegotiationGraphFactory, PremiseGraphFactory, HydeGenerator, LensInferrer, IntentIndexer, resolveChatContext, createToolRegistry, invokeToolRuntime } from '@indexnetwork/protocol';
 import type { AgentDispatcher } from '@indexnetwork/protocol';
 import type { HydeGraphDatabase, PremiseGraphDatabase, ToolDeps, ContactServiceAdapter, IntegrationAdapter, PendingQuestionSummary } from '@indexnetwork/protocol';
 import { intentQueue } from '../queues/intent.queue';
@@ -123,8 +123,14 @@ export class ToolService {
       throw new Error(`Invalid query for tool "${toolName}": ${issues}`);
     }
 
-    // Execute handler
-    const rawResult = await tool.handler({ context, query: parseResult.data });
+    // Execute handler through the shared runtime so direct REST tool calls use
+    // the same timeout and requestContext cancellation plumbing as MCP.
+    const rawResult = await invokeToolRuntime({
+      toolName,
+      tool,
+      context,
+      query: parseResult.data,
+    });
 
     // Parse JSON result
     try {

--- a/bun.lock
+++ b/bun.lock
@@ -136,7 +136,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "1.24.2",
+      "version": "1.24.3",
       "dependencies": {
         "@langchain/core": "^1.1.17",
         "@langchain/langgraph": "^1.1.2",

--- a/bun.lock
+++ b/bun.lock
@@ -136,7 +136,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "1.23.1",
+      "version": "1.24.2",
       "dependencies": {
         "@langchain/core": "^1.1.17",
         "@langchain/langgraph": "^1.1.2",

--- a/bun.lock
+++ b/bun.lock
@@ -136,7 +136,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "1.24.3",
+      "version": "1.25.0",
       "dependencies": {
         "@langchain/core": "^1.1.17",
         "@langchain/langgraph": "^1.1.2",

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "backend": {
       "name": "protocol",
-      "version": "0.26.3",
+      "version": "0.26.4",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.939.0",
         "@aws-sdk/s3-request-presigner": "^3.983.0",
@@ -64,7 +64,7 @@
     },
     "frontend": {
       "name": "frontend",
-      "version": "0.10.0",
+      "version": "0.11.2",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.14",

--- a/docs/design/protocol-deep-dive.md
+++ b/docs/design/protocol-deep-dive.md
@@ -570,10 +570,54 @@ Every registered tool goes through the same lifecycle on every call:
 4. Run the agent-registration gate: unless the tool is on the exempt list (`register_agent`, `read_docs`, `scrape_url`), a missing `agentId` produces an `Agent not registered` error that tells the caller to register first.
 5. Build per-request scoped databases via `scopedDepsFactory` and rebuild the tool registry with them.
 6. Validate arguments against the tool's original Zod schema.
-7. Invoke the raw tool handler with `{ context, query: validatedArgs }`.
+7. Invoke the raw tool handler through `ToolInvocationRuntime`, which attaches a shared `AbortSignal`, wall-clock deadline, trace/progress bridge, and output-size cap.
 8. Return the handler's formatted string as an MCP text content block.
 
-Errors are trapped and returned as MCP error responses so a single failing tool never breaks the server session.
+Errors are trapped and returned as MCP error responses so a single failing tool never breaks the server session. Runtime failures use JSON envelopes with stable codes: `TOOL_TIMEOUT`, `TOOL_CANCELLED`, and `TOOL_OUTPUT_TOO_LARGE`.
+
+### Runtime deadlines, cancellation, and output caps
+
+Every MCP tool call is bounded by `packages/protocol/src/shared/agent/tool.runtime.ts` instead of per-tool ad hoc timers. The runtime classifies tools into three timeout classes:
+
+| Class | Default | Intended tools |
+|---|---:|---|
+| `fast` | 10 s | Metadata reads, lightweight CRUD, onboarding, delivery confirmation, docs |
+| `bounded_slow` | 45 s | Normal multi-step calls that may touch storage or a small graph path |
+| `async_candidate` | 50 s | Calls that are currently synchronous but are candidates for future job/status/result/cancel flows, such as imports and discovery |
+
+Timeouts can be tuned globally by class or per tool:
+
+- `MCP_TOOL_TIMEOUT_FAST_MS`
+- `MCP_TOOL_TIMEOUT_BOUNDED_SLOW_MS`
+- `MCP_TOOL_TIMEOUT_ASYNC_CANDIDATE_MS`
+- `MCP_TOOL_TIMEOUT_<TOOL_NAME>_MS`, where the tool name is uppercased and non-alphanumeric characters become `_` (for example, `MCP_TOOL_TIMEOUT_DISCOVER_OPPORTUNITIES_MS`).
+
+The runtime also enforces response size limits before a tool result is returned to MCP or the REST-safe tool path:
+
+- `MCP_TOOL_MAX_OUTPUT_BYTES` defaults to `1000000`.
+- `MCP_TOOL_MAX_OUTPUT_<TOOL_NAME>_BYTES` overrides a single tool.
+
+The MCP HTTP controller rejects oversized inbound JSON-RPC bodies before they reach the transport via `MCP_MAX_REQUEST_BYTES`, also defaulting to `1000000`.
+
+Cancellation propagates through the same signal. MCP `notifications/cancelled`, client-side HTTP aborts exposed by the SDK, and runtime timeouts abort the active request context. Graph invocations, LangChain model calls, scraper calls, and embedding generation read that signal via the shared helpers so downstream work stops as close to the provider boundary as possible. Trace events emitted during a tool call are bridged to MCP `notifications/progress`, so capable clients can surface long-running graph/agent progress before either a result or cancellation.
+
+Runtime error envelopes are JSON text payloads shaped as:
+
+```json
+{
+  "success": false,
+  "code": "TOOL_TIMEOUT",
+  "error": "Tool discover_opportunities timed out after 50000ms.",
+  "data": {
+    "tool": "discover_opportunities",
+    "timeoutClass": "async_candidate",
+    "timeoutMs": 50000,
+    "maxOutputBytes": 1000000
+  }
+}
+```
+
+Use `TOOL_TIMEOUT` when the server deadline fired, `TOOL_CANCELLED` when the client cancelled first, and `TOOL_OUTPUT_TOO_LARGE` when the handler returned more than its configured output budget.
 
 ### MCP_INSTRUCTIONS — the canonical behavioral contract
 

--- a/docs/design/protocol-deep-dive.md
+++ b/docs/design/protocol-deep-dive.md
@@ -601,6 +601,8 @@ The MCP HTTP controller rejects oversized inbound JSON-RPC bodies before they re
 
 Cancellation propagates through the same signal. MCP `notifications/cancelled`, client-side HTTP aborts exposed by the SDK, and runtime timeouts abort the active request context. Graph invocations, LangChain model calls, scraper calls, and embedding generation read that signal via the shared helpers so downstream work stops as close to the provider boundary as possible. Trace events emitted during a tool call are bridged to MCP `notifications/progress`, so capable clients can surface long-running graph/agent progress before either a result or cancellation.
 
+`discover_opportunities` is the first tool to use the async-run escape hatch on the MCP path. When MCP callers invoke it, the tool persists an `opportunity_discovery_runs` row, enqueues `opportunity-discovery-run`, and returns `{ status: "queued", discoveryRunId }` immediately. The worker runs the same discovery formatter out of band and stores the final JSON result on the run. MCP agents then call `get_discovery_run` until `status` is `succeeded`, `failed`, or `cancelled`; they can call `cancel_discovery_run` to remove a waiting job or request cancellation of a running one. Regular web/chat callers still use the synchronous path.
+
 Runtime error envelopes are JSON text payloads shaped as:
 
 ```json

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -146,6 +146,13 @@ TRUSTED_ORIGINS=http://localhost:3000
 # Web crawling and profile extraction
 # PARALLELS_API_KEY=...
 
+# MCP runtime limits (defaults shown)
+# MCP_MAX_REQUEST_BYTES=1000000
+# MCP_TOOL_MAX_OUTPUT_BYTES=1000000
+# MCP_TOOL_TIMEOUT_FAST_MS=10000
+# MCP_TOOL_TIMEOUT_BOUNDED_SLOW_MS=45000
+# MCP_TOOL_TIMEOUT_ASYNC_CANDIDATE_MS=50000
+
 # Telegram bot (optional — enables bot notifications and chat)
 # TELEGRAM_BOT_TOKEN=          # Bot token from @BotFather
 # TELEGRAM_BOT_USERNAME=       # Bot username without @, e.g. IndexBot

--- a/docs/specs/api-reference.md
+++ b/docs/specs/api-reference.md
@@ -146,6 +146,56 @@ The surface is snapshotted onto each minted `connect_links` row at MCP-call time
 
 Today only the Telegram-bot MCP surface sends `telegram`. Every other caller — Claude Desktop, the web app, Claude Code, the CLI — omits the header and gets the web fallback.
 
+### MCP runtime limits and error envelopes
+
+Every MCP `tools/call` runs under the shared tool runtime. The runtime applies a timeout class, request cancellation signal, progress bridge, and output cap before returning a text block to the client.
+
+**Timeout classes:**
+
+| Class | Default deadline | Override |
+|---|---:|---|
+| `fast` | 10 seconds | `MCP_TOOL_TIMEOUT_FAST_MS` |
+| `bounded_slow` | 45 seconds | `MCP_TOOL_TIMEOUT_BOUNDED_SLOW_MS` |
+| `async_candidate` | 50 seconds | `MCP_TOOL_TIMEOUT_ASYNC_CANDIDATE_MS` |
+
+A single tool can be overridden with `MCP_TOOL_TIMEOUT_<TOOL_NAME>_MS`, where `<TOOL_NAME>` is uppercased and non-alphanumeric characters are replaced with `_`; for example, `MCP_TOOL_TIMEOUT_CREATE_INTENT_MS` or `MCP_TOOL_TIMEOUT_DISCOVER_OPPORTUNITIES_MS`.
+
+**Size limits:**
+
+- `MCP_MAX_REQUEST_BYTES` rejects oversized HTTP request bodies before JSON-RPC handling. Default: `1000000` bytes.
+- `MCP_TOOL_MAX_OUTPUT_BYTES` caps encoded tool output. Default: `1000000` bytes.
+- `MCP_TOOL_MAX_OUTPUT_<TOOL_NAME>_BYTES` overrides one tool, for example `MCP_TOOL_MAX_OUTPUT_READ_DOCS_BYTES`.
+
+Invalid or non-positive numeric values are ignored and the default is used.
+
+**Cancellation:**
+
+Clients may cancel in-flight MCP calls with `notifications/cancelled`. HTTP request aborts exposed by the MCP SDK are treated the same way. The runtime propagates the abort signal into graph, LLM, scraper, and embedding paths where supported.
+
+**Runtime error envelope:**
+
+When the runtime rejects a tool call, the MCP text content contains a stable JSON envelope:
+
+```json
+{
+  "success": false,
+  "code": "TOOL_TIMEOUT",
+  "error": "Tool create_intent timed out after 50000ms.",
+  "data": {
+    "tool": "create_intent",
+    "timeoutClass": "async_candidate",
+    "timeoutMs": 50000,
+    "maxOutputBytes": 1000000
+  }
+}
+```
+
+`code` is one of:
+
+- `TOOL_TIMEOUT` — the server-side deadline expired.
+- `TOOL_CANCELLED` — the client cancelled before completion.
+- `TOOL_OUTPUT_TOO_LARGE` — the encoded result exceeded the configured output cap.
+
 ### Performance Stats (Dev Only)
 
 ```

--- a/docs/specs/api-reference.md
+++ b/docs/specs/api-reference.md
@@ -172,6 +172,23 @@ Invalid or non-positive numeric values are ignored and the default is used.
 
 Clients may cancel in-flight MCP calls with `notifications/cancelled`. HTTP request aborts exposed by the MCP SDK are treated the same way. The runtime propagates the abort signal into graph, LLM, scraper, and embedding paths where supported.
 
+**Async discovery runs:**
+
+For MCP callers, `discover_opportunities` does not execute the full discovery graph inside the initial `tools/call`. It returns quickly with:
+
+```json
+{
+  "success": true,
+  "data": {
+    "status": "queued",
+    "discoveryRunId": "...",
+    "message": "Discovery started. Call get_discovery_run ..."
+  }
+}
+```
+
+Clients poll `get_discovery_run({ discoveryRunId })` until `status` is `succeeded`, `failed`, or `cancelled`. When `succeeded`, `data.result` contains the normal discovery payload. Clients may call `cancel_discovery_run({ discoveryRunId })` to cancel a queued run or request cancellation of a running run. Non-MCP chat/web paths remain synchronous.
+
 **Runtime error envelope:**
 
 When the runtime rejects a tool call, the MCP text content contains a stable JSON envelope:

--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -9,4 +9,5 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Show experiment networks such as Edge City in shared profile networks and link them to their network pages.
 - Limit automatic onboarding redirects to the home page so signed-in users can open app routes like `/networks` before finishing setup.

--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -9,5 +9,6 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Clear stale browser auth sessions automatically when user lookup fails.
 - Show experiment networks such as Edge City in shared profile networks and link them to their network pages.
 - Limit automatic onboarding redirects to the home page so signed-in users can open app routes like `/networks` before finishing setup.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/frontend/src/app/u/[id]/page.tsx
+++ b/frontend/src/app/u/[id]/page.tsx
@@ -210,7 +210,7 @@ export default function UserProfilePage() {
               <h3 className="text-base font-bold text-gray-900 font-ibm-plex-mono mb-2">Shared Networks</h3>
               <div className="flex flex-wrap gap-2">
                 {sharedNetworks.map((network) => (
-                  <Link key={network.id} to={`/index/${network.id}`} className="flex items-center gap-1.5 px-3 py-1.5 border border-gray-200 rounded-full text-sm text-gray-700 hover:border-gray-400 transition-colors">
+                  <Link key={network.id} to={`/networks/${network.id}`} className="flex items-center gap-1.5 px-3 py-1.5 border border-gray-200 rounded-full text-sm text-gray-700 hover:border-gray-400 transition-colors">
                     {network.title}
                     <span className="text-xs text-gray-400">{network._count.members}</span>
                   </Link>

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useEffect, useState, useCallback, ReactNode } from 'react';
 import { useNavigate, useLocation } from 'react-router';
 import { authClient, clearJwtToken } from '@/lib/auth-client';
-import { useAuthenticatedAPI } from '../lib/api';
+import { APIError, useAuthenticatedAPI } from '../lib/api';
 import { useAuthService } from '../services/auth';
 import { User, APIResponse } from '../lib/types';
 import AuthModal from '@/components/AuthModal';
@@ -78,6 +78,22 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
     } catch (error) {
       console.error('Failed to fetch user:', error);
+
+      // The browser can retain a Better Auth session/JWT for a user that no
+      // longer exists in the currently selected dev database. Treat auth/user
+      // lookup failures as stale auth state and clear it automatically instead
+      // of trapping the user on the error screen.
+      if (error instanceof APIError && (error.status === 401 || error.status === 404)) {
+        clearJwtToken();
+        await authClient.signOut().catch(signOutError => {
+          console.error('Failed to clear stale auth session:', signOutError);
+        });
+        setUser(null);
+        setUserFetchAttempted(false);
+        setError(null);
+        return;
+      }
+
       setError('Failed to load user data. Please try refreshing the page.');
       setUser(null);
     } finally {

--- a/packages/protocol/.env.example
+++ b/packages/protocol/.env.example
@@ -24,6 +24,19 @@ OPENROUTER_API_KEY=your-openrouter-api-key
 # RUN_OPPORTUNITY_EVAL_IN_PARALLEL=false
 
 ########################################
+# MCP runtime limits
+########################################
+
+# MCP_MAX_REQUEST_BYTES=1000000
+# MCP_TOOL_MAX_OUTPUT_BYTES=1000000
+# MCP_TOOL_TIMEOUT_FAST_MS=10000
+# MCP_TOOL_TIMEOUT_BOUNDED_SLOW_MS=45000
+# MCP_TOOL_TIMEOUT_ASYNC_CANDIDATE_MS=50000
+# Per-tool examples:
+# MCP_TOOL_TIMEOUT_DISCOVER_OPPORTUNITIES_MS=50000
+# MCP_TOOL_MAX_OUTPUT_READ_DOCS_BYTES=1000000
+
+########################################
 # Redis
 ########################################
 

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -117,7 +117,19 @@ On every tool call the server:
 1. Extracts the HTTP request from the MCP `ServerContext`.
 2. Calls `authResolver.resolveIdentity(req)` to get `{ userId, agentId }`.
 3. Gates access: MCP callers without a resolved `agentId` are blocked from every tool except `register_agent`, `read_docs`, and `scrape_url` until they register.
-4. Builds per-request scoped databases via `scopedDepsFactory` and invokes the tool handler.
+4. Builds per-request scoped databases via `scopedDepsFactory` and invokes the tool handler through the shared runtime.
+
+### Runtime controls
+
+MCP tools are bounded by `ToolInvocationRuntime`:
+
+| Class | Default | Class override |
+|---|---:|---|
+| `fast` | 10 s | `MCP_TOOL_TIMEOUT_FAST_MS` |
+| `bounded_slow` | 45 s | `MCP_TOOL_TIMEOUT_BOUNDED_SLOW_MS` |
+| `async_candidate` | 50 s | `MCP_TOOL_TIMEOUT_ASYNC_CANDIDATE_MS` |
+
+Per-tool timeout overrides use `MCP_TOOL_TIMEOUT_<TOOL_NAME>_MS`, such as `MCP_TOOL_TIMEOUT_DISCOVER_OPPORTUNITIES_MS`. Tool outputs are capped by `MCP_TOOL_MAX_OUTPUT_BYTES` (default `1000000`) or `MCP_TOOL_MAX_OUTPUT_<TOOL_NAME>_BYTES`; inbound MCP request bodies are capped by the backend with `MCP_MAX_REQUEST_BYTES` (default `1000000`). Runtime failures return JSON text envelopes with stable `code` values: `TOOL_TIMEOUT`, `TOOL_CANCELLED`, or `TOOL_OUTPUT_TOO_LARGE`.
 
 ### `MCP_INSTRUCTIONS`
 

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -131,6 +131,8 @@ MCP tools are bounded by `ToolInvocationRuntime`:
 
 Per-tool timeout overrides use `MCP_TOOL_TIMEOUT_<TOOL_NAME>_MS`, such as `MCP_TOOL_TIMEOUT_DISCOVER_OPPORTUNITIES_MS`. Tool outputs are capped by `MCP_TOOL_MAX_OUTPUT_BYTES` (default `1000000`) or `MCP_TOOL_MAX_OUTPUT_<TOOL_NAME>_BYTES`; inbound MCP request bodies are capped by the backend with `MCP_MAX_REQUEST_BYTES` (default `1000000`). Runtime failures return JSON text envelopes with stable `code` values: `TOOL_TIMEOUT`, `TOOL_CANCELLED`, or `TOOL_OUTPUT_TOO_LARGE`.
 
+For MCP callers, `discover_opportunities` is async: it returns a `discoveryRunId` immediately, and clients poll `get_discovery_run` or request cancellation with `cancel_discovery_run`. Non-MCP chat/web paths stay synchronous.
+
 ### `MCP_INSTRUCTIONS`
 
 The instructions string is the single canonical behavioral contract for every runtime that connects to Index Network — voice, entity model, discovery-first rule, output rules, and the **Negotiation turn mode** block that tells a silent subagent how to handle a live negotiation turn when its session key is prefixed `index:negotiation:`. Plugin skills and bootstrap scripts do **not** redefine this guidance; they defer to whatever ships in `MCP_INSTRUCTIONS`.

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "1.24.1",
+  "version": "1.24.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "1.24.2",
+  "version": "1.24.3",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "1.24.3",
+  "version": "1.25.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/chat/chat.agent.ts
+++ b/packages/protocol/src/chat/chat.agent.ts
@@ -19,6 +19,7 @@ import {
 } from "./chat.prompt.modules.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { createModel } from "../shared/agent/model.config.js";
+import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 import { sanitizeForDebugMeta } from "../shared/observability/debug-meta.sanitizer.js";
 import type { DebugMetaToolCall, DebugMetaLlm, DebugMetaOrchestratorNegotiations, DebugMetaDiscoveryQuestions } from "./chat-streaming.types.js";
 import type { Question, QuestionStrategy } from "../shared/schemas/question.schema.js";
@@ -304,7 +305,7 @@ export class ChatAgent {
     });
 
     // Invoke model
-    const response = await this.model.invoke(fullMessages);
+    const response = await invokeWithAbortSignal(this.model, fullMessages);
     logger.debug("Chat model response", {
       content:
         typeof response.content === "string"
@@ -785,7 +786,7 @@ export class ChatAgent {
       ),
     ];
 
-    const forcedResponse = await this.model.invoke(forceResponseMessages);
+    const forcedResponse = await invokeWithAbortSignal(this.model, forceResponseMessages);
     const responseText = extractTextContent(
       forcedResponse.content as string | Array<Record<string, unknown>>,
     );

--- a/packages/protocol/src/chat/chat.suggester.ts
+++ b/packages/protocol/src/chat/chat.suggester.ts
@@ -5,6 +5,7 @@ import type { ChatSuggestion } from "./chat-streaming.types.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { Timed } from "../shared/observability/performance.js";
 import { createModel } from "../shared/agent/model.config.js";
+import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("SuggestionGenerator");
 
@@ -72,7 +73,7 @@ export class SuggestionGenerator {
       : `Conversation:\n\n${excerpt}\n\nGenerate 3-5 follow-up suggestions.`;
 
     try {
-      const result = await this.model.invoke([
+      const result = await invokeWithAbortSignal(this.model, [
         new SystemMessage(SYSTEM_PROMPT),
         new HumanMessage(userContent),
       ]);

--- a/packages/protocol/src/chat/chat.summarizer.ts
+++ b/packages/protocol/src/chat/chat.summarizer.ts
@@ -15,6 +15,7 @@ import {
   type ChatContextDigest,
 } from "../shared/schemas/chat-context.schema.js";
 import { createModel } from "../shared/agent/model.config.js";
+import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { Timed } from "../shared/observability/performance.js";
 
@@ -87,7 +88,7 @@ export class ChatSummarizer {
     ].join("\n");
 
     try {
-      const response = await this.model.invoke([
+      const response = await invokeWithAbortSignal(this.model, [
         new SystemMessage(SYSTEM_PROMPT),
         new HumanMessage(user),
       ]);

--- a/packages/protocol/src/chat/chat.title.generator.ts
+++ b/packages/protocol/src/chat/chat.title.generator.ts
@@ -5,6 +5,7 @@ import { log } from "../shared/observability/log.js";
 import { Timed } from "../shared/observability/performance.js";
 
 import { createModel } from "../shared/agent/model.config.js";
+import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = log.lib.from("ChatTitleGenerator");
 
@@ -46,7 +47,7 @@ export class ChatTitleGenerator {
       .join("\n");
 
     try {
-      const response = await this.model.invoke([
+      const response = await invokeWithAbortSignal(this.model, [
         new SystemMessage(SYSTEM_PROMPT),
         new HumanMessage(`Conversation:\n${excerpt}\n\nSuggested title:`),
       ]);

--- a/packages/protocol/src/context/context.generator.ts
+++ b/packages/protocol/src/context/context.generator.ts
@@ -10,6 +10,7 @@
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 
 import { createModel } from "../shared/agent/model.config.js";
+import { getAbortSignalConfig, invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 import type { EmbeddingGenerator } from "../shared/interfaces/embedder.interface.js";
 
 /** Input for cold-start context generation from a full set of premises. */
@@ -58,7 +59,7 @@ export class UserContextGenerator {
     const premiseBlock = input.premises.map(p => `- ${p.text}`).join('\n');
     const networkContext = this.formatNetworkContext(input.networkPrompt, input.networkTitle);
 
-    const response = await this.model.invoke([
+    const response = await invokeWithAbortSignal(this.model, [
       new SystemMessage(COLD_START_SYSTEM_PROMPT),
       new HumanMessage(
         `${networkContext}\n\nPremises:\n${premiseBlock}\n\nWrite a focused context paragraph for this person in this network.`,
@@ -83,7 +84,7 @@ export class UserContextGenerator {
     const networkContext = this.formatNetworkContext(input.networkPrompt, input.networkTitle);
     const changeDescription = this.describeChange(input);
 
-    const response = await this.model.invoke([
+    const response = await invokeWithAbortSignal(this.model, [
       new SystemMessage(INCREMENTAL_SYSTEM_PROMPT),
       new HumanMessage(
         `${networkContext}\n\nCurrent context:\n${input.currentContext}\n\nChange:\n${changeDescription}\n\nWrite the updated context paragraph.`,
@@ -121,7 +122,7 @@ export class UserContextGenerator {
 
   /** Generate embedding from text, normalizing the return type. */
   private async embed(text: string): Promise<number[]> {
-    const result = await this.embeddingGenerator.generate(text);
+    const result = await this.embeddingGenerator.generate(text, undefined, getAbortSignalConfig());
     return Array.isArray(result[0]) ? result[0] as number[] : result as number[];
   }
 }

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -14,6 +14,13 @@ export type {
   ToolRegistry,
 } from "./shared/agent/tool.helpers.js";
 export { ChatContextAccessError, resolveChatContext } from "./shared/agent/tool.helpers.js";
+export {
+  ToolRuntimeError,
+  getToolTimeoutPolicy,
+  invokeToolRuntime,
+  toolRuntimeErrorToResult,
+} from "./shared/agent/tool.runtime.js";
+export type { ToolRuntimeErrorCode, ToolTimeoutClass, ToolTimeoutPolicy } from "./shared/agent/tool.runtime.js";
 
 // ─── Interfaces (implement these to wire up your infrastructure) ───────────────
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -11,9 +11,11 @@ export type {
   ProtocolDeps,
   DefineTool,
   RawToolDefinition,
+  CompiledGraph,
   ToolRegistry,
 } from "./shared/agent/tool.helpers.js";
 export { ChatContextAccessError, resolveChatContext } from "./shared/agent/tool.helpers.js";
+export { requestContext } from "./shared/observability/request-context.js";
 export {
   ToolRuntimeError,
   getToolTimeoutPolicy,
@@ -49,6 +51,7 @@ export type * from "./shared/interfaces/scraper.interface.js";
 export type * from "./shared/interfaces/storage.interface.js";
 export type * from "./shared/interfaces/delivery-ledger.interface.js";
 export type * from "./shared/interfaces/connect-link.interface.js";
+export type * from "./shared/interfaces/discovery-run.interface.js";
 export type * from "./shared/interfaces/negotiation-events.interface.js";
 export type { AgentDispatcher, AgentDispatchResult, NegotiationTurnPayload } from "./shared/interfaces/agent-dispatcher.interface.js";
 export type {
@@ -156,6 +159,7 @@ export type {
   OpportunityEvaluatorOptionsConstructor,
 } from "./opportunity/opportunity.evaluator.js";
 export { OpportunityPresenter, gatherPresenterContext } from "./opportunity/opportunity.presenter.js";
+export { createOpportunityTools } from "./opportunity/opportunity.tools.js";
 export type { PresenterDatabase } from "./opportunity/opportunity.presenter.js";
 export { QuestionGenerator } from "./opportunity/question.generator.js";
 export type {

--- a/packages/protocol/src/intent/intent.clarifier.ts
+++ b/packages/protocol/src/intent/intent.clarifier.ts
@@ -6,6 +6,7 @@ import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { Timed } from "../shared/observability/performance.js";
 
 import { createModel } from "../shared/agent/model.config.js";
+import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("IntentClarifier");
 
@@ -106,7 +107,7 @@ ${profileContext || "none"}
 ${activeIntentsContext || "none"}
 `;
 
-      const result = await this.model.invoke([
+      const result = await invokeWithAbortSignal(this.model, [
         new SystemMessage(systemPrompt),
         new HumanMessage(prompt),
       ]);
@@ -152,7 +153,7 @@ ${profileContext || "none"}
 # Active Intents
 ${activeIntentsContext || "none"}
 `;
-      const output = await this.suggestionModel.invoke([
+      const output = await invokeWithAbortSignal(this.suggestionModel, [
         new SystemMessage(suggestionPrompt),
         new HumanMessage(prompt),
       ]);
@@ -181,7 +182,7 @@ ${profileContext || "none"}
 # Active Intents
 ${activeIntentsContext || "none"}
 `;
-      const output = await this.clarificationDraftModel.invoke([
+      const output = await invokeWithAbortSignal(this.clarificationDraftModel, [
         new SystemMessage(clarificationDraftPrompt),
         new HumanMessage(prompt),
       ]);

--- a/packages/protocol/src/intent/intent.graph.ts
+++ b/packages/protocol/src/intent/intent.graph.ts
@@ -4,6 +4,7 @@ import { ExplicitIntentInferrer } from "./intent.inferrer.js";
 import { SemanticVerifier } from "./intent.verifier.js";
 import { IntentReconciler } from "./intent.reconciler.js";
 import { IntentGraphDatabase } from "../shared/interfaces/database.interface.js";
+import { getAbortSignalConfig } from "../shared/agent/model-signal.js";
 import type { EmbeddingGenerator } from "../shared/interfaces/embedder.interface.js";
 import type { IntentGraphQueue } from "../shared/interfaces/queue.interface.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
@@ -526,7 +527,7 @@ export class IntentGraphFactory {
               let flatEmbedding: number[] | undefined;
               if (this.embedder) {
                 try {
-                  const embedding = await this.embedder.generate(sanitizedPayload);
+                  const embedding = await this.embedder.generate(sanitizedPayload, undefined, getAbortSignalConfig());
                   flatEmbedding = Array.isArray(embedding?.[0])
                     ? (embedding as number[][])[0]
                     : (embedding as number[]);
@@ -606,7 +607,7 @@ export class IntentGraphFactory {
               let flatEmbedding: number[] | undefined;
               if (this.embedder) {
                 try {
-                  const embedding = await this.embedder.generate(sanitizedPayload);
+                  const embedding = await this.embedder.generate(sanitizedPayload, undefined, getAbortSignalConfig());
                   flatEmbedding = Array.isArray(embedding?.[0])
                     ? (embedding as number[][])[0]
                     : (embedding as number[]);

--- a/packages/protocol/src/intent/intent.indexer.ts
+++ b/packages/protocol/src/intent/intent.indexer.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { log } from "../shared/observability/log.js";
 import { Timed } from "../shared/observability/performance.js";
 import { createModel } from "../shared/agent/model.config.js";
+import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 // ──────────────────────────────────────────────────────────────
 // Response schema
@@ -140,7 +141,7 @@ export class IntentIndexer {
     ];
 
     try {
-      const result = await this.model.invoke(messages);
+      const result = await invokeWithAbortSignal(this.model, messages);
       const output = responseFormat.parse(result) as IntentIndexerOutput;
 
       logger.verbose("[IntentIndexer.invoke] Evaluation complete", {

--- a/packages/protocol/src/intent/intent.inferrer.ts
+++ b/packages/protocol/src/intent/intent.inferrer.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { Timed } from "../shared/observability/performance.js";
 import { createModel } from "../shared/agent/model.config.js";
+import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("ExplicitIntentInferrer");
 
@@ -221,7 +222,7 @@ export class ExplicitIntentInferrer {
     ];
 
     try {
-      const result = await this.model.invoke(messages);
+      const result = await invokeWithAbortSignal(this.model, messages);
       const output = responseFormat.parse(result);
 
       logger.verbose(`invoke: found ${output.intents.length} intents`, {

--- a/packages/protocol/src/intent/intent.reconciler.ts
+++ b/packages/protocol/src/intent/intent.reconciler.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { Timed } from "../shared/observability/performance.js";
 import { createModel } from "../shared/agent/model.config.js";
+import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("IntentReconciler");
 
@@ -170,8 +171,8 @@ export class IntentReconciler {
     ];
 
     try {
-      const output = await this.model.invoke(messages);
-      const normalizedActions = output.actions.map((action: z.infer<typeof responseFormat>["actions"][number]) => ({
+      const output = responseFormat.parse(await invokeWithAbortSignal(this.model, messages));
+      const normalizedActions = output.actions.map((action: z.infer<typeof responseFormat>["actions"][number]) => ({ 
         ...action,
         type: normalizeActionType(action.type),
       })) as NormalizedIntentAction[];

--- a/packages/protocol/src/intent/intent.tools.ts
+++ b/packages/protocol/src/intent/intent.tools.ts
@@ -7,6 +7,7 @@ import { requestContext } from "../shared/observability/request-context.js";
 import type { DefineTool, ToolDeps } from "../shared/agent/tool.helpers.js";
 import { success, error, UUID_REGEX } from "../shared/agent/tool.helpers.js";
 import type { UserRecord } from "../shared/interfaces/database.interface.js";
+import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("ChatTools:Intent");
 
@@ -155,7 +156,7 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       const _readIntentGraphStart = Date.now();
       const _readIntentTraceEmitter = requestContext.getStore()?.traceEmitter;
       _readIntentTraceEmitter?.({ type: "graph_start", name: "intent" });
-      const result = await graphs.intent.invoke(graphInput);
+      const result = await invokeWithAbortSignal(graphs.intent, graphInput);
       const _readIntentGraphMs = Date.now() - _readIntentGraphStart;
       _readIntentTraceEmitter?.({ type: "graph_end", name: "intent", durationMs: _readIntentGraphMs });
 
@@ -237,7 +238,7 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       const _profileGraphStart1 = Date.now();
       const _createIntentProfileTraceEmitter = requestContext.getStore()?.traceEmitter;
       _createIntentProfileTraceEmitter?.({ type: "graph_start", name: "profile" });
-      const profileResult = await graphs.profile.invoke({ userId: context.userId, operationMode: 'query' as const });
+      const profileResult = await invokeWithAbortSignal(graphs.profile, { userId: context.userId, operationMode: 'query' as const });
       const _profileGraphMs1 = Date.now() - _profileGraphStart1;
       _createIntentProfileTraceEmitter?.({ type: "graph_end", name: "profile", durationMs: _profileGraphMs1 });
       const latestUser = profileResult.profile ? undefined : typeof userDb.getUser === "function" ? await userDb.getUser() : context.user;
@@ -248,7 +249,7 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       const _intentGraphStart1 = Date.now();
       const _createIntentTraceEmitter = requestContext.getStore()?.traceEmitter;
       _createIntentTraceEmitter?.({ type: "graph_start", name: "intent" });
-      const result = await graphs.intent.invoke({
+      const result = await invokeWithAbortSignal(graphs.intent, {
         userId: context.userId,
         userProfile,
         inputContent: query.description,
@@ -311,7 +312,7 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
           const _createGraphStart = Date.now();
           const _createTraceEmitter = requestContext.getStore()?.traceEmitter;
           _createTraceEmitter?.({ type: "graph_start", name: "intent" });
-          const createResult = await graphs.intent.invoke({
+          const createResult = await invokeWithAbortSignal(graphs.intent, {
             userId: context.userId,
             userProfile,
             inputContent: v.description,
@@ -425,7 +426,7 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       const _profileGraphStart2 = Date.now();
       const _updateIntentProfileTraceEmitter = requestContext.getStore()?.traceEmitter;
       _updateIntentProfileTraceEmitter?.({ type: "graph_start", name: "profile" });
-      const profileResult = await graphs.profile.invoke({ userId: context.userId, operationMode: 'query' as const });
+      const profileResult = await invokeWithAbortSignal(graphs.profile, { userId: context.userId, operationMode: 'query' as const });
       const _profileGraphMs2 = Date.now() - _profileGraphStart2;
       _updateIntentProfileTraceEmitter?.({ type: "graph_end", name: "profile", durationMs: _profileGraphMs2 });
       const latestUser = profileResult.profile ? undefined : typeof userDb.getUser === "function" ? await userDb.getUser() : context.user;
@@ -435,7 +436,7 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       const _intentGraphStart2 = Date.now();
       const _updateIntentTraceEmitter = requestContext.getStore()?.traceEmitter;
       _updateIntentTraceEmitter?.({ type: "graph_start", name: "intent" });
-      const result = await graphs.intent.invoke({
+      const result = await invokeWithAbortSignal(graphs.intent, {
         userId: context.userId,
         userProfile,
         operationMode: 'update' as const,
@@ -500,7 +501,7 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       const _deleteIntentGraphStart = Date.now();
       const _deleteIntentTraceEmitter = requestContext.getStore()?.traceEmitter;
       _deleteIntentTraceEmitter?.({ type: "graph_start", name: "intent" });
-      const result = await graphs.intent.invoke({
+      const result = await invokeWithAbortSignal(graphs.intent, {
         userId: context.userId,
         userProfile: "",
         operationMode: 'delete' as const,
@@ -555,7 +556,7 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       const _createIntentIndexGraphStart = Date.now();
       const _createIntentIndexTraceEmitter = requestContext.getStore()?.traceEmitter;
       _createIntentIndexTraceEmitter?.({ type: "graph_start", name: "intent_network" });
-      const result = await graphs.intentIndex.invoke({
+      const result = await invokeWithAbortSignal(graphs.intentIndex, {
         userId: context.userId,
         networkId,
         intentId,
@@ -637,7 +638,7 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       const _readIntentIndexGraphStart = Date.now();
       const _readIntentIndexTraceEmitter = requestContext.getStore()?.traceEmitter;
       _readIntentIndexTraceEmitter?.({ type: "graph_start", name: "intent_network" });
-      const result = await graphs.intentIndex.invoke({
+      const result = await invokeWithAbortSignal(graphs.intentIndex, {
         userId: context.userId,
         networkId,
         intentId,
@@ -688,7 +689,7 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       const _deleteIntentIndexGraphStart = Date.now();
       const _deleteIntentIndexTraceEmitter = requestContext.getStore()?.traceEmitter;
       _deleteIntentIndexTraceEmitter?.({ type: "graph_start", name: "intent_network" });
-      const result = await graphs.intentIndex.invoke({
+      const result = await invokeWithAbortSignal(graphs.intentIndex, {
         userId: context.userId,
         networkId,
         intentId,

--- a/packages/protocol/src/intent/intent.tools.ts
+++ b/packages/protocol/src/intent/intent.tools.ts
@@ -6,6 +6,7 @@ import { requestContext } from "../shared/observability/request-context.js";
 
 import type { DefineTool, ToolDeps } from "../shared/agent/tool.helpers.js";
 import { success, error, UUID_REGEX } from "../shared/agent/tool.helpers.js";
+import type { UserRecord } from "../shared/interfaces/database.interface.js";
 
 const logger = protocolLogger("ChatTools:Intent");
 
@@ -28,6 +29,22 @@ async function ensureScopedMembership(
     return `This chat is scoped to ${context.indexName ?? 'this index'}. You are no longer a member of this community.`;
   }
   return null;
+}
+
+function buildApprovedProfileFallback(user: UserRecord | null | undefined): string {
+  const bio = user?.intro?.trim();
+  if (!user || !bio) return "";
+
+  return JSON.stringify({
+    userId: user.id,
+    identity: {
+      name: user.name ?? "",
+      bio,
+      location: user.location?.trim() ?? "",
+    },
+    narrative: { context: bio },
+    attributes: { skills: [], interests: [] },
+  });
 }
 
 export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
@@ -223,7 +240,9 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       const profileResult = await graphs.profile.invoke({ userId: context.userId, operationMode: 'query' as const });
       const _profileGraphMs1 = Date.now() - _profileGraphStart1;
       _createIntentProfileTraceEmitter?.({ type: "graph_end", name: "profile", durationMs: _profileGraphMs1 });
-      const userProfile = profileResult.profile ? JSON.stringify(profileResult.profile) : "";
+      const latestUser = profileResult.profile ? undefined : typeof userDb.getUser === "function" ? await userDb.getUser() : context.user;
+      const approvedProfileFallback = profileResult.profile ? "" : buildApprovedProfileFallback(latestUser);
+      const userProfile = profileResult.profile ? JSON.stringify(profileResult.profile) : approvedProfileFallback;
 
       // Run inference + verification only (propose mode — no DB persistence)
       const _intentGraphStart1 = Date.now();
@@ -409,7 +428,9 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       const profileResult = await graphs.profile.invoke({ userId: context.userId, operationMode: 'query' as const });
       const _profileGraphMs2 = Date.now() - _profileGraphStart2;
       _updateIntentProfileTraceEmitter?.({ type: "graph_end", name: "profile", durationMs: _profileGraphMs2 });
-      const userProfile = profileResult.profile ? JSON.stringify(profileResult.profile) : "";
+      const latestUser = profileResult.profile ? undefined : typeof userDb.getUser === "function" ? await userDb.getUser() : context.user;
+      const approvedProfileFallback = profileResult.profile ? "" : buildApprovedProfileFallback(latestUser);
+      const userProfile = profileResult.profile ? JSON.stringify(profileResult.profile) : approvedProfileFallback;
 
       const _intentGraphStart2 = Date.now();
       const _updateIntentTraceEmitter = requestContext.getStore()?.traceEmitter;

--- a/packages/protocol/src/intent/intent.verifier.ts
+++ b/packages/protocol/src/intent/intent.verifier.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { Timed } from "../shared/observability/performance.js";
 import { createModel } from "../shared/agent/model.config.js";
+import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("SemanticVerifier");
 
@@ -217,7 +218,7 @@ export class SemanticVerifier {
     ];
 
     try {
-      const result = await this.model.invoke(messages);
+      const result = await invokeWithAbortSignal(this.model, messages);
       const output = responseFormat.parse(result);
 
       logger.verbose(`[SemanticVerifier.invoke] Verdict: ${output.classification} Entropy: ${output.semantic_entropy}`);

--- a/packages/protocol/src/intent/tests/update-intent.spec.ts
+++ b/packages/protocol/src/intent/tests/update-intent.spec.ts
@@ -36,6 +36,51 @@ function captureTools(deps: ToolDeps): CapturedTool[] {
   return toolDefs;
 }
 
+describe("create_intent", () => {
+  test("falls back to approved user intro when structured profile is still pending", async () => {
+    const capturedProfiles: string[] = [];
+    const tools = captureTools({
+      userDb: {
+        getUser: async () => ({
+          id: "alice",
+          name: "Alice",
+          email: "alice@example.com",
+          intro: "I build agent tools.",
+          location: "Healdsburg",
+          socials: [],
+        }),
+      },
+      systemDb: {},
+      graphs: {
+        profile: { invoke: async () => ({ profile: null, agentTimings: [] }) },
+        intent: {
+          invoke: async (input: { userProfile?: string; operationMode?: string }) => {
+            capturedProfiles.push(input.userProfile ?? "");
+            if (input.operationMode === "propose") {
+              return {
+                verifiedIntents: [{ description: "Find agent builders", score: 0.91, verification: { classification: "request" } }],
+                agentTimings: [],
+                trace: [],
+              };
+            }
+            return { executionResults: [{ success: true }], agentTimings: [] };
+          },
+        },
+      },
+    } as unknown as ToolDeps);
+    const tool = tools.find((t) => t.name === "create_intent")!;
+
+    const result = JSON.parse(await tool.handler({
+      context: makeContext("alice"),
+      query: { description: "Find agent builders", autoApprove: true },
+    }));
+
+    expect(result.success).toBe(true);
+    expect(capturedProfiles[0]).toContain("I build agent tools.");
+    expect(capturedProfiles[0]).toContain("Healdsburg");
+  });
+});
+
 describe("update_intent", () => {
   test("accepts description and rejects legacy newDescription", () => {
     const tools = captureTools({

--- a/packages/protocol/src/mcp/mcp.server.ts
+++ b/packages/protocol/src/mcp/mcp.server.ts
@@ -16,6 +16,8 @@ import type { Question } from '../shared/schemas/question.schema.js';
 import { QuestionSchema } from '../shared/schemas/question.schema.js';
 import { dispatchElicitations } from './elicitation.dispatcher.js';
 import { createToolRegistry } from '../shared/agent/tool.registry.js';
+import { invokeToolRuntime, toolRuntimeErrorToResult } from '../shared/agent/tool.runtime.js';
+import type { TraceEmitter } from '../shared/observability/request-context.js';
 import { protocolLogger } from '../shared/observability/protocol.logger.js';
 
 const logger = protocolLogger('McpServer');
@@ -306,6 +308,35 @@ export function buildMcpOnboardingMessage(ctx: ResolvedToolContext): string {
  * @param scopedDepsFactory - Factory for creating per-request scoped databases
  * @returns A configured McpServer ready to be connected to a transport
  */
+function createMcpTraceEmitter(toolName: string, ctx: ServerContext): TraceEmitter | undefined {
+  const token = ctx.mcpReq._meta?.progressToken;
+  if (typeof token !== 'string' && typeof token !== 'number') return undefined;
+
+  let progress = 0;
+  return (event) => {
+    progress += 1;
+    const message = (() => {
+      if (event.type === 'graph_start') return `${toolName}: ${event.name} started`;
+      if (event.type === 'graph_end') return `${toolName}: ${event.name} finished${event.durationMs != null ? ` in ${event.durationMs}ms` : ''}`;
+      if (event.type === 'agent_start') return `${toolName}: ${event.name} agent started`;
+      if (event.type === 'agent_end') return `${toolName}: ${event.name} agent finished${event.durationMs != null ? ` in ${event.durationMs}ms` : ''}`;
+      if (event.type === 'opportunity_draft_ready') return `${toolName}: opportunity draft ready`;
+      return `${toolName}: progress`;
+    })();
+
+    const notification: Parameters<ServerContext['mcpReq']['notify']>[0] = {
+      method: 'notifications/progress',
+      params: { progressToken: token, progress, message },
+    };
+    void ctx.mcpReq.notify(notification).catch((err) => {
+      logger.debug('Failed to send MCP progress notification', {
+        toolName,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+  };
+}
+
 export const MCP_INSTRUCTIONS = `
 Index Network is a private, intent-driven discovery protocol. You help users find the right people and help the right people find them, via Index Network MCP tools.
 
@@ -491,8 +522,16 @@ export function createMcpServer(
           }
           const validatedArgs = parseResult.data;
 
-          // Execute the tool handler
-          const result = await requestTool.handler({ context, query: validatedArgs });
+          // Execute the tool handler through the shared runtime so MCP calls have
+          // consistent timeout, cancellation, progress, and requestContext plumbing.
+          const result = await invokeToolRuntime({
+            toolName,
+            tool: requestTool,
+            context,
+            query: validatedArgs,
+            signal: ctx.mcpReq.signal,
+            traceEmitter: createMcpTraceEmitter(toolName, ctx),
+          });
 
           const { text: sanitizedText, isError: toolIsError } = sanitizeMcpResult(result);
 
@@ -542,8 +581,9 @@ export function createMcpServer(
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
           logger.error(`MCP tool "${toolName}" failed`, { error: message });
+          const runtimeResult = toolRuntimeErrorToResult(err);
           return {
-            content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+            content: [{ type: 'text' as const, text: runtimeResult ?? JSON.stringify({ error: message }) }],
             isError: true,
           };
         }

--- a/packages/protocol/src/negotiation/insight.generator.ts
+++ b/packages/protocol/src/negotiation/insight.generator.ts
@@ -13,6 +13,7 @@ import { log } from "../shared/observability/log.js";
 import { Timed } from "../shared/observability/performance.js";
 
 import { createModel } from "../shared/agent/model.config.js";
+import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = log.lib.from("NegotiationInsightsGenerator");
 
@@ -83,7 +84,7 @@ export class NegotiationInsightsGenerator {
     const userMessage = `Negotiation digest:\n${lines.join("\n")}\n\nWrite the insight summary:`;
 
     try {
-      const response = await this.model.invoke([
+      const response = await invokeWithAbortSignal(this.model, [
         new SystemMessage(SYSTEM_PROMPT),
         new HumanMessage(userMessage),
       ]);

--- a/packages/protocol/src/negotiation/negotiation.agent.ts
+++ b/packages/protocol/src/negotiation/negotiation.agent.ts
@@ -1,4 +1,5 @@
 import { createModel } from "../shared/agent/model.config.js";
+import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 import {
   SystemNegotiationTurnSchema,
   FinalNegotiationTurnSchema,
@@ -186,12 +187,13 @@ Why this match was suggested: ${input.seedAssessment.reasoning}${input.isContinu
 ${discoveryQueryReminder}
 ${input.history.length === 0 && !input.isContinuation ? "This is the opening turn. Propose the connection case." : "Evaluate the latest arguments and respond."}`;
 
-    const result = await model.invoke(
+    const result = await invokeWithAbortSignal(
+      model,
       [
         { role: "system", content: systemPrompt },
         { role: "user", content: userMessage },
       ],
-      { signal: AbortSignal.timeout(this.turnTimeoutMs) },
+      AbortSignal.timeout(this.turnTimeoutMs),
     );
 
     return result as NegotiationTurn;

--- a/packages/protocol/src/negotiation/negotiation.graph.ts
+++ b/packages/protocol/src/negotiation/negotiation.graph.ts
@@ -1,5 +1,6 @@
 import { StateGraph } from "@langchain/langgraph";
 
+import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 import { requestContext, type TraceEmitter } from "../shared/observability/request-context.js";
 import type { NegotiationGraphDatabase } from "../shared/interfaces/database.interface.js";
 import type { NegotiationTimeoutQueue } from "../shared/interfaces/negotiation-events.interface.js";
@@ -546,7 +547,7 @@ export async function negotiateCandidates(
           ? { networkId: candidate.networkId, prompt: indexContextOverrides?.get(candidate.networkId) ?? '' }
           : indexContext;
 
-        const result = await negotiationGraph.invoke({
+        const result = await invokeWithAbortSignal(negotiationGraph, {
           sourceUser,
           candidateUser: candidate.candidateUser,
           indexContext: candidateIndexContext,

--- a/packages/protocol/src/negotiation/negotiation.summarizer.ts
+++ b/packages/protocol/src/negotiation/negotiation.summarizer.ts
@@ -13,6 +13,7 @@ import type { ChatOpenAI } from "@langchain/openai";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 
 import { createModel } from "../shared/agent/model.config.js";
+import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import {
   DiscoveryNegotiationDigestSchema,
@@ -71,9 +72,10 @@ export class NegotiationSummarizer {
     const user = buildUserPrompt(negotiation);
     let raw: unknown;
     try {
-      raw = await this.model.invoke(
+      raw = await invokeWithAbortSignal(
+        this.model,
         [new SystemMessage(SYSTEM_PROMPT), new HumanMessage(user)],
-        options?.signal ? { signal: options.signal } : undefined,
+        options?.signal,
       );
     } catch (err) {
       const aborted = options?.signal?.aborted ?? false;

--- a/packages/protocol/src/opportunity/feed/feed.categorizer.ts
+++ b/packages/protocol/src/opportunity/feed/feed.categorizer.ts
@@ -15,6 +15,7 @@ import { getIconNamesForPrompt, DEFAULT_HOME_SECTION_ICON } from '../../shared/u
 import { protocolLogger } from '../../shared/observability/protocol.logger.js';
 import { Timed } from "../../shared/observability/performance.js";
 import { createModel } from "../../shared/agent/model.config.js";
+import { invokeWithAbortSignal } from "../../shared/agent/model-signal.js";
 
 const logger = protocolLogger('HomeCategorizer');
 
@@ -151,7 +152,7 @@ Rules:
     const userContent = `Cards to categorize:\n${cardSummaries}\n\nOutput sections with id, title (CTA-style), subtitle (optional), iconName, and itemIndices.`;
 
     try {
-      const result = await this.model.invoke([
+      const result = await invokeWithAbortSignal(this.model, [
         new SystemMessage(systemPrompt),
         new HumanMessage(userContent),
       ]);

--- a/packages/protocol/src/opportunity/opportunity.discover.ts
+++ b/packages/protocol/src/opportunity/opportunity.discover.ts
@@ -35,6 +35,7 @@ import type { Question, QuestionStrategy } from "../shared/schemas/question.sche
 import { traceAgent, tracePhase } from "../shared/observability/trace.js";
 import { requestContext } from "../shared/observability/request-context.js";
 import { buildDiscoveryQuestionInput } from "./discovery-question.helper.js";
+import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("OpportunityDiscover");
 
@@ -699,7 +700,7 @@ export async function runDiscoverFromQuery(
       limit,
     },
     async () => {
-      const result = await opportunityGraph.invoke({
+      const result = await invokeWithAbortSignal(opportunityGraph, {
         userId,
         searchQuery: queryOrEmpty || undefined,
         // A single index resolves to the strict networkId override (membership-
@@ -1242,7 +1243,7 @@ export async function continueDiscovery(input: {
 
   const debugSteps: DiscoverDebugStep[] = [];
 
-  const result = await opportunityGraph.invoke({
+  const result = await invokeWithAbortSignal(opportunityGraph, {
     userId,
     searchQuery: cached.query || undefined,
     candidates: cached.candidates,

--- a/packages/protocol/src/opportunity/opportunity.enricher.ts
+++ b/packages/protocol/src/opportunity/opportunity.enricher.ts
@@ -12,6 +12,7 @@ import type {
   OpportunitySignal,
   OpportunityStatus,
 } from '../shared/interfaces/database.interface.js';
+import { getAbortSignalConfig } from '../shared/agent/model-signal.js';
 import type { Embedder } from '../shared/interfaces/embedder.interface.js';
 import type { Id } from '../shared/interfaces/database.interface.js';
 import { protocolLogger } from '../shared/observability/protocol.logger.js';
@@ -272,7 +273,7 @@ export async function enrichOrCreate(
           newReasoning,
           ...embeddable.map((o) => (o.interpretation?.reasoning ?? '').trim()),
         ];
-        const vectors = (await embedder.generate(textsToEmbed)) as number[][];
+        const vectors = (await embedder.generate(textsToEmbed, undefined, getAbortSignalConfig())) as number[][];
         const newVec = vectors[0];
         if (newVec?.length) {
           for (let i = 0; i < embeddable.length; i++) {

--- a/packages/protocol/src/opportunity/opportunity.evaluator.ts
+++ b/packages/protocol/src/opportunity/opportunity.evaluator.ts
@@ -8,6 +8,7 @@ import type { OpportunityStatus } from "../shared/interfaces/database.interface.
 import { Timed } from "../shared/observability/performance.js";
 import { stripUuids } from "./opportunity.presentation.js";
 import { createModel } from "../shared/agent/model.config.js";
+import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("OpportunityEvaluator");
 
@@ -359,7 +360,7 @@ export class OpportunityEvaluator {
         new HumanMessage(`${sourceContext}\n${existingContextPart}\nCANDIDATE PROFILE:\n${candidateContext}`)
       ];
 
-      const result = await this.model.invoke(messages);
+      const result = await invokeWithAbortSignal(this.model, messages);
       const output = responseFormat.parse(result);
 
       const mappedOpportunities = output.opportunities.map((op: Opportunity) => ({
@@ -485,7 +486,7 @@ CRITICAL SCORING RULES FOR DISCOVERY REQUESTS:
     ];
     let parsedTotal = 0;
     try {
-      const result = await this.entityBundleModel.invoke(messages);
+      const result = await invokeWithAbortSignal(this.entityBundleModel, messages);
       const parsed = entityBundleResponseFormat.parse(result);
       for (const op of parsed.opportunities) {
         op.reasoning = stripUuids(op.reasoning);

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -14,6 +14,7 @@ import type { Opportunity, OpportunityStatus } from "../shared/interfaces/databa
 import type { ConnectLinkKind } from "../shared/interfaces/connect-link.interface.js";
 import { selectByComposition, deduplicateByPerson } from "./opportunity.utils.js";
 import { mergePendingQuestions } from "./opportunity.pending-questions.js";
+import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("ChatTools:Opportunity");
 
@@ -677,7 +678,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         const _introGraphStart = Date.now();
         const _introTraceEmitter = requestContext.getStore()?.traceEmitter;
         _introTraceEmitter?.({ type: "graph_start", name: "opportunity" });
-        const result = await graphs.opportunity.invoke({
+        const result = await invokeWithAbortSignal(graphs.opportunity, {
           operationMode: "create_introduction",
           userId: context.userId,
           networkId: primaryNetworkId,
@@ -830,7 +831,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         const _scopeGraphStart = Date.now();
         const _scopeIndexMembershipTraceEmitter = requestContext.getStore()?.traceEmitter;
         _scopeIndexMembershipTraceEmitter?.({ type: "graph_start", name: "network_membership" });
-        const memberResult = await graphs.networkMembership.invoke({
+        const memberResult = await invokeWithAbortSignal(graphs.networkMembership, {
           userId: context.userId,
           networkId: effectiveIndexId,
           operationMode: "read" as const,
@@ -853,7 +854,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         const _scopeGraphStart = Date.now();
         const _scopeIndexTraceEmitter = requestContext.getStore()?.traceEmitter;
         _scopeIndexTraceEmitter?.({ type: "graph_start", name: "index" });
-        const indexResult = await graphs.index.invoke({
+        const indexResult = await invokeWithAbortSignal(graphs.index, {
           userId: context.userId,
           operationMode: "read" as const,
           showAll: true,
@@ -1553,7 +1554,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
       const _updateGraphStart = Date.now();
       const _updateTraceEmitter = requestContext.getStore()?.traceEmitter;
       _updateTraceEmitter?.({ type: "graph_start", name: "opportunity" });
-      const result = await graphs.opportunity.invoke({
+      const result = await invokeWithAbortSignal(graphs.opportunity, {
         userId: context.userId,
         operationMode: isSend ? ("send" as const) : ("update" as const),
         opportunityId: query.opportunityId,

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -11,6 +11,7 @@ import { OpportunityPresenter } from "./opportunity.presenter.js";
 import type { EvaluatorEntity } from "./opportunity.evaluator.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import type { Opportunity, OpportunityStatus } from "../shared/interfaces/database.interface.js";
+import type { DiscoveryRunInput } from "../shared/interfaces/discovery-run.interface.js";
 import type { ConnectLinkKind } from "../shared/interfaces/connect-link.interface.js";
 import { selectByComposition, deduplicateByPerson } from "./opportunity.utils.js";
 import { mergePendingQuestions } from "./opportunity.pending-questions.js";
@@ -384,7 +385,7 @@ export function buildOpportunityPresentation(
 }
 
 export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
-  const { database, userDb, systemDb, graphs, embedder, cache } = deps;
+  const { database, userDb, systemDb, graphs, cache } = deps;
 
   const discoverOpportunities = defineTool({
     name: "discover_opportunities",
@@ -401,7 +402,8 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
       "3. **Direct connection**: pass `targetUserId` + `searchQuery`. Creates an opportunity between the current user and one specific person.\n" +
       "4. **Introducer discovery**: pass `introTargetUserId` (find matches FOR that person; current user becomes the introducer). " +
       "Use when user asks 'who should I introduce to [person]?'\n\n" +
-      "**Returns:** Opportunity code blocks (render as interactive cards) with opportunityId, match reasoning, confidence score, and status. " +
+      "**Returns:** In regular chat, opportunity code blocks (render as interactive cards) with opportunityId, match reasoning, confidence score, and status. " +
+      "In MCP contexts, starts an async discovery run and returns `discoveryRunId`; poll get_discovery_run until status is `succeeded`, then present its `result`. " +
       "All results start as drafts. Supports pagination via `continueFrom` for large result sets.\n\n" +
       "**Next steps:** Use update_opportunity(opportunityId, status='pending') to send a draft to the other party.\n\n" +
       "**Discovery-first rule.** For open-ended connection-seeking requests (\"find me a mentor\", " +
@@ -519,6 +521,40 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
       // implicit branch unreachable.
       const explicitIndexId = query.networkId?.trim() || undefined;
       const effectiveIndexId = explicitIndexId;
+      if (effectiveIndexId && !UUID_REGEX.test(effectiveIndexId)) {
+        return error("Invalid network ID format.");
+      }
+
+      if (context.isMcp && deps.discoveryRuns && deps.discoveryRunQueue) {
+        const run = await deps.discoveryRuns.create({
+          userId: context.userId,
+          agentId: context.agentId ?? null,
+          input: query as DiscoveryRunInput,
+          context: {
+            userId: context.userId,
+            userName: context.userName,
+            userEmail: context.userEmail,
+            ...(context.networkId ? { networkId: context.networkId } : {}),
+            ...(context.indexName ? { indexName: context.indexName } : {}),
+            indexScope: context.indexScope,
+            ...(context.sessionId ? { sessionId: context.sessionId } : {}),
+            ...(context.agentId ? { agentId: context.agentId } : {}),
+            ...(context.clientSurface ? { clientSurface: context.clientSurface } : {}),
+          },
+        });
+        try {
+          await deps.discoveryRunQueue.enqueue(run.id);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          await deps.discoveryRuns.markFailed(run.id, message);
+          return error(`Failed to enqueue discovery run: ${message}`);
+        }
+        return success({
+          status: "queued" as const,
+          discoveryRunId: run.id,
+          message: `Discovery started. Call get_discovery_run with discoveryRunId="${run.id}" until it succeeds, fails, or is cancelled.`,
+        });
+      }
 
       // ── Continuation mode ──
       // `continueFrom` is a pagination token for resuming a prior discovery's
@@ -1217,6 +1253,75 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
     },
   });
 
+  const getDiscoveryRun = defineTool({
+    name: "get_discovery_run",
+    description:
+      "Checks the status of an async discovery run started by discover_opportunities in MCP contexts. " +
+      "Poll this tool with the discoveryRunId until status is succeeded, failed, or cancelled. " +
+      "When succeeded, the result field contains the same discovery payload that discover_opportunities would have returned synchronously.",
+    querySchema: z.object({
+      discoveryRunId: z.string().describe("Discovery run ID returned by discover_opportunities."),
+    }),
+    handler: async ({ context, query }) => {
+      if (!deps.discoveryRuns) {
+        return error("Async discovery runs are not available in this context.");
+      }
+      const run = await deps.discoveryRuns.get(query.discoveryRunId, context.userId);
+      if (!run) return error("Discovery run not found.");
+      return success({
+        discoveryRunId: run.id,
+        status: run.status,
+        progress: run.progress ?? null,
+        result: run.result ?? null,
+        error: run.error ?? null,
+        cancelRequestedAt: run.cancelRequestedAt?.toISOString?.() ?? null,
+        createdAt: run.createdAt.toISOString(),
+        startedAt: run.startedAt?.toISOString?.() ?? null,
+        completedAt: run.completedAt?.toISOString?.() ?? null,
+      });
+    },
+  });
+
+  const cancelDiscoveryRun = defineTool({
+    name: "cancel_discovery_run",
+    description:
+      "Requests cancellation for an async discovery run. If the queued job has not started, it is removed and marked cancelled. " +
+      "If already running, the worker observes cancellation and stops at the next cancellation check.",
+    querySchema: z.object({
+      discoveryRunId: z.string().describe("Discovery run ID returned by discover_opportunities."),
+    }),
+    handler: async ({ context, query }) => {
+      if (!deps.discoveryRuns || !deps.discoveryRunQueue) {
+        return error("Async discovery runs are not available in this context.");
+      }
+      const existing = await deps.discoveryRuns.get(query.discoveryRunId, context.userId);
+      if (!existing) return error("Discovery run not found.");
+      if (!["queued", "running"].includes(existing.status)) {
+        return success({
+          discoveryRunId: existing.id,
+          status: existing.status,
+          cancelled: existing.status === "cancelled",
+          message: `Discovery run is already ${existing.status}.`,
+        });
+      }
+      const run = await deps.discoveryRuns.requestCancel(query.discoveryRunId, context.userId);
+      if (!run) return error("Discovery run is no longer cancellable.");
+      const removed = await deps.discoveryRunQueue.cancel(run.id);
+      if (removed) {
+        await deps.discoveryRuns.markCancelled(run.id, "cancelled before worker start");
+      }
+      const updated = await deps.discoveryRuns.get(run.id, context.userId);
+      return success({
+        discoveryRunId: run.id,
+        status: updated?.status ?? (removed ? "cancelled" : "running"),
+        cancelled: removed,
+        message: removed
+          ? "Discovery run cancelled."
+          : "Cancellation requested. The running worker will stop at the next cancellation check.",
+      });
+    },
+  });
+
   const listOpportunities = defineTool({
     name: "list_opportunities",
     description:
@@ -1629,5 +1734,12 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
     },
   });
 
-  return [discoverOpportunities, listOpportunities, updateOpportunity, confirmOpportunityDelivery] as const;
+  return [
+    discoverOpportunities,
+    getDiscoveryRun,
+    cancelDiscoveryRun,
+    listOpportunities,
+    updateOpportunity,
+    confirmOpportunityDelivery,
+  ] as const;
 }

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -1311,13 +1311,19 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         await deps.discoveryRuns.markCancelled(run.id, "cancelled before worker start");
       }
       const updated = await deps.discoveryRuns.get(run.id, context.userId);
+      const status = updated?.status ?? (removed ? "cancelled" : run.status);
+      const message = removed
+        ? "Discovery run cancelled."
+        : status === "queued"
+          ? "Cancellation requested while the discovery run is still queued. It will be skipped or cancelled before work starts."
+          : status === "running"
+            ? "Cancellation requested. The running worker will stop at the next cancellation check."
+            : `Cancellation requested. Discovery run is now ${status}.`;
       return success({
         discoveryRunId: run.id,
-        status: updated?.status ?? (removed ? "cancelled" : "running"),
-        cancelled: removed,
-        message: removed
-          ? "Discovery run cancelled."
-          : "Cancellation requested. The running worker will stop at the next cancellation check.",
+        status,
+        cancelled: removed || status === "cancelled",
+        message,
       });
     },
   });

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -1290,9 +1290,10 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
       // Compose-balance across feed categories so the digest/ambient prompt
       // can fill both Section A (connection) and Section B (connector-flow).
       // Falls back to the unbalanced view when the helper has nothing to do.
-      const opportunities = deduped.length > 0
+      const selected = deduped.length > 0
         ? selectByComposition(deduped, context.userId)
         : deduped;
+      const opportunities = selected.slice(0, CHAT_DISPLAY_LIMIT);
 
       if (!opportunities || opportunities.length === 0) {
         return success({

--- a/packages/protocol/src/opportunity/question.generator.ts
+++ b/packages/protocol/src/opportunity/question.generator.ts
@@ -24,6 +24,7 @@ import {
   type QuestionWithStrategy,
 } from "../shared/schemas/question.schema.js";
 import { createModel } from "../shared/agent/model.config.js";
+import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { Timed } from "../shared/observability/performance.js";
 import {
@@ -68,9 +69,10 @@ export class QuestionGenerator {
 
     let raw: unknown;
     try {
-      raw = await this.model.invoke(
+      raw = await invokeWithAbortSignal(
+        this.model,
         [new SystemMessage(SYSTEM_PROMPT), new HumanMessage(user)],
-        options?.signal ? { signal: options.signal } : undefined,
+        options?.signal,
       );
     } catch (err) {
       // AbortError is the expected outcome under deadline pressure — caller

--- a/packages/protocol/src/premise/premise.analyzer.ts
+++ b/packages/protocol/src/premise/premise.analyzer.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { Timed } from "../shared/observability/performance.js";
 import { createModel } from "../shared/agent/model.config.js";
+import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("PremiseAnalyzer");
 
@@ -118,7 +119,7 @@ Classify this premise and score its felicity conditions.`;
       new HumanMessage(prompt),
     ];
 
-    const result = await this.model.invoke(messages);
+    const result = await invokeWithAbortSignal(this.model, messages);
     const output = responseFormat.parse(result);
 
     logger.verbose(`[PremiseAnalyzer.invoke] Result: ${output.speechActType} entropy=${output.semanticEntropy}`);

--- a/packages/protocol/src/premise/premise.decomposer.ts
+++ b/packages/protocol/src/premise/premise.decomposer.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { Timed } from "../shared/observability/performance.js";
 import { createModel } from "../shared/agent/model.config.js";
+import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("PremiseDecomposer");
 
@@ -109,7 +110,7 @@ export class PremiseDecomposer {
       new HumanMessage(prompt),
     ];
 
-    const result = await this.model.invoke(messages);
+    const result = await invokeWithAbortSignal(this.model, messages);
     const output = responseFormat.parse(result);
 
     logger.verbose(`[PremiseDecomposer.invoke] Extracted ${output.premises.length} premise(s)`);

--- a/packages/protocol/src/premise/premise.graph.ts
+++ b/packages/protocol/src/premise/premise.graph.ts
@@ -4,6 +4,7 @@ import { PremiseGraphState } from "./premise.state.js";
 import { PremiseAnalyzer } from "./premise.analyzer.js";
 import { PremiseIndexer } from "./premise.indexer.js";
 
+import { getAbortSignalConfig } from "../shared/agent/model-signal.js";
 import type { PremiseGraphDatabase, PremiseAnalysis } from "../shared/interfaces/database.interface.js";
 import type { Embedder } from "../shared/interfaces/embedder.interface.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
@@ -81,7 +82,7 @@ export class PremiseGraphFactory {
         logger.verbose(`[PremiseGraph.embed] Generating embedding for premise`);
 
         // Embedder.generate returns number[] | number[][], cast for single string input
-        const embedding = await this.embedder.generate(state.assertionText) as number[];
+        const embedding = await this.embedder.generate(state.assertionText, undefined, getAbortSignalConfig()) as number[];
         return { embedding };
       });
     };

--- a/packages/protocol/src/premise/premise.indexer.ts
+++ b/packages/protocol/src/premise/premise.indexer.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { Timed } from "../shared/observability/performance.js";
 import { createModel } from "../shared/agent/model.config.js";
+import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("PremiseIndexer");
 
@@ -83,7 +84,7 @@ export class PremiseIndexer {
       new HumanMessage(prompt),
     ];
 
-    const result = await this.model.invoke(messages);
+    const result = await invokeWithAbortSignal(this.model, messages);
     return responseFormat.parse(result);
   }
 }

--- a/packages/protocol/src/premise/premise.tools.ts
+++ b/packages/protocol/src/premise/premise.tools.ts
@@ -4,6 +4,7 @@ import type { DefineTool, ToolDeps } from "../shared/agent/tool.helpers.js";
 import { success, error, UUID_REGEX } from "../shared/agent/tool.helpers.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import type { PremiseGraphDatabase, PremiseRecord, PremiseValidity } from "../shared/interfaces/database.interface.js";
+import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("ChatTools:Premise");
 
@@ -46,7 +47,7 @@ export function createPremiseTools(defineTool: DefineTool, deps: ToolDeps) {
 
       logger.verbose(`[createPremise] Creating premise for user ${context.userId}: "${query.text.substring(0, 60)}..."`);
 
-      const result = await premiseGraph.invoke({
+      const result = await invokeWithAbortSignal(premiseGraph, {
         userId: context.userId,
         assertionText: query.text,
         tier: query.tier,
@@ -209,7 +210,7 @@ export function createPremiseTools(defineTool: DefineTool, deps: ToolDeps) {
         return error("Premise graph not available.");
       }
 
-      const result = await premiseGraph.invoke({
+      const result = await invokeWithAbortSignal(premiseGraph, {
         userId: context.userId,
         assertionText: query.text,
         tier: existing.assertion.tier,

--- a/packages/protocol/src/profile/profile.generator.ts
+++ b/packages/protocol/src/profile/profile.generator.ts
@@ -4,6 +4,7 @@ import { z } from "zod/v4";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { Timed } from "../shared/observability/performance.js";
 import { createModel } from "../shared/agent/model.config.js";
+import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("ProfileGenerator");
 
@@ -68,7 +69,7 @@ export class ProfileGenerator {
       new SystemMessage(systemPrompt),
       new HumanMessage(`Here is the raw data:\n${input}`)
     ];
-    const result = await this.model.invoke(messages);
+    const result = await invokeWithAbortSignal(this.model, messages);
     const output = responseFormat.parse(result);
     const textToEmbed = this.toString(output);
     logger.verbose("Generated profile", {

--- a/packages/protocol/src/profile/profile.graph.ts
+++ b/packages/protocol/src/profile/profile.graph.ts
@@ -12,6 +12,7 @@ import { timed } from "../shared/observability/performance.js";
 import { requestContext } from "../shared/observability/request-context.js";
 import type { DebugMetaAgent } from "../chat/chat-streaming.types.js";
 import { PremiseDecomposer } from "../premise/premise.decomposer.js";
+import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 /**
  * Compiled premise graph interface. Matches the invoke signature of a compiled LangGraph.
@@ -773,7 +774,7 @@ export class ProfileGraphFactory {
           let created = 0;
           for (const p of result.premises) {
             try {
-              const premiseResult = await this.premiseGraph.invoke({
+              const premiseResult = await invokeWithAbortSignal(this.premiseGraph, {
                 userId: state.userId,
                 assertionText: p.text,
                 tier: p.tier,

--- a/packages/protocol/src/profile/profile.tools.ts
+++ b/packages/protocol/src/profile/profile.tools.ts
@@ -517,25 +517,46 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
         location: query.location?.trim(),
         bioOrDescription: description,
       });
-      const _confirmGraphStart = Date.now();
+      const rawProfile = {
+        identity: {
+          name: query.name?.trim() ?? user?.name ?? '',
+          bio: description,
+          location: query.location?.trim() ?? '',
+        },
+      };
+      await persistApprovedProfileContext(rawProfile, user, context.networkId);
+
       const _confirmTraceEmitter = requestContext.getStore()?.traceEmitter;
+      const _confirmGraphStart = Date.now();
       _confirmTraceEmitter?.({ type: "graph_start", name: "profile" });
-      const result = await graphs.profile.invoke({
+      graphs.profile.invoke({
         userId: context.userId,
         operationMode: 'write' as const,
         input,
         forceUpdate: true,
-      });
-      const _confirmGraphMs = Date.now() - _confirmGraphStart;
-      _confirmTraceEmitter?.({ type: "graph_end", name: "profile", durationMs: _confirmGraphMs });
-      if (result.error) return error(result.error);
-      if (!result.profile) return error("Failed to save profile from approved text.");
-      await persistApprovedProfileContext(result.profile, user, context.networkId);
+      }).then((result) => {
+        const _confirmGraphMs = Date.now() - _confirmGraphStart;
+        _confirmTraceEmitter?.({ type: "graph_end", name: "profile", durationMs: _confirmGraphMs });
+        if (result.error || !result.profile) {
+          logger.error('Background profile generation failed', {
+            userId: context.userId,
+            error: result.error ?? 'No profile returned',
+          });
+        }
+      }).catch((err: unknown) =>
+        logger.error('Background profile generation failed', {
+          userId: context.userId,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      );
+
       return success({
         created: true,
-        message: "Profile saved from approved text.",
-        profile: toProfileSummary(result.profile),
-        _graphTimings: [{ name: 'profile', durationMs: _confirmGraphMs, agents: result.agentTimings ?? [] }],
+        message: "Profile text accepted. Your profile is being structured in the background.",
+        profile: toProfileSummary({
+          identity: rawProfile.identity,
+          attributes: { skills: [], interests: [] },
+        }),
       });
     },
   });

--- a/packages/protocol/src/profile/profile.tools.ts
+++ b/packages/protocol/src/profile/profile.tools.ts
@@ -9,6 +9,7 @@ import type { EnrichmentResult, ProfileEnricher } from "../shared/interfaces/enr
 import type { OnboardingPrivacyState, OnboardingProfileSeed, OnboardingState, PrivacyConsentSource, UserRecord } from "../shared/interfaces/database.interface.js";
 import { socialsToEnrichmentRequest, detectSocialLabel } from "../shared/utils/social-label.js";
 import { ProfileGenerator } from "./profile.generator.js";
+import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("ChatTools:Profile");
 
@@ -315,7 +316,7 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
       const _readProfileGraphStart = Date.now();
       const _readProfileTraceEmitter = requestContext.getStore()?.traceEmitter;
       _readProfileTraceEmitter?.({ type: "graph_start", name: "profile" });
-      const result = await graphs.profile.invoke({
+      const result = await invokeWithAbortSignal(graphs.profile, {
         userId: context.userId,
         operationMode: 'query' as const,
       });
@@ -713,7 +714,7 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
           const _confirmGraphStart = Date.now();
           const _confirmTraceEmitter = requestContext.getStore()?.traceEmitter;
           _confirmTraceEmitter?.({ type: "graph_start", name: "profile" });
-          const result = await graphs.profile.invoke({
+          const result = await invokeWithAbortSignal(graphs.profile, {
             userId: context.userId,
             operationMode: 'generate' as const,
           });
@@ -757,7 +758,7 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
         const _bioProfileGraphStart = Date.now();
         const _bioProfileTraceEmitter = requestContext.getStore()?.traceEmitter;
         _bioProfileTraceEmitter?.({ type: "graph_start", name: "profile" });
-        const result = await graphs.profile.invoke({
+        const result = await invokeWithAbortSignal(graphs.profile, {
           userId: context.userId,
           operationMode: 'write' as const,
           input: profileInput,
@@ -793,7 +794,7 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
       const _generateProfileGraphStart = Date.now();
       const _generateProfileTraceEmitter = requestContext.getStore()?.traceEmitter;
       _generateProfileTraceEmitter?.({ type: "graph_start", name: "profile" });
-      const result = await graphs.profile.invoke({
+      const result = await invokeWithAbortSignal(graphs.profile, {
         userId: context.userId,
         operationMode: 'generate' as const,
         forceUpdate: true,
@@ -856,7 +857,7 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
       const _updateQueryProfileGraphStart = Date.now();
       const _updateQueryProfileTraceEmitter = requestContext.getStore()?.traceEmitter;
       _updateQueryProfileTraceEmitter?.({ type: "graph_start", name: "profile" });
-      const queryResult = await graphs.profile.invoke({ userId: context.userId, operationMode: 'query' as const });
+      const queryResult = await invokeWithAbortSignal(graphs.profile, { userId: context.userId, operationMode: 'query' as const });
       const _updateQueryProfileGraphMs = Date.now() - _updateQueryProfileGraphStart;
       _updateQueryProfileTraceEmitter?.({ type: "graph_end", name: "profile", durationMs: _updateQueryProfileGraphMs });
       if (!queryResult.readResult?.hasProfile && !queryResult.profile) {
@@ -877,7 +878,7 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
       const _updateWriteProfileGraphStart = Date.now();
       const _updateWriteProfileTraceEmitter = requestContext.getStore()?.traceEmitter;
       _updateWriteProfileTraceEmitter?.({ type: "graph_start", name: "profile" });
-      const _writeResult = await graphs.profile.invoke({
+      const _writeResult = await invokeWithAbortSignal(graphs.profile, {
         userId: context.userId,
         operationMode: "write",
         input: inputForProfile,

--- a/packages/protocol/src/profile/profile.tools.ts
+++ b/packages/protocol/src/profile/profile.tools.ts
@@ -512,16 +512,18 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
       if (!description) {
         return error("Pass the approved structured draft or explicit approved profile text.");
       }
+      const approvedName = query.name?.trim();
+      const approvedLocation = query.location?.trim();
       const input = buildProfileInput({
-        name: query.name?.trim(),
-        location: query.location?.trim(),
+        name: approvedName,
+        location: approvedLocation,
         bioOrDescription: description,
       });
       const rawProfile = {
         identity: {
-          name: query.name?.trim() ?? user?.name ?? '',
+          name: approvedName && approvedName.length > 0 ? approvedName : user?.name ?? '',
           bio: description,
-          location: query.location?.trim() ?? '',
+          location: approvedLocation && approvedLocation.length > 0 ? approvedLocation : user?.location ?? '',
         },
       };
       await persistApprovedProfileContext(rawProfile, user, context.networkId);
@@ -535,8 +537,6 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
         input,
         forceUpdate: true,
       }).then((result) => {
-        const _confirmGraphMs = Date.now() - _confirmGraphStart;
-        _confirmTraceEmitter?.({ type: "graph_end", name: "profile", durationMs: _confirmGraphMs });
         if (result.error || !result.profile) {
           logger.error('Background profile generation failed', {
             userId: context.userId,
@@ -548,7 +548,10 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
           userId: context.userId,
           error: err instanceof Error ? err.message : String(err),
         })
-      );
+      ).finally(() => {
+        const _confirmGraphMs = Date.now() - _confirmGraphStart;
+        _confirmTraceEmitter?.({ type: "graph_end", name: "profile", durationMs: _confirmGraphMs });
+      });
 
       return success({
         created: true,

--- a/packages/protocol/src/profile/tests/profile.privacy-tools.spec.ts
+++ b/packages/protocol/src/profile/tests/profile.privacy-tools.spec.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach, mock } from "bun:test";
 import { z } from "zod";
 
+import { requestContext } from "../../shared/observability/request-context.js";
+
 import type { ToolDeps, ResolvedToolContext } from "../../shared/agent/tool.helpers.js";
 
 let generatedInputs: string[] = [];
@@ -48,6 +50,7 @@ describe("onboarding privacy profile tools", () => {
   let saveProfile: ReturnType<typeof mock>;
   let setUserSocials: ReturnType<typeof mock>;
   let enricher: ReturnType<typeof mock>;
+  let profileGraphInvoke: ReturnType<typeof mock>;
   let tools: CapturedTool[];
   let onboarding: ResolvedToolContext["user"]["onboarding"];
 
@@ -73,10 +76,11 @@ describe("onboarding privacy profile tools", () => {
       attributes: { skills: ["AI"], interests: ["coordination"] },
       socials: {},
     }));
+    profileGraphInvoke = mock(async () => ({}));
 
     tools = captureTools({
       userDb: {
-        getUser: async () => ({ id: "u1", name: "Alice", email: "alice@example.com", location: null, intro: null, socials: [], onboarding }),
+        getUser: async () => ({ id: "u1", name: "Alice", email: "alice@example.com", location: "Healdsburg", intro: null, socials: [], onboarding }),
         updateUser,
         getProfile: async () => null,
         saveProfile,
@@ -85,7 +89,7 @@ describe("onboarding privacy profile tools", () => {
       },
       systemDb: {},
       database: {},
-      graphs: { profile: { invoke: async () => ({}) } },
+      graphs: { profile: { invoke: profileGraphInvoke } },
       enricher: { enrichUserProfile: enricher },
       grantDefaultSystemPermissions: async () => undefined,
     } as unknown as ToolDeps);
@@ -222,5 +226,40 @@ describe("onboarding privacy profile tools", () => {
     expect(result.success).toBe(true);
     expect(saveProfile).toHaveBeenCalledWith({ ...draft, userId: "u1" });
     expect(enricher).not.toHaveBeenCalled();
+  });
+
+  it("confirming approved text preserves existing location when no correction is supplied", async () => {
+    const tool = tools.find((t) => t.name === "confirm_user_profile")!;
+    const result = parseToolResult(await tool.handler({
+      context: context(),
+      query: { bioOrDescription: "I build agent tools.", name: "Alice" },
+    }));
+
+    expect(result.success).toBe(true);
+    expect(updateUser).toHaveBeenCalledWith({
+      name: "Alice",
+      intro: "I build agent tools.",
+      location: "Healdsburg",
+    });
+  });
+
+  it("emits graph_end when background profile generation rejects", async () => {
+    const tool = tools.find((t) => t.name === "confirm_user_profile")!;
+    const events: Array<{ type: string; name: string }> = [];
+    profileGraphInvoke.mockImplementation(async () => {
+      throw new Error("profile timeout");
+    });
+
+    const result = parseToolResult(await requestContext.run(
+      { traceEmitter: (event) => events.push({ type: event.type, name: event.name }) },
+      () => tool.handler({ context: context(), query: { bioOrDescription: "I build agent tools." } }),
+    ));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(result.success).toBe(true);
+    expect(events).toEqual([
+      { type: "graph_start", name: "profile" },
+      { type: "graph_end", name: "profile" },
+    ]);
   });
 });

--- a/packages/protocol/src/questioner/questioner.agent.ts
+++ b/packages/protocol/src/questioner/questioner.agent.ts
@@ -18,6 +18,7 @@ import {
   type QuestionWithStrategy,
 } from "../shared/schemas/question.schema.js";
 import { createModel } from "../shared/agent/model.config.js";
+import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { Timed } from "../shared/observability/performance.js";
 import { getPreset } from "./questioner.presets.js";
@@ -67,9 +68,10 @@ export class QuestionerAgent {
 
     let raw: unknown;
     try {
-      raw = await this.model.invoke(
+      raw = await invokeWithAbortSignal(
+        this.model,
         [new SystemMessage(preset.systemPrompt), new HumanMessage(userMessage)],
-        options?.signal ? { signal: options.signal } : undefined,
+        options?.signal,
       );
     } catch (err) {
       const aborted = options?.signal?.aborted ?? false;

--- a/packages/protocol/src/shared/agent/model-signal.ts
+++ b/packages/protocol/src/shared/agent/model-signal.ts
@@ -1,0 +1,46 @@
+import { requestContext } from "../observability/request-context.js";
+
+/**
+ * Combines an explicit per-call AbortSignal with the current request signal.
+ * Either signal aborting should cancel the downstream LangChain/OpenAI call.
+ */
+function combineAbortSignals(signals: AbortSignal[]): AbortSignal {
+  if (signals.length === 1) return signals[0];
+  if (typeof AbortSignal.any === "function") {
+    return AbortSignal.any(signals);
+  }
+
+  const controller = new AbortController();
+  for (const signal of signals) {
+    if (signal.aborted) {
+      controller.abort(signal.reason);
+      break;
+    }
+    signal.addEventListener("abort", () => {
+      if (!controller.signal.aborted) controller.abort(signal.reason);
+    }, { once: true });
+  }
+  return controller.signal;
+}
+
+/**
+ * Returns a LangChain RunnableConfig carrying the active AbortSignal(s),
+ * when tool/runtime execution installed one in AsyncLocalStorage or a caller
+ * supplied an explicit signal.
+ */
+export function getAbortSignalConfig(signal?: AbortSignal): { signal: AbortSignal } | undefined {
+  const signals = [signal, requestContext.getStore()?.abortSignal].filter(
+    (item): item is AbortSignal => item instanceof AbortSignal,
+  );
+  return signals.length > 0 ? { signal: combineAbortSignals(signals) } : undefined;
+}
+
+/** Invokes a LangChain runnable with the current request AbortSignal when present. */
+export async function invokeWithAbortSignal<TInput, TOutput>(
+  runnable: { invoke(input: TInput, config?: { signal?: AbortSignal }): Promise<TOutput> },
+  input: TInput,
+  signal?: AbortSignal,
+): Promise<TOutput> {
+  const config = getAbortSignalConfig(signal);
+  return config ? runnable.invoke(input, config) : runnable.invoke(input);
+}

--- a/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
+++ b/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
@@ -964,10 +964,10 @@ describe("scrape_url tool", () => {
 
   test("invoke calls scraper.extractUrlContent with url and objective when provided", async () => {
     let capturedUrl: string | null = null;
-    let capturedOptions: { objective?: string } | undefined = undefined;
+    let capturedOptions: { objective?: string; signal?: AbortSignal } | undefined = undefined;
     const scraperWithSpy = {
       scrape: async () => "",
-      extractUrlContent: async (url: string, options?: { objective?: string }) => {
+      extractUrlContent: async (url: string, options?: { objective?: string; signal?: AbortSignal }) => {
         capturedUrl = url;
         capturedOptions = options;
         return "Intent-focused content";
@@ -981,6 +981,8 @@ describe("scrape_url tool", () => {
     await tool.invoke({ url: "https://github.com/org/repo", objective });
     expect(capturedUrl as unknown as string).toBe("https://github.com/org/repo");
     expect((capturedOptions as { objective?: string } | undefined)?.objective).toBe(objective);
+    expect(capturedOptions?.signal).toBeInstanceOf(AbortSignal);
+    expect(capturedOptions?.signal?.aborted).toBe(false);
   });
 
   test("invoke returns success with content when scraper returns content", async () => {

--- a/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
+++ b/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
@@ -1250,7 +1250,7 @@ describe("discover_opportunities tool", () => {
     expect(parsed.success).toBe(true);
     expect(parsed.data).toBeDefined();
     expect(Array.isArray(parsed.data.opportunities) ? parsed.data.opportunities : []).toBeDefined();
-  });
+  }, 60_000);
 
   test("introduction mode: viewer as introducer — card headline is 'PartyA → PartyB' and action is 'Introduce Them'", async () => {
     // Viewer (testUserId) is NOT in partyUserIds → viewerRole = "introducer"
@@ -1346,7 +1346,7 @@ describe("discover_opportunities tool", () => {
     expect(card.viewerRole).toBe("party");
     expect(card.headline).toBe("Connection with Other");
     expect(card.primaryActionLabel).toBe("Start Chat");
-  });
+  }, 60_000);
 
   test("introduction mode: entities only (no partyUserIds) derives partyUserIds and creates opportunity", async () => {
     const mockDb = createMockDatabase(async () => [], {
@@ -1392,7 +1392,7 @@ describe("discover_opportunities tool", () => {
     expect(opp.matchReason.length).toBeGreaterThan(0);
     expect(typeof opp.score).toBe("number");
     expect(["latent", "draft", "pending", "accepted", "rejected", "expired"]).toContain(opp.status);
-  });
+  }, 60_000);
 
   test("discovery mode: when searchQuery is non-empty and results are found, includes suggestIntentCreationForVisibility and suggestedIntentDescription", async () => {
     mockDiscoveryResult = {
@@ -2061,6 +2061,204 @@ describe("list_opportunities tool (CHAT_DISPLAY_LIMIT cap)", () => {
     expect(codeBlockCount).toBe(6);
     // Total count reported should also be capped
     expect(parsed.data.count).toBe(6);
+  });
+});
+
+describe("discover_opportunities async MCP runs", () => {
+  test("MCP discover_opportunities enqueues a discovery run and returns run id", async () => {
+    const created: Array<{ userId: string; agentId?: string | null; input: unknown; context: unknown }> = [];
+    const enqueued: string[] = [];
+    const discoveryRuns = {
+      create: async (input: { userId: string; agentId?: string | null; input: unknown; context: unknown }) => {
+        created.push(input);
+        return {
+          id: "run-async-1",
+          userId: input.userId,
+          agentId: input.agentId,
+          status: "queued" as const,
+          input: input.input,
+          context: input.context,
+          progress: { stage: "queued" },
+          createdAt: new Date(),
+        };
+      },
+      get: async () => null,
+      markRunning: async () => null,
+      updateProgress: async () => {},
+      markSucceeded: async () => {},
+      markFailed: async () => {},
+      requestCancel: async () => null,
+      markCancelled: async () => {},
+      isCancelRequested: async () => false,
+      listActive: async () => [],
+    };
+    const discoveryRunQueue = {
+      enqueue: async (runId: string) => {
+        enqueued.push(runId);
+        return { jobId: runId };
+      },
+      cancel: async () => false,
+    };
+    const mockDb = createMockDatabase(async () => []);
+    const context: ToolContext = {
+      userId: testUserId,
+      database: mockDb,
+      embedder: mockEmbedder,
+      scraper: mockScraper,
+      ...mockProtocolDeps,
+      discoveryRuns,
+      discoveryRunQueue,
+    } as ToolContext;
+    const resolved = {
+      userId: testUserId,
+      userName: "Test User",
+      userEmail: "test@example.com",
+      user: { id: testUserId, name: "Test User", email: "test@example.com" } as unknown as import("../tool.helpers").ResolvedToolContext["user"],
+      userProfile: null,
+      userNetworks: [],
+      indexScope: ["idx-1"],
+      isOnboarding: false,
+      hasName: true,
+      isMcp: true,
+      agentId: "agent-1",
+    } satisfies import("../tool.helpers").ResolvedToolContext;
+
+    const tools = await createChatTools(context, resolved);
+    const tool = tools.find((t: { name: string }) => t.name === "discover_opportunities") as { invoke: (args: { searchQuery: string }) => Promise<string> };
+    const raw = await tool.invoke({ searchQuery: "find founders" });
+    const parsed = JSON.parse(raw);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.data).toMatchObject({ status: "queued", discoveryRunId: "run-async-1" });
+    expect(enqueued).toEqual(["run-async-1"]);
+    expect(created[0]).toMatchObject({ userId: testUserId, agentId: "agent-1", input: { searchQuery: "find founders" } });
+  });
+
+  test("get_discovery_run returns the persisted run result for the current user", async () => {
+    const completedAt = new Date("2026-01-01T00:00:00.000Z");
+    const discoveryRuns = {
+      create: async () => { throw new Error("not used"); },
+      get: async (runId: string, userId: string) => ({
+        id: runId,
+        userId,
+        agentId: "agent-1",
+        status: "succeeded" as const,
+        input: { searchQuery: "find founders" },
+        context: { userId, userName: "Test User", userEmail: "test@example.com", indexScope: ["idx-1"] },
+        progress: { stage: "succeeded" },
+        result: { success: true, data: { found: true, count: 1 } },
+        error: null,
+        createdAt: completedAt,
+        startedAt: completedAt,
+        completedAt,
+      }),
+      markRunning: async () => null,
+      updateProgress: async () => {},
+      markSucceeded: async () => {},
+      markFailed: async () => {},
+      requestCancel: async () => null,
+      markCancelled: async () => {},
+      isCancelRequested: async () => false,
+      listActive: async () => [],
+    };
+    const context: ToolContext = {
+      userId: testUserId,
+      database: createMockDatabase(async () => []),
+      embedder: mockEmbedder,
+      scraper: mockScraper,
+      ...mockProtocolDeps,
+      discoveryRuns,
+      discoveryRunQueue: { enqueue: async () => ({}), cancel: async () => false },
+    } as ToolContext;
+    const resolved = {
+      userId: testUserId,
+      userName: "Test User",
+      userEmail: "test@example.com",
+      user: { id: testUserId, name: "Test User", email: "test@example.com" } as unknown as import("../tool.helpers").ResolvedToolContext["user"],
+      userProfile: null,
+      userNetworks: [],
+      indexScope: ["idx-1"],
+      isOnboarding: false,
+      hasName: true,
+      isMcp: true,
+      agentId: "agent-1",
+    } satisfies import("../tool.helpers").ResolvedToolContext;
+
+    const tools = await createChatTools(context, resolved);
+    const tool = tools.find((t: { name: string }) => t.name === "get_discovery_run") as { invoke: (args: { discoveryRunId: string }) => Promise<string> };
+    const parsed = JSON.parse(await tool.invoke({ discoveryRunId: "run-complete-1" }));
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.data).toMatchObject({ discoveryRunId: "run-complete-1", status: "succeeded", result: { success: true, data: { found: true, count: 1 } } });
+  });
+
+  test("cancel_discovery_run requests cancellation and removes queued jobs", async () => {
+    const cancelRequests: string[] = [];
+    const cancelled: string[] = [];
+    const discoveryRuns = {
+      create: async () => { throw new Error("not used"); },
+      get: async (runId: string, userId: string) => ({
+        id: runId,
+        userId,
+        agentId: "agent-1",
+        status: cancelled.includes(runId) ? "cancelled" as const : "queued" as const,
+        input: { searchQuery: "find founders" },
+        context: { userId, userName: "Test User", userEmail: "test@example.com", indexScope: ["idx-1"] },
+        progress: { stage: "queued" },
+        createdAt: new Date(),
+      }),
+      markRunning: async () => null,
+      updateProgress: async () => {},
+      markSucceeded: async () => {},
+      markFailed: async () => {},
+      requestCancel: async (runId: string, userId: string) => {
+        cancelRequests.push(runId);
+        return {
+          id: runId,
+          userId,
+          agentId: "agent-1",
+          status: "queued" as const,
+          input: { searchQuery: "find founders" },
+          context: { userId, userName: "Test User", userEmail: "test@example.com", indexScope: ["idx-1"] },
+          progress: { stage: "cancellation_requested" },
+          createdAt: new Date(),
+        };
+      },
+      markCancelled: async (runId: string) => { cancelled.push(runId); },
+      isCancelRequested: async () => false,
+      listActive: async () => [],
+    };
+    const context: ToolContext = {
+      userId: testUserId,
+      database: createMockDatabase(async () => []),
+      embedder: mockEmbedder,
+      scraper: mockScraper,
+      ...mockProtocolDeps,
+      discoveryRuns,
+      discoveryRunQueue: { enqueue: async () => ({}), cancel: async () => true },
+    } as ToolContext;
+    const resolved = {
+      userId: testUserId,
+      userName: "Test User",
+      userEmail: "test@example.com",
+      user: { id: testUserId, name: "Test User", email: "test@example.com" } as unknown as import("../tool.helpers").ResolvedToolContext["user"],
+      userProfile: null,
+      userNetworks: [],
+      indexScope: ["idx-1"],
+      isOnboarding: false,
+      hasName: true,
+      isMcp: true,
+      agentId: "agent-1",
+    } satisfies import("../tool.helpers").ResolvedToolContext;
+
+    const tools = await createChatTools(context, resolved);
+    const tool = tools.find((t: { name: string }) => t.name === "cancel_discovery_run") as { invoke: (args: { discoveryRunId: string }) => Promise<string> };
+    const parsed = JSON.parse(await tool.invoke({ discoveryRunId: "run-cancel-1" }));
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.data).toMatchObject({ discoveryRunId: "run-cancel-1", status: "cancelled", cancelled: true });
+    expect(cancelRequests).toEqual(["run-cancel-1"]);
+    expect(cancelled).toEqual(["run-cancel-1"]);
   });
 });
 

--- a/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
+++ b/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
@@ -10,7 +10,7 @@ mock.module("../../../../../backend/queues/notification.queue", () => ({
   queueOpportunityNotification: async () =>
     ({ id: "mock-job" } as unknown as Awaited<ReturnType<typeof import("../../../../../backend/queues/notification.queue").queueOpportunityNotification>>),
 }));
-mock.module("../../graphs/intent.graph", () => ({
+mock.module("../../../intent/intent.graph.js", () => ({
   IntentGraphFactory: class {
     private database: ChatGraphCompositeDatabase;
     constructor(database: ChatGraphCompositeDatabase) {
@@ -191,7 +191,7 @@ let mockDiscoveryResult: {
   count: 0,
   message: "You need to join at least one index (community) to discover opportunities.",
 };
-mock.module("../../support/opportunity.discover", () => ({
+mock.module("../../../opportunity/opportunity.discover.js", () => ({
   runDiscoverFromQuery: async () => mockDiscoveryResult,
   continueDiscovery: async () => mockDiscoveryResult,
 }));
@@ -207,7 +207,7 @@ const testUserId = "test-user-id-for-tools";
 
 type MockOverrides = Partial<Pick<
   ChatGraphCompositeDatabase,
-  "getUser" | "getNetwork" | "getOwnedIndexes" | "isIndexOwner" | "isNetworkMember" | "getNetworkMembersForOwner" | "getNetworkMembersForMember" | "getNetworkIntentsForOwner" | "getNetworkMemberships" | "getNetworkMembership" | "getNetworkIntentsForMember" | "getNetworkWithPermissions" | "getOpportunity" | "updateOpportunityStatus" | "getActiveIntents" | "getIntentsInIndexForMember" | "getNetworkIdsForIntent" | "opportunityExistsBetweenActors" | "findOpportunitiesByActors" | "createOpportunity"
+  "getUser" | "getNetwork" | "getOwnedIndexes" | "isIndexOwner" | "isNetworkMember" | "getNetworkMembersForOwner" | "getNetworkMembersForMember" | "getNetworkIntentsForOwner" | "getNetworkMemberships" | "getNetworkMembership" | "getNetworkIntentsForMember" | "getNetworkWithPermissions" | "getIntent" | "getOpportunity" | "getOpportunitiesForUser" | "updateOpportunityStatus" | "stampOpportunityActorAction" | "getActiveIntents" | "getIntentsInIndexForMember" | "getNetworkIdsForIntent" | "opportunityExistsBetweenActors" | "findOpportunitiesByActors" | "createOpportunity"
 >> & {
   /** Optional stub for getActiveIntentsAcrossIndexes (used by indexScope read path). */
   getActiveIntentsAcrossIndexes?: (userId: string, indexIds: string[]) => Promise<ActiveIntent[]>;
@@ -242,6 +242,7 @@ function createMockDatabase(
     getPublicIndexesNotJoined: async () => ({ networks: [] }),
     getNetworkMembership: noopNull,
     getNetworkWithPermissions: async () => null,
+    getIntent: noopNull,
     getIntentForIndexing: noopNull,
     getNetworkMemberContext: noopNull,
     isIntentAssignedToIndex: noopBool,
@@ -273,7 +274,9 @@ function createMockDatabase(
     addMemberToNetwork: async () => ({ success: true }),
     getMembersFromUserIndexes: async () => [],
     getOpportunity: noopNull,
+    getOpportunitiesForUser: noopArray,
     updateOpportunityStatus: noopNull,
+    stampOpportunityActorAction: noopNull,
     getActiveIntentsAcrossIndexes: noopArray,
   };
   return { ...base, ...overrides } as unknown as ChatGraphCompositeDatabase;
@@ -1070,7 +1073,10 @@ describe("update_intent and delete_intent (Phase 3 index-scoping)", () => {
     const mockDb = createMockDatabase(async (uid, idx) => {
       if (uid === testUserId && idx === networkId) return [intentInIndex];
       return [];
-    }, { isNetworkMember: async () => true });
+    }, {
+      isNetworkMember: async () => true,
+      getIntent: async () => ({ id: intentNotInIndex, userId: testUserId, payload: "Out of scope", summary: null, archivedAt: null } as never),
+    });
     const context: ToolContext = { userId: testUserId, database: mockDb, embedder: mockEmbedder, scraper: mockScraper, networkId, ...mockProtocolDeps };
     const tools = await createChatTools(context);
     const tool = tools.find((t: { name: string }) => t.name === "update_intent") as { invoke: (args: { intentId: string; description: string }) => Promise<string> };
@@ -1085,7 +1091,10 @@ describe("update_intent and delete_intent (Phase 3 index-scoping)", () => {
     const mockDb = createMockDatabase(async (uid, idx) => {
       if (uid === testUserId && idx === networkId) return [intentInIndex];
       return [];
-    }, { isNetworkMember: async () => true });
+    }, {
+      isNetworkMember: async () => true,
+      getIntent: async () => ({ id: intentNotInIndex, userId: testUserId, payload: "Out of scope", summary: null, archivedAt: null } as never),
+    });
     const context: ToolContext = { userId: testUserId, database: mockDb, embedder: mockEmbedder, scraper: mockScraper, networkId, ...mockProtocolDeps };
     const tools = await createChatTools(context);
     const tool = tools.find((t: { name: string }) => t.name === "delete_intent") as { invoke: (args: { intentId: string }) => Promise<string> };
@@ -1102,6 +1111,7 @@ describe("update_intent and delete_intent (Phase 3 index-scoping)", () => {
       return [];
     }, {
       isNetworkMember: async () => true,
+      getIntent: async (intentId: string) => ({ id: intentId, userId: testUserId, payload: intentInIndex.payload, summary: intentInIndex.summary, archivedAt: null } as never),
       getNetworkIdsForIntent: async (intentId: string) => (intentId === intentInIndex.id ? [networkId] : []),
     });
     const context: ToolContext = { userId: testUserId, database: mockDb, embedder: mockEmbedder, scraper: mockScraper, networkId, ...mockProtocolDeps };
@@ -1120,6 +1130,7 @@ describe("update_intent and delete_intent (Phase 3 index-scoping)", () => {
       return [];
     }, {
       isNetworkMember: async () => true,
+      getIntent: async (intentId: string) => ({ id: intentId, userId: testUserId, payload: intentInIndex.payload, summary: intentInIndex.summary, archivedAt: null } as never),
       getNetworkIdsForIntent: async (intentId: string) => (intentId === intentInIndex.id ? [networkId] : []),
     });
     const context: ToolContext = { userId: testUserId, database: mockDb, embedder: mockEmbedder, scraper: mockScraper, networkId, ...mockProtocolDeps };
@@ -1129,7 +1140,7 @@ describe("update_intent and delete_intent (Phase 3 index-scoping)", () => {
     const parsed = JSON.parse(result);
     expect(parsed.success).toBe(true);
     expect(parsed.data).toBeDefined();
-    expect(parsed.data.message).toBe("Intent archived.");
+    expect(parsed.data.message).toBe("Intent archived successfully.");
   });
 });
 
@@ -1538,11 +1549,11 @@ describe("discover_opportunities tool", () => {
     expect(parsed.data.createIntentSuggested).toBeUndefined();
   });
 
-  test("discovery mode: caps displayed opportunity cards at CHAT_DISPLAY_LIMIT (3) even when graph returns more", async () => {
+  test("discovery mode: caps displayed opportunity cards at CHAT_DISPLAY_LIMIT (6) even when graph returns more", async () => {
     mockDiscoveryResult = {
       found: true,
-      count: 5,
-      opportunities: Array.from({ length: 5 }, (_, i) => ({
+      count: 8,
+      opportunities: Array.from({ length: 8 }, (_, i) => ({
         opportunityId: `opp-cap-${i + 1}`,
         userId: `candidate-${i + 1}`,
         name: `Candidate ${i + 1}`,
@@ -1573,10 +1584,10 @@ describe("discover_opportunities tool", () => {
     const parsed = JSON.parse(result);
     expect(parsed.success).toBe(true);
     expect(parsed.data.found).toBe(true);
-    expect(parsed.data.count).toBe(3);
+    expect(parsed.data.count).toBe(6);
     // Count opportunity code blocks in the message
     const blocks = parsed.data.message.match(/```opportunity\n[\s\S]*?\n```/g) ?? [];
-    expect(blocks.length).toBe(3);
+    expect(blocks.length).toBe(6);
     // No discoveryId in pagination → falls through to signal suggestion instead of "see more"
     expect(parsed.data.message).toContain("create a signal");
   });
@@ -1584,8 +1595,8 @@ describe("discover_opportunities tool", () => {
   test("discovery mode: offers 'see more' when discoveryId is available and extra cards were capped", async () => {
     mockDiscoveryResult = {
       found: true,
-      count: 5,
-      opportunities: Array.from({ length: 5 }, (_, i) => ({
+      count: 8,
+      opportunities: Array.from({ length: 8 }, (_, i) => ({
         opportunityId: `opp-more-${i + 1}`,
         userId: `candidate-more-${i + 1}`,
         name: `Candidate ${i + 1}`,
@@ -1615,17 +1626,17 @@ describe("discover_opportunities tool", () => {
     };
     const result = await tool.invoke({ searchQuery: "looking for co-founders" });
     const parsed = JSON.parse(result);
-    expect(parsed.data.count).toBe(3);
+    expect(parsed.data.count).toBe(6);
     // 3 remaining from pagination + 2 extra from cap = 5 total remaining
     expect(parsed.data.message).toContain("5 more candidates");
     expect(parsed.data.message).toContain("disc-123");
   });
 
-  test("continueFrom mode: caps displayed opportunity cards at CHAT_DISPLAY_LIMIT (3) even when graph returns more", async () => {
+  test("continueFrom mode: caps displayed opportunity cards at CHAT_DISPLAY_LIMIT (6) even when graph returns more", async () => {
     mockDiscoveryResult = {
       found: true,
-      count: 5,
-      opportunities: Array.from({ length: 5 }, (_, i) => ({
+      count: 8,
+      opportunities: Array.from({ length: 8 }, (_, i) => ({
         opportunityId: `opp-continue-${i + 1}`,
         userId: `candidate-continue-${i + 1}`,
         name: `Candidate Continue ${i + 1}`,
@@ -1646,10 +1657,10 @@ describe("discover_opportunities tool", () => {
     const parsed = JSON.parse(result);
     expect(parsed.success).toBe(true);
     expect(parsed.data.found).toBe(true);
-    expect(parsed.data.count).toBe(3);
+    expect(parsed.data.count).toBe(6);
     // Count opportunity code blocks in the message
     const blocks = parsed.data.message.match(/```opportunity\n[\s\S]*?\n```/g) ?? [];
-    expect(blocks.length).toBe(3);
+    expect(blocks.length).toBe(6);
     // Should mention remaining candidates (2 from pagination + 2 extra from cap = 4)
     expect(parsed.data.message).toContain("more candidates");
   });
@@ -1705,10 +1716,10 @@ describe("update_opportunity tool (send via status pending)", () => {
       updatedAt: new Date(),
       expiresAt: null,
     };
-    const updateStatusSpy = mock(async () => null);
+    const stampSpy = mock(async () => ({ ...latentOpportunity, status: "pending" as const }));
     const mockDb = createMockDatabase(async () => [], {
       getOpportunity: async () => latentOpportunity,
-      updateOpportunityStatus: updateStatusSpy,
+      stampOpportunityActorAction: stampSpy,
     });
     const context: ToolContext = { userId: testUserId, database: mockDb, embedder: mockEmbedder, scraper: mockScraper, ...mockProtocolDeps };
     const tools = await createChatTools(context);
@@ -1718,7 +1729,7 @@ describe("update_opportunity tool (send via status pending)", () => {
     expect(parsed.success).toBe(true);
     expect(parsed.data.opportunityId).toBe(opportunityId);
     expect(parsed.data.status).toBe("pending");
-    expect(updateStatusSpy).toHaveBeenCalledWith(opportunityId, "pending");
+    expect(stampSpy).toHaveBeenCalledWith(opportunityId, testUserId, "pending");
   });
 
   test("when opportunity is draft and user is actor, status pending promotes to pending and returns success", async () => {
@@ -1737,10 +1748,10 @@ describe("update_opportunity tool (send via status pending)", () => {
       updatedAt: new Date(),
       expiresAt: null,
     };
-    const updateStatusSpy = mock(async () => null);
+    const stampSpy = mock(async () => ({ ...draftOpportunity, status: "pending" as const }));
     const mockDb = createMockDatabase(async () => [], {
       getOpportunity: async () => draftOpportunity,
-      updateOpportunityStatus: updateStatusSpy,
+      stampOpportunityActorAction: stampSpy,
     });
     const context: ToolContext = { userId: testUserId, database: mockDb, embedder: mockEmbedder, scraper: mockScraper, ...mockProtocolDeps };
     const tools = await createChatTools(context);
@@ -1750,7 +1761,7 @@ describe("update_opportunity tool (send via status pending)", () => {
     expect(parsed.success).toBe(true);
     expect(parsed.data.opportunityId).toBe(opportunityId);
     expect(parsed.data.status).toBe("pending");
-    expect(updateStatusSpy).toHaveBeenCalledWith(opportunityId, "pending");
+    expect(stampSpy).toHaveBeenCalledWith(opportunityId, testUserId, "pending");
   });
 
   test("when opportunity not found, returns error", async () => {
@@ -1819,7 +1830,7 @@ describe("update_opportunity tool (send via status pending)", () => {
     const result = await tool.invoke({ opportunityId, status: "pending" });
     const parsed = JSON.parse(result);
     expect(parsed.success).toBe(false);
-    expect(parsed.error).toMatch(/not part of this opportunity|not part|Valid opportunityId/i);
+    expect(parsed.error).toMatch(/not part of this opportunity|not part|not found|Valid opportunityId/i);
   });
 });
 
@@ -1974,8 +1985,8 @@ describe("list_opportunities tool (CHAT_DISPLAY_LIMIT cap)", () => {
     })) as unknown as Opportunity[];
   }
 
-  test("returns at most 3 opportunity code blocks when database has 5 opportunities", async () => {
-    const fakeOpps = buildFakeOpportunities(5);
+  test("returns at most 6 opportunity code blocks when database has 8 opportunities", async () => {
+    const fakeOpps = buildFakeOpportunities(8);
     let capturedLimit: number | undefined;
     const mockDb = createMockDatabase(async () => [], {
       getOpportunitiesForUser: async (_userId: string, opts?: { networkId?: string; limit?: number }) => {
@@ -2042,14 +2053,14 @@ describe("list_opportunities tool (CHAT_DISPLAY_LIMIT cap)", () => {
     expect(parsed.success).toBe(true);
     expect(parsed.data.found).toBe(true);
 
-    // Verify CHAT_DISPLAY_LIMIT (3) was passed to the database query
-    expect(capturedLimit).toBe(3);
+    // Verify the wider fetch budget was passed so selectByComposition can balance buckets.
+    expect(capturedLimit).toBe(30);
 
     // Count actual ```opportunity code blocks (start-of-line or after newline, not mid-sentence mentions)
     const codeBlockCount = (parsed.data.message.match(/(?:^|\n)```opportunity\n/g) || []).length;
-    expect(codeBlockCount).toBe(3);
+    expect(codeBlockCount).toBe(6);
     // Total count reported should also be capped
-    expect(parsed.data.count).toBe(3);
+    expect(parsed.data.count).toBe(6);
   });
 });
 
@@ -2266,10 +2277,10 @@ describe("createChatTools — MCP connect-link wiring", () => {
     expect(parsed.data.message).not.toContain("acceptUrl:");
   });
 
-  test("does NOT mint when opp is non-actionable (draft + party = sender, no link)", async () => {
+  test("mints send_direct when opp is draft + party", async () => {
     const mintCalls: Array<unknown> = [];
-    const mintConnectLink = async () => {
-      mintCalls.push(1);
+    const mintConnectLink = async (input: unknown) => {
+      mintCalls.push(input);
       return { url: FAKE_URL };
     };
 
@@ -2302,8 +2313,13 @@ describe("createChatTools — MCP connect-link wiring", () => {
     const parsed = JSON.parse(raw);
 
     expect(parsed.success).toBe(true);
-    expect(mintCalls.length).toBe(0); // sender-on-draft must not mint
-    expect(parsed.data.message).not.toContain("acceptUrl:");
+    expect(mintCalls.length).toBe(1);
+    expect(mintCalls[0]).toMatchObject({
+      userId: VIEWER_ID,
+      opportunityId: OPP_ID,
+      kind: "send_direct",
+    });
+    expect(parsed.data.message).toContain("acceptUrl:");
   });
 
   test("list_opportunities does NOT mint for pending + introducer", async () => {

--- a/packages/protocol/src/shared/agent/tests/tool.runtime.spec.ts
+++ b/packages/protocol/src/shared/agent/tests/tool.runtime.spec.ts
@@ -74,6 +74,26 @@ describe("tool runtime", () => {
     await expect(promise).rejects.toMatchObject({ code: "TOOL_CANCELLED" });
   });
 
+  test("normalizes string abort reasons into typed cancellation errors", async () => {
+    const controller = new AbortController();
+    const promise = invokeToolRuntime({
+      toolName: "create_premise",
+      tool: {
+        handler: async () => {
+          await Promise.resolve();
+          throw "local client cancelled";
+        },
+      },
+      context,
+      query: {},
+      signal: controller.signal,
+      timeoutMs: 1_000,
+    });
+
+    controller.abort("local client cancelled");
+    await expect(promise).rejects.toMatchObject({ code: "TOOL_CANCELLED" });
+  });
+
   test("rejects with a typed output-too-large error", async () => {
     await expect(invokeToolRuntime({
       toolName: "read_docs",

--- a/packages/protocol/src/shared/agent/tests/tool.runtime.spec.ts
+++ b/packages/protocol/src/shared/agent/tests/tool.runtime.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { invokeWithAbortSignal } from "../model-signal.js";
 import { requestContext } from "../../observability/request-context.js";
 import type { ResolvedToolContext } from "../tool.helpers.js";
 import {
@@ -82,6 +83,45 @@ describe("tool runtime", () => {
       timeoutMs: 100,
       maxOutputBytes: 5,
     })).rejects.toMatchObject({ code: "TOOL_OUTPUT_TOO_LARGE" });
+  });
+
+  test("passes request abort signal into model invocations", async () => {
+    const controller = new AbortController();
+    let observedSignal: AbortSignal | undefined;
+    const runnable = {
+      invoke: async (_input: string, config?: { signal?: AbortSignal }) => {
+        observedSignal = config?.signal;
+        return "ok";
+      },
+    };
+
+    const result = await requestContext.run({ abortSignal: controller.signal }, () =>
+      invokeWithAbortSignal(runnable, "input"),
+    );
+
+    expect(result).toBe("ok");
+    expect(observedSignal).toBe(controller.signal);
+  });
+
+  test("combines explicit and request abort signals for model invocations", async () => {
+    const inherited = new AbortController();
+    const explicit = new AbortController();
+    let observedSignal: AbortSignal | undefined;
+    const runnable = {
+      invoke: async (_input: string, config?: { signal?: AbortSignal }) => {
+        observedSignal = config?.signal;
+        return "ok";
+      },
+    };
+
+    await requestContext.run({ abortSignal: inherited.signal }, () =>
+      invokeWithAbortSignal(runnable, "input", explicit.signal),
+    );
+
+    expect(observedSignal).toBeInstanceOf(AbortSignal);
+    expect(observedSignal?.aborted).toBe(false);
+    inherited.abort(new Error("request cancelled"));
+    expect(observedSignal?.aborted).toBe(true);
   });
 
   test("serializes runtime errors into MCP/REST-safe JSON envelopes", () => {

--- a/packages/protocol/src/shared/agent/tests/tool.runtime.spec.ts
+++ b/packages/protocol/src/shared/agent/tests/tool.runtime.spec.ts
@@ -25,6 +25,8 @@ const context = {
 describe("tool runtime", () => {
   test("classifies audited tool timeout policies", () => {
     expect(getToolTimeoutPolicy("read_docs").class).toBe("fast");
+    expect(getToolTimeoutPolicy("get_discovery_run").class).toBe("fast");
+    expect(getToolTimeoutPolicy("cancel_discovery_run").class).toBe("fast");
     expect(getToolTimeoutPolicy("read_docs").maxOutputBytes).toBeGreaterThan(0);
     expect(getToolTimeoutPolicy("list_opportunities").class).toBe("bounded_slow");
     expect(getToolTimeoutPolicy("discover_opportunities").class).toBe("async_candidate");

--- a/packages/protocol/src/shared/agent/tests/tool.runtime.spec.ts
+++ b/packages/protocol/src/shared/agent/tests/tool.runtime.spec.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+
+import { requestContext } from "../../observability/request-context.js";
+import type { ResolvedToolContext } from "../tool.helpers.js";
+import {
+  ToolRuntimeError,
+  getToolTimeoutPolicy,
+  invokeToolRuntime,
+  toolRuntimeErrorToResult,
+} from "../tool.runtime.js";
+
+const context = {
+  userId: "user-1",
+  userName: "User",
+  userEmail: "user@example.com",
+  user: { id: "user-1", name: "User", email: "user@example.com" },
+  userProfile: null,
+  userNetworks: [],
+  indexScope: [],
+  isOnboarding: false,
+  hasName: true,
+} as unknown as ResolvedToolContext;
+
+describe("tool runtime", () => {
+  test("classifies audited tool timeout policies", () => {
+    expect(getToolTimeoutPolicy("read_docs").class).toBe("fast");
+    expect(getToolTimeoutPolicy("read_docs").maxOutputBytes).toBeGreaterThan(0);
+    expect(getToolTimeoutPolicy("list_opportunities").class).toBe("bounded_slow");
+    expect(getToolTimeoutPolicy("discover_opportunities").class).toBe("async_candidate");
+  });
+
+  test("injects requestContext abort signal into tool handlers", async () => {
+    const result = await invokeToolRuntime({
+      toolName: "read_docs",
+      tool: {
+        handler: async () => {
+          const signal = requestContext.getStore()?.abortSignal;
+          expect(signal).toBeInstanceOf(AbortSignal);
+          expect(signal?.aborted).toBe(false);
+          return JSON.stringify({ success: true });
+        },
+      },
+      context,
+      query: {},
+      timeoutMs: 100,
+    });
+
+    expect(JSON.parse(result)).toEqual({ success: true });
+  });
+
+  test("rejects with a typed timeout error", async () => {
+    await expect(invokeToolRuntime({
+      toolName: "scrape_url",
+      tool: { handler: async () => new Promise<string>(() => undefined) },
+      context,
+      query: {},
+      timeoutMs: 10,
+    })).rejects.toMatchObject({ code: "TOOL_TIMEOUT" });
+  });
+
+  test("rejects with a typed cancellation error", async () => {
+    const controller = new AbortController();
+    const promise = invokeToolRuntime({
+      toolName: "read_docs",
+      tool: { handler: async () => new Promise<string>(() => undefined) },
+      context,
+      query: {},
+      signal: controller.signal,
+      timeoutMs: 1_000,
+    });
+
+    controller.abort(new Error("test cancellation"));
+    await expect(promise).rejects.toMatchObject({ code: "TOOL_CANCELLED" });
+  });
+
+  test("rejects with a typed output-too-large error", async () => {
+    await expect(invokeToolRuntime({
+      toolName: "read_docs",
+      tool: { handler: async () => "0123456789" },
+      context,
+      query: {},
+      timeoutMs: 100,
+      maxOutputBytes: 5,
+    })).rejects.toMatchObject({ code: "TOOL_OUTPUT_TOO_LARGE" });
+  });
+
+  test("serializes runtime errors into MCP/REST-safe JSON envelopes", () => {
+    const err = new ToolRuntimeError(
+      "TOOL_TIMEOUT",
+      "Tool scrape_url timed out after 10ms.",
+      "scrape_url",
+      { class: "async_candidate", timeoutMs: 10, maxOutputBytes: 1000 },
+    );
+
+    expect(JSON.parse(toolRuntimeErrorToResult(err) ?? "{}")).toEqual({
+      success: false,
+      code: "TOOL_TIMEOUT",
+      error: "Tool scrape_url timed out after 10ms.",
+      data: {
+        tool: "scrape_url",
+        timeoutClass: "async_candidate",
+        timeoutMs: 10,
+        maxOutputBytes: 1000,
+      },
+    });
+  });
+});

--- a/packages/protocol/src/shared/agent/tool.factory.ts
+++ b/packages/protocol/src/shared/agent/tool.factory.ts
@@ -201,6 +201,8 @@ export async function createChatTools(
     grantDefaultSystemPermissions: deps.grantDefaultSystemPermissions,
     agentDispatcher: deps.agentDispatcher,
     deliveryLedger: deps.deliveryLedger,
+    discoveryRuns: deps.discoveryRuns,
+    discoveryRunQueue: deps.discoveryRunQueue,
     mintConnectToken: deps.mintConnectToken,
     mintConnectLink: deps.mintConnectLink,
     frontendUrl: deps.frontendUrl,

--- a/packages/protocol/src/shared/agent/tool.factory.ts
+++ b/packages/protocol/src/shared/agent/tool.factory.ts
@@ -25,6 +25,7 @@ import {
   resolveChatContext,
 } from "./tool.helpers.js";
 import { error, redactSensitiveFields } from "./tool.helpers.js";
+import { invokeToolRuntime, toolRuntimeErrorToResult } from "./tool.runtime.js";
 import { createProfileTools } from "../../profile/profile.tools.js";
 import { createIntentTools } from "../../intent/intent.tools.js";
 import { createNetworkTools } from "../../network/network.tools.js";
@@ -101,11 +102,18 @@ export async function createChatTools(
           query: redactSensitiveFields(query),
         });
         try {
-          return await opts.handler({ context: resolvedContext, query });
+          return await invokeToolRuntime({
+            toolName: opts.name,
+            tool: { handler: async ({ context, query }) => opts.handler({ context, query: query as z.infer<T> }) },
+            context: resolvedContext,
+            query,
+          });
         } catch (err) {
           logger.error(`${opts.name} failed`, {
             error: err instanceof Error ? err.message : String(err),
           });
+          const runtimeResult = toolRuntimeErrorToResult(err);
+          if (runtimeResult) return runtimeResult;
           const reason = err instanceof Error ? err.message : String(err);
           return error(`Failed to execute ${opts.name}: ${reason}`);
         }

--- a/packages/protocol/src/shared/agent/tool.helpers.ts
+++ b/packages/protocol/src/shared/agent/tool.helpers.ts
@@ -30,6 +30,7 @@ import type { MintConnectLink } from "../interfaces/connect-link.interface.js";
 import type { QuestionerDatabase } from "../interfaces/questioner.interface.js";
 import type { QuestionerEnqueueFn } from "../../questioner/questioner.types.js";
 import type { PendingQuestionSummary } from "../schemas/pending-question.schema.js";
+import type { DiscoveryRunQueue, DiscoveryRunStore } from "../interfaces/discovery-run.interface.js";
 
 export type ProfileContext = ProfileDocument | null;
 
@@ -193,6 +194,10 @@ export interface ToolContext {
   queueNegotiateExisting?: (opportunityId: string, userId: string) => Promise<void>;
   /** Delivery ledger for committing opportunity delivery rows (optional — absent in chat context). */
   deliveryLedger?: DeliveryLedger;
+  /** Persistence for async MCP discovery runs (optional — absent in non-MCP/test contexts). */
+  discoveryRuns?: DiscoveryRunStore;
+  /** Queue for async MCP discovery run execution (optional — absent in non-MCP/test contexts). */
+  discoveryRunQueue?: DiscoveryRunQueue;
   /** Mints a short-lived connect token for opportunity accept links (optional — absent in non-MCP contexts). */
   mintConnectToken?: (userId: string, opportunityId: string) => Promise<string>;
   /** Mints (or reuses) a short connect link, snapshotting the greeting (optional — absent in non-MCP contexts). */
@@ -444,6 +449,10 @@ export interface ToolDeps {
   agentDispatcher?: AgentDispatcher;
   /** Delivery ledger for committing opportunity delivery rows (optional — absent in chat context). */
   deliveryLedger?: DeliveryLedger;
+  /** Persistence for async MCP discovery runs (optional — absent in non-MCP/test contexts). */
+  discoveryRuns?: DiscoveryRunStore;
+  /** Queue for async MCP discovery run execution (optional — absent in non-MCP/test contexts). */
+  discoveryRunQueue?: DiscoveryRunQueue;
   /** Mints a short-lived connect token for opportunity accept links (optional — absent in non-MCP contexts). */
   mintConnectToken?: (userId: string, opportunityId: string) => Promise<string>;
   /** Mints (or reuses) a short connect link, snapshotting the greeting (optional — absent in non-MCP contexts). */

--- a/packages/protocol/src/shared/agent/tool.registry.ts
+++ b/packages/protocol/src/shared/agent/tool.registry.ts
@@ -14,6 +14,7 @@ import { createNegotiationTools } from '../../negotiation/negotiation.tools.js';
 import { createChatTools } from '../../chat/chat.tools.js';
 import { createPremiseTools } from '../../premise/premise.tools.js';
 import { protocolLogger } from '../observability/protocol.logger.js';
+import { requestContext } from '../observability/request-context.js';
 
 const logger = protocolLogger('ToolRegistry');
 
@@ -48,6 +49,10 @@ export function createToolRegistry(deps: ToolDeps): ToolRegistry {
         try {
           return await opts.handler({ context: input.context, query: input.query as z.infer<T> });
         } catch (err) {
+          const abortSignal = requestContext.getStore()?.abortSignal;
+          if (abortSignal?.aborted) {
+            throw err;
+          }
           logger.error(`${opts.name} failed`, {
             error: err instanceof Error ? err.message : String(err),
           });

--- a/packages/protocol/src/shared/agent/tool.runtime.ts
+++ b/packages/protocol/src/shared/agent/tool.runtime.ts
@@ -117,11 +117,6 @@ export class ToolRuntimeError extends Error {
   }
 }
 
-function isAbortErrorLike(err: unknown): boolean {
-  if (!(err instanceof Error)) return false;
-  return err.name === "AbortError" || err.name === "TimeoutError" || /abort|cancel/i.test(err.message);
-}
-
 function combineSignals(signals: Array<AbortSignal | undefined>): {
   signal: AbortSignal;
   abort: (reason?: unknown) => void;
@@ -169,6 +164,7 @@ export async function invokeToolRuntime(input: ToolInvocationRuntimeInput): Prom
     combined.abort(new Error(`Tool ${input.toolName} timed out after ${policy.timeoutMs}ms`));
   }, policy.timeoutMs);
 
+  let removeAbortListener = () => {};
   const abortPromise = new Promise<never>((_, reject) => {
     const onAbort = () => {
       const code: ToolRuntimeErrorCode = timedOut ? "TOOL_TIMEOUT" : "TOOL_CANCELLED";
@@ -182,6 +178,7 @@ export async function invokeToolRuntime(input: ToolInvocationRuntimeInput): Prom
       ));
     };
     combined.signal.addEventListener("abort", onAbort, { once: true });
+    removeAbortListener = () => combined.signal.removeEventListener("abort", onAbort);
   });
 
   try {
@@ -207,7 +204,7 @@ export async function invokeToolRuntime(input: ToolInvocationRuntimeInput): Prom
     return result;
   } catch (err) {
     if (err instanceof ToolRuntimeError) throw err;
-    if (combined.signal.aborted && isAbortErrorLike(err)) {
+    if (combined.signal.aborted) {
       const code: ToolRuntimeErrorCode = timedOut ? "TOOL_TIMEOUT" : "TOOL_CANCELLED";
       throw new ToolRuntimeError(
         code,
@@ -221,6 +218,7 @@ export async function invokeToolRuntime(input: ToolInvocationRuntimeInput): Prom
     throw err;
   } finally {
     clearTimeout(timer);
+    removeAbortListener();
     combined.cleanup();
   }
 }

--- a/packages/protocol/src/shared/agent/tool.runtime.ts
+++ b/packages/protocol/src/shared/agent/tool.runtime.ts
@@ -41,6 +41,8 @@ const FAST_TOOLS = new Set([
   "delete_network_membership",
   "confirm_opportunity_delivery",
   "read_docs",
+  "get_discovery_run",
+  "cancel_discovery_run",
   "remove_contact",
   "register_agent",
   "list_agents",

--- a/packages/protocol/src/shared/agent/tool.runtime.ts
+++ b/packages/protocol/src/shared/agent/tool.runtime.ts
@@ -1,0 +1,241 @@
+import type { TraceEmitter } from "../observability/request-context.js";
+import { requestContext } from "../observability/request-context.js";
+
+import type { RawToolDefinition, ResolvedToolContext } from "./tool.helpers.js";
+
+export type ToolTimeoutClass = "fast" | "bounded_slow" | "async_candidate";
+export type ToolRuntimeErrorCode = "TOOL_TIMEOUT" | "TOOL_CANCELLED" | "TOOL_OUTPUT_TOO_LARGE";
+
+export interface ToolTimeoutPolicy {
+  class: ToolTimeoutClass;
+  timeoutMs: number;
+  maxOutputBytes: number;
+}
+
+export interface ToolInvocationRuntimeInput {
+  toolName: string;
+  tool: Pick<RawToolDefinition, "handler">;
+  context: ResolvedToolContext;
+  query: unknown;
+  signal?: AbortSignal;
+  traceEmitter?: TraceEmitter;
+  timeoutMs?: number;
+  maxOutputBytes?: number;
+}
+
+const FAST_TIMEOUT_MS = 10_000;
+const BOUNDED_SLOW_TIMEOUT_MS = 45_000;
+const ASYNC_CANDIDATE_TIMEOUT_MS = 50_000;
+const DEFAULT_MAX_OUTPUT_BYTES = 1_000_000;
+
+const FAST_TOOLS = new Set([
+  "record_onboarding_privacy_consent",
+  "create_intent_index",
+  "delete_intent_index",
+  "search_intents",
+  "read_networks",
+  "update_network",
+  "create_network",
+  "delete_network",
+  "create_network_membership",
+  "delete_network_membership",
+  "confirm_opportunity_delivery",
+  "read_docs",
+  "remove_contact",
+  "register_agent",
+  "list_agents",
+  "update_agent",
+  "delete_agent",
+  "grant_agent_permission",
+  "revoke_agent_permission",
+  "retract_premise",
+]);
+
+const ASYNC_CANDIDATE_TOOLS = new Set([
+  "read_user_profiles",
+  "preview_user_profile",
+  "create_user_profile",
+  "create_intent",
+  "update_intent",
+  "discover_opportunities",
+  "scrape_url",
+  "import_gmail_contacts",
+  "import_contacts",
+  "respond_to_negotiation",
+  "create_premise",
+  "update_premise",
+]);
+
+function parsePositiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 && parsed <= Number.MAX_SAFE_INTEGER
+    ? parsed
+    : fallback;
+}
+
+function toolNameEnv(toolName: string): string {
+  return `MCP_TOOL_TIMEOUT_${toolName.toUpperCase().replace(/[^A-Z0-9]+/g, "_")}_MS`;
+}
+
+function toolNameOutputEnv(toolName: string): string {
+  return `MCP_TOOL_MAX_OUTPUT_${toolName.toUpperCase().replace(/[^A-Z0-9]+/g, "_")}_BYTES`;
+}
+
+export function getToolTimeoutPolicy(toolName: string): ToolTimeoutPolicy {
+  const classification: ToolTimeoutClass = FAST_TOOLS.has(toolName)
+    ? "fast"
+    : ASYNC_CANDIDATE_TOOLS.has(toolName)
+      ? "async_candidate"
+      : "bounded_slow";
+
+  const classDefault = classification === "fast"
+    ? parsePositiveIntEnv("MCP_TOOL_TIMEOUT_FAST_MS", FAST_TIMEOUT_MS)
+    : classification === "async_candidate"
+      ? parsePositiveIntEnv("MCP_TOOL_TIMEOUT_ASYNC_CANDIDATE_MS", ASYNC_CANDIDATE_TIMEOUT_MS)
+      : parsePositiveIntEnv("MCP_TOOL_TIMEOUT_BOUNDED_SLOW_MS", BOUNDED_SLOW_TIMEOUT_MS);
+
+  const defaultMaxOutputBytes = parsePositiveIntEnv("MCP_TOOL_MAX_OUTPUT_BYTES", DEFAULT_MAX_OUTPUT_BYTES);
+
+  return {
+    class: classification,
+    timeoutMs: parsePositiveIntEnv(toolNameEnv(toolName), classDefault),
+    maxOutputBytes: parsePositiveIntEnv(toolNameOutputEnv(toolName), defaultMaxOutputBytes),
+  };
+}
+
+export class ToolRuntimeError extends Error {
+  constructor(
+    public readonly code: ToolRuntimeErrorCode,
+    message: string,
+    public readonly toolName: string,
+    public readonly policy: ToolTimeoutPolicy,
+  ) {
+    super(message);
+    this.name = "ToolRuntimeError";
+  }
+}
+
+function isAbortErrorLike(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return err.name === "AbortError" || err.name === "TimeoutError" || /abort|cancel/i.test(err.message);
+}
+
+function combineSignals(signals: Array<AbortSignal | undefined>): {
+  signal: AbortSignal;
+  abort: (reason?: unknown) => void;
+  cleanup: () => void;
+} {
+  const controller = new AbortController();
+  const listeners: Array<() => void> = [];
+
+  for (const source of signals) {
+    if (!source) continue;
+    if (source.aborted) {
+      controller.abort(source.reason);
+      break;
+    }
+    const onAbort = () => {
+      if (!controller.signal.aborted) controller.abort(source.reason);
+    };
+    source.addEventListener("abort", onAbort, { once: true });
+    listeners.push(() => source.removeEventListener("abort", onAbort));
+  }
+
+  return {
+    signal: controller.signal,
+    abort: (reason?: unknown) => {
+      if (!controller.signal.aborted) controller.abort(reason);
+    },
+    cleanup: () => {
+      for (const cleanup of listeners) cleanup();
+    },
+  };
+}
+
+export async function invokeToolRuntime(input: ToolInvocationRuntimeInput): Promise<string> {
+  const basePolicy = getToolTimeoutPolicy(input.toolName);
+  const policy = {
+    ...basePolicy,
+    ...(input.timeoutMs !== undefined ? { timeoutMs: input.timeoutMs } : {}),
+    ...(input.maxOutputBytes !== undefined ? { maxOutputBytes: input.maxOutputBytes } : {}),
+  };
+  const inherited = requestContext.getStore();
+  const combined = combineSignals([input.signal, inherited?.abortSignal]);
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    combined.abort(new Error(`Tool ${input.toolName} timed out after ${policy.timeoutMs}ms`));
+  }, policy.timeoutMs);
+
+  const abortPromise = new Promise<never>((_, reject) => {
+    const onAbort = () => {
+      const code: ToolRuntimeErrorCode = timedOut ? "TOOL_TIMEOUT" : "TOOL_CANCELLED";
+      reject(new ToolRuntimeError(
+        code,
+        code === "TOOL_TIMEOUT"
+          ? `Tool ${input.toolName} timed out after ${policy.timeoutMs}ms.`
+          : `Tool ${input.toolName} was cancelled before it completed.`,
+        input.toolName,
+        policy,
+      ));
+    };
+    combined.signal.addEventListener("abort", onAbort, { once: true });
+  });
+
+  try {
+    const run = () => input.tool.handler({ context: input.context, query: input.query });
+    const toolPromise = requestContext.run(
+      {
+        ...inherited,
+        abortSignal: combined.signal,
+        traceEmitter: input.traceEmitter ?? inherited?.traceEmitter,
+      },
+      run,
+    );
+    const result = await Promise.race([toolPromise, abortPromise]);
+    const outputBytes = new TextEncoder().encode(result).byteLength;
+    if (outputBytes > policy.maxOutputBytes) {
+      throw new ToolRuntimeError(
+        "TOOL_OUTPUT_TOO_LARGE",
+        `Tool ${input.toolName} returned ${outputBytes} bytes, exceeding the ${policy.maxOutputBytes} byte limit.`,
+        input.toolName,
+        policy,
+      );
+    }
+    return result;
+  } catch (err) {
+    if (err instanceof ToolRuntimeError) throw err;
+    if (combined.signal.aborted && isAbortErrorLike(err)) {
+      const code: ToolRuntimeErrorCode = timedOut ? "TOOL_TIMEOUT" : "TOOL_CANCELLED";
+      throw new ToolRuntimeError(
+        code,
+        code === "TOOL_TIMEOUT"
+          ? `Tool ${input.toolName} timed out after ${policy.timeoutMs}ms.`
+          : `Tool ${input.toolName} was cancelled before it completed.`,
+        input.toolName,
+        policy,
+      );
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+    combined.cleanup();
+  }
+}
+
+export function toolRuntimeErrorToResult(err: unknown): string | null {
+  if (!(err instanceof ToolRuntimeError)) return null;
+  return JSON.stringify({
+    success: false,
+    code: err.code,
+    error: err.message,
+    data: {
+      tool: err.toolName,
+      timeoutClass: err.policy.class,
+      timeoutMs: err.policy.timeoutMs,
+      maxOutputBytes: err.policy.maxOutputBytes,
+    },
+  });
+}

--- a/packages/protocol/src/shared/agent/utility.tools.ts
+++ b/packages/protocol/src/shared/agent/utility.tools.ts
@@ -1,4 +1,7 @@
 import { z } from "zod";
+
+import { requestContext } from "../observability/request-context.js";
+
 import type { DefineTool, ToolDeps } from "./tool.helpers.js";
 import { success, error, normalizeUrl } from "./tool.helpers.js";
 
@@ -29,6 +32,7 @@ export function createUtilityTools(defineTool: DefineTool, deps: ToolDeps) {
 
       const content = await scraper.extractUrlContent(normalizedUrl, {
         objective: query.objective?.trim() || undefined,
+        signal: requestContext.getStore()?.abortSignal,
       });
 
       if (!content) {

--- a/packages/protocol/src/shared/hyde/hyde.generator.ts
+++ b/packages/protocol/src/shared/hyde/hyde.generator.ts
@@ -9,6 +9,7 @@ import type { HydeTargetCorpus } from './lens.inferrer.js';
 import { Timed } from "../observability/performance.js";
 import { protocolLogger } from '../observability/protocol.logger.js';
 import { createModel } from "../agent/model.config.js";
+import { invokeWithAbortSignal } from "../agent/model-signal.js";
 
 const logger = protocolLogger("HydeGenerator");
 
@@ -67,7 +68,7 @@ export class HydeGenerator {
       new HumanMessage(promptText),
     ];
 
-    const result = await this.model.invoke(messages);
+    const result = await invokeWithAbortSignal(this.model, messages);
     const parsed = responseFormat.parse(result);
     const text = parsed.hypotheticalDocument ?? '';
 

--- a/packages/protocol/src/shared/hyde/hyde.graph.ts
+++ b/packages/protocol/src/shared/hyde/hyde.graph.ts
@@ -7,6 +7,8 @@
 
 import { StateGraph, START, END } from '@langchain/langgraph';
 import { createHash } from 'crypto';
+
+import { getAbortSignalConfig } from '../agent/model-signal.js';
 import { HydeGraphState, type HydeDocumentState } from './hyde.state.js';
 import { LensInferrer } from './lens.inferrer.js';
 import { HydeGenerator } from './hyde.generator.js';
@@ -216,7 +218,7 @@ export class HydeGraphFactory {
         if (toEmbed.length > 0) {
           logger.verbose('Embedding documents', { count: toEmbed.length });
           const texts = toEmbed.map((t) => t.doc.hydeText);
-          const embeddings = await self.embedder.generate(texts);
+          const embeddings = await self.embedder.generate(texts, undefined, getAbortSignalConfig());
           const embeddingArray = Array.isArray(embeddings[0])
             ? (embeddings as number[][])
             : [embeddings as number[]];

--- a/packages/protocol/src/shared/hyde/lens.inferrer.ts
+++ b/packages/protocol/src/shared/hyde/lens.inferrer.ts
@@ -8,6 +8,7 @@ import { z } from 'zod';
 import { Timed } from "../observability/performance.js";
 import { protocolLogger } from '../observability/protocol.logger.js';
 import { createModel } from "../agent/model.config.js";
+import { invokeWithAbortSignal } from "../agent/model-signal.js";
 
 export type HydeTargetCorpus = 'profiles' | 'intents' | 'premises';
 
@@ -100,7 +101,7 @@ export class LensInferrer {
     ];
 
     try {
-      const result = await this.model.invoke(messages);
+      const result = await invokeWithAbortSignal(this.model, messages);
       const parsed = responseFormat.parse(result);
       const lenses = parsed.lenses.slice(0, maxLenses);
 

--- a/packages/protocol/src/shared/interfaces/discovery-run.interface.ts
+++ b/packages/protocol/src/shared/interfaces/discovery-run.interface.ts
@@ -1,0 +1,84 @@
+import type { ResolvedToolContext } from "../agent/tool.helpers.js";
+
+export type DiscoveryRunStatus = "queued" | "running" | "succeeded" | "failed" | "cancelled";
+
+export interface DiscoveryRunInput {
+  continueFrom?: string;
+  searchQuery?: string;
+  networkId?: string;
+  intentId?: string;
+  targetUserId?: string;
+  introTargetUserId?: string;
+  partyUserIds?: string[];
+  entities?: Array<{
+    userId: string;
+    profile?: {
+      name?: string;
+      bio?: string;
+      location?: string;
+      interests?: string[];
+      skills?: string[];
+      context?: string;
+    };
+    intents?: Array<{
+      intentId: string;
+      payload: string;
+      summary?: string;
+    }>;
+    networkId: string;
+  }>;
+  hint?: string;
+}
+
+export interface DiscoveryRunRecord {
+  id: string;
+  userId: string;
+  agentId?: string | null;
+  status: DiscoveryRunStatus;
+  input: DiscoveryRunInput;
+  context: Pick<ResolvedToolContext,
+    "userId" |
+    "userName" |
+    "userEmail" |
+    "networkId" |
+    "indexName" |
+    "indexScope" |
+    "sessionId" |
+    "agentId" |
+    "clientSurface"
+  >;
+  progress?: Record<string, unknown> | null;
+  result?: unknown;
+  error?: string | null;
+  cancelRequestedAt?: Date | null;
+  createdAt: Date;
+  startedAt?: Date | null;
+  completedAt?: Date | null;
+  expiresAt?: Date | null;
+}
+
+export interface CreateDiscoveryRunInput {
+  userId: string;
+  agentId?: string | null;
+  input: DiscoveryRunInput;
+  context: DiscoveryRunRecord["context"];
+  expiresAt?: Date;
+}
+
+export interface DiscoveryRunStore {
+  create(input: CreateDiscoveryRunInput): Promise<DiscoveryRunRecord>;
+  get(runId: string, userId: string): Promise<DiscoveryRunRecord | null>;
+  markRunning(runId: string): Promise<DiscoveryRunRecord | null>;
+  updateProgress(runId: string, progress: Record<string, unknown>): Promise<void>;
+  markSucceeded(runId: string, result: unknown): Promise<void>;
+  markFailed(runId: string, error: string): Promise<void>;
+  requestCancel(runId: string, userId: string): Promise<DiscoveryRunRecord | null>;
+  markCancelled(runId: string, reason?: string): Promise<void>;
+  isCancelRequested(runId: string): Promise<boolean>;
+  listActive(userId: string, limit?: number): Promise<DiscoveryRunRecord[]>;
+}
+
+export interface DiscoveryRunQueue {
+  enqueue(runId: string): Promise<{ jobId?: string | number } | void>;
+  cancel(runId: string): Promise<boolean>;
+}

--- a/packages/protocol/src/shared/interfaces/embedder.interface.ts
+++ b/packages/protocol/src/shared/interfaces/embedder.interface.ts
@@ -45,8 +45,12 @@ export interface HydeCandidate {
 // Embedding and vector store
 // ═══════════════════════════════════════════════════════════════════════════════
 
+export interface EmbeddingGenerateOptions {
+  signal?: AbortSignal;
+}
+
 export interface EmbeddingGenerator {
-  generate(text: string | string[], dimensions?: number): Promise<number[] | number[][]>;
+  generate(text: string | string[], dimensions?: number, options?: EmbeddingGenerateOptions): Promise<number[] | number[][]>;
 }
 
 export interface VectorSearchResult<T> {

--- a/packages/protocol/src/shared/interfaces/scraper.interface.ts
+++ b/packages/protocol/src/shared/interfaces/scraper.interface.ts
@@ -8,6 +8,8 @@ export interface ExtractUrlContentOptions {
    * "User wants to update their profile from this page.", or omit for generic extraction.
    */
   objective?: string;
+  /** Optional cancellation signal for caller/client disconnect or runtime deadline. */
+  signal?: AbortSignal;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Release `dev` to `main` from `release/2026-06-01`.
- Update `frontend/CHANGELOG.md` with the latest unreleased frontend fixes.
- Include backend/protocol MCP changes in this release changelog; the repo currently only has a tracked package changelog for `frontend/`.

## Changelog
### Added
- Queue async MCP opportunity discovery runs so long-running searches can continue without blocking tool calls.

### Changed
- Document MCP runtime limits and cancellation behavior for protocol users.

### Fixed
- Clear stale browser auth sessions automatically when user lookup fails.
- Show experiment networks such as Edge City in shared profile networks and link them to their network pages.
- Limit automatic onboarding redirects to the home page so signed-in users can open app routes like `/networks` before finishing setup.
- Propagate MCP cancellation to model calls and preserve typed cancellation errors.
- Enforce shared MCP tool runtime timeouts to prevent long-running calls from hanging.
- Acknowledge profile confirmation immediately while completing profile graph work asynchronously.

## Verification
- Not run; release/changelog-only branch commit.