### PR TITLE
fix(protocol): propagate actual exception in profile graph catch blocks

### DIFF
--- a/packages/protocol/src/profile/profile.graph.ts
+++ b/packages/protocol/src/profile/profile.graph.ts
@@ -239,7 +239,7 @@ export class ProfileGraphFactory {
           });
           return {
             profile: undefined,
-            error: "Failed to load profile from database"
+            error: `Failed to load profile from database: ${error instanceof Error ? error.message : String(error)}`
           };
         }
       });
@@ -326,7 +326,7 @@ export class ProfileGraphFactory {
             error: error instanceof Error ? error.message : String(error)
           });
           return {
-            error: "Web scrape failed"
+            error: `Web scrape failed: ${error instanceof Error ? error.message : String(error)}`
           };
         }
       });
@@ -590,7 +590,7 @@ export class ProfileGraphFactory {
             error: error instanceof Error ? error.message : String(error)
           });
           return {
-            error: "Profile generation failed",
+            error: `Profile generation failed: ${error instanceof Error ? error.message : String(error)}`,
             agentTimings: agentTimingsAccum
           };
         }
@@ -675,7 +675,7 @@ export class ProfileGraphFactory {
             error: error instanceof Error ? error.message : String(error)
           });
           return {
-            error: "Failed to save profile"
+            error: `Failed to save profile: ${error instanceof Error ? error.message : String(error)}`
           };
         }
       });


### PR DESCRIPTION
## Summary

- Four catch blocks in `profile.graph.ts` were swallowing exceptions into generic strings (`"Profile generation failed"`, `"Web scrape failed"`, `"Failed to load profile from database"`, `"Failed to save profile"`) while only logging the real message locally
- Sentry captured the generic string, making issues like BACKEND-A impossible to diagnose from the alert alone (root cause was a 402 OpenRouter credits error, which was completely invisible in the Sentry event)
- Each error string now appends the exception message so Sentry surfaces the actual cause

## Test Plan

- [ ] `bun run build` in `packages/protocol` passes (tsc clean)
- [ ] Next occurrence of a profile graph failure in Sentry shows the real exception message alongside the phase that failed