### PR TITLE
fix(protocol): surface publicLookup block for AgentVillage identity gate (IND-350)

### DIFF
--- a/packages/protocol/src/profile/profile.tools.ts
+++ b/packages/protocol/src/profile/profile.tools.ts
@@ -572,7 +572,8 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
     description:
       "Builds a structured profile draft for onboarding without saving anything. Use this after recording privacy consent and before asking the user to approve the profile. " +
       "If allowPublicLookup is false, this tool uses only explicit text, EdgeOS/event data the user allowed, and user-provided social URLs. If allowPublicLookup is true, persisted public lookup consent is required. " +
-      "In MCP contexts, starts an async profile run and returns `profileRunId`; poll get_profile_run until status is `succeeded`, then present its `result`.",
+      "In MCP contexts, starts an async profile run and returns `profileRunId`; poll get_profile_run until status is `succeeded`, then present its `result`." +
+      " When public lookup runs, the result includes a `publicLookup` block (`used`, `confidentMatch`, the looked-up `identity` of name/role/location, and `socials`) so the caller can confirm identity before saving; when no lookup runs it is `{ used: false }`.",
     querySchema: z.object({
       name: z.string().optional().describe("Name explicitly provided by the user. For authenticated public lookup, the account identity is used first and this is only a fallback."),
       location: z.string().optional().describe("Location explicitly provided by the user or allowed event data."),
@@ -650,6 +651,18 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
         message: "Profile draft generated. Show this to the user and ask whether it looks right before calling confirm_user_profile.",
         profile: toProfileSummary(profile),
         draft: profile,
+        publicLookup: enrichment
+          ? {
+              used: true,
+              confidentMatch: enrichment.confidentMatch,
+              identity: {
+                name: enrichment.identity.name,
+                role: enrichment.identity.bio,
+                location: enrichment.identity.location,
+              },
+              socials: enrichment.socials,
+            }
+          : { used: false },
       });
     },
   });

--- a/packages/protocol/src/profile/profile.tools.ts
+++ b/packages/protocol/src/profile/profile.tools.ts
@@ -573,7 +573,7 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
       "Builds a structured profile draft for onboarding without saving anything. Use this after recording privacy consent and before asking the user to approve the profile. " +
       "If allowPublicLookup is false, this tool uses only explicit text, EdgeOS/event data the user allowed, and user-provided social URLs. If allowPublicLookup is true, persisted public lookup consent is required. " +
       "In MCP contexts, starts an async profile run and returns `profileRunId`; poll get_profile_run until status is `succeeded`, then present its `result`." +
