### PR TITLE
refactor(protocol)!: remove configureProtocol global state, thread ModelConfig through ChatAgent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,7 +288,7 @@ Negotiation-specific events (`negotiation_session_start/end`, `negotiation_turn`
 
 ### OpenRouter Configuration
 
-Model settings centralized in `packages/protocol/src/shared/agent/model.config.ts`. Key env vars: `OPENROUTER_API_KEY` (required), `CHAT_MODEL` (override), `CHAT_REASONING_EFFORT` (`minimal|low|medium|high|xhigh`), `RUN_OPPORTUNITY_EVAL_IN_PARALLEL` (experimental), `NEGOTIATION_MAX_TURNS_CHAT` (default 4, chat-path negotiations), `NEGOTIATION_MAX_TURNS_AMBIENT` (default 6, ambient/background negotiations). Use `ToolContext.modelConfig` to inject config per-request (pass it to `createChatTools` or `ChatAgent.create`).
+Model settings centralized in `packages/protocol/src/shared/agent/model.config.ts`. Key env vars: `OPENROUTER_API_KEY` (required), `CHAT_MODEL` (override), `CHAT_REASONING_EFFORT` (`minimal|low|medium|high|xhigh`), `RUN_OPPORTUNITY_EVAL_IN_PARALLEL` (experimental), `NEGOTIATION_MAX_TURNS_CHAT` (default 4, chat-path negotiations), `NEGOTIATION_MAX_TURNS_AMBIENT` (default 6, ambient/background negotiations). Use `ToolContext.modelConfig` to inject config per-request via `ChatAgent.create`; only `ChatAgent` honors this — all other protocol agents require `OPENROUTER_API_KEY` in the environment.
 
 ### Rate Limiting
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,7 +288,7 @@ Negotiation-specific events (`negotiation_session_start/end`, `negotiation_turn`
 
 ### OpenRouter Configuration
 
-Model settings centralized in `packages/protocol/src/shared/agent/model.config.ts`. Key env vars: `OPENROUTER_API_KEY` (required), `CHAT_MODEL` (override), `CHAT_REASONING_EFFORT` (`minimal|low|medium|high|xhigh`), `RUN_OPPORTUNITY_EVAL_IN_PARALLEL` (experimental), `NEGOTIATION_MAX_TURNS_CHAT` (default 4, chat-path negotiations), `NEGOTIATION_MAX_TURNS_AMBIENT` (default 6, ambient/background negotiations). Use `configureProtocol({ apiKey, chatModel, ... })` to inject config programmatically.
+Model settings centralized in `packages/protocol/src/shared/agent/model.config.ts`. Key env vars: `OPENROUTER_API_KEY` (required), `CHAT_MODEL` (override), `CHAT_REASONING_EFFORT` (`minimal|low|medium|high|xhigh`), `RUN_OPPORTUNITY_EVAL_IN_PARALLEL` (experimental), `NEGOTIATION_MAX_TURNS_CHAT` (default 4, chat-path negotiations), `NEGOTIATION_MAX_TURNS_AMBIENT` (default 6, ambient/background negotiations). Use `ToolContext.modelConfig` to inject config per-request (pass it to `createChatTools` or `ChatAgent.create`).
 
 ### Rate Limiting
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,7 +288,7 @@ Negotiation-specific events (`negotiation_session_start/end`, `negotiation_turn`
 
 ### OpenRouter Configuration
 
-Model settings centralized in `packages/protocol/src/shared/agent/model.config.ts`. Key env vars: `OPENROUTER_API_KEY` (required), `CHAT_MODEL` (override), `CHAT_REASONING_EFFORT` (`minimal|low|medium|high|xhigh`), `RUN_OPPORTUNITY_EVAL_IN_PARALLEL` (experimental), `NEGOTIATION_MAX_TURNS_CHAT` (default 4, chat-path negotiations), `NEGOTIATION_MAX_TURNS_AMBIENT` (default 6, ambient/background negotiations). Use `ToolContext.modelConfig` to inject config per-request via `ChatAgent.create`; only `ChatAgent` honors this — all other protocol agents require `OPENROUTER_API_KEY` in the environment.
+Model settings centralized in `packages/protocol/src/shared/agent/model.config.ts`. Key env vars: `OPENROUTER_API_KEY` (required), `CHAT_MODEL` (override), `CHAT_REASONING_EFFORT` (`minimal|low|medium|high|xhigh`), `RUN_OPPORTUNITY_EVAL_IN_PARALLEL` (experimental), `NEGOTIATION_MAX_TURNS_CHAT` (default 4, chat-path negotiations), `NEGOTIATION_MAX_TURNS_AMBIENT` (default 6, ambient/background negotiations). Use `ToolContext.modelConfig` to inject config per-request via `ChatAgent.create`; only `ChatAgent` reads `ModelConfig` from `ToolContext` — most other protocol agents rely on `OPENROUTER_API_KEY` in the environment (some accept an explicit `ModelConfig` as a direct parameter to `createModel()`).
 
 ### Rate Limiting
 

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -26,7 +26,7 @@ const tools = await createChatTools({
 });
 ```
 
-`apiKey` and `baseURL` can also be overridden here. Note: `modelConfig` is only honored by `ChatAgent`. All other protocol agents (evaluators, generators, etc.) always require `OPENROUTER_API_KEY` set in the environment.
+`apiKey` and `baseURL` can also be overridden. Note: `modelConfig` is only honored by `ChatAgent` — it reads all `ModelConfig` fields (`apiKey`, `baseURL`, `chatModel`, `chatReasoningEffort`) from `ToolContext` when the chat graph runs. All other protocol agents (evaluators, generators, etc.) rely on `OPENROUTER_API_KEY` set in the environment.
 
 ### 2. Implement the adapters
 

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -17,6 +17,8 @@ The package reads `OPENROUTER_API_KEY` (required), `CHAT_MODEL`, and `CHAT_REASO
 To override the chat model or reasoning effort per request, set `modelConfig` on `ToolContext`:
 
 ```typescript
+import { createChatTools } from "@indexnetwork/protocol";
+
 const tools = await createChatTools({
   // ... other deps ...
   modelConfig: {

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -26,7 +26,7 @@ const tools = await createChatTools({
 });
 ```
 
-`apiKey` and `baseURL` can also be overridden here if you need to use a different OpenRouter key per request.
+`apiKey` and `baseURL` can also be overridden here. Note: `modelConfig` is only honored by `ChatAgent`. All other protocol agents (evaluators, generators, etc.) always require `OPENROUTER_API_KEY` set in the environment.
 
 ### 2. Implement the adapters
 

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -12,17 +12,21 @@ npm install @indexnetwork/protocol
 
 ### 1. Configure the LLM
 
-Call `configureProtocol` once at startup before creating any tools or graphs:
+The package reads `OPENROUTER_API_KEY` (required), `CHAT_MODEL`, and `CHAT_REASONING_EFFORT` from environment variables. No startup call is needed.
+
+To override the chat model or reasoning effort per request, set `modelConfig` on `ToolContext`:
 
 ```typescript
-import { configureProtocol } from "@indexnetwork/protocol";
-
-configureProtocol({
-  apiKey: process.env.OPENROUTER_API_KEY,
-  chatModel: "google/gemini-2.5-flash",       // optional — has a default
-  chatReasoningEffort: "low",                  // optional: minimal | low | medium | high | xhigh
+const tools = await createChatTools({
+  // ... other deps ...
+  modelConfig: {
+    chatModel: "google/gemini-2.5-flash",       // optional — has a default
+    chatReasoningEffort: "low",                  // optional: minimal | low | medium | high | xhigh
+  },
 });
 ```
+
+`apiKey` and `baseURL` can also be overridden here if you need to use a different OpenRouter key per request.
 
 ### 2. Implement the adapters
 

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "1.26.9",
+  "version": "2.0.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/chat/chat.agent.ts
+++ b/packages/protocol/src/chat/chat.agent.ts
@@ -18,7 +18,7 @@ import {
   type IterationContext,
 } from "./chat.prompt.modules.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
-import { createModel } from "../shared/agent/model.config.js";
+import { createModel, type ModelConfig } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 import { sanitizeForDebugMeta } from "../shared/observability/debug-meta.sanitizer.js";
 import type { DebugMetaToolCall, DebugMetaLlm, DebugMetaOrchestratorNegotiations, DebugMetaDiscoveryQuestions } from "./chat-streaming.types.js";
@@ -227,8 +227,9 @@ export class ChatAgent {
   private constructor(
     private resolvedContext: ResolvedToolContext,
     tools: Awaited<ReturnType<typeof createChatTools>>,
+    modelConfig?: ModelConfig,
   ) {
-    this.model = createModel("chat");
+    this.model = createModel("chat", modelConfig);
 
     // Store tools and index by name
     this.tools = tools;
@@ -266,7 +267,7 @@ export class ChatAgent {
       sessionId: context.sessionId,
     });
     const tools = await createChatTools(context, resolved);
-    return new ChatAgent(resolved, tools);
+    return new ChatAgent(resolved, tools, context.modelConfig);
   }
 
   /**

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1,7 +1,7 @@
 // ─── Public API (recommended for external consumers) ──────────────────────────
 
 export { createChatTools } from "./shared/agent/tool.factory.js";
-export { configureProtocol, getModelName } from "./shared/agent/model.config.js";
+export { getModelName } from "./shared/agent/model.config.js";
 export type { ChatTools } from "./shared/agent/tool.factory.js";
 export type { ModelConfig, ModelSettings } from "./shared/agent/model.config.js";
 export type {

--- a/packages/protocol/src/shared/agent/model.config.ts
+++ b/packages/protocol/src/shared/agent/model.config.ts
@@ -10,7 +10,7 @@ export interface ModelSettings {
 
 /**
  * Runtime configuration for the protocol package.
- * Set once via configureProtocol() at application startup.
+ * Pass via ToolContext.modelConfig to override env vars for the chat model.
  * All fields fall back to environment variables if not provided.
  */
 export interface ModelConfig {
@@ -24,22 +24,7 @@ export interface ModelConfig {
   chatReasoningEffort?: 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
 }
 
-/** Module-level config set by configureProtocol(). Merged with per-call overrides. */
-let _activeConfig: ModelConfig = {};
-
-/**
- * Configure the protocol package with runtime credentials and settings.
- * Call once at application startup before any agents are used.
- * Falls back to environment variables for any field not provided.
- *
- * @param config - Runtime configuration overrides
- */
-export function configureProtocol(config: ModelConfig): void {
-  _activeConfig = config;
-}
-
 function getModelConfig(config?: ModelConfig) {
-  const merged: ModelConfig = { ..._activeConfig, ...config };
   return {
     intentInferrer:       { model: "google/gemini-2.5-flash" },
     intentIndexer:        { model: "google/gemini-2.5-flash" },
@@ -66,10 +51,10 @@ function getModelConfig(config?: ModelConfig) {
     premiseIndexer:       { model: "google/gemini-2.5-flash" },
     userContextGenerator: { model: "google/gemini-2.5-flash", temperature: 0.3, maxTokens: 512 },
     chat: {
-      model: merged.chatModel ?? process.env.CHAT_MODEL ?? "google/gemini-3-pro-preview",
+      model: config?.chatModel ?? process.env.CHAT_MODEL ?? "google/gemini-3-pro-preview",
       maxTokens: 8192,
       reasoning: {
-        effort: (merged.chatReasoningEffort ?? process.env.CHAT_REASONING_EFFORT ?? "low") as NonNullable<ModelSettings["reasoning"]>["effort"],
+        effort: (config?.chatReasoningEffort ?? process.env.CHAT_REASONING_EFFORT ?? "low") as NonNullable<ModelSettings["reasoning"]>["effort"],
         exclude: true,
       },
     },
@@ -79,7 +64,7 @@ function getModelConfig(config?: ModelConfig) {
 /**
  * Returns the model name string for the given agent key.
  * @param agent - Key from MODEL_CONFIG identifying which agent's settings to use.
- * @param config - Optional runtime config overrides (merged with module-level config).
+ * @param config - Optional runtime config overrides.
  */
 export function getModelName(agent: keyof ReturnType<typeof getModelConfig>, config?: ModelConfig): string {
   return getModelConfig(config)[agent].model;
@@ -88,15 +73,14 @@ export function getModelName(agent: keyof ReturnType<typeof getModelConfig>, con
 /**
  * Creates a ChatOpenAI instance configured for OpenRouter.
  * @param agent - Key identifying which agent's model settings to use.
- * @param config - Optional runtime config overrides (merged with module-level config).
+ * @param config - Optional runtime config overrides.
  */
 export function createModel(agent: keyof ReturnType<typeof getModelConfig>, config?: ModelConfig): ChatOpenAI {
-  const merged: ModelConfig = { ..._activeConfig, ...config };
-  const apiKey = merged.apiKey ?? process.env.OPENROUTER_API_KEY;
+  const apiKey = config?.apiKey ?? process.env.OPENROUTER_API_KEY;
   if (!apiKey?.trim()) {
-    throw new Error(`createModel(${agent}): OPENROUTER_API_KEY is required. Pass via configureProtocol({ apiKey }) or set the OPENROUTER_API_KEY environment variable.`);
+    throw new Error(`createModel(${agent}): OPENROUTER_API_KEY is required. Pass via ToolContext.modelConfig.apiKey or set the OPENROUTER_API_KEY environment variable.`);
   }
-  const cfg = getModelConfig(merged)[agent] as ModelSettings;
+  const cfg = getModelConfig(config)[agent] as ModelSettings;
   // Hard upper bound on a single LLM call. Without this, langchain's HTTP
   // client waits until the upstream cuts the socket (~3 minutes via
   // OpenRouter), blocking the entire chat response. 60 s is generous enough
@@ -113,7 +97,7 @@ export function createModel(agent: keyof ReturnType<typeof getModelConfig>, conf
   return new ChatOpenAI({
     model: cfg.model,
     configuration: {
-      baseURL: merged.baseURL ?? process.env.OPENROUTER_BASE_URL ?? "https://openrouter.ai/api/v1",
+      baseURL: config?.baseURL ?? process.env.OPENROUTER_BASE_URL ?? "https://openrouter.ai/api/v1",
       apiKey,
     },
     temperature: cfg.temperature,

--- a/packages/protocol/src/shared/agent/model.config.ts
+++ b/packages/protocol/src/shared/agent/model.config.ts
@@ -10,8 +10,10 @@ export interface ModelSettings {
 
 /**
  * Runtime configuration for the protocol package.
- * Pass via `ToolContext.modelConfig` (honored by `ChatAgent`) or directly to `createModel()`.
- * Only `ChatAgent` reads this from `ToolContext`; all other protocol agents require env vars.
+ * When passed via `ToolContext.modelConfig`, all fields (`apiKey`, `baseURL`, `chatModel`,
+ * `chatReasoningEffort`) are honored by `ChatAgent` when the chat graph runs.
+ * Other protocol agents don't read from `ToolContext` but may accept an explicit `ModelConfig`
+ * as a direct parameter to `createModel()`.
  * All fields fall back to environment variables if not provided.
  */
 export interface ModelConfig {

--- a/packages/protocol/src/shared/agent/model.config.ts
+++ b/packages/protocol/src/shared/agent/model.config.ts
@@ -10,7 +10,8 @@ export interface ModelSettings {
 
 /**
  * Runtime configuration for the protocol package.
- * Pass via ToolContext.modelConfig to override env vars for the chat model.
+ * Pass via `ToolContext.modelConfig` (honored by `ChatAgent`) or directly to `createModel()`.
+ * Only `ChatAgent` reads this from `ToolContext`; all other protocol agents require env vars.
  * All fields fall back to environment variables if not provided.
  */
 export interface ModelConfig {
@@ -78,7 +79,7 @@ export function getModelName(agent: keyof ReturnType<typeof getModelConfig>, con
 export function createModel(agent: keyof ReturnType<typeof getModelConfig>, config?: ModelConfig): ChatOpenAI {
   const apiKey = config?.apiKey ?? process.env.OPENROUTER_API_KEY;
   if (!apiKey?.trim()) {
-    throw new Error(`createModel(${agent}): OPENROUTER_API_KEY is required. Pass via ToolContext.modelConfig.apiKey or set the OPENROUTER_API_KEY environment variable.`);
+    throw new Error(`createModel(${agent}): OPENROUTER_API_KEY is required. Pass via the config argument, ToolContext.modelConfig.apiKey, or set the OPENROUTER_API_KEY environment variable.`);
   }
   const cfg = getModelConfig(config)[agent] as ModelSettings;
   // Hard upper bound on a single LLM call. Without this, langchain's HTTP

--- a/packages/protocol/src/shared/agent/tests/model.config.spec.ts
+++ b/packages/protocol/src/shared/agent/tests/model.config.spec.ts
@@ -2,10 +2,25 @@ import { describe, it, expect } from "bun:test";
 import { getModelName } from "../model.config.js";
 
 describe("getModelName", () => {
-  it("returns the default chat model when no config is passed", () => {
-    const model = getModelName("chat");
-    expect(typeof model).toBe("string");
-    expect(model.length).toBeGreaterThan(0);
+  it("returns the hardcoded default when CHAT_MODEL env var is unset", () => {
+    const saved = process.env.CHAT_MODEL;
+    delete process.env.CHAT_MODEL;
+    try {
+      expect(getModelName("chat")).toBe("google/gemini-3-pro-preview");
+    } finally {
+      if (saved !== undefined) process.env.CHAT_MODEL = saved;
+    }
+  });
+
+  it("returns the CHAT_MODEL env var when set and no config is passed", () => {
+    const saved = process.env.CHAT_MODEL;
+    process.env.CHAT_MODEL = "test/env-model";
+    try {
+      expect(getModelName("chat")).toBe("test/env-model");
+    } finally {
+      if (saved !== undefined) process.env.CHAT_MODEL = saved;
+      else delete process.env.CHAT_MODEL;
+    }
   });
 
   it("returns the override chatModel when config is passed", () => {

--- a/packages/protocol/src/shared/agent/tests/model.config.spec.ts
+++ b/packages/protocol/src/shared/agent/tests/model.config.spec.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "bun:test";
+import { getModelName } from "../model.config.js";
+
+describe("getModelName", () => {
+  it("returns the default chat model when no config is passed", () => {
+    const model = getModelName("chat");
+    expect(typeof model).toBe("string");
+    expect(model.length).toBeGreaterThan(0);
+  });
+
+  it("returns the override chatModel when config is passed", () => {
+    const model = getModelName("chat", { chatModel: "test/override-model" });
+    expect(model).toBe("test/override-model");
+  });
+
+  it("returns the hardcoded model for non-chat agents regardless of config", () => {
+    const model = getModelName("opportunityEvaluator", { chatModel: "test/override-model" });
+    expect(model).toBe("google/gemini-2.5-flash");
+  });
+});

--- a/packages/protocol/src/shared/agent/tool.factory.ts
+++ b/packages/protocol/src/shared/agent/tool.factory.ts
@@ -14,7 +14,6 @@ import { IntentIndexer } from "../../intent/intent.indexer.js";
 import { NegotiationGraphFactory } from "../../negotiation/negotiation.graph.js";
 import { PremiseGraphFactory } from "../../premise/premise.graph.js";
 import { protocolLogger } from "../observability/protocol.logger.js";
-import { configureProtocol } from "./model.config.js";
 
 import type { QuestionerEnqueueFn } from "../../questioner/questioner.types.js";
 
@@ -59,11 +58,6 @@ export async function createChatTools(
   deps: ToolContext,
   preResolvedContext?: ResolvedToolContext
 ) {
-  // Apply model config so all agents created in this session use the right credentials.
-  if (deps.modelConfig) {
-    configureProtocol(deps.modelConfig);
-  }
-
   const { database, embedder, scraper } = deps;
 
   // ─── Resolve context from DB ───────────────────────────────────────────────

--- a/scripts/claude/protocol.CLAUDE.md
+++ b/scripts/claude/protocol.CLAUDE.md
@@ -30,7 +30,7 @@ Each domain exposes a `*GraphFactory` class. Pattern:
 2. `{domain}/{domain}.graph.ts` — `*GraphFactory` class; constructor receives typed deps (subsets of the interfaces in `shared/interfaces/`). Compile graph in the constructor.
 3. Export the factory from `src/index.ts`.
 
-Graphs must not import from `backend/` or call `configureProtocol` — they call `createModel()` from `shared/agent/model.config.ts`.
+Graphs must not import from `backend/` or use global config state — they call `createModel()` from `shared/agent/model.config.ts`.
 
 ## Adding a new infrastructure interface
 


### PR DESCRIPTION
## Summary

- Removes the module-level `_activeConfig` mutable variable and `configureProtocol()` function from `@indexnetwork/protocol` — the only piece of global mutable state in the package
- Threads `ModelConfig` explicitly through `ChatAgent` private constructor and `ChatAgent.create()`, so `createModel("chat", modelConfig)` receives the per-request override directly instead of via a global side-effect
- Removes the `configureProtocol(deps.modelConfig)` call from `createChatTools` in `tool.factory.ts`
- Removes `configureProtocol` from the public npm API (`src/index.ts`) — `ModelConfig` and `ModelSettings` types remain exported
- Bumps package version `1.26.9` → `2.0.0` (breaking: public API removal)
- Updates README and inline docs to reflect env-var + per-request `ToolContext.modelConfig` pattern

## Test Plan

- [ ] `cd packages/protocol && bun test src/shared/agent/tests/model.config.spec.ts` — 3 tests pass (default fallback, chatModel override, non-chat agents ignore config)
- [ ] `cd packages/protocol && bun run build` — clean TypeScript build
- [ ] Grep confirms zero references to `configureProtocol` or `_activeConfig` in `packages/protocol/src/`