### PR TITLE
fix(protocol): propagate actual exception in profile graph catch blocks

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "1.26.8",
+  "version": "1.26.9",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/profile/profile.graph.ts
+++ b/packages/protocol/src/profile/profile.graph.ts
@@ -239,7 +239,7 @@ export class ProfileGraphFactory {
           });
           return {
             profile: undefined,
-            error: "Failed to load profile from database"
+            error: `Failed to load profile from database: ${error instanceof Error ? error.message : String(error)}`
           };
         }
       });
@@ -326,7 +326,7 @@ export class ProfileGraphFactory {
             error: error instanceof Error ? error.message : String(error)
           });
           return {
-            error: "Web scrape failed"
+            error: `Web scrape failed: ${error instanceof Error ? error.message : String(error)}`
           };
         }
       });
@@ -590,7 +590,7 @@ export class ProfileGraphFactory {
             error: error instanceof Error ? error.message : String(error)
           });
           return {
-            error: "Profile generation failed",
+            error: `Profile generation failed: ${error instanceof Error ? error.message : String(error)}`,
             agentTimings: agentTimingsAccum
           };
         }
@@ -675,7 +675,7 @@ export class ProfileGraphFactory {
             error: error instanceof Error ? error.message : String(error)
           });
           return {
-            error: "Failed to save profile"
+            error: `Failed to save profile: ${error instanceof Error ? error.message : String(error)}`
           };
         }
       });


### PR DESCRIPTION
## Summary

Cherry-pick of #922 onto `main`.

- Four catch blocks in `profile.graph.ts` swallowed exceptions into generic strings (`"Profile generation failed"`, `"Web scrape failed"`, etc.) — Sentry captured the generic string, making production issues impossible to diagnose
- Each error string now appends the exception message (e.g. `"Profile generation failed: 402 insufficient credits"`)
- Protocol bumped `1.26.8` → `1.26.9`

## Test Plan

- [x] `tsc` clean
- [ ] Next profile graph failure in Sentry shows the real exception alongside the phase