### PR TITLE
fix(protocol): prefer authenticated identity for profile preview

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -136,7 +136,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@langchain/core": "^1.1.17",
         "@langchain/langgraph": "^1.1.2",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/profile/profile.tools.ts
+++ b/packages/protocol/src/profile/profile.tools.ts
@@ -27,11 +27,29 @@ function isMeaningfulEnrichment(enrichment: EnrichmentResult | null): enrichment
 export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
   const { userDb, systemDb, database, graphs, enricher, grantDefaultSystemPermissions } = deps;
 
+  function trimToUndefined(value: string | null | undefined): string | undefined {
+    const trimmed = value?.trim();
+    return trimmed && trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  function isPlaceholderName(value: string): boolean {
+    const normalized = value.trim().toLowerCase();
+    return normalized === 'unknown' || normalized === 'user';
+  }
+
+  function resolveAuthenticatedLookupIdentity(user: UserRecord, context: { userName?: string; userEmail?: string }) {
+    const userName = trimToUndefined(user.name);
+    const contextName = trimToUndefined(context.userName);
+    const name = [userName, contextName].find((candidate) => candidate !== undefined && !isPlaceholderName(candidate));
+    const email = trimToUndefined(user.email) ?? trimToUndefined(context.userEmail);
+    return { name, email };
+  }
+
   async function enrichFromUserRecord(user: { name?: string | null; email?: string | null; socials: Array<{ id: string; userId: string; label: string; value: string }> }) {
     const enrichmentSocials = socialsToEnrichmentRequest(user.socials);
     return enricher.enrichUserProfile({
-      name: user.name || undefined,
-      email: user.email || undefined,
+      name: trimToUndefined(user.name),
+      email: trimToUndefined(user.email),
       linkedin: enrichmentSocials.linkedin || undefined,
       twitter: enrichmentSocials.twitter || undefined,
       github: enrichmentSocials.github || undefined,
@@ -412,7 +430,7 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
       "Builds a structured profile draft for onboarding without saving anything. Use this after recording privacy consent and before asking the user to approve the profile. " +
       "If allowPublicLookup is false, this tool uses only explicit text, EdgeOS/event data the user allowed, and user-provided social URLs. If allowPublicLookup is true, persisted public lookup consent is required.",
     querySchema: z.object({
-      name: z.string().optional().describe("Name explicitly provided by the user or already known from the authenticated account."),
+      name: z.string().optional().describe("Name explicitly provided by the user. For authenticated public lookup, the account identity is used first and this is only a fallback."),
       location: z.string().optional().describe("Location explicitly provided by the user or allowed event data."),
       bioOrDescription: z.string().optional().describe("Explicit self-description provided by the user."),
       edgeosProfileText: z.string().optional().describe("EdgeOS/event profile text, only if the user granted EdgeOS import consent."),
@@ -429,7 +447,8 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
       const onboarding = user.onboarding ?? context.user.onboarding;
       const hasEdgeosConsent = hasEdgeosImportConsent(onboarding);
       const seed = hasEdgeosConsent ? selectProfileSeed(onboarding, context.networkId) : undefined;
-      const name = query.name?.trim() || seed?.name || user.name || undefined;
+      const authenticatedIdentity = resolveAuthenticatedLookupIdentity(user, context);
+      const name = seed?.name || authenticatedIdentity.name || query.name?.trim() || undefined;
       const location = query.location?.trim() || seed?.location || user.location || undefined;
       const bioOrDescription = query.bioOrDescription?.trim() || seed?.bio || user.intro || undefined;
       const edgeosProfileText = query.edgeosProfileText?.trim() || undefined;
@@ -454,9 +473,10 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
         if (!hasPublicProfileLookupConsent(user.onboarding ?? context.user.onboarding)) {
           return error("Public profile lookup consent has not been recorded. Ask the user first, then call record_onboarding_privacy_consent(publicProfileLookupGranted=true).");
         }
+        const hasAuthenticatedIdentity = authenticatedIdentity.name !== undefined || authenticatedIdentity.email !== undefined;
         enrichment = await enrichFromUserRecord({
-          name,
-          email: user.email,
+          name: authenticatedIdentity.name ?? (hasAuthenticatedIdentity ? undefined : name),
+          email: authenticatedIdentity.email,
           socials: socials.map((social, index) => ({ id: `preview-${index}`, userId: context.userId, ...social })),
         });
       }

--- a/packages/protocol/src/profile/tests/profile.privacy-tools.spec.ts
+++ b/packages/protocol/src/profile/tests/profile.privacy-tools.spec.ts
@@ -53,6 +53,7 @@ describe("onboarding privacy profile tools", () => {
   let profileGraphInvoke: ReturnType<typeof mock>;
   let tools: CapturedTool[];
   let onboarding: ResolvedToolContext["user"]["onboarding"];
+  let currentUser: ResolvedToolContext["user"];
 
   const context = (): ResolvedToolContext => ({
     userId: "u1",
@@ -62,9 +63,11 @@ describe("onboarding privacy profile tools", () => {
   beforeEach(() => {
     generatedInputs = [];
     onboarding = {};
+    currentUser = { id: "u1", name: "Alice", email: "alice@example.com", location: "Healdsburg", intro: null, socials: [], onboarding };
     updateUser = mock(async (data: { onboarding?: typeof onboarding }) => {
       if (data.onboarding) onboarding = data.onboarding;
-      return { id: "u1", name: "Alice", email: "alice@example.com", socials: [], onboarding };
+      currentUser = { ...currentUser, ...data, onboarding };
+      return currentUser;
     });
     saveProfile = mock(async () => {});
     setUserSocials = mock(async () => {});
@@ -80,7 +83,7 @@ describe("onboarding privacy profile tools", () => {
 
     tools = captureTools({
       userDb: {
-        getUser: async () => ({ id: "u1", name: "Alice", email: "alice@example.com", location: "Healdsburg", intro: null, socials: [], onboarding }),
+        getUser: async () => ({ ...currentUser, onboarding }),
         updateUser,
         getProfile: async () => null,
         saveProfile,
@@ -162,6 +165,29 @@ describe("onboarding privacy profile tools", () => {
 
     expect(result.success).toBe(false);
     expect(enricher).not.toHaveBeenCalled();
+    expect(saveProfile).not.toHaveBeenCalled();
+  });
+
+  it("preview with public lookup prefers authenticated identity over agent-supplied name", async () => {
+    onboarding = {
+      privacy: {
+        publicProfileLookup: {
+          granted: true,
+          decidedAt: "2026-05-29T00:00:00.000Z",
+          source: "agentvillage_onboarding",
+        },
+      },
+    };
+    currentUser = { ...currentUser, name: "Steven Paul Jobs", email: "steve@apple.com" };
+    const tool = tools.find((t) => t.name === "preview_user_profile")!;
+    const result = parseToolResult(await tool.handler({ context: context(), query: { name: "Steve", allowPublicLookup: true } }));
+
+    expect(result.success).toBe(true);
+    expect(enricher).toHaveBeenCalledTimes(1);
+    const enrichmentRequest = enricher.mock.calls[0][0] as Record<string, unknown>;
+    expect(enrichmentRequest.name).toBe("Steven Paul Jobs");
+    expect(enrichmentRequest.email).toBe("steve@apple.com");
+    expect(generatedInputs[0]).toContain("Name: Steven Paul Jobs");
     expect(saveProfile).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- Make preview_user_profile use authenticated user name/email before agent-supplied name for public lookup
- Preserve agent-supplied name as fallback when authenticated identity is unavailable
- Add regression coverage for first-name-only agent input
- Bump @indexnetwork/protocol to 1.25.1

## Tests
- bun test packages/protocol/src/profile/tests/profile.privacy-tools.spec.ts
- cd packages/protocol && bun run build

Linear: EDG-44