### PR TITLE
Release 2026-06-05

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol",
-  "version": "0.27.2",
+  "version": "0.27.3",
   "license": "MIT",
   "private": true,
   "scripts": {
@@ -32,6 +32,7 @@
     "maintenance:expire-opportunities": "bun ./src/cli/expire-opportunities.ts",
     "maintenance:rediscover-opportunities": "bun ./src/cli/rediscover-user-opportunities.ts",
     "maintenance:decompose-profiles": "bun ./src/cli/decompose-profiles.ts",
+    "maintenance:backfill-approved-profile-premises": "bun ./src/cli/backfill-approved-profile-premises.ts",
     "maintenance:backfill-premises": "bun ./src/cli/backfill-premises.ts",
     "maintenance:compare-discovery": "bun ./src/cli/compare-discovery.ts",
     "maintenance:backfill-context-hyde": "bun ./src/cli/backfill-context-hyde.ts",

--- a/backend/src/cli/backfill-approved-profile-premises.ts
+++ b/backend/src/cli/backfill-approved-profile-premises.ts
@@ -7,7 +7,7 @@
  * recorded data-use consent grant. Use --dry-run first.
  *
  * Usage:
- *   bun ./src/cli/backfill-approved-profile-premises.ts --network <networkId> [--limit=N] [--dry-run]
+ *   bun run maintenance:backfill-approved-profile-premises -- --network <networkId> [--limit=N] [--dry-run]
  *
  * Escape hatches are intentionally explicit:
  *   --allow-incomplete-onboarding
@@ -57,7 +57,7 @@ function parseArgs(): Args {
   const limitValue = Number.parseInt(argValue(args, '--limit') ?? '', 10);
 
   if (!networkId) {
-    console.error('Usage: bun ./src/cli/backfill-approved-profile-premises.ts --network <networkId> [--limit=N] [--dry-run]');
+    console.error('Usage: bun run maintenance:backfill-approved-profile-premises -- --network <networkId> [--limit=N] [--dry-run]');
     process.exit(1);
   }
 

--- a/backend/src/cli/backfill-approved-profile-premises.ts
+++ b/backend/src/cli/backfill-approved-profile-premises.ts
@@ -16,18 +16,18 @@
 import dotenv from 'dotenv';
 import path from 'path';
 
+import type { PremiseGraphDatabase } from '@indexnetwork/protocol';
+
 const envFile = process.env.NODE_ENV === 'development' ? '.env.development' : '.env.production';
 dotenv.config({ path: path.resolve(process.cwd(), envFile) });
 
-import { and, eq, isNull, sql } from 'drizzle-orm';
-import { PremiseDecomposer, PremiseGraphFactory } from '@indexnetwork/protocol';
-import type { PremiseGraphDatabase } from '@indexnetwork/protocol';
-
-import db, { closeDb } from '../lib/drizzle/drizzle';
-import { networkMembers, premises, userProfiles, users } from '../schemas/database.schema';
-import { ChatDatabaseAdapter } from '../adapters/database.adapter';
-import { EmbedderAdapter } from '../adapters/embedder.adapter';
-import { premiseQueue } from '../queues/premise.queue';
+const { and, eq, isNull, sql } = await import('drizzle-orm');
+const { PremiseDecomposer, PremiseGraphFactory } = await import('@indexnetwork/protocol');
+const { default: db, closeDb } = await import('../lib/drizzle/drizzle');
+const { networkMembers, premises, userProfiles, users } = await import('../schemas/database.schema');
+const { ChatDatabaseAdapter } = await import('../adapters/database.adapter');
+const { EmbedderAdapter } = await import('../adapters/embedder.adapter');
+const { premiseQueue } = await import('../queues/premise.queue');
 
 const DEFAULT_LIMIT = 100;
 const BACKFILL_CONFIDENCE = 0.9;

--- a/backend/src/cli/backfill-approved-profile-premises.ts
+++ b/backend/src/cli/backfill-approved-profile-premises.ts
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+/**
+ * Incident backfill CLI: convert approved onboarding profiles into premises.
+ *
+ * Strict by default: targets only non-ghost members of one network who have a
+ * saved profile, zero active premises, completed onboarding, and at least one
+ * recorded data-use consent grant. Use --dry-run first.
+ *
+ * Usage:
+ *   bun ./src/cli/backfill-approved-profile-premises.ts --network <networkId> [--limit=N] [--dry-run]
+ *
+ * Escape hatches are intentionally explicit:
+ *   --allow-incomplete-onboarding
+ *   --allow-missing-consent
+ */
+import dotenv from 'dotenv';
+import path from 'path';
+
+const envFile = process.env.NODE_ENV === 'development' ? '.env.development' : '.env.production';
+dotenv.config({ path: path.resolve(process.cwd(), envFile) });
+
+import { and, eq, isNull, sql } from 'drizzle-orm';
+import { PremiseDecomposer, PremiseGraphFactory } from '@indexnetwork/protocol';
+import type { PremiseGraphDatabase } from '@indexnetwork/protocol';
+
+import db, { closeDb } from '../lib/drizzle/drizzle';
+import { networkMembers, premises, userProfiles, users } from '../schemas/database.schema';
+import { ChatDatabaseAdapter } from '../adapters/database.adapter';
+import { EmbedderAdapter } from '../adapters/embedder.adapter';
+import { premiseQueue } from '../queues/premise.queue';
+
+const DEFAULT_LIMIT = 100;
+const BACKFILL_CONFIDENCE = 0.9;
+
+interface ProfileIdentity { name: string; bio: string; location: string }
+interface ProfileNarrative { context: string }
+interface ProfileAttributes { interests: string[]; skills: string[] }
+
+interface Args {
+  networkId: string;
+  limit: number;
+  dryRun: boolean;
+  requireConsent: boolean;
+  requireOnboardingComplete: boolean;
+}
+
+function argValue(args: string[], name: string): string | undefined {
+  const exact = args.find((a) => a.startsWith(`${name}=`));
+  if (exact) return exact.slice(name.length + 1);
+  const idx = args.indexOf(name);
+  return idx >= 0 ? args[idx + 1] : undefined;
+}
+
+function parseArgs(): Args {
+  const args = process.argv.slice(2);
+  const networkId = argValue(args, '--network') ?? argValue(args, '--network-id') ?? '';
+  const limitValue = Number.parseInt(argValue(args, '--limit') ?? '', 10);
+
+  if (!networkId) {
+    console.error('Usage: bun ./src/cli/backfill-approved-profile-premises.ts --network <networkId> [--limit=N] [--dry-run]');
+    process.exit(1);
+  }
+
+  return {
+    networkId,
+    limit: Number.isFinite(limitValue) && limitValue > 0 ? limitValue : DEFAULT_LIMIT,
+    dryRun: args.includes('--dry-run'),
+    requireConsent: !args.includes('--allow-missing-consent'),
+    requireOnboardingComplete: !args.includes('--allow-incomplete-onboarding'),
+  };
+}
+
+function buildProfileText(
+  identity: ProfileIdentity | null,
+  narrative: ProfileNarrative | null,
+  attributes: ProfileAttributes | null,
+): string {
+  const lines: string[] = [];
+  if (identity?.name) lines.push(`My name is ${identity.name}.`);
+  if (identity?.location) lines.push(`I am based in ${identity.location}.`);
+  if (identity?.bio) lines.push(identity.bio);
+  if (narrative?.context) lines.push(narrative.context);
+  if (attributes?.skills?.length) lines.push(`My skills include ${attributes.skills.join(', ')}.`);
+  if (attributes?.interests?.length) lines.push(`My interests include ${attributes.interests.join(', ')}.`);
+  return lines.join('\n');
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs();
+  console.log([
+    'backfill-approved-profile-premises',
+    `network=${args.networkId}`,
+    `limit=${args.limit}`,
+    `dryRun=${args.dryRun}`,
+    `requireConsent=${args.requireConsent}`,
+    `requireOnboardingComplete=${args.requireOnboardingComplete}`,
+  ].join(' '));
+
+  const conditions = [
+    eq(networkMembers.networkId, args.networkId),
+    isNull(networkMembers.deletedAt),
+    isNull(users.deletedAt),
+    eq(users.isGhost, false),
+    isNull(premises.id),
+  ];
+
+  if (args.requireOnboardingComplete) {
+    conditions.push(sql`${users.onboarding}->>'completedAt' IS NOT NULL`);
+  }
+
+  if (args.requireConsent) {
+    conditions.push(sql`(
+      ${users.onboarding}#>>'{privacy,edgeosImport,granted}' = 'true'
+      OR ${users.onboarding}#>>'{privacy,publicProfileLookup,granted}' = 'true'
+    )`);
+  }
+
+  const rows = await db
+    .select({
+      userId: userProfiles.userId,
+      email: users.email,
+      name: users.name,
+      identity: userProfiles.identity,
+      narrative: userProfiles.narrative,
+      attributes: userProfiles.attributes,
+    })
+    .from(userProfiles)
+    .innerJoin(users, eq(users.id, userProfiles.userId))
+    .innerJoin(networkMembers, eq(networkMembers.userId, userProfiles.userId))
+    .leftJoin(
+      premises,
+      and(
+        eq(premises.userId, userProfiles.userId),
+        eq(premises.status, 'ACTIVE'),
+        isNull(premises.deletedAt),
+      ),
+    )
+    .where(and(...conditions))
+    .limit(args.limit);
+
+  if (rows.length === 0) {
+    console.log('No matching users with approved profiles missing active premises.');
+    return;
+  }
+
+  console.log(`Found ${rows.length} matching user(s).`);
+
+  const database = new ChatDatabaseAdapter();
+  const embedder = new EmbedderAdapter();
+  const decomposer = new PremiseDecomposer();
+  const premiseGraph = new PremiseGraphFactory(
+    database as unknown as PremiseGraphDatabase,
+    embedder,
+  ).createGraph();
+
+  let totalUsers = 0;
+  let totalPremises = 0;
+
+  for (const row of rows) {
+    const text = buildProfileText(
+      row.identity as ProfileIdentity | null,
+      row.narrative as ProfileNarrative | null,
+      row.attributes as ProfileAttributes | null,
+    );
+
+    if (!text.trim()) {
+      console.log(`  [${row.email}] Empty profile — skipping`);
+      continue;
+    }
+
+    console.log(`  [${row.email}] Decomposing approved profile (${text.length} chars)...`);
+    const result = await decomposer.invoke(text);
+    console.log(`  [${row.email}] Extracted ${result.premises.length} premise(s)`);
+
+    if (args.dryRun) {
+      for (const p of result.premises) {
+        console.log(`    - [${p.tier}] ${p.text}`);
+      }
+      totalUsers++;
+      continue;
+    }
+
+    let created = 0;
+    for (const p of result.premises) {
+      try {
+        const premiseResult = await premiseGraph.invoke({
+          userId: row.userId,
+          assertionText: p.text,
+          tier: p.tier as 'assertive' | 'contextual',
+          provenanceSource: 'onboarding' as const,
+          provenanceConfidence: BACKFILL_CONFIDENCE,
+        });
+        if (premiseResult.premise) created++;
+        else if (premiseResult.error) {
+          console.warn(`    Failed: ${p.text.substring(0, 60)} — ${premiseResult.error}`);
+        }
+      } catch (err) {
+        console.warn(`    Error: ${p.text.substring(0, 60)} — ${err instanceof Error ? err.message : err}`);
+      }
+    }
+
+    console.log(`  [${row.email}] Created ${created}/${result.premises.length} premises`);
+    if (created > 0) {
+      await premiseQueue.addProfileRegenJob({ userId: row.userId, trigger: 'premise_created' });
+    }
+
+    totalUsers++;
+    totalPremises += created;
+  }
+
+  console.log(`Done. Processed ${totalUsers} user(s), created ${totalPremises} premise(s).`);
+}
+
+main()
+  .then(async () => {
+    await Promise.all([closeDb(), premiseQueue.queue.close()]);
+  })
+  .catch(async (e: unknown) => {
+    const msg = e instanceof Error ? e.message : `${e}`;
+    console.error('backfill-approved-profile-premises error:', msg);
+    await Promise.all([
+      closeDb().catch(() => {}),
+      premiseQueue.queue.close().catch(() => {}),
+    ]);
+    process.exit(1);
+  });

--- a/backend/src/cli/backfill-approved-profile-premises.ts
+++ b/backend/src/cli/backfill-approved-profile-premises.ts
@@ -186,7 +186,7 @@ async function main(): Promise<void> {
         const premiseResult = await premiseGraph.invoke({
           userId: row.userId,
           assertionText: p.text,
-          tier: p.tier as 'assertive' | 'contextual',
+          tier: p.tier,
           provenanceSource: 'onboarding' as const,
           provenanceConfidence: BACKFILL_CONFIDENCE,
         });

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "backend": {
       "name": "protocol",
-      "version": "0.27.0",
+      "version": "0.27.3",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.939.0",
         "@aws-sdk/s3-request-presigner": "^3.983.0",

--- a/bun.lock
+++ b/bun.lock
@@ -65,7 +65,7 @@
     },
     "frontend": {
       "name": "frontend",
-      "version": "0.11.2",
+      "version": "0.11.3",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.14",
@@ -127,7 +127,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "1.26.2",
+      "version": "1.26.3",
       "dependencies": {
         "@langchain/core": "^1.1.17",
         "@langchain/langgraph": "^1.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/frontend/src/components/chat/IntentProposalCard.tsx
+++ b/frontend/src/components/chat/IntentProposalCard.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Check, RotateCcw, X } from "lucide-react";
+import { AlertTriangle, Check, X } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
@@ -10,6 +10,10 @@ export interface IntentProposalData {
   networkId?: string;
   confidence?: number | null;
   speechActType?: string | null;
+  semanticEntropy?: number | null;
+  referentialBreadth?: "narrow" | "moderate" | "broad" | null;
+  missingSelectionalConstraints?: string[];
+  specificityWarning?: string | null;
 }
 
 interface IntentProposalCardProps {
@@ -61,13 +65,17 @@ export default function IntentProposalCard({
   const statusResolved = currentStatus !== undefined;
   const effectiveStatus = currentStatus ?? (actionTaken ? actionTaken : "pending");
   const isPending = statusResolved && effectiveStatus === "pending" && !actionTaken && !actionError;
+  const specificityWarning = card.specificityWarning?.trim();
+  const requiresManualApproval = Boolean(specificityWarning || card.referentialBreadth === "broad");
 
-  // Start countdown on mount when pending
+  // Start countdown on mount when pending. Broad attributive signals require
+  // explicit approval so the user has a chance to refine instead of silently
+  // broadcasting a high-breadth proposal.
   useEffect(() => {
-    if (!isPending || !onApprove || countdownStarted.current) return;
+    if (!isPending || !onApprove || countdownStarted.current || requiresManualApproval) return;
     countdownStarted.current = true;
     setCountdown(COUNTDOWN_SECONDS);
-  }, [isPending, onApprove]);
+  }, [isPending, onApprove, requiresManualApproval]);
 
   // Countdown tick
   useEffect(() => {
@@ -247,6 +255,12 @@ export default function IntentProposalCard({
           )}>
             {card.description || "No description provided"}
           </p>
+          {specificityWarning && effectiveStatus !== "rejected" && (
+            <div className="mt-2 flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 px-2.5 py-2 text-[12px] leading-relaxed text-amber-800">
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <span>{specificityWarning}</span>
+            </div>
+          )}
         </div>
 
         <div className="flex items-center gap-3 shrink-0">
@@ -261,30 +275,40 @@ export default function IntentProposalCard({
                   Skip
                 </button>
               )}
-              <button
-                type="button"
-                onClick={handleApproveNow}
-                className="relative w-8 h-8 rounded-full bg-gray-100 border border-gray-300 flex items-center justify-center text-gray-500 hover:bg-gray-200 hover:text-gray-700 transition-colors overflow-hidden group"
-                title="Create now"
-              >
-                <span className="text-xs font-medium group-hover:hidden z-10 relative tabular-nums">
-                  {countdown ?? COUNTDOWN_SECONDS}
-                </span>
-                <Check className="w-4 h-4 z-10 relative hidden group-hover:block" />
-                <svg className="absolute inset-[1px] pointer-events-none -rotate-90" viewBox="0 0 30 30">
-                  <circle
-                    cx="15"
-                    cy="15"
-                    r="14"
-                    fill="none"
-                    stroke="rgb(75,85,99)"
-                    strokeWidth="1.5"
-                    strokeDasharray="87.96"
-                    strokeDashoffset={87.96 * (1 - (countdown ?? COUNTDOWN_SECONDS) / COUNTDOWN_SECONDS)}
-                    className="transition-[stroke-dashoffset] duration-1000 linear"
-                  />
-                </svg>
-              </button>
+              {requiresManualApproval ? (
+                <button
+                  type="button"
+                  onClick={handleApproveNow}
+                  className="rounded-full border border-amber-300 bg-amber-50 px-3 py-1.5 text-xs font-medium text-amber-800 hover:bg-amber-100"
+                >
+                  Create anyway
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={handleApproveNow}
+                  className="relative w-8 h-8 rounded-full bg-gray-100 border border-gray-300 flex items-center justify-center text-gray-500 hover:bg-gray-200 hover:text-gray-700 transition-colors overflow-hidden group"
+                  title="Create now"
+                >
+                  <span className="text-xs font-medium group-hover:hidden z-10 relative tabular-nums">
+                    {countdown ?? COUNTDOWN_SECONDS}
+                  </span>
+                  <Check className="w-4 h-4 z-10 relative hidden group-hover:block" />
+                  <svg className="absolute inset-[1px] pointer-events-none -rotate-90" viewBox="0 0 30 30">
+                    <circle
+                      cx="15"
+                      cy="15"
+                      r="14"
+                      fill="none"
+                      stroke="rgb(75,85,99)"
+                      strokeWidth="1.5"
+                      strokeDasharray="87.96"
+                      strokeDashoffset={87.96 * (1 - (countdown ?? COUNTDOWN_SECONDS) / COUNTDOWN_SECONDS)}
+                      className="transition-[stroke-dashoffset] duration-1000 linear"
+                    />
+                  </svg>
+                </button>
+              )}
             </>
           )}
 

--- a/frontend/src/components/chat/IntentProposalCard.tsx
+++ b/frontend/src/components/chat/IntentProposalCard.tsx
@@ -42,6 +42,14 @@ export function IntentProposalSkeleton() {
 const COUNTDOWN_SECONDS = 5;
 
 /**
+ * Fallback warning shown when a proposal requires manual approval (broad signal)
+ * but the backend didn't supply a specific warning string (older or partial
+ * payload). Mirrors DEFAULT_SPECIFICITY_WARNING in the protocol package.
+ */
+const DEFAULT_SPECIFICITY_WARNING =
+  "This signal is broad and may produce many weak matches. Add a more concrete role, outcome, location, timeframe, domain, or specific need to get better recommendations.";
+
+/**
  * Auto-save card for intent creation in chat.
  * Countdown from 5 with Skip option; auto-saves after countdown; Undo after save.
  */
@@ -67,6 +75,12 @@ export default function IntentProposalCard({
   const isPending = statusResolved && effectiveStatus === "pending" && !actionTaken && !actionError;
   const specificityWarning = card.specificityWarning?.trim();
   const requiresManualApproval = Boolean(specificityWarning || card.referentialBreadth === "broad");
+  // When manual approval is required, always show a warning banner — fall back to
+  // the default if the backend sent a broad breadth without a specific message, so
+  // the disabled countdown is explained rather than looking stuck.
+  const displayWarning = requiresManualApproval
+    ? specificityWarning || DEFAULT_SPECIFICITY_WARNING
+    : undefined;
 
   // Start countdown on mount when pending. Broad attributive signals require
   // explicit approval so the user has a chance to refine instead of silently
@@ -255,10 +269,10 @@ export default function IntentProposalCard({
           )}>
             {card.description || "No description provided"}
           </p>
-          {specificityWarning && effectiveStatus !== "rejected" && (
+          {displayWarning && effectiveStatus !== "rejected" && (
             <div className="mt-2 flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 px-2.5 py-2 text-[12px] leading-relaxed text-amber-800">
               <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-              <span>{specificityWarning}</span>
+              <span>{displayWarning}</span>
             </div>
           )}
         </div>

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "1.26.2",
+  "version": "1.26.3",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/intent/intent.graph.ts
+++ b/packages/protocol/src/intent/intent.graph.ts
@@ -2,6 +2,7 @@ import { StateGraph, START, END } from "@langchain/langgraph";
 import { IntentGraphState, VerifiedIntent, ExecutionResult } from "./intent.state.js";
 import { ExplicitIntentInferrer } from "./intent.inferrer.js";
 import { SemanticVerifier } from "./intent.verifier.js";
+import { DEFAULT_SPECIFICITY_WARNING } from "./intent.specificity.js";
 import { IntentReconciler } from "./intent.reconciler.js";
 import { IntentGraphDatabase } from "../shared/interfaces/database.interface.js";
 import { getAbortSignalConfig } from "../shared/agent/model-signal.js";
@@ -105,6 +106,11 @@ const isVague = (description: string, entropy: number, clarity: number): boolean
   if (entropy > MAX_PERMISSIBLE_ENTROPY) return true;
   if (clarity < MIN_CLEAR_INTENT_SCORE) return true;
   return false;
+};
+
+const getSpecificityWarning = (verdict: { specificity_warning?: string | null }): string => {
+  const warning = verdict.specificity_warning?.trim();
+  return warning && warning.length > 0 ? warning : DEFAULT_SPECIFICITY_WARNING;
 };
 
 const toSpeechActType = (classification?: string): "COMMISSIVE" | "DIRECTIVE" | null => {
@@ -310,6 +316,15 @@ export class IntentGraphFactory {
                 return null;
               }
 
+              if (state.operationMode !== 'propose' && verdict.referential_breadth === 'broad') {
+                logger.warn(`Dropping broad attributive intent before persistence: "${description}"`, {
+                  referentialBreadth: verdict.referential_breadth,
+                  missingSelectionalConstraints: verdict.missing_selectional_constraints,
+                  warning: getSpecificityWarning(verdict),
+                });
+                return null;
+              }
+
               // Calculate Score
               const score = Math.min(
                 verdict.felicity_scores.authority,
@@ -344,14 +359,18 @@ export class IntentGraphFactory {
           const fs = v.verification?.felicity_scores;
           const entropy = v.verification?.semantic_entropy;
           const classification = v.verification?.classification;
+          const referentialBreadth = v.verification?.referential_breadth;
           return {
             node: "verification",
-            detail: `"${v.description.slice(0, 40)}${v.description.length > 40 ? '...' : ''}" → ${classification}`,
+            detail: `"${v.description.slice(0, 40)}${v.description.length > 40 ? '...' : ''}" → ${classification}${referentialBreadth ? ` (${referentialBreadth} referential breadth)` : ''}`,
             data: fs ? {
               clarity: fs.clarity,
               authority: fs.authority,
               sincerity: fs.sincerity,
               entropy: entropy != null ? Math.round(entropy * 100) / 100 : undefined,
+              referentialBreadth,
+              missingSelectionalConstraints: v.verification?.missing_selectional_constraints,
+              specificityWarning: v.verification?.specificity_warning ?? undefined,
               classification,
               score: v.score,
             } : undefined,

--- a/packages/protocol/src/intent/intent.specificity.ts
+++ b/packages/protocol/src/intent/intent.specificity.ts
@@ -1,0 +1,2 @@
+/** Default user-facing warning for broad attributive intent proposals. */
+export const DEFAULT_SPECIFICITY_WARNING = "This signal is broad and may produce many weak matches. Add a more concrete role, outcome, location, timeframe, domain, or specific need to get better recommendations.";

--- a/packages/protocol/src/intent/intent.tools.ts
+++ b/packages/protocol/src/intent/intent.tools.ts
@@ -319,7 +319,9 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
         if (broadIntents.length > 0) {
           const first = broadIntents[0];
           const missing = first.verification?.missing_selectional_constraints ?? [];
-          const missingHint = missing.length > 0 ? ` Missing selectional constraints: ${missing.join(", ")}.` : "";
+          const missingHint = missing.length > 0
+            ? ` Missing specifics: ${missing.map((m) => m.replace(/_/g, " ")).join(", ")}.`
+            : "";
           return error(
             `${specificityWarningFor(first)}${missingHint} ` +
             `Please ask the user to clarify before creating this signal, or retry with a narrower description.`,

--- a/packages/protocol/src/intent/intent.tools.ts
+++ b/packages/protocol/src/intent/intent.tools.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import type { ExecutionResult, VerifiedIntent } from "./intent.state.js";
+import { DEFAULT_SPECIFICITY_WARNING } from "./intent.specificity.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { requestContext } from "../shared/observability/request-context.js";
 
@@ -46,6 +47,15 @@ function buildApprovedProfileFallback(user: UserRecord | null | undefined): stri
     narrative: { context: bio },
     attributes: { skills: [], interests: [] },
   });
+}
+
+function isBroadAttributiveIntent(intent: VerifiedIntent): boolean {
+  return intent.verification?.referential_breadth === "broad";
+}
+
+function specificityWarningFor(intent: VerifiedIntent): string {
+  const warning = intent.verification?.specificity_warning?.trim();
+  return warning && warning.length > 0 ? warning : DEFAULT_SPECIFICITY_WARNING;
 }
 
 export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
@@ -305,6 +315,18 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
 
       // ── Auto-approve path (for MCP agents or explicit opt-in) ──
       if (shouldAutoApprove) {
+        const broadIntents = (verified as VerifiedIntent[]).filter(isBroadAttributiveIntent);
+        if (broadIntents.length > 0) {
+          const first = broadIntents[0];
+          const missing = first.verification?.missing_selectional_constraints ?? [];
+          const missingHint = missing.length > 0 ? ` Missing selectional constraints: ${missing.join(", ")}.` : "";
+          return error(
+            `${specificityWarningFor(first)}${missingHint} ` +
+            `Please ask the user to clarify before creating this signal, or retry with a narrower description.`,
+            debugSteps,
+          );
+        }
+
         const createdIntents: Array<{ description: string; confidence: number | null; speechActType: string | null }> = [];
         const createTimings: Array<{ name: string; durationMs: number; agents: unknown[] }> = [];
 
@@ -354,12 +376,17 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       // Build intent_proposal code fences for each verified intent
       const proposalBlocks = verified.map((v: VerifiedIntent) => {
         const proposalId = crypto.randomUUID();
+        const isBroad = isBroadAttributiveIntent(v);
         const data = {
           proposalId,
           description: v.description,
           ...(effectiveIndexId ? { networkId: effectiveIndexId } : {}),
           confidence: v.score != null ? Math.round(v.score * 100) / 100 : null,
           speechActType: v.verification?.classification ?? null,
+          semanticEntropy: v.verification?.semantic_entropy ?? null,
+          referentialBreadth: v.verification?.referential_breadth ?? null,
+          missingSelectionalConstraints: v.verification?.missing_selectional_constraints ?? [],
+          specificityWarning: isBroad ? specificityWarningFor(v) : v.verification?.specificity_warning ?? null,
         };
         return (
           "```intent_proposal\n" +
@@ -449,6 +476,11 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
 
       if (result.executionResults?.some((r: ExecutionResult) => !r.success)) {
         return error("Failed to update intent.");
+      }
+      if (!result.executionResults?.some((r: ExecutionResult) => r.success)) {
+        return error(
+          "Intent update was not applied. The new description may be too broad, too vague, or failed semantic verification. Please ask the user to clarify with a more concrete role, outcome, location, timeframe, domain, or specific need.",
+        );
       }
       return success({
         message: "Intent updated.",

--- a/packages/protocol/src/intent/intent.verifier.ts
+++ b/packages/protocol/src/intent/intent.verifier.ts
@@ -8,6 +8,16 @@ import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("SemanticVerifier");
 
+const referentialBreadthSchema = z.enum(["narrow", "moderate", "broad"]);
+const missingSelectionalConstraintSchema = z.enum([
+  "role",
+  "outcome",
+  "location",
+  "timeframe",
+  "domain",
+  "concrete_need",
+]);
+
 const model = createModel("intentVerifier");
 // ──────────────────────────────────────────────────────────────
 // 1. SYSTEM PROMPT
@@ -122,6 +132,26 @@ REFERENTIAL ANCHOR → referential_anchor field
   "I want to join Google" → "Google"
   "I want to join a startup" → null
 
+REFERENTIAL BREADTH → referential_breadth field
+  Estimate the extension size of the open candidate class: how many people could plausibly satisfy the description.
+  This is NOT the same as semantic_entropy. Semantic entropy measures underspecification/constraint density;
+  referential breadth measures whether the attributive description narrows the satisfier class enough for discovery.
+
+  narrow   → a small satisfier class due to concrete role/outcome/location/timeframe/specific need.
+             Example: "Find a robotics founder in Healdsburg this week to test my meditation hardware prototype"
+  moderate → a bounded professional/community class, but some constraints are still missing.
+             Example: "Meet AI safety researchers working on evals in London"
+  broad    → a large satisfier class; many people could plausibly match even if topical constraints are present.
+             Example: "Meet creative people, builders, and makers interested in AI, meditation, and tech exploration"
+
+MISSING SELECTIONAL CONSTRAINTS → missing_selectional_constraints field
+  Report the constraints whose absence keeps the candidate class too broad:
+  role, outcome, location, timeframe, domain, concrete_need.
+
+SPECIFICITY WARNING → specificity_warning field
+  If referential_breadth is broad, provide a concise user-facing warning asking for a more concrete role,
+  outcome, location, timeframe, domain, or need. Otherwise output null.
+
 ═══════════════════════════════════════════════════
 STEP 3 — FLAGS
 ═══════════════════════════════════════════════════
@@ -131,6 +161,7 @@ Add flags when scores fall below threshold:
   sincerity < 70  → "WEAK_COMMITMENT"
   clarity < 50    → "VAGUE_INTENT"
   classification is ASSERTIVE or EXPRESSIVE → "NOISE"
+  referential_breadth is broad → "BROAD_ATTRIBUTIVE_REFERENCE"
 `;
 
 // ──────────────────────────────────────────────────────────────
@@ -169,8 +200,20 @@ const responseFormat = z.object({
     "Named specific entity the utterance refers to (Donnellan referential), or null for attributive reference"
   ),
 
+  referential_breadth: referentialBreadthSchema.describe(
+    "Extension size of the open candidate class: narrow, moderate, or broad. Distinct from semantic entropy."
+  ),
+
+  missing_selectional_constraints: z.array(missingSelectionalConstraintSchema).describe(
+    "Selectional constraints whose absence leaves the satisfier class too broad."
+  ),
+
+  specificity_warning: z.string().nullable().describe(
+    "Concise user-facing warning when referential_breadth is broad; otherwise null."
+  ),
+
   flags: z.array(z.string()).describe(
-    "Semantic violation tags: SKILL_MISMATCH (authority<70), WEAK_COMMITMENT (sincerity<70), VAGUE_INTENT (clarity<50), NOISE (ASSERTIVE or EXPRESSIVE)"
+    "Semantic violation tags: SKILL_MISMATCH (authority<70), WEAK_COMMITMENT (sincerity<70), VAGUE_INTENT (clarity<50), NOISE (ASSERTIVE or EXPRESSIVE), BROAD_ATTRIBUTIVE_REFERENCE (referential_breadth=broad)"
   ),
 });
 
@@ -178,6 +221,8 @@ const responseFormat = z.object({
 // 3. TYPE DEFINITIONS
 // ──────────────────────────────────────────────────────────────
 
+export type ReferentialBreadth = z.infer<typeof referentialBreadthSchema>;
+export type MissingSelectionalConstraint = z.infer<typeof missingSelectionalConstraintSchema>;
 export type SemanticVerifierOutput = z.infer<typeof responseFormat>;
 
 // ──────────────────────────────────────────────────────────────

--- a/packages/protocol/src/intent/tests/update-intent.spec.ts
+++ b/packages/protocol/src/intent/tests/update-intent.spec.ts
@@ -36,6 +36,12 @@ function captureTools(deps: ToolDeps): CapturedTool[] {
   return toolDefs;
 }
 
+function extractFirstIntentProposal(message: string): Record<string, unknown> {
+  const match = message.match(/```intent_proposal\s*\n([\s\S]*?)\n```/);
+  if (!match) throw new Error("intent proposal block not found");
+  return JSON.parse(match[1]) as Record<string, unknown>;
+}
+
 describe("create_intent", () => {
   test("falls back to approved user intro when structured profile is still pending", async () => {
     const capturedProfiles: string[] = [];
@@ -78,6 +84,98 @@ describe("create_intent", () => {
     expect(result.success).toBe(true);
     expect(capturedProfiles[0]).toContain("I build agent tools.");
     expect(capturedProfiles[0]).toContain("Healdsburg");
+  });
+
+  test("rejects broad referential-breadth signals in MCP auto-approve mode", async () => {
+    let createCalls = 0;
+    const tools = captureTools({
+      userDb: {},
+      systemDb: {},
+      graphs: {
+        profile: { invoke: async () => ({ profile: null, agentTimings: [] }) },
+        intent: {
+          invoke: async (input: { operationMode?: string }) => {
+            if (input.operationMode === "propose") {
+              return {
+                verifiedIntents: [{
+                  description: "Meet creative people, builders, and makers interested in AI and somatic exploration",
+                  score: 82,
+                  verification: {
+                    classification: "DIRECTIVE",
+                    semantic_entropy: 0.42,
+                    referential_breadth: "broad",
+                    missing_selectional_constraints: ["role", "outcome", "timeframe"],
+                    specificity_warning: "This signal is broad and may produce many weak matches.",
+                  },
+                }],
+                agentTimings: [],
+                trace: [],
+              };
+            }
+            createCalls++;
+            return { executionResults: [{ success: true }], agentTimings: [] };
+          },
+        },
+      },
+    } as unknown as ToolDeps);
+    const tool = tools.find((t) => t.name === "create_intent")!;
+
+    const result = JSON.parse(await tool.handler({
+      context: makeContext("alice"),
+      query: {
+        description: "Meet creative people, builders, and makers interested in AI and somatic exploration",
+        autoApprove: true,
+      },
+    }));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("broad");
+    expect(result.error).toContain("role, outcome, timeframe");
+    expect(createCalls).toBe(0);
+  });
+
+  test("surfaces referential-breadth warnings in web proposal cards", async () => {
+    const tools = captureTools({
+      userDb: {},
+      systemDb: {},
+      graphs: {
+        profile: { invoke: async () => ({ profile: null, agentTimings: [] }) },
+        intent: {
+          invoke: async () => ({
+            verifiedIntents: [{
+              description: "Meet creative people, builders, and makers interested in AI and somatic exploration",
+              score: 82,
+              verification: {
+                classification: "DIRECTIVE",
+                semantic_entropy: 0.42,
+                referential_breadth: "broad",
+                missing_selectional_constraints: ["role", "outcome", "timeframe"],
+                specificity_warning: "This signal is broad and may produce many weak matches.",
+              },
+            }],
+            agentTimings: [],
+            trace: [],
+          }),
+        },
+      },
+    } as unknown as ToolDeps);
+    const tool = tools.find((t) => t.name === "create_intent")!;
+    const context = { ...makeContext("alice"), isMcp: false } as ResolvedToolContext;
+
+    const result = JSON.parse(await tool.handler({
+      context,
+      query: {
+        description: "Meet creative people, builders, and makers interested in AI and somatic exploration",
+        autoApprove: false,
+      },
+    }));
+
+    expect(result.success).toBe(true);
+    const proposal = extractFirstIntentProposal(result.data.message);
+    expect(proposal.referentialBreadth).toBe("broad");
+    expect(proposal.specificityWarning).toContain("broad");
+    expect(proposal.missingSelectionalConstraints).toEqual(["role", "outcome", "timeframe"]);
+    expect(proposal.semanticEntropy).toBe(0.42);
   });
 });
 
@@ -143,6 +241,32 @@ describe("update_intent", () => {
     expect(capturedInputContent).toBe("Find a design partner for a CRPG UI");
     expect(parsed.success).toBe(true);
     expect(parsed.data.message).toBe("Intent updated.");
+  });
+
+  test("returns an error when verification filters the update into a no-op", async () => {
+    const tools = captureTools({
+      userDb: {},
+      systemDb: {
+        getIntent: async () => ({ id: "11111111-1111-4111-8111-111111111111", userId: "alice" }),
+      },
+      graphs: {
+        profile: { invoke: async () => ({ profile: null, agentTimings: [] }) },
+        intent: { invoke: async () => ({ verifiedIntents: [], actions: [], executionResults: [], agentTimings: [] }) },
+      },
+    } as unknown as ToolDeps);
+    const tool = tools.find((t) => t.name === "update_intent")!;
+
+    const result = JSON.parse(await tool.handler({
+      context: makeContext("alice"),
+      query: {
+        intentId: "11111111-1111-4111-8111-111111111111",
+        description: "Meet creative people, builders, and makers interested in AI and somatic exploration",
+      },
+    }));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("not applied");
+    expect(result.error).toContain("too broad");
   });
 });
 

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -1470,7 +1470,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
       if (isDigestMode) {
         // ── Digest mode: use LLM presenter for rich, second-person card text ──
         const presenter = new OpportunityPresenter();
-        const presenterDb = database as PresenterDatabase;
+        const presenterDb: PresenterDatabase = database;
         const PRESENTER_CONCURRENCY = 6;
 
         for (let i = 0; i < opportunities.length; i += PRESENTER_CONCURRENCY) {

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -358,7 +358,7 @@ export function buildOpportunityPresentation(
         if (card.profileUrl) lines.push(`   profileUrl: ${card.profileUrl}`);
         if (card.acceptUrl) lines.push(`   acceptUrl: ${card.acceptUrl}`);
         if (card.feedCategory) lines.push(`   feedCategory: ${card.feedCategory}`);
-        if (opts.includeDigestMarkers && card.score != null) lines.push(`   confidence: ${Math.round(card.score)}`);
+        if (opts.includeDigestMarkers && card.score != null) lines.push(`   confidence: ${Math.round(card.score * 100)}`);
         // Only surface opportunityId when there's no acceptUrl. Exposing the
         // UUID alongside an actionable link gives the LLM a foothold to
         // hallucinate bare `/api/opportunities/<id>/connect` URLs.

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -1470,7 +1470,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
       if (isDigestMode) {
         // ── Digest mode: use LLM presenter for rich, second-person card text ──
         const presenter = new OpportunityPresenter();
-        const db = database as unknown as PresenterDatabase & typeof database;
+        const presenterDb = database as PresenterDatabase;
         const PRESENTER_CONCURRENCY = 6;
 
         for (let i = 0; i < opportunities.length; i += PRESENTER_CONCURRENCY) {
@@ -1548,7 +1548,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
 
                 try {
                   const ctx = await gatherPresenterContext(
-                    db,
+                    presenterDb,
                     opp,
                     context.userId,
                     counterpartUserId,

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -8,7 +8,21 @@ import { MINIMAL_MAIN_TEXT_MAX_CHARS, getPrimaryActionLabel, SECONDARY_ACTION_LA
 import { viewerCentricCardSummary, narratorRemarkFromReasoning, stripUuids } from "./opportunity.presentation.js";
 import { runDiscoverFromQuery, continueDiscovery } from "./opportunity.discover.js";
 import { OpportunityPresenter, gatherPresenterContext, type PresenterDatabase } from "./opportunity.presenter.js";
-import { stripLeadingNarratorName } from "./feed/feed.graph.js";
+
+function stripLeadingNarratorName(remark: string, narratorName: string): string {
+  let t = remark.trim();
+  if (!t || !narratorName.trim()) return remark;
+  const name = narratorName.trim();
+  const nameLower = name.toLowerCase();
+  for (;;) {
+    const lower = t.toLowerCase();
+    if (!lower.startsWith(nameLower)) break;
+    const rest = t.slice(name.length).replace(/^\s*[:,\-–—]\s*/i, '').trim();
+    if (rest.length === 0 || rest === t) break;
+    t = rest;
+  }
+  return t;
+}
 import type { EvaluatorEntity } from "./opportunity.evaluator.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import type { Opportunity, OpportunityStatus } from "../shared/interfaces/database.interface.js";

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -5,9 +5,10 @@ import { requestContext } from "../shared/observability/request-context.js";
 import type { DefineTool, ToolDeps } from "../shared/agent/tool.helpers.js";
 import { success, error, UUID_REGEX } from "../shared/agent/tool.helpers.js";
 import { MINIMAL_MAIN_TEXT_MAX_CHARS, getPrimaryActionLabel, SECONDARY_ACTION_LABEL } from "./opportunity.labels.js";
-import { viewerCentricCardSummary, narratorRemarkFromReasoning } from "./opportunity.presentation.js";
+import { viewerCentricCardSummary, narratorRemarkFromReasoning, stripUuids } from "./opportunity.presentation.js";
 import { runDiscoverFromQuery, continueDiscovery } from "./opportunity.discover.js";
-import { OpportunityPresenter } from "./opportunity.presenter.js";
+import { OpportunityPresenter, gatherPresenterContext, type PresenterDatabase } from "./opportunity.presenter.js";
+import { stripLeadingNarratorName } from "./feed/feed.graph.js";
 import type { EvaluatorEntity } from "./opportunity.evaluator.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import type { Opportunity, OpportunityStatus } from "../shared/interfaces/database.interface.js";
@@ -1461,109 +1462,310 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         if (user) userMap.set(userId, user);
       });
 
-      const cardDataList: Array<ReturnType<typeof buildMinimalOpportunityCard>> = [];
+      const isDigestMode = context.isMcp === true && query.includeDigestMarkers === true;
+      const cardDataList: Array<Record<string, unknown> & { opportunityId: string }> = [];
       const seenOpportunityIds = new Set<string>();
       const skippedIds: string[] = [];
 
-      for (const opp of opportunities) {
-        if (seenOpportunityIds.has(opp.id)) continue;
-        seenOpportunityIds.add(opp.id);
-        try {
-          const counterpartActor = opp.actors.find(
-            (a) => a.userId !== context.userId && a.role !== "introducer",
-          );
-          const counterpartUserId = counterpartActor?.userId;
-          if (!counterpartUserId) continue;
+      if (isDigestMode) {
+        // ── Digest mode: use LLM presenter for rich, second-person card text ──
+        const presenter = new OpportunityPresenter();
+        const db = database as unknown as PresenterDatabase & typeof database;
+        const PRESENTER_CONCURRENCY = 6;
 
-          const viewerIsIntroducerHere = opp.actors.some(
-            (a) => a.role === "introducer" && a.userId === context.userId,
-          );
-          const secondPartyActorForHeadline = viewerIsIntroducerHere
-            ? opp.actors.find(
-                (a) =>
-                  a.userId !== context.userId &&
-                  a.userId !== counterpartUserId &&
-                  a.role !== "introducer",
-              )
-            : undefined;
-          const secondPartyNameForHeadline = secondPartyActorForHeadline
-            ? (profileMap.get(secondPartyActorForHeadline.userId)?.identity?.name ??
-              userMap.get(secondPartyActorForHeadline.userId)?.name ??
-              undefined)
-            : undefined;
+        for (let i = 0; i < opportunities.length; i += PRESENTER_CONCURRENCY) {
+          const chunk = opportunities.slice(i, i + PRESENTER_CONCURRENCY);
+          const chunkCards = await Promise.all(
+            chunk.map(async (opp) => {
+              if (seenOpportunityIds.has(opp.id)) return null;
+              seenOpportunityIds.add(opp.id);
+              try {
+                const counterpartActor = opp.actors.find(
+                  (a) => a.userId !== context.userId && a.role !== "introducer",
+                );
+                const counterpartUserId = counterpartActor?.userId;
+                if (!counterpartUserId) return null;
 
-          const introducerActor = opp.actors.find(
-            (a) => a.role === "introducer" && a.userId !== context.userId,
-          );
-          const createdByName = opp.detection.createdByName;
+                const viewerIsIntroducerHere = opp.actors.some(
+                  (a) => a.role === "introducer" && a.userId === context.userId,
+                );
+                const secondPartyActorForHeadline = viewerIsIntroducerHere
+                  ? opp.actors.find(
+                      (a) =>
+                        a.userId !== context.userId &&
+                        a.userId !== counterpartUserId &&
+                        a.role !== "introducer",
+                    )
+                  : undefined;
 
-          const counterpartProfile = profileMap.get(counterpartUserId) ?? null;
-          const counterpartUser = userMap.get(counterpartUserId) ?? null;
-          const introducerProfile =
-            introducerActor && !createdByName
-              ? profileMap.get(introducerActor.userId) ?? null
+                const introducerActor = opp.actors.find(
+                  (a) => a.role === "introducer" && a.userId !== context.userId,
+                );
+                const createdByName = opp.detection.createdByName;
+
+                const counterpartUser = userMap.get(counterpartUserId) ?? null;
+                const counterpartName =
+                  profileMap.get(counterpartUserId)?.identity?.name ??
+                  counterpartUser?.name ??
+                  "Someone";
+                const introducerName =
+                  createdByName ??
+                  (introducerActor
+                    ? (profileMap.get(introducerActor.userId)?.identity?.name ?? null)
+                    : null);
+                const introducerUser = introducerActor
+                  ? userMap.get(introducerActor.userId) ?? null
+                  : null;
+
+                const secondPartyUser = secondPartyActorForHeadline
+                  ? userMap.get(secondPartyActorForHeadline.userId) ?? null
+                  : null;
+                const secondPartyNameForHeadline = secondPartyActorForHeadline
+                  ? (profileMap.get(secondPartyActorForHeadline.userId)?.identity?.name ??
+                    secondPartyUser?.name ??
+                    undefined)
+                  : undefined;
+
+                const viewerActor = opp.actors.find((a) => a.userId === context.userId);
+                const viewerRole = viewerActor?.role ?? "party";
+                const isCounterpartGhost = counterpartUser?.isGhost ?? false;
+
+                // Build fallback card in case LLM presenter fails
+                const fallbackCard = buildMinimalOpportunityCard(
+                  opp,
+                  context.userId,
+                  counterpartUserId,
+                  counterpartName,
+                  counterpartUser?.avatar ?? null,
+                  introducerName,
+                  introducerUser?.avatar ?? null,
+                  viewerName,
+                  secondPartyNameForHeadline,
+                  secondPartyUser?.avatar ?? null,
+                  secondPartyActorForHeadline?.userId,
+                  isCounterpartGhost,
+                );
+
+                try {
+                  const ctx = await gatherPresenterContext(
+                    db,
+                    opp,
+                    context.userId,
+                    counterpartUserId,
+                  );
+
+                  const presentation = await presenter.presentHomeCard({
+                    ...ctx,
+                    opportunityStatus: opp.status,
+                  });
+
+                  // Build narrator chip from presenter output
+                  let narratorChip: { name: string; text: string; avatar?: string | null; userId?: string };
+                  const introducerIsCounterpart = introducerActor && counterpartActor && introducerActor.userId === counterpartActor.userId;
+                  if (introducerActor && introducerActor.userId !== context.userId && !introducerIsCounterpart) {
+                    const narratorName = introducerName ?? "Someone";
+                    narratorChip = {
+                      name: narratorName,
+                      text: stripLeadingNarratorName(presentation.narratorRemark, narratorName),
+                      avatar: introducerUser?.avatar ?? null,
+                      userId: introducerActor.userId,
+                    };
+                  } else if (introducerActor?.userId === context.userId) {
+                    narratorChip = { name: "You", text: presentation.narratorRemark, userId: context.userId };
+                  } else {
+                    narratorChip = { name: "Index", text: presentation.narratorRemark };
+                  }
+
+                  const card: Record<string, unknown> = {
+                    opportunityId: opp.id,
+                    userId: counterpartUserId,
+                    name: counterpartName,
+                    avatar: counterpartUser?.avatar ?? null,
+                    mainText: stripUuids(presentation.personalizedSummary),
+                    cta: presentation.suggestedAction,
+                    headline: viewerIsIntroducerHere && secondPartyNameForHeadline
+                      ? `${counterpartName} → ${secondPartyNameForHeadline}`
+                      : presentation.headline,
+                    primaryActionLabel: getPrimaryActionLabel(viewerRole),
+                    secondaryActionLabel: SECONDARY_ACTION_LABEL,
+                    mutualIntentsLabel: presentation.mutualIntentsLabel,
+                    narratorChip,
+                    viewerRole,
+                    score: typeof opp.interpretation?.confidence === "number"
+                      ? opp.interpretation.confidence
+                      : undefined,
+                    status: opp.status,
+                    isGhost: isCounterpartGhost,
+                    ...(viewerIsIntroducerHere && secondPartyNameForHeadline
+                      ? {
+                          secondParty: {
+                            name: secondPartyNameForHeadline,
+                            ...(secondPartyUser?.avatar != null ? { avatar: secondPartyUser.avatar } : {}),
+                            ...(secondPartyActorForHeadline?.userId ? { userId: secondPartyActorForHeadline.userId } : {}),
+                          },
+                        }
+                      : {}),
+                  };
+
+                  // Attach actionable links for MCP callers
+                  if (context.isMcp && deps.mintConnectLink) {
+                    const viewerApproved =
+                      viewerActor?.role === "introducer" ? viewerActor.approved === true : undefined;
+                    await attachActionableLinks(card as Record<string, unknown> & {
+                      opportunityId: string;
+                      viewerRole: string;
+                      status: string;
+                    }, {
+                      viewerId: context.userId,
+                      viewerApproved,
+                      counterpartUserId,
+                      mintConnectLink: deps.mintConnectLink,
+                      frontendUrl: deps.frontendUrl,
+                      preferredSurface: context.clientSurface,
+                    });
+                  }
+
+                  return card as Record<string, unknown> & { opportunityId: string };
+                } catch (presenterErr) {
+                  logger.warn("LLM presenter failed for list_opportunities digest card, using fallback", {
+                    opportunityId: opp.id,
+                    err: presenterErr,
+                  });
+                  // Attach links to fallback card too
+                  if (context.isMcp && deps.mintConnectLink) {
+                    const viewerApproved =
+                      viewerActor?.role === "introducer" ? viewerActor.approved === true : undefined;
+                    await attachActionableLinks(fallbackCard as Record<string, unknown> & {
+                      opportunityId: string;
+                      viewerRole: string;
+                      status: string;
+                    }, {
+                      viewerId: context.userId,
+                      viewerApproved,
+                      counterpartUserId,
+                      mintConnectLink: deps.mintConnectLink,
+                      frontendUrl: deps.frontendUrl,
+                      preferredSurface: context.clientSurface,
+                    });
+                  }
+                  return fallbackCard as Record<string, unknown> & { opportunityId: string };
+                }
+              } catch (err) {
+                logger.warn("Skipping opportunity that failed to build card", {
+                  opportunityId: opp.id,
+                  err,
+                });
+                skippedIds.push(opp.id);
+                return null;
+              }
+            }),
+          );
+          for (const card of chunkCards) {
+            if (card) cardDataList.push(card);
+          }
+        }
+      } else {
+        // ── Chat mode: fast heuristic path (no LLM) ──
+        for (const opp of opportunities) {
+          if (seenOpportunityIds.has(opp.id)) continue;
+          seenOpportunityIds.add(opp.id);
+          try {
+            const counterpartActor = opp.actors.find(
+              (a) => a.userId !== context.userId && a.role !== "introducer",
+            );
+            const counterpartUserId = counterpartActor?.userId;
+            if (!counterpartUserId) continue;
+
+            const viewerIsIntroducerHere = opp.actors.some(
+              (a) => a.role === "introducer" && a.userId === context.userId,
+            );
+            const secondPartyActorForHeadline = viewerIsIntroducerHere
+              ? opp.actors.find(
+                  (a) =>
+                    a.userId !== context.userId &&
+                    a.userId !== counterpartUserId &&
+                    a.role !== "introducer",
+                )
+              : undefined;
+            const secondPartyNameForHeadline = secondPartyActorForHeadline
+              ? (profileMap.get(secondPartyActorForHeadline.userId)?.identity?.name ??
+                userMap.get(secondPartyActorForHeadline.userId)?.name ??
+                undefined)
+              : undefined;
+
+            const introducerActor = opp.actors.find(
+              (a) => a.role === "introducer" && a.userId !== context.userId,
+            );
+            const createdByName = opp.detection.createdByName;
+
+            const counterpartProfile = profileMap.get(counterpartUserId) ?? null;
+            const counterpartUser = userMap.get(counterpartUserId) ?? null;
+            const introducerProfile =
+              introducerActor && !createdByName
+                ? profileMap.get(introducerActor.userId) ?? null
+                : null;
+
+            const counterpartName =
+              counterpartProfile?.identity?.name ??
+              counterpartUser?.name ??
+              "Someone";
+            const introducerName =
+              createdByName ??
+              (introducerActor ? introducerProfile?.identity?.name ?? null : null);
+            const introducerUser = introducerActor
+              ? userMap.get(introducerActor.userId) ?? null
               : null;
 
-          const counterpartName =
-            counterpartProfile?.identity?.name ??
-            counterpartUser?.name ??
-            "Someone";
-          const introducerName =
-            createdByName ??
-            (introducerActor ? introducerProfile?.identity?.name ?? null : null);
-          const introducerUser = introducerActor
-            ? userMap.get(introducerActor.userId) ?? null
-            : null;
-
-          const secondPartyUser = secondPartyActorForHeadline
-            ? userMap.get(secondPartyActorForHeadline.userId) ?? null
-            : null;
-          const cardData = buildMinimalOpportunityCard(
-            opp,
-            context.userId,
-            counterpartUserId,
-            counterpartName,
-            counterpartUser?.avatar ?? null,
-            introducerName,
-            introducerUser?.avatar ?? null,
-            viewerName,
-            secondPartyNameForHeadline,
-            secondPartyUser?.avatar ?? null,
-            secondPartyActorForHeadline?.userId,
-          );
-
-          // For MCP callers (e.g. Edge Claw), mint a connect token and attach
-          // acceptUrl + profileUrl when the (status, viewerRole) is actionable
-          // for the viewer. Non-actionable combos (sender-on-draft,
-          // pending-on-introducer-waiting, rejected, etc.) deliberately get
-          // no link — the LLM would otherwise hallucinate `/api/.../connect`
-          // URLs from the exposed opportunityId.
-          if (context.isMcp && deps.mintConnectLink) {
-            const viewerActor = opp.actors.find((a) => a.userId === context.userId);
-            const viewerApproved =
-              viewerActor?.role === "introducer" ? viewerActor.approved === true : undefined;
-            await attachActionableLinks(cardData as Record<string, unknown> & {
-              opportunityId: string;
-              viewerRole: string;
-              status: string;
-            }, {
-              viewerId: context.userId,
-              viewerApproved,
+            const secondPartyUser = secondPartyActorForHeadline
+              ? userMap.get(secondPartyActorForHeadline.userId) ?? null
+              : null;
+            const cardData = buildMinimalOpportunityCard(
+              opp,
+              context.userId,
               counterpartUserId,
-              mintConnectLink: deps.mintConnectLink,
-              frontendUrl: deps.frontendUrl,
-              preferredSurface: context.clientSurface,
-            });
-          }
+              counterpartName,
+              counterpartUser?.avatar ?? null,
+              introducerName,
+              introducerUser?.avatar ?? null,
+              viewerName,
+              secondPartyNameForHeadline,
+              secondPartyUser?.avatar ?? null,
+              secondPartyActorForHeadline?.userId,
+            );
 
-          cardDataList.push(cardData);
-        } catch (err) {
-          logger.warn("Skipping opportunity that failed to build minimal card", {
-            opportunityId: opp.id,
-            err,
-          });
-          skippedIds.push(opp.id);
-          continue;
+            // For MCP callers (e.g. Edge Claw), mint a connect token and attach
+            // acceptUrl + profileUrl when the (status, viewerRole) is actionable
+            // for the viewer. Non-actionable combos (sender-on-draft,
+            // pending-on-introducer-waiting, rejected, etc.) deliberately get
+            // no link — the LLM would otherwise hallucinate `/api/.../connect`
+            // URLs from the exposed opportunityId.
+            if (context.isMcp && deps.mintConnectLink) {
+              const viewerActor = opp.actors.find((a) => a.userId === context.userId);
+              const viewerApproved =
+                viewerActor?.role === "introducer" ? viewerActor.approved === true : undefined;
+              await attachActionableLinks(cardData as Record<string, unknown> & {
+                opportunityId: string;
+                viewerRole: string;
+                status: string;
+              }, {
+                viewerId: context.userId,
+                viewerApproved,
+                counterpartUserId,
+                mintConnectLink: deps.mintConnectLink,
+                frontendUrl: deps.frontendUrl,
+                preferredSurface: context.clientSurface,
+              });
+            }
+
+            cardDataList.push(cardData);
+          } catch (err) {
+            logger.warn("Skipping opportunity that failed to build minimal card", {
+              opportunityId: opp.id,
+              err,
+            });
+            skippedIds.push(opp.id);
+            continue;
+          }
         }
       }
 

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -19,10 +19,11 @@ function stripLeadingNarratorName(remark: string, narratorName: string): string 
     if (!lower.startsWith(nameLower)) break;
     // Require a word boundary after the name so a short name like "Al" does not
     // mangle a longer word ("Always …" → "ways …"). The char after the name must
-    // be a separator (punctuation/whitespace) or the end of the string.
+    // be a separator (sentence/clause punctuation or whitespace) or end of string.
+    // Keep this set in sync with the separator stripped from `rest` below.
     const boundary = t.charAt(name.length);
-    if (boundary && !/[\s:,\-–—]/.test(boundary)) break;
-    const rest = t.slice(name.length).replace(/^\s*[:,\-–—]\s*/i, '').trim();
+    if (boundary && !/[\s.:,\-–—]/.test(boundary)) break;
+    const rest = t.slice(name.length).replace(/^\s*[.:,\-–—]\s*/i, '').trim();
     if (rest.length === 0 || rest === t) break;
     t = rest;
   }

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -1584,7 +1584,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
                   let narratorChip: { name: string; text: string; avatar?: string | null; userId?: string };
                   const introducerIsCounterpart = introducerActor && counterpartActor && introducerActor.userId === counterpartActor.userId;
                   if (introducerActor && introducerActor.userId !== context.userId && !introducerIsCounterpart) {
-                    const narratorName = introducerName ?? "Someone";
+                    const narratorName = introducerName?.trim() || "Someone";
                     narratorChip = {
                       name: narratorName,
                       text: stripLeadingNarratorName(presentation.narratorRemark, narratorName),

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -17,6 +17,11 @@ function stripLeadingNarratorName(remark: string, narratorName: string): string 
   for (;;) {
     const lower = t.toLowerCase();
     if (!lower.startsWith(nameLower)) break;
+    // Require a word boundary after the name so a short name like "Al" does not
+    // mangle a longer word ("Always …" → "ways …"). The char after the name must
+    // be a separator (punctuation/whitespace) or the end of the string.
+    const boundary = t.charAt(name.length);
+    if (boundary && !/[\s:,\-–—]/.test(boundary)) break;
     const rest = t.slice(name.length).replace(/^\s*[:,\-–—]\s*/i, '').trim();
     if (rest.length === 0 || rest === t) break;
     t = rest;

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -314,6 +314,7 @@ type OpportunityCardLike = Record<string, unknown> & {
   feedCategory?: string | undefined;
   acceptUrl?: string | undefined;
   profileUrl?: string | undefined;
+  score?: number | undefined;
 };
 
 /**
@@ -357,6 +358,7 @@ export function buildOpportunityPresentation(
         if (card.profileUrl) lines.push(`   profileUrl: ${card.profileUrl}`);
         if (card.acceptUrl) lines.push(`   acceptUrl: ${card.acceptUrl}`);
         if (card.feedCategory) lines.push(`   feedCategory: ${card.feedCategory}`);
+        if (opts.includeDigestMarkers && card.score != null) lines.push(`   confidence: ${Math.round(card.score)}`);
         // Only surface opportunityId when there's no acceptUrl. Exposing the
         // UUID alongside an actionable link gives the LLM a foothold to
         // hallucinate bare `/api/opportunities/<id>/connect` URLs.
@@ -378,7 +380,7 @@ export function buildOpportunityPresentation(
       `${opts.leadIn}\n\n${prose}\n\n` +
       `Summarize these for the user in natural prose — mention first names and a brief match reason per connection. ` +
       `${linkInstructions}` +
-      `Do NOT print raw JSON, field labels, opportunityIds, or confidence scores. ` +
+      `Do NOT print raw JSON, field labels, or opportunityIds. ` +
       `${idInstructions}`
     );
   }

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts
@@ -42,7 +42,6 @@ afterAll(() => mock.restore());
 
 // ─── Imports after mocks ──────────────────────────────────────────────────────
 
-const { buildMinimalOpportunityCard } = await import('../opportunity.tools.js');
 const { createOpportunityTools } = await import('../opportunity.tools.js');
 const { z } = await import('zod');
 

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts
@@ -1,0 +1,212 @@
+// Stub API key to prevent module-level createModel() from throwing
+process.env.OPENROUTER_API_KEY = 'test-key-unused';
+
+import { mock, describe, expect, it, afterAll } from 'bun:test';
+
+import type { OpportunityPresenter } from '../opportunity.presenter.js';
+import type { PresenterDatabase } from '../opportunity.presenter.js';
+
+// ─── Module-level mocks: must run before any static import of opportunity.tools ───
+
+let presentHomeCardMock: ReturnType<typeof mock>;
+let gatherPresenterContextMock: ReturnType<typeof mock>;
+
+mock.module('../opportunity.presenter.js', () => {
+  presentHomeCardMock = mock(async () => ({
+    headline: 'Test Headline',
+    personalizedSummary: 'Test personalized summary.',
+    suggestedAction: 'Test action',
+    narratorRemark: 'Test narrator remark',
+    mutualIntentsLabel: undefined,
+  }));
+  gatherPresenterContextMock = mock(async (
+    presenterDb: PresenterDatabase,
+    opp: any,
+    viewerId: string,
+  ) => ({
+    opportunityStatus: opp.status,
+  }));
+
+  return {
+    OpportunityPresenter: class {
+      presentHomeCard(input: any) {
+        return presentHomeCardMock(input);
+      }
+    },
+    gatherPresenterContext: (...args: any[]) => gatherPresenterContextMock(...args),
+    PresenterDatabase: undefined as any, // type-only, not consumed at runtime
+  };
+});
+
+afterAll(() => mock.restore());
+
+// ─── Imports after mocks ──────────────────────────────────────────────────────
+
+const { buildMinimalOpportunityCard } = await import('../opportunity.tools.js');
+const { createOpportunityTools } = await import('../opportunity.tools.js');
+const { z } = await import('zod');
+
+import type { ToolDeps } from '../../shared/agent/tool.helpers.js';
+import type {
+  ChatGraphCompositeDatabase,
+  Opportunity,
+  UserRecord,
+  ProfileRow,
+} from '../../shared/interfaces/database.interface.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const testUserId = 'u-test-viewer';
+
+function makeOpp(
+  id: string,
+  counterpartUserId: string,
+  status: string = 'pending',
+  confidence: number = 0.85,
+): Opportunity {
+  return {
+    id,
+    status,
+    interpretation: { reasoning: `Reasoning for ${counterpartUserId}`, confidence },
+    actors: [
+      { userId: testUserId, role: 'party' },
+      { userId: counterpartUserId, role: 'party' },
+    ],
+    detection: { source: 'discovery', createdByName: null },
+    context: {},
+    confidence: confidence,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    expiresAt: null,
+  } as unknown as Opportunity;
+}
+
+function defineTool<T extends z.ZodType>(opts: {
+  name: string;
+  description: string;
+  querySchema: T;
+  handler: (input: { context: any; query: z.infer<T> }) => Promise<string>;
+}) {
+  return opts;
+}
+
+function parseResult(text: string) {
+  return JSON.parse(text) as { success: boolean; data?: Record<string, unknown>; error?: string };
+}
+
+let getOppsForUser = mock(async () => [] as Opportunity[]);
+let getUser = mock(async () => ({ id: testUserId, name: 'Test User' }) as UserRecord | null);
+let getProfile = mock(async () => (null) as ProfileRow | null);
+
+const noopGraph = { invoke: async () => ({}) };
+
+function makeDeps(overrides: Partial<Parameters<typeof createOpportunityTools>[1]> = {}): ToolDeps {
+  const mockDb = {
+    getOpportunitiesForUser: getOppsForUser,
+    getUser,
+    getProfile,
+    getActiveIntents: mock(async () => []),
+    getNetwork: mock(async () => null),
+    getPremisesForUser: mock(async () => []),
+  };
+  return {
+    database: mockDb as unknown as ChatGraphCompositeDatabase,
+    userDb: {
+      getUser,
+      getProfile,
+      getUserSocials: mock(async () => []),
+      saveProfile: mock(async () => {}),
+      updateUser: mock(async () => {}),
+      setUserSocials: mock(async () => {}),
+      getPremisesForUser: mock(async () => []),
+      getActiveIntents: mock(async () => []),
+      getNetwork: mock(async () => null),
+    } as any,
+    systemDb: {} as any,
+    scraper: {} as any,
+    embedder: { embedText: mock(async () => []), generateEmbedding: mock(async () => []) } as any,
+    cache: {} as any,
+    integration: {} as any,
+    contactService: {} as any,
+    integrationImporter: {} as any,
+    enricher: {} as any,
+    negotiationDatabase: {} as any,
+    graphs: {
+      profile: noopGraph as any,
+      intent: noopGraph as any,
+      index: noopGraph as any,
+      networkMembership: noopGraph as any,
+      intentIndex: noopGraph as any,
+      opportunity: noopGraph as any,
+      premise: noopGraph as any,
+    },
+    ...overrides,
+  } as ToolDeps;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('list_opportunities digest presenter path', () => {
+  it('uses LLM presenter text when includeDigestMarkers=true and isMcp=true', async () => {
+    getOppsForUser = mock(async () => [makeOpp('opp-1', 'c-1')]);
+    getUser = mock(async () => ({ id: testUserId, name: 'Viewer' }) as UserRecord | null);
+    getProfile = mock(async () => ({ identity: { name: 'Alice', bio: '', location: '' }, userId: 'c-1' }) as ProfileRow | null);
+
+    const deps = makeDeps();
+    const tools = createOpportunityTools(defineTool as any, deps);
+    const listTool = tools.find((t: any) => t.name === 'list_opportunities')!;
+
+    const result = parseResult(
+      await listTool.handler({
+        context: {
+          userId: testUserId,
+          isMcp: true,
+          networkId: undefined,
+          sessionId: undefined,
+          userName: 'Viewer',
+          userNetworks: [],
+        },
+        query: { includeDigestMarkers: true },
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(gatherPresenterContextMock).toHaveBeenCalled();
+    expect(presentHomeCardMock).toHaveBeenCalled();
+    expect(String(result.data?.message)).toContain('Test personalized summary');
+  });
+
+  it('falls back to buildMinimalOpportunityCard when presenter throws', async () => {
+    getOppsForUser = mock(async () => [makeOpp('opp-2', 'c-2')]);
+    getUser = mock(async () => ({ id: testUserId, name: 'Viewer' }) as UserRecord | null);
+    getProfile = mock(async () => ({ identity: { name: 'Bob', bio: '', location: '' }, userId: 'c-2' }) as ProfileRow | null);
+
+    presentHomeCardMock = mock(async () => {
+      throw new Error('Presenter failed');
+    });
+
+    const deps = makeDeps();
+    const tools = createOpportunityTools(defineTool as any, deps);
+    const listTool = tools.find((t: any) => t.name === 'list_opportunities')!;
+
+    const result = parseResult(
+      await listTool.handler({
+        context: {
+          userId: testUserId,
+          isMcp: true,
+          networkId: undefined,
+          sessionId: undefined,
+          userName: 'Viewer',
+          userNetworks: [],
+        },
+        query: { includeDigestMarkers: true },
+      }),
+    );
+
+    // Should succeed and include the counterpart name from the fallback
+    expect(result.success).toBe(true);
+    expect(String(result.data?.message)).toContain('Bob');
+    // Fallback card should NOT contain presenter-specific text
+    expect(String(result.data?.message)).not.toContain('Test personalized summary');
+  });
+});

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts
@@ -21,7 +21,7 @@ mock.module('../opportunity.presenter.js', () => {
   }));
   gatherPresenterContextMock = mock(async (
     presenterDb: PresenterDatabase,
-    opp: any,
+    opp: { status: string },
     viewerId: string,
   ) => ({
     opportunityStatus: opp.status,
@@ -29,12 +29,12 @@ mock.module('../opportunity.presenter.js', () => {
 
   return {
     OpportunityPresenter: class {
-      presentHomeCard(input: any) {
+      presentHomeCard(input: unknown) {
         return presentHomeCardMock(input);
       }
     },
-    gatherPresenterContext: (...args: any[]) => gatherPresenterContextMock(...args),
-    PresenterDatabase: undefined as any, // type-only, not consumed at runtime
+    gatherPresenterContext: (...args: unknown[]) => gatherPresenterContextMock(...args),
+    PresenterDatabase: undefined as unknown as PresenterDatabase, // type-only, not consumed at runtime
   };
 });
 

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts
@@ -1,5 +1,5 @@
-// Stub API key to prevent module-level createModel() from throwing
-process.env.OPENROUTER_API_KEY = 'test-key-unused';
+// Stub API key to prevent module-level createModel() from throwing — only set when absent
+process.env.OPENROUTER_API_KEY ||= 'test-key-unused';
 
 import { mock, describe, expect, it, afterAll } from 'bun:test';
 

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts
@@ -46,7 +46,7 @@ const { buildMinimalOpportunityCard } = await import('../opportunity.tools.js');
 const { createOpportunityTools } = await import('../opportunity.tools.js');
 const { z } = await import('zod');
 
-import type { ToolDeps } from '../../shared/agent/tool.helpers.js';
+import type { ToolDeps, DefineTool } from '../../shared/agent/tool.helpers.js';
 import type {
   ChatGraphCompositeDatabase,
   Opportunity,
@@ -121,25 +121,25 @@ function makeDeps(overrides: Partial<Parameters<typeof createOpportunityTools>[1
       getPremisesForUser: mock(async () => []),
       getActiveIntents: mock(async () => []),
       getNetwork: mock(async () => null),
-    } as any,
-    systemDb: {} as any,
-    scraper: {} as any,
-    embedder: { embedText: mock(async () => []), generateEmbedding: mock(async () => []) } as any,
-    cache: {} as any,
-    integration: {} as any,
-    contactService: {} as any,
-    integrationImporter: {} as any,
-    enricher: {} as any,
-    negotiationDatabase: {} as any,
+    } as unknown as ToolDeps["userDb"],
+    systemDb: {} as unknown as ToolDeps["systemDb"],
+    scraper: {} as unknown as ToolDeps["scraper"],
+    embedder: { embedText: mock(async () => []), generateEmbedding: mock(async () => []) } as unknown as ToolDeps["embedder"],
+    cache: {} as unknown as ToolDeps["cache"],
+    integration: {} as unknown as ToolDeps["integration"],
+    contactService: {} as unknown as ToolDeps["contactService"],
+    integrationImporter: {} as unknown as ToolDeps["integrationImporter"],
+    enricher: {} as unknown as ToolDeps["enricher"],
+    negotiationDatabase: {} as unknown as ToolDeps["negotiationDatabase"],
     graphs: {
-      profile: noopGraph as any,
-      intent: noopGraph as any,
-      index: noopGraph as any,
-      networkMembership: noopGraph as any,
-      intentIndex: noopGraph as any,
-      opportunity: noopGraph as any,
-      premise: noopGraph as any,
-    },
+      profile: noopGraph,
+      intent: noopGraph,
+      index: noopGraph,
+      networkMembership: noopGraph,
+      intentIndex: noopGraph,
+      opportunity: noopGraph,
+      premise: noopGraph,
+    } as unknown as ToolDeps["graphs"],
     ...overrides,
   } as ToolDeps;
 }
@@ -153,8 +153,8 @@ describe('list_opportunities digest presenter path', () => {
     getProfile = mock(async () => ({ identity: { name: 'Alice', bio: '', location: '' }, userId: 'c-1' }) as ProfileRow | null);
 
     const deps = makeDeps();
-    const tools = createOpportunityTools(defineTool as any, deps);
-    const listTool = tools.find((t: any) => t.name === 'list_opportunities')!;
+    const tools = createOpportunityTools(defineTool as unknown as DefineTool, deps);
+    const listTool = tools.find((t: { name: string }) => t.name === 'list_opportunities')!;
 
     const result = parseResult(
       await listTool.handler({
@@ -186,8 +186,8 @@ describe('list_opportunities digest presenter path', () => {
     });
 
     const deps = makeDeps();
-    const tools = createOpportunityTools(defineTool as any, deps);
-    const listTool = tools.find((t: any) => t.name === 'list_opportunities')!;
+    const tools = createOpportunityTools(defineTool as unknown as DefineTool, deps);
+    const listTool = tools.find((t: { name: string }) => t.name === 'list_opportunities')!;
 
     const result = parseResult(
       await listTool.handler({

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts
@@ -3,7 +3,6 @@ process.env.OPENROUTER_API_KEY ||= 'test-key-unused';
 
 import { mock, describe, expect, it, afterAll } from 'bun:test';
 
-import type { OpportunityPresenter } from '../opportunity.presenter.js';
 import type { PresenterDatabase } from '../opportunity.presenter.js';
 
 // ─── Module-level mocks: must run before any static import of opportunity.tools ───
@@ -22,7 +21,7 @@ mock.module('../opportunity.presenter.js', () => {
   gatherPresenterContextMock = mock(async (
     presenterDb: PresenterDatabase,
     opp: { status: string },
-    viewerId: string,
+    _viewerId: string,
   ) => ({
     opportunityStatus: opp.status,
   }));

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts
@@ -85,7 +85,7 @@ function defineTool<T extends z.ZodType>(opts: {
   name: string;
   description: string;
   querySchema: T;
-  handler: (input: { context: any; query: z.infer<T> }) => Promise<string>;
+  handler: (input: { context: unknown; query: z.infer<T> }) => Promise<string>;
 }) {
   return opts;
 }

--- a/packages/protocol/src/profile/profile.tools.ts
+++ b/packages/protocol/src/profile/profile.tools.ts
@@ -26,11 +26,13 @@ function isMeaningfulEnrichment(enrichment: EnrichmentResult | null): enrichment
     );
 }
 
-type ApprovedProfileDraft = {
-  identity: { name: string; bio: string; location: string };
-  narrative: { context: string };
-  attributes: { interests: string[]; skills: string[] };
-};
+const approvedProfileDraftSchema = z.object({
+  identity: z.object({ name: z.string(), bio: z.string(), location: z.string() }),
+  narrative: z.object({ context: z.string() }),
+  attributes: z.object({ interests: z.array(z.string()), skills: z.array(z.string()) }),
+});
+
+type ApprovedProfileDraft = z.infer<typeof approvedProfileDraftSchema>;
 
 export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
   const { userDb, systemDb, database, graphs, enricher, grantDefaultSystemPermissions, reportToolError } = deps;
@@ -657,11 +659,7 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
       "Saves an explicitly approved onboarding profile draft. Call this only after the user has seen the draft from preview_user_profile and approved it or provided corrections. " +
       "This path uses only the approved draft/explicit correction text and does not scrape or run public lookup.",
     querySchema: z.object({
-      draft: z.object({
-        identity: z.object({ name: z.string(), bio: z.string(), location: z.string() }),
-        narrative: z.object({ context: z.string() }),
-        attributes: z.object({ interests: z.array(z.string()), skills: z.array(z.string()) }),
-      }).optional().describe("The structured profile draft returned by preview_user_profile after user approval."),
+      draft: approvedProfileDraftSchema.optional().describe("The structured profile draft returned by preview_user_profile after user approval."),
       bioOrDescription: z.string().optional().describe("Approved correction or explicit profile text if not passing a structured draft."),
       name: z.string().optional().describe("Approved name correction."),
       location: z.string().optional().describe("Approved location correction."),

--- a/packages/protocol/src/profile/profile.tools.ts
+++ b/packages/protocol/src/profile/profile.tools.ts
@@ -241,7 +241,7 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
     traceEmitter?.({ type: "graph_start", name: "profile" });
     try {
       const graphInput = {
-        userId: context.userId,
+        userId: profile.userId,
         operationMode: 'write' as const,
         input,
         forceUpdate: true,
@@ -253,14 +253,14 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
       if (result.error) {
         const err = new Error(result.error);
         logger.error('Approved draft premise decomposition failed', {
-          userId: context.userId,
+          userId: profile.userId,
           error: result.error,
         });
         reportToolError?.(err, {
           subsystem: 'profile',
           operation: 'profile.confirm_draft_decompose',
           toolName: 'confirm_user_profile',
-          userId: context.userId,
+          userId: profile.userId,
           tags: { toolName: 'confirm_user_profile', execution: context.isMcp ? 'background' : 'sync' },
         });
         return;
@@ -273,14 +273,14 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
       // authoritative, and a concurrent user-driven profile update could race.
     } catch (err) {
       logger.error('Approved draft premise decomposition failed', {
-        userId: context.userId,
+        userId: profile.userId,
         error: err instanceof Error ? err.message : String(err),
       });
       reportToolError?.(err, {
         subsystem: 'profile',
         operation: 'profile.confirm_draft_decompose',
         toolName: 'confirm_user_profile',
-        userId: context.userId,
+        userId: profile.userId,
         tags: { toolName: 'confirm_user_profile', execution: context.isMcp ? 'background' : 'sync' },
       });
     } finally {

--- a/packages/protocol/src/profile/profile.tools.ts
+++ b/packages/protocol/src/profile/profile.tools.ts
@@ -679,7 +679,12 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
             });
           });
         } else {
-          await decomposeApprovedDraftProfile(context, profile);
+          decomposeApprovedDraftProfile(context, profile).catch((err: unknown) => {
+            logger.error('Approved draft premise decomposition failed (web)', {
+              userId: context.userId,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          });
         }
 
         return success({

--- a/packages/protocol/src/profile/profile.tools.ts
+++ b/packages/protocol/src/profile/profile.tools.ts
@@ -264,10 +264,11 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
         return;
       }
 
-      // The write graph may regenerate the profile from newly-created premises.
-      // The user explicitly approved this structured draft, so keep the approved
-      // draft as the persisted profile while retaining the graph-created premises.
-      await userDb.saveProfile(profile);
+      // The write graph's decompose → aggregate → generate → save_profile
+      // pipeline persists the aggregate profile. The approved draft was already
+      // saved before decomposition started, so the DB is consistent regardless
+      // of graph outcome.  Do not re-save here — the graph's save_profile is
+      // authoritative, and a concurrent user-driven profile update could race.
     } catch (err) {
       logger.error('Approved draft premise decomposition failed', {
         userId: context.userId,

--- a/packages/protocol/src/profile/profile.tools.ts
+++ b/packages/protocol/src/profile/profile.tools.ts
@@ -230,7 +230,6 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
   }
 
   async function decomposeApprovedDraftProfile(
-    context: ResolvedToolContext,
     profile: ApprovedProfileDraft & { userId: string },
   ): Promise<void> {
     const input = buildApprovedDraftProfileInput(profile);
@@ -246,9 +245,11 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
         input,
         forceUpdate: true,
       };
-      const result = context.isMcp
-        ? await graphs.profile.invoke(graphInput)
-        : await invokeWithAbortSignal(graphs.profile, graphInput);
+      // Always invoked as a background fire-and-forget task (see confirm_user_profile
+      // call sites), so decomposition must outlive the originating request — invoke
+      // the graph directly and never bind the request abort signal, which would
+      // cancel it as soon as the web request completes.
+      const result = await graphs.profile.invoke(graphInput);
 
       if (result.error) {
         const err = new Error(result.error);
@@ -261,7 +262,7 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
           operation: 'profile.confirm_draft_decompose',
           toolName: 'confirm_user_profile',
           userId: profile.userId,
-          tags: { toolName: 'confirm_user_profile', execution: context.isMcp ? 'background' : 'sync' },
+          tags: { toolName: 'confirm_user_profile', execution: 'background' },
         });
         return;
       }
@@ -281,7 +282,7 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
         operation: 'profile.confirm_draft_decompose',
         toolName: 'confirm_user_profile',
         userId: profile.userId,
-        tags: { toolName: 'confirm_user_profile', execution: context.isMcp ? 'background' : 'sync' },
+        tags: { toolName: 'confirm_user_profile', execution: 'background' },
       });
     } finally {
       traceEmitter?.({ type: "graph_end", name: "profile", durationMs: Date.now() - graphStart });
@@ -671,21 +672,15 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
         await userDb.saveProfile(profile);
         await persistApprovedProfileContext(profile, user, context.networkId);
 
-        if (context.isMcp) {
-          decomposeApprovedDraftProfile(context, profile).catch((err: unknown) => {
-            logger.error('Approved draft premise decomposition failed', {
-              userId: context.userId,
-              error: err instanceof Error ? err.message : String(err),
-            });
+        const decomposeLogLabel = context.isMcp
+          ? 'Approved draft premise decomposition failed'
+          : 'Approved draft premise decomposition failed (web)';
+        decomposeApprovedDraftProfile(profile).catch((err: unknown) => {
+          logger.error(decomposeLogLabel, {
+            userId: profile.userId,
+            error: err instanceof Error ? err.message : String(err),
           });
-        } else {
-          decomposeApprovedDraftProfile(context, profile).catch((err: unknown) => {
-            logger.error('Approved draft premise decomposition failed (web)', {
-              userId: context.userId,
-              error: err instanceof Error ? err.message : String(err),
-            });
-          });
-        }
+        });
 
         return success({
           created: true,

--- a/packages/protocol/src/profile/profile.tools.ts
+++ b/packages/protocol/src/profile/profile.tools.ts
@@ -26,6 +26,12 @@ function isMeaningfulEnrichment(enrichment: EnrichmentResult | null): enrichment
     );
 }
 
+type ApprovedProfileDraft = {
+  identity: { name: string; bio: string; location: string };
+  narrative: { context: string };
+  attributes: { interests: string[]; skills: string[] };
+};
+
 export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
   const { userDb, systemDb, database, graphs, enricher, grantDefaultSystemPermissions, reportToolError } = deps;
 
@@ -208,6 +214,75 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
       skills: profile.attributes.skills,
       interests: profile.attributes.interests,
     };
+  }
+
+  function buildApprovedDraftProfileInput(draft: ApprovedProfileDraft): string {
+    return [
+      draft.identity.name ? `My name is ${draft.identity.name}.` : '',
+      draft.identity.location ? `I am based in ${draft.identity.location}.` : '',
+      draft.identity.bio || '',
+      draft.narrative.context || '',
+      draft.attributes.skills.length ? `My skills include ${draft.attributes.skills.join(', ')}.` : '',
+      draft.attributes.interests.length ? `My interests include ${draft.attributes.interests.join(', ')}.` : '',
+    ].filter((part) => part.trim().length > 0).join('\n');
+  }
+
+  async function decomposeApprovedDraftProfile(
+    context: ResolvedToolContext,
+    profile: ApprovedProfileDraft & { userId: string },
+  ): Promise<void> {
+    const input = buildApprovedDraftProfileInput(profile);
+    if (!input.trim()) return;
+
+    const traceEmitter = requestContext.getStore()?.traceEmitter;
+    const graphStart = Date.now();
+    traceEmitter?.({ type: "graph_start", name: "profile" });
+    try {
+      const graphInput = {
+        userId: context.userId,
+        operationMode: 'write' as const,
+        input,
+        forceUpdate: true,
+      };
+      const result = context.isMcp
+        ? await graphs.profile.invoke(graphInput)
+        : await invokeWithAbortSignal(graphs.profile, graphInput);
+
+      if (result.error) {
+        const err = new Error(result.error);
+        logger.error('Approved draft premise decomposition failed', {
+          userId: context.userId,
+          error: result.error,
+        });
+        reportToolError?.(err, {
+          subsystem: 'profile',
+          operation: 'profile.confirm_draft_decompose',
+          toolName: 'confirm_user_profile',
+          userId: context.userId,
+          tags: { toolName: 'confirm_user_profile', execution: context.isMcp ? 'background' : 'sync' },
+        });
+        return;
+      }
+
+      // The write graph may regenerate the profile from newly-created premises.
+      // The user explicitly approved this structured draft, so keep the approved
+      // draft as the persisted profile while retaining the graph-created premises.
+      await userDb.saveProfile(profile);
+    } catch (err) {
+      logger.error('Approved draft premise decomposition failed', {
+        userId: context.userId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      reportToolError?.(err, {
+        subsystem: 'profile',
+        operation: 'profile.confirm_draft_decompose',
+        toolName: 'confirm_user_profile',
+        userId: context.userId,
+        tags: { toolName: 'confirm_user_profile', execution: context.isMcp ? 'background' : 'sync' },
+      });
+    } finally {
+      traceEmitter?.({ type: "graph_end", name: "profile", durationMs: Date.now() - graphStart });
+    }
   }
 
   const readUserProfiles = defineTool({
@@ -596,9 +671,23 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
         const profile = { ...query.draft, userId: context.userId };
         await userDb.saveProfile(profile);
         await persistApprovedProfileContext(profile, user, context.networkId);
+
+        if (context.isMcp) {
+          decomposeApprovedDraftProfile(context, profile).catch((err: unknown) => {
+            logger.error('Approved draft premise decomposition failed', {
+              userId: context.userId,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          });
+        } else {
+          await decomposeApprovedDraftProfile(context, profile);
+        }
+
         return success({
           created: true,
-          message: "Profile saved from approved draft.",
+          message: context.isMcp
+            ? "Profile saved from approved draft. Premise extraction is running in the background."
+            : "Profile saved from approved draft.",
           profile: toProfileSummary(profile),
         });
       }

--- a/packages/protocol/src/profile/tests/profile.privacy-tools.spec.ts
+++ b/packages/protocol/src/profile/tests/profile.privacy-tools.spec.ts
@@ -251,7 +251,7 @@ describe("onboarding privacy profile tools", () => {
 
     expect(result.success).toBe(true);
     expect(saveProfile).toHaveBeenCalledWith({ ...draft, userId: "u1" });
-    expect(saveProfile).toHaveBeenCalledTimes(2);
+    expect(saveProfile).toHaveBeenCalledTimes(1);
     expect(profileGraphInvoke).toHaveBeenCalledTimes(1);
     expect(profileGraphInvoke).toHaveBeenCalledWith({
       userId: "u1",

--- a/packages/protocol/src/profile/tests/profile.privacy-tools.spec.ts
+++ b/packages/protocol/src/profile/tests/profile.privacy-tools.spec.ts
@@ -240,7 +240,7 @@ describe("onboarding privacy profile tools", () => {
     expect(saveProfile).not.toHaveBeenCalled();
   });
 
-  it("confirm saves an approved structured draft", async () => {
+  it("confirm saves an approved structured draft and sends it through premise decomposition", async () => {
     const tool = tools.find((t) => t.name === "confirm_user_profile")!;
     const draft = {
       identity: { name: "Alice", bio: "Builder", location: "Healdsburg" },
@@ -251,7 +251,42 @@ describe("onboarding privacy profile tools", () => {
 
     expect(result.success).toBe(true);
     expect(saveProfile).toHaveBeenCalledWith({ ...draft, userId: "u1" });
+    expect(saveProfile).toHaveBeenCalledTimes(2);
+    expect(profileGraphInvoke).toHaveBeenCalledTimes(1);
+    expect(profileGraphInvoke).toHaveBeenCalledWith({
+      userId: "u1",
+      operationMode: "write",
+      input: [
+        "My name is Alice.",
+        "I am based in Healdsburg.",
+        "Builder",
+        "Alice builds tools.",
+        "My skills include TypeScript.",
+        "My interests include agents.",
+      ].join("\n"),
+      forceUpdate: true,
+    });
     expect(enricher).not.toHaveBeenCalled();
+  });
+
+  it("confirm schedules draft premise decomposition without blocking MCP callers", async () => {
+    const tool = tools.find((t) => t.name === "confirm_user_profile")!;
+    const draft = {
+      identity: { name: "Alice", bio: "Builder", location: "Healdsburg" },
+      narrative: { context: "Alice builds tools." },
+      attributes: { skills: ["TypeScript"], interests: ["agents"] },
+    };
+    profileGraphInvoke.mockImplementation(() => new Promise(() => {}));
+
+    const result = parseToolResult(await tool.handler({
+      context: { ...context(), isMcp: true } as ResolvedToolContext,
+      query: { draft },
+    }));
+
+    expect(result.success).toBe(true);
+    expect(String(result.data?.message)).toContain("background");
+    expect(saveProfile).toHaveBeenCalledTimes(1);
+    expect(profileGraphInvoke).toHaveBeenCalledTimes(1);
   });
 
   it("confirming approved text preserves existing location when no correction is supplied", async () => {


### PR DESCRIPTION
## Release 2026-06-05

Merges `dev` into `main`.

### New Features

- Daily digest (`list_opportunities` with `includeDigestMarkers=true`) renders opportunity cards through the LLM presenter for natural second-person prose with personalized headlines.
- Opportunity confidence scores exposed in MCP digest markers for ranking by score instead of recency.
- Intent proposal cards show specificity warnings for broad attributive intents, requiring explicit approval instead of auto-creating.

### Bug Fixes

- Guard against overly broad attributive intents that lack referential specificity — broad signals trigger a specificity warning and require explicit approval instead of silent auto-approval.
- Approved profile drafts are now decomposed into premises during enrichment.
- Race condition eliminated in profile draft decomposition pipeline.
- Approved-draft premise decomposition now runs as a true background task on the web path (no longer cancelled when the request completes) and is tagged as `background` in telemetry.
- Narrator-name stripping now requires a word boundary after the name, so short names no longer mangle longer words (e.g. "Al" no longer turns "Always …" into "ways …").
- CLI backfill scripts load environment variables before database imports.

### Refactors

- AgentVillage digest prompts moved from `index-network` to `edge-esmeralda` skill.
- AgentVillage submodule updated for digest confidence ranking in daily brief.
- `ApprovedProfileDraft` derived from shared Zod schema, redundant cast removed.
- `PresenterDatabase` cast simplified (double `unknown` → direct).
- Typed assignment replaces cast in opportunity digest presenter.
- Approved-draft decomposition helper uses `profile.userId` consistently for graph input and error attribution.

### Tests

- Digest presenter test coverage added.