### PR TITLE
feat(protocol): add digest opportunity markers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -127,7 +127,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "1.26.1",
+      "version": "1.26.2",
       "dependencies": {
         "@langchain/core": "^1.1.17",
         "@langchain/langgraph": "^1.1.2",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -333,7 +333,13 @@ type OpportunityCardLike = Record<string, unknown> & {
  */
 export function buildOpportunityPresentation(
   cards: OpportunityCardLike[],
-  opts: { isMcp: boolean; leadIn: string; label?: "opportunity" | "opportunities" },
+  opts: {
+    isMcp: boolean;
+    leadIn: string;
+    label?: "opportunity" | "opportunities";
+    /** Include hidden digest metadata markers so scheduled brief tooling can confirm delivery. */
+    includeDigestMarkers?: boolean;
+  },
 ): string {
   if (cards.length === 0) return opts.leadIn;
 
@@ -341,6 +347,10 @@ export function buildOpportunityPresentation(
     const prose = cards
       .map((card, i) => {
         const lines: string[] = [`${i + 1}. ${card.name ?? "Unknown"}`];
+        if (opts.includeDigestMarkers) {
+          const markerId = String(card.opportunityId).replace(/[\s>]/g, "");
+          if (markerId) lines.push(`   <!-- digest-opportunity:id=${markerId} -->`);
+        }
         if (card.mainText) lines.push(`   ${card.mainText}`);
         if (card.status) lines.push(`   status: ${card.status}`);
         if (card.profileUrl) lines.push(`   profileUrl: ${card.profileUrl}`);
@@ -1344,6 +1354,10 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         .string()
         .optional()
         .describe("Index UUID to filter opportunities to a specific community. Get from read_networks. Defaults to the scoped index in index-scoped chats. Omit to see opportunities across all indexes."),
+      includeDigestMarkers: z
+        .boolean()
+        .optional()
+        .describe("Internal scheduled-digest mode only. When true, includes hidden delivery markers so the digest send pass can confirm only edited-in opportunities."),
     }),
     handler: async ({ context, query }) => {
       // Strict scope enforcement: when chat is index-scoped, only allow that index
@@ -1593,6 +1607,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         message: buildOpportunityPresentation(cardDataList, {
           isMcp: context.isMcp ?? false,
           leadIn: `You have ${cardDataList.length} opportunity(ies).`,
+          includeDigestMarkers: context.isMcp === true && query.includeDigestMarkers === true,
         }),
         ...(listDebugSteps.length ? { debugSteps: listDebugSteps } : {}),
       });

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.spec.ts
@@ -478,8 +478,28 @@ describe("buildOpportunityPresentation — MCP opportunityId omission", () => {
     );
 
     expect(out).not.toContain("opportunityId: opp-actionable-1");
+    expect(out).not.toContain("digest-opportunity:id=opp-actionable-1");
     expect(out).toContain("acceptUrl: https://api.test/c/Abc1234567");
     expect(out).not.toContain("Use opportunityId values only when calling update_opportunity");
+  });
+
+  test("includes hidden digest marker for actionable cards only when requested", () => {
+    const out = buildOpportunityPresentation(
+      [{
+        opportunityId: "opp-actionable-1",
+        name: "Alice",
+        mainText: "Both work on protocol design.",
+        status: "pending",
+        acceptUrl: "https://api.test/c/Abc1234567",
+        profileUrl: "https://app.test/u/opp-actionable-1-counterpart?link_preview=false",
+        feedCategory: "connection",
+      }],
+      { isMcp: true, leadIn: "Found 1 connection.", includeDigestMarkers: true },
+    );
+
+    expect(out).not.toContain("opportunityId: opp-actionable-1");
+    expect(out).toContain("<!-- digest-opportunity:id=opp-actionable-1 -->");
+    expect(out).toContain("acceptUrl: https://api.test/c/Abc1234567");
   });
 
   test("keeps opportunityId line when card has NO acceptUrl (draft sender etc.)", () => {


### PR DESCRIPTION
## New Features

- Add an internal `includeDigestMarkers` option to `list_opportunities` for scheduled digest MCP callers.
- Emit hidden `<!-- digest-opportunity:id=... -->` markers only when explicitly requested, while keeping visible `opportunityId:` omitted for actionable `acceptUrl` cards.

## Tests

```sh
cd packages/protocol && bun test src/opportunity/tests/opportunity.tools.spec.ts
cd packages/protocol && bun test src/shared/agent/tests/tool.factory.spec.ts --test-name-pattern "list_opportunities mints approve_introduction|invokes deps.mintConnectLink|does NOT mint for pending \\+ introducer|digest"
```

## Notes

- Bumps `@indexnetwork/protocol` from `1.26.0` to `1.26.1`.
- AgentVillage daily brief context builder depends on this for reliable digest delivery confirmation.
