### PR TITLE
Release 2026-06-04

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -32,6 +32,7 @@ CONNECT_JWT_SECRET=              # Secret for signing connect redirect JWTs (48h
 # Used by protocol-init.ts and opportunity.controller.ts. Precedence: BASE_URL > API_BASE_URL > APP_URL.
 # Prefer setting BASE_URL (the dominant convention across the backend); API_BASE_URL is accepted as a fallback.
 # API_BASE_URL=https://api.index.network
+# APP_URL=https://index.network
 
 # Google OAuth (leave empty to disable Google OAuth Login option)
 # GOOGLE_CLIENT_ID=
@@ -50,13 +51,20 @@ OPENROUTER_API_KEY=your-openrouter-api-key
 
 # OpenRouter base URL (default: https://openrouter.ai/api/v1)
 # OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+# Hard cap for individual OpenRouter requests, in ms (default: 60000)
+# OPENROUTER_REQUEST_TIMEOUT_MS=60000
+# Max OpenRouter retries after the initial attempt (default: 1)
+# OPENROUTER_MAX_RETRIES=1
 
 # Chat agent model (default: google/gemini-3-pro-preview)
 # CHAT_MODEL=google/gemini-3-pro-preview
 # CHAT_REASONING_EFFORT=low   # minimal | low | medium | high | xhigh
 
-# Opportunity evaluation mode (experimental: fire one LLM call per candidate in parallel)
-# RUN_OPPORTUNITY_EVAL_IN_PARALLEL=false
+# Opportunity discovery/evaluation tuning
+# RUN_OPPORTUNITY_EVAL_IN_PARALLEL=false    # Experimental: fire one LLM call per candidate in parallel
+# DISCOVERY_CONTEXT_TO_INTENT=1             # Set to 0 to disable context-to-intent discovery
+# NEGOTIATION_MAX_TURNS_CHAT=4
+# NEGOTIATION_MAX_TURNS_AMBIENT=6
 
 # Per-turn LLM round-trip cap for IndexNegotiator, in ms (default: 15000).
 # Bounds individual negotiator calls so a single slow upstream tail can't blow
@@ -144,6 +152,7 @@ S3_SECRET_ACCESS_KEY=your-secret-access-key
 # SENTRY_ENVIRONMENT=development
 # SENTRY_RELEASE=index-backend@<git-sha>   # Optional; inferred from Railway/GitHub commit SHA when unset.
 # SENTRY_TRACES_SAMPLE_RATE=0.1
+# ENABLE_SENTRY_TEST_ENDPOINT=false
 
 # Logging
 # LOG_LEVEL=debug              # debug (dev default) | info (prod default) | warn | error
@@ -197,6 +206,7 @@ S3_SECRET_ACCESS_KEY=your-secret-access-key
 # TELEGRAM_BOT_TOKEN=          # Bot token from @BotFather
 # TELEGRAM_BOT_USERNAME=       # Bot username without @, e.g. IndexBot
 # TELEGRAM_WEBHOOK_SECRET=     # Random secret for webhook validation
+# TELEGRAM_WEBHOOK_URL=        # Optional explicit webhook base URL; falls back to BASE_URL or APP_URL
 
 ########################################
 # 13. Rate Limiter
@@ -218,3 +228,16 @@ LIMITER_DISABLE=
 
 # Set to "true" to enable background question generation via the QuestionerQueue.
 QUESTIONER_ENABLED=false
+
+########################################
+# 15. MCP / Tool Runtime
+########################################
+
+# Request body cap for the MCP endpoint (default: 1048576 bytes)
+# MCP_MAX_REQUEST_BYTES=1048576
+
+# Tool runtime timeout classes used by @indexnetwork/protocol.
+# MCP_TOOL_TIMEOUT_FAST_MS=10000
+# MCP_TOOL_TIMEOUT_BOUNDED_SLOW_MS=45000
+# MCP_TOOL_TIMEOUT_ASYNC_CANDIDATE_MS=50000
+# MCP_TOOL_MAX_OUTPUT_BYTES=1000000

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -3990,6 +3990,15 @@ export class ChatDatabaseAdapter {
   }
 
   /**
+   * Retrieve a capped set of active source premises scoped to target networks.
+   * Delegates to OpportunityDatabaseAdapter so OpportunityGraph can avoid
+   * loading every premise for premise-rich users.
+   */
+  async getPremisesForUserInNetworks(userId: string, networkIds: string[], status?: 'ACTIVE' | 'RETRACTED' | 'EXPIRED', limit?: number) {
+    return this.opportunityAdapter.getPremisesForUserInNetworks(userId, networkIds, status, limit);
+  }
+
+  /**
    * Cosine similarity search against premise embeddings, scoped to shared networks.
    * Delegates to OpportunityDatabaseAdapter (which hosts the raw SQL query).
    */
