### PR TITLE
Release 2026-06-04 protocol URL fix

### DIFF
--- a/backend/src/controllers/mcp.controller.ts
+++ b/backend/src/controllers/mcp.controller.ts
@@ -47,6 +47,7 @@ import { negotiationTimeoutQueue } from '../queues/negotiations/timeout.queue';
 import { signConnectToken } from '../services/connect-token.service';
 import type { ConnectLinkKind } from '../services/connect-link.service';
 import { mintConnectLink as mintConnectLinkSvc, buildConnectShortUrl } from '../services/connect-link.service';
+import { resolveProtocolBaseUrl } from '../lib/protocol-url';
 
 import { IntentGraphFactory, ProfileGraphFactory, OpportunityGraphFactory, HydeGraphFactory, NetworkGraphFactory, NetworkMembershipGraphFactory, IntentNetworkGraphFactory, NegotiationGraphFactory, HydeGenerator, LensInferrer, IntentIndexer, createMcpServer, ChatGraphFactory, PremiseGraphFactory } from '@indexnetwork/protocol';
 import type { HydeGraphDatabase, PremiseGraphDatabase, ToolDeps, McpAuthResolver, ScopedDepsFactory, Embedder, ChatGraphCompositeDatabase, QuestionerEnqueuePayload, PendingQuestionSummary } from '@indexnetwork/protocol';
@@ -73,12 +74,7 @@ const negotiationSummaryService = new NegotiationSummaryService();
 const integrationImporter = new IntegrationService(integration, contactService);
 const agentDispatcher = new AgentDispatcherImpl(agentService, negotiationTimeoutQueue);
 
-const apiBaseUrl = (
-  process.env.BASE_URL ||
-  process.env.API_BASE_URL ||
-  process.env.APP_URL ||
-  'http://localhost:3001'
-).replace(/\/+$/, '');
+const apiBaseUrl = resolveProtocolBaseUrl();
 
 const mintConnectLink = async ({ userId, opportunityId, kind, greeting, preferredSurface }: {
   userId: string;

--- a/backend/src/controllers/opportunity.controller.ts
+++ b/backend/src/controllers/opportunity.controller.ts
@@ -8,6 +8,7 @@ import { RateLimit } from '../guards/limiter.guard';
 import type { AuthenticatedUser } from '../guards/auth.guard';
 import { signConnectToken, verifyConnectToken } from '../services/connect-token.service';
 import { mintConnectLink, type ConnectLinkKind } from '../services/connect-link.service';
+import { resolveProtocolBaseUrl } from '../lib/protocol-url';
 import { queueOpportunityNotification } from '../queues/notification.queue';
 import { log } from '../lib/log';
 
@@ -339,15 +340,9 @@ export class OpportunityController {
       greeting,
     });
 
-    // Public origin for short links. Falls back to a dev default; matches
-    // the precedence used by protocol-init.ts so MCP-minted and HTTP-minted
-    // URLs share the same host.
-    const apiBaseUrl = (
-      process.env.BASE_URL ||
-      process.env.API_BASE_URL ||
-      process.env.APP_URL ||
-      'http://localhost:3001'
-    ).replace(/\/+$/, '');
+    // Public origin for short links — the protocol host only (never the
+    // frontend APP_URL), shared with the MCP-minted path via this helper.
+    const apiBaseUrl = resolveProtocolBaseUrl();
 
     return Response.json({ url: `${apiBaseUrl}/c/${code}` });
   }

