### PR TITLE
fix(protocol): guard against self-match opportunities (hotfix)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -127,7 +127,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "1.26.3",
+      "version": "1.26.7",
       "dependencies": {
         "@langchain/core": "^1.1.17",
         "@langchain/langgraph": "^1.1.2",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "1.26.6",
+  "version": "1.26.7",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -1427,10 +1427,47 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         },
       );
 
+      const skippedIds: string[] = [];
+      const buildListDebugSteps = (): Array<{ step: string; detail?: string; data?: Record<string, unknown> }> => {
+        const steps: Array<{ step: string; detail?: string; data?: Record<string, unknown> }> = [];
+        if (skippedIds.length > 0) {
+          steps.push({
+            step: "opportunity_display_skips",
+            detail: `${skippedIds.length} opportunity card(s) couldn't be displayed`,
+            data: {
+              skippedCount: skippedIds.length,
+              totalOpportunities: fetched.length,
+              skippedOpportunityIds: skippedIds,
+            },
+          });
+        }
+        return steps;
+      };
+      const recordCallerMismatch = (opp: Opportunity): void => {
+        logger.warn("list_opportunities: skipping opportunity where caller is not an actor", {
+          opportunityId: opp.id,
+          viewerId: context.userId,
+          actorUserIds: opp.actors
+            .map((a) => a.userId)
+            .filter((userId): userId is string => typeof userId === "string"),
+        });
+        skippedIds.push(opp.id);
+      };
+
+      // Read invariant: only surface opportunities the caller actually
+      // participates in. Apply before latent filtering, dedup/selection, and
+      // profile/user batch fetches so a mismatched row cannot influence which
+      // valid opportunities are selected or trigger cross-user reads.
+      const callerScoped = fetched.filter((opp) => {
+        if (opp.actors.some((a) => a.userId === context.userId)) return true;
+        recordCallerMismatch(opp);
+        return false;
+      });
+
       // Latent rows in chat are introducer-as-viewer only. The ACL layer
       // (isActionableForViewer) returns true for several other latent cases —
       // those belong to the home feed, not the digest/ambient surface.
