### PR TITLE
release: 2026-06-04

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,9 +294,9 @@ Model settings centralized in `packages/protocol/src/shared/agent/model.config.t
 
 The protocol applies per-route-class limits via the `RateLimit(class)` guard from `src/guards/limiter.guard.ts`. Three classes:
 
-- `read` — all `GET` routes (default 120/min)
-- `write` — all `POST/PUT/PATCH/DELETE` routes (default 60/min)
-- `auth_write` — credential-mutation endpoints on `/api/auth/*` (default 10/min); enforced by Better Auth's own `rateLimit` block
+- `read` — all `GET` routes (default 1200/min)
+- `write` — all `POST/PUT/PATCH/DELETE` routes (default 600/min)
+- `auth_write` — credential-mutation endpoints on `/api/auth/*` (default 100/min); enforced by Better Auth's own `rateLimit` block
 
 Buckets are keyed per identifier: verified JWT user (signature-checked) or client IP for everything else. Unverified credentials (raw API keys, session cookies) deliberately do NOT get their own buckets — that would let a client rotate values per request to evade IP throttling. Apply via `@UseGuards(RateLimit('read'), AuthOrApiKeyGuard)` — `RateLimit` must be FIRST so it short-circuits before any DB work. Agent-poller endpoints (`POST /agents/:id/negotiations/pickup`, `GET /agents/:id/opportunities/pending`, `GET /agents/:id/opportunities/accepted`) intentionally omit the guard. Storage is Redis (shared across Bun instances) when either `REDIS_URL` or `REDIS_HOST` is set; otherwise the limiter uses an in-memory fallback (single-process, dev only — not multi-instance safe). Set `LIMITER_DISABLE=1` to disable as an incident escape hatch.
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -214,9 +214,9 @@ S3_SECRET_ACCESS_KEY=your-secret-access-key
 
 # Rate limiter — per-route-class request budgets.
 # All values are requests-per-minute. Empty/missing uses the built-in defaults.
-LIMITER_AUTH_WRITE_PER_MIN=10
-LIMITER_READ_PER_MIN=120
-LIMITER_WRITE_PER_MIN=60
+LIMITER_AUTH_WRITE_PER_MIN=100
+LIMITER_READ_PER_MIN=1200
+LIMITER_WRITE_PER_MIN=600
 # Comma-separated; first matching IPv4/IPv6 wins. Default chain handles Envoy + most edge proxies.
 LIMITER_IP_HEADERS=x-envoy-external-address,x-forwarded-for,x-original-forwarded-for,x-real-ip
 # Escape hatch: set to 1 to disable the limiter entirely (incidents only).

--- a/backend/src/lib/limiter/config.ts
+++ b/backend/src/lib/limiter/config.ts
@@ -15,15 +15,15 @@ const intEnv = (name: string, fallback: number): number => {
 };
 
 export const CLASS_CONFIG: Record<LimiterClass, ClassConfig> = {
-  auth_write: { perMinute: intEnv('LIMITER_AUTH_WRITE_PER_MIN', 10), windowSec: 60 },
-  read:       { perMinute: intEnv('LIMITER_READ_PER_MIN', 120),      windowSec: 60 },
-  write:      { perMinute: intEnv('LIMITER_WRITE_PER_MIN', 60),      windowSec: 60 },
+  auth_write: { perMinute: intEnv('LIMITER_AUTH_WRITE_PER_MIN', 100), windowSec: 60 },
+  read:       { perMinute: intEnv('LIMITER_READ_PER_MIN', 1200),      windowSec: 60 },
+  write:      { perMinute: intEnv('LIMITER_WRITE_PER_MIN', 600),      windowSec: 60 },
 };
 
 const CLASS_ENV: Record<LimiterClass, { envVar: string; fallback: number }> = {
-  auth_write: { envVar: 'LIMITER_AUTH_WRITE_PER_MIN', fallback: 10 },
-  read:       { envVar: 'LIMITER_READ_PER_MIN',       fallback: 120 },
-  write:      { envVar: 'LIMITER_WRITE_PER_MIN',      fallback: 60 },
+  auth_write: { envVar: 'LIMITER_AUTH_WRITE_PER_MIN', fallback: 100 },
+  read:       { envVar: 'LIMITER_READ_PER_MIN',       fallback: 1200 },
+  write:      { envVar: 'LIMITER_WRITE_PER_MIN',      fallback: 600 },
 };
 
 /**

--- a/backend/src/lib/limiter/tests/config.spec.ts
+++ b/backend/src/lib/limiter/tests/config.spec.ts
@@ -10,9 +10,9 @@ describe('limiter config', () => {
     delete process.env.LIMITER_WRITE_PER_MIN;
     delete process.env.LIMITER_AUTH_WRITE_PER_MIN;
     const { CLASS_CONFIG } = await import(`../config?cb=${Math.random()}`);
-    expect(CLASS_CONFIG.read.perMinute).toBe(120);
-    expect(CLASS_CONFIG.write.perMinute).toBe(60);
-    expect(CLASS_CONFIG.auth_write.perMinute).toBe(10);
+    expect(CLASS_CONFIG.read.perMinute).toBe(1200);
+    expect(CLASS_CONFIG.write.perMinute).toBe(600);
+    expect(CLASS_CONFIG.auth_write.perMinute).toBe(100);
   });
 
   test('env vars override defaults', async () => {


### PR DESCRIPTION
## Summary
- Promote dev changes from release/2026-06-04 to main
- Includes PR #896: increase protocol rate limiter defaults by 10x

## Tests
- PR #896 checks passed before merge into dev
- `OPENROUTER_API_KEY=dummy bun test src/lib/limiter/tests/config.spec.ts src/lib/limiter/tests/guard.spec.ts src/lib/limiter/tests/bypass.spec.ts`