-      " When public lookup runs, the result includes a `publicLookup` block (`used`, `confidentMatch`, the looked-up `identity` of name/role/location, and `socials`) so the caller can confirm identity before saving; when no lookup runs it is `{ used: false }`.",
+      " When public lookup runs, the result includes a `publicLookup` block reporting whether a candidate identity was found (`used`, `confidentMatch`) and what it was (`identity` of name/role/location, plus `socials`), so the caller can confirm identity before saving. A candidate can be returned (`used: true`) without being confident enough to enter the draft; when no lookup runs the block is `{ used: false }`.",
     querySchema: z.object({
       name: z.string().optional().describe("Name explicitly provided by the user. For authenticated public lookup, the account identity is used first and this is only a fallback."),
       location: z.string().optional().describe("Location explicitly provided by the user or allowed event data."),
@@ -655,6 +655,7 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
           ? {
               used: true,
               confidentMatch: enrichment.confidentMatch,
+              // identity.bio is the role/headline string returned by the lookup
               identity: {
                 name: enrichment.identity.name,
                 role: enrichment.identity.bio,

--- a/packages/protocol/src/profile/tests/profile.public-lookup.spec.ts
+++ b/packages/protocol/src/profile/tests/profile.public-lookup.spec.ts
@@ -92,7 +92,9 @@ describe("preview_user_profile publicLookup block", () => {
       context: baseContext,
       query: { bioOrDescription: "I build things", allowPublicLookup: false },
     });
-    const { data } = JSON.parse(result);
+    const parsed = JSON.parse(result);
+    expect(parsed.success).toBe(true);
+    const { data } = parsed;
     expect(data.publicLookup).toEqual({ used: false });
   });
 
@@ -103,7 +105,9 @@ describe("preview_user_profile publicLookup block", () => {
       context: baseContext,
       query: { bioOrDescription: "I build things", allowPublicLookup: true },
     });
-    const { data } = JSON.parse(result);
+    const parsed = JSON.parse(result);
+    expect(parsed.success).toBe(true);
+    const { data } = parsed;
     expect(data.publicLookup.used).toBe(true);
     expect(data.publicLookup.confidentMatch).toBe(true);
     expect(data.publicLookup.identity).toEqual({
@@ -125,7 +129,9 @@ describe("preview_user_profile publicLookup block", () => {
       context: baseContext,
       query: { bioOrDescription: "I build things", allowPublicLookup: true },
     });
-    const { data } = JSON.parse(result);
+    const parsed = JSON.parse(result);
+    expect(parsed.success).toBe(true);
+    const { data } = parsed;
     expect(data.publicLookup.used).toBe(true);
     expect(data.publicLookup.confidentMatch).toBe(false);
     expect(lastGeneratorInput).not.toContain("Unrelated wrong-person bio");

--- a/packages/protocol/src/profile/tests/profile.public-lookup.spec.ts
+++ b/packages/protocol/src/profile/tests/profile.public-lookup.spec.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+import type { ToolDeps, ResolvedToolContext } from "../../shared/agent/tool.helpers.js";
+import type { EnrichmentResult } from "../../shared/interfaces/enrichment.interface.js";
+
+// Replace the LLM-backed generator BEFORE profile.tools.js is imported.
+let lastGeneratorInput: string | undefined;
+mock.module("../profile.generator.js", () => ({
+  ProfileGenerator: class {
+    async invoke(input: string) {
+      lastGeneratorInput = input;
+      return {
+        output: {
+          identity: { name: "Drafted Name", bio: "drafted bio", location: "Remote" },
+          narrative: { context: "drafted context" },
+          attributes: { skills: [], interests: [] },
+        },
+        textToEmbed: "embed",
+      };
+    }
+  },
+}));
+
+const { createProfileTools } = await import("../profile.tools.js");
+
+interface CapturedTool {
+  name: string;
+  handler: (input: { context: ResolvedToolContext; query: unknown }) => Promise<string>;
+}
+
+function captureTools(deps: ToolDeps): CapturedTool[] {
+  const toolDefs: CapturedTool[] = [];
+  const defineTool = (def: { name: string; handler: CapturedTool["handler"] }) => {
+    toolDefs.push({ name: def.name, handler: def.handler });
+    return def;
+  };
+  createProfileTools(defineTool as unknown as Parameters<typeof createProfileTools>[0], deps);
+  return toolDefs;
+}
+
+const baseContext = {
+  userId: "test-user",
+  userName: "Test User",
+  userEmail: "test@example.com",
+  user: { onboarding: { privacy: { publicProfileLookup: { granted: true } } } },
+} as unknown as ResolvedToolContext;
+
+function makeEnrichment(overrides: Partial<EnrichmentResult>): EnrichmentResult {
+  return {
+    identity: { name: "Ada Lovelace", bio: "Founder at Analytical Engines", location: "London" },
+    narrative: { context: "Pioneer of computing." },
+    attributes: { skills: ["mathematics"], interests: ["computing"] },
+    socials: { linkedin: "adalovelace" },
+    confidentMatch: true,
+    isHuman: true,
+    ...overrides,
+  };
+}
+
+function buildDeps(enrichment: EnrichmentResult | null): ToolDeps {
+  return {
+    userDb: {
+      getUser: async () => ({
+        id: "test-user",
+        name: "Test User",
+        email: "test@example.com",
+        socials: [],
+        onboarding: { privacy: { publicProfileLookup: { granted: true } } },
+      }),
+      updateUser: async () => ({}),
+      getUserSocials: async () => [],
+      setUserSocials: async () => {},
+    },
+    systemDb: {},
+    database: {},
+    graphs: { profile: { invoke: async () => ({}) } },
+    enricher: { enrichUserProfile: async () => enrichment },
+    grantDefaultSystemPermissions: async () => undefined,
+  } as unknown as ToolDeps;
+}
+
+function getPreview(deps: ToolDeps): CapturedTool {
+  return captureTools(deps).find((t) => t.name === "preview_user_profile")!;
+}
+
+describe("preview_user_profile publicLookup block", () => {
+  beforeEach(() => { lastGeneratorInput = undefined; });
+
+  it("reports used:false when no public lookup runs", async () => {
+    const preview = getPreview(buildDeps(null));
+    const result = await preview.handler({
+      context: baseContext,
+      query: { bioOrDescription: "I build things", allowPublicLookup: false },
+    });
+    const { data } = JSON.parse(result);
+    expect(data.publicLookup).toEqual({ used: false });
+  });
+
+  it("surfaces looked-up identity + confidentMatch when lookup is confident", async () => {
+    const enrichment = makeEnrichment({ confidentMatch: true });
+    const preview = getPreview(buildDeps(enrichment));
+    const result = await preview.handler({
+      context: baseContext,
+      query: { bioOrDescription: "I build things", allowPublicLookup: true },
+    });
+    const { data } = JSON.parse(result);
+    expect(data.publicLookup.used).toBe(true);
+    expect(data.publicLookup.confidentMatch).toBe(true);
+    expect(data.publicLookup.identity).toEqual({
+      name: "Ada Lovelace",
+      role: "Founder at Analytical Engines",
+      location: "London",
+    });
+    expect(data.publicLookup.socials).toEqual({ linkedin: "adalovelace" });
+    expect(lastGeneratorInput).toContain("Founder at Analytical Engines");
+  });
+
+  it("never feeds not-confident lookup facts into the draft (load-bearing gate)", async () => {
+    const enrichment = makeEnrichment({
+      confidentMatch: false,
+      identity: { name: "Wrong Person", bio: "Unrelated wrong-person bio", location: "Nowhere" },
+    });
+    const preview = getPreview(buildDeps(enrichment));
+    const result = await preview.handler({
+      context: baseContext,
+      query: { bioOrDescription: "I build things", allowPublicLookup: true },
+    });
+    const { data } = JSON.parse(result);
+    expect(data.publicLookup.used).toBe(true);
+    expect(data.publicLookup.confidentMatch).toBe(false);
+    expect(lastGeneratorInput).not.toContain("Unrelated wrong-person bio");
+    expect(lastGeneratorInput).not.toContain("Enriched bio");
+  });
+});


### PR DESCRIPTION
Part 1 of IND-350. Surfaces the looked-up identity + confidence from `preview_user_profile` so AgentVillage onboarding can run an explicit "is this you?" check before public-lookup data enters a user's profile. The companion skill change lands separately in `Edge-City/agentvillage` (Part 2).

## New Features
- `preview_user_profile` now returns a `publicLookup` block alongside the blended draft:
  - `{ used: false }` when no public lookup ran (consent off, `allowPublicLookup=false`, or the enricher returned nothing).
  - `{ used: true, confidentMatch, identity: { name, role, location }, socials }` when a candidate was returned. `identity.role` is the looked-up bio/headline; `socials` is the enrichment socials verbatim.
  - Flows through the async profile-run `result` automatically (the worker re-invokes the same handler).

## Tests
- `packages/protocol/src/profile/tests/profile.public-lookup.spec.ts` (deterministic; mocks the generator module, no LLM call):
  - `allowPublicLookup:false` → `{ used: false }`.
  - confident lookup → block reflects the enrichment, and the data is folded into the draft input.
  - not-confident lookup → block surfaces `used:true`/`confidentMatch:false`, and **none of the looked-up facts reach the draft input** (the load-bearing "not confident never enters the profile" gate, now covered by a test).

## Notes
- No DB schema change, no migration; `isMeaningfulEnrichment` / `buildProfileInput` unchanged.
- Version folds into the unreleased `1.26.8` already on `dev` (npm latest is `1.26.7`).