--- a/backend/src/lib/mcp/mcp-config.ts
+++ b/backend/src/lib/mcp/mcp-config.ts
@@ -1,3 +1,5 @@
+import { resolveProtocolBaseUrl } from '../protocol-url';
+
 export interface McpServerConfig {
   name: string;
   url: string;
@@ -8,18 +10,13 @@ export interface McpServerConfig {
  * Builds the MCP server config snippet returned by the headless signup endpoint.
  * Callers embed this in their runtime's MCP servers config.
  *
- * URL precedence matches `protocol-init.ts` and `opportunity.controller.ts`:
- * `BASE_URL || API_BASE_URL || APP_URL`, with the production protocol host as
- * the final fallback so a misconfigured deployment never returns a localhost
- * URL to integrators.
+ * The `/mcp` endpoint is served by the protocol host, so the base URL comes
+ * from `resolveProtocolBaseUrl` (protocol-host vars only, never the frontend
+ * `APP_URL`). The public protocol host is the fallback so a misconfigured
+ * deployment never returns a localhost URL to integrators.
  */
 export const buildMcpServerConfig = (apiKey: string): McpServerConfig => {
-  const base = (
-    process.env.BASE_URL ||
-    process.env.API_BASE_URL ||
-    process.env.APP_URL ||
-    'https://protocol.index.network'
-  ).replace(/\/+$/, '');
+  const base = resolveProtocolBaseUrl('https://protocol.index.network');
   return {
     name: 'index',
     url: `${base}/mcp`,

--- a/backend/src/lib/mcp/mcp-config.ts
+++ b/backend/src/lib/mcp/mcp-config.ts
@@ -12,11 +12,11 @@ export interface McpServerConfig {
  *
  * The `/mcp` endpoint is served by the protocol host, so the base URL comes
  * from `resolveProtocolBaseUrl` (protocol-host vars only, never the frontend
- * `APP_URL`). The public protocol host is the fallback so a misconfigured
- * deployment never returns a localhost URL to integrators.
+ * `APP_URL`), which defaults to the public protocol host when unset so a
+ * misconfigured deployment never returns a localhost URL to integrators.
  */
 export const buildMcpServerConfig = (apiKey: string): McpServerConfig => {
-  const base = resolveProtocolBaseUrl('https://protocol.index.network');
+  const base = resolveProtocolBaseUrl();
   return {
     name: 'index',
     url: `${base}/mcp`,

--- a/backend/src/lib/protocol-url.ts
+++ b/backend/src/lib/protocol-url.ts
@@ -11,14 +11,15 @@ let warnedMissingProtocolBaseUrl = false;
  * `APP_URL`/`FRONTEND_URL`. A frontend host (e.g. `index.network`) must never
  * leak into these URLs — it would 404 against the SPA instead of resolving on
  * the protocol host. When neither var is set the provided `fallback` is used
- * (localhost for in-process dev callers, the public protocol host for URLs
- * handed to external integrators); in production a missing protocol base URL is
- * logged once so the misconfig surfaces loudly.
+ * (defaults to the public protocol host so a misconfigured deployment still
+ * mints a usable, correct-host URL rather than a localhost or frontend one);
+ * in production a missing protocol base URL is logged once so the misconfig
+ * surfaces loudly.
  *
  * @param fallback - Base URL to use when no protocol-host env var is set.
  * @returns Protocol base URL with any trailing slashes stripped.
  */
-export function resolveProtocolBaseUrl(fallback = 'http://localhost:3001'): string {
+export function resolveProtocolBaseUrl(fallback = 'https://protocol.index.network'): string {
   const explicit = process.env.BASE_URL || process.env.API_BASE_URL;
   if (explicit) return explicit.replace(/\/+$/, '');
 

--- a/backend/src/lib/protocol-url.ts
+++ b/backend/src/lib/protocol-url.ts
@@ -1,0 +1,33 @@
+import { log } from './log';
+
+let warnedMissingProtocolBaseUrl = false;
+
+/**
+ * Resolve the public base URL of the protocol service.
+ *
+ * Protocol-host routes — short connect links (`/c/:code`) and the MCP endpoint
+ * (`/mcp`) — are served ONLY by the protocol backend, so this consults only the
+ * protocol-host vars (`BASE_URL`, then `API_BASE_URL`) and never the frontend
+ * `APP_URL`/`FRONTEND_URL`. A frontend host (e.g. `index.network`) must never
+ * leak into these URLs — it would 404 against the SPA instead of resolving on
+ * the protocol host. When neither var is set the provided `fallback` is used
+ * (localhost for in-process dev callers, the public protocol host for URLs
+ * handed to external integrators); in production a missing protocol base URL is
+ * logged once so the misconfig surfaces loudly.
+ *
+ * @param fallback - Base URL to use when no protocol-host env var is set.
+ * @returns Protocol base URL with any trailing slashes stripped.
+ */
+export function resolveProtocolBaseUrl(fallback = 'http://localhost:3001'): string {
+  const explicit = process.env.BASE_URL || process.env.API_BASE_URL;
+  if (explicit) return explicit.replace(/\/+$/, '');
+
+  if (process.env.NODE_ENV === 'production' && !warnedMissingProtocolBaseUrl) {
+    warnedMissingProtocolBaseUrl = true;
+    log.lib.error(
+      'protocol-url: BASE_URL/API_BASE_URL unset in production — protocol URLs may be unusable. ' +
+        'Set BASE_URL to the protocol host (e.g. https://protocol.index.network).',
+    );
+  }
+  return fallback.replace(/\/+$/, '');
+}

--- a/backend/src/lib/tests/protocol-url.spec.ts
+++ b/backend/src/lib/tests/protocol-url.spec.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+
+import { resolveProtocolBaseUrl } from '../protocol-url';
+
+describe('resolveProtocolBaseUrl', () => {
+  const saved = {
+    BASE_URL: process.env.BASE_URL,
+    API_BASE_URL: process.env.API_BASE_URL,
+    APP_URL: process.env.APP_URL,
+    NODE_ENV: process.env.NODE_ENV,
+  };
+
+  beforeEach(() => {
+    delete process.env.BASE_URL;
+    delete process.env.API_BASE_URL;
+    delete process.env.APP_URL;
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  test('prefers BASE_URL and strips trailing slashes', () => {
+    process.env.BASE_URL = 'https://protocol.index.network/';
+    expect(resolveProtocolBaseUrl()).toBe('https://protocol.index.network');
+  });
+
+  test('falls back to API_BASE_URL when BASE_URL is unset', () => {
+    process.env.API_BASE_URL = 'https://api.index.network';
+    expect(resolveProtocolBaseUrl()).toBe('https://api.index.network');
+  });
+
+  test('NEVER uses the frontend APP_URL', () => {
+    process.env.APP_URL = 'https://index.network';
+    // The whole point of the fix: a frontend host must not leak into a
+    // protocol-host URL. With no protocol var set, the dev fallback is used.
+    expect(resolveProtocolBaseUrl()).toBe('http://localhost:3001');
+  });
+
+  test('uses the provided fallback when no protocol var is set', () => {
+    process.env.APP_URL = 'https://index.network';
+    expect(resolveProtocolBaseUrl('https://protocol.index.network')).toBe(
+      'https://protocol.index.network',
+    );
+  });
+});

--- a/backend/src/lib/tests/protocol-url.spec.ts
+++ b/backend/src/lib/tests/protocol-url.spec.ts
@@ -33,17 +33,16 @@ describe('resolveProtocolBaseUrl', () => {
     expect(resolveProtocolBaseUrl()).toBe('https://api.index.network');
   });
 
-  test('NEVER uses the frontend APP_URL', () => {
+  test('NEVER uses the frontend APP_URL — defaults to the protocol host', () => {
     process.env.APP_URL = 'https://index.network';
     // The whole point of the fix: a frontend host must not leak into a
-    // protocol-host URL. With no protocol var set, the dev fallback is used.
-    expect(resolveProtocolBaseUrl()).toBe('http://localhost:3001');
+    // protocol-host URL. With no protocol var set, the default protocol host
+    // is used instead of APP_URL.
+    expect(resolveProtocolBaseUrl()).toBe('https://protocol.index.network');
   });
 
-  test('uses the provided fallback when no protocol var is set', () => {
+  test('uses a caller-supplied fallback over the default when no protocol var is set', () => {
     process.env.APP_URL = 'https://index.network';
-    expect(resolveProtocolBaseUrl('https://protocol.index.network')).toBe(
-      'https://protocol.index.network',
-    );
+    expect(resolveProtocolBaseUrl('http://localhost:3001')).toBe('http://localhost:3001');
   });
 });

--- a/backend/src/queues/opportunity/discovery-run.queue.ts
+++ b/backend/src/queues/opportunity/discovery-run.queue.ts
@@ -32,6 +32,7 @@ import { cacheAdapter, hydeCacheAdapter, RedisCacheAdapter } from '../../adapter
 import { scraperAdapter } from '../../adapters/scraper.adapter';
 import { discoveryRunAdapter } from '../../adapters/discovery-run.adapter';
 import { mintConnectLink as mintConnectLinkSvc, buildConnectShortUrl } from '../../services/connect-link.service';
+import { resolveProtocolBaseUrl } from '../../lib/protocol-url';
 import type { ConnectLinkKind } from '../../services/connect-link.service';
 import { negotiationRunExistingQueue } from '../negotiations/run-existing.queue';
 
@@ -46,12 +47,7 @@ export interface DiscoveryRunQueueDeps {
   agentDispatcher?: Pick<AgentDispatcher, 'hasPersonalAgent'>;
 }
 
-const apiBaseUrl = (
-  process.env.BASE_URL ||
-  process.env.API_BASE_URL ||
-  process.env.APP_URL ||
-  'http://localhost:3001'
-).replace(/\/+$/, '');
+const apiBaseUrl = resolveProtocolBaseUrl();
 
 const mintConnectLink = async ({ userId, opportunityId, kind, greeting, preferredSurface }: {
   userId: string;


### PR DESCRIPTION
## Changelog

### Fixed
- Keep protocol-host URLs for `/c/:code` connect links and `/mcp` configs on the protocol backend host instead of falling back to the frontend `APP_URL`.
- Default protocol URLs to `https://protocol.index.network` when `BASE_URL`/`API_BASE_URL` are missing, so misconfigured deployments do not mint localhost or frontend-host links.

## Diff checked

Compared `release/2026-06-04-protocol-url` against `origin/main`. Changed areas:
- `backend/src/lib/protocol-url.ts`
- `backend/src/lib/mcp/mcp-config.ts`
- `backend/src/controllers/mcp.controller.ts`
- `backend/src/controllers/opportunity.controller.ts`
- `backend/src/queues/opportunity/discovery-run.queue.ts`
- `backend/src/lib/tests/protocol-url.spec.ts`

## Validation

- PR #892 checks passed before merging into `dev`.
- No additional local tests were run for this follow-up release PR.
