### PR TITLE
fix(protocol): cap premise discovery fan-out

### DIFF
--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -3990,6 +3990,15 @@ export class ChatDatabaseAdapter {
   }
 
   /**
+   * Retrieve a capped set of active source premises scoped to target networks.
+   * Delegates to OpportunityDatabaseAdapter so OpportunityGraph can avoid
+   * loading every premise for premise-rich users.
+   */
+  async getPremisesForUserInNetworks(userId: string, networkIds: string[], status?: 'ACTIVE' | 'RETRACTED' | 'EXPIRED', limit?: number) {
+    return this.opportunityAdapter.getPremisesForUserInNetworks(userId, networkIds, status, limit);
+  }
+
+  /**
    * Cosine similarity search against premise embeddings, scoped to shared networks.
    * Delegates to OpportunityDatabaseAdapter (which hosts the raw SQL query).
    */
@@ -4000,6 +4009,20 @@ export class ChatDatabaseAdapter {
     limit: number;
   }) {
     return this.opportunityAdapter.searchPremisesBySimilarity(params);
+  }
+
+  /**
+   * Batched cosine similarity search against premise embeddings.
+   * Delegates to OpportunityDatabaseAdapter to avoid one DB round-trip per
+   * source premise during discovery.
+   */
+  async searchPremisesBySimilarityBatch(params: {
+    sources: Array<{ premiseId: string; embedding: number[] }>;
+    networkIds: string[];
+    excludeUserId: string;
+    limitPerSource: number;
+  }) {
+    return this.opportunityAdapter.searchPremisesBySimilarityBatch(params);
   }
 
   async updatePremise(premiseId: string, updates: {
@@ -5309,6 +5332,88 @@ export class OpportunityDatabaseAdapter {
   }
 
   /**
+   * Retrieve a capped set of embedded premises for a user, scoped to target networks.
+   * Premises are ordered by network relevancy score, then recency, so the
+   * premise-to-premise discovery path searches representative premises instead
+   * of every active premise a user has ever accumulated.
+   * @param userId - The source user whose premises should seed discovery
+   * @param networkIds - Target network IDs that premises must be assigned to
+   * @param status - Optional status filter
+   * @param limit - Maximum number of source premises to return
+   * @returns Scoped premise records with non-null embeddings
+   */
+  async getPremisesForUserInNetworks(userId: string, networkIds: string[], status?: 'ACTIVE' | 'RETRACTED' | 'EXPIRED', limit = 40): Promise<Array<{
+    id: string; userId: string;
+    assertion: { text: string; tier: 'assertive' | 'contextual'; summary?: string };
+    provenance: { source: 'explicit' | 'enrichment' | 'integration' | 'onboarding'; sourceId?: string; confidence: number; timestamp: string };
+    analysis: { speechActType: 'DECLARATIVE' | 'ASSERTIVE'; felicityAuthority: number; felicitySincerity: number; felicityClarity: number; semanticEntropy: number } | null;
+    validity: { validFrom?: string; validUntil?: string; volatile: boolean };
+    embedding: number[];
+    status: 'ACTIVE' | 'RETRACTED' | 'EXPIRED';
+    createdAt: Date; updatedAt: Date; retractedAt: Date | null;
+  }>> {
+    if (networkIds.length === 0 || limit <= 0) return [];
+    const statusClause = status ? sql`AND p.status = ${status}` : sql``;
+    const rows = await db.execute<{
+      id: string;
+      userId: string;
+      assertion: unknown;
+      provenance: unknown;
+      analysis: unknown | null;
+      validity: unknown;
+      embedding: number[];
+      status: 'ACTIVE' | 'RETRACTED' | 'EXPIRED';
+      createdAt: Date;
+      updatedAt: Date;
+      retractedAt: Date | null;
+    }>(sql`
+      WITH scoped AS (
+        SELECT
+          p.id,
+          MAX(COALESCE(pn.relevancy_score::double precision, 0)) AS max_relevancy
+        FROM ${schema.premises} p
+        JOIN ${schema.premiseNetworks} pn ON p.id = pn.premise_id
+        WHERE p.user_id = ${userId}
+          AND pn.network_id = ANY(ARRAY[${sql.join(networkIds.map(id => sql`${id}`), sql`, `)}]::text[])
+          ${statusClause}
+          AND p.embedding IS NOT NULL
+          AND p.deleted_at IS NULL
+        GROUP BY p.id
+      )
+      SELECT
+        p.id AS "id",
+        p.user_id AS "userId",
+        p.assertion AS "assertion",
+        p.provenance AS "provenance",
+        p.analysis AS "analysis",
+        p.validity AS "validity",
+        p.embedding AS "embedding",
+        p.status AS "status",
+        p.created_at AS "createdAt",
+        p.updated_at AS "updatedAt",
+        p.retracted_at AS "retractedAt"
+      FROM scoped s
+      JOIN ${schema.premises} p ON p.id = s.id
+      ORDER BY s.max_relevancy DESC, p.created_at DESC
+      LIMIT ${limit}
+    `);
+
+    return rows.map((row) => ({
+      id: row.id,
+      userId: row.userId,
+      assertion: row.assertion as { text: string; tier: 'assertive' | 'contextual'; summary?: string },
+      provenance: row.provenance as { source: 'explicit' | 'enrichment' | 'integration' | 'onboarding'; sourceId?: string; confidence: number; timestamp: string },
+      analysis: row.analysis as { speechActType: 'DECLARATIVE' | 'ASSERTIVE'; felicityAuthority: number; felicitySincerity: number; felicityClarity: number; semanticEntropy: number } | null,
+      validity: row.validity as { validFrom?: string; validUntil?: string; volatile: boolean },
+      embedding: row.embedding,
+      status: row.status,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+      retractedAt: row.retractedAt,
+    }));
+  }
+
+  /**
    * Cosine similarity search against premise embeddings, scoped to shared networks.
    * Used by the opportunity graph's premise discovery path (path D).
    * @param params - Search parameters including embedding vector, network scope, and exclusions
@@ -5352,7 +5457,7 @@ export class OpportunityDatabaseAdapter {
         1 - (p.embedding <=> ${vectorStr}::vector) AS similarity
       FROM ${schema.premises} p
       JOIN ${schema.premiseNetworks} pn ON p.id = pn.premise_id
-      WHERE pn.network_id = ANY(ARRAY[${sql.join(networkIds.map(id => sql`${id}`), sql`, `)}])
+      WHERE pn.network_id = ANY(ARRAY[${sql.join(networkIds.map(id => sql`${id}`), sql`, `)}]::text[])
         AND p.user_id != ${excludeUserId}
         AND p.status = 'ACTIVE'
         AND p.embedding IS NOT NULL
@@ -5368,6 +5473,91 @@ export class OpportunityDatabaseAdapter {
       assertionText: string;
       similarity: number;
     }>;
+      },
+    );
+  }
+
+  /**
+   * Batched cosine similarity search against premise embeddings, scoped to shared networks.
+   * Uses a VALUES CTE plus LATERAL nearest-neighbor searches so OpportunityGraph
+   * emits one DB span and one DB round-trip for all selected source premises.
+   * @param params - Batch search parameters including source embeddings and candidate scope
+   * @returns Matching premises ranked per source premise
+   */
+  async searchPremisesBySimilarityBatch(params: {
+    sources: Array<{ premiseId: string; embedding: number[] }>;
+    networkIds: string[];
+    excludeUserId: string;
+    limitPerSource: number;
+  }) {
+    if (params.sources.length === 0 || params.networkIds.length === 0 || params.limitPerSource <= 0) return [];
+    return traceAppOperation(
+      {
+        name: 'batch vector search premises by similarity',
+        op: 'db.vector_search',
+        attributes: {
+          subsystem: 'database',
+          'db.system': 'postgresql',
+          'db.operation': 'vector_search',
+          'search.strategy': 'premise-similarity-batch',
+          'search.source_premise_count': params.sources.length,
+          'search.index_scope_count': params.networkIds.length,
+          'search.limit_per_source': params.limitPerSource,
+        },
+      },
+      async () => {
+        const sourceValues = sql.join(
+          params.sources.map(source => sql`(${source.premiseId}, ${`[${source.embedding.join(',')}]`}::vector)`),
+          sql`, `,
+        );
+
+        const rows = await db.execute<{
+          sourcePremiseId: string;
+          premiseId: string;
+          userId: string;
+          networkId: string;
+          assertionText: string;
+          similarity: number;
+        }>(sql`
+          WITH source_embeddings(source_premise_id, embedding) AS (
+            VALUES ${sourceValues}
+          )
+          SELECT
+            matches.source_premise_id AS "sourcePremiseId",
+            matches.premise_id AS "premiseId",
+            matches.user_id AS "userId",
+            matches.network_id AS "networkId",
+            matches.assertion_text AS "assertionText",
+            matches.similarity AS "similarity"
+          FROM source_embeddings se
+          CROSS JOIN LATERAL (
+            SELECT
+              se.source_premise_id,
+              p.id AS premise_id,
+              p.user_id,
+              pn.network_id,
+              p.assertion->>'text' AS assertion_text,
+              1 - (p.embedding <=> se.embedding) AS similarity
+            FROM ${schema.premises} p
+            JOIN ${schema.premiseNetworks} pn ON p.id = pn.premise_id
+            WHERE pn.network_id = ANY(ARRAY[${sql.join(params.networkIds.map(id => sql`${id}`), sql`, `)}]::text[])
+              AND p.user_id != ${params.excludeUserId}
+              AND p.status = 'ACTIVE'
+              AND p.embedding IS NOT NULL
+              AND p.deleted_at IS NULL
+            ORDER BY p.embedding <=> se.embedding
+            LIMIT ${params.limitPerSource}
+          ) matches
+        `);
+
+        return rows as Array<{
+          sourcePremiseId: string;
+          premiseId: string;
+          userId: string;
+          networkId: string;
+          assertionText: string;
+          similarity: number;
+        }>;
       },
     );
   }

--- a/bun.lock
+++ b/bun.lock
@@ -127,7 +127,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "1.26.0",
+      "version": "1.26.1",
       "dependencies": {
         "@langchain/core": "^1.1.17",
         "@langchain/langgraph": "^1.1.2",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -85,6 +85,20 @@ const logger = protocolLogger('OpportunityGraph');
 /** Time window for persist-node dedup. Parallel jobs arrive within seconds; 10 min catches those while allowing new opportunities for long-connected pairs. */
 const DEDUP_WINDOW_MS = 10 * 60 * 1000;
 
+/** Default cap for source premises used by premise-to-premise discovery. Prevents BACKEND-5-style fan-out. */
+const DEFAULT_SOURCE_PREMISE_DISCOVERY_LIMIT = 40;
+
+/** Per-source cap for candidate premise matches. */
+const PREMISE_MATCH_LIMIT_PER_SOURCE = 20;
+
+/** Resolve the source premise discovery cap from env, preserving 0 as an explicit disable switch. */
+function getSourcePremiseDiscoveryLimit(): number {
+  const raw = process.env.DISCOVERY_SOURCE_PREMISE_LIMIT;
+  if (raw === undefined || raw.trim() === '') return DEFAULT_SOURCE_PREMISE_DISCOVERY_LIMIT;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_SOURCE_PREMISE_DISCOVERY_LIMIT;
+}
+
 /** Input shape for the HyDE graph invoke call (query-based embedding). */
 export interface HydeGeneratorInvokeInput {
   sourceType: 'query';
@@ -272,10 +286,9 @@ export class OpportunityGraphFactory {
               };
             }
             const discoveryUserId = state.onBehalfOfUserId ?? state.userId;
-            const [intents, profile, userPremises] = await Promise.all([
+            const [intents, profile] = await Promise.all([
               this.database.getActiveIntents(discoveryUserId),
               this.database.getProfile(discoveryUserId),
-              this.database.getPremisesForUser(discoveryUserId, 'ACTIVE'),
             ]);
             const indexedIntents: IndexedIntent[] = intents.map((intent: ActiveIntent) => ({
               intentId: intent.id,
@@ -290,12 +303,11 @@ export class OpportunityGraphFactory {
                   attributes: profile.attributes ?? undefined,
                 }
               : null;
-            const sourcePremises = (userPremises ?? [])
-              .filter(p => p.embedding && p.embedding.length > 0)
-              .map(p => ({
-                premiseId: p.id as Id<'premises'>,
-                embedding: p.embedding!,
-              }));
+            // Source premises are loaded after scope is resolved so premise discovery
+            // only uses premises assigned to the target network(s), and only up to
+            // DISCOVERY_SOURCE_PREMISE_LIMIT. Loading all premises here caused
+            // BACKEND-5: thousands of parallel vector searches for premise-rich users.
+            const sourcePremises: Array<{ premiseId: Id<'premises'>; embedding: number[] }> = [];
             const contextToIntentEnabled = process.env.DISCOVERY_CONTEXT_TO_INTENT !== '0';
             const rawContexts = contextToIntentEnabled
               ? await this.database.getUserContexts(discoveryUserId)
@@ -315,7 +327,7 @@ export class OpportunityGraphFactory {
               sourceContexts,
               trace: [{
                 node: "prep",
-                detail: `${userNetworkIds.length} network(s), ${intents.length} intent(s), ${sourcePremises.length} premise(s), ${sourceContexts.length} context(s), ${profile ? 'profile loaded' : 'no profile'}`,
+                detail: `${userNetworkIds.length} network(s), ${intents.length} intent(s), premise discovery deferred, ${sourceContexts.length} context(s), ${profile ? 'profile loaded' : 'no profile'}`,
               }],
             };
           },
@@ -944,39 +956,64 @@ export class OpportunityGraphFactory {
            * scoped to target networks. Additive — merges into existing candidates.
            */
           async function runPremiseDiscovery(): Promise<CandidateMatch[]> {
-            if (!state.sourcePremises?.length) return [];
             const targetNetworkIds = state.targetNetworks.map(t => t.networkId);
             if (targetNetworkIds.length === 0) return [];
 
-            logger.verbose('[Graph:Discovery] runPremiseDiscovery start', {
-              premiseCount: state.sourcePremises.length,
-              targetNetworks: targetNetworkIds.length,
-            });
+            const sourceLimit = getSourcePremiseDiscoveryLimit();
+            if (sourceLimit === 0) {
+              logger.verbose('[Graph:Discovery] runPremiseDiscovery disabled by DISCOVERY_SOURCE_PREMISE_LIMIT=0');
+              return [];
+            }
 
-            const searchResults = await Promise.all(
-              state.sourcePremises.map(sp =>
-                self.database.searchPremisesBySimilarity({
-                  embedding: sp.embedding,
-                  networkIds: targetNetworkIds,
-                  excludeUserId: discoveryUserId,
-                  limit: 20,
-                })
-              )
+            const sourcePremisesFromDb = self.database.getPremisesForUserInNetworks
+              ? await self.database.getPremisesForUserInNetworks(discoveryUserId, targetNetworkIds, 'ACTIVE', sourceLimit)
+              : await self.database.getPremisesForUser(discoveryUserId, 'ACTIVE');
+            const sourcePremises = (sourcePremisesFromDb.length > 0
+              ? sourcePremisesFromDb
+                  .filter(p => p.embedding && p.embedding.length > 0)
+                  .slice(0, sourceLimit)
+                  .map(p => ({ premiseId: p.id as Id<'premises'>, embedding: p.embedding! }))
+              : (state.sourcePremises ?? []).slice(0, sourceLimit)
             );
 
+            if (sourcePremises.length === 0) return [];
+
+            logger.verbose('[Graph:Discovery] runPremiseDiscovery start', {
+              premiseCount: sourcePremises.length,
+              sourceLimit,
+              targetNetworks: targetNetworkIds.length,
+              batched: !!self.database.searchPremisesBySimilarityBatch,
+            });
+
+            const rawResults = self.database.searchPremisesBySimilarityBatch
+              ? await self.database.searchPremisesBySimilarityBatch({
+                  sources: sourcePremises,
+                  networkIds: targetNetworkIds,
+                  excludeUserId: discoveryUserId,
+                  limitPerSource: PREMISE_MATCH_LIMIT_PER_SOURCE,
+                })
+              : (await Promise.all(
+                  sourcePremises.map(sp =>
+                    self.database.searchPremisesBySimilarity({
+                      embedding: sp.embedding,
+                      networkIds: targetNetworkIds,
+                      excludeUserId: discoveryUserId,
+                      limit: PREMISE_MATCH_LIMIT_PER_SOURCE,
+                    })
+                  )
+                )).flat();
+
             const premiseCandidates: CandidateMatch[] = [];
-            for (const results of searchResults) {
-              for (const r of results) {
-                premiseCandidates.push({
-                  candidateUserId: r.userId as Id<'users'>,
-                  candidatePremiseId: r.premiseId as Id<'premises'>,
-                  networkId: r.networkId as Id<'networks'>,
-                  similarity: typeof r.similarity === 'number' ? r.similarity : parseFloat(String(r.similarity)),
-                  lens: 'premise_match',
-                  candidatePayload: r.assertionText ?? '',
-                  discoverySource: 'premise-similarity',
-                });
-              }
+            for (const r of rawResults) {
+              premiseCandidates.push({
+                candidateUserId: r.userId as Id<'users'>,
+                candidatePremiseId: r.premiseId as Id<'premises'>,
+                networkId: r.networkId as Id<'networks'>,
+                similarity: typeof r.similarity === 'number' ? r.similarity : parseFloat(String(r.similarity)),
+                lens: 'premise_match',
+                candidatePayload: r.assertionText ?? '',
+                discoverySource: 'premise-similarity',
+              });
             }
 
             // Dedup by userId + premiseId + networkId (a premise can appear in multiple networks)
@@ -989,6 +1026,7 @@ export class OpportunityGraphFactory {
             }
             const deduped = Array.from(byKey.values());
             logger.verbose('[Graph:Discovery] runPremiseDiscovery complete', {
+              sourcePremiseCount: sourcePremises.length,
               rawCount: premiseCandidates.length,
               dedupedCount: deduped.length,
             });

--- a/packages/protocol/src/opportunity/tests/opportunity.graph.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.graph.spec.ts
@@ -363,6 +363,64 @@ describe('Opportunity Graph', () => {
       expect(result.candidates.length).toBeGreaterThanOrEqual(1);
     });
 
+    test('premise discovery uses scoped capped source premises and one batched DB search', async () => {
+      const previousSourcePremiseLimit = process.env.DISCOVERY_SOURCE_PREMISE_LIMIT;
+      process.env.DISCOVERY_SOURCE_PREMISE_LIMIT = '40';
+
+      try {
+        const { compiledGraph, mockDb, mockEmbedder } = createMockGraph();
+        spyOn(mockEmbedder, 'searchWithHydeEmbeddings').mockResolvedValue([]);
+        const legacySearchSpy = spyOn(mockDb, 'searchPremisesBySimilarity');
+
+        const scopedCalls: Array<{ userId: string; networkIds: string[]; status?: string; limit?: number }> = [];
+        mockDb.getPremisesForUserInNetworks = async (userId, networkIds, status, limit) => {
+          scopedCalls.push({ userId, networkIds, status, limit });
+          return [
+            { id: 'premise-1', userId, assertion: { text: 'Builds protocols', tier: 'assertive' as const }, provenance: { source: 'enrichment' as const, confidence: 1, timestamp: new Date().toISOString() }, analysis: null, validity: { volatile: false }, embedding: dummyEmbedding, status: 'ACTIVE' as const, createdAt: new Date(), updatedAt: new Date(), retractedAt: null },
+            { id: 'premise-2', userId, assertion: { text: 'Knows founders', tier: 'assertive' as const }, provenance: { source: 'enrichment' as const, confidence: 1, timestamp: new Date().toISOString() }, analysis: null, validity: { volatile: false }, embedding: dummyEmbedding, status: 'ACTIVE' as const, createdAt: new Date(), updatedAt: new Date(), retractedAt: null },
+          ];
+        };
+
+        const batchCalls: Array<Parameters<NonNullable<OpportunityGraphDatabase['searchPremisesBySimilarityBatch']>>[0]> = [];
+        mockDb.searchPremisesBySimilarityBatch = async (params) => {
+          batchCalls.push(params);
+          return [{
+            sourcePremiseId: 'premise-1',
+            premiseId: 'candidate-premise-1',
+            userId: 'b0000000-0000-4000-8000-000000000002',
+            networkId: 'idx-1',
+            assertionText: 'Can help protocols find founders',
+            similarity: 0.88,
+          }];
+        };
+
+        const result = (await compiledGraph.invoke({
+          userId: 'a0000000-0000-4000-8000-000000000001' as Id<'users'>,
+          searchQuery: 'co-founder',
+          options: {},
+        } as OpportunityGraphInvokeInput)) as OpportunityGraphInvokeResult;
+
+        expect(scopedCalls).toHaveLength(1);
+        expect(scopedCalls[0]).toMatchObject({
+          userId: 'a0000000-0000-4000-8000-000000000001',
+          networkIds: ['idx-1'],
+          status: 'ACTIVE',
+          limit: 40,
+        });
+        expect(batchCalls).toHaveLength(1);
+        expect(batchCalls[0].sources.map(s => s.premiseId)).toEqual(['premise-1', 'premise-2']);
+        expect(batchCalls[0].limitPerSource).toBe(20);
+        expect(legacySearchSpy).not.toHaveBeenCalled();
+        expect(result.candidates.some(c => c.discoverySource === 'premise-similarity')).toBe(true);
+      } finally {
+        if (previousSourcePremiseLimit === undefined) {
+          delete process.env.DISCOVERY_SOURCE_PREMISE_LIMIT;
+        } else {
+          process.env.DISCOVERY_SOURCE_PREMISE_LIMIT = previousSourcePremiseLimit;
+        }
+      }
+    });
+
     test('when search returns only profile type (no intent), profile candidates are included', async () => {
       const { compiledGraph, mockEmbedder } = createMockGraph();
       spyOn(mockEmbedder, 'searchWithHydeEmbeddings').mockResolvedValue([

--- a/packages/protocol/src/shared/interfaces/database.interface.ts
+++ b/packages/protocol/src/shared/interfaces/database.interface.ts
@@ -1451,6 +1451,13 @@ export interface Database {
 
   getPremisesForUser(userId: string, status?: 'ACTIVE' | 'RETRACTED' | 'EXPIRED'): Promise<PremiseRecord[]>;
 
+  /**
+   * Retrieve a user's premises assigned to one of the provided networks.
+   * Optional for older/test adapters; OpportunityGraph falls back to capped
+   * getPremisesForUser results when unavailable.
+   */
+  getPremisesForUserInNetworks?(userId: string, networkIds: string[], status?: 'ACTIVE' | 'RETRACTED' | 'EXPIRED', limit?: number): Promise<PremiseRecord[]>;
+
   updatePremise(premiseId: string, updates: {
     assertion?: PremiseAssertion;
     analysis?: PremiseAnalysis;
@@ -1474,6 +1481,26 @@ export interface Database {
     excludeUserId: string;
     limit: number;
   }): Promise<Array<{
+    premiseId: string;
+    userId: string;
+    networkId: string;
+    assertionText: string;
+    similarity: number;
+  }>>;
+
+  /**
+   * Batched version of premise similarity search. Executes one bounded DB call
+   * for all selected source premises instead of one query per source premise.
+   * Optional for older/test adapters; OpportunityGraph falls back to the
+   * single-source method when unavailable.
+   */
+  searchPremisesBySimilarityBatch?(params: {
+    sources: Array<{ premiseId: string; embedding: number[] }>;
+    networkIds: string[];
+    excludeUserId: string;
+    limitPerSource: number;
+  }): Promise<Array<{
+    sourcePremiseId: string;
     premiseId: string;
     userId: string;
     networkId: string;
@@ -2024,8 +2051,10 @@ export type ChatGraphCompositeDatabase = Pick<
   | 'mergeGhostUser'
   // ProfileGraph aggregate mode (premise-to-profile materialization)
   | 'getPremisesForUser'
+  | 'getPremisesForUserInNetworks'
   // Premise-to-premise discovery (path D) in OpportunityGraph
   | 'searchPremisesBySimilarity'
+  | 'searchPremisesBySimilarityBatch'
   // User context methods (context-to-intent discovery) in OpportunityGraph
   | 'getUserContext'
   | 'getUserContexts'
@@ -2071,7 +2100,9 @@ export type OpportunityGraphDatabase = Pick<
   | 'getIntent'
   // Premise-to-premise discovery (path D)
   | 'getPremisesForUser'
+  | 'getPremisesForUserInNetworks'
   | 'searchPremisesBySimilarity'
+  | 'searchPremisesBySimilarityBatch'
   // User context methods (context-to-intent discovery)
   | 'getUserContext'
   | 'getUserContexts'


### PR DESCRIPTION
## Summary
- defer premise loading until opportunity discovery scope is known
- load only scoped/capped source premises for premise-to-premise discovery
- batch premise similarity searches into one DB round-trip/span instead of one query per source premise
- bump @indexnetwork/protocol to 1.26.1

## Verification
- bun --env-file=/Users/aposto/Projects/index/backend/.env.test test src/opportunity/tests/opportunity.graph.spec.ts -t "premise discovery uses scoped capped"
- cd backend && bun run build
- cd backend && bun run lint

Sentry: BACKEND-5