@@ -4000,6 +4009,20 @@ export class ChatDatabaseAdapter {
     limit: number;
   }) {
     return this.opportunityAdapter.searchPremisesBySimilarity(params);
+  }
+
+  /**
+   * Batched cosine similarity search against premise embeddings.
+   * Delegates to OpportunityDatabaseAdapter to avoid one DB round-trip per
+   * source premise during discovery.
+   */
+  async searchPremisesBySimilarityBatch(params: {
+    sources: Array<{ premiseId: string; embedding: number[] }>;
+    networkIds: string[];
+    excludeUserId: string;
+    limitPerSource: number;
+  }) {
+    return this.opportunityAdapter.searchPremisesBySimilarityBatch(params);
   }
 
   async updatePremise(premiseId: string, updates: {
@@ -5309,6 +5332,88 @@ export class OpportunityDatabaseAdapter {
   }
 
   /**
+   * Retrieve a capped set of embedded premises for a user, scoped to target networks.
+   * Premises are ordered by network relevancy score, then recency, so the
+   * premise-to-premise discovery path searches representative premises instead
+   * of every active premise a user has ever accumulated.
+   * @param userId - The source user whose premises should seed discovery
+   * @param networkIds - Target network IDs that premises must be assigned to
+   * @param status - Optional status filter
+   * @param limit - Maximum number of source premises to return
+   * @returns Scoped premise records with non-null embeddings
+   */
+  async getPremisesForUserInNetworks(userId: string, networkIds: string[], status?: 'ACTIVE' | 'RETRACTED' | 'EXPIRED', limit = 40): Promise<Array<{
+    id: string; userId: string;
+    assertion: { text: string; tier: 'assertive' | 'contextual'; summary?: string };
+    provenance: { source: 'explicit' | 'enrichment' | 'integration' | 'onboarding'; sourceId?: string; confidence: number; timestamp: string };
+    analysis: { speechActType: 'DECLARATIVE' | 'ASSERTIVE'; felicityAuthority: number; felicitySincerity: number; felicityClarity: number; semanticEntropy: number } | null;
+    validity: { validFrom?: string; validUntil?: string; volatile: boolean };
+    embedding: number[];
+    status: 'ACTIVE' | 'RETRACTED' | 'EXPIRED';
+    createdAt: Date; updatedAt: Date; retractedAt: Date | null;
+  }>> {
+    if (networkIds.length === 0 || limit <= 0) return [];
+    const statusClause = status ? sql`AND p.status = ${status}` : sql``;
+    const rows = await db.execute<{
+      id: string;
+      userId: string;
+      assertion: unknown;
+      provenance: unknown;
+      analysis: unknown | null;
+      validity: unknown;
+      embedding: number[];
+      status: 'ACTIVE' | 'RETRACTED' | 'EXPIRED';
+      createdAt: Date;
+      updatedAt: Date;
+      retractedAt: Date | null;
+    }>(sql`
+      WITH scoped AS (
+        SELECT
+          p.id,
+          MAX(COALESCE(pn.relevancy_score::double precision, 0)) AS max_relevancy
+        FROM ${schema.premises} p
+        JOIN ${schema.premiseNetworks} pn ON p.id = pn.premise_id
+        WHERE p.user_id = ${userId}
+          AND pn.network_id = ANY(ARRAY[${sql.join(networkIds.map(id => sql`${id}`), sql`, `)}]::text[])
+          ${statusClause}
+          AND p.embedding IS NOT NULL
+          AND p.deleted_at IS NULL
+        GROUP BY p.id
+      )
+      SELECT
+        p.id AS "id",
+        p.user_id AS "userId",
+        p.assertion AS "assertion",
+        p.provenance AS "provenance",
+        p.analysis AS "analysis",
+        p.validity AS "validity",
+        p.embedding AS "embedding",
+        p.status AS "status",
+        p.created_at AS "createdAt",
+        p.updated_at AS "updatedAt",
+        p.retracted_at AS "retractedAt"
+      FROM scoped s
+      JOIN ${schema.premises} p ON p.id = s.id
+      ORDER BY s.max_relevancy DESC, p.created_at DESC
+      LIMIT ${limit}
+    `);
+
+    return rows.map((row) => ({
+      id: row.id,
+      userId: row.userId,
+      assertion: row.assertion as { text: string; tier: 'assertive' | 'contextual'; summary?: string },
+      provenance: row.provenance as { source: 'explicit' | 'enrichment' | 'integration' | 'onboarding'; sourceId?: string; confidence: number; timestamp: string },
+      analysis: row.analysis as { speechActType: 'DECLARATIVE' | 'ASSERTIVE'; felicityAuthority: number; felicitySincerity: number; felicityClarity: number; semanticEntropy: number } | null,
+      validity: row.validity as { validFrom?: string; validUntil?: string; volatile: boolean },
+      embedding: row.embedding,
+      status: row.status,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+      retractedAt: row.retractedAt,
+    }));
+  }
+
+  /**
    * Cosine similarity search against premise embeddings, scoped to shared networks.
    * Used by the opportunity graph's premise discovery path (path D).
    * @param params - Search parameters including embedding vector, network scope, and exclusions
@@ -5352,7 +5457,7 @@ export class OpportunityDatabaseAdapter {
         1 - (p.embedding <=> ${vectorStr}::vector) AS similarity
       FROM ${schema.premises} p
       JOIN ${schema.premiseNetworks} pn ON p.id = pn.premise_id
-      WHERE pn.network_id = ANY(ARRAY[${sql.join(networkIds.map(id => sql`${id}`), sql`, `)}])
+      WHERE pn.network_id = ANY(ARRAY[${sql.join(networkIds.map(id => sql`${id}`), sql`, `)}]::text[])
         AND p.user_id != ${excludeUserId}
         AND p.status = 'ACTIVE'
         AND p.embedding IS NOT NULL
@@ -5368,6 +5473,91 @@ export class OpportunityDatabaseAdapter {
       assertionText: string;
       similarity: number;
     }>;
+      },
+    );
+  }
+
+  /**
+   * Batched cosine similarity search against premise embeddings, scoped to shared networks.
+   * Uses a VALUES CTE plus LATERAL nearest-neighbor searches so OpportunityGraph
+   * emits one DB span and one DB round-trip for all selected source premises.
+   * @param params - Batch search parameters including source embeddings and candidate scope
+   * @returns Matching premises ranked per source premise
+   */
+  async searchPremisesBySimilarityBatch(params: {
+    sources: Array<{ premiseId: string; embedding: number[] }>;
+    networkIds: string[];
+    excludeUserId: string;
+    limitPerSource: number;
+  }) {
+    if (params.sources.length === 0 || params.networkIds.length === 0 || params.limitPerSource <= 0) return [];
+    return traceAppOperation(
+      {
+        name: 'batch vector search premises by similarity',
+        op: 'db.vector_search',
+        attributes: {
+          subsystem: 'database',
+          'db.system': 'postgresql',
+          'db.operation': 'vector_search',
+          'search.strategy': 'premise-similarity-batch',
+          'search.source_premise_count': params.sources.length,
+          'search.index_scope_count': params.networkIds.length,
+          'search.limit_per_source': params.limitPerSource,
+        },
+      },
+      async () => {
+        const sourceValues = sql.join(
+          params.sources.map(source => sql`(${source.premiseId}, ${`[${source.embedding.join(',')}]`}::vector)`),
+          sql`, `,
+        );
+
+        const rows = await db.execute<{
+          sourcePremiseId: string;
+          premiseId: string;
+          userId: string;
+          networkId: string;
+          assertionText: string;
+          similarity: number;
+        }>(sql`
+          WITH source_embeddings(source_premise_id, embedding) AS (
+            VALUES ${sourceValues}
+          )
+          SELECT
+            matches.source_premise_id AS "sourcePremiseId",
+            matches.premise_id AS "premiseId",
+            matches.user_id AS "userId",
+            matches.network_id AS "networkId",
+            matches.assertion_text AS "assertionText",
+            matches.similarity AS "similarity"
+          FROM source_embeddings se
+          CROSS JOIN LATERAL (
+            SELECT
+              se.source_premise_id,
+              p.id AS premise_id,
+              p.user_id,
+              pn.network_id,
+              p.assertion->>'text' AS assertion_text,
+              1 - (p.embedding <=> se.embedding) AS similarity
+            FROM ${schema.premises} p
+            JOIN ${schema.premiseNetworks} pn ON p.id = pn.premise_id
+            WHERE pn.network_id = ANY(ARRAY[${sql.join(params.networkIds.map(id => sql`${id}`), sql`, `)}]::text[])
+              AND p.user_id != ${params.excludeUserId}
+              AND p.status = 'ACTIVE'
+              AND p.embedding IS NOT NULL
+              AND p.deleted_at IS NULL
+            ORDER BY p.embedding <=> se.embedding
+            LIMIT ${params.limitPerSource}
+          ) matches
+        `);
+
+        return rows as Array<{
+          sourcePremiseId: string;
+          premiseId: string;
+          userId: string;
+          networkId: string;
+          assertionText: string;
+          similarity: number;
+        }>;
       },
     );
   }

--- a/backend/src/startup.env.ts
+++ b/backend/src/startup.env.ts
@@ -26,7 +26,7 @@ const isDeployment =
   runtimeEnvironment === 'production' ||
   Boolean(process.env.RAILWAY_ENVIRONMENT || process.env.RAILWAY_ENVIRONMENT_NAME);
 const requiredUnlessTest = isTest ? z.string().optional() : z.string().trim().min(1);
-const requiredInDeployment = isTest || !isDeployment ? z.string().optional() : z.string().trim().min(1);
+const requiredInProduction = isTest || runtimeEnvironment !== 'production' ? z.string().optional() : z.string().trim().min(1);
 const optionalUrl = z.union([z.literal(''), z.string().url()]).optional();
 const optionalInt = z.union([z.literal(''), z.string().regex(/^\d+$/)]).optional();
 const optionalBoolean = z.union([z.literal(''), z.enum(['true', 'false'])]).optional();
@@ -44,7 +44,7 @@ const envSchema = z.object({
 
   // 2. Authentication
   BETTER_AUTH_SECRET: requiredUnlessTest,
-  CONNECT_JWT_SECRET: requiredInDeployment,
+  CONNECT_JWT_SECRET: requiredInProduction,
   GOOGLE_CLIENT_ID: z.string().optional(),
   GOOGLE_CLIENT_SECRET: z.string().optional(),
   TRUSTED_ORIGINS: z.string().optional(),
@@ -93,7 +93,7 @@ const envSchema = z.object({
   RUN_OPPORTUNITY_EVAL_IN_PARALLEL: optionalBoolean,
   DISCOVERY_CONTEXT_TO_INTENT: z.union([z.literal(''), z.literal('0'), z.literal('1')]).optional(),
   ENABLE_DISCOVERY_QUESTIONS: optionalBoolean,
-  DISCOVERY_QUESTIONS_INPUT_MODE: z.union([z.literal(''), z.enum(['transcripts', 'insights'])]).optional(),
+  DISCOVERY_QUESTIONS_INPUT_MODE: z.string().optional(),
   DISCOVERY_QUESTIONS_TIMEOUT_MS: optionalInt,
   NEGOTIATION_SUMMARY_TIMEOUT_MS: optionalInt,
   NEGOTIATION_MAX_TURNS_CHAT: optionalInt,
@@ -182,6 +182,7 @@ function collectEnvWarnings(): string[] {
   };
 
   warnMissingAny(['BASE_URL', 'API_BASE_URL', 'APP_URL'], 'set the deployed API origin so MCP configs, connect links, and webhooks do not fall back to defaults.');
+  warnMissing('CONNECT_JWT_SECRET', 'connect redirect tokens will use the local development fallback unless NODE_ENV=production, where startup fails.');
   warnMissingAny(['FRONTEND_URL', 'APP_URL'], 'set the deployed frontend origin for auth, notifications, and integration callbacks.');
   warnMissingAny(['REDIS_URL', 'REDIS_HOST'], 'set Railway Redis; otherwise queues/cache/limiter may target localhost or in-memory fallbacks.');
   warnMissing('S3_ENDPOINT', 'set the Railway bucket endpoint when using Tigris/S3-compatible storage.');
@@ -197,6 +198,10 @@ function collectEnvWarnings(): string[] {
   warnPartial(['TELEGRAM_BOT_TOKEN', 'TELEGRAM_WEBHOOK_SECRET'], 'set both values or Telegram webhook registration will be skipped/rejected.');
   if (hasValue('TELEGRAM_BOT_TOKEN') && !hasValue('TELEGRAM_BOT_USERNAME')) {
     warnings.push('TELEGRAM_BOT_USERNAME: set the bot username so Telegram integration links can be generated.');
+  }
+  const discoveryQuestionsInputMode = process.env.DISCOVERY_QUESTIONS_INPUT_MODE?.trim();
+  if (discoveryQuestionsInputMode && !['transcripts', 'insights'].includes(discoveryQuestionsInputMode)) {
+    warnings.push('DISCOVERY_QUESTIONS_INPUT_MODE: expected "transcripts" or "insights"; current value will fall back to transcript mode.');
   }
 
   return warnings;

--- a/backend/src/startup.env.ts
+++ b/backend/src/startup.env.ts
@@ -20,74 +20,131 @@ config({ path: dotenvPath });
 // — all existing process.env.* usage continues to work as-is.
 // ---------------------------------------------------------------------------
 
-const isTest = environment === 'test';
-const requiredUnlessTest = isTest ? z.string().optional() : z.string().min(1);
+const runtimeEnvironment = process.env.NODE_ENV;
+const isTest = runtimeEnvironment === 'test';
+const isDeployment =
+  runtimeEnvironment === 'production' ||
+  Boolean(process.env.RAILWAY_ENVIRONMENT || process.env.RAILWAY_ENVIRONMENT_NAME);
+const requiredUnlessTest = isTest ? z.string().optional() : z.string().trim().min(1);
+const requiredInDeployment = isTest || !isDeployment ? z.string().optional() : z.string().trim().min(1);
+const optionalUrl = z.union([z.literal(''), z.string().url()]).optional();
+const optionalInt = z.union([z.literal(''), z.string().regex(/^\d+$/)]).optional();
+const optionalBoolean = z.union([z.literal(''), z.enum(['true', 'false'])]).optional();
+const optionalOne = z.union([z.literal(''), z.literal('1')]).optional();
 
 const envSchema = z.object({
   // 1. Core
   DATABASE_URL: z.string().url(),
-  PORT: z.string().default('3001'),
+  PORT: z.string().regex(/^\d+$/).default('3001'),
   NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
-  BASE_URL: z.string().url().optional(),
-  FRONTEND_URL: z.string().url().optional(),
+  BASE_URL: optionalUrl,
+  API_BASE_URL: optionalUrl,
+  APP_URL: optionalUrl,
+  FRONTEND_URL: optionalUrl,
 
   // 2. Authentication
   BETTER_AUTH_SECRET: requiredUnlessTest,
+  CONNECT_JWT_SECRET: requiredInDeployment,
   GOOGLE_CLIENT_ID: z.string().optional(),
   GOOGLE_CLIENT_SECRET: z.string().optional(),
   TRUSTED_ORIGINS: z.string().optional(),
 
   // 3. LLM / AI (OpenRouter)
   OPENROUTER_API_KEY: requiredUnlessTest,
-  OPENROUTER_BASE_URL: z.string().url().optional(),
+  OPENROUTER_BASE_URL: optionalUrl,
+  OPENROUTER_REQUEST_TIMEOUT_MS: optionalInt,
+  OPENROUTER_MAX_RETRIES: optionalInt,
   CHAT_MODEL: z.string().optional(),
   CHAT_REASONING_EFFORT: z.enum(['minimal', 'low', 'medium', 'high', 'xhigh']).optional(),
   EMBEDDING_MODEL: z.string().optional(),
-  EMBEDDING_DIMENSIONS: z.string().regex(/^\d+$/).optional(),
+  EMBEDDING_DIMENSIONS: optionalInt,
   SMARTEST_VERIFIER_MODEL: z.string().optional(),
   SMARTEST_GENERATOR_MODEL: z.string().optional(),
 
   // 4. Redis
   REDIS_URL: z.string().optional(),
   REDIS_HOST: z.string().optional(),
-  REDIS_PORT: z.string().regex(/^\d+$/).optional(),
+  REDIS_PORT: optionalInt,
   REDIS_USERNAME: z.string().optional(),
   REDIS_PASSWORD: z.string().optional(),
-  REDIS_DB: z.string().regex(/^\d+$/).optional(),
+  REDIS_DB: optionalInt,
 
   // 5. Storage (S3-compatible)
-  S3_ENDPOINT: z.string().url().optional(),
+  S3_ENDPOINT: optionalUrl,
   S3_REGION: z.string().optional(),
-  S3_BUCKET: z.string().optional(),
-  S3_ACCESS_KEY_ID: z.string().optional(),
-  S3_SECRET_ACCESS_KEY: z.string().optional(),
-  PRESIGNED_URL_EXPIRATION_SECONDS: z.string().regex(/^\d+$/).optional(),
+  S3_BUCKET: requiredUnlessTest,
+  S3_ACCESS_KEY_ID: requiredUnlessTest,
+  S3_SECRET_ACCESS_KEY: requiredUnlessTest,
+  PRESIGNED_URL_EXPIRATION_SECONDS: optionalInt,
 
-  // 7. Email (Resend)
+  // 6. Email (Resend)
   RESEND_API_KEY: z.string().optional(),
-  EMAIL_PRODUCTION_MODE: z.string().optional(),
-  TESTING_EMAIL_ADDRESS: z.string().email().optional(),
+  EMAIL_PRODUCTION_MODE: optionalBoolean,
+  TESTING_EMAIL_ADDRESS: z.union([z.literal(''), z.string().email()]).optional(),
 
-  // 8. Integrations
+  // 7. Integrations
   COMPOSIO_API_KEY: z.string().optional(),
-  UNSTRUCTURED_API_URL: z.string().url().optional(),
+  UNSTRUCTURED_API_URL: optionalUrl,
   PARALLELS_API_KEY: z.string().optional(),
 
-  // 10. Onboarding
+  // 8. Discovery / protocol runtime
   AUTO_JOIN_INDEX_IDS: z.string().optional(),
+  CONTACT_DEDUP_STRATEGY: z.enum(['conservative', 'balanced', 'aggressive', 'off']).optional(),
+  RUN_OPPORTUNITY_EVAL_IN_PARALLEL: optionalBoolean,
+  DISCOVERY_CONTEXT_TO_INTENT: z.union([z.literal(''), z.literal('0'), z.literal('1')]).optional(),
+  ENABLE_DISCOVERY_QUESTIONS: optionalBoolean,
+  DISCOVERY_QUESTIONS_INPUT_MODE: z.union([z.literal(''), z.enum(['transcripts', 'insights'])]).optional(),
+  DISCOVERY_QUESTIONS_TIMEOUT_MS: optionalInt,
+  NEGOTIATION_SUMMARY_TIMEOUT_MS: optionalInt,
+  NEGOTIATION_MAX_TURNS_CHAT: optionalInt,
+  NEGOTIATION_MAX_TURNS_AMBIENT: optionalInt,
+  NEGOTIATOR_TURN_TIMEOUT_MS: optionalInt,
+  QUESTIONER_ENABLED: optionalBoolean,
 
-  // 9. Observability
+  // 9. MCP / tool runtime
+  MCP_MAX_REQUEST_BYTES: optionalInt,
+  MCP_TOOL_TIMEOUT_FAST_MS: optionalInt,
+  MCP_TOOL_TIMEOUT_BOUNDED_SLOW_MS: optionalInt,
+  MCP_TOOL_TIMEOUT_ASYNC_CANDIDATE_MS: optionalInt,
+  MCP_TOOL_MAX_OUTPUT_BYTES: optionalInt,
+
+  // 10. Rate limiting
+  LIMITER_AUTH_WRITE_PER_MIN: optionalInt,
+  LIMITER_READ_PER_MIN: optionalInt,
+  LIMITER_WRITE_PER_MIN: optionalInt,
+  LIMITER_IP_HEADERS: z.string().optional(),
+  LIMITER_DISABLE: optionalOne,
+
+  // 11. Telegram Bot
+  TELEGRAM_BOT_TOKEN: z.string().optional(),
+  TELEGRAM_BOT_USERNAME: z.string().optional(),
+  TELEGRAM_WEBHOOK_SECRET: z.string().optional(),
+  TELEGRAM_WEBHOOK_URL: optionalUrl,
+
+  // 12. Observability
   LANGFUSE_PUBLIC_KEY: z.string().optional(),
   LANGFUSE_SECRET_KEY: z.string().optional(),
-  LANGFUSE_BASE_URL: z.string().url().optional(),
-  SENTRY_DSN: z.string().url().optional(),
+  LANGFUSE_BASE_URL: optionalUrl,
+  SENTRY_DSN: optionalUrl,
   SENTRY_ENVIRONMENT: z.string().optional(),
   SENTRY_RELEASE: z.string().optional(),
   SENTRY_TRACES_SAMPLE_RATE: z.string().optional(),
-  LOG_LEVEL: z.enum(['verbose', 'debug', 'info', 'warn', 'error']).optional(),
+  ENABLE_SENTRY_TEST_ENDPOINT: optionalBoolean,
+  LOG_LEVEL: z.union([z.literal(''), z.enum(['verbose', 'debug', 'info', 'warn', 'error'])]).optional(),
   LOG_FILTER: z.string().optional(),
-  ENABLE_DEBUG_API: z.string().optional(),
-  ADMIN_QUEUES_PORT: z.string().regex(/^\d+$/).optional(),
+  ENABLE_DEBUG_API: optionalBoolean,
+  ADMIN_QUEUES_PORT: optionalInt,
+
+  // 13. Platform-provided metadata
+  RAILWAY_ENVIRONMENT: z.string().optional(),
+  RAILWAY_ENVIRONMENT_NAME: z.string().optional(),
+  RAILWAY_GIT_COMMIT_SHA: z.string().optional(),
+  GITHUB_SHA: z.string().optional(),
+
+  // 14. Test / local-only compatibility flags seen in the codebase
+  OPENAI_API_KEY: z.string().optional(),
+  DEBUG: z.string().optional(),
+  FORCE_COLOR: z.string().optional(),
 });
 
 const result = envSchema.safeParse(process.env);
@@ -98,4 +155,57 @@ if (!result.success) {
     console.error(`   ${issue.path.join('.')}: ${issue.message}`);
   }
   process.exit(1);
+}
+
+const hasValue = (name: string): boolean => {
+  const value = process.env[name];
+  return value !== undefined && value.trim() !== '';
+};
+
+const hasAnyValue = (names: string[]): boolean => names.some(hasValue);
+
+function collectEnvWarnings(): string[] {
+  if (!isDeployment) return [];
+
+  const warnings: string[] = [];
+  const warnMissing = (name: string, message: string): void => {
+    if (!hasValue(name)) warnings.push(`${name}: ${message}`);
+  };
+  const warnMissingAny = (names: string[], message: string): void => {
+    if (!hasAnyValue(names)) warnings.push(`${names.join(' / ')}: ${message}`);
+  };
+  const warnPartial = (names: string[], message: string): void => {
+    const present = names.filter(hasValue);
+    if (present.length > 0 && present.length < names.length) {
+      warnings.push(`${names.join(' + ')}: ${message}`);
+    }
+  };
+
+  warnMissingAny(['BASE_URL', 'API_BASE_URL', 'APP_URL'], 'set the deployed API origin so MCP configs, connect links, and webhooks do not fall back to defaults.');
+  warnMissingAny(['FRONTEND_URL', 'APP_URL'], 'set the deployed frontend origin for auth, notifications, and integration callbacks.');
+  warnMissingAny(['REDIS_URL', 'REDIS_HOST'], 'set Railway Redis; otherwise queues/cache/limiter may target localhost or in-memory fallbacks.');
+  warnMissing('S3_ENDPOINT', 'set the Railway bucket endpoint when using Tigris/S3-compatible storage.');
+  warnMissing('S3_REGION', 'set the S3 region, often "auto" for Railway buckets.');
+  warnMissing('RESEND_API_KEY', 'emails will be skipped, including invite and notification email flows.');
+  warnMissing('SENTRY_DSN', 'backend errors and traces will not be reported to Sentry.');
+  warnMissing('COMPOSIO_API_KEY', 'external integrations such as Gmail, Notion, Slack, Airtable, and Google Docs are disabled.');
+  warnMissing('UNSTRUCTURED_API_URL', 'document parsing for some uploaded file types is disabled.');
+  warnMissing('PARALLELS_API_KEY', 'web crawling/profile extraction for links is disabled.');
+
+  warnPartial(['GOOGLE_CLIENT_ID', 'GOOGLE_CLIENT_SECRET'], 'set both values or Google OAuth will not work.');
+  warnPartial(['LANGFUSE_PUBLIC_KEY', 'LANGFUSE_SECRET_KEY'], 'set both values or Langfuse tracing will not work.');
+  warnPartial(['TELEGRAM_BOT_TOKEN', 'TELEGRAM_WEBHOOK_SECRET'], 'set both values or Telegram webhook registration will be skipped/rejected.');
+  if (hasValue('TELEGRAM_BOT_TOKEN') && !hasValue('TELEGRAM_BOT_USERNAME')) {
+    warnings.push('TELEGRAM_BOT_USERNAME: set the bot username so Telegram integration links can be generated.');
+  }
+
+  return warnings;
+}
+
+const warnings = collectEnvWarnings();
+if (warnings.length > 0) {
+  console.warn('⚠️ Environment warnings:');
+  for (const warning of warnings) {
+    console.warn(`   ${warning}`);
+  }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -127,7 +127,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "1.26.0",
+      "version": "1.26.1",
       "dependencies": {
         "@langchain/core": "^1.1.17",
         "@langchain/langgraph": "^1.1.2",

--- a/bun.lock
+++ b/bun.lock
@@ -127,7 +127,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "1.26.1",
+      "version": "1.26.2",
       "dependencies": {
         "@langchain/core": "^1.1.17",
         "@langchain/langgraph": "^1.1.2",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "1.26.1",
+  "version": "1.26.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -85,6 +85,20 @@ const logger = protocolLogger('OpportunityGraph');
 /** Time window for persist-node dedup. Parallel jobs arrive within seconds; 10 min catches those while allowing new opportunities for long-connected pairs. */
 const DEDUP_WINDOW_MS = 10 * 60 * 1000;
 
+/** Default cap for source premises used by premise-to-premise discovery. Prevents BACKEND-5-style fan-out. */
+const DEFAULT_SOURCE_PREMISE_DISCOVERY_LIMIT = 40;
+
+/** Per-source cap for candidate premise matches. */
+const PREMISE_MATCH_LIMIT_PER_SOURCE = 20;
+
+/** Resolve the source premise discovery cap from env, preserving 0 as an explicit disable switch. */
+function getSourcePremiseDiscoveryLimit(): number {
+  const raw = process.env.DISCOVERY_SOURCE_PREMISE_LIMIT;
+  if (raw === undefined || raw.trim() === '') return DEFAULT_SOURCE_PREMISE_DISCOVERY_LIMIT;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_SOURCE_PREMISE_DISCOVERY_LIMIT;
+}
+
 /** Input shape for the HyDE graph invoke call (query-based embedding). */
 export interface HydeGeneratorInvokeInput {
   sourceType: 'query';
@@ -272,10 +286,9 @@ export class OpportunityGraphFactory {
               };
             }
             const discoveryUserId = state.onBehalfOfUserId ?? state.userId;
-            const [intents, profile, userPremises] = await Promise.all([
+            const [intents, profile] = await Promise.all([
               this.database.getActiveIntents(discoveryUserId),
               this.database.getProfile(discoveryUserId),
-              this.database.getPremisesForUser(discoveryUserId, 'ACTIVE'),
             ]);
             const indexedIntents: IndexedIntent[] = intents.map((intent: ActiveIntent) => ({
               intentId: intent.id,
@@ -290,12 +303,11 @@ export class OpportunityGraphFactory {
                   attributes: profile.attributes ?? undefined,
                 }
               : null;
-            const sourcePremises = (userPremises ?? [])
-              .filter(p => p.embedding && p.embedding.length > 0)
-              .map(p => ({
-                premiseId: p.id as Id<'premises'>,
-                embedding: p.embedding!,
-              }));
+            // Source premises are loaded after scope is resolved so premise discovery
+            // only uses premises assigned to the target network(s), and only up to
+            // DISCOVERY_SOURCE_PREMISE_LIMIT. Loading all premises here caused
+            // BACKEND-5: thousands of parallel vector searches for premise-rich users.
+            const sourcePremises: Array<{ premiseId: Id<'premises'>; embedding: number[] }> = [];
             const contextToIntentEnabled = process.env.DISCOVERY_CONTEXT_TO_INTENT !== '0';
             const rawContexts = contextToIntentEnabled
               ? await this.database.getUserContexts(discoveryUserId)
@@ -315,7 +327,7 @@ export class OpportunityGraphFactory {
               sourceContexts,
               trace: [{
                 node: "prep",
-                detail: `${userNetworkIds.length} network(s), ${intents.length} intent(s), ${sourcePremises.length} premise(s), ${sourceContexts.length} context(s), ${profile ? 'profile loaded' : 'no profile'}`,
+                detail: `${userNetworkIds.length} network(s), ${intents.length} intent(s), premise discovery deferred, ${sourceContexts.length} context(s), ${profile ? 'profile loaded' : 'no profile'}`,
               }],
             };
           },
@@ -944,39 +956,64 @@ export class OpportunityGraphFactory {
            * scoped to target networks. Additive — merges into existing candidates.
            */
           async function runPremiseDiscovery(): Promise<CandidateMatch[]> {
-            if (!state.sourcePremises?.length) return [];
             const targetNetworkIds = state.targetNetworks.map(t => t.networkId);
             if (targetNetworkIds.length === 0) return [];
 
-            logger.verbose('[Graph:Discovery] runPremiseDiscovery start', {
-              premiseCount: state.sourcePremises.length,
-              targetNetworks: targetNetworkIds.length,
-            });
+            const sourceLimit = getSourcePremiseDiscoveryLimit();
+            if (sourceLimit === 0) {
+              logger.verbose('[Graph:Discovery] runPremiseDiscovery disabled by DISCOVERY_SOURCE_PREMISE_LIMIT=0');
+              return [];
+            }
 
-            const searchResults = await Promise.all(
-              state.sourcePremises.map(sp =>
-                self.database.searchPremisesBySimilarity({
-                  embedding: sp.embedding,
-                  networkIds: targetNetworkIds,
-                  excludeUserId: discoveryUserId,
-                  limit: 20,
-                })
-              )
+            const sourcePremisesFromDb = self.database.getPremisesForUserInNetworks
+              ? await self.database.getPremisesForUserInNetworks(discoveryUserId, targetNetworkIds, 'ACTIVE', sourceLimit)
+              : await self.database.getPremisesForUser(discoveryUserId, 'ACTIVE');
+            const sourcePremises = (sourcePremisesFromDb.length > 0
+              ? sourcePremisesFromDb
+                  .filter(p => p.embedding && p.embedding.length > 0)
+                  .slice(0, sourceLimit)
+                  .map(p => ({ premiseId: p.id as Id<'premises'>, embedding: p.embedding! }))
+              : (state.sourcePremises ?? []).slice(0, sourceLimit)
             );
 
+            if (sourcePremises.length === 0) return [];
+
+            logger.verbose('[Graph:Discovery] runPremiseDiscovery start', {
+              premiseCount: sourcePremises.length,
+              sourceLimit,
+              targetNetworks: targetNetworkIds.length,
+              batched: !!self.database.searchPremisesBySimilarityBatch,
+            });
+
+            const rawResults = self.database.searchPremisesBySimilarityBatch
+              ? await self.database.searchPremisesBySimilarityBatch({
+                  sources: sourcePremises,
+                  networkIds: targetNetworkIds,
+                  excludeUserId: discoveryUserId,
+                  limitPerSource: PREMISE_MATCH_LIMIT_PER_SOURCE,
+                })
+              : (await Promise.all(
+                  sourcePremises.map(sp =>
+                    self.database.searchPremisesBySimilarity({
+                      embedding: sp.embedding,
+                      networkIds: targetNetworkIds,
+                      excludeUserId: discoveryUserId,
+                      limit: PREMISE_MATCH_LIMIT_PER_SOURCE,
+                    })
+                  )
+                )).flat();
+
             const premiseCandidates: CandidateMatch[] = [];
-            for (const results of searchResults) {
-              for (const r of results) {
-                premiseCandidates.push({
-                  candidateUserId: r.userId as Id<'users'>,
-                  candidatePremiseId: r.premiseId as Id<'premises'>,
-                  networkId: r.networkId as Id<'networks'>,
-                  similarity: typeof r.similarity === 'number' ? r.similarity : parseFloat(String(r.similarity)),
-                  lens: 'premise_match',
-                  candidatePayload: r.assertionText ?? '',
-                  discoverySource: 'premise-similarity',
-                });
-              }
+            for (const r of rawResults) {
+              premiseCandidates.push({
+                candidateUserId: r.userId as Id<'users'>,
+                candidatePremiseId: r.premiseId as Id<'premises'>,
+                networkId: r.networkId as Id<'networks'>,
+                similarity: typeof r.similarity === 'number' ? r.similarity : parseFloat(String(r.similarity)),
+                lens: 'premise_match',
+                candidatePayload: r.assertionText ?? '',
+                discoverySource: 'premise-similarity',
+              });
             }
 
             // Dedup by userId + premiseId + networkId (a premise can appear in multiple networks)
@@ -989,6 +1026,7 @@ export class OpportunityGraphFactory {
             }
             const deduped = Array.from(byKey.values());
             logger.verbose('[Graph:Discovery] runPremiseDiscovery complete', {
+              sourcePremiseCount: sourcePremises.length,
               rawCount: premiseCandidates.length,
               dedupedCount: deduped.length,
             });

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -333,7 +333,13 @@ type OpportunityCardLike = Record<string, unknown> & {
  */
 export function buildOpportunityPresentation(
   cards: OpportunityCardLike[],
-  opts: { isMcp: boolean; leadIn: string; label?: "opportunity" | "opportunities" },
+  opts: {
+    isMcp: boolean;
+    leadIn: string;
+    label?: "opportunity" | "opportunities";
+    /** Include hidden digest metadata markers so scheduled brief tooling can confirm delivery. */
+    includeDigestMarkers?: boolean;
+  },
 ): string {
   if (cards.length === 0) return opts.leadIn;
 
@@ -341,6 +347,10 @@ export function buildOpportunityPresentation(
     const prose = cards
       .map((card, i) => {
         const lines: string[] = [`${i + 1}. ${card.name ?? "Unknown"}`];
+        if (opts.includeDigestMarkers) {
+          const markerId = String(card.opportunityId).replace(/[\s>]/g, "");
+          if (markerId) lines.push(`   <!-- digest-opportunity:id=${markerId} -->`);
+        }
         if (card.mainText) lines.push(`   ${card.mainText}`);
         if (card.status) lines.push(`   status: ${card.status}`);
         if (card.profileUrl) lines.push(`   profileUrl: ${card.profileUrl}`);
@@ -1344,6 +1354,10 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         .string()
         .optional()
         .describe("Index UUID to filter opportunities to a specific community. Get from read_networks. Defaults to the scoped index in index-scoped chats. Omit to see opportunities across all indexes."),
+      includeDigestMarkers: z
+        .boolean()
+        .optional()
+        .describe("Internal scheduled-digest mode only. When true, includes hidden delivery markers so the digest send pass can confirm only edited-in opportunities."),
     }),
     handler: async ({ context, query }) => {
       // Strict scope enforcement: when chat is index-scoped, only allow that index
@@ -1593,6 +1607,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         message: buildOpportunityPresentation(cardDataList, {
           isMcp: context.isMcp ?? false,
           leadIn: `You have ${cardDataList.length} opportunity(ies).`,
+          includeDigestMarkers: context.isMcp === true && query.includeDigestMarkers === true,
         }),
         ...(listDebugSteps.length ? { debugSteps: listDebugSteps } : {}),
       });

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -333,13 +333,7 @@ type OpportunityCardLike = Record<string, unknown> & {
  */
 export function buildOpportunityPresentation(
   cards: OpportunityCardLike[],
-  opts: {
-    isMcp: boolean;
-    leadIn: string;
-    label?: "opportunity" | "opportunities";
-    /** Include hidden digest metadata markers so scheduled brief tooling can confirm delivery. */
-    includeDigestMarkers?: boolean;
-  },
+  opts: { isMcp: boolean; leadIn: string; label?: "opportunity" | "opportunities" },
 ): string {
   if (cards.length === 0) return opts.leadIn;
 
@@ -347,10 +341,6 @@ export function buildOpportunityPresentation(
     const prose = cards
       .map((card, i) => {
         const lines: string[] = [`${i + 1}. ${card.name ?? "Unknown"}`];
-        if (opts.includeDigestMarkers) {
-          const markerId = String(card.opportunityId).replace(/[\s>]/g, "");
-          if (markerId) lines.push(`   <!-- digest-opportunity:id=${markerId} -->`);
-        }
         if (card.mainText) lines.push(`   ${card.mainText}`);
         if (card.status) lines.push(`   status: ${card.status}`);
         if (card.profileUrl) lines.push(`   profileUrl: ${card.profileUrl}`);
@@ -1354,10 +1344,6 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         .string()
         .optional()
         .describe("Index UUID to filter opportunities to a specific community. Get from read_networks. Defaults to the scoped index in index-scoped chats. Omit to see opportunities across all indexes."),
-      includeDigestMarkers: z
-        .boolean()
-        .optional()
-        .describe("Internal scheduled-digest mode only. When true, includes hidden delivery markers so the digest send pass can confirm only edited-in opportunities."),
     }),
     handler: async ({ context, query }) => {
       // Strict scope enforcement: when chat is index-scoped, only allow that index
@@ -1607,7 +1593,6 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         message: buildOpportunityPresentation(cardDataList, {
           isMcp: context.isMcp ?? false,
           leadIn: `You have ${cardDataList.length} opportunity(ies).`,
-          includeDigestMarkers: context.isMcp === true && query.includeDigestMarkers === true,
         }),
         ...(listDebugSteps.length ? { debugSteps: listDebugSteps } : {}),
       });

--- a/packages/protocol/src/opportunity/tests/opportunity.graph.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.graph.spec.ts
@@ -363,6 +363,64 @@ describe('Opportunity Graph', () => {
       expect(result.candidates.length).toBeGreaterThanOrEqual(1);
     });
 
+    test('premise discovery uses scoped capped source premises and one batched DB search', async () => {
+      const previousSourcePremiseLimit = process.env.DISCOVERY_SOURCE_PREMISE_LIMIT;
+      process.env.DISCOVERY_SOURCE_PREMISE_LIMIT = '40';
+
+      try {
+        const { compiledGraph, mockDb, mockEmbedder } = createMockGraph();
+        spyOn(mockEmbedder, 'searchWithHydeEmbeddings').mockResolvedValue([]);
+        const legacySearchSpy = spyOn(mockDb, 'searchPremisesBySimilarity');
+
+        const scopedCalls: Array<{ userId: string; networkIds: string[]; status?: string; limit?: number }> = [];
+        mockDb.getPremisesForUserInNetworks = async (userId, networkIds, status, limit) => {
+          scopedCalls.push({ userId, networkIds, status, limit });
+          return [
+            { id: 'premise-1', userId, assertion: { text: 'Builds protocols', tier: 'assertive' as const }, provenance: { source: 'enrichment' as const, confidence: 1, timestamp: new Date().toISOString() }, analysis: null, validity: { volatile: false }, embedding: dummyEmbedding, status: 'ACTIVE' as const, createdAt: new Date(), updatedAt: new Date(), retractedAt: null },
+            { id: 'premise-2', userId, assertion: { text: 'Knows founders', tier: 'assertive' as const }, provenance: { source: 'enrichment' as const, confidence: 1, timestamp: new Date().toISOString() }, analysis: null, validity: { volatile: false }, embedding: dummyEmbedding, status: 'ACTIVE' as const, createdAt: new Date(), updatedAt: new Date(), retractedAt: null },
+          ];
+        };
+
+        const batchCalls: Array<Parameters<NonNullable<OpportunityGraphDatabase['searchPremisesBySimilarityBatch']>>[0]> = [];
+        mockDb.searchPremisesBySimilarityBatch = async (params) => {
+          batchCalls.push(params);
+          return [{
+            sourcePremiseId: 'premise-1',
+            premiseId: 'candidate-premise-1',
+            userId: 'b0000000-0000-4000-8000-000000000002',
+            networkId: 'idx-1',
+            assertionText: 'Can help protocols find founders',
+            similarity: 0.88,
+          }];
+        };
+
+        const result = (await compiledGraph.invoke({
+          userId: 'a0000000-0000-4000-8000-000000000001' as Id<'users'>,
+          searchQuery: 'co-founder',
+          options: {},
+        } as OpportunityGraphInvokeInput)) as OpportunityGraphInvokeResult;
+
+        expect(scopedCalls).toHaveLength(1);
+        expect(scopedCalls[0]).toMatchObject({
+          userId: 'a0000000-0000-4000-8000-000000000001',
+          networkIds: ['idx-1'],
+          status: 'ACTIVE',
+          limit: 40,
+        });
+        expect(batchCalls).toHaveLength(1);
+        expect(batchCalls[0].sources.map(s => s.premiseId)).toEqual(['premise-1', 'premise-2']);
+        expect(batchCalls[0].limitPerSource).toBe(20);
+        expect(legacySearchSpy).not.toHaveBeenCalled();
+        expect(result.candidates.some(c => c.discoverySource === 'premise-similarity')).toBe(true);
+      } finally {
+        if (previousSourcePremiseLimit === undefined) {
+          delete process.env.DISCOVERY_SOURCE_PREMISE_LIMIT;
+        } else {
+          process.env.DISCOVERY_SOURCE_PREMISE_LIMIT = previousSourcePremiseLimit;
+        }
+      }
+    });
+
     test('when search returns only profile type (no intent), profile candidates are included', async () => {
       const { compiledGraph, mockEmbedder } = createMockGraph();
       spyOn(mockEmbedder, 'searchWithHydeEmbeddings').mockResolvedValue([

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.spec.ts
@@ -478,28 +478,8 @@ describe("buildOpportunityPresentation — MCP opportunityId omission", () => {
     );
 
     expect(out).not.toContain("opportunityId: opp-actionable-1");
-    expect(out).not.toContain("digest-opportunity:id=opp-actionable-1");
     expect(out).toContain("acceptUrl: https://api.test/c/Abc1234567");
     expect(out).not.toContain("Use opportunityId values only when calling update_opportunity");
-  });
-
-  test("includes hidden digest marker for actionable cards only when requested", () => {
-    const out = buildOpportunityPresentation(
-      [{
-        opportunityId: "opp-actionable-1",
-        name: "Alice",
-        mainText: "Both work on protocol design.",
-        status: "pending",
-        acceptUrl: "https://api.test/c/Abc1234567",
-        profileUrl: "https://app.test/u/opp-actionable-1-counterpart?link_preview=false",
-        feedCategory: "connection",
-      }],
-      { isMcp: true, leadIn: "Found 1 connection.", includeDigestMarkers: true },
-    );
-
-    expect(out).not.toContain("opportunityId: opp-actionable-1");
-    expect(out).toContain("<!-- digest-opportunity:id=opp-actionable-1 -->");
-    expect(out).toContain("acceptUrl: https://api.test/c/Abc1234567");
   });
 
   test("keeps opportunityId line when card has NO acceptUrl (draft sender etc.)", () => {

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.spec.ts
@@ -478,8 +478,28 @@ describe("buildOpportunityPresentation — MCP opportunityId omission", () => {
     );
 
     expect(out).not.toContain("opportunityId: opp-actionable-1");
+    expect(out).not.toContain("digest-opportunity:id=opp-actionable-1");
     expect(out).toContain("acceptUrl: https://api.test/c/Abc1234567");
     expect(out).not.toContain("Use opportunityId values only when calling update_opportunity");
+  });
+
+  test("includes hidden digest marker for actionable cards only when requested", () => {
+    const out = buildOpportunityPresentation(
+      [{
+        opportunityId: "opp-actionable-1",
+        name: "Alice",
+        mainText: "Both work on protocol design.",
+        status: "pending",
+        acceptUrl: "https://api.test/c/Abc1234567",
+        profileUrl: "https://app.test/u/opp-actionable-1-counterpart?link_preview=false",
+        feedCategory: "connection",
+      }],
+      { isMcp: true, leadIn: "Found 1 connection.", includeDigestMarkers: true },
+    );
+
+    expect(out).not.toContain("opportunityId: opp-actionable-1");
+    expect(out).toContain("<!-- digest-opportunity:id=opp-actionable-1 -->");
+    expect(out).toContain("acceptUrl: https://api.test/c/Abc1234567");
   });
 
   test("keeps opportunityId line when card has NO acceptUrl (draft sender etc.)", () => {

--- a/packages/protocol/src/shared/interfaces/database.interface.ts
+++ b/packages/protocol/src/shared/interfaces/database.interface.ts
@@ -1451,6 +1451,13 @@ export interface Database {
 
   getPremisesForUser(userId: string, status?: 'ACTIVE' | 'RETRACTED' | 'EXPIRED'): Promise<PremiseRecord[]>;
 
+  /**
+   * Retrieve a user's premises assigned to one of the provided networks.
+   * Optional for older/test adapters; OpportunityGraph falls back to capped
+   * getPremisesForUser results when unavailable.
+   */
+  getPremisesForUserInNetworks?(userId: string, networkIds: string[], status?: 'ACTIVE' | 'RETRACTED' | 'EXPIRED', limit?: number): Promise<PremiseRecord[]>;
+
   updatePremise(premiseId: string, updates: {
     assertion?: PremiseAssertion;
     analysis?: PremiseAnalysis;
@@ -1474,6 +1481,26 @@ export interface Database {
     excludeUserId: string;
     limit: number;
   }): Promise<Array<{
+    premiseId: string;
+    userId: string;
+    networkId: string;
+    assertionText: string;
+    similarity: number;
+  }>>;
+
+  /**
+   * Batched version of premise similarity search. Executes one bounded DB call
+   * for all selected source premises instead of one query per source premise.
+   * Optional for older/test adapters; OpportunityGraph falls back to the
+   * single-source method when unavailable.
+   */
+  searchPremisesBySimilarityBatch?(params: {
+    sources: Array<{ premiseId: string; embedding: number[] }>;
+    networkIds: string[];
+    excludeUserId: string;
+    limitPerSource: number;
+  }): Promise<Array<{
+    sourcePremiseId: string;
     premiseId: string;
     userId: string;
     networkId: string;
@@ -2024,8 +2051,10 @@ export type ChatGraphCompositeDatabase = Pick<
   | 'mergeGhostUser'
   // ProfileGraph aggregate mode (premise-to-profile materialization)
   | 'getPremisesForUser'
+  | 'getPremisesForUserInNetworks'
   // Premise-to-premise discovery (path D) in OpportunityGraph
   | 'searchPremisesBySimilarity'
+  | 'searchPremisesBySimilarityBatch'
   // User context methods (context-to-intent discovery) in OpportunityGraph
   | 'getUserContext'
   | 'getUserContexts'
@@ -2071,7 +2100,9 @@ export type OpportunityGraphDatabase = Pick<
   | 'getIntent'
   // Premise-to-premise discovery (path D)
   | 'getPremisesForUser'
+  | 'getPremisesForUserInNetworks'
   | 'searchPremisesBySimilarity'
+  | 'searchPremisesBySimilarityBatch'
   // User context methods (context-to-intent discovery)
   | 'getUserContext'
   | 'getUserContexts'


### PR DESCRIPTION
## Changelog

### Added
- Add internal digest opportunity markers for scheduled digest/brief MCP callers so delivery confirmation can be reliable without exposing visible opportunity IDs in actionable cards.

### Fixed
- Cap premise-to-premise discovery fan-out by deferring scoped premise loading, limiting source premises, and batching similarity searches to prevent premise-rich users from triggering excessive database work.
- Soften Railway dev environment validation so missing dev-only secrets and invalid discovery-question mode values warn instead of crash-looping the deployment.

### Changed
- Expand backend startup environment validation and deployment warnings for commonly forgotten Railway variables.
- Bump `@indexnetwork/protocol` to `1.26.2` and backend protocol service to `0.27.2`.
- Update the AgentVillage submodule pointer with the latest Edge/Index skill sync state.

## Diff checked

Compared `release/2026-06-04` against `origin/main` before opening this PR. Notable changed areas:
- `backend/.env.example`, `backend/package.json`, `backend/src/startup.env.ts`
- `backend/src/adapters/database.adapter.ts`
- `packages/protocol/package.json`
- `packages/protocol/src/opportunity/*`
- `packages/protocol/src/shared/interfaces/database.interface.ts`
- `packages/agentvillage` submodule pointer

## Validation

- Railway dev `protocol` deployment succeeded after the env-validation hotfix.
- No local test suite was run for this release-branch PR.
