### PR TITLE
fix: preserve Telegram reachable handles

### DIFF
--- a/backend/src/controllers/mcp.controller.ts
+++ b/backend/src/controllers/mcp.controller.ts
@@ -214,6 +214,57 @@ function parseApiKeyMetadata(raw: string | null | undefined): { agentId?: string
   }
 }
 
+type ResolvedMcpIdentity = {
+  userId: string;
+  agentId?: string;
+  isSessionAuth?: boolean;
+  networkScopeId?: string | null;
+  clientSurface?: 'telegram' | 'web';
+};
+
+function normalizeTelegramHeader(raw: string | null | undefined): string | null {
+  const trimmed = raw
+    ?.trim()
+    .replace(/^@/, '')
+    .replace(/^(?:https?:\/\/)?(?:t\.me|telegram\.me)\//, '')
+    .split(/[/?#]/)[0];
+
+  if (!trimmed) return null;
+  if (!/^[A-Za-z0-9_]{5,32}$/.test(trimmed)) return null;
+  return trimmed;
+}
+
+export function telegramHandleFromRequest(request: Request): string | null {
+  return normalizeTelegramHeader(
+    request.headers.get('x-index-telegram-username') ??
+    request.headers.get('x-index-telegram-handle'),
+  );
+}
+
+async function finalizeMcpIdentity(request: Request, identity: ResolvedMcpIdentity): Promise<ResolvedMcpIdentity> {
+  if (identity.clientSurface !== 'telegram') return identity;
+  const telegramHandle = telegramHandleFromRequest(request);
+  if (!telegramHandle) return identity;
+
+  try {
+    const existingSocials = await chatDatabaseAdapter.getUserSocials(identity.userId);
+    const kept = existingSocials
+      .filter((social) => social.label !== 'telegram')
+      .map((social) => ({ label: social.label, value: social.value }));
+    await chatDatabaseAdapter.setUserSocials(identity.userId, [
+      ...kept,
+      { label: 'telegram', value: telegramHandle },
+    ]);
+  } catch (err) {
+    logger.warn('Failed to persist Telegram MCP handle', {
+      userId: identity.userId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  return identity;
+}
+
 // Module-scope on purpose: dedupes the warn across the process lifetime so an
 // unknown header value only logs once per server process, not once per request.
 const seenInvalidSurfaces = new Set<string>();
@@ -246,7 +297,7 @@ export function parseClientSurface(raw: string | null): 'telegram' | 'web' {
 }
 
 const authResolver: McpAuthResolver = {
-  async resolveIdentity(request: Request): Promise<{ userId: string; agentId?: string; isSessionAuth?: boolean; networkScopeId?: string | null; clientSurface?: 'telegram' | 'web' }> {
+  async resolveIdentity(request: Request): Promise<ResolvedMcpIdentity> {
     const clientSurface = parseClientSurface(request.headers.get('x-index-surface'));
     const authHeader = request.headers.get('Authorization');
     const [scheme, token] = authHeader?.split(/\s+/, 2) ?? [];
@@ -261,8 +312,8 @@ const authResolver: McpAuthResolver = {
         // (not omitted) so callers cannot conflate "no scope" with "scope unset".
         try {
           const { payload } = await jwtVerify(token, JWKS, { issuer: BASE_URL, audience: JWT_AUDIENCE });
-          if (typeof payload.id === 'string') return { userId: payload.id, isSessionAuth: true, networkScopeId: null, clientSurface };
-          if (typeof payload.sub === 'string') return { userId: payload.sub, isSessionAuth: true, networkScopeId: null, clientSurface };
+          if (typeof payload.id === 'string') return finalizeMcpIdentity(request, { userId: payload.id, isSessionAuth: true, networkScopeId: null, clientSurface });
+          if (typeof payload.sub === 'string') return finalizeMcpIdentity(request, { userId: payload.sub, isSessionAuth: true, networkScopeId: null, clientSurface });
           throw new Error('JWT payload missing user ID');
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
@@ -281,7 +332,7 @@ const authResolver: McpAuthResolver = {
           });
           if (res.ok) {
             const data = await res.json() as { userId?: string } | null;
-            if (data?.userId) return { userId: data.userId, isSessionAuth: true, networkScopeId: null, clientSurface };
+            if (data?.userId) return finalizeMcpIdentity(request, { userId: data.userId, isSessionAuth: true, networkScopeId: null, clientSurface });
           }
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
@@ -343,17 +394,17 @@ const authResolver: McpAuthResolver = {
             const networkScopeId = metadata.agentId
               ? await resolveAgentNetworkScopeById(metadata.agentId)
               : null;
-            return {
+            return finalizeMcpIdentity(request, {
               userId,
               ...(metadata.agentId ? { agentId: metadata.agentId } : {}),
               networkScopeId,
               clientSurface,
-            };
+            });
           }
         }
 
         if (sessionUserId) {
-          return { userId: sessionUserId, networkScopeId: null, clientSurface };
+          return finalizeMcpIdentity(request, { userId: sessionUserId, networkScopeId: null, clientSurface });
         }
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);

--- a/backend/src/controllers/mcp.controller.ts
+++ b/backend/src/controllers/mcp.controller.ts
@@ -52,6 +52,7 @@ import type { HydeGraphDatabase, PremiseGraphDatabase, ToolDeps, McpAuthResolver
 import { BASE_URL, JWT_AUDIENCE } from '../lib/betterauth/betterauth';
 import { log } from '../lib/log';
 import { captureAppException } from '../lib/sentry';
+import { mergeTelegramHandleIntoSocials } from '../lib/telegram/socials';
 import { resolveAgentNetworkScopeById } from '../guards/agent-scope.guard';
 import { PremiseEvents } from '../events/premise.event';
 
@@ -248,13 +249,10 @@ async function finalizeMcpIdentity(request: Request, identity: ResolvedMcpIdenti
 
   try {
     const existingSocials = await chatDatabaseAdapter.getUserSocials(identity.userId);
-    const kept = existingSocials
-      .filter((social) => social.label !== 'telegram')
-      .map((social) => ({ label: social.label, value: social.value }));
-    await chatDatabaseAdapter.setUserSocials(identity.userId, [
-      ...kept,
-      { label: 'telegram', value: telegramHandle },
-    ]);
+    const merged = mergeTelegramHandleIntoSocials(existingSocials, telegramHandle);
+    if (!merged) return identity;
+
+    await chatDatabaseAdapter.setUserSocials(identity.userId, merged);
   } catch (err) {
     logger.warn('Failed to persist Telegram MCP handle', {
       userId: identity.userId,

--- a/backend/src/controllers/tests/mcp-surface.spec.ts
+++ b/backend/src/controllers/tests/mcp-surface.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, spyOn, test } from 'bun:test';
 
-import { parseClientSurface } from '../mcp.controller';
+import { parseClientSurface, telegramHandleFromRequest } from '../mcp.controller';
+
+function requestWithHeaders(headers: Record<string, string>): Request {
+  return new Request('https://protocol.index.network/mcp', { headers });
+}
 
 describe('parseClientSurface', () => {
   test('returns "web" when header is null', () => {
@@ -47,5 +51,26 @@ describe('parseClientSurface', () => {
     ).length;
     expect(callCount).toBe(1);
     spy.mockRestore();
+  });
+});
+
+describe('telegramHandleFromRequest', () => {
+  test('normalizes x-index-telegram-username', () => {
+    expect(telegramHandleFromRequest(requestWithHeaders({
+      'x-index-telegram-username': ' @alice_tg ',
+    }))).toBe('alice_tg');
+  });
+
+  test('accepts x-index-telegram-handle fallback', () => {
+    expect(telegramHandleFromRequest(requestWithHeaders({
+      'x-index-telegram-handle': 'https://t.me/alice_tg',
+    }))).toBe('alice_tg');
+  });
+
+  test('rejects invalid or missing handles', () => {
+    expect(telegramHandleFromRequest(requestWithHeaders({}))).toBeNull();
+    expect(telegramHandleFromRequest(requestWithHeaders({
+      'x-index-telegram-username': 'bad',
+    }))).toBeNull();
   });
 });

--- a/backend/src/controllers/webhooks.controller.ts
+++ b/backend/src/controllers/webhooks.controller.ts
@@ -9,6 +9,7 @@ const logger = log.controller.from('webhooks');
 interface TelegramUpdate {
   message?: {
     chat: { id: number };
+    from?: { username?: string };
     text?: string;
   };
 }
@@ -44,7 +45,7 @@ export class WebhooksController {
     const message = body.message;
     if (message?.text) {
       const chatId = String(message.chat.id);
-      handleInbound(chatId, message.text).catch((err) => {
+      handleInbound(chatId, message.text, undefined, undefined, message.from?.username).catch((err) => {
         logger.error('Telegram inbound handling failed', { chatId, error: err });
       });
     }

--- a/backend/src/gateways/telegram.gateway.ts
+++ b/backend/src/gateways/telegram.gateway.ts
@@ -7,6 +7,7 @@ import {
   formatOpportunityCardHtml,
   formatOpportunityCardPlainText,
 } from '../lib/telegram/formatter';
+import { mergeTelegramHandleIntoSocials } from '../lib/telegram/socials';
 
 const logger = log.lib.from('telegram.gateway');
 
@@ -211,11 +212,10 @@ async function upsertTelegramHandleFromUsername(
   if (!handle) return;
 
   const existingSocials = await deps.getUserSocials(userId);
-  const kept = existingSocials
-    .filter((social) => social.label !== 'telegram')
-    .map((social) => ({ label: social.label, value: social.value }));
+  const merged = mergeTelegramHandleIntoSocials(existingSocials, handle);
+  if (!merged) return;
 
-  await deps.setUserSocials(userId, [...kept, { label: 'telegram', value: handle }]);
+  await deps.setUserSocials(userId, merged);
 }
 
 // ── Structured-block formatting ────────────────────────────────────────────────

--- a/backend/src/gateways/telegram.gateway.ts
+++ b/backend/src/gateways/telegram.gateway.ts
@@ -13,6 +13,18 @@ const logger = log.lib.from('telegram.gateway');
 export const CONNECT_TOKEN_PREFIX = 'telegram:connect:';
 export const CONNECT_TOKEN_TTL_SEC = 15 * 60;
 
+function normalizeTelegramHandle(raw: string | null | undefined): string | null {
+  const trimmed = raw
+    ?.trim()
+    .replace(/^@/, '')
+    .replace(/^(?:https?:\/\/)?(?:t\.me|telegram\.me)\//, '')
+    .split(/[/?#]/)[0];
+
+  if (!trimmed) return null;
+  if (!/^[A-Za-z0-9_]{5,32}$/.test(trimmed)) return null;
+  return trimmed;
+}
+
 // ── Stream event subset (gateway only cares about a few event types) ────────
 
 /** Minimal event shape the gateway consumes from the chat graph stream. */
@@ -31,6 +43,8 @@ export interface GatewayDeps {
   getTelegramPrefs(userId: string): Promise<TelegramPrefs | null>;
   updateTelegramPrefs(userId: string, prefs: TelegramPrefs): Promise<void>;
   findByTelegramChatId(chatId: string): Promise<{ userId: string; sessionId?: string } | null>;
+  getUserSocials(userId: string): Promise<Array<{ label: string; value: string }>>;
+  setUserSocials(userId: string, socials: { label: string; value: string }[]): Promise<void>;
   createChatSession(data: { id: string; userId: string; title?: string }): Promise<void>;
   createChatMessage(data: { id: string; sessionId: string; role: 'user' | 'assistant' | 'system'; content: string }): Promise<void>;
   processMessage(userId: string, text: string): Promise<{ responseText: string; error?: string }>;
@@ -54,6 +68,8 @@ function productionDeps(): GatewayDeps {
     getTelegramPrefs: (userId) => userDatabaseAdapter.getTelegramPrefs(userId),
     updateTelegramPrefs: (userId, prefs) => userDatabaseAdapter.updateTelegramPrefs(userId, prefs),
     findByTelegramChatId: (chatId) => userDatabaseAdapter.findByTelegramChatId(chatId),
+    getUserSocials: (userId) => userDatabaseAdapter.getSocials(userId),
+    setUserSocials: (userId, socials) => userDatabaseAdapter.setSocials(userId, socials),
     createChatSession: (data) => conversationDatabaseAdapter.createChatSession(data),
     createChatMessage: (data) => conversationDatabaseAdapter.createChatMessage(data),
     processMessage: (userId, text) => chatSessionService.processMessage(userId, text),
@@ -186,6 +202,22 @@ const STATUS_THROTTLE_MS = 5_000;
 
 const PROCESS_TIMEOUT_MS = 120_000;
 
+async function upsertTelegramHandleFromUsername(
+  userId: string,
+  username: string | null | undefined,
+  deps: GatewayDeps,
+): Promise<void> {
+  const handle = normalizeTelegramHandle(username);
+  if (!handle) return;
+
+  const existingSocials = await deps.getUserSocials(userId);
+  const kept = existingSocials
+    .filter((social) => social.label !== 'telegram')
+    .map((social) => ({ label: social.label, value: social.value }));
+
+  await deps.setUserSocials(userId, [...kept, { label: 'telegram', value: handle }]);
+}
+
 // ── Structured-block formatting ────────────────────────────────────────────────
 
 /**
@@ -244,10 +276,11 @@ export async function handleInbound(
   text: string,
   deps: GatewayDeps = productionDeps(),
   redis: RedisReader = productionRedis(),
+  telegramUsername?: string | null,
 ): Promise<void> {
   if (text.startsWith('/start ')) {
     const token = text.slice(7).trim();
-    await handleConnectToken(chatId, token, deps, redis);
+    await handleConnectToken(chatId, token, deps, redis, telegramUsername);
     return;
   }
 
@@ -264,6 +297,10 @@ export async function handleInbound(
 
   const { userId } = found;
   let { sessionId } = found;
+
+  await upsertTelegramHandleFromUsername(userId, telegramUsername, deps).catch((err) => {
+    logger.warn('Failed to persist Telegram username', { userId, chatId, error: err });
+  });
 
   // Ensure a chat session exists (may not if the user messages before any outbound notification)
   if (!sessionId) {
@@ -455,6 +492,7 @@ async function handleConnectToken(
   token: string,
   deps: GatewayDeps,
   redis: RedisReader,
+  telegramUsername?: string | null,
 ): Promise<void> {
   const userId = await redis.get(`${CONNECT_TOKEN_PREFIX}${token}`);
   if (!userId) {
@@ -470,5 +508,8 @@ async function handleConnectToken(
     notifications: { opportunityAccepted: true },
   };
   await deps.updateTelegramPrefs(userId, newPrefs);
+  await upsertTelegramHandleFromUsername(userId, telegramUsername, deps).catch((err) => {
+    logger.warn('Failed to persist Telegram username during connect', { userId, chatId, error: err });
+  });
   await deps.sendTelegramMessage(chatId, CONNECTED_MSG);
 }

--- a/backend/src/gateways/tests/telegram.gateway.spec.ts
+++ b/backend/src/gateways/tests/telegram.gateway.spec.ts
@@ -1,7 +1,7 @@
 import { config } from 'dotenv';
 config({ path: '.env.test', override: true });
 
-import { describe, it, expect, beforeEach } from 'bun:test';
+import { describe, it, expect, beforeEach, mock } from 'bun:test';
 import type { TelegramPrefs } from '../../schemas/database.schema';
 import type { GatewayStreamEvent } from '../telegram.gateway';
 
@@ -34,7 +34,7 @@ function defaultDeps() {
     updateTelegramPrefs: async (userId: string, prefs: TelegramPrefs) => { telegramPrefs.set(userId, prefs); },
     findByTelegramChatId: async (chatId: string) => chatIdIndex.get(chatId) ?? null,
     getUserSocials: async (userId: string) => userSocials.get(userId) ?? [],
-    setUserSocials: async (userId: string, socials: { label: string; value: string }[]) => { userSocials.set(userId, socials); },
+    setUserSocials: mock(async (userId: string, socials: { label: string; value: string }[]) => { userSocials.set(userId, socials); }),
     createChatSession: async (data: { id: string; userId: string; title?: string }) => { sessions.set(data.id, data); },
     createChatMessage: async (data: { id: string; sessionId: string; role: string; content: string }) => { messages.push(data); },
     processMessage: async (_userId: string, _text: string) => ({ responseText: 'Hello from Index!' }),
@@ -241,6 +241,24 @@ describe('handleInbound (blocking)', () => {
 
     expect(deps.userSocials.get('user-known')).toContainEqual({ label: 'telegram', value: 'new_handle' });
     expect(deps.userSocials.get('user-known')?.filter((s) => s.label === 'telegram')).toHaveLength(1);
+  });
+
+  it('skips social writes when Telegram username is unchanged', async () => {
+    const prefs: TelegramPrefs = {
+      chatId: 'chat-unchanged',
+      sessionId: 'sess-unchanged',
+      connectedAt: '2026-04-14T00:00:00Z',
+      notifications: { opportunityAccepted: true },
+    };
+    deps.seedTelegramUser('user-unchanged', prefs);
+    deps.userSocials.set('user-unchanged', [
+      { label: 'github', value: 'alice-gh' },
+      { label: 'telegram', value: 'same_handle' },
+    ]);
+
+    await callInbound('chat-unchanged', 'hello', undefined, 'same_handle');
+
+    expect(deps.setUserSocials).not.toHaveBeenCalled();
   });
 
   it('replies with expired-token message for unknown token', async () => {

--- a/backend/src/gateways/tests/telegram.gateway.spec.ts
+++ b/backend/src/gateways/tests/telegram.gateway.spec.ts
@@ -18,6 +18,7 @@ function defaultDeps() {
   const messages: Array<{ sessionId: string; role: string; content: string }> = [];
   const sent: SentMessage[] = [];
   const telegramPrefs = new Map<string, TelegramPrefs>();
+  const userSocials = new Map<string, Array<{ label: string; value: string }>>();
   const chatIdIndex = new Map<string, { userId: string; sessionId?: string }>();
   const chatActions: string[] = [];
 
@@ -26,11 +27,14 @@ function defaultDeps() {
     messages,
     sessions,
     telegramPrefs,
+    userSocials,
     chatIdIndex,
     chatActions,
     getTelegramPrefs: async (userId: string) => telegramPrefs.get(userId) ?? null,
     updateTelegramPrefs: async (userId: string, prefs: TelegramPrefs) => { telegramPrefs.set(userId, prefs); },
     findByTelegramChatId: async (chatId: string) => chatIdIndex.get(chatId) ?? null,
+    getUserSocials: async (userId: string) => userSocials.get(userId) ?? [],
+    setUserSocials: async (userId: string, socials: { label: string; value: string }[]) => { userSocials.set(userId, socials); },
     createChatSession: async (data: { id: string; userId: string; title?: string }) => { sessions.set(data.id, data); },
     createChatMessage: async (data: { id: string; sessionId: string; role: string; content: string }) => { messages.push(data); },
     processMessage: async (_userId: string, _text: string) => ({ responseText: 'Hello from Index!' }),
@@ -130,13 +134,13 @@ describe('handleInbound (blocking)', () => {
     redisFake = new Map();
   });
 
-  async function callInbound(chatId: string, text: string, overrides?: Partial<ReturnType<typeof defaultDeps>>) {
+  async function callInbound(chatId: string, text: string, overrides?: Partial<ReturnType<typeof defaultDeps>>, telegramUsername?: string | null) {
     const d = overrides ? { ...deps, ...overrides } : deps;
     const { handleInbound } = await import('../telegram.gateway');
     await handleInbound(chatId, text, d, {
       get: async (key: string) => redisFake.get(key) ?? null,
       del: async (key: string) => { redisFake.delete(key); },
-    });
+    }, telegramUsername);
   }
 
   it('replies with connect prompt and button for unknown chatId', async () => {
@@ -209,6 +213,34 @@ describe('handleInbound (blocking)', () => {
     expect(deps.sent[0].text).toContain('connected');
     // Token consumed
     expect(redisFake.has('telegram:connect:valid-token')).toBe(false);
+  });
+
+  it('captures Telegram username during /start without removing other socials', async () => {
+    redisFake.set('telegram:connect:valid-token', 'user-new');
+    deps.userSocials.set('user-new', [{ label: 'github', value: 'alice-gh' }]);
+
+    await callInbound('chat-new', '/start valid-token', undefined, '@alice_tg');
+
+    expect(deps.userSocials.get('user-new')).toEqual([
+      { label: 'github', value: 'alice-gh' },
+      { label: 'telegram', value: 'alice_tg' },
+    ]);
+  });
+
+  it('captures Telegram username on known inbound messages', async () => {
+    const prefs: TelegramPrefs = {
+      chatId: 'chat-known',
+      sessionId: 'sess-1',
+      connectedAt: '2026-04-14T00:00:00Z',
+      notifications: { opportunityAccepted: true },
+    };
+    deps.seedTelegramUser('user-known', prefs);
+    deps.userSocials.set('user-known', [{ label: 'telegram', value: 'old_handle' }]);
+
+    await callInbound('chat-known', 'hello', undefined, 'new_handle');
+
+    expect(deps.userSocials.get('user-known')).toContainEqual({ label: 'telegram', value: 'new_handle' });
+    expect(deps.userSocials.get('user-known')?.filter((s) => s.label === 'telegram')).toHaveLength(1);
   });
 
   it('replies with expired-token message for unknown token', async () => {

--- a/backend/src/lib/telegram/socials.ts
+++ b/backend/src/lib/telegram/socials.ts
@@ -1,0 +1,25 @@
+export interface SocialRow {
+  label: string;
+  value: string;
+}
+
+/**
+ * Merge a Telegram handle into a user's social rows without clobbering unrelated labels.
+ *
+ * @param existingSocials - Existing social rows for the user.
+ * @param telegramHandle - Normalized Telegram handle without an @ prefix.
+ * @returns The replacement social list, or null when the stored Telegram handle is already unchanged.
+ */
+export function mergeTelegramHandleIntoSocials(
+  existingSocials: SocialRow[],
+  telegramHandle: string,
+): SocialRow[] | null {
+  const existingTelegram = existingSocials.find((social) => social.label === 'telegram');
+  if (existingTelegram?.value === telegramHandle) return null;
+
+  const kept = existingSocials
+    .filter((social) => social.label !== 'telegram')
+    .map((social) => ({ label: social.label, value: social.value }));
+
+  return [...kept, { label: 'telegram', value: telegramHandle }];
+}

--- a/backend/src/lib/telegram/tests/socials.spec.ts
+++ b/backend/src/lib/telegram/tests/socials.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test';
+
+import { mergeTelegramHandleIntoSocials } from '../socials';
+
+describe('mergeTelegramHandleIntoSocials', () => {
+  test('adds Telegram while preserving unrelated socials', () => {
+    expect(mergeTelegramHandleIntoSocials([
+      { label: 'github', value: 'alice-gh' },
+      { label: 'linkedin', value: 'alice-li' },
+    ], 'alice_tg')).toEqual([
+      { label: 'github', value: 'alice-gh' },
+      { label: 'linkedin', value: 'alice-li' },
+      { label: 'telegram', value: 'alice_tg' },
+    ]);
+  });
+
+  test('replaces existing Telegram without duplicating it', () => {
+    const merged = mergeTelegramHandleIntoSocials([
+      { label: 'telegram', value: 'old_tg' },
+      { label: 'github', value: 'alice-gh' },
+    ], 'new_tg');
+
+    expect(merged).toEqual([
+      { label: 'github', value: 'alice-gh' },
+      { label: 'telegram', value: 'new_tg' },
+    ]);
+  });
+
+  test('returns null when Telegram handle is already unchanged', () => {
+    expect(mergeTelegramHandleIntoSocials([
+      { label: 'github', value: 'alice-gh' },
+      { label: 'telegram', value: 'alice_tg' },
+    ], 'alice_tg')).toBeNull();
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -126,7 +126,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "1.25.3",
+      "version": "1.25.4",
       "dependencies": {
         "@langchain/core": "^1.1.17",
         "@langchain/langgraph": "^1.1.2",

--- a/docs/specs/api-reference.md
+++ b/docs/specs/api-reference.md
@@ -144,7 +144,7 @@ The value drives the click-time redirect on opportunity connect links (`/c/{code
 
 The surface is snapshotted onto each minted `connect_links` row at MCP-call time (the auth resolver reads the header, the protocol threads it through `ResolvedToolContext.clientSurface`, and `mintConnectLink` writes it). First mint wins for the link's lifetime; rotation of an expired row re-stamps the surface.
 
-Today only the Telegram-bot MCP surface sends `telegram`. Every other caller — Claude Desktop, the web app, Claude Code, the CLI — omits the header and gets the web fallback.
+Today only the Telegram-bot MCP surface sends `telegram`. Every other caller — Claude Desktop, the web app, Claude Code, the CLI — omits the header and gets the web fallback. Telegram MCP clients may also send `x-index-telegram-username` (or `x-index-telegram-handle`); when present with `x-index-surface: telegram`, the MCP auth resolver upserts that handle into `user_socials` while preserving other socials.
 
 ### MCP runtime limits and error envelopes
 
@@ -2149,7 +2149,7 @@ Start OAuth flow to connect a toolkit.
 
 **Response**:
 - For `gmail`/`slack`: OAuth redirect URL from the integration adapter.
-- For `telegram`: `{ "deepLink": "https://t.me/<bot_username>?start=<token>" }` where `<token>` is a short-lived one-time token (15 min TTL). Opening the link prompts Telegram to message the bot with `/start <token>`, which completes the connection.
+- For `telegram`: `{ "deepLink": "https://t.me/<bot_username>?start=<token>" }` where `<token>` is a short-lived one-time token (15 min TTL). Opening the link prompts Telegram to message the bot with `/start <token>`, which completes the connection. If Telegram includes `message.from.username`, the gateway also upserts a public `user_socials` row with `label = 'telegram'` while preserving other socials.
 
 ### POST /api/integrations/:toolkit/link
 
@@ -2255,7 +2255,7 @@ Inbound endpoint for Telegram Bot API updates. Called by Telegram when the bot r
 
 **Auth**: Header `X-Telegram-Bot-Api-Secret-Token` must match `TELEGRAM_WEBHOOK_SECRET`. Otherwise responds `401`.
 
-**Body**: Telegram `Update` object (JSON). The handler only inspects `message.chat.id` and `message.text`.
+**Body**: Telegram `Update` object (JSON). The handler inspects `message.chat.id`, `message.text`, and optional `message.from.username`. When a valid username is present, it is stored as the user's public Telegram social handle without clearing other socials.
 
 **Response**: Always `200 OK`. Inbound handling is fire-and-forget so the endpoint never blocks Telegram's delivery pipeline.
 
@@ -3139,7 +3139,7 @@ Tools are organized by domain. Each tool has its own input schema (see `GET /api
 | `preview_user_profile` | Profile | Generate a non-persisted onboarding profile draft from allowed sources |
 | `confirm_user_profile` | Profile | Save an approved profile draft or explicit correction text |
 | `create_user_profile` | Profile | Legacy/generic profile generation from social links or bio |
-| `update_user_profile` | Profile | Update profile details |
+| `update_user_profile` | Profile | Update profile details or merge reachable social handles |
 | `complete_onboarding` | Profile | Mark onboarding complete |
 | `read_intents` | Intent | List user's intents with optional filters |
 | `create_intent` | Intent | Create a new intent from natural language |

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "1.25.3",
+  "version": "1.25.4",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/profile/profile.tools.ts
+++ b/packages/protocol/src/profile/profile.tools.ts
@@ -85,8 +85,7 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
   }
 
   function normalizeSocialUpdate(label: string, value: string): { label: string; value: string } | null {
-    const rawLabel = label.trim();
-    const normalizedLabel = rawLabel.toLowerCase() === 'telegram' ? 'telegram' : rawLabel;
+    const normalizedLabel = label.trim().toLowerCase();
     if (!normalizedLabel) return null;
     const trimmedValue = value.trim();
     if (!trimmedValue) return null;

--- a/packages/protocol/src/profile/profile.tools.ts
+++ b/packages/protocol/src/profile/profile.tools.ts
@@ -8,6 +8,7 @@ import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import type { EnrichmentResult, ProfileEnricher } from "../shared/interfaces/enrichment.interface.js";
 import type { OnboardingPrivacyState, OnboardingProfileSeed, OnboardingState, PrivacyConsentSource, UserRecord } from "../shared/interfaces/database.interface.js";
 import { socialsToEnrichmentRequest, detectSocialLabel } from "../shared/utils/social-label.js";
+import { normalizeTelegramHandle } from "../shared/utils/telegram-handle.js";
 import { ProfileGenerator } from "./profile.generator.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
@@ -83,6 +84,41 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
     return scoped[scoped.length - 1] ?? seeds[seeds.length - 1];
   }
 
+  function normalizeSocialUpdate(label: string, value: string): { label: string; value: string } | null {
+    const rawLabel = label.trim();
+    const normalizedLabel = rawLabel.toLowerCase() === 'telegram' ? 'telegram' : rawLabel;
+    if (!normalizedLabel) return null;
+    const trimmedValue = value.trim();
+    if (!trimmedValue) return null;
+    if (normalizedLabel === 'telegram') {
+      const handle = normalizeTelegramHandle(trimmedValue);
+      return handle ? { label: normalizedLabel, value: handle } : null;
+    }
+    return { label: normalizedLabel, value: trimmedValue };
+  }
+
+  async function mergeUserSocials(incoming: { label: string; value: string }[]): Promise<void> {
+    const normalizedIncoming = incoming
+      .map((social) => normalizeSocialUpdate(social.label, social.value))
+      .filter((social): social is { label: string; value: string } => social !== null);
+    if (normalizedIncoming.length === 0) return;
+
+    const existingSocials = await userDb.getUserSocials();
+    const incomingLabels = new Set(normalizedIncoming.map((social) => social.label));
+    const kept = existingSocials
+      .filter((social) => !incomingLabels.has(social.label) || social.label === 'custom')
+      .map((social) => ({ label: social.label, value: social.value }));
+    const merged = incomingLabels.has('custom')
+      ? [...kept.filter((social) => social.label !== 'custom'), ...normalizedIncoming]
+      : [...kept, ...normalizedIncoming];
+    await userDb.setUserSocials(merged);
+  }
+
+  function socialsRecordToRows(socials: Record<string, string> | undefined): { label: string; value: string }[] {
+    if (!socials) return [];
+    return Object.entries(socials).map(([label, value]) => ({ label, value }));
+  }
+
   async function persistApprovedProfileContext(profile: { identity: { name: string; bio: string; location: string } }, user: UserRecord | null, networkId?: string): Promise<void> {
     await userDb.updateUser({
       name: profile.identity.name,
@@ -95,15 +131,7 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
     const seed = selectProfileSeed(onboarding, networkId);
     if (!seed?.socials?.length) return;
 
-    const existingSocials = await userDb.getUserSocials();
-    const seededLabels = new Set(seed.socials.map((social) => social.label));
-    const kept = existingSocials
-      .filter((social) => !seededLabels.has(social.label) || social.label === 'custom')
-      .map((social) => ({ label: social.label, value: social.value }));
-    const merged = seededLabels.has('custom')
-      ? [...kept.filter((social) => social.label !== 'custom'), ...seed.socials]
-      : [...kept, ...seed.socials];
-    await userDb.setUserSocials(merged);
+    await mergeUserSocials(seed.socials);
   }
 
   function buildProfileInput(parts: {
@@ -628,7 +656,6 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
         });
       }
       if (hasSocialsFromQuery) {
-        const existingSocials = await userDb.getUserSocials();
         const newSocials: { label: string; value: string }[] = [];
         if (linkedinUrl) newSocials.push({ label: 'linkedin', value: linkedinUrl });
         if (githubUrl) newSocials.push({ label: 'github', value: githubUrl });
@@ -636,14 +663,7 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
         if (websites?.length) {
           for (const w of websites) newSocials.push({ label: detectSocialLabel(w) === 'custom' ? 'custom' : detectSocialLabel(w), value: w });
         }
-        const newLabels = new Set(newSocials.map(s => s.label));
-        const kept = existingSocials
-          .filter(s => !newLabels.has(s.label) || s.label === 'custom')
-          .map(s => ({ label: s.label, value: s.value }));
-        const merged = newLabels.has('custom')
-          ? [...kept.filter(s => s.label !== 'custom'), ...newSocials]
-          : [...kept, ...newSocials];
-        await userDb.setUserSocials(merged);
+        await mergeUserSocials(newSocials);
       }
       logger.verbose("Persisted user-info fields to user record", { userId: context.userId });
 
@@ -692,15 +712,7 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
                 for (const w of enrichment.socials.websites) enrichedSocials.push({ label: 'custom', value: w });
               }
               if (enrichedSocials.length > 0) {
-                const existingSocials = await userDb.getUserSocials();
-                const enrichedLabels = new Set(enrichedSocials.map(s => s.label));
-                const kept = existingSocials
-                  .filter(s => !enrichedLabels.has(s.label) || s.label === 'custom')
-                  .map(s => ({ label: s.label, value: s.value }));
-                const merged = enrichedLabels.has('custom')
-                  ? [...kept.filter(s => s.label !== 'custom'), ...enrichedSocials]
-                  : [...kept, ...enrichedSocials];
-                await userDb.setUserSocials(merged);
+                await mergeUserSocials(enrichedSocials);
               }
 
               return success({
@@ -859,20 +871,33 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
       "Updates the authenticated user's existing profile using a verb-style instruction interface.\n\n" +
       "**How to use it:**\n" +
       "- `action`: a natural-language instruction describing what to change (e.g. \"add interests\", \"update bio\", \"remove skill\", \"set location\").\n" +
-      "- `details`: the content to apply (e.g. \"procedural generation, roguelikes, narrative games\").\n\n" +
+      "- `details`: the content to apply (e.g. \"procedural generation, roguelikes, narrative games\").\n" +
+      "- `socials`: optional social handles to merge into the user's reachable profile (e.g. `{ telegram: \"@alice\" }`).\n\n" +
       "**Examples:**\n" +
       "- `action=\"add interests\"`, `details=\"procedural generation, roguelikes\"`\n" +
       "- `action=\"update bio\"`, `details=\"Product designer focused on desktop CRPG interfaces\"`\n" +
-      "- `action=\"set location\"`, `details=\"Berlin\"`\n\n" +
+      "- `action=\"set location\"`, `details=\"Berlin\"`\n" +
+      "- `socials={ telegram: \"@alice\" }` to silently add a reachable chat handle without regenerating the profile.\n\n" +
       "**When to use:** When the user wants to make specific changes without regenerating the whole profile. For full profile regeneration from social URLs, use create_user_profile instead.\n\n" +
       "**Important:** If the user provides a URL to update from, call scrape_url first, then pass the scraped content in `details`.\n\n" +
       "**Returns:** Confirmation that the profile was updated.",
     querySchema: z.object({
       profileId: z.string().optional().describe("Profile UUID from read_user_profiles. Omit to update the current user's own profile (most common usage)."),
-      action: z.string().describe("Natural language description of ALL changes to make in a single call. Examples: 'update bio to focus on AI research', 'add Python and Rust to skills', 'change location to Berlin and add machine learning to interests'."),
+      action: z.string().optional().describe("Natural language description of ALL changes to make in a single call. Examples: 'update bio to focus on AI research', 'add Python and Rust to skills', 'change location to Berlin and add machine learning to interests'. Optional when only updating socials."),
       details: z.string().optional().describe("Additional context or content to incorporate. Use this to pass scraped URL content (from scrape_url) or longer text the user provided."),
+      socials: z.record(z.string()).optional().describe("Social handles or URLs to merge into the user profile, keyed by label. Example: { telegram: '@alice', github: 'alice' }. Existing socials with other labels are preserved."),
     }),
     handler: async ({ context, query }) => {
+      const socialUpdates = socialsRecordToRows(query.socials);
+      const inputForProfile = [query.action, query.details].filter(Boolean).join("\n");
+      if (!inputForProfile.trim()) {
+        if (socialUpdates.length > 0) {
+          await mergeUserSocials(socialUpdates);
+          return success({ message: "Profile socials updated." });
+        }
+        return error("Please specify what to update (e.g. action: 'update bio to X') or provide socials.");
+      }
+
       // Use profileGraph query mode to validate profile existence and get id
       const _updateQueryProfileGraphStart = Date.now();
       const _updateQueryProfileTraceEmitter = requestContext.getStore()?.traceEmitter;
@@ -889,9 +914,8 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
         return error("Invalid profileId. Use the profile id from read_user_profiles.");
       }
 
-      const inputForProfile = [query.action, query.details].filter(Boolean).join("\n") || (query.details ?? query.action);
-      if (!inputForProfile.trim()) {
-        return error("Please specify what to update (e.g. action: 'update bio to X').");
+      if (socialUpdates.length > 0) {
+        await mergeUserSocials(socialUpdates);
       }
 
       // Execute update directly

--- a/packages/protocol/src/profile/tests/profile.tools.social-merge.spec.ts
+++ b/packages/protocol/src/profile/tests/profile.tools.social-merge.spec.ts
@@ -32,8 +32,10 @@ describe("create_user_profile social merge logic", () => {
   let mockUpdateUser: ReturnType<typeof mock>;
   let mockGetProfile: ReturnType<typeof mock>;
   let mockGetUser: ReturnType<typeof mock>;
+  let mockInvokeProfile: ReturnType<typeof mock>;
   let tools: CapturedTool[];
   let createUserProfileTool: CapturedTool;
+  let updateUserProfileTool: CapturedTool;
 
   const baseContext: ResolvedToolContext = {
     userId: "test-user",
@@ -54,6 +56,7 @@ describe("create_user_profile social merge logic", () => {
       email: "test@example.com",
       socials: [],
     }));
+    mockInvokeProfile = mock(async () => ({ readResult: { hasProfile: true, profile: { id: "profile-1" } } }));
 
     const deps = {
       userDb: {
@@ -65,13 +68,14 @@ describe("create_user_profile social merge logic", () => {
       },
       systemDb: {},
       database: {},
-      graphs: { profile: { invoke: async () => ({}) } },
+      graphs: { profile: { invoke: mockInvokeProfile } },
       enricher: { enrichUserProfile: async () => null },
       grantDefaultSystemPermissions: async () => undefined,
     } as unknown as ToolDeps;
 
     tools = captureTools(deps);
     createUserProfileTool = tools.find((t) => t.name === "create_user_profile")!;
+    updateUserProfileTool = tools.find((t) => t.name === "update_user_profile")!;
   });
 
   it("does not call setUserSocials when no social URLs provided", async () => {
@@ -197,5 +201,46 @@ describe("create_user_profile social merge logic", () => {
 
     const arg = mockSetUserSocials.mock.calls[0][0] as Array<{ label: string; value: string }>;
     expect(arg).toContainEqual({ label: "linkedin", value: "https://linkedin.com/in/alice" });
+  });
+
+  it("update_user_profile merges social-only updates without invoking the graph", async () => {
+    mockGetUserSocials.mockResolvedValue([
+      { id: "1", userId: "test-user", label: "github", value: "alice-gh" },
+      { id: "2", userId: "test-user", label: "telegram", value: "old_tg" },
+    ]);
+
+    const result = await updateUserProfileTool.handler({
+      context: baseContext,
+      query: { socials: { telegram: "@alice_tg" } },
+    });
+
+    expect(result).toContain("Profile socials updated");
+    expect(mockInvokeProfile).not.toHaveBeenCalled();
+    const arg = mockSetUserSocials.mock.calls[0][0] as Array<{ label: string; value: string }>;
+    expect(arg).toEqual([
+      { label: "github", value: "alice-gh" },
+      { label: "telegram", value: "alice_tg" },
+    ]);
+  });
+
+  it("update_user_profile persists socials while preserving non-overlapping labels before profile edits", async () => {
+    mockGetUserSocials.mockResolvedValue([
+      { id: "1", userId: "test-user", label: "linkedin", value: "alice-li" },
+      { id: "2", userId: "test-user", label: "github", value: "alice-gh" },
+    ]);
+    mockInvokeProfile
+      .mockResolvedValueOnce({ readResult: { hasProfile: true, profile: { id: "profile-1" } } })
+      .mockResolvedValueOnce({});
+
+    await updateUserProfileTool.handler({
+      context: baseContext,
+      query: { action: "set location", details: "Berlin", socials: { telegram: "alice_tg" } },
+    });
+
+    const arg = mockSetUserSocials.mock.calls[0][0] as Array<{ label: string; value: string }>;
+    expect(arg).toContainEqual({ label: "linkedin", value: "alice-li" });
+    expect(arg).toContainEqual({ label: "github", value: "alice-gh" });
+    expect(arg).toContainEqual({ label: "telegram", value: "alice_tg" });
+    expect(mockInvokeProfile).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/protocol/src/profile/tests/profile.tools.social-merge.spec.ts
+++ b/packages/protocol/src/profile/tests/profile.tools.social-merge.spec.ts
@@ -223,6 +223,20 @@ describe("create_user_profile social merge logic", () => {
     ]);
   });
 
+  it("update_user_profile lowercases social labels before merging", async () => {
+    mockGetUserSocials.mockResolvedValue([
+      { id: "1", userId: "test-user", label: "github", value: "old-gh" },
+    ]);
+
+    await updateUserProfileTool.handler({
+      context: baseContext,
+      query: { socials: { GitHub: "new-gh" } },
+    });
+
+    const arg = mockSetUserSocials.mock.calls[0][0] as Array<{ label: string; value: string }>;
+    expect(arg).toEqual([{ label: "github", value: "new-gh" }]);
+  });
+
   it("update_user_profile persists socials while preserving non-overlapping labels before profile edits", async () => {
     mockGetUserSocials.mockResolvedValue([
       { id: "1", userId: "test-user", label: "linkedin", value: "alice-li" },


### PR DESCRIPTION
## Changelog

### Fixed
- Preserve users' public Telegram handles when social updates arrive through profile tools or Telegram gateway interactions.
- Auto-populate `user_socials.telegram` from Telegram webhook `from.username` on `/start` and normal inbound bot messages.
- Auto-populate Telegram handles from AgentVillage Telegram-surface MCP headers when available.

### Changed
- Add social-only `update_user_profile` support for reachable handles without invoking profile regeneration.
- Update API docs for Telegram webhook and MCP Telegram handle propagation.
- Bump `@indexnetwork/protocol` to 1.25.4.
- Update AgentVillage submodule pointer for Edge-City/agentvillage#43.

## Related
- AgentVillage PR: https://github.com/Edge-City/agentvillage/pull/43

## Tests
- `cd backend && bun test src/gateways/tests/telegram.gateway.spec.ts`
- `cd backend && bun test src/controllers/tests/mcp-surface.spec.ts`
- `cd backend && bun run lint` (existing warnings only)
- `cd packages/protocol && bun test src/profile/tests/profile.tools.social-merge.spec.ts`
- `cd packages/protocol && bun run build`
- `cd packages/agentvillage && bun test install/tests/cron_specs.test.ts`