### PR TITLE
fix(protocol): guard broad attributive intents

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -65,7 +65,7 @@
     },
     "frontend": {
       "name": "frontend",
-      "version": "0.11.2",
+      "version": "0.11.3",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.14",
@@ -127,7 +127,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "1.26.2",
+      "version": "1.26.3",
       "dependencies": {
         "@langchain/core": "^1.1.17",
         "@langchain/langgraph": "^1.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/frontend/src/components/chat/IntentProposalCard.tsx
+++ b/frontend/src/components/chat/IntentProposalCard.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Check, RotateCcw, X } from "lucide-react";
+import { AlertTriangle, Check, X } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
@@ -10,6 +10,10 @@ export interface IntentProposalData {
   networkId?: string;
   confidence?: number | null;
   speechActType?: string | null;
+  semanticEntropy?: number | null;
+  referentialBreadth?: "narrow" | "moderate" | "broad" | null;
+  missingSelectionalConstraints?: string[];
+  specificityWarning?: string | null;
 }
 
 interface IntentProposalCardProps {
@@ -61,13 +65,17 @@ export default function IntentProposalCard({
   const statusResolved = currentStatus !== undefined;
   const effectiveStatus = currentStatus ?? (actionTaken ? actionTaken : "pending");
   const isPending = statusResolved && effectiveStatus === "pending" && !actionTaken && !actionError;
+  const specificityWarning = card.specificityWarning?.trim();
+  const requiresManualApproval = Boolean(specificityWarning || card.referentialBreadth === "broad");
 
-  // Start countdown on mount when pending
+  // Start countdown on mount when pending. Broad attributive signals require
+  // explicit approval so the user has a chance to refine instead of silently
+  // broadcasting a high-breadth proposal.
   useEffect(() => {
-    if (!isPending || !onApprove || countdownStarted.current) return;
+    if (!isPending || !onApprove || countdownStarted.current || requiresManualApproval) return;
     countdownStarted.current = true;
     setCountdown(COUNTDOWN_SECONDS);
-  }, [isPending, onApprove]);
+  }, [isPending, onApprove, requiresManualApproval]);
 
   // Countdown tick
   useEffect(() => {
@@ -247,6 +255,12 @@ export default function IntentProposalCard({
           )}>
             {card.description || "No description provided"}
           </p>
+          {specificityWarning && effectiveStatus !== "rejected" && (
+            <div className="mt-2 flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 px-2.5 py-2 text-[12px] leading-relaxed text-amber-800">
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <span>{specificityWarning}</span>
+            </div>
+          )}
         </div>
 
         <div className="flex items-center gap-3 shrink-0">
@@ -261,30 +275,40 @@ export default function IntentProposalCard({
                   Skip
                 </button>
               )}
-              <button
-                type="button"
-                onClick={handleApproveNow}
-                className="relative w-8 h-8 rounded-full bg-gray-100 border border-gray-300 flex items-center justify-center text-gray-500 hover:bg-gray-200 hover:text-gray-700 transition-colors overflow-hidden group"
-                title="Create now"
-              >
-                <span className="text-xs font-medium group-hover:hidden z-10 relative tabular-nums">
-                  {countdown ?? COUNTDOWN_SECONDS}
-                </span>
-                <Check className="w-4 h-4 z-10 relative hidden group-hover:block" />
-                <svg className="absolute inset-[1px] pointer-events-none -rotate-90" viewBox="0 0 30 30">
-                  <circle
-                    cx="15"
-                    cy="15"
-                    r="14"
-                    fill="none"
-                    stroke="rgb(75,85,99)"
-                    strokeWidth="1.5"
-                    strokeDasharray="87.96"
-                    strokeDashoffset={87.96 * (1 - (countdown ?? COUNTDOWN_SECONDS) / COUNTDOWN_SECONDS)}
-                    className="transition-[stroke-dashoffset] duration-1000 linear"
-                  />
-                </svg>
-              </button>
+              {requiresManualApproval ? (
+                <button
+                  type="button"
+                  onClick={handleApproveNow}
+                  className="rounded-full border border-amber-300 bg-amber-50 px-3 py-1.5 text-xs font-medium text-amber-800 hover:bg-amber-100"
+                >
+                  Create anyway
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={handleApproveNow}
+                  className="relative w-8 h-8 rounded-full bg-gray-100 border border-gray-300 flex items-center justify-center text-gray-500 hover:bg-gray-200 hover:text-gray-700 transition-colors overflow-hidden group"
+                  title="Create now"
+                >
+                  <span className="text-xs font-medium group-hover:hidden z-10 relative tabular-nums">
+                    {countdown ?? COUNTDOWN_SECONDS}
+                  </span>
+                  <Check className="w-4 h-4 z-10 relative hidden group-hover:block" />
+                  <svg className="absolute inset-[1px] pointer-events-none -rotate-90" viewBox="0 0 30 30">
+                    <circle
+                      cx="15"
+                      cy="15"
+                      r="14"
+                      fill="none"
+                      stroke="rgb(75,85,99)"
+                      strokeWidth="1.5"
+                      strokeDasharray="87.96"
+                      strokeDashoffset={87.96 * (1 - (countdown ?? COUNTDOWN_SECONDS) / COUNTDOWN_SECONDS)}
+                      className="transition-[stroke-dashoffset] duration-1000 linear"
+                    />
+                  </svg>
+                </button>
+              )}
             </>
           )}
 

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "1.26.2",
+  "version": "1.26.3",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/intent/intent.graph.ts
+++ b/packages/protocol/src/intent/intent.graph.ts
@@ -2,6 +2,7 @@ import { StateGraph, START, END } from "@langchain/langgraph";
 import { IntentGraphState, VerifiedIntent, ExecutionResult } from "./intent.state.js";
 import { ExplicitIntentInferrer } from "./intent.inferrer.js";
 import { SemanticVerifier } from "./intent.verifier.js";
+import { DEFAULT_SPECIFICITY_WARNING } from "./intent.specificity.js";
 import { IntentReconciler } from "./intent.reconciler.js";
 import { IntentGraphDatabase } from "../shared/interfaces/database.interface.js";
 import { getAbortSignalConfig } from "../shared/agent/model-signal.js";
@@ -105,6 +106,11 @@ const isVague = (description: string, entropy: number, clarity: number): boolean
   if (entropy > MAX_PERMISSIBLE_ENTROPY) return true;
   if (clarity < MIN_CLEAR_INTENT_SCORE) return true;
   return false;
+};
+
+const getSpecificityWarning = (verdict: { specificity_warning?: string | null }): string => {
+  const warning = verdict.specificity_warning?.trim();
+  return warning && warning.length > 0 ? warning : DEFAULT_SPECIFICITY_WARNING;
 };
 
 const toSpeechActType = (classification?: string): "COMMISSIVE" | "DIRECTIVE" | null => {
@@ -310,6 +316,15 @@ export class IntentGraphFactory {
                 return null;
               }
 
+              if (state.operationMode !== 'propose' && verdict.referential_breadth === 'broad') {
+                logger.warn(`Dropping broad attributive intent before persistence: "${description}"`, {
+                  referentialBreadth: verdict.referential_breadth,
+                  missingSelectionalConstraints: verdict.missing_selectional_constraints,
+                  warning: getSpecificityWarning(verdict),
+                });
+                return null;
+              }
+
               // Calculate Score
               const score = Math.min(
                 verdict.felicity_scores.authority,
@@ -344,14 +359,18 @@ export class IntentGraphFactory {
           const fs = v.verification?.felicity_scores;
           const entropy = v.verification?.semantic_entropy;
           const classification = v.verification?.classification;
+          const referentialBreadth = v.verification?.referential_breadth;
           return {
             node: "verification",
-            detail: `"${v.description.slice(0, 40)}${v.description.length > 40 ? '...' : ''}" → ${classification}`,
+            detail: `"${v.description.slice(0, 40)}${v.description.length > 40 ? '...' : ''}" → ${classification}${referentialBreadth ? ` (${referentialBreadth} referential breadth)` : ''}`,
             data: fs ? {
               clarity: fs.clarity,
               authority: fs.authority,
               sincerity: fs.sincerity,
               entropy: entropy != null ? Math.round(entropy * 100) / 100 : undefined,
+              referentialBreadth,
+              missingSelectionalConstraints: v.verification?.missing_selectional_constraints,
+              specificityWarning: v.verification?.specificity_warning ?? undefined,
               classification,
               score: v.score,
             } : undefined,

--- a/packages/protocol/src/intent/intent.specificity.ts
+++ b/packages/protocol/src/intent/intent.specificity.ts
@@ -1,0 +1,2 @@
+/** Default user-facing warning for broad attributive intent proposals. */
+export const DEFAULT_SPECIFICITY_WARNING = "This signal is broad and may produce many weak matches. Add a more concrete role, outcome, location, timeframe, domain, or specific need to get better recommendations.";

--- a/packages/protocol/src/intent/intent.tools.ts
+++ b/packages/protocol/src/intent/intent.tools.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import type { ExecutionResult, VerifiedIntent } from "./intent.state.js";
+import { DEFAULT_SPECIFICITY_WARNING } from "./intent.specificity.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { requestContext } from "../shared/observability/request-context.js";
 
@@ -46,6 +47,15 @@ function buildApprovedProfileFallback(user: UserRecord | null | undefined): stri
     narrative: { context: bio },
     attributes: { skills: [], interests: [] },
   });
+}
+
+function isBroadAttributiveIntent(intent: VerifiedIntent): boolean {
+  return intent.verification?.referential_breadth === "broad";
+}
+
+function specificityWarningFor(intent: VerifiedIntent): string {
+  const warning = intent.verification?.specificity_warning?.trim();
+  return warning && warning.length > 0 ? warning : DEFAULT_SPECIFICITY_WARNING;
 }
 
 export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
@@ -305,6 +315,18 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
 
       // ── Auto-approve path (for MCP agents or explicit opt-in) ──
       if (shouldAutoApprove) {
+        const broadIntents = (verified as VerifiedIntent[]).filter(isBroadAttributiveIntent);
+        if (broadIntents.length > 0) {
+          const first = broadIntents[0];
+          const missing = first.verification?.missing_selectional_constraints ?? [];
+          const missingHint = missing.length > 0 ? ` Missing selectional constraints: ${missing.join(", ")}.` : "";
+          return error(
+            `${specificityWarningFor(first)}${missingHint} ` +
+            `Please ask the user to clarify before creating this signal, or retry with a narrower description.`,
+            debugSteps,
+          );
+        }
+
         const createdIntents: Array<{ description: string; confidence: number | null; speechActType: string | null }> = [];
         const createTimings: Array<{ name: string; durationMs: number; agents: unknown[] }> = [];
 
@@ -354,12 +376,17 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       // Build intent_proposal code fences for each verified intent
       const proposalBlocks = verified.map((v: VerifiedIntent) => {
         const proposalId = crypto.randomUUID();
+        const isBroad = isBroadAttributiveIntent(v);
         const data = {
           proposalId,
           description: v.description,
           ...(effectiveIndexId ? { networkId: effectiveIndexId } : {}),
           confidence: v.score != null ? Math.round(v.score * 100) / 100 : null,
           speechActType: v.verification?.classification ?? null,
+          semanticEntropy: v.verification?.semantic_entropy ?? null,
+          referentialBreadth: v.verification?.referential_breadth ?? null,
+          missingSelectionalConstraints: v.verification?.missing_selectional_constraints ?? [],
+          specificityWarning: isBroad ? specificityWarningFor(v) : v.verification?.specificity_warning ?? null,
         };
         return (
           "```intent_proposal\n" +
@@ -449,6 +476,11 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
 
       if (result.executionResults?.some((r: ExecutionResult) => !r.success)) {
         return error("Failed to update intent.");
+      }
+      if (!result.executionResults?.some((r: ExecutionResult) => r.success)) {
+        return error(
+          "Intent update was not applied. The new description may be too broad, too vague, or failed semantic verification. Please ask the user to clarify with a more concrete role, outcome, location, timeframe, domain, or specific need.",
+        );
       }
       return success({
         message: "Intent updated.",

--- a/packages/protocol/src/intent/intent.verifier.ts
+++ b/packages/protocol/src/intent/intent.verifier.ts
@@ -8,6 +8,16 @@ import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("SemanticVerifier");
 
+const referentialBreadthSchema = z.enum(["narrow", "moderate", "broad"]);
+const missingSelectionalConstraintSchema = z.enum([
+  "role",
+  "outcome",
+  "location",
+  "timeframe",
+  "domain",
+  "concrete_need",
+]);
+
 const model = createModel("intentVerifier");
 // ──────────────────────────────────────────────────────────────
 // 1. SYSTEM PROMPT
@@ -122,6 +132,26 @@ REFERENTIAL ANCHOR → referential_anchor field
   "I want to join Google" → "Google"
   "I want to join a startup" → null
 
+REFERENTIAL BREADTH → referential_breadth field
+  Estimate the extension size of the open candidate class: how many people could plausibly satisfy the description.
+  This is NOT the same as semantic_entropy. Semantic entropy measures underspecification/constraint density;
+  referential breadth measures whether the attributive description narrows the satisfier class enough for discovery.
+
+  narrow   → a small satisfier class due to concrete role/outcome/location/timeframe/specific need.
+             Example: "Find a robotics founder in Healdsburg this week to test my meditation hardware prototype"
+  moderate → a bounded professional/community class, but some constraints are still missing.
+             Example: "Meet AI safety researchers working on evals in London"
+  broad    → a large satisfier class; many people could plausibly match even if topical constraints are present.
+             Example: "Meet creative people, builders, and makers interested in AI, meditation, and tech exploration"
+
+MISSING SELECTIONAL CONSTRAINTS → missing_selectional_constraints field
+  Report the constraints whose absence keeps the candidate class too broad:
+  role, outcome, location, timeframe, domain, concrete_need.
+
+SPECIFICITY WARNING → specificity_warning field
+  If referential_breadth is broad, provide a concise user-facing warning asking for a more concrete role,
+  outcome, location, timeframe, domain, or need. Otherwise output null.
+
 ═══════════════════════════════════════════════════
 STEP 3 — FLAGS
 ═══════════════════════════════════════════════════
@@ -131,6 +161,7 @@ Add flags when scores fall below threshold:
   sincerity < 70  → "WEAK_COMMITMENT"
   clarity < 50    → "VAGUE_INTENT"
   classification is ASSERTIVE or EXPRESSIVE → "NOISE"
+  referential_breadth is broad → "BROAD_ATTRIBUTIVE_REFERENCE"
 `;
 
 // ──────────────────────────────────────────────────────────────
@@ -169,8 +200,20 @@ const responseFormat = z.object({
     "Named specific entity the utterance refers to (Donnellan referential), or null for attributive reference"
   ),
 
+  referential_breadth: referentialBreadthSchema.describe(
+    "Extension size of the open candidate class: narrow, moderate, or broad. Distinct from semantic entropy."
+  ),
+
+  missing_selectional_constraints: z.array(missingSelectionalConstraintSchema).describe(
+    "Selectional constraints whose absence leaves the satisfier class too broad."
+  ),
+
+  specificity_warning: z.string().nullable().describe(
+    "Concise user-facing warning when referential_breadth is broad; otherwise null."
+  ),
+
   flags: z.array(z.string()).describe(
-    "Semantic violation tags: SKILL_MISMATCH (authority<70), WEAK_COMMITMENT (sincerity<70), VAGUE_INTENT (clarity<50), NOISE (ASSERTIVE or EXPRESSIVE)"
+    "Semantic violation tags: SKILL_MISMATCH (authority<70), WEAK_COMMITMENT (sincerity<70), VAGUE_INTENT (clarity<50), NOISE (ASSERTIVE or EXPRESSIVE), BROAD_ATTRIBUTIVE_REFERENCE (referential_breadth=broad)"
   ),
 });
 
@@ -178,6 +221,8 @@ const responseFormat = z.object({
 // 3. TYPE DEFINITIONS
 // ──────────────────────────────────────────────────────────────
 
+export type ReferentialBreadth = z.infer<typeof referentialBreadthSchema>;
+export type MissingSelectionalConstraint = z.infer<typeof missingSelectionalConstraintSchema>;
 export type SemanticVerifierOutput = z.infer<typeof responseFormat>;
 
 // ──────────────────────────────────────────────────────────────

--- a/packages/protocol/src/intent/tests/update-intent.spec.ts
+++ b/packages/protocol/src/intent/tests/update-intent.spec.ts
@@ -36,6 +36,12 @@ function captureTools(deps: ToolDeps): CapturedTool[] {
   return toolDefs;
 }
 
+function extractFirstIntentProposal(message: string): Record<string, unknown> {
+  const match = message.match(/```intent_proposal\s*\n([\s\S]*?)\n```/);
+  if (!match) throw new Error("intent proposal block not found");
+  return JSON.parse(match[1]) as Record<string, unknown>;
+}
+
 describe("create_intent", () => {
   test("falls back to approved user intro when structured profile is still pending", async () => {
     const capturedProfiles: string[] = [];
@@ -78,6 +84,98 @@ describe("create_intent", () => {
     expect(result.success).toBe(true);
     expect(capturedProfiles[0]).toContain("I build agent tools.");
     expect(capturedProfiles[0]).toContain("Healdsburg");
+  });
+
+  test("rejects broad referential-breadth signals in MCP auto-approve mode", async () => {
+    let createCalls = 0;
+    const tools = captureTools({
+      userDb: {},
+      systemDb: {},
+      graphs: {
+        profile: { invoke: async () => ({ profile: null, agentTimings: [] }) },
+        intent: {
+          invoke: async (input: { operationMode?: string }) => {
+            if (input.operationMode === "propose") {
+              return {
+                verifiedIntents: [{
+                  description: "Meet creative people, builders, and makers interested in AI and somatic exploration",
+                  score: 82,
+                  verification: {
+                    classification: "DIRECTIVE",
+                    semantic_entropy: 0.42,
+                    referential_breadth: "broad",
+                    missing_selectional_constraints: ["role", "outcome", "timeframe"],
+                    specificity_warning: "This signal is broad and may produce many weak matches.",
+                  },
+                }],
+                agentTimings: [],
+                trace: [],
+              };
+            }
+            createCalls++;
+            return { executionResults: [{ success: true }], agentTimings: [] };
+          },
+        },
+      },
+    } as unknown as ToolDeps);
+    const tool = tools.find((t) => t.name === "create_intent")!;
+
+    const result = JSON.parse(await tool.handler({
+      context: makeContext("alice"),
+      query: {
+        description: "Meet creative people, builders, and makers interested in AI and somatic exploration",
+        autoApprove: true,
+      },
+    }));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("broad");
+    expect(result.error).toContain("role, outcome, timeframe");
+    expect(createCalls).toBe(0);
+  });
+
+  test("surfaces referential-breadth warnings in web proposal cards", async () => {
+    const tools = captureTools({
+      userDb: {},
+      systemDb: {},
+      graphs: {
+        profile: { invoke: async () => ({ profile: null, agentTimings: [] }) },
+        intent: {
+          invoke: async () => ({
+            verifiedIntents: [{
+              description: "Meet creative people, builders, and makers interested in AI and somatic exploration",
+              score: 82,
+              verification: {
+                classification: "DIRECTIVE",
+                semantic_entropy: 0.42,
+                referential_breadth: "broad",
+                missing_selectional_constraints: ["role", "outcome", "timeframe"],
+                specificity_warning: "This signal is broad and may produce many weak matches.",
+              },
+            }],
+            agentTimings: [],
+            trace: [],
+          }),
+        },
+      },
+    } as unknown as ToolDeps);
+    const tool = tools.find((t) => t.name === "create_intent")!;
+    const context = { ...makeContext("alice"), isMcp: false } as ResolvedToolContext;
+
+    const result = JSON.parse(await tool.handler({
+      context,
+      query: {
+        description: "Meet creative people, builders, and makers interested in AI and somatic exploration",
+        autoApprove: false,
+      },
+    }));
+
+    expect(result.success).toBe(true);
+    const proposal = extractFirstIntentProposal(result.data.message);
+    expect(proposal.referentialBreadth).toBe("broad");
+    expect(proposal.specificityWarning).toContain("broad");
+    expect(proposal.missingSelectionalConstraints).toEqual(["role", "outcome", "timeframe"]);
+    expect(proposal.semanticEntropy).toBe(0.42);
   });
 });
 
@@ -143,6 +241,32 @@ describe("update_intent", () => {
     expect(capturedInputContent).toBe("Find a design partner for a CRPG UI");
     expect(parsed.success).toBe(true);
     expect(parsed.data.message).toBe("Intent updated.");
+  });
+
+  test("returns an error when verification filters the update into a no-op", async () => {
+    const tools = captureTools({
+      userDb: {},
+      systemDb: {
+        getIntent: async () => ({ id: "11111111-1111-4111-8111-111111111111", userId: "alice" }),
+      },
+      graphs: {
+        profile: { invoke: async () => ({ profile: null, agentTimings: [] }) },
+        intent: { invoke: async () => ({ verifiedIntents: [], actions: [], executionResults: [], agentTimings: [] }) },
+      },
+    } as unknown as ToolDeps);
+    const tool = tools.find((t) => t.name === "update_intent")!;
+
+    const result = JSON.parse(await tool.handler({
+      context: makeContext("alice"),
+      query: {
+        intentId: "11111111-1111-4111-8111-111111111111",
+        description: "Meet creative people, builders, and makers interested in AI and somatic exploration",
+      },
+    }));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("not applied");
+    expect(result.error).toContain("too broad");
   });
 });
 


### PR DESCRIPTION
## Bug Fixes
- Adds referential breadth assessment to semantic verification as a linguistically grounded complement to semantic entropy.
- Rejects broad attributive signals in MCP/auto-approve before persistence and background discovery can run.
- Surfaces specificity warnings on web proposal cards and requires explicit approval for broad proposals.

## Tests
- `cd packages/protocol && bun test src/intent/tests/update-intent.spec.ts`
- `cd packages/protocol && bun run build`
- `cd frontend && bun run lint` (passes with existing warnings)
- `cd frontend && bun run build`

Linear: IND-347