-      const visible = fetched.filter((opp) => {
+      const visible = callerScoped.filter((opp) => {
         if (opp.status !== "latent") return true;
         const me = opp.actors.find((a) => a.userId === context.userId);
         return me?.role === "introducer";
@@ -1449,6 +1486,17 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
       const opportunities = selected.slice(0, CHAT_DISPLAY_LIMIT);
 
       if (!opportunities || opportunities.length === 0) {
+        if (skippedIds.length > 0) {
+          const listDebugSteps = buildListDebugSteps();
+          return success({
+            found: false,
+            count: 0,
+            summary: "Some opportunities couldn't be displayed",
+            message:
+              "I found opportunities, but couldn't render them. Please try again.",
+            ...(listDebugSteps.length ? { debugSteps: listDebugSteps } : {}),
+          });
+        }
         return success({
           found: false,
           count: 0,
@@ -1492,7 +1540,6 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
       const isDigestMode = context.isMcp === true && query.includeDigestMarkers === true;
       const cardDataList: Array<Record<string, unknown> & { opportunityId: string }> = [];
       const seenOpportunityIds = new Set<string>();
-      const skippedIds: string[] = [];
 
       if (isDigestMode) {
         // ── Digest mode: use LLM presenter for rich, second-person card text ──
@@ -1506,22 +1553,6 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
             chunk.map(async (opp) => {
               if (seenOpportunityIds.has(opp.id)) return null;
               seenOpportunityIds.add(opp.id);
-              // Read invariant: the digest must only surface opportunities the
-              // caller actually participates in. A card whose caller is not an
-              // actor signals bad data or an identity/credential mismatch
-              // upstream — skip it loudly rather than render someone else's
-              // connection and mint a connect link under the wrong identity.
-              if (!opp.actors.some((a) => a.userId === context.userId)) {
-                logger.warn("list_opportunities: skipping opportunity where caller is not an actor", {
-                  opportunityId: opp.id,
-                  viewerId: context.userId,
-                  actorUserIds: opp.actors
-                    .map((a) => a.userId)
-                    .filter((userId): userId is string => typeof userId === "string"),
-                });
-                skippedIds.push(opp.id);
-                return null;
-              }
               try {
                 const counterpartActor = opp.actors.find(
                   (a) => a.userId !== context.userId && a.role !== "introducer",
@@ -1685,19 +1716,6 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         for (const opp of opportunities) {
           if (seenOpportunityIds.has(opp.id)) continue;
           seenOpportunityIds.add(opp.id);
-          // Read invariant: only surface opportunities the caller participates
-          // in (see digest-mode note above). Skip loudly on a mismatch.
-          if (!opp.actors.some((a) => a.userId === context.userId)) {
-            logger.warn("list_opportunities: skipping opportunity where caller is not an actor", {
-              opportunityId: opp.id,
-              viewerId: context.userId,
-              actorUserIds: opp.actors
-                .map((a) => a.userId)
-                .filter((userId): userId is string => typeof userId === "string"),
-            });
-            skippedIds.push(opp.id);
-            continue;
-          }
           try {
             const counterpartActor = opp.actors.find(
               (a) => a.userId !== context.userId && a.role !== "introducer",
@@ -1798,18 +1816,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         }
       }
 
-      const listDebugSteps: Array<{ step: string; detail?: string; data?: Record<string, unknown> }> = [];
-      if (skippedIds.length > 0) {
-        listDebugSteps.push({
-          step: "card_build_errors",
-          detail: `${skippedIds.length} opportunity card(s) failed to build`,
-          data: {
-            skippedCount: skippedIds.length,
-            totalOpportunities: opportunities.length,
-            skippedOpportunityIds: skippedIds,
-          },
-        });
-      }
+      const listDebugSteps = buildListDebugSteps();
 
       if (cardDataList.length === 0) {
         if (skippedIds.length > 0) {

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -1519,6 +1519,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
                     .map((a) => a.userId)
                     .filter((userId): userId is string => typeof userId === "string"),
                 });
+                skippedIds.push(opp.id);
                 return null;
               }
               try {
@@ -1694,6 +1695,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
                 .map((a) => a.userId)
                 .filter((userId): userId is string => typeof userId === "string"),
             });
+            skippedIds.push(opp.id);
             continue;
           }
           try {

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -1515,7 +1515,9 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
                 logger.warn("list_opportunities: skipping opportunity where caller is not an actor", {
                   opportunityId: opp.id,
                   viewerId: context.userId,
-                  actorUserIds: opp.actors.map((a) => a.userId),
+                  actorUserIds: opp.actors
+                    .map((a) => a.userId)
+                    .filter((userId): userId is string => typeof userId === "string"),
                 });
                 return null;
               }
@@ -1688,7 +1690,9 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
             logger.warn("list_opportunities: skipping opportunity where caller is not an actor", {
               opportunityId: opp.id,
               viewerId: context.userId,
-              actorUserIds: opp.actors.map((a) => a.userId),
+              actorUserIds: opp.actors
+                .map((a) => a.userId)
+                .filter((userId): userId is string => typeof userId === "string"),
             });
             continue;
           }

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -1506,6 +1506,19 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
             chunk.map(async (opp) => {
               if (seenOpportunityIds.has(opp.id)) return null;
               seenOpportunityIds.add(opp.id);
+              // Read invariant: the digest must only surface opportunities the
+              // caller actually participates in. A card whose caller is not an
+              // actor signals bad data or an identity/credential mismatch
+              // upstream — skip it loudly rather than render someone else's
+              // connection and mint a connect link under the wrong identity.
+              if (!opp.actors.some((a) => a.userId === context.userId)) {
+                logger.warn("list_opportunities: skipping opportunity where caller is not an actor", {
+                  opportunityId: opp.id,
+                  viewerId: context.userId,
+                  actorUserIds: opp.actors.map((a) => a.userId),
+                });
+                return null;
+              }
               try {
                 const counterpartActor = opp.actors.find(
                   (a) => a.userId !== context.userId && a.role !== "introducer",
@@ -1669,6 +1682,16 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         for (const opp of opportunities) {
           if (seenOpportunityIds.has(opp.id)) continue;
           seenOpportunityIds.add(opp.id);
+          // Read invariant: only surface opportunities the caller participates
+          // in (see digest-mode note above). Skip loudly on a mismatch.
+          if (!opp.actors.some((a) => a.userId === context.userId)) {
+            logger.warn("list_opportunities: skipping opportunity where caller is not an actor", {
+              opportunityId: opp.id,
+              viewerId: context.userId,
+              actorUserIds: opp.actors.map((a) => a.userId),
+            });
+            continue;
+          }
           try {
             const counterpartActor = opp.actors.find(
               (a) => a.userId !== context.userId && a.role !== "introducer",

--- a/packages/protocol/src/opportunity/opportunity.utils.ts
+++ b/packages/protocol/src/opportunity/opportunity.utils.ts
@@ -52,6 +52,16 @@ export function deriveRolesFromCorpus(corpus: HydeTargetCorpus): DerivedRoles {
  * one or two non-introducer actors (1 = 1:1 intro e.g. "I want to connect with X";
  * 2 = introducer connecting two others).
  *
+ * Also rejects self-matches — the same person occupying both sides of a
+ * connection. The discovery/persist pipeline trusts the LLM evaluator's actor
+ * list, which can collapse onto a single user; downstream readers then garble
+ * identity (e.g. a connect link/greeting rendered in one party's voice while the
+ * card shows the viewer "matched with themselves"). Two degenerate shapes are
+ * blocked here, at the single persist chokepoint:
+ *   - a duplicate non-introducer party, e.g. `[X(agent), X(patient)]`
+ *   - an introducer who is also a participant ("Amina introduced you to Amina")
+ * Only `userId`-bearing actors are checked; role-only actors (legacy/tests) pass.
+ *
  * @param actors - Array of actors with at least a role and optional userId
  * @throws Error when the actor set is invalid
  */
@@ -63,6 +73,27 @@ export function validateOpportunityActors(actors: Array<{ userId?: string; role:
     throw new Error(
       'An opportunity with an introducer must have one or two other actors.'
     );
+  }
+
+  // Self-match guard. Compare only actors that carry a userId so role-only
+  // shapes (used by some callers/tests) are unaffected.
+  const introducerUserIds = new Set(
+    actors.filter((a) => a.role === 'introducer' && a.userId).map((a) => a.userId as string),
+  );
+  const nonIntroducerUserIds = actors
+    .filter((a) => a.role !== 'introducer' && a.userId)
+    .map((a) => a.userId as string);
+
+  for (const userId of nonIntroducerUserIds) {
+    if (introducerUserIds.has(userId)) {
+      throw new Error(
+        'An opportunity actor cannot be both the introducer and a participant (self-match).'
+      );
+    }
+  }
+
+  if (new Set(nonIntroducerUserIds).size !== nonIntroducerUserIds.length) {
+    throw new Error('An opportunity cannot match a user with themselves (duplicate participant).');
   }
 }
 

--- a/packages/protocol/src/opportunity/opportunity.utils.ts
+++ b/packages/protocol/src/opportunity/opportunity.utils.ts
@@ -58,9 +58,12 @@ export function deriveRolesFromCorpus(corpus: HydeTargetCorpus): DerivedRoles {
  * identity (e.g. a connect link/greeting rendered in one party's voice while the
  * card shows the viewer "matched with themselves"). Two degenerate shapes are
  * blocked here, at the single persist chokepoint:
- *   - a duplicate non-introducer party, e.g. `[X(agent), X(patient)]`
+ *   - every userId-bearing non-introducer actor collapses to the same user,
+ *     e.g. `[X(agent), X(patient)]`
  *   - an introducer who is also a participant ("Amina introduced you to Amina")
  * Only `userId`-bearing actors are checked; role-only actors (legacy/tests) pass.
+ * Duplicate rows for one participant are allowed when at least one other distinct
+ * participant is present (some callers model multiple intents as multiple actor rows).
  *
  * @param actors - Array of actors with at least a role and optional userId
  * @throws Error when the actor set is invalid
@@ -92,7 +95,8 @@ export function validateOpportunityActors(actors: Array<{ userId?: string; role:
     }
   }
 
-  if (new Set(nonIntroducerUserIds).size !== nonIntroducerUserIds.length) {
+  const uniqueNonIntroducerUserIds = new Set(nonIntroducerUserIds);
+  if (nonIntroducerUserIds.length > 1 && uniqueNonIntroducerUserIds.size === 1) {
     throw new Error('An opportunity cannot match a user with themselves (duplicate participant).');
   }
 }

--- a/packages/protocol/src/opportunity/tests/opportunity.utils.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.utils.spec.ts
@@ -366,7 +366,7 @@ describe('opportunity.utils', () => {
       ).not.toThrow();
     });
 
-    test('rejects a discovery self-match (duplicate non-introducer party)', () => {
+    test('rejects a discovery self-match where all non-introducer rows are the same user', () => {
       const self = 'c2505011-2e45-426e-81dd-b9abb9b72023';
       expect(() =>
         validateOpportunityActors([
@@ -374,6 +374,16 @@ describe('opportunity.utils', () => {
           { userId: self, role: 'patient' },
         ])
       ).toThrow(/match a user with themselves/);
+    });
+
+    test('accepts duplicate rows for one participant when another distinct participant is present', () => {
+      expect(() =>
+        validateOpportunityActors([
+          { userId: 'c2505011-2e45-426e-81dd-b9abb9b72023', role: 'agent' },
+          { userId: 'c2505011-2e45-426e-81dd-b9abb9b72023', role: 'patient' },
+          { userId: 'a1234567-b234-c345-d456-e56789abcdef', role: 'party' },
+        ])
+      ).not.toThrow();
     });
 
     test('rejects an introducer who is also a participant ("Amina introduced you to Amina")', () => {

--- a/packages/protocol/src/opportunity/tests/opportunity.utils.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.utils.spec.ts
@@ -365,6 +365,45 @@ describe('opportunity.utils', () => {
         ])
       ).not.toThrow();
     });
+
+    test('rejects a discovery self-match (duplicate non-introducer party)', () => {
+      const self = 'c2505011-2e45-426e-81dd-b9abb9b72023';
+      expect(() =>
+        validateOpportunityActors([
+          { userId: self, role: 'agent' },
+          { userId: self, role: 'patient' },
+        ])
+      ).toThrow(/match a user with themselves/);
+    });
+
+    test('rejects an introducer who is also a participant ("Amina introduced you to Amina")', () => {
+      const amina = 'a1234567-b234-c345-d456-e56789abcdef';
+      expect(() =>
+        validateOpportunityActors([
+          { userId: amina, role: 'introducer' },
+          { userId: amina, role: 'party' },
+        ])
+      ).toThrow(/both the introducer and a participant/);
+    });
+
+    test('accepts a 1:1 intro where introducer and party are distinct users', () => {
+      expect(() =>
+        validateOpportunityActors([
+          { userId: 'a1234567-b234-c345-d456-e56789abcdef', role: 'introducer' },
+          { userId: 'c2505011-2e45-426e-81dd-b9abb9b72023', role: 'party' },
+        ])
+      ).not.toThrow();
+    });
+
+    test('accepts a 2-party intro where all three users are distinct', () => {
+      expect(() =>
+        validateOpportunityActors([
+          { userId: 'a1234567-b234-c345-d456-e56789abcdef', role: 'party' },
+          { userId: 'b2345678-c345-d456-e567-f6789abcdef0', role: 'party' },
+          { userId: 'c2505011-2e45-426e-81dd-b9abb9b72023', role: 'introducer' },
+        ])
+      ).not.toThrow();
+    });
   });
 });
 


### PR DESCRIPTION
## New Features

None.

## Bug Fixes

- Harden opportunity persistence against self-match actor sets by rejecting duplicate non-introducer participant user IDs and introducer-as-participant shapes.
- Harden `list_opportunities` in both digest and chat modes so it only surfaces opportunities where the caller is an actor, skipping and warning on identity/credential mismatches instead of rendering another user's connection.
- Keep the root `bun.lock` workspace metadata in sync with the `@indexnetwork/protocol` package version bump.

## Refactors

None.

## Documentation

- Document the incident context and operational follow-up in this PR description: the original digest identity-binding remediation is tracked separately from these defense-in-depth guardrails.

## Tests

- Added unit coverage for self-match validation, including duplicate parties, introducer-as-participant rejection, and valid 1:1 / 2-party introductions.
- Verified protocol package build with `cd packages/protocol && bun run build`.

## Versioning

- `@indexnetwork/protocol` 1.26.6 → 1.26.7

https://claude.ai/code/session_0157jBxKSVKaJG43XAWJNsGU

---
_Generated by [Claude Code](https://claude.ai/code/session_0157jBxKSVKaJG43XAWJNsGU)_
