### PR TITLE
fix(opportunities): resolve enriched replacements

### DIFF
--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -2998,6 +2998,9 @@ export class ChatDatabaseAdapter {
   async getOpportunity(id: string): Promise<OpportunityRow | null> {
     return this.opportunityAdapter.getOpportunity(id);
   }
+  async findEnrichedReplacementOpportunities(opportunityId: string): Promise<OpportunityRow[]> {
+    return this.opportunityAdapter.findEnrichedReplacementOpportunities(opportunityId);
+  }
   async getOpportunitiesByIds(ids: string[]): Promise<OpportunityRow[]> {
     return this.opportunityAdapter.getOpportunitiesByIds(ids);
   }
@@ -4831,6 +4834,17 @@ export class OpportunityDatabaseAdapter {
     const rows = await db.select().from(opportunities).where(eq(opportunities.id, id)).limit(1);
     const row = rows[0];
     return row ? toOpportunityRow(row) : null;
+  }
+
+  async findEnrichedReplacementOpportunities(opportunityId: string): Promise<OpportunityRow[]> {
+    const rows = await db
+      .select()
+      .from(opportunities)
+      .where(
+        sql`${opportunities.detection} @> ${JSON.stringify({ enrichedFrom: [opportunityId] })}::jsonb`,
+      )
+      .orderBy(desc(opportunities.createdAt));
+    return rows.map(toOpportunityRow);
   }
 
   async getOpportunitiesByIds(ids: string[]): Promise<OpportunityRow[]> {
@@ -6728,6 +6742,7 @@ export function createSystemDatabase(
      * tools that need cross-actor access during the discovery pipeline.
      */
     getOpportunity: (id: string) => db.getOpportunity(id),
+    findEnrichedReplacementOpportunities: (opportunityId: string) => db.findEnrichedReplacementOpportunities(opportunityId),
     getOpportunitiesForNetwork: async (networkId: string, options?: Parameters<ChatDatabaseAdapter['getOpportunitiesForNetwork']>[1]) => {
       verifyScope(networkId);
       return db.getOpportunitiesForNetwork(networkId, options);

--- a/backend/src/services/opportunity.service.ts
+++ b/backend/src/services/opportunity.service.ts
@@ -285,6 +285,55 @@ export class OpportunityService {
     });
   }
 
+  private assertOpportunityVisible(opp: Opportunity, viewerId: string): { error: string; status: number } | null {
+    const isActor = opp.actors.some((a) => a.userId === viewerId);
+    if (!isActor) {
+      return { error: 'Not authorized to view this opportunity', status: 403 };
+    }
+    if (!canUserSeeOpportunity(opp.actors, opp.status, viewerId)) {
+      return { error: 'Not authorized to view this opportunity', status: 403 };
+    }
+    return null;
+  }
+
+  private async resolveVisibleEnrichedReplacement(
+    original: Opportunity,
+    viewerId: string,
+  ): Promise<{ opportunity: Opportunity; resolvedFromOpportunityId?: string }> {
+    let current = original;
+    let resolvedFromOpportunityId: string | undefined;
+    const seenIds = new Set<string>([original.id]);
+
+    for (let depth = 0; depth < 5 && current.status === 'expired'; depth++) {
+      const replacements = await this.db.findEnrichedReplacementOpportunities(current.id);
+      const replacement = replacements.find((candidate) => {
+        if (seenIds.has(candidate.id)) return false;
+
+        const visibilityError = this.assertOpportunityVisible(candidate, viewerId);
+        if (visibilityError) {
+          logger.warn('[OpportunityService] Enriched replacement hidden from viewer', {
+            originalOpportunityId: original.id,
+            replacementOpportunityId: candidate.id,
+            viewerId,
+            status: candidate.status,
+          });
+          return false;
+        }
+
+        return true;
+      });
+
+      if (!replacement) break;
+      seenIds.add(replacement.id);
+      resolvedFromOpportunityId ??= original.id;
+      current = replacement;
+    }
+
+    return resolvedFromOpportunityId
+      ? { opportunity: current, resolvedFromOpportunityId }
+      : { opportunity: current };
+  }
+
   /**
    * Get a single opportunity with full presentation details.
    * 
@@ -295,19 +344,19 @@ export class OpportunityService {
   async getOpportunityWithPresentation(opportunityId: string, viewerId: string) {
     logger.verbose('[OpportunityService] Getting opportunity', { opportunityId, viewerId });
 
-    const opp = await this.db.getOpportunity(opportunityId);
+    let opp = await this.db.getOpportunity(opportunityId);
     if (!opp) {
       return null;
     }
 
     // Check if viewer is an actor and allowed to see per role-based visibility (Latent Opportunity Lifecycle)
-    const isActor = opp.actors.some((a) => a.userId === viewerId);
-    if (!isActor) {
-      return { error: 'Not authorized to view this opportunity', status: 403 };
+    const visibilityError = this.assertOpportunityVisible(opp, viewerId);
+    if (visibilityError) {
+      return visibilityError;
     }
-    if (!canUserSeeOpportunity(opp.actors, opp.status, viewerId)) {
-      return { error: 'Not authorized to view this opportunity', status: 403 };
-    }
+
+    const replacementResolution = await this.resolveVisibleEnrichedReplacement(opp, viewerId);
+    opp = replacementResolution.opportunity;
 
     const myActor = opp.actors.find((a) => a.userId === viewerId)!;
     const introducer = opp.actors.find((a) => a.role === 'introducer');
@@ -361,6 +410,9 @@ export class OpportunityService {
       primaryActionLabel: getPrimaryActionLabel(myActor.role),
       createdAt: opp.createdAt instanceof Date ? opp.createdAt.toISOString() : opp.createdAt,
       expiresAt: opp.expiresAt ? (opp.expiresAt instanceof Date ? opp.expiresAt.toISOString() : opp.expiresAt) : undefined,
+      ...(replacementResolution.resolvedFromOpportunityId
+        ? { resolvedFromOpportunityId: replacementResolution.resolvedFromOpportunityId }
+        : {}),
     };
   }
 

--- a/backend/src/services/tests/opportunity.service.enrichedReplacement.spec.ts
+++ b/backend/src/services/tests/opportunity.service.enrichedReplacement.spec.ts
@@ -1,0 +1,132 @@
+/** Config */
+import { config } from "dotenv";
+config({ path: ".env.test", override: true });
+
+import { describe, expect, it, mock } from "bun:test";
+
+import type { Opportunity, OpportunityControllerDatabase } from '@indexnetwork/protocol';
+
+process.env.OPENROUTER_API_KEY ??= 'test-openrouter-key';
+
+const { OpportunityService } = await import('../opportunity.service');
+
+const VIEWER_ID = 'viewer-001';
+const PEER_ID = 'peer-002';
+const NETWORK_ID = 'idx-001';
+const OLD_OPPORTUNITY_ID = 'opp-old-001';
+const NEW_OPPORTUNITY_ID = 'opp-new-002';
+const HIDDEN_OPPORTUNITY_ID = 'opp-hidden-003';
+
+function makeOpportunity(id: string, status: Opportunity['status']): Opportunity {
+  return {
+    id,
+    detection: { source: 'opportunity_graph', timestamp: new Date().toISOString() },
+    actors: [
+      { networkId: NETWORK_ID, userId: VIEWER_ID, role: 'patient' },
+      { networkId: NETWORK_ID, userId: PEER_ID, role: 'agent' },
+    ],
+    interpretation: {
+      category: 'collaboration',
+      reasoning: 'Both users are exploring agentic discovery workflows.',
+      confidence: 0.91,
+      signals: [],
+    },
+    context: { networkId: NETWORK_ID },
+    confidence: '0.91',
+    status,
+    createdAt: new Date('2026-06-01T10:00:00.000Z'),
+    updatedAt: new Date('2026-06-01T10:00:00.000Z'),
+    expiresAt: null,
+  };
+}
+
+function createDb(
+  opportunities: Record<string, Opportunity>,
+  replacementsById: Record<string, Opportunity[]> = {},
+) {
+  return {
+    getOpportunity: mock((id: string) => Promise.resolve(opportunities[id] ?? null)),
+    findEnrichedReplacementOpportunities: mock((id: string) => {
+      if (id in replacementsById) return Promise.resolve(replacementsById[id]);
+      if (id === OLD_OPPORTUNITY_ID && opportunities[NEW_OPPORTUNITY_ID]) {
+        return Promise.resolve([opportunities[NEW_OPPORTUNITY_ID]]);
+      }
+      return Promise.resolve([]);
+    }),
+    getUser: mock((id: string) => Promise.resolve({
+      id,
+      name: id === PEER_ID ? 'Peer User' : 'Viewer User',
+      avatar: null,
+      isGhost: false,
+      deletedAt: null,
+    })),
+    getNetwork: mock((id: string) => Promise.resolve({ id, title: 'Test Index' })),
+  } as unknown as OpportunityControllerDatabase;
+}
+
+describe('OpportunityService.getOpportunityWithPresentation enriched replacement resolution', () => {
+  it('returns the enriched replacement when the requested opportunity was superseded', async () => {
+    const oldOpportunity = makeOpportunity(OLD_OPPORTUNITY_ID, 'expired');
+    const newOpportunity = {
+      ...makeOpportunity(NEW_OPPORTUNITY_ID, 'pending'),
+      detection: { source: 'enrichment', enrichedFrom: [OLD_OPPORTUNITY_ID], timestamp: new Date().toISOString() },
+    } satisfies Opportunity;
+    const db = createDb({ [OLD_OPPORTUNITY_ID]: oldOpportunity, [NEW_OPPORTUNITY_ID]: newOpportunity });
+    const service = new OpportunityService(db);
+
+    const result = await service.getOpportunityWithPresentation(OLD_OPPORTUNITY_ID, VIEWER_ID);
+
+    expect(result).not.toBeNull();
+    expect(result).not.toHaveProperty('error');
+    expect((result as { id: string }).id).toBe(NEW_OPPORTUNITY_ID);
+    expect((result as { resolvedFromOpportunityId?: string }).resolvedFromOpportunityId).toBe(OLD_OPPORTUNITY_ID);
+    expect(db.findEnrichedReplacementOpportunities).toHaveBeenCalledWith(OLD_OPPORTUNITY_ID);
+  });
+
+  it('skips invisible replacements and returns the newest visible replacement', async () => {
+    const oldOpportunity = makeOpportunity(OLD_OPPORTUNITY_ID, 'expired');
+    const visibleReplacement = {
+      ...makeOpportunity(NEW_OPPORTUNITY_ID, 'pending'),
+      createdAt: new Date('2026-06-01T10:01:00.000Z'),
+      detection: { source: 'enrichment', enrichedFrom: [OLD_OPPORTUNITY_ID], timestamp: new Date().toISOString() },
+    } satisfies Opportunity;
+    const hiddenReplacement = {
+      ...makeOpportunity(HIDDEN_OPPORTUNITY_ID, 'pending'),
+      actors: [
+        { networkId: NETWORK_ID, userId: 'other-viewer-001', role: 'patient' },
+        { networkId: NETWORK_ID, userId: PEER_ID, role: 'agent' },
+      ],
+      createdAt: new Date('2026-06-01T10:02:00.000Z'),
+      detection: { source: 'enrichment', enrichedFrom: [OLD_OPPORTUNITY_ID], timestamp: new Date().toISOString() },
+    } satisfies Opportunity;
+    const db = createDb(
+      {
+        [OLD_OPPORTUNITY_ID]: oldOpportunity,
+        [NEW_OPPORTUNITY_ID]: visibleReplacement,
+        [HIDDEN_OPPORTUNITY_ID]: hiddenReplacement,
+      },
+      { [OLD_OPPORTUNITY_ID]: [hiddenReplacement, visibleReplacement] },
+    );
+    const service = new OpportunityService(db);
+
+    const result = await service.getOpportunityWithPresentation(OLD_OPPORTUNITY_ID, VIEWER_ID);
+
+    expect(result).not.toBeNull();
+    expect(result).not.toHaveProperty('error');
+    expect((result as { id: string }).id).toBe(NEW_OPPORTUNITY_ID);
+    expect((result as { resolvedFromOpportunityId?: string }).resolvedFromOpportunityId).toBe(OLD_OPPORTUNITY_ID);
+  });
+
+  it('keeps returning the original expired opportunity when there is no enriched replacement', async () => {
+    const oldOpportunity = makeOpportunity(OLD_OPPORTUNITY_ID, 'expired');
+    const db = createDb({ [OLD_OPPORTUNITY_ID]: oldOpportunity });
+    const service = new OpportunityService(db);
+
+    const result = await service.getOpportunityWithPresentation(OLD_OPPORTUNITY_ID, VIEWER_ID);
+
+    expect(result).not.toBeNull();
+    expect(result).not.toHaveProperty('error');
+    expect((result as { id: string }).id).toBe(OLD_OPPORTUNITY_ID);
+    expect((result as { resolvedFromOpportunityId?: string }).resolvedFromOpportunityId).toBeUndefined();
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -110,7 +110,7 @@
     },
     "packages/cli": {
       "name": "@indexnetwork/cli",
-      "version": "0.10.7",
+      "version": "0.10.9",
       "bin": {
         "index": "bin/index.cjs",
       },
@@ -118,10 +118,10 @@
         "@types/bun": "latest",
       },
       "optionalDependencies": {
-        "@indexnetwork/cli-darwin-arm64": "0.10.7",
-        "@indexnetwork/cli-darwin-x64": "0.10.7",
-        "@indexnetwork/cli-linux-arm64": "0.10.7",
-        "@indexnetwork/cli-linux-x64": "0.10.7",
+        "@indexnetwork/cli-darwin-arm64": "0.10.9",
+        "@indexnetwork/cli-darwin-x64": "0.10.9",
+        "@indexnetwork/cli-linux-arm64": "0.10.9",
+        "@indexnetwork/cli-linux-x64": "0.10.9",
       },
     },
     "packages/protocol": {

--- a/docs/specs/api-reference.md
+++ b/docs/specs/api-reference.md
@@ -2547,14 +2547,14 @@ Discover opportunities via HyDE graph.
 
 ### GET /api/opportunities/:id
 
-Get one opportunity with presentation for the viewer.
+Get one opportunity with presentation for the viewer. If the requested opportunity was expired because it was superseded by an enriched opportunity, the endpoint returns the newest visible replacement using the existing `detection.enrichedFrom` link.
 
 **Auth**: AuthGuard
 
 **Path params**:
 - `id` — Opportunity ID
 
-**Response**: JSON with opportunity details and presentation.
+**Response**: JSON with opportunity details and presentation. When a replacement was returned, `id` is the replacement opportunity ID and `resolvedFromOpportunityId` contains the originally requested ID.
 
 ### GET /api/opportunities/:id/invite-message
 

--- a/frontend/src/services/opportunities.ts
+++ b/frontend/src/services/opportunities.ts
@@ -105,6 +105,8 @@ export interface OpportunityDetailResponse {
   confidence?: number;
   network?: { id: string; title: string };
   introducedBy?: { id: string; name: string; avatar?: string | null };
+  /** Present when the requested opportunity was superseded by this enriched opportunity. */
+  resolvedFromOpportunityId?: string;
 }
 
 /** Single opportunity entry returned by GET /opportunities/chat-context. */

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/cli",
-  "version": "0.10.7",
+  "version": "0.10.9",
   "description": "Command-line interface for Index Network",
   "license": "MIT",
   "type": "module",
@@ -20,10 +20,10 @@
     "publish:all": "bun scripts/publish.ts"
   },
   "optionalDependencies": {
-    "@indexnetwork/cli-linux-x64": "0.10.7",
-    "@indexnetwork/cli-linux-arm64": "0.10.7",
-    "@indexnetwork/cli-darwin-x64": "0.10.7",
-    "@indexnetwork/cli-darwin-arm64": "0.10.7"
+    "@indexnetwork/cli-linux-x64": "0.10.9",
+    "@indexnetwork/cli-linux-arm64": "0.10.9",
+    "@indexnetwork/cli-darwin-x64": "0.10.9",
+    "@indexnetwork/cli-darwin-arm64": "0.10.9"
   },
   "devDependencies": {
     "@types/bun": "latest"

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -167,6 +167,8 @@ export interface OpportunityDetail {
   isGhost?: boolean;
   primaryActionLabel?: string;
   createdAt?: string;
+  /** Present when the requested opportunity was superseded by this enriched opportunity. */
+  resolvedFromOpportunityId?: string;
 }
 
 // ── Network types ───────────────────────────────────────────────────

--- a/packages/protocol/src/shared/interfaces/database.interface.ts
+++ b/packages/protocol/src/shared/interfaces/database.interface.ts
@@ -1208,6 +1208,16 @@ export interface Database {
   getOpportunitiesByIds(ids: string[]): Promise<Opportunity[]>;
 
   /**
+   * Find opportunities that superseded a previous opportunity through enrichment.
+   * Uses the existing JSONB `detection.enrichedFrom` array, so no schema-level relation is required.
+   * Results are newest-first so callers can choose the newest visible replacement.
+   *
+   * @param opportunityId - Superseded opportunity ID
+   * @returns Replacement opportunities, newest first
+   */
+  findEnrichedReplacementOpportunities(opportunityId: string): Promise<Opportunity[]>;
+
+  /**
    * Resolve an opportunity identifier (full UUID or short prefix) to a full UUID.
    * @param idOrPrefix - Full UUID or short hex prefix
    * @param userId - The user ID (for visibility scoping)
@@ -2205,6 +2215,7 @@ export type OpportunityControllerDatabase = Pick<
   Database,
   | 'getOpportunity'
   | 'getOpportunitiesByIds'
+  | 'findEnrichedReplacementOpportunities'
   | 'getOpportunitiesForUser'
   | 'getOpportunitiesForNetwork'
   | 'resolveOpportunityId'


### PR DESCRIPTION
## Summary
- Resolve expired opportunity detail requests to their newest enriched replacement using existing detection.enrichedFrom metadata
- Add backend JSONB lookup, visibility-safe replacement following, and typed response marker
- Document the detail endpoint behavior and bump touched package versions

## Tests
- cd packages/protocol && bun run build
- cd backend && bun test src/services/tests/opportunity.service.enrichedReplacement.spec.ts
- cd backend && bun test src/adapters/tests/adapter-interface-alignment.spec.ts
- cd backend && bun run lint (0 errors; existing warnings)