### PR TITLE
fix(opportunity): hide expired/rejected from default opportunity list (IND-254)

### DIFF
--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -3027,7 +3027,7 @@ export class ChatDatabaseAdapter {
   }
   async getOpportunitiesForNetwork(
     networkId: string,
-    options?: { status?: string; limit?: number; offset?: number }
+    options?: { status?: string; statuses?: string[]; limit?: number; offset?: number }
   ): Promise<OpportunityRow[]> {
     return this.opportunityAdapter.getOpportunitiesForNetwork(networkId, options);
   }

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -5017,7 +5017,7 @@ export class OpportunityDatabaseAdapter {
 
   async getOpportunitiesForNetwork(
     networkId: string,
-    options?: { status?: string; limit?: number; offset?: number }
+    options?: { status?: string; statuses?: string[]; limit?: number; offset?: number }
   ): Promise<OpportunityRow[]> {
     // Actor-anchored scope: an opportunity belongs to the network when at
     // least one actor was matched there. Replaces an earlier `context.networkId`
@@ -5028,6 +5028,9 @@ export class OpportunityDatabaseAdapter {
       WHERE actor->>'networkId' = ${networkId}
     )`];
     if (options?.status) conditions.push(eq(opportunities.status, options.status as typeof opportunities.$inferSelect.status));
+    if (options?.statuses?.length) {
+      conditions.push(inArray(opportunities.status, options.statuses as Array<typeof opportunities.$inferSelect.status>));
+    }
     let q = db
       .select()
       .from(opportunities)

--- a/backend/src/adapters/tests/database.adapter.spec.ts
+++ b/backend/src/adapters/tests/database.adapter.spec.ts
@@ -965,6 +965,43 @@ describe('OpportunityDatabaseAdapter', () => {
         await db.delete(networks).where(eq(networks.id, otherNetworkId));
       }
     });
+
+    it('getOpportunitiesForNetwork narrows results by the statuses filter (IND-254)', async () => {
+      // The network/community list relies on this SQL `statuses` filter to hide
+      // stale/pre-draft opportunities (the service passes a live-status allow-list).
+      // Assert the adapter actually narrows by status, and that with no filter it
+      // returns every status (the default allow-list lives in the service, not here).
+      const mk = (status: 'pending' | 'expired' | 'latent') =>
+        adapter.createOpportunity({
+          detection: { source: 'opportunity_graph', createdBy: 'agent-opportunity-finder', timestamp: new Date().toISOString() },
+          actors: [
+            { networkId: fixture.networkId, userId: fixture.userAId, role: 'patient' },
+            { networkId: fixture.networkId, userId: fixture.userBId, role: 'agent' },
+          ],
+          interpretation: { category: 'collaboration', reasoning: `status filter ${status}`, confidence: 0.8 },
+          context: { networkId: fixture.networkId },
+          confidence: '0.8',
+          status,
+        });
+      const pendingOpp = await mk('pending');
+      const expiredOpp = await mk('expired');
+      const latentOpp = await mk('latent');
+
+      try {
+        const live = await adapter.getOpportunitiesForNetwork(fixture.networkId, { statuses: ['negotiating', 'pending', 'stalled', 'accepted'] });
+        expect(live.some((o) => o.id === pendingOpp.id)).toBe(true);
+        expect(live.some((o) => o.id === expiredOpp.id)).toBe(false);
+        expect(live.some((o) => o.id === latentOpp.id)).toBe(false);
+
+        // No status filter ⇒ adapter returns every status (no default narrowing here).
+        const all = await adapter.getOpportunitiesForNetwork(fixture.networkId);
+        expect(all.some((o) => o.id === pendingOpp.id)).toBe(true);
+        expect(all.some((o) => o.id === expiredOpp.id)).toBe(true);
+        expect(all.some((o) => o.id === latentOpp.id)).toBe(true);
+      } finally {
+        await db.delete(opportunities).where(inArray(opportunities.id, [pendingOpp.id, expiredOpp.id, latentOpp.id]));
+      }
+    });
   });
 
   describe('draft visibility (getOpportunitiesForUser)', () => {

--- a/backend/src/services/opportunity.service.ts
+++ b/backend/src/services/opportunity.service.ts
@@ -20,10 +20,13 @@ const logger = log.service.from("OpportunityService");
  * Lifecycle statuses surfaced in the default opportunity list (when no explicit
  * `status` filter is given). This is everything a user currently sees EXCEPT the
  * terminal-stale `expired` and `rejected`, which otherwise clutter the live list
- * inline with active matches (IND-254). Pre-send `draft` is already excluded by
- * the adapter's visibility rules. A caller can still request a single terminal
- * status explicitly (e.g. `?status=expired`) for a history view — that path
- * bypasses this default.
+ * inline with active matches (IND-254). Pre-send `draft` is excluded simply by
+ * its absence from this list: passing an explicit `statuses` filter makes the
+ * adapter treat it as a caller-chosen filter, which bypasses the adapter's own
+ * `!= 'draft'` default branch — so the omission here is what keeps drafts out on
+ * this path, not that branch. A caller can still request a single terminal status
+ * explicitly (e.g. `?status=expired`) for a history view — that path bypasses
+ * this default.
  */
 const DEFAULT_LIST_STATUSES: OpportunityStatus[] = ['latent', 'negotiating', 'pending', 'stalled', 'accepted'];
 

--- a/backend/src/services/opportunity.service.ts
+++ b/backend/src/services/opportunity.service.ts
@@ -27,6 +27,16 @@ const logger = log.service.from("OpportunityService");
  */
 const DEFAULT_LIST_STATUSES: OpportunityStatus[] = ['latent', 'negotiating', 'pending', 'stalled', 'accepted'];
 
+/**
+ * Default statuses for the per-network community list. Stricter than
+ * {@link DEFAULT_LIST_STATUSES}: it also drops `latent`. The per-user list can
+ * include `latent` because the adapter applies a role-based visibility guard
+ * that gates candidate-pool opportunities per actor — but the network list only
+ * checks membership, with no per-actor guard, so surfacing `latent` would leak
+ * pre-draft candidates to every member. Live community statuses only.
+ */
+const DEFAULT_NETWORK_LIST_STATUSES: OpportunityStatus[] = ['negotiating', 'pending', 'stalled', 'accepted'];
+
 interface OpportunityStatusUpdateResult {
   opportunity: Awaited<ReturnType<OpportunityControllerDatabase['updateOpportunityStatus']>>;
   counterpartUserId?: string;
@@ -813,13 +823,13 @@ export class OpportunityService {
       return { error: 'Not a member of this network', status: 403 };
     }
 
-    // Same live-status default as the per-user list (IND-254): hide terminal-stale
-    // expired/rejected unless a specific status is requested. The network list had
-    // no status filtering at all, so this also stops draft/latent leaking into the
-    // community opportunity view.
+    // IND-254: the network list had no status filtering at all, so it leaked
+    // draft/latent and terminal-stale expired/rejected into the community view.
+    // Default to live community statuses (no latent — there's no per-actor
+    // visibility guard here) unless a specific status is requested.
     return this.db.getOpportunitiesForNetwork(
       networkId,
-      options?.status ? options : { ...options, statuses: DEFAULT_LIST_STATUSES },
+      options?.status ? options : { ...options, statuses: DEFAULT_NETWORK_LIST_STATUSES },
     );
   }
 

--- a/backend/src/services/opportunity.service.ts
+++ b/backend/src/services/opportunity.service.ts
@@ -270,6 +270,7 @@ export class OpportunityService {
     userId: string,
     options?: {
       status?: 'pending' | 'stalled' | 'accepted' | 'rejected' | 'expired';
+      statuses?: OpportunityStatus[];
       networkId?: string;
       limit?: number;
       offset?: number;
@@ -278,11 +279,12 @@ export class OpportunityService {
     logger.verbose('[OpportunityService] Getting opportunities for user', { userId, options });
 
     // No explicit status filter ⇒ show only live statuses, hiding terminal-stale
-    // expired/rejected from the default list (IND-254). An explicit single status
-    // (e.g. ?status=expired) is honored as-is for a history view.
+    // expired/rejected from the default list (IND-254). An explicit `status` or
+    // `statuses` filter (e.g. ?status=expired for a history view) is honored as-is.
+    const hasExplicitStatus = !!options?.status || (options?.statuses?.length ?? 0) > 0;
     const rows = await this.db.getOpportunitiesForUser(
       userId,
-      options?.status ? options : { ...options, statuses: DEFAULT_LIST_STATUSES },
+      hasExplicitStatus ? options : { ...options, statuses: DEFAULT_LIST_STATUSES },
     );
 
     // Resolve actor names in bulk for CLI/API consumers
@@ -813,6 +815,7 @@ export class OpportunityService {
     userId: string,
     options?: {
       status?: 'pending' | 'stalled' | 'accepted' | 'rejected' | 'expired';
+      statuses?: OpportunityStatus[];
       limit?: number;
       offset?: number;
     }
@@ -821,7 +824,7 @@ export class OpportunityService {
 
     const isOwner = await this.db.isIndexOwner(networkId, userId);
     const isMember = await this.db.isNetworkMember(networkId, userId);
-    
+
     if (!isOwner && !isMember) {
       return { error: 'Not a member of this network', status: 403 };
     }
@@ -829,10 +832,11 @@ export class OpportunityService {
     // IND-254: the network list had no status filtering at all, so it leaked
     // draft/latent and terminal-stale expired/rejected into the community view.
     // Default to live community statuses (no latent — there's no per-actor
-    // visibility guard here) unless a specific status is requested.
+    // visibility guard here) unless an explicit status/statuses filter is given.
+    const hasExplicitStatus = !!options?.status || (options?.statuses?.length ?? 0) > 0;
     return this.db.getOpportunitiesForNetwork(
       networkId,
-      options?.status ? options : { ...options, statuses: DEFAULT_NETWORK_LIST_STATUSES },
+      hasExplicitStatus ? options : { ...options, statuses: DEFAULT_NETWORK_LIST_STATUSES },
     );
   }
 

--- a/backend/src/services/opportunity.service.ts
+++ b/backend/src/services/opportunity.service.ts
@@ -16,6 +16,17 @@ import { normalizeTelegramHandle } from '@indexnetwork/protocol';
 
 const logger = log.service.from("OpportunityService");
 
+/**
+ * Lifecycle statuses surfaced in the default opportunity list (when no explicit
+ * `status` filter is given). This is everything a user currently sees EXCEPT the
+ * terminal-stale `expired` and `rejected`, which otherwise clutter the live list
+ * inline with active matches (IND-254). Pre-send `draft` is already excluded by
+ * the adapter's visibility rules. A caller can still request a single terminal
+ * status explicitly (e.g. `?status=expired`) for a history view — that path
+ * bypasses this default.
+ */
+const DEFAULT_LIST_STATUSES: OpportunityStatus[] = ['latent', 'negotiating', 'pending', 'stalled', 'accepted'];
+
 interface OpportunityStatusUpdateResult {
   opportunity: Awaited<ReturnType<OpportunityControllerDatabase['updateOpportunityStatus']>>;
   counterpartUserId?: string;
@@ -253,7 +264,13 @@ export class OpportunityService {
   ) {
     logger.verbose('[OpportunityService] Getting opportunities for user', { userId, options });
 
-    const rows = await this.db.getOpportunitiesForUser(userId, options);
+    // No explicit status filter ⇒ show only live statuses, hiding terminal-stale
+    // expired/rejected from the default list (IND-254). An explicit single status
+    // (e.g. ?status=expired) is honored as-is for a history view.
+    const rows = await this.db.getOpportunitiesForUser(
+      userId,
+      options?.status ? options : { ...options, statuses: DEFAULT_LIST_STATUSES },
+    );
 
     // Resolve actor names in bulk for CLI/API consumers
     const allUserIds = new Set<string>();
@@ -796,7 +813,14 @@ export class OpportunityService {
       return { error: 'Not a member of this network', status: 403 };
     }
 
-    return this.db.getOpportunitiesForNetwork(networkId, options);
+    // Same live-status default as the per-user list (IND-254): hide terminal-stale
+    // expired/rejected unless a specific status is requested. The network list had
+    // no status filtering at all, so this also stops draft/latent leaking into the
+    // community opportunity view.
+    return this.db.getOpportunitiesForNetwork(
+      networkId,
+      options?.status ? options : { ...options, statuses: DEFAULT_LIST_STATUSES },
+    );
   }
 
   /**

--- a/backend/src/services/tests/opportunity.service.listStatusFilter.spec.ts
+++ b/backend/src/services/tests/opportunity.service.listStatusFilter.spec.ts
@@ -2,52 +2,31 @@
 import { config } from "dotenv";
 config({ path: ".env.test", override: true });
 
-import { describe, it, expect, mock, afterAll } from "bun:test";
+import { describe, it, expect, mock } from "bun:test";
 
-import type { Opportunity } from "@indexnetwork/protocol";
+import type { Opportunity, OpportunityControllerDatabase } from "@indexnetwork/protocol";
+import { OpportunityService } from "../opportunity.service";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // IND-254: the default opportunity list (no explicit status) must hide
 // terminal-stale `expired`/`rejected` while still honoring an explicit
 // `?status=expired` for a history view. The service expresses this by passing a
 // live-status allow-list to the adapter when no single status is requested.
+//
+// The per-user list keeps `latent` (gated per-actor by the adapter's visibility
+// guard); the per-network list drops `latent` too, since it has no per-actor
+// guard and would otherwise leak candidate-pool opportunities to all members.
 // ─────────────────────────────────────────────────────────────────────────────
 
-const EXPECTED_LIVE_STATUSES = ["latent", "negotiating", "pending", "stalled", "accepted"];
-
-// Mock adapters that the OpportunityService constructor initializes
-const MockChatDatabaseAdapter = class {
-  getHydeDocument() { return null; }
-};
-mock.module("../../adapters/database.adapter", () => ({
-  ChatDatabaseAdapter: MockChatDatabaseAdapter,
-  chatDatabaseAdapter: new MockChatDatabaseAdapter(),
-}));
-mock.module("../../adapters/embedder.adapter", () => ({
-  EmbedderAdapter: class {},
-}));
-mock.module("../../adapters/cache.adapter", () => ({
-  RedisCacheAdapter: class {
-    mget() { return Promise.resolve([]); }
-    get() { return Promise.resolve(null); }
-    set() { return Promise.resolve(); }
-    del() { return Promise.resolve(); }
-  },
-}));
-
-afterAll(() => {
-  mock.restore();
-});
-
-const { OpportunityService } = await import("../opportunity.service");
+const EXPECTED_USER_STATUSES = ["latent", "negotiating", "pending", "stalled", "accepted"];
+const EXPECTED_NETWORK_STATUSES = ["negotiating", "pending", "stalled", "accepted"];
 
 type Captured = { opts?: Record<string, unknown> };
 
 function createService() {
-  const service = new OpportunityService();
   const userCall: Captured = {};
   const networkCall: Captured = {};
-  (service as unknown as Record<string, unknown>).db = {
+  const db = {
     getOpportunitiesForUser: mock((_userId: string, opts?: Record<string, unknown>) => {
       userCall.opts = opts;
       return Promise.resolve([] as Opportunity[]);
@@ -59,7 +38,8 @@ function createService() {
     getUser: mock(() => Promise.resolve(null)),
     isIndexOwner: mock(() => Promise.resolve(true)),
     isNetworkMember: mock(() => Promise.resolve(true)),
-  };
+  } as unknown as OpportunityControllerDatabase;
+  const service = new OpportunityService(db);
   return { service, userCall, networkCall };
 }
 
@@ -69,7 +49,7 @@ describe("OpportunityService list status filtering (IND-254)", () => {
       const { service, userCall } = createService();
       await service.getOpportunitiesForUser("user-1");
 
-      expect(userCall.opts?.statuses).toEqual(EXPECTED_LIVE_STATUSES);
+      expect(userCall.opts?.statuses).toEqual(EXPECTED_USER_STATUSES);
       expect(userCall.opts?.statuses).not.toContain("expired");
       expect(userCall.opts?.statuses).not.toContain("rejected");
       expect(userCall.opts?.status).toBeUndefined();
@@ -88,16 +68,18 @@ describe("OpportunityService list status filtering (IND-254)", () => {
       await service.getOpportunitiesForUser("user-1", { networkId: "net-1" });
 
       expect(userCall.opts?.networkId).toBe("net-1");
-      expect(userCall.opts?.statuses).toEqual(EXPECTED_LIVE_STATUSES);
+      expect(userCall.opts?.statuses).toEqual(EXPECTED_USER_STATUSES);
     });
   });
 
   describe("getOpportunitiesForNetwork", () => {
-    it("defaults to live statuses when no status is given", async () => {
+    it("defaults to live community statuses (no latent/expired/rejected) when no status is given", async () => {
       const { service, networkCall } = createService();
       await service.getOpportunitiesForNetwork("net-1", "user-1");
 
-      expect(networkCall.opts?.statuses).toEqual(EXPECTED_LIVE_STATUSES);
+      expect(networkCall.opts?.statuses).toEqual(EXPECTED_NETWORK_STATUSES);
+      expect(networkCall.opts?.statuses).not.toContain("latent");
+      expect(networkCall.opts?.statuses).not.toContain("expired");
       expect(networkCall.opts?.status).toBeUndefined();
     });
 

--- a/backend/src/services/tests/opportunity.service.listStatusFilter.spec.ts
+++ b/backend/src/services/tests/opportunity.service.listStatusFilter.spec.ts
@@ -1,0 +1,112 @@
+/** Config */
+import { config } from "dotenv";
+config({ path: ".env.test", override: true });
+
+import { describe, it, expect, mock, afterAll } from "bun:test";
+
+import type { Opportunity } from "@indexnetwork/protocol";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// IND-254: the default opportunity list (no explicit status) must hide
+// terminal-stale `expired`/`rejected` while still honoring an explicit
+// `?status=expired` for a history view. The service expresses this by passing a
+// live-status allow-list to the adapter when no single status is requested.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const EXPECTED_LIVE_STATUSES = ["latent", "negotiating", "pending", "stalled", "accepted"];
+
+// Mock adapters that the OpportunityService constructor initializes
+const MockChatDatabaseAdapter = class {
+  getHydeDocument() { return null; }
+};
+mock.module("../../adapters/database.adapter", () => ({
+  ChatDatabaseAdapter: MockChatDatabaseAdapter,
+  chatDatabaseAdapter: new MockChatDatabaseAdapter(),
+}));
+mock.module("../../adapters/embedder.adapter", () => ({
+  EmbedderAdapter: class {},
+}));
+mock.module("../../adapters/cache.adapter", () => ({
+  RedisCacheAdapter: class {
+    mget() { return Promise.resolve([]); }
+    get() { return Promise.resolve(null); }
+    set() { return Promise.resolve(); }
+    del() { return Promise.resolve(); }
+  },
+}));
+
+afterAll(() => {
+  mock.restore();
+});
+
+const { OpportunityService } = await import("../opportunity.service");
+
+type Captured = { opts?: Record<string, unknown> };
+
+function createService() {
+  const service = new OpportunityService();
+  const userCall: Captured = {};
+  const networkCall: Captured = {};
+  (service as unknown as Record<string, unknown>).db = {
+    getOpportunitiesForUser: mock((_userId: string, opts?: Record<string, unknown>) => {
+      userCall.opts = opts;
+      return Promise.resolve([] as Opportunity[]);
+    }),
+    getOpportunitiesForNetwork: mock((_networkId: string, opts?: Record<string, unknown>) => {
+      networkCall.opts = opts;
+      return Promise.resolve([] as Opportunity[]);
+    }),
+    getUser: mock(() => Promise.resolve(null)),
+    isIndexOwner: mock(() => Promise.resolve(true)),
+    isNetworkMember: mock(() => Promise.resolve(true)),
+  };
+  return { service, userCall, networkCall };
+}
+
+describe("OpportunityService list status filtering (IND-254)", () => {
+  describe("getOpportunitiesForUser", () => {
+    it("defaults to live statuses (no expired/rejected) when no status is given", async () => {
+      const { service, userCall } = createService();
+      await service.getOpportunitiesForUser("user-1");
+
+      expect(userCall.opts?.statuses).toEqual(EXPECTED_LIVE_STATUSES);
+      expect(userCall.opts?.statuses).not.toContain("expired");
+      expect(userCall.opts?.statuses).not.toContain("rejected");
+      expect(userCall.opts?.status).toBeUndefined();
+    });
+
+    it("honors an explicit terminal status (history view) without injecting the allow-list", async () => {
+      const { service, userCall } = createService();
+      await service.getOpportunitiesForUser("user-1", { status: "expired" });
+
+      expect(userCall.opts?.status).toBe("expired");
+      expect(userCall.opts?.statuses).toBeUndefined();
+    });
+
+    it("preserves other options (networkId) alongside the default allow-list", async () => {
+      const { service, userCall } = createService();
+      await service.getOpportunitiesForUser("user-1", { networkId: "net-1" });
+
+      expect(userCall.opts?.networkId).toBe("net-1");
+      expect(userCall.opts?.statuses).toEqual(EXPECTED_LIVE_STATUSES);
+    });
+  });
+
+  describe("getOpportunitiesForNetwork", () => {
+    it("defaults to live statuses when no status is given", async () => {
+      const { service, networkCall } = createService();
+      await service.getOpportunitiesForNetwork("net-1", "user-1");
+
+      expect(networkCall.opts?.statuses).toEqual(EXPECTED_LIVE_STATUSES);
+      expect(networkCall.opts?.status).toBeUndefined();
+    });
+
+    it("honors an explicit terminal status without injecting the allow-list", async () => {
+      const { service, networkCall } = createService();
+      await service.getOpportunitiesForNetwork("net-1", "user-1", { status: "rejected" });
+
+      expect(networkCall.opts?.status).toBe("rejected");
+      expect(networkCall.opts?.statuses).toBeUndefined();
+    });
+  });
+});

--- a/backend/src/services/tests/opportunity.service.listStatusFilter.spec.ts
+++ b/backend/src/services/tests/opportunity.service.listStatusFilter.spec.ts
@@ -63,6 +63,13 @@ describe("OpportunityService list status filtering (IND-254)", () => {
       expect(userCall.opts?.statuses).toBeUndefined();
     });
 
+    it("preserves an explicit statuses filter instead of overwriting it with the default", async () => {
+      const { service, userCall } = createService();
+      await service.getOpportunitiesForUser("user-1", { statuses: ["expired", "rejected"] });
+
+      expect(userCall.opts?.statuses).toEqual(["expired", "rejected"]);
+    });
+
     it("preserves other options (networkId) alongside the default allow-list", async () => {
       const { service, userCall } = createService();
       await service.getOpportunitiesForUser("user-1", { networkId: "net-1" });
@@ -89,6 +96,13 @@ describe("OpportunityService list status filtering (IND-254)", () => {
 
       expect(networkCall.opts?.status).toBe("rejected");
       expect(networkCall.opts?.statuses).toBeUndefined();
+    });
+
+    it("preserves an explicit statuses filter instead of overwriting it with the default", async () => {
+      const { service, networkCall } = createService();
+      await service.getOpportunitiesForNetwork("net-1", "user-1", { statuses: ["expired"] });
+
+      expect(networkCall.opts?.statuses).toEqual(["expired"]);
     });
   });
 });


### PR DESCRIPTION
Closes IND-254.

## Bug Fixes

The default opportunity list (`GET /opportunities` and the per-network community list `GET /:networkId/opportunities`) was showing **expired** and **rejected** opportunities inline with active ones — the orange "Expired" cards from the bug report.

**Root cause:** when no `?status` filter is passed, the service forwarded no `statuses` to the adapter, so the query fell through to the adapter default that excludes only `draft`. Every other status — including terminal-stale `expired`/`rejected` — passed through into the feed.

**Fix (backend-only):**
- `OpportunityService.getOpportunitiesForUser` / `getOpportunitiesForNetwork` now default to a live-status allow-list — `['latent','negotiating','pending','stalled','accepted']` — when no explicit status is requested. Expired/rejected are hidden; everything else that was shown before is unchanged.
- Deliberately fixed at the **service** layer, not the adapter default: `maintenance.graph` calls the adapter directly for dedup and must keep seeing rejected/expired so it never re-suggests a declined match.
- An explicit `?status=expired` (or `rejected`) still works as a history view — `listStatusSchema` already permits it.
- Added `statuses` support to the adapter's `getOpportunitiesForNetwork`, which previously had no status filtering at all (it was also leaking `draft`/`latent` into the community opportunity view).

No frontend or `@indexnetwork/protocol` change required — the stale cards simply stop arriving in the default API response. `OpportunityQueryOptions` already carries `statuses`.

## Tests

- New `backend/src/services/tests/opportunity.service.listStatusFilter.spec.ts` (5 cases): default hides expired/rejected for both list methods, explicit status passes through without injecting the allow-list, and unrelated options (networkId) are preserved.
- All 25 existing opportunity-service specs pass; `tsc --noEmit` clean; eslint clean.

## Test Plan
- [ ] `GET /opportunities` with no status returns no expired/rejected cards
- [ ] `GET /opportunities?status=expired` still returns expired (history view)
- [ ] `GET /:networkId/opportunities` no longer shows draft/latent/expired/rejected by default
- [ ] Maintenance dedup still avoids re-suggesting rejected matches (unaffected — uses adapter directly)