### PR TITLE
feat(protocol): use LLM presenter for list_opportunities digest path

### DIFF
--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -1470,7 +1470,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
       if (isDigestMode) {
         // ── Digest mode: use LLM presenter for rich, second-person card text ──
         const presenter = new OpportunityPresenter();
-        const presenterDb = database as PresenterDatabase;
+        const presenterDb: PresenterDatabase = database;
         const PRESENTER_CONCURRENCY = 6;
 
         for (let i = 0; i < opportunities.length; i += PRESENTER_CONCURRENCY) {

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -1470,7 +1470,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
       if (isDigestMode) {
         // ── Digest mode: use LLM presenter for rich, second-person card text ──
         const presenter = new OpportunityPresenter();
-        const db = database as unknown as PresenterDatabase & typeof database;
+        const presenterDb = database as PresenterDatabase;
         const PRESENTER_CONCURRENCY = 6;
 
         for (let i = 0; i < opportunities.length; i += PRESENTER_CONCURRENCY) {
@@ -1548,7 +1548,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
 
                 try {
                   const ctx = await gatherPresenterContext(
-                    db,
+                    presenterDb,
                     opp,
                     context.userId,
                     counterpartUserId,

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -5,9 +5,10 @@ import { requestContext } from "../shared/observability/request-context.js";
 import type { DefineTool, ToolDeps } from "../shared/agent/tool.helpers.js";
 import { success, error, UUID_REGEX } from "../shared/agent/tool.helpers.js";
 import { MINIMAL_MAIN_TEXT_MAX_CHARS, getPrimaryActionLabel, SECONDARY_ACTION_LABEL } from "./opportunity.labels.js";
-import { viewerCentricCardSummary, narratorRemarkFromReasoning } from "./opportunity.presentation.js";
+import { viewerCentricCardSummary, narratorRemarkFromReasoning, stripUuids } from "./opportunity.presentation.js";
 import { runDiscoverFromQuery, continueDiscovery } from "./opportunity.discover.js";
-import { OpportunityPresenter } from "./opportunity.presenter.js";
+import { OpportunityPresenter, gatherPresenterContext, type PresenterDatabase } from "./opportunity.presenter.js";
+import { stripLeadingNarratorName } from "./feed/feed.graph.js";
 import type { EvaluatorEntity } from "./opportunity.evaluator.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import type { Opportunity, OpportunityStatus } from "../shared/interfaces/database.interface.js";
@@ -1461,109 +1462,310 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         if (user) userMap.set(userId, user);
       });
 
-      const cardDataList: Array<ReturnType<typeof buildMinimalOpportunityCard>> = [];
+      const isDigestMode = context.isMcp === true && query.includeDigestMarkers === true;
+      const cardDataList: Array<Record<string, unknown> & { opportunityId: string }> = [];
       const seenOpportunityIds = new Set<string>();
       const skippedIds: string[] = [];
 
-      for (const opp of opportunities) {
-        if (seenOpportunityIds.has(opp.id)) continue;
-        seenOpportunityIds.add(opp.id);
-        try {
-          const counterpartActor = opp.actors.find(
-            (a) => a.userId !== context.userId && a.role !== "introducer",
-          );
-          const counterpartUserId = counterpartActor?.userId;
-          if (!counterpartUserId) continue;
+      if (isDigestMode) {
+        // ── Digest mode: use LLM presenter for rich, second-person card text ──
+        const presenter = new OpportunityPresenter();
+        const db = database as unknown as PresenterDatabase & typeof database;
+        const PRESENTER_CONCURRENCY = 6;
 
-          const viewerIsIntroducerHere = opp.actors.some(
-            (a) => a.role === "introducer" && a.userId === context.userId,
-          );
-          const secondPartyActorForHeadline = viewerIsIntroducerHere
-            ? opp.actors.find(
-                (a) =>
-                  a.userId !== context.userId &&
-                  a.userId !== counterpartUserId &&
-                  a.role !== "introducer",
-              )
-            : undefined;
-          const secondPartyNameForHeadline = secondPartyActorForHeadline
-            ? (profileMap.get(secondPartyActorForHeadline.userId)?.identity?.name ??
-              userMap.get(secondPartyActorForHeadline.userId)?.name ??
-              undefined)
-            : undefined;
+        for (let i = 0; i < opportunities.length; i += PRESENTER_CONCURRENCY) {
+          const chunk = opportunities.slice(i, i + PRESENTER_CONCURRENCY);
+          const chunkCards = await Promise.all(
+            chunk.map(async (opp) => {
+              if (seenOpportunityIds.has(opp.id)) return null;
+              seenOpportunityIds.add(opp.id);
+              try {
+                const counterpartActor = opp.actors.find(
+                  (a) => a.userId !== context.userId && a.role !== "introducer",
+                );
+                const counterpartUserId = counterpartActor?.userId;
+                if (!counterpartUserId) return null;
 
-          const introducerActor = opp.actors.find(
-            (a) => a.role === "introducer" && a.userId !== context.userId,
-          );
-          const createdByName = opp.detection.createdByName;
+                const viewerIsIntroducerHere = opp.actors.some(
+                  (a) => a.role === "introducer" && a.userId === context.userId,
+                );
+                const secondPartyActorForHeadline = viewerIsIntroducerHere
+                  ? opp.actors.find(
+                      (a) =>
+                        a.userId !== context.userId &&
+                        a.userId !== counterpartUserId &&
+                        a.role !== "introducer",
+                    )
+                  : undefined;
 
-          const counterpartProfile = profileMap.get(counterpartUserId) ?? null;
-          const counterpartUser = userMap.get(counterpartUserId) ?? null;
-          const introducerProfile =
-            introducerActor && !createdByName
-              ? profileMap.get(introducerActor.userId) ?? null
+                const introducerActor = opp.actors.find(
+                  (a) => a.role === "introducer" && a.userId !== context.userId,
+                );
+                const createdByName = opp.detection.createdByName;
+
+                const counterpartUser = userMap.get(counterpartUserId) ?? null;
+                const counterpartName =
+                  profileMap.get(counterpartUserId)?.identity?.name ??
+                  counterpartUser?.name ??
+                  "Someone";
+                const introducerName =
+                  createdByName ??
+                  (introducerActor
+                    ? (profileMap.get(introducerActor.userId)?.identity?.name ?? null)
+                    : null);
+                const introducerUser = introducerActor
+                  ? userMap.get(introducerActor.userId) ?? null
+                  : null;
+
+                const secondPartyUser = secondPartyActorForHeadline
+                  ? userMap.get(secondPartyActorForHeadline.userId) ?? null
+                  : null;
+                const secondPartyNameForHeadline = secondPartyActorForHeadline
+                  ? (profileMap.get(secondPartyActorForHeadline.userId)?.identity?.name ??
+                    secondPartyUser?.name ??
+                    undefined)
+                  : undefined;
+
+                const viewerActor = opp.actors.find((a) => a.userId === context.userId);
+                const viewerRole = viewerActor?.role ?? "party";
+                const isCounterpartGhost = counterpartUser?.isGhost ?? false;
+
+                // Build fallback card in case LLM presenter fails
+                const fallbackCard = buildMinimalOpportunityCard(
+                  opp,
+                  context.userId,
+                  counterpartUserId,
+                  counterpartName,
+                  counterpartUser?.avatar ?? null,
+                  introducerName,
+                  introducerUser?.avatar ?? null,
+                  viewerName,
+                  secondPartyNameForHeadline,
+                  secondPartyUser?.avatar ?? null,
+                  secondPartyActorForHeadline?.userId,
+                  isCounterpartGhost,
+                );
+
+                try {
+                  const ctx = await gatherPresenterContext(
+                    db,
+                    opp,
+                    context.userId,
+                    counterpartUserId,
+                  );
+
+                  const presentation = await presenter.presentHomeCard({
+                    ...ctx,
+                    opportunityStatus: opp.status,
+                  });
+
+                  // Build narrator chip from presenter output
+                  let narratorChip: { name: string; text: string; avatar?: string | null; userId?: string };
+                  const introducerIsCounterpart = introducerActor && counterpartActor && introducerActor.userId === counterpartActor.userId;
+                  if (introducerActor && introducerActor.userId !== context.userId && !introducerIsCounterpart) {
+                    const narratorName = introducerName ?? "Someone";
+                    narratorChip = {
+                      name: narratorName,
+                      text: stripLeadingNarratorName(presentation.narratorRemark, narratorName),
+                      avatar: introducerUser?.avatar ?? null,
+                      userId: introducerActor.userId,
+                    };
+                  } else if (introducerActor?.userId === context.userId) {
+                    narratorChip = { name: "You", text: presentation.narratorRemark, userId: context.userId };
+                  } else {
+                    narratorChip = { name: "Index", text: presentation.narratorRemark };
+                  }
+
+                  const card: Record<string, unknown> = {
+                    opportunityId: opp.id,
+                    userId: counterpartUserId,
+                    name: counterpartName,
+                    avatar: counterpartUser?.avatar ?? null,
+                    mainText: stripUuids(presentation.personalizedSummary),
+                    cta: presentation.suggestedAction,
+                    headline: viewerIsIntroducerHere && secondPartyNameForHeadline
+                      ? `${counterpartName} → ${secondPartyNameForHeadline}`
+                      : presentation.headline,
+                    primaryActionLabel: getPrimaryActionLabel(viewerRole),
+                    secondaryActionLabel: SECONDARY_ACTION_LABEL,
+                    mutualIntentsLabel: presentation.mutualIntentsLabel,
+                    narratorChip,
+                    viewerRole,
+                    score: typeof opp.interpretation?.confidence === "number"
+                      ? opp.interpretation.confidence
+                      : undefined,
+                    status: opp.status,
+                    isGhost: isCounterpartGhost,
+                    ...(viewerIsIntroducerHere && secondPartyNameForHeadline
+                      ? {
+                          secondParty: {
+                            name: secondPartyNameForHeadline,
+                            ...(secondPartyUser?.avatar != null ? { avatar: secondPartyUser.avatar } : {}),
+                            ...(secondPartyActorForHeadline?.userId ? { userId: secondPartyActorForHeadline.userId } : {}),
+                          },
+                        }
+                      : {}),
+                  };
+
+                  // Attach actionable links for MCP callers
+                  if (context.isMcp && deps.mintConnectLink) {
+                    const viewerApproved =
+                      viewerActor?.role === "introducer" ? viewerActor.approved === true : undefined;
+                    await attachActionableLinks(card as Record<string, unknown> & {
+                      opportunityId: string;
+                      viewerRole: string;
+                      status: string;
+                    }, {
+                      viewerId: context.userId,
+                      viewerApproved,
+                      counterpartUserId,
+                      mintConnectLink: deps.mintConnectLink,
+                      frontendUrl: deps.frontendUrl,
+                      preferredSurface: context.clientSurface,
+                    });
+                  }
+
+                  return card as Record<string, unknown> & { opportunityId: string };
+                } catch (presenterErr) {
+                  logger.warn("LLM presenter failed for list_opportunities digest card, using fallback", {
+                    opportunityId: opp.id,
+                    err: presenterErr,
+                  });
+                  // Attach links to fallback card too
+                  if (context.isMcp && deps.mintConnectLink) {
+                    const viewerApproved =
+                      viewerActor?.role === "introducer" ? viewerActor.approved === true : undefined;
+                    await attachActionableLinks(fallbackCard as Record<string, unknown> & {
+                      opportunityId: string;
+                      viewerRole: string;
+                      status: string;
+                    }, {
+                      viewerId: context.userId,
+                      viewerApproved,
+                      counterpartUserId,
+                      mintConnectLink: deps.mintConnectLink,
+                      frontendUrl: deps.frontendUrl,
+                      preferredSurface: context.clientSurface,
+                    });
+                  }
+                  return fallbackCard as Record<string, unknown> & { opportunityId: string };
+                }
+              } catch (err) {
+                logger.warn("Skipping opportunity that failed to build card", {
+                  opportunityId: opp.id,
+                  err,
+                });
+                skippedIds.push(opp.id);
+                return null;
+              }
+            }),
+          );
+          for (const card of chunkCards) {
+            if (card) cardDataList.push(card);
+          }
+        }
+      } else {
+        // ── Chat mode: fast heuristic path (no LLM) ──
+        for (const opp of opportunities) {
+          if (seenOpportunityIds.has(opp.id)) continue;
+          seenOpportunityIds.add(opp.id);
+          try {
+            const counterpartActor = opp.actors.find(
+              (a) => a.userId !== context.userId && a.role !== "introducer",
+            );
+            const counterpartUserId = counterpartActor?.userId;
+            if (!counterpartUserId) continue;
+
+            const viewerIsIntroducerHere = opp.actors.some(
+              (a) => a.role === "introducer" && a.userId === context.userId,
+            );
+            const secondPartyActorForHeadline = viewerIsIntroducerHere
+              ? opp.actors.find(
+                  (a) =>
+                    a.userId !== context.userId &&
+                    a.userId !== counterpartUserId &&
+                    a.role !== "introducer",
+                )
+              : undefined;
+            const secondPartyNameForHeadline = secondPartyActorForHeadline
+              ? (profileMap.get(secondPartyActorForHeadline.userId)?.identity?.name ??
+                userMap.get(secondPartyActorForHeadline.userId)?.name ??
+                undefined)
+              : undefined;
+
+            const introducerActor = opp.actors.find(
+              (a) => a.role === "introducer" && a.userId !== context.userId,
+            );
+            const createdByName = opp.detection.createdByName;
+
+            const counterpartProfile = profileMap.get(counterpartUserId) ?? null;
+            const counterpartUser = userMap.get(counterpartUserId) ?? null;
+            const introducerProfile =
+              introducerActor && !createdByName
+                ? profileMap.get(introducerActor.userId) ?? null
+                : null;
+
+            const counterpartName =
+              counterpartProfile?.identity?.name ??
+              counterpartUser?.name ??
+              "Someone";
+            const introducerName =
+              createdByName ??
+              (introducerActor ? introducerProfile?.identity?.name ?? null : null);
+            const introducerUser = introducerActor
+              ? userMap.get(introducerActor.userId) ?? null
               : null;
 
-          const counterpartName =
-            counterpartProfile?.identity?.name ??
-            counterpartUser?.name ??
-            "Someone";
-          const introducerName =
-            createdByName ??
-            (introducerActor ? introducerProfile?.identity?.name ?? null : null);
-          const introducerUser = introducerActor
-            ? userMap.get(introducerActor.userId) ?? null
-            : null;
-
-          const secondPartyUser = secondPartyActorForHeadline
-            ? userMap.get(secondPartyActorForHeadline.userId) ?? null
-            : null;
-          const cardData = buildMinimalOpportunityCard(
-            opp,
-            context.userId,
-            counterpartUserId,
-            counterpartName,
-            counterpartUser?.avatar ?? null,
-            introducerName,
-            introducerUser?.avatar ?? null,
-            viewerName,
-            secondPartyNameForHeadline,
-            secondPartyUser?.avatar ?? null,
-            secondPartyActorForHeadline?.userId,
-          );
-
-          // For MCP callers (e.g. Edge Claw), mint a connect token and attach
-          // acceptUrl + profileUrl when the (status, viewerRole) is actionable
-          // for the viewer. Non-actionable combos (sender-on-draft,
-          // pending-on-introducer-waiting, rejected, etc.) deliberately get
-          // no link — the LLM would otherwise hallucinate `/api/.../connect`
-          // URLs from the exposed opportunityId.
-          if (context.isMcp && deps.mintConnectLink) {
-            const viewerActor = opp.actors.find((a) => a.userId === context.userId);
-            const viewerApproved =
-              viewerActor?.role === "introducer" ? viewerActor.approved === true : undefined;
-            await attachActionableLinks(cardData as Record<string, unknown> & {
-              opportunityId: string;
-              viewerRole: string;
-              status: string;
-            }, {
-              viewerId: context.userId,
-              viewerApproved,
+            const secondPartyUser = secondPartyActorForHeadline
+              ? userMap.get(secondPartyActorForHeadline.userId) ?? null
+              : null;
+            const cardData = buildMinimalOpportunityCard(
+              opp,
+              context.userId,
               counterpartUserId,
-              mintConnectLink: deps.mintConnectLink,
-              frontendUrl: deps.frontendUrl,
-              preferredSurface: context.clientSurface,
-            });
-          }
+              counterpartName,
+              counterpartUser?.avatar ?? null,
+              introducerName,
+              introducerUser?.avatar ?? null,
+              viewerName,
+              secondPartyNameForHeadline,
+              secondPartyUser?.avatar ?? null,
+              secondPartyActorForHeadline?.userId,
+            );
 
-          cardDataList.push(cardData);
-        } catch (err) {
-          logger.warn("Skipping opportunity that failed to build minimal card", {
-            opportunityId: opp.id,
-            err,
-          });
-          skippedIds.push(opp.id);
-          continue;
+            // For MCP callers (e.g. Edge Claw), mint a connect token and attach
+            // acceptUrl + profileUrl when the (status, viewerRole) is actionable
+            // for the viewer. Non-actionable combos (sender-on-draft,
+            // pending-on-introducer-waiting, rejected, etc.) deliberately get
+            // no link — the LLM would otherwise hallucinate `/api/.../connect`
+            // URLs from the exposed opportunityId.
+            if (context.isMcp && deps.mintConnectLink) {
+              const viewerActor = opp.actors.find((a) => a.userId === context.userId);
+              const viewerApproved =
+                viewerActor?.role === "introducer" ? viewerActor.approved === true : undefined;
+              await attachActionableLinks(cardData as Record<string, unknown> & {
+                opportunityId: string;
+                viewerRole: string;
+                status: string;
+              }, {
+                viewerId: context.userId,
+                viewerApproved,
+                counterpartUserId,
+                mintConnectLink: deps.mintConnectLink,
+                frontendUrl: deps.frontendUrl,
+                preferredSurface: context.clientSurface,
+              });
+            }
+
+            cardDataList.push(cardData);
+          } catch (err) {
+            logger.warn("Skipping opportunity that failed to build minimal card", {
+              opportunityId: opp.id,
+              err,
+            });
+            skippedIds.push(opp.id);
+            continue;
+          }
         }
       }
 

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts
@@ -1,0 +1,212 @@
+// Stub API key to prevent module-level createModel() from throwing
+process.env.OPENROUTER_API_KEY = 'test-key-unused';
+
+import { mock, describe, expect, it, afterAll } from 'bun:test';
+
+import type { OpportunityPresenter } from '../opportunity.presenter.js';
+import type { PresenterDatabase } from '../opportunity.presenter.js';
+
+// ─── Module-level mocks: must run before any static import of opportunity.tools ───
+
+let presentHomeCardMock: ReturnType<typeof mock>;
+let gatherPresenterContextMock: ReturnType<typeof mock>;
+
+mock.module('../opportunity.presenter.js', () => {
+  presentHomeCardMock = mock(async () => ({
+    headline: 'Test Headline',
+    personalizedSummary: 'Test personalized summary.',
+    suggestedAction: 'Test action',
+    narratorRemark: 'Test narrator remark',
+    mutualIntentsLabel: undefined,
+  }));
+  gatherPresenterContextMock = mock(async (
+    presenterDb: PresenterDatabase,
+    opp: any,
+    viewerId: string,
+  ) => ({
+    opportunityStatus: opp.status,
+  }));
+
+  return {
+    OpportunityPresenter: class {
+      presentHomeCard(input: any) {
+        return presentHomeCardMock(input);
+      }
+    },
+    gatherPresenterContext: (...args: any[]) => gatherPresenterContextMock(...args),
+    PresenterDatabase: undefined as any, // type-only, not consumed at runtime
+  };
+});
+
+afterAll(() => mock.restore());
+
+// ─── Imports after mocks ──────────────────────────────────────────────────────
+
+const { buildMinimalOpportunityCard } = await import('../opportunity.tools.js');
+const { createOpportunityTools } = await import('../opportunity.tools.js');
+const { z } = await import('zod');
+
+import type { ToolDeps } from '../../shared/agent/tool.helpers.js';
+import type {
+  ChatGraphCompositeDatabase,
+  Opportunity,
+  UserRecord,
+  ProfileRow,
+} from '../../shared/interfaces/database.interface.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const testUserId = 'u-test-viewer';
+
+function makeOpp(
+  id: string,
+  counterpartUserId: string,
+  status: string = 'pending',
+  confidence: number = 0.85,
+): Opportunity {
+  return {
+    id,
+    status,
+    interpretation: { reasoning: `Reasoning for ${counterpartUserId}`, confidence },
+    actors: [
+      { userId: testUserId, role: 'party' },
+      { userId: counterpartUserId, role: 'party' },
+    ],
+    detection: { source: 'discovery', createdByName: null },
+    context: {},
+    confidence: confidence,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    expiresAt: null,
+  } as unknown as Opportunity;
+}
+
+function defineTool<T extends z.ZodType>(opts: {
+  name: string;
+  description: string;
+  querySchema: T;
+  handler: (input: { context: any; query: z.infer<T> }) => Promise<string>;
+}) {
+  return opts;
+}
+
+function parseResult(text: string) {
+  return JSON.parse(text) as { success: boolean; data?: Record<string, unknown>; error?: string };
+}
+
+let getOppsForUser = mock(async () => [] as Opportunity[]);
+let getUser = mock(async () => ({ id: testUserId, name: 'Test User' }) as UserRecord | null);
+let getProfile = mock(async () => (null) as ProfileRow | null);
+
+const noopGraph = { invoke: async () => ({}) };
+
+function makeDeps(overrides: Partial<Parameters<typeof createOpportunityTools>[1]> = {}): ToolDeps {
+  const mockDb = {
+    getOpportunitiesForUser: getOppsForUser,
+    getUser,
+    getProfile,
+    getActiveIntents: mock(async () => []),
+    getNetwork: mock(async () => null),
+    getPremisesForUser: mock(async () => []),
+  };
+  return {
+    database: mockDb as unknown as ChatGraphCompositeDatabase,
+    userDb: {
+      getUser,
+      getProfile,
+      getUserSocials: mock(async () => []),
+      saveProfile: mock(async () => {}),
+      updateUser: mock(async () => {}),
+      setUserSocials: mock(async () => {}),
+      getPremisesForUser: mock(async () => []),
+      getActiveIntents: mock(async () => []),
+      getNetwork: mock(async () => null),
+    } as any,
+    systemDb: {} as any,
+    scraper: {} as any,
+    embedder: { embedText: mock(async () => []), generateEmbedding: mock(async () => []) } as any,
+    cache: {} as any,
+    integration: {} as any,
+    contactService: {} as any,
+    integrationImporter: {} as any,
+    enricher: {} as any,
+    negotiationDatabase: {} as any,
+    graphs: {
+      profile: noopGraph as any,
+      intent: noopGraph as any,
+      index: noopGraph as any,
+      networkMembership: noopGraph as any,
+      intentIndex: noopGraph as any,
+      opportunity: noopGraph as any,
+      premise: noopGraph as any,
+    },
+    ...overrides,
+  } as ToolDeps;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('list_opportunities digest presenter path', () => {
+  it('uses LLM presenter text when includeDigestMarkers=true and isMcp=true', async () => {
+    getOppsForUser = mock(async () => [makeOpp('opp-1', 'c-1')]);
+    getUser = mock(async () => ({ id: testUserId, name: 'Viewer' }) as UserRecord | null);
+    getProfile = mock(async () => ({ identity: { name: 'Alice', bio: '', location: '' }, userId: 'c-1' }) as ProfileRow | null);
+
+    const deps = makeDeps();
+    const tools = createOpportunityTools(defineTool as any, deps);
+    const listTool = tools.find((t: any) => t.name === 'list_opportunities')!;
+
+    const result = parseResult(
+      await listTool.handler({
+        context: {
+          userId: testUserId,
+          isMcp: true,
+          networkId: undefined,
+          sessionId: undefined,
+          userName: 'Viewer',
+          userNetworks: [],
+        },
+        query: { includeDigestMarkers: true },
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(gatherPresenterContextMock).toHaveBeenCalled();
+    expect(presentHomeCardMock).toHaveBeenCalled();
+    expect(String(result.data?.message)).toContain('Test personalized summary');
+  });
+
+  it('falls back to buildMinimalOpportunityCard when presenter throws', async () => {
+    getOppsForUser = mock(async () => [makeOpp('opp-2', 'c-2')]);
+    getUser = mock(async () => ({ id: testUserId, name: 'Viewer' }) as UserRecord | null);
+    getProfile = mock(async () => ({ identity: { name: 'Bob', bio: '', location: '' }, userId: 'c-2' }) as ProfileRow | null);
+
+    presentHomeCardMock = mock(async () => {
+      throw new Error('Presenter failed');
+    });
+
+    const deps = makeDeps();
+    const tools = createOpportunityTools(defineTool as any, deps);
+    const listTool = tools.find((t: any) => t.name === 'list_opportunities')!;
+
+    const result = parseResult(
+      await listTool.handler({
+        context: {
+          userId: testUserId,
+          isMcp: true,
+          networkId: undefined,
+          sessionId: undefined,
+          userName: 'Viewer',
+          userNetworks: [],
+        },
+        query: { includeDigestMarkers: true },
+      }),
+    );
+
+    // Should succeed and include the counterpart name from the fallback
+    expect(result.success).toBe(true);
+    expect(String(result.data?.message)).toContain('Bob');
+    // Fallback card should NOT contain presenter-specific text
+    expect(String(result.data?.message)).not.toContain('Test personalized summary');
+  });
+});

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts
@@ -1,5 +1,5 @@
-// Stub API key to prevent module-level createModel() from throwing
-process.env.OPENROUTER_API_KEY = 'test-key-unused';
+// Stub API key to prevent module-level createModel() from throwing — only set when absent
+process.env.OPENROUTER_API_KEY ||= 'test-key-unused';
 
 import { mock, describe, expect, it, afterAll } from 'bun:test';
 


### PR DESCRIPTION
## Summary

Daily digest (`list_opportunities` with `includeDigestMarkers=true`) now renders opportunity cards through the LLM-based `OpportunityPresenter.presentHomeCard()` instead of `buildMinimalOpportunityCard`'s heuristic text.

## Problem

The daily digest pipeline (`list_opportunities` → agentvillage `stage-daily-brief.ts`) was using `buildMinimalOpportunityCard`, which produces cards via regex heuristics (`viewerCentricCardSummary`, `narratorRemarkFromReasoning`) rather than the LLM presenter used by the home feed and agent pickup paths. This produced third-person evaluator language (“the discoverer, Helen, is building...” instead of natural second-person prose), requiring ~65 lines of compensating regex hacks in `stage-daily-brief.ts`.

## Changes

### `packages/protocol`

- **`opportunity.tools.ts`**: When `includeDigestMarkers=true`, the `list_opportunities` handler now calls `gatherPresenterContext()` + `presenter.presentHomeCard()` in a concurrency-6 batch. Falls back to `buildMinimalOpportunityCard` on LLM failure. Chat mode (no digest markers) keeps the fast heuristic path unchanged.
- Bump to `1.26.3`

### `packages/agentvillage`

- **`stage-daily-brief.ts`**: Removed `stripFillerSentences()` (8 hardcoded filler patterns), `normalizeOpportunityText()` (“the discoverer” → “they”, etc.), `opportunityTemplate()` (5 regex templates), and `readableSentences()`. Simplified `opportunityReason()` to just take the first sentence — the LLM presenter's output is already well-formed prose.
- Updated test fixtures to use presenter-quality text.