### PR TITLE
feat(backend): add Sentry performance tracing

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -136,8 +136,10 @@ S3_SECRET_ACCESS_KEY=your-secret-access-key
 # LANGFUSE_SECRET_KEY=
 # LANGFUSE_BASE_URL=https://us.cloud.langfuse.com
 
-# Sentry (error tracking)
+# Sentry (error tracking and performance tracing)
 # SENTRY_DSN=
+# SENTRY_ENVIRONMENT=development
+# SENTRY_TRACES_SAMPLE_RATE=0.1
 
 # Logging
 # LOG_LEVEL=debug              # debug (dev default) | info (prod default) | warn | error

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -8,6 +8,7 @@ import { eq, and, or, isNull, isNotNull, sql, count, desc, gt, lt, lte, ne, inAr
 
 import * as schema from '../schemas/database.schema';
 import db from '../lib/drizzle/drizzle';
+import { traceAppOperation } from '../lib/sentry-performance';
 import type { User, NotificationPreferences, OnboardingState, TelegramPrefs } from '../schemas/database.schema';
 import type {
   Conversation,
@@ -4180,6 +4181,20 @@ export class ChatDatabaseAdapter {
     limit: number;
     minScore?: number;
   }) {
+    return traceAppOperation(
+      {
+        name: 'vector search context intents',
+        op: 'db.vector_search',
+        attributes: {
+          subsystem: 'database',
+          'db.system': 'postgresql',
+          'db.operation': 'vector_search',
+          'search.strategy': 'context-to-intent',
+          'search.index_scope_count': params.networkIds.length,
+          'search.limit': params.limit,
+        },
+      },
+      async () => {
     const { embedding, networkIds, excludeUserId, limit, minScore = 0.30 } = params;
     if (networkIds.length === 0) return [];
     const vectorStr = `[${embedding.join(',')}]`;
@@ -4220,6 +4235,8 @@ export class ChatDatabaseAdapter {
       summary: string | null;
       similarity: number;
     }>;
+      },
+    );
   }
 
 }
@@ -5046,7 +5063,18 @@ export class OpportunityDatabaseAdapter {
     data: CreateOpportunityInput,
     expireIds: string[]
   ): Promise<{ created: OpportunityRow; expired: OpportunityRow[] }> {
-    return db.transaction(async (tx) => {
+    return traceAppOperation(
+      {
+        name: 'db create opportunity and expire ids',
+        op: 'db.transaction',
+        attributes: {
+          subsystem: 'database',
+          'db.system': 'postgresql',
+          'db.operation': 'transaction',
+          'opportunity.expire_count': expireIds.length,
+        },
+      },
+      () => db.transaction(async (tx) => {
       const [inserted] = await tx
         .insert(opportunities)
         .values({
@@ -5072,7 +5100,8 @@ export class OpportunityDatabaseAdapter {
         if (row) expired.push(toOpportunityRow(row));
       }
       return { created, expired };
-    });
+    }),
+    );
   }
 
   /** Condition: opportunity actors contain both userId and counterpartUserId. */
@@ -5277,6 +5306,20 @@ export class OpportunityDatabaseAdapter {
     excludeUserId: string;
     limit: number;
   }) {
+    return traceAppOperation(
+      {
+        name: 'vector search premises by similarity',
+        op: 'db.vector_search',
+        attributes: {
+          subsystem: 'database',
+          'db.system': 'postgresql',
+          'db.operation': 'vector_search',
+          'search.strategy': 'premise-similarity',
+          'search.index_scope_count': params.networkIds.length,
+          'search.limit': params.limit,
+        },
+      },
+      async () => {
     const { embedding, networkIds, excludeUserId, limit } = params;
     const vectorStr = `[${embedding.join(',')}]`;
 
@@ -5311,6 +5354,8 @@ export class OpportunityDatabaseAdapter {
       assertionText: string;
       similarity: number;
     }>;
+      },
+    );
   }
 }
 

--- a/backend/src/adapters/embedder.adapter.ts
+++ b/backend/src/adapters/embedder.adapter.ts
@@ -11,6 +11,7 @@ import {
   OPENROUTER_EMBEDDING_MODEL,
 } from '../lib/embedder/embedder.config';
 import db from '../lib/drizzle/drizzle';
+import { traceAppOperation } from '../lib/sentry-performance';
 import * as schema from '../schemas/database.schema';
 // ─────────────────────────────────────────────────────────────────────────────
 // Local types (structurally aligned with lib/protocol/interfaces/embedder.interface)
