### PR TITLE
fix(protocol): normalize raw pgvector embedding reads to number[] (IND-348)

### DIFF
--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -5361,7 +5361,10 @@ export class OpportunityDatabaseAdapter {
       provenance: unknown;
       analysis: unknown | null;
       validity: unknown;
-      embedding: number[];
+      // Raw db.execute bypasses Drizzle's vector mapper: a pgvector column
+      // arrives as a string here, not number[]. Typed `unknown` so every
+      // caller must route through normalizeEmbedding (IND-348).
+      embedding: unknown;
       status: 'ACTIVE' | 'RETRACTED' | 'EXPIRED';
       createdAt: Date;
       updatedAt: Date;

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -9,6 +9,7 @@ import { eq, and, or, isNull, isNotNull, sql, count, desc, gt, lt, lte, ne, inAr
 import * as schema from '../schemas/database.schema';
 import db from '../lib/drizzle/drizzle';
 import { traceAppOperation } from '../lib/sentry-performance';
+import { normalizeEmbedding } from '../lib/embedding/vector';
 import type { User, NotificationPreferences, OnboardingState, TelegramPrefs } from '../schemas/database.schema';
 import type {
   Conversation,
@@ -209,8 +210,7 @@ interface HydeDocumentRow {
   expiresAt: Date | null;
 }
 function toHydeDocument(row: typeof hydeDocuments.$inferSelect): HydeDocumentRow {
-  const embedding = row.hydeEmbedding;
-  const vec = Array.isArray(embedding) ? embedding : (typeof embedding === 'string' ? (JSON.parse(embedding) as number[]) : []);
+  const vec = normalizeEmbedding(row.hydeEmbedding);
   return {
     id: row.id,
     sourceType: row.sourceType as HydeSourceTypeLocal,
@@ -5405,7 +5405,10 @@ export class OpportunityDatabaseAdapter {
       provenance: row.provenance as { source: 'explicit' | 'enrichment' | 'integration' | 'onboarding'; sourceId?: string; confidence: number; timestamp: string },
       analysis: row.analysis as { speechActType: 'DECLARATIVE' | 'ASSERTIVE'; felicityAuthority: number; felicitySincerity: number; felicityClarity: number; semanticEntropy: number } | null,
       validity: row.validity as { validFrom?: string; validUntil?: string; volatile: boolean },
-      embedding: row.embedding,
+      // Raw `db.execute` bypasses Drizzle's vector mapper, so `embedding` arrives
+      // as a pgvector string here — normalize to number[] before consumers call
+      // `.join(',')` to rebuild the vector literal (IND-348).
+      embedding: normalizeEmbedding(row.embedding),
       status: row.status,
       createdAt: row.createdAt,
       updatedAt: row.updatedAt,

--- a/backend/src/lib/embedding/tests/vector.spec.ts
+++ b/backend/src/lib/embedding/tests/vector.spec.ts
@@ -1,0 +1,38 @@
+import { describe, test, expect } from 'bun:test';
+
+import { normalizeEmbedding } from '../vector';
+
+describe('normalizeEmbedding', () => {
+  test('parses a pgvector string into a real number[] (the IND-348 crash path)', () => {
+    // Raw `db.execute` reads of a pgvector column arrive as a string, not number[].
+    const result = normalizeEmbedding('[0.1,0.2,0.3]');
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toEqual([0.1, 0.2, 0.3]);
+    // The exact operation that threw `source.embedding.join is not a function`.
+    expect(() => result.join(',')).not.toThrow();
+    expect(result.join(',')).toBe('0.1,0.2,0.3');
+  });
+
+  test('passes a number[] through unchanged', () => {
+    const input = [0.5, 0.25];
+    const result = normalizeEmbedding(input);
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toEqual([0.5, 0.25]);
+  });
+
+  test('returns [] for null', () => {
+    expect(normalizeEmbedding(null)).toEqual([]);
+  });
+
+  test('returns [] for undefined', () => {
+    expect(normalizeEmbedding(undefined)).toEqual([]);
+  });
+
+  test('returns [] for an empty pgvector string', () => {
+    expect(normalizeEmbedding('[]')).toEqual([]);
+  });
+
+  test('returns [] for an unparseable string instead of throwing', () => {
+    expect(normalizeEmbedding('not-a-vector')).toEqual([]);
+  });
+});

--- a/backend/src/lib/embedding/vector.ts
+++ b/backend/src/lib/embedding/vector.ts
@@ -1,0 +1,25 @@
+/**
+ * Normalize an embedding value read from the database into a real `number[]`.
+ *
+ * Drizzle's `vector` column mapper parses a pgvector column (`"[0.1,0.2]"`) into
+ * a `number[]` only when read through the query builder (`db.select()`). A raw
+ * `db.execute(sql\`...\`)` read bypasses that mapper, so the column arrives as a
+ * string. Consumers that call `.join(',')` to rebuild a pgvector literal then
+ * crash with `embedding.join is not a function`. Apply this at every raw-read
+ * boundary so downstream code always receives the declared `number[]`.
+ *
+ * @param value - The embedding as it came back from the driver (array, pgvector string, or null)
+ * @returns The embedding as a `number[]`; `[]` when absent or unparseable
+ */
+export function normalizeEmbedding(value: unknown): number[] {
+  if (Array.isArray(value)) return value as number[];
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      return Array.isArray(parsed) ? (parsed as number[]) : [];
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}

--- a/bun.lock
+++ b/bun.lock
@@ -127,7 +127,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "1.26.7",
+      "version": "1.26.8",
       "dependencies": {
         "@langchain/core": "^1.1.17",
         "@langchain/langgraph": "^1.1.2",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "1.26.7",
+  "version": "1.26.8",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -970,7 +970,7 @@ export class OpportunityGraphFactory {
               : await self.database.getPremisesForUser(discoveryUserId, 'ACTIVE');
             const sourcePremises = (sourcePremisesFromDb.length > 0
               ? sourcePremisesFromDb
-                  .filter(p => p.embedding && p.embedding.length > 0)
+                  .filter(p => Array.isArray(p.embedding) && p.embedding.length > 0)
                   .slice(0, sourceLimit)
                   .map(p => ({ premiseId: p.id as Id<'premises'>, embedding: p.embedding! }))
               : (state.sourcePremises ?? []).slice(0, sourceLimit)


### PR DESCRIPTION
## Summary

`discover_opportunities` crashed in the premise-to-premise discovery path with `source.embedding.join is not a function`, returning 0 results (IND-348).

**Root cause:** `premises.embedding` is a Drizzle `vector` column. Drizzle's vector mapper parses the pgvector string `"[0.1,…]"` into a real `number[]` only when read through the query builder (`db.select()`). `getPremisesForUserInNetworks` reads it via raw `db.execute(sql\`…\`)`, which bypasses the mapper — so `embedding` arrived as a *string* despite the declared `number[]` return type. The guard `p.embedding && p.embedding.length > 0` passed (strings have `.length`), and the string crashed at `.join(',')` when rebuilding the vector literal.

## Bug Fixes

- **`backend/src/lib/embedding/vector.ts`** — new DB-free `normalizeEmbedding(value)` helper (parses pgvector strings, passes arrays through, `[]` for null/unparseable).
- Applied at the read boundary in `getPremisesForUserInNetworks`; `toHydeDocument` refactored to reuse it (one canonical normalizer).
- Hardened the guard at `opportunity.graph.ts:973` to `Array.isArray(p.embedding) && p.embedding.length > 0` (defense in depth).
- Audited every raw `db.execute` embedding read feeding `.join(',')`: `getPremisesForUserInNetworks` was the only one returning a raw vector column to JS; all other sites use input/query embeddings or compute similarity in SQL.

## Tests

- New unit test `backend/src/lib/embedding/tests/vector.spec.ts` (6 cases) reproduces the exact `.join` crash path: red before the fix, green after.

## Chores

- Bump `@indexnetwork/protocol` to 1.26.8.

## Test Plan

- [x] `bun test src/lib/embedding/tests/vector.spec.ts` — 6/6 pass
- [x] `tsc` clean for `backend` and `@indexnetwork/protocol`
- [x] ESLint clean on touched files
- [ ] (optional) Live repro: re-run `discover_opportunities` for an Edge City member with active premises and confirm opportunity cards surface

Fixes IND-348