### PR TITLE
fix(protocol): decompose approved profile drafts

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol",
-  "version": "0.27.2",
+  "version": "0.27.3",
   "license": "MIT",
   "private": true,
   "scripts": {
@@ -32,6 +32,7 @@
     "maintenance:expire-opportunities": "bun ./src/cli/expire-opportunities.ts",
     "maintenance:rediscover-opportunities": "bun ./src/cli/rediscover-user-opportunities.ts",
     "maintenance:decompose-profiles": "bun ./src/cli/decompose-profiles.ts",
+    "maintenance:backfill-approved-profile-premises": "bun ./src/cli/backfill-approved-profile-premises.ts",
     "maintenance:backfill-premises": "bun ./src/cli/backfill-premises.ts",
     "maintenance:compare-discovery": "bun ./src/cli/compare-discovery.ts",
     "maintenance:backfill-context-hyde": "bun ./src/cli/backfill-context-hyde.ts",

--- a/backend/src/cli/backfill-approved-profile-premises.ts
+++ b/backend/src/cli/backfill-approved-profile-premises.ts
@@ -16,18 +16,18 @@
 import dotenv from 'dotenv';
 import path from 'path';
 
+import type { PremiseGraphDatabase } from '@indexnetwork/protocol';
+
 const envFile = process.env.NODE_ENV === 'development' ? '.env.development' : '.env.production';
 dotenv.config({ path: path.resolve(process.cwd(), envFile) });
 
-import { and, eq, isNull, sql } from 'drizzle-orm';
-import { PremiseDecomposer, PremiseGraphFactory } from '@indexnetwork/protocol';
-import type { PremiseGraphDatabase } from '@indexnetwork/protocol';
-
-import db, { closeDb } from '../lib/drizzle/drizzle';
-import { networkMembers, premises, userProfiles, users } from '../schemas/database.schema';
-import { ChatDatabaseAdapter } from '../adapters/database.adapter';
-import { EmbedderAdapter } from '../adapters/embedder.adapter';
-import { premiseQueue } from '../queues/premise.queue';
+const { and, eq, isNull, sql } = await import('drizzle-orm');
+const { PremiseDecomposer, PremiseGraphFactory } = await import('@indexnetwork/protocol');
+const { default: db, closeDb } = await import('../lib/drizzle/drizzle');
+const { networkMembers, premises, userProfiles, users } = await import('../schemas/database.schema');
+const { ChatDatabaseAdapter } = await import('../adapters/database.adapter');
+const { EmbedderAdapter } = await import('../adapters/embedder.adapter');
+const { premiseQueue } = await import('../queues/premise.queue');
 
 const DEFAULT_LIMIT = 100;
 const BACKFILL_CONFIDENCE = 0.9;

--- a/backend/src/cli/backfill-approved-profile-premises.ts
+++ b/backend/src/cli/backfill-approved-profile-premises.ts
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+/**
+ * Incident backfill CLI: convert approved onboarding profiles into premises.
+ *
+ * Strict by default: targets only non-ghost members of one network who have a
+ * saved profile, zero active premises, completed onboarding, and at least one
+ * recorded data-use consent grant. Use --dry-run first.
+ *
+ * Usage:
+ *   bun ./src/cli/backfill-approved-profile-premises.ts --network <networkId> [--limit=N] [--dry-run]
+ *
+ * Escape hatches are intentionally explicit:
+ *   --allow-incomplete-onboarding
+ *   --allow-missing-consent
+ */
+import dotenv from 'dotenv';
+import path from 'path';
+
+const envFile = process.env.NODE_ENV === 'development' ? '.env.development' : '.env.production';
+dotenv.config({ path: path.resolve(process.cwd(), envFile) });
+
+import { and, eq, isNull, sql } from 'drizzle-orm';
+import { PremiseDecomposer, PremiseGraphFactory } from '@indexnetwork/protocol';
+import type { PremiseGraphDatabase } from '@indexnetwork/protocol';
+
+import db, { closeDb } from '../lib/drizzle/drizzle';
+import { networkMembers, premises, userProfiles, users } from '../schemas/database.schema';
+import { ChatDatabaseAdapter } from '../adapters/database.adapter';
+import { EmbedderAdapter } from '../adapters/embedder.adapter';
+import { premiseQueue } from '../queues/premise.queue';
+
+const DEFAULT_LIMIT = 100;
+const BACKFILL_CONFIDENCE = 0.9;
+
+interface ProfileIdentity { name: string; bio: string; location: string }
+interface ProfileNarrative { context: string }
+interface ProfileAttributes { interests: string[]; skills: string[] }
+
+interface Args {
+  networkId: string;
+  limit: number;
+  dryRun: boolean;
+  requireConsent: boolean;
+  requireOnboardingComplete: boolean;
+}
+
+function argValue(args: string[], name: string): string | undefined {
+  const exact = args.find((a) => a.startsWith(`${name}=`));
+  if (exact) return exact.slice(name.length + 1);
+  const idx = args.indexOf(name);
+  return idx >= 0 ? args[idx + 1] : undefined;
+}
+
+function parseArgs(): Args {
+  const args = process.argv.slice(2);
+  const networkId = argValue(args, '--network') ?? argValue(args, '--network-id') ?? '';
+  const limitValue = Number.parseInt(argValue(args, '--limit') ?? '', 10);
+
+  if (!networkId) {
+    console.error('Usage: bun ./src/cli/backfill-approved-profile-premises.ts --network <networkId> [--limit=N] [--dry-run]');
+    process.exit(1);
+  }
+
+  return {
+    networkId,
+    limit: Number.isFinite(limitValue) && limitValue > 0 ? limitValue : DEFAULT_LIMIT,
+    dryRun: args.includes('--dry-run'),
+    requireConsent: !args.includes('--allow-missing-consent'),
+    requireOnboardingComplete: !args.includes('--allow-incomplete-onboarding'),
+  };
+}
+
+function buildProfileText(
+  identity: ProfileIdentity | null,
+  narrative: ProfileNarrative | null,
+  attributes: ProfileAttributes | null,
+): string {
+  const lines: string[] = [];
+  if (identity?.name) lines.push(`My name is ${identity.name}.`);
+  if (identity?.location) lines.push(`I am based in ${identity.location}.`);
+  if (identity?.bio) lines.push(identity.bio);
+  if (narrative?.context) lines.push(narrative.context);
+  if (attributes?.skills?.length) lines.push(`My skills include ${attributes.skills.join(', ')}.`);
+  if (attributes?.interests?.length) lines.push(`My interests include ${attributes.interests.join(', ')}.`);
+  return lines.join('\n');
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs();
+  console.log([
+    'backfill-approved-profile-premises',
+    `network=${args.networkId}`,
+    `limit=${args.limit}`,
+    `dryRun=${args.dryRun}`,
+    `requireConsent=${args.requireConsent}`,
+    `requireOnboardingComplete=${args.requireOnboardingComplete}`,
+  ].join(' '));
+
+  const conditions = [
+    eq(networkMembers.networkId, args.networkId),
+    isNull(networkMembers.deletedAt),
+    isNull(users.deletedAt),
+    eq(users.isGhost, false),
+    isNull(premises.id),
+  ];
+
+  if (args.requireOnboardingComplete) {
+    conditions.push(sql`${users.onboarding}->>'completedAt' IS NOT NULL`);
+  }
+
+  if (args.requireConsent) {
+    conditions.push(sql`(
+      ${users.onboarding}#>>'{privacy,edgeosImport,granted}' = 'true'
+      OR ${users.onboarding}#>>'{privacy,publicProfileLookup,granted}' = 'true'
+    )`);
+  }
+
+  const rows = await db
+    .select({
+      userId: userProfiles.userId,
+      email: users.email,
+      name: users.name,
+      identity: userProfiles.identity,
+      narrative: userProfiles.narrative,
+      attributes: userProfiles.attributes,
+    })
+    .from(userProfiles)
+    .innerJoin(users, eq(users.id, userProfiles.userId))
+    .innerJoin(networkMembers, eq(networkMembers.userId, userProfiles.userId))
+    .leftJoin(
+      premises,
+      and(
+        eq(premises.userId, userProfiles.userId),
+        eq(premises.status, 'ACTIVE'),
+        isNull(premises.deletedAt),
+      ),
+    )
+    .where(and(...conditions))
+    .limit(args.limit);
+
+  if (rows.length === 0) {
+    console.log('No matching users with approved profiles missing active premises.');
+    return;
+  }
+
+  console.log(`Found ${rows.length} matching user(s).`);
+
+  const database = new ChatDatabaseAdapter();
+  const embedder = new EmbedderAdapter();
+  const decomposer = new PremiseDecomposer();
+  const premiseGraph = new PremiseGraphFactory(
+    database as unknown as PremiseGraphDatabase,
+    embedder,
+  ).createGraph();
+
+  let totalUsers = 0;
+  let totalPremises = 0;
+
+  for (const row of rows) {
+    const text = buildProfileText(
+      row.identity as ProfileIdentity | null,
+      row.narrative as ProfileNarrative | null,
+      row.attributes as ProfileAttributes | null,
+    );
+
+    if (!text.trim()) {
+      console.log(`  [${row.email}] Empty profile — skipping`);
+      continue;
+    }
+
+    console.log(`  [${row.email}] Decomposing approved profile (${text.length} chars)...`);
+    const result = await decomposer.invoke(text);
+    console.log(`  [${row.email}] Extracted ${result.premises.length} premise(s)`);
+
+    if (args.dryRun) {
+      for (const p of result.premises) {
+        console.log(`    - [${p.tier}] ${p.text}`);
+      }
+      totalUsers++;
+      continue;
+    }
+
+    let created = 0;
+    for (const p of result.premises) {
+      try {
+        const premiseResult = await premiseGraph.invoke({
+          userId: row.userId,
+          assertionText: p.text,
+          tier: p.tier as 'assertive' | 'contextual',
+          provenanceSource: 'onboarding' as const,
+          provenanceConfidence: BACKFILL_CONFIDENCE,
+        });
+        if (premiseResult.premise) created++;
+        else if (premiseResult.error) {
+          console.warn(`    Failed: ${p.text.substring(0, 60)} — ${premiseResult.error}`);
+        }
+      } catch (err) {
+        console.warn(`    Error: ${p.text.substring(0, 60)} — ${err instanceof Error ? err.message : err}`);
+      }
+    }
+
+    console.log(`  [${row.email}] Created ${created}/${result.premises.length} premises`);
+    if (created > 0) {
+      await premiseQueue.addProfileRegenJob({ userId: row.userId, trigger: 'premise_created' });
+    }
+
+    totalUsers++;
+    totalPremises += created;
+  }
+
+  console.log(`Done. Processed ${totalUsers} user(s), created ${totalPremises} premise(s).`);
+}
+
+main()
+  .then(async () => {
+    await Promise.all([closeDb(), premiseQueue.queue.close()]);
+  })
+  .catch(async (e: unknown) => {
+    const msg = e instanceof Error ? e.message : `${e}`;
+    console.error('backfill-approved-profile-premises error:', msg);
+    await Promise.all([
+      closeDb().catch(() => {}),
+      premiseQueue.queue.close().catch(() => {}),
+    ]);
+    process.exit(1);
+  });

--- a/backend/src/cli/backfill-approved-profile-premises.ts
+++ b/backend/src/cli/backfill-approved-profile-premises.ts
@@ -186,7 +186,7 @@ async function main(): Promise<void> {
         const premiseResult = await premiseGraph.invoke({
           userId: row.userId,
           assertionText: p.text,
-          tier: p.tier as 'assertive' | 'contextual',
+          tier: p.tier,
           provenanceSource: 'onboarding' as const,
           provenanceConfidence: BACKFILL_CONFIDENCE,
         });

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "backend": {
       "name": "protocol",
-      "version": "0.27.0",
+      "version": "0.27.3",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.939.0",
         "@aws-sdk/s3-request-presigner": "^3.983.0",

--- a/packages/protocol/src/profile/profile.tools.ts
+++ b/packages/protocol/src/profile/profile.tools.ts
@@ -26,11 +26,13 @@ function isMeaningfulEnrichment(enrichment: EnrichmentResult | null): enrichment
     );
 }
 
-type ApprovedProfileDraft = {
-  identity: { name: string; bio: string; location: string };
-  narrative: { context: string };
-  attributes: { interests: string[]; skills: string[] };
-};
+const approvedProfileDraftSchema = z.object({
+  identity: z.object({ name: z.string(), bio: z.string(), location: z.string() }),
+  narrative: z.object({ context: z.string() }),
+  attributes: z.object({ interests: z.array(z.string()), skills: z.array(z.string()) }),
+});
+
+type ApprovedProfileDraft = z.infer<typeof approvedProfileDraftSchema>;
 
 export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
   const { userDb, systemDb, database, graphs, enricher, grantDefaultSystemPermissions, reportToolError } = deps;
@@ -657,11 +659,7 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
       "Saves an explicitly approved onboarding profile draft. Call this only after the user has seen the draft from preview_user_profile and approved it or provided corrections. " +
       "This path uses only the approved draft/explicit correction text and does not scrape or run public lookup.",
     querySchema: z.object({
-      draft: z.object({
-        identity: z.object({ name: z.string(), bio: z.string(), location: z.string() }),
-        narrative: z.object({ context: z.string() }),
-        attributes: z.object({ interests: z.array(z.string()), skills: z.array(z.string()) }),
-      }).optional().describe("The structured profile draft returned by preview_user_profile after user approval."),
+      draft: approvedProfileDraftSchema.optional().describe("The structured profile draft returned by preview_user_profile after user approval."),
       bioOrDescription: z.string().optional().describe("Approved correction or explicit profile text if not passing a structured draft."),
       name: z.string().optional().describe("Approved name correction."),
       location: z.string().optional().describe("Approved location correction."),

--- a/packages/protocol/src/profile/profile.tools.ts
+++ b/packages/protocol/src/profile/profile.tools.ts
@@ -264,10 +264,11 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
         return;
       }
 
-      // The write graph may regenerate the profile from newly-created premises.
-      // The user explicitly approved this structured draft, so keep the approved
-      // draft as the persisted profile while retaining the graph-created premises.
-      await userDb.saveProfile(profile);
+      // The write graph's decompose → aggregate → generate → save_profile
+      // pipeline persists the aggregate profile. The approved draft was already
+      // saved before decomposition started, so the DB is consistent regardless
+      // of graph outcome.  Do not re-save here — the graph's save_profile is
+      // authoritative, and a concurrent user-driven profile update could race.
     } catch (err) {
       logger.error('Approved draft premise decomposition failed', {
         userId: context.userId,

--- a/packages/protocol/src/profile/profile.tools.ts
+++ b/packages/protocol/src/profile/profile.tools.ts
@@ -26,6 +26,12 @@ function isMeaningfulEnrichment(enrichment: EnrichmentResult | null): enrichment
     );
 }
 
+type ApprovedProfileDraft = {
+  identity: { name: string; bio: string; location: string };
+  narrative: { context: string };
+  attributes: { interests: string[]; skills: string[] };
+};
+
 export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
   const { userDb, systemDb, database, graphs, enricher, grantDefaultSystemPermissions, reportToolError } = deps;
 
@@ -208,6 +214,75 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
       skills: profile.attributes.skills,
       interests: profile.attributes.interests,
     };
+  }
+
+  function buildApprovedDraftProfileInput(draft: ApprovedProfileDraft): string {
+    return [
+      draft.identity.name ? `My name is ${draft.identity.name}.` : '',
+      draft.identity.location ? `I am based in ${draft.identity.location}.` : '',
+      draft.identity.bio || '',
+      draft.narrative.context || '',
+      draft.attributes.skills.length ? `My skills include ${draft.attributes.skills.join(', ')}.` : '',
+      draft.attributes.interests.length ? `My interests include ${draft.attributes.interests.join(', ')}.` : '',
+    ].filter((part) => part.trim().length > 0).join('\n');
+  }
+
+  async function decomposeApprovedDraftProfile(
+    context: ResolvedToolContext,
+    profile: ApprovedProfileDraft & { userId: string },
+  ): Promise<void> {
+    const input = buildApprovedDraftProfileInput(profile);
+    if (!input.trim()) return;
+
+    const traceEmitter = requestContext.getStore()?.traceEmitter;
+    const graphStart = Date.now();
+    traceEmitter?.({ type: "graph_start", name: "profile" });
+    try {
+      const graphInput = {
+        userId: context.userId,
+        operationMode: 'write' as const,
+        input,
+        forceUpdate: true,
+      };
+      const result = context.isMcp
+        ? await graphs.profile.invoke(graphInput)
+        : await invokeWithAbortSignal(graphs.profile, graphInput);
+
+      if (result.error) {
+        const err = new Error(result.error);
+        logger.error('Approved draft premise decomposition failed', {
+          userId: context.userId,
+          error: result.error,
+        });
+        reportToolError?.(err, {
+          subsystem: 'profile',
+          operation: 'profile.confirm_draft_decompose',
+          toolName: 'confirm_user_profile',
+          userId: context.userId,
+          tags: { toolName: 'confirm_user_profile', execution: context.isMcp ? 'background' : 'sync' },
+        });
+        return;
+      }
+
+      // The write graph may regenerate the profile from newly-created premises.
+      // The user explicitly approved this structured draft, so keep the approved
+      // draft as the persisted profile while retaining the graph-created premises.
+      await userDb.saveProfile(profile);
+    } catch (err) {
+      logger.error('Approved draft premise decomposition failed', {
+        userId: context.userId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      reportToolError?.(err, {
+        subsystem: 'profile',
+        operation: 'profile.confirm_draft_decompose',
+        toolName: 'confirm_user_profile',
+        userId: context.userId,
+        tags: { toolName: 'confirm_user_profile', execution: context.isMcp ? 'background' : 'sync' },
+      });
+    } finally {
+      traceEmitter?.({ type: "graph_end", name: "profile", durationMs: Date.now() - graphStart });
+    }
   }
 
   const readUserProfiles = defineTool({
@@ -596,9 +671,23 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
         const profile = { ...query.draft, userId: context.userId };
         await userDb.saveProfile(profile);
         await persistApprovedProfileContext(profile, user, context.networkId);
+
+        if (context.isMcp) {
+          decomposeApprovedDraftProfile(context, profile).catch((err: unknown) => {
+            logger.error('Approved draft premise decomposition failed', {
+              userId: context.userId,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          });
+        } else {
+          await decomposeApprovedDraftProfile(context, profile);
+        }
+
         return success({
           created: true,
-          message: "Profile saved from approved draft.",
+          message: context.isMcp
+            ? "Profile saved from approved draft. Premise extraction is running in the background."
+            : "Profile saved from approved draft.",
           profile: toProfileSummary(profile),
         });
       }

--- a/packages/protocol/src/profile/tests/profile.privacy-tools.spec.ts
+++ b/packages/protocol/src/profile/tests/profile.privacy-tools.spec.ts
@@ -251,7 +251,7 @@ describe("onboarding privacy profile tools", () => {
 
     expect(result.success).toBe(true);
     expect(saveProfile).toHaveBeenCalledWith({ ...draft, userId: "u1" });
-    expect(saveProfile).toHaveBeenCalledTimes(2);
+    expect(saveProfile).toHaveBeenCalledTimes(1);
     expect(profileGraphInvoke).toHaveBeenCalledTimes(1);
     expect(profileGraphInvoke).toHaveBeenCalledWith({
       userId: "u1",

--- a/packages/protocol/src/profile/tests/profile.privacy-tools.spec.ts
+++ b/packages/protocol/src/profile/tests/profile.privacy-tools.spec.ts
@@ -240,7 +240,7 @@ describe("onboarding privacy profile tools", () => {
     expect(saveProfile).not.toHaveBeenCalled();
   });
 
-  it("confirm saves an approved structured draft", async () => {
+  it("confirm saves an approved structured draft and sends it through premise decomposition", async () => {
     const tool = tools.find((t) => t.name === "confirm_user_profile")!;
     const draft = {
       identity: { name: "Alice", bio: "Builder", location: "Healdsburg" },
@@ -251,7 +251,42 @@ describe("onboarding privacy profile tools", () => {
 
     expect(result.success).toBe(true);
     expect(saveProfile).toHaveBeenCalledWith({ ...draft, userId: "u1" });
+    expect(saveProfile).toHaveBeenCalledTimes(2);
+    expect(profileGraphInvoke).toHaveBeenCalledTimes(1);
+    expect(profileGraphInvoke).toHaveBeenCalledWith({
+      userId: "u1",
+      operationMode: "write",
+      input: [
+        "My name is Alice.",
+        "I am based in Healdsburg.",
+        "Builder",
+        "Alice builds tools.",
+        "My skills include TypeScript.",
+        "My interests include agents.",
+      ].join("\n"),
+      forceUpdate: true,
+    });
     expect(enricher).not.toHaveBeenCalled();
+  });
+
+  it("confirm schedules draft premise decomposition without blocking MCP callers", async () => {
+    const tool = tools.find((t) => t.name === "confirm_user_profile")!;
+    const draft = {
+      identity: { name: "Alice", bio: "Builder", location: "Healdsburg" },
+      narrative: { context: "Alice builds tools." },
+      attributes: { skills: ["TypeScript"], interests: ["agents"] },
+    };
+    profileGraphInvoke.mockImplementation(() => new Promise(() => {}));
+
+    const result = parseToolResult(await tool.handler({
+      context: { ...context(), isMcp: true } as ResolvedToolContext,
+      query: { draft },
+    }));
+
+    expect(result.success).toBe(true);
+    expect(String(result.data?.message)).toContain("background");
+    expect(saveProfile).toHaveBeenCalledTimes(1);
+    expect(profileGraphInvoke).toHaveBeenCalledTimes(1);
   });
 
   it("confirming approved text preserves existing location when no correction is supplied", async () => {


### PR DESCRIPTION
## Bug Fixes
- Route approved structured `confirm_user_profile(draft=...)` payloads through the profile write graph so premise decomposition runs.
- Keep MCP/AgentVillage draft confirmation non-blocking while premise extraction runs in the background.
- Preserve the user-approved structured profile after decomposition.

## Maintenance
- Add a strict `maintenance:backfill-approved-profile-premises` command for repairing Edge City members with approved profiles and zero active premises.
- Bump backend and `@indexnetwork/protocol` patch versions.

## Tests
- `cd packages/protocol && bun test src/profile/tests/profile.privacy-tools.spec.ts`
- `cd backend && bun run build`