@@ -87,6 +88,27 @@ export class EmbedderAdapter {
     dimensions?: number,
     options?: { signal?: AbortSignal }
   ): Promise<number[] | number[][]> {
+    return traceAppOperation(
+      {
+        name: 'embedding generate',
+        op: 'ai.embedding',
+        attributes: {
+          subsystem: 'embedding',
+          provider: 'openrouter',
+          model: OPENROUTER_EMBEDDING_MODEL,
+          'embedding.input_count': Array.isArray(text) ? text.length : 1,
+          'embedding.dimensions': dimensions ?? this.dimensions,
+        },
+      },
+      () => this.generateInner(text, dimensions, options),
+    );
+  }
+
+  private async generateInner(
+    text: string | string[],
+    dimensions?: number,
+    options?: { signal?: AbortSignal }
+  ): Promise<number[] | number[][]> {
     const texts = Array.isArray(text) ? text : [text];
     const cleanTexts = texts.map((t) => t.replace(/\n/g, ' ').trim()).filter(Boolean);
     if (cleanTexts.length === 0) {
@@ -140,6 +162,28 @@ export class EmbedderAdapter {
   // ─────────────────────────────────────────────────────────────────────────
 
   async searchWithHydeEmbeddings(
+    lensEmbeddings: LensEmbedding[],
+    options: HydeSearchOptions
+  ): Promise<HydeCandidate[]> {
+    return traceAppOperation(
+      {
+        name: 'vector search HyDE embeddings',
+        op: 'db.vector_search',
+        attributes: {
+          subsystem: 'database',
+          'db.system': 'postgresql',
+          'db.operation': 'vector_search',
+          'search.strategy': 'hyde',
+          'search.lens_count': lensEmbeddings.length,
+          'search.index_scope_count': options.indexScope.length,
+          'search.limit': options.limit ?? 80,
+        },
+      },
+      () => this.searchWithHydeEmbeddingsInner(lensEmbeddings, options),
+    );
+  }
+
+  private async searchWithHydeEmbeddingsInner(
     lensEmbeddings: LensEmbedding[],
     options: HydeSearchOptions
   ): Promise<HydeCandidate[]> {

--- a/backend/src/instrument.ts
+++ b/backend/src/instrument.ts
@@ -21,6 +21,19 @@ const sentryEnvironment =
   'development';
 const sentryDsn = process.env.SENTRY_DSN;
 
+function sampleRateFromEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(1, Math.max(0, parsed));
+}
+
+const tracesSampleRate = sampleRateFromEnv(
+  'SENTRY_TRACES_SAMPLE_RATE',
+  process.env.NODE_ENV === 'development' ? 1.0 : 0.1,
+);
+
 // Loaded via Bun's --preload flag so Sentry initializes before application imports.
 Sentry.init({
   dsn: sentryDsn,
@@ -31,7 +44,20 @@ Sentry.init({
   sendDefaultPii: true,
 
   // Capture all traces in development and sample production traffic.
-  tracesSampleRate: process.env.NODE_ENV === 'development' ? 1.0 : 0.1,
+  tracesSampleRate,
+
+  integrations: (defaultIntegrations) => [
+    ...defaultIntegrations.filter((integration) => !['LangChain', 'LangGraph', 'PostgresJs'].includes(integration.name)),
+    Sentry.langChainIntegration({
+      recordInputs: false,
+      recordOutputs: false,
+    }),
+    Sentry.langGraphIntegration({
+      recordInputs: false,
+      recordOutputs: false,
+    }),
+    Sentry.postgresJsIntegration(),
+  ],
 
   // Enable Sentry Logs.
   enableLogs: true,
@@ -41,4 +67,5 @@ Sentry.setTags({
   service: 'backend',
   runtime: 'bun',
   'app.environment': sentryEnvironment,
+  'sentry.traces_sample_rate': tracesSampleRate,
 });

--- a/backend/src/lib/bullmq/bullmq.ts
+++ b/backend/src/lib/bullmq/bullmq.ts
@@ -1,6 +1,7 @@
 import { Queue, Worker, QueueEvents, Job, Processor, WorkerOptions, QueueOptions, JobsOptions } from 'bullmq';
 import type { RedisOptions } from 'ioredis';
 
+import { traceAppOperation } from '../sentry-performance';
 import { log } from '../log';
 
 const logger = log.lib.from("bullmq");
@@ -107,7 +108,23 @@ export class QueueFactory {
    */
   static createWorker<T = any>(name: string, processor: Processor<T>, options?: Omit<WorkerOptions, 'connection'>): Worker<T> {
     logger.info(`[QueueFactory] Initializing Worker: ${name}`);
-    return new Worker<T>(name, processor, {
+    const tracedProcessor: Processor<T> = (job, token) => traceAppOperation(
+      {
+        name: `queue ${name} ${job.name}`,
+        op: 'queue.process',
+        forceTransaction: true,
+        attributes: {
+          subsystem: 'queue',
+          queue: name,
+          'messaging.destination.name': name,
+          'messaging.message.id': String(job.id ?? ''),
+          'messaging.message.receive_count': job.attemptsMade + 1,
+          'job.name': job.name,
+        },
+      },
+      () => processor(job, token),
+    );
+    return new Worker<T>(name, tracedProcessor, {
       connection: SHARED_REDIS_OPTS,
       concurrency: 1, // Default to sequential processing
       ...options,

--- a/backend/src/lib/performance/performance.wrapper.ts
+++ b/backend/src/lib/performance/performance.wrapper.ts
@@ -1,13 +1,27 @@
+import { traceAppOperation } from "../sentry-performance";
+
 import { recordTiming } from "./performance.aggregator";
 
 export async function timed<T>(name: string, fn: () => Promise<T>): Promise<T> {
-  const start = performance.now();
-  try {
-    const result = await fn();
-    recordTiming(name, performance.now() - start);
-    return result;
-  } catch (err) {
-    recordTiming(name, performance.now() - start);
-    throw err;
-  }
+  return traceAppOperation(
+    {
+      name,
+      op: 'backend.operation',
+      attributes: {
+        subsystem: 'backend',
+        'code.function': name,
+      },
+    },
+    async () => {
+      const start = performance.now();
+      try {
+        const result = await fn();
+        recordTiming(name, performance.now() - start);
+        return result;
+      } catch (err) {
+        recordTiming(name, performance.now() - start);
+        throw err;
+      }
+    },
+  );
 }

--- a/backend/src/lib/sentry-performance.ts
+++ b/backend/src/lib/sentry-performance.ts
@@ -1,0 +1,65 @@
+import * as Sentry from '@sentry/bun';
+
+type SentrySpanAttributeValue = string | number | boolean;
+
+type CompactSentrySpanAttributes = Record<string, SentrySpanAttributeValue | undefined>;
+
+export type SentrySpanAttributes = Record<string, SentrySpanAttributeValue | null | undefined>;
+
+export interface TraceAppOperationOptions {
+  name: string;
+  op: string;
+  forceTransaction?: boolean;
+  attributes?: SentrySpanAttributes;
+}
+
+function compactAttributes(attributes: SentrySpanAttributes | undefined): CompactSentrySpanAttributes {
+  const compacted: CompactSentrySpanAttributes = {};
+  for (const [key, value] of Object.entries(attributes ?? {})) {
+    if (value !== null && value !== undefined) {
+      compacted[key] = value;
+    }
+  }
+  return compacted;
+}
+
+/**
+ * Wraps an async operation in a Sentry span.
+ * @param options - Span name, operation, transaction flag, and safe attributes.
+ * @param fn - The async operation to execute inside the active span.
+ * @returns The wrapped operation result.
+ */
+export function traceAppOperation<T>(
+  options: TraceAppOperationOptions,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return Sentry.startSpan(
+    {
+      name: options.name,
+      op: options.op,
+      forceTransaction: options.forceTransaction,
+      attributes: compactAttributes(options.attributes),
+    },
+    fn,
+  );
+}
+
+/**
+ * Adds safe attributes to the currently active span when one exists.
+ * @param attributes - Sentry span attributes; nullish values are ignored.
+ */
+export function setSpanAttributes(attributes: SentrySpanAttributes): void {
+  const span = Sentry.getActiveSpan();
+  if (!span) return;
+  span.setAttributes(compactAttributes(attributes));
+}
+
+/**
+ * Sets the HTTP status on the currently active span when one exists.
+ * @param status - HTTP response status code.
+ */
+export function setSpanHttpStatus(status: number): void {
+  const span = Sentry.getActiveSpan();
+  if (!span) return;
+  Sentry.setHttpStatus(span, status);
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -43,6 +43,7 @@ import { bindLimiterServer } from './lib/limiter/identifier';
 import { log } from './lib/log';
 import { getCorsHeaders } from './lib/cors';
 import { captureAppException } from './lib/sentry';
+import { setSpanAttributes, setSpanHttpStatus, traceAppOperation } from './lib/sentry-performance';
 import { adminQueuesApp } from './controllers/queues.controller';
 import { mcpHandler, chatFactory } from './controllers/mcp.controller';
 import { chatSessionService } from './services/chat.service';
@@ -77,7 +78,7 @@ import { premiseQueue } from './queues/premise.queue';
 import { init as initTelegramGateway } from './gateways/telegram.gateway';
 import { setWebhook } from './lib/telegram/bot-api';
 import { opportunityService } from './services/opportunity.service';
-import { NegotiationGraphFactory, UserContextGenerator, HydeGraphFactory, HydeGenerator, LensInferrer } from '@indexnetwork/protocol';
+import { NegotiationGraphFactory, UserContextGenerator, HydeGraphFactory, HydeGenerator, LensInferrer, setTimingWrapper } from '@indexnetwork/protocol';
 import type { HydeGraphDatabase } from '@indexnetwork/protocol';
 import { conversationDatabaseAdapter, chatDatabaseAdapter } from './adapters/database.adapter';
 import { EmbedderAdapter, embedderAdapter } from './adapters/embedder.adapter';
@@ -87,6 +88,18 @@ import { AgentDispatcherImpl } from './services/agent-dispatcher.service';
 
 // Wire ChatGraphFactory into chat service at startup
 chatSessionService.setFactory(chatFactory);
+
+setTimingWrapper((name, fn) => traceAppOperation(
+  {
+    name,
+    op: 'protocol.phase',
+    attributes: {
+      subsystem: 'protocol',
+      'code.function': name,
+    },
+  },
+  fn,
+));
 
 // Wire negotiation into the background discovery queue so latent opportunities
 // from the IntentEvents.onCreated path are negotiated, matching the chat/MCP paths.
@@ -461,6 +474,18 @@ const server = Bun.serve({
 
     logger.verbose('Request', { method, path: url.pathname });
 
+    return traceAppOperation(
+      {
+        name: `${method} ${classifyRequestSubsystem(url.pathname)}`,
+        op: 'http.server',
+        forceTransaction: true,
+        attributes: {
+          subsystem: classifyRequestSubsystem(url.pathname),
+          'http.request.method': method,
+          'url.path': url.pathname,
+        },
+      },
+      async () => {
     try {
     // Sentry smoke-test endpoint. Intentionally throws so the top-level request
     // boundary captures and reports the error. Disabled in production unless
@@ -571,7 +596,18 @@ const server = Bun.serve({
 
         if (isMatch) {
           const routeParams = params ?? {} as Record<string, string>;
-          logger.verbose('Matched route', { path: fullPath, handler: `${target.name}.${String(route.methodName)}`, params: routeParams });
+          const handlerName = `${target.name}.${String(route.methodName)}`;
+          const activeSpan = Sentry.getActiveSpan();
+          if (activeSpan) {
+            Sentry.updateSpanName(activeSpan, `${method} ${fullPath}`);
+          }
+          setSpanAttributes({
+            'http.route': fullPath,
+            controller: target.name,
+            handler: handlerName,
+            subsystem: fullPath.startsWith('/api/tools') ? 'protocol' : 'controller',
+          });
+          logger.verbose('Matched route', { path: fullPath, handler: handlerName, params: routeParams });
           try {
             const instance = controllerInstances.get(target);
             if (!instance) {
@@ -608,6 +644,7 @@ const server = Bun.serve({
 
             // If result is a Response object, add CORS headers and return it.
             if (result instanceof Response) {
+              setSpanHttpStatus(result.status);
               // Clone the response with CORS headers added
               const newHeaders = new Headers(result.headers);
               Object.entries(corsHeaders).forEach(([key, value]) => {
@@ -623,6 +660,7 @@ const server = Bun.serve({
               });
             }
             // Otherwise assume JSON
+            setSpanHttpStatus(200);
             return Response.json(result, { headers: { ...corsHeaders, ...limiterHeaders } });
 
           } catch (error: unknown) {
@@ -635,9 +673,11 @@ const server = Bun.serve({
             // Map agent-scope violations to 403 (network-scoped API keys hitting
             // a network they aren't bound to)
             if (error instanceof ScopeViolationError) {
+              setSpanHttpStatus(403);
               return new Response(JSON.stringify({ error: 'forbidden', detail: message }), { status: 403, headers: { 'Content-Type': 'application/json', ...corsHeaders } });
             }
             if (error instanceof RateLimiterError) {
+              setSpanHttpStatus(429);
               return new Response(error.toBody(), error.toResponseInit(corsHeaders));
             }
             // Map common auth errors
@@ -647,12 +687,15 @@ const server = Bun.serve({
               message === 'Invalid or expired access token' ||
               message === 'Invalid API key'
             ) {
+              setSpanHttpStatus(401);
               return new Response(JSON.stringify({ error: message }), { status: 401, headers: { 'Content-Type': 'application/json', ...corsHeaders } });
             }
             if (message === 'User not found' || message === 'Account deactivated') {
+              setSpanHttpStatus(403);
               return new Response(JSON.stringify({ error: message }), { status: 403, headers: { 'Content-Type': 'application/json', ...corsHeaders } });
             }
             if (message === 'Not found') {
+              setSpanHttpStatus(404);
               return new Response(JSON.stringify({ error: message }), { status: 404, headers: { 'Content-Type': 'application/json', ...corsHeaders } });
             }
 
@@ -670,6 +713,7 @@ const server = Bun.serve({
                 params: routeParams,
               },
             });
+            setSpanHttpStatus(500);
             return new Response(JSON.stringify({ error: message }), { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } });
           }
         }
@@ -677,6 +721,7 @@ const server = Bun.serve({
     }
 
     logger.verbose('No match found', { path: url.pathname });
+    setSpanHttpStatus(404);
     return new Response('Not Found', { status: 404, headers: corsHeaders });
     } catch (error: unknown) {
       logger.error('Unhandled request error', {
@@ -696,11 +741,14 @@ const server = Bun.serve({
       if (url.pathname === '/throw-error') {
         await Sentry.flush(5000);
       }
+      setSpanHttpStatus(500);
       return new Response(
         JSON.stringify({ error: 'Internal Server Error', eventId }),
         { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
       );
     }
+      },
+    );
   },
 });
 

--- a/bun.lock
+++ b/bun.lock
@@ -104,16 +104,6 @@
         "vitest": "^4.0.18",
       },
     },
-    "packages/agentvillage": {
-      "name": "@edge-city/agentvillage",
-      "version": "0.3.5",
-      "bin": {
-        "agentvillage": "./install/install.ts",
-      },
-      "dependencies": {
-        "yaml": "^2.8.0",
-      },
-    },
     "packages/claude-plugin": {
       "name": "@indexnetwork/claude-plugin",
       "version": "0.1.5",
@@ -136,7 +126,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "1.25.1",
+      "version": "1.25.2",
       "dependencies": {
         "@langchain/core": "^1.1.17",
         "@langchain/langgraph": "^1.1.2",
@@ -309,8 +299,6 @@
     "@dabh/diagnostics": ["@dabh/diagnostics@2.0.8", "", { "dependencies": { "@so-ric/colorspace": "^1.1.6", "enabled": "2.0.x", "kuler": "^2.0.0" } }, "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q=="],
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
-
-    "@edge-city/agentvillage": ["@edge-city/agentvillage@workspace:packages/agentvillage"],
 
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "1.25.1",
+  "version": "1.25.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -17,6 +17,7 @@ export type {
 } from "./shared/agent/tool.helpers.js";
 export { ChatContextAccessError, resolveChatContext } from "./shared/agent/tool.helpers.js";
 export { requestContext } from "./shared/observability/request-context.js";
+export { setTimingWrapper } from "./shared/observability/performance.js";
 export {
   ToolRuntimeError,
   getToolTimeoutPolicy,

--- a/packages/protocol/src/shared/agent/tool.runtime.ts
+++ b/packages/protocol/src/shared/agent/tool.runtime.ts
@@ -1,3 +1,4 @@
+import { timed } from "../observability/performance.js";
 import type { TraceEmitter } from "../observability/request-context.js";
 import { requestContext } from "../observability/request-context.js";
 
@@ -152,6 +153,10 @@ function combineSignals(signals: Array<AbortSignal | undefined>): {
 }
 
 export async function invokeToolRuntime(input: ToolInvocationRuntimeInput): Promise<string> {
+  return timed(`ToolRuntime.${input.toolName}`, () => invokeToolRuntimeInner(input));
+}
+
+async function invokeToolRuntimeInner(input: ToolInvocationRuntimeInput): Promise<string> {
   const basePolicy = getToolTimeoutPolicy(input.toolName);
   const policy = {
     ...basePolicy,

--- a/packages/protocol/src/shared/observability/performance.ts
+++ b/packages/protocol/src/shared/observability/performance.ts
@@ -4,8 +4,10 @@
  */
 
 type TimingCallback = (name: string, durationMs: number) => void;
+type TimingWrapper = <T>(name: string, fn: () => Promise<T>) => Promise<T>;
 
 let onTiming: TimingCallback | undefined;
+let timingWrapper: TimingWrapper | undefined;
 
 /** Set a global callback for timing events (e.g. for aggregation/logging). */
 export function setTimingCallback(cb: TimingCallback | undefined) {
@@ -13,19 +15,32 @@ export function setTimingCallback(cb: TimingCallback | undefined) {
 }
 
 /**
+ * Set a global wrapper around timed operations.
+ * Host applications can use this to attach protocol timings to their tracing backend
+ * without coupling the protocol package to any observability vendor.
+ */
+export function setTimingWrapper(wrapper: TimingWrapper | undefined) {
+  timingWrapper = wrapper;
+}
+
+/**
  * Wraps an async function with timing measurement.
  * Reports duration to the global timing callback if set.
  */
 export async function timed<T>(name: string, fn: () => Promise<T>): Promise<T> {
-  const start = performance.now();
-  try {
-    const result = await fn();
-    onTiming?.(name, performance.now() - start);
-    return result;
-  } catch (err) {
-    onTiming?.(name, performance.now() - start);
-    throw err;
-  }
+  const run = async () => {
+    const start = performance.now();
+    try {
+      const result = await fn();
+      onTiming?.(name, performance.now() - start);
+      return result;
+    } catch (err) {
+      onTiming?.(name, performance.now() - start);
+      throw err;
+    }
+  };
+
+  return timingWrapper ? timingWrapper(name, run) : run();
 }
 
 /**

--- a/packages/protocol/src/shared/observability/tests/performance.spec.ts
+++ b/packages/protocol/src/shared/observability/tests/performance.spec.ts
@@ -2,14 +2,16 @@ import { config } from "dotenv";
 config({ path: '.env.test', override: true });
 
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { timed, setTimingCallback, Timed } from "../performance.js";
+import { timed, setTimingCallback, setTimingWrapper, Timed } from "../performance.js";
 
 beforeEach(() => {
   setTimingCallback(undefined);
+  setTimingWrapper(undefined);
 });
 
 afterEach(() => {
   setTimingCallback(undefined);
+  setTimingWrapper(undefined);
 });
 
 describe("timed()", () => {
@@ -53,6 +55,19 @@ describe("timed()", () => {
     await timed("silent-op", async () => "ok");
 
     expect(calls).toHaveLength(0);
+  });
+
+  it("runs through the timing wrapper when configured", async () => {
+    const wrapped: string[] = [];
+    setTimingWrapper(async (name, fn) => {
+      wrapped.push(name);
+      return fn();
+    });
+
+    const result = await timed("wrapped-op", async () => "ok");
+
+    expect(result).toBe("ok");
+    expect(wrapped).toEqual(["wrapped-op"]);
   });
 });
 


### PR DESCRIPTION
## Summary
- add Sentry span helpers and wrap Bun request handling with root HTTP transactions
- wire protocol timing hooks into Sentry spans for graph phases and tool runtime execution
- enable Sentry LangChain/LangGraph/Postgres.js integrations with prompt/output capture disabled
- add queue job, embedding, vector-search, and opportunity-persistence spans for slow-path visibility
- expose SENTRY_TRACES_SAMPLE_RATE in backend env examples and bump @indexnetwork/protocol to 1.25.2

## Verification
- `bun run build`
- `cd backend && bun run build`
- `cd backend && bun run lint` (passes with existing warnings)
- `cd packages/protocol && bun test src/shared/observability/tests/performance.spec.ts`
- `cd packages/protocol && bun run build`

## Notes
- Sentry tracing is still DSN-gated and test-mode disabled via existing instrumentation.
- LangChain/LangGraph spans intentionally do not record prompts or outputs to avoid leaking conversation content into performance traces.