### PR TITLE
Release 2026-06-09

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,28 +1,6 @@
 {
   "permissions": {
-    "allow": [
-      "Read",
-      "Bash(git check-ignore:*)",
-      "Bash(git branch:*)",
-      "Bash(git log:*)",
-      "Bash(git status:*)",
-      "Bash(git diff:*)",
-      "Bash(git remote:*)",
-      "Bash(git fetch:*)",
-      "Bash(git worktree:*)",
-      "Bash(git checkout:*)",
-      "Bash(ls:*)",
-      "Bash(grep:*)",
-      "Bash(mkdir:*)",
-      "Bash(cat:*)",
-      "Bash(command -v:*)",
-      "Bash(bun run:*)",
-      "Bash(bun test:*)",
-      "Bash(bun install:*)",
-      "Bash(gh pr:*)",
-      "Bash(gh auth:*)",
-      "Bash(railway:*)"
-    ],
+    "allow": ["Read", "Bash"],
     "defaultMode": "acceptEdits"
   },
   "hooks": {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,28 @@
 {
   "permissions": {
-    "allow": ["Read", "Bash"],
+    "allow": [
+      "Read",
+      "Bash(git check-ignore:*)",
+      "Bash(git branch:*)",
+      "Bash(git log:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git remote:*)",
+      "Bash(git fetch:*)",
+      "Bash(git worktree:*)",
+      "Bash(git checkout:*)",
+      "Bash(ls:*)",
+      "Bash(grep:*)",
+      "Bash(mkdir:*)",
+      "Bash(cat:*)",
+      "Bash(command -v:*)",
+      "Bash(bun run:*)",
+      "Bash(bun test:*)",
+      "Bash(bun install:*)",
+      "Bash(gh pr:*)",
+      "Bash(gh auth:*)",
+      "Bash(railway:*)"
+    ],
     "defaultMode": "acceptEdits"
   },
   "hooks": {

--- a/.gitignore
+++ b/.gitignore
@@ -1,37 +1,17 @@
 # ===================
-# OS Files
+# OS
 # ===================
 .DS_Store
 
 # ===================
-# IDE & Editor
+# Editors & Local Tooling
 # ===================
 .vscode/*
 !.vscode/index.code-workspace
 .cursor/
 .claude/settings.local.json
 .claude/worktrees
-
-# ===================
-# Docker & Infrastructure
-# ===================
-docker-compose.yml
-env.docker
-postgres/
-
-# ===================
-# Temporary Files & Uploads
-# ===================
-backend/temp-uploads/
-txt/
-
-# ===================
-# Documentation & Reports
-# ===================
-*.report.md
-docs/superpowers/
-packages/protocol/CLAUDE.md
-packages/protocol/.claude
+.rules
 
 # ===================
 # Dependencies
@@ -39,26 +19,33 @@ packages/protocol/.claude
 node_modules/
 
 # ===================
-# Git & Version Control
+# Local Worktrees
 # ===================
 .worktrees/
 
 # ===================
-# Environment Files
+# Docker & Local Infrastructure
 # ===================
-.mcp.json
+docker-compose.yml
+env.docker
+postgres/
 
 # ===================
-# Project Configuration (Zed Agent Rules)
+# Temporary Data & Uploads
 # ===================
-.rules
+backend/temp-uploads/
+txt/
 
 # ===================
-# Generated skills (local workspace dev output)
+# Generated Local Artifacts
 # ===================
+docs/superpowers/
 /skills/**/SKILL.md
+packages/protocol/.claude
+packages/protocol/CLAUDE.md
 
 # ===================
-# Matching eval run reports (ephemeral; --report output)
+# Reports & Eval Outputs
 # ===================
+*.report.md
 packages/protocol/eval/matching/runs/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,11 @@
-[submodule "packages/agentvillage"]
-	path = packages/agentvillage
+[submodule "packages/edge-city/agentvillage"]
+	path = packages/edge-city/agentvillage
 	url = https://github.com/Edge-City/agentvillage.git
+[submodule "packages/edge-city/agentvillage-landing"]
+	path = packages/edge-city/agentvillage-landing
+	url = git@github.com:Edge-City/agentvillage-landing.git
+	branch = main
+[submodule "packages/edge-city/agentvillage-controlplane"]
+	path = packages/edge-city/agentvillage-controlplane
+	url = git@github.com:Edge-City/agentvillage-controlplane.git
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,3 @@
-[submodule "packages/edge-city/agentvillage"]
-	path = packages/edge-city/agentvillage
+[submodule "packages/agentvillage"]
+	path = packages/agentvillage
 	url = https://github.com/Edge-City/agentvillage.git
-[submodule "packages/edge-city/agentvillage-landing"]
-	path = packages/edge-city/agentvillage-landing
-	url = git@github.com:Edge-City/agentvillage-landing.git
-	branch = main
-[submodule "packages/edge-city/agentvillage-controlplane"]
-	path = packages/edge-city/agentvillage-controlplane
-	url = git@github.com:Edge-City/agentvillage-controlplane.git
-	branch = main

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,22 @@
+{
+  "mcpServers": {
+    "linear-index": {
+      "url": "https://mcp.linear.app/mcp",
+      "auth": "oauth",
+      "oauth": {
+        "clientName": "Pi Linear Index Network"
+      }
+    },
+    "linear-edge-city": {
+      "url": "https://mcp.linear.app/mcp",
+      "auth": "oauth",
+      "oauth": {
+        "clientName": "Pi Linear Edge City"
+      }
+    },
+    "railway": {
+      "command": "railway",
+      "args": ["mcp"]
+    }
+  }
+}

--- a/.pi/npm/.gitignore
+++ b/.pi/npm/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,0 +1,12 @@
+{
+  "packages": [
+    "npm:@juicesharp/rpiv-pi",
+    "npm:@juicesharp/rpiv-advisor",
+    "npm:@juicesharp/rpiv-args",
+    "npm:@juicesharp/rpiv-ask-user-question",
+    "npm:@juicesharp/rpiv-btw",
+    "npm:@juicesharp/rpiv-todo",
+    "npm:@juicesharp/rpiv-web-tools",
+    "npm:@juicesharp/rpiv-workflow"
+  ]
+}

--- a/.pi/skills/finish-pr/SKILL.md
+++ b/.pi/skills/finish-pr/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: finish-pr
+description: "Finish a pull request end-to-end: validate local build/run health, ensure GitHub checks and review threads are clear, merge the PR, verify post-merge GitHub/Railway deployment health, and close or update related GitHub and Linear issues. Use when the user says a PR is ready to finish, ship, merge, or close out."
+---
+
+# Finish PR
+
+Use this workflow when a pull request is ready to ship and the user wants the surrounding GitHub, Linear, and deployment state finished too.
+
+## Goal
+
+Safely finish a PR end-to-end:
+
+1. identify the PR and related issues,
+2. verify the branch builds and runs locally,
+3. ensure GitHub checks/reviews are green,
+4. merge the PR only after explicit confirmation,
+5. verify post-merge CI and Railway deployment health,
+6. update or close related GitHub and Linear issues,
+7. summarize exactly what shipped and what remains.
+
+## Safety rules
+
+- Do not merge without explicit user confirmation in the current session.
+- Do not deploy, restart, rollback, or mutate Railway resources unless the user explicitly asked for that action. Verification is okay; mutation needs confirmation.
+- Do not close Linear or GitHub issues until the PR is merged and post-merge deployment checks pass, unless the user explicitly asks to close them earlier.
+- Never claim deployment success from a queued/in-progress status. Wait for a terminal success state or report that it is still pending.
+- If Railway MCP tools are unavailable, stop and tell the user to configure/connect Railway MCP instead of pretending to verify deployment.
+- If checks fail, keep issues open and report the blocker.
+
+## Supporting rpiv skills
+
+Use other rpiv skills when they fit the situation:
+
+- `receiving-code-review`: use before finishing if unresolved Copilot or human review conversations remain.
+- `validate`: use when the PR implements an rpiv plan and you need to verify plan success criteria before merge.
+- `code-review`: use for an independent final review when the diff is large, risky, or has had multiple review rounds.
+- `changelog`: use if the PR changes a released package or the user wants release notes updated before merge.
+- `commit`: use if local finishing changes are needed and should be committed before push.
+
+Do not invoke heavyweight skills for trivial PRs with already-green checks and no open review threads.
+
+## Workflow
+
+### 1. Identify the PR
+
+If the user provides a PR number, use it. Otherwise infer from the current branch:
+
+```bash
+gh pr view --json number,title,headRefName,baseRefName,url,state,mergeStateStatus,reviewDecision,isDraft,author
+```
+
+Identify owner and repo:
+
+```bash
+gh repo view --json owner,name,url
+```
+
+Fetch fuller PR metadata:
+
+```bash
+gh pr view PR_NUMBER --json number,title,body,url,state,isDraft,headRefName,baseRefName,mergeStateStatus,reviewDecision,commits,files,closingIssuesReferences,latestReviews,statusCheckRollup
+```
+
+Stop if the PR is closed, merged, draft, or targeting the wrong base branch unless the user explicitly confirms how to proceed.
+
+### 2. Identify related GitHub and Linear issues
+
+Collect related issue references from:
+
+- `closingIssuesReferences` from `gh pr view`,
+- PR title/body,
+- branch name,
+- commit messages,
+- Linear links or identifiers in the PR body/comments, e.g. `ABC-123`.
+
+For GitHub issues, inspect each related issue:
+
+```bash
+gh issue view ISSUE_NUMBER --json number,title,state,url,labels,assignees
+```
+
+For Linear issues, use available Linear tools when present:
+
+- `linear_indexnetwork_get_issue` for exact identifiers like `ABC-123`,
+- `linear_indexnetwork_list_comments` to inspect issue discussion when needed,
+- `linear_indexnetwork_save_comment` to add shipped/deployment notes,
+- `linear_indexnetwork_save_issue` to move the issue to the appropriate done state.
+
+If no related issues are discoverable, continue but mention that no linked GitHub/Linear issues were found.
+
+### 3. Ensure the working tree is clean and pushed
+
+Check local state:
+
+```bash
+git status --short --branch
+git log --oneline --decorate -5
+```
+
+If there are uncommitted changes:
+
+- inspect them,
+- decide whether they are part of finishing the PR,
+- commit them with the `commit` skill or ask the user what to do.
+
+Push any local commits before checking remote PR state:
+
+```bash
+git push
+```
+
+### 4. Run local build/run verification
+
+Use project guidance first. For this repository, prefer targeted commands:
+
+```bash
+cd packages/protocol && bun run build
+cd backend && bun run build
+cd frontend && bun run build
+```
+
+Run targeted tests relevant to the diff. Avoid full slow suites unless the PR is broad or the user asks.
+
+If the user explicitly wants a local run/smoke test, start only the necessary service(s), capture logs, hit a lightweight health/page/API check, and then shut the process down. Do not leave dev servers running.
+
+### 5. Check GitHub readiness before merge
+
+Check PR status and reviews:
+
+```bash
+gh pr checks PR_NUMBER --watch
+gh pr view PR_NUMBER --json mergeStateStatus,reviewDecision,statusCheckRollup,isDraft
+```
+
+Check unresolved review threads. Use the `receiving-code-review` skill if unresolved Copilot or human review feedback remains.
+
+Do not merge if:
+
+- required checks are failing or pending,
+- required reviews are missing,
+- the PR is draft,
+- unresolved blocking review conversations remain,
+- local verification failed.
+
+### 6. Confirm and merge
+
+Before merging, summarize:
+
+- PR title and URL,
+- base branch,
+- local verification results,
+- GitHub checks/review state,
+- related GitHub/Linear issues that will be updated after merge.
+
+Ask the user for explicit confirmation to merge.
+
+After confirmation, merge using the repository's preferred strategy. If unknown, inspect repo conventions or ask. Common command:
+
+```bash
+gh pr merge PR_NUMBER --squash --delete-branch
+```
+
+If the PR should use merge commit or rebase instead, use the user/repo preference.
+
+### 7. Verify post-merge GitHub checks
+
+After merge, identify the merge/base branch commit:
+
+```bash
+gh pr view PR_NUMBER --json state,mergedAt,mergeCommit,url
+```
+
+Check workflow runs for the target branch/commit:
+
+```bash
+gh run list --branch BASE_BRANCH --limit 10
+```
+
+If needed, watch the relevant run:
+
+```bash
+gh run watch RUN_ID
+```
+
+Do not proceed to issue closure until required post-merge checks have passed or the user explicitly accepts a pending state.
+
+### 8. Verify Railway deployment with MCP
+
+Use Railway MCP tools if available. First discover/connect them instead of guessing tool names:
+
+```text
+mcp({ search: "railway deployment project service environment logs status" })
+mcp({ server: "railway" })
+```
+
+Then use the available Railway MCP tool(s) to verify:
+
+- target project,
+- target environment,
+- target service(s),
+- deployment triggered by the merged branch/commit,
+- build status,
+- deploy status,
+- recent logs for startup/runtime errors,
+- app health URL or smoke endpoint if available.
+
+If a Railway deployment is still building/deploying, wait only as long as is reasonable, then report it as pending with the deployment URL/status. Do not claim success.
+
+If Railway MCP is not configured or does not expose enough tools to verify status/logs, stop and report that deployment verification could not be completed.
+
+### 9. Finish related GitHub issues
+
+For GitHub issues auto-closed by PR keywords, verify state:
+
+```bash
+gh issue view ISSUE_NUMBER --json number,title,state,url
+```
+
+If an issue is not auto-closed but should be closed, confirm the PR merge and deployment succeeded, then close with a comment:
+
+```bash
+gh issue comment ISSUE_NUMBER --body "Shipped in PR PR_URL and verified after deployment: SUMMARY."
+gh issue close ISSUE_NUMBER --reason completed
+```
+
+If deployment is pending or failed, leave the issue open and comment with the blocker/status only if useful.
+
+### 10. Finish related Linear issues
+
+For each related Linear issue:
+
+1. Add a comment with PR URL, merge commit, verification commands, and Railway deployment status.
+2. Move the issue to the appropriate done/completed status only after merge and deployment verification succeed.
+
+Use Linear tools rather than guessing API calls:
+
+- `linear_indexnetwork_get_issue` to inspect current issue state,
+- `linear_indexnetwork_list_issue_statuses` if you need the team's done-state name,
+- `linear_indexnetwork_save_comment` to add the shipment note,
+- `linear_indexnetwork_save_issue` to update state.
+
+If the correct done status is ambiguous, ask the user rather than guessing.
+
+### 11. Final summary
+
+Report:
+
+- PR number and URL,
+- merge strategy and merge commit,
+- local verification commands and results,
+- GitHub post-merge checks and results,
+- Railway project/environment/service/deployment status,
+- GitHub issues closed or left open,
+- Linear issues updated or left open,
+- any remaining blockers or manual follow-up.

--- a/.pi/skills/open-release-pr/SKILL.md
+++ b/.pi/skills/open-release-pr/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: open-release-pr
+description: Open a dated release branch from dev and create a GitHub pull request into main with a generated changelog from git log and git diff. Use when preparing a dev-to-main release PR or when the user asks to cut/open a release PR.
+---
+
+# Open Release PR
+
+Use this workflow to cut a release PR from `dev` to `main` with a changelog that summarizes all changes and linked issues included in the release.
+
+## Goal
+
+1. Create a `release/<DATE>` branch from the latest `dev`.
+2. Push that branch to GitHub.
+3. Open a PR targeting `main`.
+4. Generate the PR body from `git log` and `git diff` so it includes:
+   - all meaningful changes between `main` and `dev`,
+   - related GitHub issues/PRs when discoverable,
+   - related Linear issues when identifiers are present,
+   - a diff/file summary and verification state.
+
+## Preconditions
+
+- Work from the repository checkout that should release to GitHub.
+- `gh` CLI is installed and authenticated.
+- `dev` and `main` exist locally or on `origin`.
+- The current working tree must be clean before creating the release branch.
+
+## Safety rules
+
+- Do not merge the release PR. This skill only opens or updates the PR.
+- Do not create a release branch while there are uncommitted changes; stop and ask the user what to do.
+- Do not overwrite an existing `release/<DATE>` branch without explicit user confirmation.
+- Do not invent issue links. Only mention GitHub or Linear issues that are present in commit messages, PR metadata, branch names, or other inspected repository/GitHub data.
+- If changelog generation is ambiguous, include the raw evidence section instead of omitting changes.
+- If GitHub commands fail, stop and report the exact failing command and stderr.
+
+## Date and branch naming
+
+Use today's local date unless the user supplies a date. Format it as ISO `YYYY-MM-DD`.
+
+```bash
+DATE="$(date +%F)"
+BRANCH="release/$DATE"
+```
+
+If `release/$DATE` already exists locally or remotely, inspect it:
+
+```bash
+git branch --list "$BRANCH"
+git ls-remote --heads origin "$BRANCH"
+```
+
+Then ask the user whether to reuse it, delete/recreate it, or use a suffixed branch like `release/$DATE-2`.
+
+## Workflow
+
+### 1. Verify repository and branch state
+
+Identify GitHub repository metadata:
+
+```bash
+gh repo view --json owner,name,url,defaultBranchRef
+```
+
+Check local state:
+
+```bash
+git status --short --branch
+git remote -v
+```
+
+Stop if `git status --short` shows uncommitted changes.
+
+Fetch release branches and base branches:
+
+```bash
+git fetch origin dev main --prune
+```
+
+Verify both refs exist:
+
+```bash
+git rev-parse --verify origin/dev
+git rev-parse --verify origin/main
+```
+
+### 2. Compute release range
+
+Use the merge base between `origin/main` and `origin/dev` as the release base:
+
+```bash
+BASE="$(git merge-base origin/main origin/dev)"
+HEAD="$(git rev-parse origin/dev)"
+```
+
+Collect the required evidence from git log and git diff:
+
+```bash
+git log --reverse --date=short --pretty=format:'%h%x09%ad%x09%an%x09%s' "$BASE..$HEAD"
+git log --reverse --pretty=format:'%H%n%B%n---END-COMMIT---' "$BASE..$HEAD"
+git diff --stat "$BASE..$HEAD"
+git diff --name-status "$BASE..$HEAD"
+```
+
+If there are no commits between `BASE` and `HEAD`, stop: there is nothing to release.
+
+### 3. Detect included PRs and issues
+
+Extract references from commit subjects and bodies:
+
+- GitHub issue/PR references: `#123`, `GH-123`, full GitHub issue/PR URLs.
+- Closing keywords: `fixes #123`, `closes #123`, `resolves #123`.
+- Linear issue identifiers: uppercase project keys like `ABC-123`.
+
+Useful commands:
+
+```bash
+git log --reverse --pretty=format:'%s%n%b%n' "$BASE..$HEAD" > /tmp/release-log.txt
+rg -o '#[0-9]+' /tmp/release-log.txt | sort -u
+rg -o '[A-Z][A-Z0-9]+-[0-9]+' /tmp/release-log.txt | sort -u
+rg -o 'https://github\.com/[^ ]+/(issues|pull)/[0-9]+' /tmp/release-log.txt | sort -u
+```
+
+For each GitHub issue or PR number found, inspect it when possible:
+
+```bash
+gh issue view ISSUE_NUMBER --json number,title,state,url,labels
+# If it is not an issue, try:
+gh pr view PR_NUMBER --json number,title,state,url,mergedAt,baseRefName,headRefName
+```
+
+For Linear identifiers, use available Linear tools when present:
+
+- `linear_indexnetwork_get_issue` for exact IDs like `ABC-123`,
+- `linear_indexnetwork_list_comments` only if issue context is needed.
+
+If a detected identifier cannot be fetched, still list it as an unverified reference.
+
+### 4. Build the changelog
+
+Create a temporary PR body file. The changelog must be derived from the collected `git log` and `git diff` evidence.
+
+Recommended structure:
+
+````markdown
+## Release changelog
+
+### Highlights
+- Concise human summary of the main release themes, derived from the commits and diff.
+
+### Changes
+- `<commit subject>` (`<short-sha>`)
+- Group related commits when that makes the changelog easier to read, but do not drop meaningful changes.
+
+### Issues and PRs
+- Closes/updates/fixes #123 — issue title if available.
+- Linear ABC-123 — issue title if available.
+- If none were found: `No linked GitHub or Linear issues were detected in the release commits.`
+
+### Diff summary
+```text
+<paste git diff --stat BASE..HEAD>
+```
+
+### Changed files
+```text
+<paste git diff --name-status BASE..HEAD>
+```
+
+### Verification
+- [ ] Release branch created from `origin/dev` at `<HEAD>`.
+- [ ] GitHub checks pass on this PR.
+- [ ] Release PR reviewed and approved.
+````
+
+Keep the changelog concise but complete. For a long release, group changes under Conventional Commit headings when possible:
+
+- New Features (`feat`)
+- Bug Fixes (`fix`)
+- Refactors (`refactor`, `perf`)
+- Documentation (`docs`)
+- Tests (`test`)
+- Chores (`chore`, `build`, `ci`, `style`)
+- Other
+
+### 5. Create and push the release branch
+
+Create the release branch from `origin/dev`:
+
+```bash
+git switch --detach origin/dev
+git switch -c "$BRANCH"
+git push -u origin "$BRANCH"
+```
+
+If branch creation or push fails because the branch already exists, stop and ask the user how to proceed.
+
+### 6. Open the GitHub PR into main
+
+Open the PR targeting `main`:
+
+```bash
+gh pr create \
+  --base main \
+  --head "$BRANCH" \
+  --title "Release $DATE" \
+  --body-file /tmp/release-pr-body.md
+```
+
+After creation, fetch and report the PR:
+
+```bash
+gh pr view "$BRANCH" --json number,title,url,baseRefName,headRefName,state,isDraft,statusCheckRollup
+```
+
+### 7. If the PR already exists
+
+If `gh pr create` reports that a PR already exists for the branch, update its body instead of creating a duplicate:
+
+```bash
+gh pr edit "$BRANCH" --title "Release $DATE" --body-file /tmp/release-pr-body.md
+```
+
+Then fetch the PR details with `gh pr view`.
+
+### 8. Final summary
+
+Report:
+
+- release branch name,
+- PR number and URL,
+- base/head commit range,
+- number of commits included,
+- detected GitHub issues/PRs,
+- detected Linear issues,
+- verification/check status if available,
+- any changelog caveats or references that could not be resolved.
+
+Do not claim the release has shipped. It has only been opened for review.

--- a/.pi/skills/receiving-code-review/SKILL.md
+++ b/.pi/skills/receiving-code-review/SKILL.md
@@ -1,0 +1,274 @@
+---
+name: receiving-code-review
+description: Handle incoming PR review feedback, especially GitHub Copilot conversations, by fetching unresolved review threads, deciding whether fixes are needed, applying fixes, replying with reasoning, and resolving conversations. Use when the user asks to receive, address, or resolve PR review feedback.
+---
+
+# Receiving Code Review
+
+Use this workflow to handle incoming PR review feedback on a GitHub pull request, with first-class support for GitHub Copilot review conversations.
+
+## Goal
+
+For every unresolved review conversation from Copilot:
+
+1. inspect the comment and referenced code,
+2. decide whether a code change is actually needed,
+3. either fix the code or explain why no fix is needed,
+4. reply in the review thread, and
+5. manually resolve the conversation.
+
+Then, when the PR is ready for another pass, ask the user to manually request a fresh Copilot review from the GitHub PR page. Repeat review rounds until Copilot stops finding substantive issues or starts producing low-signal/useless feedback.
+
+Do not silently resolve Copilot conversations.
+
+## Preconditions
+
+- The repository uses GitHub pull requests.
+- The `gh` CLI is installed and authenticated.
+- Work from the current repository checkout.
+- If the user does not provide a PR number, infer it from the current branch.
+
+## Command safety rule
+
+Do not guess GitHub API command shapes.
+
+Use the command templates in this skill as the source of truth. If a command fails with 404, 422, or a schema error:
+
+1. stop the workflow,
+2. inspect the object you are using (`gh api repos/OWNER/REPO/pulls/comments/COMMENT_ID`, `gh pr view`, or the GraphQL thread payload),
+3. fix the ID/path mismatch,
+4. then retry.
+
+Never resolve a thread until the reply succeeded or you have intentionally posted the no-fix explanation.
+
+## Copilot identity matching
+
+GitHub may expose Copilot review comments under different logins depending on API surface. Treat these as Copilot identities:
+
+- `copilot-pull-request-reviewer`
+- `github-copilot[bot]`
+- `Copilot`
+
+When filtering GraphQL review threads, match unresolved threads where any comment author login is one of the above.
+
+## Workflow
+
+### 1. Identify the PR
+
+If the user provides a PR number, use it. Otherwise run:
+
+```bash
+gh pr view --json number,title,headRefName,baseRefName,url
+```
+
+Identify GitHub owner and repo:
+
+```bash
+gh repo view --json owner,name,url
+```
+
+Use `owner.login` and `name` from that JSON in all later commands.
+
+### 2. Fetch unresolved Copilot review threads
+
+Use GraphQL review threads, not only flat PR comments, because resolving requires the GraphQL review-thread ID.
+
+```bash
+gh api graphql \
+  -f owner="$OWNER" \
+  -f repo="$REPO" \
+  -F number="$PR_NUMBER" \
+  -f query='
+query($owner:String!, $repo:String!, $number:Int!) {
+  repository(owner:$owner, name:$repo) {
+    pullRequest(number:$number) {
+      url
+      reviewThreads(first:100) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          isResolved
+          path
+          line
+          startLine
+          comments(first:50) {
+            nodes {
+              id
+              databaseId
+              author { login }
+              body
+              path
+              line
+              startLine
+              url
+              diffHunk
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+Filter to threads where:
+
+- `isResolved` is `false`, and
+- at least one comment author login is one of the Copilot identities listed above.
+
+Use:
+
+- `reviewThreads.nodes[].id` as `THREAD_ID` for resolving.
+- `comments.nodes[].databaseId` as `COMMENT_ID` for REST replies.
+
+If `pageInfo.hasNextPage` is `true`, fetch subsequent pages with `after: $cursor` before deciding the work is complete.
+
+### 3. Evaluate each thread
+
+For every unresolved Copilot thread:
+
+1. Read the referenced file and surrounding code.
+2. Check adjacent implementations or project conventions when relevant.
+3. Decide whether Copilot's suggestion is correct.
+
+Use this decision rule:
+
+- **Fix needed**: the comment identifies a real bug, missing edge case, broken convention, maintainability issue, security issue, performance issue, or test gap.
+- **No fix needed**: the suggestion is incorrect, already handled elsewhere, conflicts with architecture, adds unnecessary complexity, or breaks an intentional design.
+
+### Optional: use rpiv skills for hard review work
+
+Use rpiv skills as supporting workflows when the Copilot feedback is broader than a local one-file fix:
+
+- Use `code-review` when multiple comments imply a broader diff-quality issue or when you want an independent review of your pending fixes before replying.
+- Use `research` when a comment touches an unfamiliar subsystem and you need grounded codebase context before deciding fix vs no-fix.
+- Use `validate` after applying a plan-backed or multi-phase fix to verify the implementation against existing plan success criteria.
+
+Do not invoke heavyweight rpiv workflows for trivial mechanical comments. For simple comments, inspect the local code directly and proceed.
+
+### Optional: update Copilot reviewer instructions
+
+This repository may provide Copilot review guidance in `.github/instructions/pr-reviewer.instructions.md`.
+
+Update that file when Copilot is producing wrong or noisy reviews because it lacks stable project context, for example:
+
+- it repeatedly flags an intentional architecture boundary or layering pattern as a problem,
+- it misunderstands generated files, subtree/submodule ownership, or source-of-truth files,
+- it asks for tests/docs that conflict with the project's targeted-verification policy,
+- it misses a recurring project convention that should guide future reviews,
+- it keeps re-raising resolved non-issues across review rounds.
+
+Keep instruction updates short, durable, and review-oriented. Do not add one-off explanations for a single PR unless they generalize to future reviews. Prefer bullets that tell Copilot what to prioritize, what to ignore, and where source-of-truth files live.
+
+If you update `.github/instructions/pr-reviewer.instructions.md`:
+
+1. read the existing file first,
+2. make the smallest useful change,
+3. commit and push it with the PR fixes,
+4. mention the instruction update in your round summary,
+5. ask the user to request a fresh Copilot review so the new context can affect the next round.
+
+### 4. Apply fixes when needed
+
+When a fix is needed:
+
+1. Edit the code.
+2. Run targeted tests, lint, typecheck, or a focused verification command when practical.
+3. Commit and push the fix if the user expects the PR to be updated remotely.
+4. Reply to the Copilot review comment with a concise summary of the fix.
+5. Resolve the thread.
+
+Reply to a PR review comment using this exact REST endpoint shape:
+
+```bash
+gh api -X POST \
+  "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments/$COMMENT_ID/replies" \
+  -f body="Fixed in COMMIT_SHA: ..."
+```
+
+Resolve a review thread using this GraphQL mutation:
+
+```bash
+gh api graphql \
+  -f threadId="$THREAD_ID" \
+  -f query='
+mutation($threadId:ID!) {
+  resolveReviewThread(input:{threadId:$threadId}) {
+    thread { id isResolved }
+  }
+}'
+```
+
+### 5. Explain and resolve when no fix is needed
+
+When no fix is needed:
+
+1. Reply in the review thread with technical reasoning.
+2. Then resolve the thread.
+
+Good no-fix reply examples:
+
+- `This is intentionally handled by <existing mechanism>; adding the suggested branch would duplicate behavior and diverge from <project pattern>.`
+- `Leaving this unchanged because <reason>. The suggested change would break <specific contract>.`
+- `This path is already covered by <guard/function/test>; no code change is needed.`
+
+Use the same reply and resolve commands from the previous section.
+
+### 6. Verify this review round
+
+After all threads in the current round are handled:
+
+1. Re-fetch review threads with the GraphQL query above.
+2. Confirm there are no unresolved Copilot threads.
+3. Summarize the current round:
+   - PR number and URL,
+   - threads fixed,
+   - threads resolved without code changes,
+   - commits pushed,
+   - verification commands run and their results,
+   - any remaining blockers.
+
+### 7. Request another Copilot review round
+
+Copilot re-review is manually requested by the user on the GitHub PR page. Do not assume Copilot will automatically review after you push or reply.
+
+When the current round is clean and the PR still benefits from another Copilot pass:
+
+1. If Copilot's last round exposed a repeat misunderstanding, consider whether `.github/instructions/pr-reviewer.instructions.md` needs a durable context update before asking for another review.
+2. Tell the user: `Please request another Copilot review manually from the GitHub PR page. I'll wait for the next round.`
+3. Explain that Copilot usually takes a couple of minutes.
+4. After the user says the review was requested or enough time has passed, re-fetch review threads with the GraphQL query above.
+5. Treat newly unresolved Copilot threads as the next round and repeat this workflow.
+
+Do not use `gh pr edit --add-reviewer @copilot` unless the user explicitly asks for CLI-based review requests; this project workflow expects the user to request Copilot manually in GitHub.
+
+### 8. Detect low-signal Copilot review rounds
+
+At some point repeated Copilot reviews may stop being useful. Detect this and tell the user it is okay to stop requesting more Copilot reviews.
+
+Mark a Copilot round as low-signal when most or all new comments are one or more of:
+
+- speculative `consider`/`maybe` suggestions without a concrete bug, contract violation, or maintainability win,
+- style-only suggestions that conflict with project conventions or add churn,
+- comments on code already changed or explained in a previous round,
+- suggestions that would weaken boundaries, tests, security, or intentional design,
+- duplicate feedback already resolved earlier,
+- requests for broad extra tests/docs where targeted verification is already adequate for the change scope,
+- nitpicks that do not improve correctness, safety, or long-term maintainability.
+
+Still reply to and resolve any unresolved low-signal threads with concise technical reasoning. Then stop the re-review loop and tell the user:
+
+`Copilot's latest round looks low-signal: it did not identify substantive issues worth changing. It is okay to stop requesting additional Copilot reviews.`
+
+Include the evidence: number of rounds, number of comments fixed vs no-fix, and why the latest round was considered low-signal.
+
+## Important project-specific guidance
+
+- GitHub Copilot does not auto-resolve conversations when commits are pushed or suggestions are applied. Resolve each thread manually.
+- Copilot does not respond to follow-up comments in threads. Replies are for human context only.
+- Re-requesting Copilot review is a separate manual action by the user on the GitHub PR page.
+- A fresh Copilot review commonly takes a couple of minutes to appear; do not assume immediate results.
+- Repeat review rounds only while the feedback remains substantive.
+- If Copilot re-raises a previously resolved comment on re-review, treat it as a new unresolved thread and evaluate it again, but count repeated non-actionable feedback toward the low-signal stopping condition.
+- Prefer targeted tests over full suites unless the change scope requires broader verification.
+- Never claim a thread is resolved until the GitHub API confirms it is resolved.

--- a/.rpiv/artifacts/designs/2026-06-09_11-18-44_protocol-package-violations.md
+++ b/.rpiv/artifacts/designs/2026-06-09_11-18-44_protocol-package-violations.md
@@ -1,0 +1,617 @@
+---
+date: 2026-06-09T11:18:44+0300
+author: Yankı Ekin Yüksel
+commit: cc4ceda7a
+branch: dev
+repository: index
+topic: "Fix protocol package boundary violations"
+tags: [design, protocol, boundaries, interfaces, mcp, tools, schemas]
+status: ready
+parent: .rpiv/artifacts/research/2026-06-09_10-42-15_protocol-package-violations.md
+last_updated: 2026-06-09T11:18:44+0300
+last_updated_by: Yankı Ekin Yüksel
+---
+
+# Design: Fix protocol package boundary violations
+
+## Summary
+Extract shared domain DTOs to `shared/schemas/` to eliminate reverse imports from shared interfaces into domain implementation modules. Narrow the public API surface by replacing `export type *` with explicit exports and removing internal orchestration types. Fix the `PremiseGraphDatabase` type-contract violation by adding missing methods to `ChatGraphCompositeDatabase`. Remove the unused Postgres checkpoint adapter dependency. Replace `Request` in `McpAuthResolver` with a plain `McpAuthInput` DTO.
+
+## Requirements
+- Remove domain implementation imports from `shared/interfaces/` files
+- Extract `ProfileDocument`, `DiscoveryQuestionInput`, `NegotiationTurn`, `UserNegotiationContext`, `SeedAssessment` to `shared/schemas/`
+- Replace `export type * from "./shared/interfaces/database.interface.js"` with narrow explicit exports in `index.ts`
+- Remove `DefineTool`, `RawToolDefinition`, `ToolRegistry` from root barrel
+- Add premise CRUD methods to `ChatGraphCompositeDatabase` and remove `as unknown as` casts
+- Remove `@langchain/langgraph-checkpoint-postgres` from `package.json`
+- Replace `Request` parameter in `McpAuthResolver.resolveIdentity()` with plain `McpAuthInput` DTO
+- All changes must be compile-safe and backward-compatible with existing downstream consumers
+
+## Current State Analysis
+
+### Key Discoveries
+- `packages/protocol/src/shared/interfaces/database.interface.ts:1` imports `ProfileDocument` from `profile/profile.generator.ts:37`, but generator imports LangChain/Zod runtime and constructs LLM models — the type should live in shared schemas
+- `packages/protocol/src/shared/interfaces/question-generator.interface.ts:10` imports `DiscoveryQuestionInput` from `opportunity/question.prompt.ts`; this interface is already `@deprecated` but still imported
+- `packages/protocol/src/shared/interfaces/agent-dispatcher.interface.ts:9` imports `NegotiationTurn`, `UserNegotiationContext`, `SeedAssessment` from `negotiation/negotiation.state.ts`; two are pure interfaces, one is `z.infer`-derived
+- `packages/protocol/src/shared/agent/tool.helpers.ts:3` imports `ProfileDocument` from `profile/profile.generator.ts`
+- `PremiseGraphDatabase` at `database.interface.ts:1968-1970` requires 5 methods NOT in `ChatGraphCompositeDatabase`: `createPremise`, `getPremise`, `updatePremise`, `assignPremiseToNetwork`, `getPremiseNetworks`
+- `packages/protocol/src/shared/agent/tool.factory.ts:130` and `packages/protocol/src/premise/premise.tools.ts:12` use `as unknown as PremiseGraphDatabase` casts
+- `packages/protocol/package.json:25` lists `@langchain/langgraph-checkpoint-postgres` but source only imports `BaseCheckpointSaver` from `@langchain/langgraph`
+- `packages/protocol/src/shared/interfaces/auth.interface.ts:29` accepts `Request` in `resolveIdentity`; backend implements it in `mcp.controller.ts:426-560` reading headers directly
+
+### Patterns to follow
+- `packages/protocol/src/shared/schemas/question.schema.ts:1-60` — clean DTO pattern: Zod schema + `z.infer` type, zero domain imports
+- `packages/protocol/src/shared/interfaces/cache.interface.ts:1-41` — narrow port: no domain imports, clean Pick-based subtypes
+- `packages/protocol/src/shared/schemas/chat-context.schema.ts:1-21` — minimal schema: `z` from zod only, clear clamping
+- `packages/protocol/src/chat/chat.graph.ts:81-86` — positive injection pattern: accepts `BaseCheckpointSaver` interface, never imports `PostgresSaver`
+
+### Constraints
+- Backend code at `backend/src/services/tool.service.ts:17` and `backend/src/controllers/mcp.controller.ts:54-55` imports internal types like `ToolDeps` and `CompiledGraph` from the protocol root — removal must not break these consumers
+- The `package.json` export map exposes only `"."` at line 7 — no subpath exports exist
+- Graph factory exports from `index.ts:103-119` are per developer checkpoint tolerated host seams, NOT to be removed
+
+## Scope
+
+### Building
+- Extract `ProfileDocument` shape to `shared/schemas/profile.schema.ts`
+- Extract `DiscoveryQuestionInput` and all nested types (DiscoverySourceProfile, DiscoverySummary, DiscoveryNegotiation, DiscoveryTurn, DiscoveryOutcome) to `shared/schemas/discovery-question.schema.ts`
+- Extract `NegotiationTurn`, `UserNegotiationContext`, `SeedAssessment` to `shared/schemas/negotiation-state.schema.ts`
+- Update all shared interfaces to import from schemas instead of domain modules
+- Replace `export type * from database.interface.js` with explicit named exports in `index.ts`
+- Remove `DefineTool`, `RawToolDefinition`, `ToolRegistry` from root barrel
+- Add premise CRUD methods (`createPremise`, `getPremise`, `updatePremise`, `assignPremiseToNetwork`, `getPremiseNetworks`) to `ChatGraphCompositeDatabase`
+- Remove `as unknown as PremiseGraphDatabase` casts from `tool.factory.ts` and `premise.tools.ts`
+- Remove `@langchain/langgraph-checkpoint-postgres` from `package.json`
+- Create `McpAuthInput` DTO, change `McpAuthResolver.resolveIdentity` signature, update backend implementation
+
+### Not Building
+- Full `ToolDeps` deprecation or removal — still needed by backend composition roots
+- Raw `database` field removal from `ToolContext` — marked deprecated but host code still uses it
+- Deep refactor of graph factory registration or tool registry architecture
+- Migration of remaining raw-DB-using tools (profile.tools.ts, opportunity.tools.ts) to scoped DBs
+- Backend scoped DB factory restructuring
+- Subpath export map addition (`package.json exports` field)
+- Removing deprecated `QuestionGeneratorReader` interface entirely
+
+## Decisions
+
+### Extract shared domain DTOs to shared/schemas/
+**Ambiguity**: Domain types (ProfileDocument, negotiation state, discovery question input) are defined in domain implementation modules but imported by shared interfaces.
+**Explored**: (A) Extract to shared/schemas/ following `question.schema.ts` pattern. (B) Leave in place. (C) Inline in each interface.
+**Decision**: Extract all three to shared/schemas/ using the established Zod-schema + inferred-type pattern. These become the canonical DTO definitions; domain modules that currently define them re-export or derive from the shared schema. Follows the `question.schema.ts:1-60` pattern.
+
+### Narrow public API exports
+**Ambiguity**: Root barrel at `index.ts:47` uses `export type *` from `database.interface.ts`, leaking ~50+ internal types. Internal orchestration types (`DefineTool`, `RawToolDefinition`, `ToolRegistry`) are root-exported.
+**Explored**: (A) Replace `export type *` with explicit narrow exports of stable host contract types only; remove internal orchestration types. (B) Leave as-is. (C) Remove all non-interface types.
+**Decision**: Replace `export type * from database.interface.js` with explicit named exports for stable contracts only (like `cache.interface.ts` does with narrow Pick exports). Remove `DefineTool`, `RawToolDefinition`, `ToolRegistry` from root barrel. Keep `ToolDeps` and `CompiledGraph` (backend needs them). Graph factory exports remain tolerated host seams.
+
+### Fix PremiseGraphDatabase type-contract violation
+**Ambiguity**: PremiseGraphDatabase has 5 methods not in ChatGraphCompositeDatabase, requiring `as unknown as` casts.
+**Explored**: (A) Add the 5 missing premise CRUD methods to ChatGraphCompositeDatabase. (B) Push toward scoped DB usage instead.
+**Decision**: Add `createPremise`, `getPremise`, `updatePremise`, `assignPremiseToNetwork`, `getPremiseNetworks` to `ChatGraphCompositeDatabase` and remove the unsafe casts. This is the minimal fix that restores type safety without requiring a deep tool rewrite.
+
+### Remove unused Postgres checkpoint dependency
+**Ambiguity**: `@langchain/langgraph-checkpoint-postgres` in `package.json:25` is not imported by protocol source.
+**Explored**: (A) Remove it. (B) Keep it for future use. (C) Move to devDependencies.
+**Decision**: Remove from `dependencies`. Protocol source only uses `BaseCheckpointSaver` from `@langchain/langgraph`. Backend owns the actual `PostgresSaver` import at `backend/src/adapters/checkpointer.adapter.ts:18` and has its own dependency.
+
+### MCP auth DTO extraction
+**Ambiguity**: `McpAuthResolver.resolveIdentity(request: Request)` at `auth.interface.ts:29` couples the shared interface to a platform HTTP Request object.
+**Explored**: (A) Create `McpAuthInput` DTO with header fields. (B) Leave Request for now. (C) Abstract the MCP SDK context instead.
+**Decision**: Create `McpAuthInput` type containing the fields the resolver actually needs (authorization token, api key, client surface, telegram headers). Change `resolveIdentity(McpAuthInput)` signature. Extract `McpAuthInput` from `Request` at the backend MCP controller edge before calling protocol.
+
+## Architecture
+
+### packages/protocol/src/shared/schemas/profile.schema.ts — NEW
+
+```typescript
+import { z } from "zod";
+
+export const ProfileIdentitySchema = z.object({
+  name: z.string(),
+  bio: z.string(),
+  location: z.string(),
+});
+
+export const ProfileNarrativeSchema = z.object({
+  context: z.string(),
+});
+
+export const ProfileAttributesSchema = z.object({
+  interests: z.array(z.string()),
+  skills: z.array(z.string()),
+});
+
+export const ProfileDocumentSchema = z.object({
+  userId: z.string(),
+  identity: ProfileIdentitySchema,
+  narrative: ProfileNarrativeSchema,
+  attributes: ProfileAttributesSchema,
+});
+
+export type ProfileDocument = z.infer<typeof ProfileDocumentSchema>;
+```
+
+### packages/protocol/src/shared/schemas/discovery-question.schema.ts — NEW
+
+```typescript
+import { z } from "zod";
+import type { DiscoveryNegotiationDigest } from "./negotiation-digest.schema.js";
+import type { ChatContextDigest } from "./chat-context.schema.js";
+
+export const NegotiationRoleSchema = z.enum(["agent", "patient", "peer"]);
+export type NegotiationRole = z.infer<typeof NegotiationRoleSchema>;
+
+export const DiscoveryTurnSchema = z.object({
+  action: z.enum(["propose", "accept", "reject", "counter", "question"]),
+  reasoning: z.string(),
+  suggestedRoles: z.object({
+    ownUser: NegotiationRoleSchema,
+    otherUser: NegotiationRoleSchema,
+  }),
+});
+export type DiscoveryTurn = z.infer<typeof DiscoveryTurnSchema>;
+
+export const DiscoveryOutcomeSchema = z.object({
+  hasOpportunity: z.boolean(),
+  reasoning: z.string(),
+  agreedRoles: z.array(z.object({
+    userId: z.string(),
+    role: NegotiationRoleSchema,
+  })).optional(),
+  reason: z.enum(["turn_cap", "timeout"]).optional(),
+});
+export type DiscoveryOutcome = z.infer<typeof DiscoveryOutcomeSchema>;
+
+export const DiscoveryNegotiationSchema = z.object({
+  counterpartyId: z.string(),
+  counterpartyHint: z.string(),
+  indexContext: z.string(),
+  turns: z.array(DiscoveryTurnSchema),
+  outcome: DiscoveryOutcomeSchema,
+  seedAssessmentScore: z.number().optional(),
+});
+export type DiscoveryNegotiation = z.infer<typeof DiscoveryNegotiationSchema>;
+
+export const DiscoverySummarySchema = z.object({
+  totalCandidates: z.number(),
+  opportunitiesFound: z.number(),
+  noOpportunityCount: z.number(),
+  timeoutCount: z.number(),
+  roleDistribution: z.record(z.string(), z.number()).optional(),
+});
+export type DiscoverySummary = {
+  totalCandidates: number;
+  opportunitiesFound: number;
+  noOpportunityCount: number;
+  timeoutCount: number;
+  roleDistribution?: Partial<Record<NegotiationRole, number>>;
+};
+
+export const DiscoverySourceProfileSchema = z.object({
+  name: z.string().optional(),
+  bio: z.string().optional(),
+  location: z.string().optional(),
+  skills: z.array(z.string()).optional(),
+  interests: z.array(z.string()).optional(),
+});
+export type DiscoverySourceProfile = z.infer<typeof DiscoverySourceProfileSchema>;
+
+export interface DiscoveryQuestionInput {
+  query: string;
+  sourceProfile: DiscoverySourceProfile;
+  negotiationDigests: DiscoveryNegotiationDigest[];
+  summary: DiscoverySummary;
+  chatContext?: ChatContextDigest;
+  now: string;
+}
+```
+
+### packages/protocol/src/shared/interfaces/database.interface.ts — MODIFY (line 1)
+
+```typescript
+// BEFORE:
+// import { ProfileDocument } from '../../profile/profile.generator.js';
+// AFTER:
+import { ProfileDocument } from '../schemas/profile.schema.js';
+```
+
+### packages/protocol/src/shared/agent/tool.helpers.ts — MODIFY (line 3)
+
+```typescript
+// BEFORE:
+// import type { ProfileDocument } from "../../profile/profile.generator.js";
+// AFTER:
+import type { ProfileDocument } from "../schemas/profile.schema.js";
+```
+
+### packages/protocol/src/shared/interfaces/question-generator.interface.ts — MODIFY (line 10)
+
+```typescript
+// BEFORE:
+// import type { DiscoveryQuestionInput } from "../../opportunity/question.prompt.js";
+// AFTER:
+import type { DiscoveryQuestionInput } from "../schemas/discovery-question.schema.js";
+```
+
+### packages/protocol/src/index.ts — MODIFY
+
+```typescript
+// Added after the PendingQuestionSummary export:
+export {
+  ProfileIdentitySchema,
+  ProfileNarrativeSchema,
+  ProfileAttributesSchema,
+  ProfileDocumentSchema,
+  type ProfileDocument,
+} from "./shared/schemas/profile.schema.js";
+export type {
+  DiscoverySourceProfile,
+  DiscoverySummary,
+  DiscoveryNegotiation,
+  DiscoveryTurn,
+  DiscoveryOutcome,
+  DiscoveryQuestionInput,
+  NegotiationRole,
+} from "./shared/schemas/discovery-question.schema.js";
+
+// Removed old re-exports from "./opportunity/question.prompt.js":
+// export type { DiscoveryQuestionInput, DiscoveryNegotiation, ... };
+```
+
+### packages/protocol/src/shared/schemas/negotiation-state.schema.ts — NEW
+
+```typescript
+import { z } from "zod";
+
+export const NegotiationTurnSchema = z.object({
+  action: z.enum(["propose", "accept", "reject", "counter", "question"]),
+  assessment: z.object({
+    reasoning: z.string(),
+    suggestedRoles: z.object({
+      ownUser: z.enum(["agent", "patient", "peer"]),
+      otherUser: z.enum(["agent", "patient", "peer"]),
+    }),
+  }),
+  message: z.string().nullable().optional(),
+});
+export type NegotiationTurn = z.infer<typeof NegotiationTurnSchema>;
+
+export const NegotiationOutcomeSchema = z.object({
+  hasOpportunity: z.boolean(),
+  agreedRoles: z.array(z.object({
+    userId: z.string(),
+    role: z.enum(["agent", "patient", "peer"]),
+  })),
+  reasoning: z.string(),
+  turnCount: z.number(),
+  reason: z.enum(["turn_cap", "timeout"]).optional(),
+});
+export type NegotiationOutcome = z.infer<typeof NegotiationOutcomeSchema>;
+
+export interface UserNegotiationContext {
+  id: string;
+  intents: Array<{ id: string; title: string; description: string; confidence: number }>;
+  profile: { name?: string; bio?: string; location?: string; interests?: string[]; skills?: string[] };
+}
+
+export interface SeedAssessment {
+  reasoning: string;
+  valencyRole: string;
+  actors?: Array<{ userId: string; role: string }>;
+}
+```
+
+### packages/protocol/src/shared/interfaces/agent-dispatcher.interface.ts — MODIFY
+
+```typescript
+// BEFORE:
+// import type { NegotiationTurn, UserNegotiationContext, SeedAssessment } from '../../negotiation/negotiation.state.js';
+// AFTER:
+import type { NegotiationTurn, UserNegotiationContext, SeedAssessment } from '../schemas/negotiation-state.schema.js';
+```
+
+### packages/protocol/src/negotiation/negotiation.state.ts — no change needed (local copies retained for graph-internal consumers)
+
+### packages/protocol/src/index.ts — MODIFY (Slice 2 re-exports)
+
+```typescript
+// BEFORE:
+// export type { NegotiationTurn, UserNegotiationContext, SeedAssessment, NegotiationGraphLike } from "./negotiation/negotiation.state.js";
+// AFTER:
+export type {
+  UserNegotiationContext,
+  NegotiationTurn,
+  NegotiationOutcome,
+  SeedAssessment,
+} from "./shared/schemas/negotiation-state.schema.js";
+export type { NegotiationGraphLike } from "./negotiation/negotiation.state.js";
+```
+
+### packages/protocol/src/shared/interfaces/database.interface.ts — MODIFY (Slice 4)
+
+```typescript
+// Added to the ChatGraphCompositeDatabase Pick<> union under // Premise lifecycle:
+//   | 'createPremise'
+//   | 'getPremise'
+//   | 'updatePremise'
+//   | 'assignPremiseToNetwork'
+//   | 'getPremiseNetworks'
+// These 5 methods were missing from ChatGraphCompositeDatabase but required
+// by PremiseGraphDatabase, forcing `as unknown as` casts.
+```
+
+### packages/protocol/src/shared/agent/tool.factory.ts — MODIFY
+
+```typescript
+// BEFORE:
+// const premiseGraph = new PremiseGraphFactory(database as unknown as PremiseGraphDatabase, embedder).createGraph();
+// AFTER:
+const premiseGraph = new PremiseGraphFactory(database as PremiseGraphDatabase, embedder).createGraph();
+```
+
+### packages/protocol/src/premise/premise.tools.ts — MODIFY
+
+```typescript
+// BEFORE:
+// const database = deps.database as unknown as PremiseGraphDatabase;
+// AFTER:
+const database = deps.database as PremiseGraphDatabase;
+```
+
+### packages/protocol/package.json — MODIFY
+
+```json
+{
+  "dependencies": {
+    "@langchain/core": "^1.1.17",
+    "@langchain/langgraph": "^1.1.2",
+    "@langchain/openai": "^1.2.3",
+    // @langchain/langgraph-checkpoint-postgres removed — not imported by source
+  }
+}
+```
+
+### packages/protocol/src/shared/schemas/mcp-auth.schema.ts — NEW
+
+```typescript
+export interface McpAuthInput {
+  bearerToken?: string;
+  apiKey?: string;
+  clientSurface?: 'telegram' | 'web';
+  telegramHandle?: string;
+  telegramUsername?: string;
+}
+```
+
+### packages/protocol/src/shared/interfaces/auth.interface.ts — MODIFY
+
+```typescript
+// BEFORE:
+// resolveIdentity(request: Request): Promise<{...}>;
+// AFTER:
+import type { McpAuthInput } from '../schemas/mcp-auth.schema.js';
+// ...
+resolveIdentity(input: McpAuthInput): Promise<{userId: string; agentId?: string; isSessionAuth?: boolean; networkScopeId?: string | null; clientSurface?: 'telegram' | 'web'}>;
+```
+
+### packages/protocol/src/mcp/mcp.server.ts — MODIFY
+
+```typescript
+// Extracts McpAuthInput from ctx.http?.req headers before calling resolveIdentity:
+const mcpAuthInput: McpAuthInput = {
+  bearerToken: extractBearerToken(httpReq),
+  apiKey: httpReq.headers.get('x-api-key') ?? undefined,
+  clientSurface: parseClientSurface(httpReq.headers.get('x-index-surface')),
+  telegramHandle: httpReq.headers.get('x-index-telegram-handle') ?? undefined,
+  telegramUsername: httpReq.headers.get('x-index-telegram-username') ?? undefined,
+};
+const { userId, agentId, isSessionAuth, networkScopeId, clientSurface } = await authResolver.resolveIdentity(mcpAuthInput);
+
+// Added helpers:
+function extractBearerToken(req: Request): string | undefined { ... }
+function parseClientSurface(raw: string | null): 'telegram' | 'web' { ... }
+```
+
+### backend/src/controllers/mcp.controller.ts — MODIFY (Slices 3+5)
+
+```typescript
+// Import added: McpAuthInput
+// resolver signature: resolveIdentity(input: McpAuthInput) instead of resolveIdentity(request: Request)
+// Header reads changed from request.headers.get('X') to input.x
+// finalizeMcpIdentity signature: (telegramHandle, identity) instead of (request, identity)
+// resolveUserId bridges: extracts McpAuthInput from Request inline
+```
+
+### backend/src/services/tool.service.ts — MODIFY (Slice 3)
+
+```typescript
+// No code changes needed — ToolDeps and compiled graph imports remain intact
+// (DefineTool, ToolRegistry, ToolErrorReport removals from barrel did not affect this file)
+```
+
+## Slices
+
+### Slice 1: Profile + DiscoveryQuestion DTO extraction
+
+**Files**: `packages/protocol/src/shared/schemas/profile.schema.ts` (NEW), `packages/protocol/src/shared/schemas/discovery-question.schema.ts` (NEW), `packages/protocol/src/shared/interfaces/database.interface.ts` (MODIFY), `packages/protocol/src/shared/agent/tool.helpers.ts` (MODIFY), `packages/protocol/src/shared/interfaces/question-generator.interface.ts` (MODIFY), `packages/protocol/src/index.ts` (MODIFY)
+
+#### Automated Verification:
+- [ ] Type checking passes: `cd packages/protocol && bun run build`
+- [ ] Tests pass: `cd packages/protocol && bun test`
+- [ ] No imports from `profile/profile.generator.ts` or `opportunity/question.prompt.ts` remain in `shared/interfaces/database.interface.ts`
+- [ ] No imports from `profile/profile.generator.ts` remain in `shared/agent/tool.helpers.ts`
+
+#### Manual Verification:
+- [ ] `profile.schema.ts` defines `ProfileDocument` as a pure Zod-inferred type without LangChain or model imports
+- [ ] `discovery-question.schema.ts` defines all discovery question types without domain implementation imports
+- [ ] `database.interface.ts` imports `ProfileDocument` from `../schemas/profile.schema.js` not from `../../profile/profile.generator.js`
+- [ ] `tool.helpers.ts` imports `ProfileDocument` from `../schemas/profile.schema.js` not from `../../profile/profile.generator.js`
+
+### Slice 2: Negotiation state DTO extraction
+
+**Files**: `packages/protocol/src/shared/schemas/negotiation-state.schema.ts` (NEW), `packages/protocol/src/shared/interfaces/agent-dispatcher.interface.ts` (MODIFY), `packages/protocol/src/negotiation/negotiation.state.ts` (MODIFY), `packages/protocol/src/index.ts` (MODIFY)
+
+#### Automated Verification:
+- [ ] Type checking passes: `cd packages/protocol && bun run build`
+- [ ] Tests pass: `cd packages/protocol && bun test`
+- [ ] No imports from `negotiation/negotiation.state.ts` remain in `shared/interfaces/agent-dispatcher.interface.ts`
+
+#### Manual Verification:
+- [ ] `negotiation-state.schema.ts` defines `NegotiationTurn` as a pure static interface (not `z.infer`)
+- [ ] `negotiation.state.ts` defines `NegotiationTurn`, `NegotiationOutcome`, `UserNegotiationContext`, `SeedAssessment` structurally identical to the shared schema (dual definitions — schema is canonical for shared interfaces; domain file keeps local copies for graph internals)
+- [ ] `agent-dispatcher.interface.ts` imports negotiation types from `../schemas/negotiation-state.schema.js`
+
+### Slice 3: Public API narrowing
+
+**Files**: `packages/protocol/src/index.ts` (MODIFY), `backend/src/controllers/mcp.controller.ts` (MODIFY), `backend/src/services/tool.service.ts` (MODIFY)
+
+#### Automated Verification:
+- [ ] Type checking passes: `bun run build` at root
+- [ ] `export type * from "./shared/interfaces/database.interface.js"` is replaced with explicit named exports
+- [ ] No references to `DefineTool`, `RawToolDefinition`, or `ToolRegistry` remain in `index.ts` as root exports
+
+#### Manual Verification:
+- [ ] Backend code (`mcp.controller.ts`, `tool.service.ts`) still compiles without root imports of removed types
+- [ ] Negotiation state types are re-exported from schemas, not from `negotiation/negotiation.state.js`
+
+### Slice 4: Premise cast fix + Postgres dep removal
+
+**Files**: `packages/protocol/src/shared/interfaces/database.interface.ts` (MODIFY), `packages/protocol/src/shared/agent/tool.factory.ts` (MODIFY), `packages/protocol/src/premise/premise.tools.ts` (MODIFY), `packages/protocol/package.json` (MODIFY)
+
+#### Automated Verification:
+- [ ] Type checking passes: `cd packages/protocol && bun run build`
+- [ ] Tests pass: `cd packages/protocol && bun test`
+- [ ] No `as unknown as PremiseGraphDatabase` casts remain in `tool.factory.ts` or `premise.tools.ts`
+- [ ] `@langchain/langgraph-checkpoint-postgres` is removed from `package.json`
+
+#### Manual Verification:
+- [ ] `ChatGraphCompositeDatabase` includes `createPremise`, `getPremise`, `updatePremise`, `assignPremiseToNetwork`, `getPremiseNetworks`
+- [ ] `tool.factory.ts:130` uses `database as PremiseGraphDatabase` (no `as unknown as`)
+- [ ] `premise.tools.ts:12` uses `deps.database` matching `PremiseGraphDatabase` (no `as unknown as`)
+
+### Slice 5: MCP auth DTO refactor
+
+**Files**: `packages/protocol/src/shared/schemas/mcp-auth.schema.ts` (NEW), `packages/protocol/src/shared/interfaces/auth.interface.ts` (MODIFY), `packages/protocol/src/mcp/mcp.server.ts` (MODIFY), `backend/src/controllers/mcp.controller.ts` (MODIFY), `packages/protocol/src/index.ts` (MODIFY)
+
+#### Automated Verification:
+- [ ] Type checking passes at both protocol and backend levels: `cd packages/protocol && bun run build` and `cd backend && bun run build`
+- [ ] `McpAuthResolver.resolveIdentity` no longer accepts `Request` — accepts `McpAuthInput` instead
+- [ ] `mcp.server.ts` extracts `McpAuthInput` from `ctx.http?.req` before calling `resolveIdentity`
+
+#### Manual Verification:
+- [ ] `mcp-auth.schema.ts` defines `McpAuthInput` with typed fields for authorization, API key, surface, and telegram headers
+- [ ] Backend `mcp.controller.ts` extracts `McpAuthInput` from the HTTP Request before passing to the resolver
+- [ ] `mcp.server.ts` no longer passes raw `Request` to `authResolver`
+
+## Desired End State
+
+```typescript
+// Shared interface imports from shared schemas — clean, no domain implementation coupling
+// packages/protocol/src/shared/interfaces/database.interface.ts
+import { ProfileDocument } from '../schemas/profile.schema.js';
+
+export interface Database {
+  getProfile(userId: string): Promise<ProfileDocument | null>;
+  saveProfile(userId: string, profile: ProfileDocument): Promise<void>;
+  // ...
+}
+
+// packages/protocol/src/shared/interfaces/agent-dispatcher.interface.ts
+import type { NegotiationTurn, UserNegotiationContext, SeedAssessment } from '../schemas/negotiation-state.schema.js';
+
+export interface AgentDispatcher {
+  dispatch(userId: string, scope: ...,
+    payload: NegotiationTurnPayload, options: ...): Promise<AgentDispatchResult>;
+}
+
+// packages/protocol/src/index.ts — explicit exports, no export type *
+export type { Database, UserDatabase, SystemDatabase } from './shared/interfaces/database.interface.js';
+// No: DefineTool, RawToolDefinition, ToolRegistry
+
+// packages/protocol/src/shared/interfaces/auth.interface.ts
+export interface McpAuthResolver {
+  resolveIdentity(input: McpAuthInput): Promise<{ userId: string; agentId?: string; /* ... */ }>;
+}
+
+// packages/protocol/src/shared/agent/tool.factory.ts — no as unknown as
+new PremiseGraphFactory(database as PremiseGraphDatabase, embedder)
+```
+
+## File Map
+```
+packages/protocol/src/shared/schemas/profile.schema.ts                              # NEW — ProfileDocument DTO
+packages/protocol/src/shared/schemas/discovery-question.schema.ts                   # NEW — DiscoveryQuestionInput DTO
+packages/protocol/src/shared/schemas/negotiation-state.schema.ts                    # NEW — NegotiationTurn, UserNegotiationContext, SeedAssessment DTO
+packages/protocol/src/shared/schemas/mcp-auth.schema.ts                             # NEW — McpAuthInput DTO
+packages/protocol/src/shared/interfaces/database.interface.ts                       # MODIFY — import ProfileDocument from schema, add premise CRUD to composite
+packages/protocol/src/shared/interfaces/agent-dispatcher.interface.ts               # MODIFY — import from schema
+packages/protocol/src/shared/interfaces/question-generator.interface.ts             # MODIFY — import from schema
+packages/protocol/src/shared/interfaces/auth.interface.ts                           # MODIFY — McpAuthInput signature
+packages/protocol/src/shared/agent/tool.helpers.ts                                  # MODIFY — import ProfileDocument from schema
+packages/protocol/src/shared/agent/tool.factory.ts                                  # MODIFY — remove as unknown as PremiseGraphDatabase cast
+packages/protocol/src/premise/premise.tools.ts                                      # MODIFY — remove as unknown as PremiseGraphDatabase cast
+packages/protocol/src/mcp/mcp.server.ts                                             # MODIFY — extract McpAuthInput before auth
+packages/protocol/package.json                                                      # MODIFY — remove Postgres checkpoint dep
+packages/protocol/src/index.ts                                                      # MODIFY — narrow exports (×3: schema re-exports, API narrowing, auth)
+backend/src/controllers/mcp.controller.ts                                           # MODIFY — import adjusted types, extract McpAuthInput
+backend/src/services/tool.service.ts                                                # MODIFY — handle removed internal exports
+```
+
+## Ordering Constraints
+- Slice 1 must precede Slices 2 and 3 (types need to be in schemas first)
+- Slice 2 can run independently of Slice 1 (different types, same pattern)
+- Slices 4 and 5 are independent of Slices 1-3
+- Slice 5 modifies `mcp.controller.ts` — Slice 3 also modifies it; Slice 5 should come after Slice 3 to avoid merge conflicts in that file
+
+## Verification Notes
+- Run `bun run build` in packages/protocol and backend after each slice
+- Run `cd packages/protocol && bun test` after each slice
+- Check `grep -r "as unknown as PremiseGraphDatabase" packages/protocol/` after Slice 4 — must return 0
+- Check `grep -r "DefineTool" packages/protocol/src/index.ts` after Slice 3 — must return 0
+- Check `grep -r "RawToolDefinition" packages/protocol/src/index.ts` after Slice 3 — must return 0
+- Check `grep -r "langgraph-checkpoint-postgres" packages/protocol/package.json` after Slice 4 — must return 0
+- Dual-definition pattern: `negotiation.state.ts` and `negotiation-state.schema.ts` define structurally identical types. The schema is canonical for shared interfaces; domain file keeps local copies for backward compatibility with graph internals. A lint rule or build check should enforce structural parity between the two files.
+
+## Performance Considerations
+- All changes are compile-time / import-level — no runtime performance impact
+- DTO extraction moves type definitions but does not change runtime behavior
+- Removal of Postgres dep may marginally reduce `node_modules` size but has no runtime effect
+
+## Migration Notes
+- Not applicable — all changes are backward-compatible import refactors
+- No data schema or persisted format changes
+- Old domain imports remain viable if consumers haven't been updated (domain modules re-export from schemas where needed)
+
+## Pattern References
+- `packages/protocol/src/shared/schemas/question.schema.ts:1-60` — pattern for clean DTO: Zod schema + `z.infer` type, zero domain imports
+- `packages/protocol/src/shared/schemas/chat-context.schema.ts:1-21` — minimal schema example
+- `packages/protocol/src/shared/interfaces/cache.interface.ts:1-41` — pattern for narrow port: no domain imports, clean Pick-based subtypes
+- `packages/protocol/src/shared/schemas/negotiation-digest.schema.ts:14-18` — existing negotiation-adjacent schema in shared/
+- `packages/protocol/src/chat/chat.graph.ts:81-86` — positive injection pattern for adapter-specific infra
+
+## Developer Context
+**Q (research, Q1+Q2): Should shared interface domain-type imports be extracted to schemas or left as-is?**
+A: Extract to schemas. Follow `question.schema.ts` pattern.
+
+**Q (research, API surface): Should graph factory root exports be treated as violations?**
+A: Split severity — graph factories stay as tolerated host seams. Raw runtime/registry and broad DB exports are violations.
+
+**Q (research, MCP auth): How to fix `Request` in McpAuthResolver?**
+A: Create `McpAuthInput` DTO, change `resolveIdentity` signature, extract from `Request` at MCP controller edge before calling protocol.
+
+**Q (design, directional): Should this design extract orthogonal DTO groups into separate slices?**
+A: Yes — 5 slices.
+
+**Q (design, scope): Include MCP auth refactor?**
+A: Yes — full refactor with DTO type, changed signature, backend update.
+
+## Design History
+- Slice 1: Profile + DiscoveryQuestion DTO extraction — approved as generated
+- Slice 2: Negotiation state DTO extraction — approved as generated
+- Slice 3: Public API narrowing — approved as generated
+- Slice 4: Premise cast fix + Postgres dep removal — approved as generated
+- Slice 5: MCP auth DTO refactor — approved as generated
+
+## References
+- `.rpiv/artifacts/research/2026-06-09_10-42-15_protocol-package-violations.md` — Violation detection research

--- a/.rpiv/artifacts/designs/2026-06-09_11-48-41_connect-links-auth-redirect.md
+++ b/.rpiv/artifacts/designs/2026-06-09_11-48-41_connect-links-auth-redirect.md
@@ -1,0 +1,248 @@
+---
+date: 2026-06-09T11:48:41+0300
+author: Yankı Ekin Yüksel
+commit: cc4ceda7a
+branch: dev
+repository: index
+topic: "Connect links unauthenticated auth redirect — design"
+tags: [design, frontend, auth, connect-links, chat]
+status: ready
+parent: .rpiv/artifacts/research/2026-06-09_11-18-58_connect-links-auth-redirect.md
+last_updated: 2026-06-09T11:48:41+0300
+last_updated_by: Yankı Ekin Yüksel
+---
+
+# Design: Connect links unauthenticated auth redirect
+
+## Summary
+
+Extend `AuthContext.openLoginModal()` to accept an optional `callbackURL` string parameter, threading it through as `pendingCallbackURL` state to `AuthModal.callbackURL`. Replace the ChatPage's hard `navigate('/')` bounce with `openLoginModal(window.location.href)`, gated by a `useRef` to fire once. No changes to existing callers — backwards compatible via optional parameter.
+
+## Requirements
+
+- Unauthenticated visitors landing on `/u/:id/chat?msg=...` can authenticate without losing the URL path or query params
+- After authentication (email/password, magic-link, or Google OAuth), the user lands on the same chat URL with `msg` preserved
+- The backend `/c/:code/go` endpoint is untouched — it already returns correct URLs
+- If the user dismisses the login modal without authenticating, stay on page — no redirect
+- All 5 existing `openLoginModal()` callers (Header, landing, invitation, index join) continue to work unchanged
+
+## Current State Analysis
+
+### Key Discoveries
+
+- `AuthModal` (`AuthModal.tsx:13`) already has `callbackURL?: string` prop, used by magic-link (`line 65`) and Google OAuth (`line 120`). Email/password (`line 96-99`) does not use callbackURL — session established via XHR, no browser redirect.
+- `AuthContext` (`AuthContext.tsx:189-192`) renders `<AuthModal>` without passing `callbackURL`. The prop is only used by the standalone `/login` page (`login/page.tsx:41-44`).
+- `AuthContext.openLoginModal` (`AuthContext.tsx:18,45-47`) is `() => void` — no parameter support. The `useCallback` deps are `[]` (setters are stable).
+- `ChatPage` (`page.tsx:30-34`) uses `navigate('/')` when `isAuthenticated` is false, losing all URL state.
+- `useRef` already imported at `page.tsx:1`, `opportunityAcceptedRef` at `page.tsx:26`.
+- `/u/` is in `publicPrefixes` (`AuthContext.tsx:133`) — global auth guard does not block the page.
+- Better Auth server correctly preserves `callbackURL` through magic-link (embedded in email query param) and Google OAuth (encrypted in server-side state). The `jwtClient()` plugin is uninvolved in OAuth redirects.
+- 5 existing callers all pass zero args — optional `?` parameter is sufficient for backward compatibility.
+- `Header.tsx:36-47` provides the ref-gating pattern model: `loginInitiatedRef.useRef(false)` + `useEffect` checking `isAuthenticated && loginInitiatedRef.current`.
+- Context functions with optional parameters have precedent: `AIChatContext.clearChat(options?)` (`AIChatContext.tsx:958`), `NotificationContext.success(title, message?, duration?)` (`NotificationContext.tsx:58`), `ConversationContext.loadMessages(id, opts?)` (`ConversationContext.tsx:69`).
+
+## Scope
+
+### Building
+- `frontend/src/contexts/AuthContext.tsx` — widen `openLoginModal` signature, add `pendingCallbackURL` state, wire to `AuthModal`
+- `frontend/src/app/u/[id]/chat/page.tsx` — replace `navigate('/')` with `openLoginModal(window.location.href)` gated by `useRef`
+
+### Not Building
+- Generic site-wide `returnTo` redirect infrastructure
+- `/login` page changes (MCP-specific flow must not be touched)
+- Backend `/c/:code/go` resolver (already correct)
+- Existing callers (Header, landing, invitation page, index join page) — all backward compatible
+- AuthModal `callbackURL` prop — already exists and works
+- Better Auth server config — no changes needed
+- `publicPrefixes` in AuthContext — `/u/` already present
+
+## Decisions
+
+### Approach: inline login modal vs. redirect to /login
+Extend `AuthContext.openLoginModal()` to accept optional `callbackURL`, rather than routing through `/login`. Chosen in discover (`evidence: frontend/src/app/login/page.tsx:21-25` — MCP-specific forwarding would conflict).
+
+### Modal dismiss behavior
+Stay on page when dismissed — no redirect. Chosen in discover.
+
+### Backend unchanged
+Connect-link backend resolver at `connect-link.controller.ts:173-174` already builds correct URLs. Chosen — evidence confirmed in research.
+
+### callbackURL not cleared on auto-close
+When `AuthContext.tsx:115-120` auto-closes the modal on auth success, `pendingCallbackURL` is not explicitly cleared. Email/password: user already on correct page. OAuth/magic-link: browser already redirected away. Confirmed in checkpoint.
+
+### Spinner persistence after dismiss
+After modal dismiss, ChatPage's spinner (`page.tsx:85-90`) remains visible because `isLoading` stays `true` (fetchData returns early when unauthenticated). Accepted — FRD req #4 satisfied.
+
+### Backward compatibility: optional parameter sufficient
+`openLoginModal(callbackURL?: string)` — all 5 existing callers pass zero args, `?` defaults to `undefined`. No caller changes needed. Pattern modeled after `NotificationContext.tsx:58`.
+
+### Ref-gating pattern: model after Header.tsx
+ChatPage's `loginPromptedRef` follows `Header.tsx:36-47` pattern: `useRef(false)` + `useEffect` with guard condition + ref set to `true` before action. Header pattern is proven (no follow-up bugs).
+
+## Architecture
+
+### `frontend/src/contexts/AuthContext.tsx:18,32,45-47,115-120,189-192` — MODIFY
+
+Type change: `openLoginModal: (callbackURL?: string) => void`
+Add state: `const [pendingCallbackURL, setPendingCallbackURL] = useState<string | undefined>(undefined);`
+Update useCallback: store callbackURL + open modal atomically
+Update onClose: clear pendingCallbackURL alongside loginModalOpen
+Update JSX: `<AuthModal callbackURL={pendingCallbackURL}>`
+
+```typescript
+  openLoginModal: (callbackURL?: string) => void;
+```
+
+```typescript
+  const [pendingCallbackURL, setPendingCallbackURL] = useState<string | undefined>(undefined);
+```
+
+```typescript
+  const openLoginModal = useCallback((callbackURL?: string) => {
+    setPendingCallbackURL(callbackURL);
+    setLoginModalOpen(true);
+  }, []);
+```
+
+```tsx
+      <AuthModal
+        isOpen={loginModalOpen}
+        onClose={() => { setPendingCallbackURL(undefined); setLoginModalOpen(false); }}
+        callbackURL={pendingCallbackURL}
+      />
+```
+
+### `frontend/src/app/u/[id]/chat/page.tsx:30-34` — MODIFY
+
+Add `const loginPromptedRef = useRef(false);`
+Replace `navigate('/')` useEffect with:
+```
+useEffect(() => {
+  if (!authLoading && !isAuthenticated && !loginPromptedRef.current) {
+    loginPromptedRef.current = true;
+    openLoginModal(window.location.href);
+  }
+}, [authLoading, isAuthenticated, openLoginModal]);
+```
+
+```typescript
+  const { isAuthenticated, isLoading: authLoading, openLoginModal } = useAuthContext();
+```
+
+```typescript
+  const loginPromptedRef = useRef(false);
+```
+
+```typescript
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated && !loginPromptedRef.current) {
+      loginPromptedRef.current = true;
+      openLoginModal(window.location.href);
+    }
+  }, [authLoading, isAuthenticated, openLoginModal]);
+```
+
+## Slices
+
+### Slice 1: AuthContext extension
+
+**Files**: `frontend/src/contexts/AuthContext.tsx`
+
+#### Automated Verification:
+- [ ] TypeScript compiles: `cd frontend && bun run build` exits 0
+- [ ] `openLoginModal` type widened — no existing caller produces type errors
+
+#### Manual Verification:
+- [ ] Open `/u/:id/chat` in logged-out browser → login modal appears (with callbackURL plumbing)
+- [ ] Click Header "Login" button → modal appears with default behavior (no callbackURL)
+- [ ] Authenticate via email/password → modal closes, user stays on page
+- [ ] AuthModal receives `callbackURL` prop when passed from Slice 2's `openLoginModal(window.location.href)`
+
+### Slice 2: ChatPage replacement
+
+**Files**: `frontend/src/app/u/[id]/chat/page.tsx`
+
+#### Automated Verification:
+- [ ] TypeScript compiles: `cd frontend && bun run build` exits 0
+- [ ] `navigate('/')` no longer present in ChatPage
+
+#### Manual Verification:
+- [ ] Open connect short-link (`/c/...`) in logged-out browser → chat page loads → login modal appears
+- [ ] Sign in via email/password → lands on `/u/:id/chat` with prefilled message
+- [ ] Sign in via magic-link → email returns to `/u/:id/chat?msg=...` with prefilled message
+- [ ] Sign in via Google OAuth → OAuth redirect returns to `/u/:id/chat?msg=...` with prefilled message
+- [ ] Dismiss login modal (click ×) → stays on `/u/:id/chat` page, spinner visible, no redirect
+- [ ] Authenticated user opening connect link → goes directly to chat (no modal) — existing behavior preserved
+
+## Desired End State
+
+```tsx
+// AuthContext.tsx — after change
+type AuthContextType = {
+  openLoginModal: (callbackURL?: string) => void;
+  // ...
+};
+
+// ChatPage — after change
+const loginPromptedRef = useRef(false);
+
+useEffect(() => {
+  if (!authLoading && !isAuthenticated && !loginPromptedRef.current) {
+    loginPromptedRef.current = true;
+    openLoginModal(window.location.href);
+  }
+}, [authLoading, isAuthenticated, openLoginModal]);
+```
+
+## File Map
+
+- `frontend/src/contexts/AuthContext.tsx`  # MODIFY — widen openLoginModal, add pendingCallbackURL
+- `frontend/src/app/u/[id]/chat/page.tsx`  # MODIFY — replace navigate('/') with openLoginModal
+
+## Ordering Constraints
+
+Slice 1 must come before Slice 2 (Slice 2 uses the widened `openLoginModal` signature).
+
+## Verification Notes
+
+- **AuthModal URL config**: AuthModal URL config has broken in production before (`72dd330a9`, `3e3a56c47`). No changes to AuthModal's fetch/redirect URLs in this design — only passing `callbackURL` through a prop that already exists.
+- **Route visibility**: `/u/` is already in `publicPrefixes` (`AuthContext.tsx:133`). No change needed. If this were a different route prefix, it would need to be added (per `c78ed185e` precedent lesson).
+- **Back-button redirect loop**: Current `navigate('/')` lacks `{ replace: true }` (`page.tsx:34`). The inline modal replacement naturally solves this since there's no redirect at all. Removed, not separately fixed.
+- **Ghost user edge case**: Chat page has ghost user claiming logic (`f8de285f9`, `a0d830109`). The modal replacement does not affect ghost-claim code paths because ghost users have an existing session (are authenticated). Not exercised by this flow.
+
+## Performance Considerations
+
+- One additional `useState` (pendingCallbackURL) per AuthContext mount — negligible memory cost.
+- `useCallback` deps remain `[]` — no re-creation on re-renders. State setters are stable React references.
+- No additional network requests beyond the login modal's existing provider fetch.
+- No extra renders beyond the existing modal open/close lifecycle.
+
+## Migration Notes
+
+N/A — no persisted data, no schema changes.
+
+## Pattern References
+
+- `frontend/src/contexts/NotificationContext.tsx:58` — context function with optional parameters (pattern for `openLoginModal(callbackURL?)`)
+- `frontend/src/contexts/AIChatContext.tsx:958` — `clearChat(options?)` with empty `useCallback` deps `[]` (pattern for `openLoginModal`)
+- `frontend/src/components/Header.tsx:36-47` — `loginInitiatedRef` + guarded `useEffect` (pattern for ChatPage `loginPromptedRef`)
+- `frontend/src/app/login/page.tsx:37-44` — `callbackURL={window.location.href}` passed to AuthModal (existing usage of callbackURL prop)
+
+## Developer Context
+
+**Q (direction — auto-close cleanup): When the modal auto-closes on auth success, should pendingCallbackURL be cleared?**
+A: Follow — don't clear on auto-close. Overwritten on next openLoginModal() call.
+
+**Q (dismiss UX): Spinner persists after modal dismiss. Acceptable for initial fix?**
+A: Accept spinner after dismiss.
+
+## Design History
+
+- Slice 1: AuthContext extension — approved as generated
+- Slice 2: ChatPage replacement — approved as generated
+
+## References
+
+- `.rpiv/artifacts/research/2026-06-09_11-18-58_connect-links-auth-redirect.md` — Detailed code path analysis
+- `.rpiv/artifacts/discover/2026-06-09_11-05-29_connect-links-auth-redirect.md` — Feature requirements
+- Linear issue [IND-354](https://linear.app/indexnetwork/issue/IND-354/connect-links-c-drop-unauthenticated-users-on-homepage-losing-chat)

--- a/.rpiv/artifacts/discover/2026-06-09_11-05-29_connect-links-auth-redirect.md
+++ b/.rpiv/artifacts/discover/2026-06-09_11-05-29_connect-links-auth-redirect.md
@@ -1,0 +1,120 @@
+---
+date: 2026-06-09T11:05:29+0300
+author: Yankı Ekin Yüksel
+commit: cc4ceda7a
+branch: dev
+repository: index
+topic: "Connect links unauthenticated auth redirect"
+tags: [intent, frd, frontend, auth, connect-links]
+status: complete
+last_updated: 2026-06-09T11:05:29+0300
+last_updated_by: Yankı Ekin Yüksel
+---
+
+# FRD: Connect links unauthenticated auth redirect
+
+## Summary
+
+Connect short-links (`/c/:code`) resolve to `/u/:id/chat?msg=<greeting>` but drop unauthenticated visitors on the homepage with no return path. Instead of a hard bounce, the chat page should show the login modal inline with a callback URL that preserves the chat destination and prefilled message across OAuth/magic-link flows.
+
+## Problem & Intent
+
+Connect short-links are intentionally unauthenticated — possession of the opaque short code grants access. When a visitor clicks one in a logged-out session, the backend correctly resolves to a chat deep-link with a prefilled greeting. But the frontend chat page hard-bounces unauthenticated users to `/` with no redirect awareness, discarding both the intended counterparty and the prefilled message. The visitor lands on the homepage confused, with no way to reach the conversation they were invited to.
+
+The fix should let the visitor authenticate and land exactly where the short-link intended — at the chat with that specific user, with the greeting already prefilled in the input box.
+
+## Goals
+
+- Unauthenticated visitors landing on `/u/:id/chat?msg=...` can authenticate without losing the URL path or query params
+- After authentication (email/password, magic-link, or Google OAuth), the user lands on that same chat URL with `msg` preserved
+- The backend `/c/:code/go` endpoint is untouched — it already returns correct URLs
+
+## Non-Goals
+
+- Not changing the backend connect-link resolver behavior
+- Not adding a generic site-wide `returnTo` redirect infrastructure — this is a targeted fix for the chat page
+- Not altering the `/login` page (MCP-specific flow)
+
+## Functional Requirements
+
+1. Chat page SHALL show the login modal inline when an unauthenticated visitor lands on `/u/:id/chat`
+2. Chat page SHALL pass `window.location.href` as `callbackURL` to the login mechanism so OAuth/magic-link flows return to the correct path with `?msg=...` preserved
+3. AuthContext SHALL expose a mechanism to set a pending `callbackURL` that flows through to `AuthModal`
+4. If the user dismisses the login modal without authenticating, the page SHALL remain in its current state — no redirect to `/`
+5. Email/password sign-in SHALL auto-close the modal and show the chat with prefilled message on success
+6. Magic-link and Google OAuth flows SHALL redirect back to the original `/u/:id/chat?msg=...` URL after authentication
+
+## Non-Functional Requirements
+
+- **Performance**: No additional network requests beyond the login modal's existing provider fetch
+- **Security**: No sensitive data (the `?msg=...` greeting contents) must appear in magic-link email bodies beyond what the `callbackURL` already contains — this is existing behavior
+- **UX / Accessibility**: Modal should render over the chat page, not replace it. Loading state (spinner) before auth should not flash the login page background
+- **Reliability**: The login prompt fires exactly once per page load — dismissing the modal does not re-prompt
+
+## Constraints & Assumptions
+
+- AuthModal already accepts a `callbackURL` prop (used by magic-link and Google sign-in) — the plumbing exists but is not wired from AuthContext
+- The `/login` page is MCP-specific and forwards query params to `/api/auth/mcp/authorize` — must not route general login through it
+- The `/u/` prefix is marked as public in AuthContext (`AuthContext.tsx:133`), so the global auth guard does not block the chat page from rendering
+- The existing chat page `useEffect` currently calls `navigate('/')` — this is the only code path to replace
+- A `useRef` flag prevents re-showing the login modal on subsequent renders after dismissal
+
+## Acceptance Criteria
+
+- [ ] Open `https://protocol.index.network/c/UvThrrgHxC?link_preview=false` in a logged-out browser session — login modal appears instead of homepage redirect
+- [ ] Sign in via email/password — lands on `/u/:id/chat` with the prefilled message in the input box
+- [ ] Sign in via magic-link — email link returns to `/u/:id/chat?msg=...` with the prefilled message
+- [ ] Sign in via Google OAuth — OAuth redirect returns to `/u/:id/chat?msg=...` with the prefilled message
+- [ ] Dismiss the login modal (click ×) — stays on `/u/:id/chat` page, no redirect
+- [ ] Authenticated user opening a connect link goes directly to chat (no modal) — existing behavior preserved
+- [ ] The `navigate('/')` call is removed from `ChatPage` and replaced by the inline login pattern
+
+## Recommended Approach
+
+Extend `AuthContext.openLoginModal()` to accept an optional `callbackURL` string parameter. Store it in pending state and pass it through to `AuthModal`. In `ChatPage`, replace the `navigate('/')` in the auth-guard `useEffect` with a call to `openLoginModal(window.location.href)`, gated by a `useRef` to fire only once. The login modal renders inline over the chat page; email/password sign-in auto-closes the modal; OAuth/magic-link flows use the `callbackURL` to return to the correct URL.
+
+## Decisions
+
+### Mechanism: inline login modal vs. redirect to /login
+**Question**: What mechanism should the chat page use to handle unauthenticated visitors?
+**Recommended**: Use `openLoginModal()` inline with `callbackURL = window.location.href`
+**Chosen**: Use `openLoginModal()` inline
+**Rationale**: No redirect bounce, preserves `msg` naturally in-memory (still in URL search params), reuses existing `callbackURL` plumbing in `AuthModal`. The `/login` page is MCP-specific and would risk breakage.
+
+### Modal dismiss behavior
+**Question**: If the user dismisses the login modal without authenticating, what should happen?
+**Recommended**: Stay on page when dismissed
+**Chosen**: Stay on page
+**Rationale**: The user is already on the intended page — no reason to redirect to home. Causes less surprise than the current hard bounce.
+
+### Pre-resolution: AuthModal callbackURL plumbing
+**Question**: Pre-resolved from codebase evidence — AuthModal already has `callbackURL` prop support but AuthContext doesn't wire it through
+**Chosen**: Confirmed
+**Rationale**: `evidence: frontend/src/components/AuthModal.tsx:12-13` — prop exists; `evidence: frontend/src/contexts/AuthContext.tsx:189-192` — no callbackURL passed
+
+### Pre-resolution: No generic returnTo convention
+**Question**: Pre-resolved from codebase evidence — AuthContext hardcodes `navigate('/')` with no return-URL preservation
+**Chosen**: Confirmed
+**Rationale**: `evidence: frontend/src/contexts/AuthContext.tsx:136-139`
+
+### Pre-resolution: Backend URLs already correct
+**Question**: Pre-resolved from codebase evidence — backend `/c/:code/go` correctly builds `/u/:id/chat?msg=...` URLs
+**Chosen**: Confirmed
+**Rationale**: `evidence: backend/src/controllers/connect-link.controller.ts:173-174`
+
+## Open Questions
+
+None.
+
+## Suggested Follow-ups
+
+- The current `navigate('/')` in ChatPage does not use `{ replace: true }` (`page.tsx:34`), creating a browser-back redirect loop. Since this call is removed by the fix, no separate action needed.
+- The loading state when unauthenticated renders a null page behind the modal — could show the loading tree animation instead for a smoother initial render.
+
+## References
+
+- Linear issue [IND-354](https://linear.app/indexnetwork/issue/IND-354/connect-links-c-drop-unauthenticated-users-on-homepage-losing-chat)
+- `backend/src/controllers/connect-link.controller.ts` — backend resolver (unaffected)
+- `frontend/src/app/u/[id]/chat/page.tsx` — chat page (primary target)
+- `frontend/src/contexts/AuthContext.tsx` — auth state and login modal rendering
+- `frontend/src/components/AuthModal.tsx` — login modal with existing callbackURL prop

--- a/.rpiv/artifacts/plans/2026-06-09_12-54-22_ind-354-connect-links-auth-redirect.md
+++ b/.rpiv/artifacts/plans/2026-06-09_12-54-22_ind-354-connect-links-auth-redirect.md
@@ -1,0 +1,189 @@
+---
+date: 2026-06-09T12:54:22+0300
+author: Yankı Ekin Yüksel
+commit: cc4ceda7a
+branch: dev
+repository: index
+topic: "IND-354: Connect links unauthenticated auth redirect"
+tags: [plan, frontend, auth, connect-links, chat]
+status: ready
+parent: .rpiv/artifacts/designs/2026-06-09_11-48-41_connect-links-auth-redirect.md
+last_updated: 2026-06-09T12:54:22+0300
+last_updated_by: Yankı Ekin Yüksel
+---
+
+# IND-354: Connect Links Auth Redirect Implementation Plan
+
+## Overview
+
+Connect short-links (`/c/:code`) resolve to `/u/:id/chat?msg=<greeting>` but drop unauthenticated visitors on the homepage with no return path. This plan extends `AuthContext.openLoginModal()` to accept an optional `callbackURL` parameter, threads it through to `AuthModal.callbackURL`, and replaces the ChatPage's `navigate('/')` bounce with an inline login modal. See the design artifact for full architectural context.
+
+Design: `.rpiv/artifacts/designs/2026-06-09_11-48-41_connect-links-auth-redirect.md`
+
+## Desired End State
+
+An unauthenticated visitor landing on `/u/:id/chat?msg=<greeting>` sees the login modal overlaid on the chat page instead of being redirected to `/`. After authentication:
+
+- **Email/password**: modal auto-closes, chat page renders with `msg` preserved in the input
+- **Magic-link**: email click returns to `/u/:id/chat?msg=...` with the greeting prefilled
+- **Google OAuth**: redirect returns to `/u/:id/chat?msg=...` with the greeting prefilled
+
+Dismissing the modal leaves the user on the chat page (spinner visible, no redirect). All 5 existing `openLoginModal()` callers (Header, landing, invitation, index join) continue to work unchanged.
+
+## What We're NOT Doing
+
+- Generic site-wide `returnTo` redirect infrastructure
+- `/login` page changes (MCP-specific flow — must not be touched)
+- Backend `/c/:code/go` resolver (already correct)
+- Existing callers (Header, landing, invitation page, index join page) — all backward compatible
+- AuthModal `callbackURL` prop — already exists and works
+- Better Auth server config — no changes needed
+- `publicPrefixes` in AuthContext — `/u/` already present
+
+---
+
+## Phase 1: AuthContext Extension
+
+### Overview
+
+Widen `openLoginModal` signature from `() => void` to `(callbackURL?: string) => void`. Add `pendingCallbackURL` state alongside `loginModalOpen`. Update the `useCallback` to store the callbackURL and open the modal atomically. Update `onClose` to clear `pendingCallbackURL`. Pass `callbackURL={pendingCallbackURL}` to `<AuthModal>`.
+
+### Changes Required:
+
+#### 1. `frontend/src/contexts/AuthContext.tsx` — MODIFY
+
+**Changes**:
+1. Type definition (line 18): `openLoginModal: () => void;` → `openLoginModal: (callbackURL?: string) => void;`
+2. Add state (after line 32): `const [pendingCallbackURL, setPendingCallbackURL] = useState<string | undefined>(undefined);`
+3. `useCallback` (lines 45-47): accept optional `callbackURL`, store it, open modal
+4. `onClose` (line 191): clear `pendingCallbackURL` alongside `loginModalOpen`
+5. JSX (line 189-192): pass `callbackURL={pendingCallbackURL}` to `<AuthModal>`
+
+```typescript
+  openLoginModal: (callbackURL?: string) => void;
+```
+
+```typescript
+  const [pendingCallbackURL, setPendingCallbackURL] = useState<string | undefined>(undefined);
+```
+
+```typescript
+  const openLoginModal = useCallback((callbackURL?: string) => {
+    setPendingCallbackURL(callbackURL);
+    setLoginModalOpen(true);
+  }, []);
+```
+
+```tsx
+      <AuthModal
+        isOpen={loginModalOpen}
+        onClose={() => { setPendingCallbackURL(undefined); setLoginModalOpen(false); }}
+        callbackURL={pendingCallbackURL}
+      />
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] TypeScript compiles: `cd frontend && bun run build` exits 0
+- [x] `openLoginModal` type widened — no existing caller produces type errors
+
+#### Manual Verification:
+- [ ] Open `/u/:id/chat` in logged-out browser → login modal appears (with callbackURL plumbing)
+- [ ] Click Header "Login" button → modal appears with default behavior (no callbackURL)
+- [ ] Authenticate via email/password → modal closes, user stays on page
+- [ ] AuthModal receives `callbackURL` prop when passed from Phase 2's `openLoginModal(window.location.href)`
+
+---
+
+## Phase 2: ChatPage Replacement
+
+### Overview
+
+Replace the `navigate('/')` in the auth-guard `useEffect` with `openLoginModal(window.location.href)`, gated by a `loginPromptedRef` `useRef` that fires exactly once per page load. `navigate` import is preserved — still used by `handleClose`, `handleBack`, and the error button.
+
+### Changes Required:
+
+#### 1. `frontend/src/app/u/[id]/chat/page.tsx` — MODIFY
+
+**Changes**:
+1. Destructure `openLoginModal` from `useAuthContext()` alongside `isAuthenticated` and `isLoading`
+2. Add `const loginPromptedRef = useRef(false);`
+3. Replace the auth-guard `useEffect`: `navigate('/')` → `openLoginModal(window.location.href)` gated by `loginPromptedRef`
+
+```typescript
+  const { isAuthenticated, isLoading: authLoading, openLoginModal } = useAuthContext();
+```
+
+```typescript
+  const loginPromptedRef = useRef(false);
+```
+
+```typescript
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated && !loginPromptedRef.current) {
+      loginPromptedRef.current = true;
+      openLoginModal(window.location.href);
+    }
+  }, [authLoading, isAuthenticated, openLoginModal]);
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] TypeScript compiles: `cd frontend && bun run build` exits 0
+- [ ] `navigate('/')` no longer present in ChatPage
+
+#### Manual Verification:
+- [ ] Open connect short-link (`/c/...`) in logged-out browser → chat page loads → login modal appears
+- [ ] Sign in via email/password → lands on `/u/:id/chat` with prefilled message
+- [ ] Sign in via magic-link → email returns to `/u/:id/chat?msg=...` with prefilled message
+- [ ] Sign in via Google OAuth → OAuth redirect returns to `/u/:id/chat?msg=...` with prefilled message
+- [ ] Dismiss login modal (click ×) → stays on `/u/:id/chat` page, spinner visible, no redirect
+- [ ] Authenticated user opening connect link → goes directly to chat (no modal) — existing behavior preserved
+
+---
+
+## Plan Review (Step 4)
+
+_Independent post-finalization review by artifact-code-reviewer and artifact-coverage-reviewer subagents._
+
+_No findings — both reviewers cleared the artifact._
+
+---
+
+## Testing Strategy
+
+### Automated:
+- `cd frontend && bun run build` — TypeScript compilation check on both phases
+
+### Manual Testing Steps:
+1. Open connect short-link (`/c/...`) in logged-out browser → should see login modal, not homepage redirect
+2. Sign in via email/password → lands on chat URL with msg preserved
+3. Sign in via magic-link → email returns to chat URL with msg preserved
+4. Sign in via Google OAuth → redirect returns to chat URL with msg preserved
+5. Dismiss modal → stays on chat page (no redirect)
+6. Click Header "Login" → modal appears (default behavior, no callbackURL)
+7. Authenticated user → goes directly to chat (no modal)
+
+## Performance Considerations
+
+- One additional `useState` (pendingCallbackURL) per AuthContext mount — negligible memory cost
+- `useCallback` deps remain `[]` — no re-creation on re-renders. State setters are stable React references
+- No additional network requests beyond the login modal's existing provider fetch
+- No extra renders beyond the existing modal open/close lifecycle
+
+## Migration Notes
+
+N/A — no persisted data, no schema changes.
+
+## Developer Context
+
+*Initial write. Findings from Step 4 review will be recorded here.*
+
+## References
+
+- Design: `.rpiv/artifacts/designs/2026-06-09_11-48-41_connect-links-auth-redirect.md`
+- Research: `.rpiv/artifacts/research/2026-06-09_11-18-58_connect-links-auth-redirect.md`
+- Discover: `.rpiv/artifacts/discover/2026-06-09_11-05-29_connect-links-auth-redirect.md`
+- Linear issue: [IND-354](https://linear.app/indexnetwork/issue/IND-354/connect-links-c-drop-unauthenticated-users-on-homepage-losing-chat)

--- a/.rpiv/artifacts/plans/2026-06-09_13-10-22_protocol-package-violations.md
+++ b/.rpiv/artifacts/plans/2026-06-09_13-10-22_protocol-package-violations.md
@@ -6,7 +6,7 @@ branch: dev
 repository: index
 topic: "Fix protocol package boundary violations"
 tags: [plan, protocol, boundaries, interfaces, mcp, tools, schemas]
-status: in-review
+status: ready
 parent: .rpiv/artifacts/designs/2026-06-09_11-18-44_protocol-package-violations.md
 last_updated: 2026-06-09T13:10:22+0300
 last_updated_by: Yankı Ekin Yüksel
@@ -213,16 +213,16 @@ export type {
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Type checking passes: `cd packages/protocol && bun run build`
-- [ ] Tests pass: `cd packages/protocol && bun test`
-- [ ] No imports from `profile/profile.generator.ts` or `opportunity/question.prompt.ts` remain in `shared/interfaces/database.interface.ts`
-- [ ] No imports from `profile/profile.generator.ts` remain in `shared/agent/tool.helpers.ts`
+- [x] Type checking passes: `cd packages/protocol && bun run build`
+- [x] Tests pass: `cd packages/protocol && bun test`
+- [x] No imports from `profile/profile.generator.ts` or `opportunity/question.prompt.ts` remain in `shared/interfaces/database.interface.ts`
+- [x] No imports from `profile/profile.generator.ts` remain in `shared/agent/tool.helpers.ts`
 
 #### Manual Verification:
-- [ ] `profile.schema.ts` defines `ProfileDocument` as a pure Zod-inferred type without LangChain or model imports
-- [ ] `discovery-question.schema.ts` defines all discovery question types without domain implementation imports
-- [ ] `database.interface.ts` imports `ProfileDocument` from `../schemas/profile.schema.js` not from `../../profile/profile.generator.js`
-- [ ] `tool.helpers.ts` imports `ProfileDocument` from `../schemas/profile.schema.js` not from `../../profile/profile.generator.js`
+- [x] `profile.schema.ts` defines `ProfileDocument` as a pure Zod-inferred type without LangChain or model imports
+- [x] `discovery-question.schema.ts` defines all discovery question types without domain implementation imports
+- [x] `database.interface.ts` imports `ProfileDocument` from `../schemas/profile.schema.js` not from `../../profile/profile.generator.js`
+- [x] `tool.helpers.ts` imports `ProfileDocument` from `../schemas/profile.schema.js` not from `../../profile/profile.generator.js`
 
 ---
 
@@ -309,14 +309,15 @@ export type { NegotiationGraphLike } from "./negotiation/negotiation.state.js";
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Type checking passes: `cd packages/protocol && bun run build`
-- [ ] Tests pass: `cd packages/protocol && bun test`
-- [ ] No imports from `negotiation/negotiation.state.ts` remain in `shared/interfaces/agent-dispatcher.interface.ts`
+- [x] Type checking passes: `cd packages/protocol && bun run build`
+- [x] Tests pass: `cd packages/protocol && bun test`
+- [x] No imports from `negotiation/negotiation.state.ts` remain in `shared/interfaces/agent-dispatcher.interface.ts`
+- [x] Structural parity between dual definitions: `diff <(grep -n "^export" packages/protocol/src/shared/schemas/negotiation-state.schema.ts) <(grep -n "^export\|^export type\|^export interface" packages/protocol/src/negotiation/negotiation.state.ts | head -4)` passes
 
 #### Manual Verification:
-- [ ] `negotiation-state.schema.ts` defines `NegotiationTurn` as a pure static interface (not `z.infer`)
-- [ ] `negotiation.state.ts` defines `NegotiationTurn`, `NegotiationOutcome`, `UserNegotiationContext`, `SeedAssessment` structurally identical to the shared schema (dual definitions — schema is canonical for shared interfaces; domain file keeps local copies for graph internals)
-- [ ] `agent-dispatcher.interface.ts` imports negotiation types from `../schemas/negotiation-state.schema.js`
+- [x] `negotiation-state.schema.ts` defines `NegotiationTurnSchema` as the canonical Zod schema and derives `NegotiationTurn` with `z.infer`
+- [x] `negotiation.state.ts` defines `NegotiationTurn`, `NegotiationOutcome`, `UserNegotiationContext`, `SeedAssessment` structurally identical to the shared schema (dual definitions — schema is canonical for shared interfaces; domain file keeps local copies for graph internals)
+- [x] `agent-dispatcher.interface.ts` imports negotiation types from `../schemas/negotiation-state.schema.js`
 
 ---
 
@@ -359,12 +360,14 @@ export type {
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Type checking passes: `cd packages/protocol && bun run build`
-- [ ] No references to `DefineTool`, `RawToolDefinition`, or `ToolRegistry` remain in `index.ts` as root exports
+- [x] Type checking passes: `cd packages/protocol && bun run build`
+- [x] Tests pass: `cd packages/protocol && bun test`
+- [x] No references to `DefineTool`, `RawToolDefinition`, or `ToolRegistry` remain in `index.ts` as root exports
 
 #### Manual Verification:
-- [ ] Backend code (`mcp.controller.ts`, `tool.service.ts`) still compiles without root imports of removed types
-- [ ] Negotiation state types are re-exported from schemas, not from `negotiation/negotiation.state.js`
+- [x] Backend code (`mcp.controller.ts`, `tool.service.ts`) still compiles without root imports of removed types
+- [x] Negotiation state types are re-exported from schemas, not from `negotiation/negotiation.state.js`
+- [x] Verify README and protocol package docs no longer reference removed exports `DefineTool`, `RawToolDefinition`, `ToolRegistry`
 
 ---
 
@@ -434,15 +437,16 @@ const database = deps.database as PremiseGraphDatabase;
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Type checking passes: `cd packages/protocol && bun run build`
-- [ ] Tests pass: `cd packages/protocol && bun test`
-- [ ] No `as unknown as PremiseGraphDatabase` casts remain in `tool.factory.ts` or `premise.tools.ts` (production code; test stubs exempt)
-- [ ] `@langchain/langgraph-checkpoint-postgres` is removed from `package.json`
+- [x] Type checking passes: `cd packages/protocol && bun run build`
+- [x] Tests pass: `cd packages/protocol && bun test`
+- [x] No `as unknown as PremiseGraphDatabase` casts remain in `tool.factory.ts` or `premise.tools.ts` (production code; test stubs exempt)
+- [x] `@langchain/langgraph-checkpoint-postgres` is removed from `package.json`
 
 #### Manual Verification:
-- [ ] `ChatGraphCompositeDatabase` includes `createPremise`, `getPremise`, `updatePremise`, `assignPremiseToNetwork`, `getPremiseNetworks`
-- [ ] `tool.factory.ts:130` uses `database as PremiseGraphDatabase` (no `as unknown as`)
-- [ ] `premise.tools.ts:12` uses `deps.database` matching `PremiseGraphDatabase` (no `as unknown as`)
+- [x] `ChatGraphCompositeDatabase` includes `createPremise`, `getPremise`, `updatePremise`, `assignPremiseToNetwork`, `getPremiseNetworks`
+- [x] `tool.factory.ts:130` uses `database as PremiseGraphDatabase` (no `as unknown as`)
+- [x] `premise.tools.ts:12` uses `deps.database` matching `PremiseGraphDatabase` (no `as unknown as`)
+- [x] Backend adapter (`ChatDatabaseAdapter`) already implements premise CRUD methods — no backend change needed; the bug was only that `ChatGraphCompositeDatabase` omitted them from its `Pick<>`
 
 ---
 
@@ -571,14 +575,17 @@ export type { McpAuthInput } from "./shared/schemas/mcp-auth.schema.js";
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Type checking passes at both protocol and backend levels: `cd packages/protocol && bun run build` and `cd backend && bun run build`
-- [ ] `McpAuthResolver.resolveIdentity` no longer accepts `Request` — accepts `McpAuthInput` instead
-- [ ] `mcp.server.ts` extracts `McpAuthInput` from `ctx.http?.req` before calling `resolveIdentity`
+- [x] Type checking passes at both protocol and backend levels: `cd packages/protocol && bun run build` and `cd backend && bun run build`
+- [x] Tests pass: `cd packages/protocol && bun test`
+- [x] `McpAuthResolver.resolveIdentity` no longer accepts `Request` — accepts `McpAuthInput` instead
+- [x] `mcp.server.ts` extracts `McpAuthInput` from `ctx.http?.req` before calling `resolveIdentity`
+- [x] No auth credentials logged: `grep -r "bearerToken\|apiKey" packages/protocol/src/mcp/mcp.server.ts | grep -v "get("` returns only extraction lines, not logging lines
 
 #### Manual Verification:
-- [ ] `mcp-auth.schema.ts` defines `McpAuthInput` with typed fields for authorization, API key, surface, and telegram headers
-- [ ] Backend `mcp.controller.ts` extracts `McpAuthInput` from the HTTP Request before passing to the resolver
-- [ ] `mcp.server.ts` no longer passes raw `Request` to `authResolver`
+- [x] `mcp-auth.schema.ts` defines `McpAuthInput` with typed fields for authorization, API key, surface, and telegram headers
+- [x] Backend `mcp.controller.ts` extracts `McpAuthInput` from the HTTP Request before passing to the resolver
+- [x] `mcp.server.ts` no longer passes raw `Request` to `authResolver`
+- [x] Verify `mcp.server.ts` does not log `bearerToken` or `apiKey` values in plaintext
 
 ---
 
@@ -607,7 +614,18 @@ Not applicable — all changes are backward-compatible import refactors. No data
 
 ## Developer Context
 
-(Reserved for Step 4 review findings triage.)
+## Plan Review (Step 4)
+
+_Independent post-finalization review by artifact-code-reviewer and artifact-coverage-reviewer subagents. Findings triaged at Step 5._
+
+| source   | plan-loc          | codebase-loc                | severity   | dimension             | finding   | recommendation   | resolution         |
+| -------- | ----------------- | --------------------------- | ---------- | --------------------- | --------- | ---------------- | ------------------ |
+| code     | (all phases)      | HEAD                        | —          | code-quality          | Zero findings — plan matches live codebase character-for-character across all 5 phases | n/a | n/a |
+| coverage | Precedents & Lessons §4 | <n/a>                   | blocker    | verification-coverage | Lesson "Database-interface expansions need bounded fan-out and backend adapter implementation in the same change set" — Phase 4 adds 5 premise CRUD methods to ChatGraphCompositeDatabase but no backend adapter implements them and no fan-out guard is added | Add backend adapter check or scope Phase 4 | applied: backend adapter already implements premise CRUD methods; added clarifying manual verification bullet confirming no backend change needed (the bug was only the missing Pick<>) |
+| coverage | Precedents & Lessons §5 | <n/a>                   | concern    | verification-coverage | Lesson "Public API/model-config changes require immediate docs/export cleanup" — Phase 3 removes barrel exports but no criteria updates docs | Add docs cleanup to Phase 3 | applied: added manual verification bullet for README/docs cleanup in Phase 3 |
+| coverage | Precedents & Lessons §2 | <n/a>                   | concern    | verification-coverage | Lesson "MCP/auth changes risk data leaks" — Phase 5 has no criteria for log redaction or auth path testing | Add grep + manual auth leak check to Phase 5 | applied: added grep and manual verification for credential logging in Phase 5 |
+| coverage | Verification Notes §2 | <n/a>                   | concern    | verification-coverage | Phase 3 and Phase 5 lack `bun test` criteria | Add test criteria | applied: added `cd packages/protocol && bun test` to Phase 3 and Phase 5 Automated Verification |
+| coverage | Verification Notes §7 | <n/a>                   | suggestion | verification-coverage | No automated enforcement of structural parity between dual definitions | Add parity check | applied: added `diff`-based structural parity check to Phase 2 Automated Verification |
 
 ## References
 

--- a/.rpiv/artifacts/plans/2026-06-09_13-10-22_protocol-package-violations.md
+++ b/.rpiv/artifacts/plans/2026-06-09_13-10-22_protocol-package-violations.md
@@ -1,0 +1,615 @@
+---
+date: 2026-06-09T13:10:22+0300
+author: Yankı Ekin Yüksel
+commit: cc4ceda7a
+branch: dev
+repository: index
+topic: "Fix protocol package boundary violations"
+tags: [plan, protocol, boundaries, interfaces, mcp, tools, schemas]
+status: in-review
+parent: .rpiv/artifacts/designs/2026-06-09_11-18-44_protocol-package-violations.md
+last_updated: 2026-06-09T13:10:22+0300
+last_updated_by: Yankı Ekin Yüksel
+---
+
+# Fix Protocol Package Boundary Violations — Implementation Plan
+
+## Overview
+
+Fix 8 protocol package boundary violations found by research: shared interface domain-type leaks, broad DB port erosion, unsafe premise casts, exposed internal API types, MCP auth Request coupling, and an unused adapter-specific dependency. Five phases, each leaving the codebase in a working state.
+
+Design artifact: `.rpiv/artifacts/designs/2026-06-09_11-18-44_protocol-package-violations.md`
+
+## Desired End State
+
+Shared interfaces import from `shared/schemas/` instead of domain implementation modules. `DefineTool`, `ToolRegistry`, `ToolErrorReport` removed from root barrel. `PremiseGraphDatabase` casts are type-safe (no `as unknown as`). `@langchain/langgraph-checkpoint-postgres` removed from protocol dependencies. `McpAuthResolver.resolveIdentity` accepts a plain `McpAuthInput` DTO instead of platform `Request`. All builds pass.
+
+## What We're NOT Doing
+
+- Full `ToolDeps` deprecation or removal
+- Raw `database` field removal from `ToolContext`
+- Deep refactor of graph factory registration or tool registry architecture
+- Migration of remaining raw-DB-using tools to scoped DBs
+- Backend scoped DB factory restructuring
+- Subpath export map addition
+- Removing deprecated `QuestionGeneratorReader` interface entirely
+
+## Phase 1: Profile + DiscoveryQuestion DTO Extraction
+
+### Overview
+Extract ProfileDocument and DiscoveryQuestionInput types from domain implementation modules to shared/schemas/ as pure Zod schemas. Update shared interfaces to import from schemas instead.
+
+### Changes Required:
+
+#### 1. New schema: profile.schema.ts
+**File**: `packages/protocol/src/shared/schemas/profile.schema.ts`
+**Changes**: NEW — ProfileDocument Zod schema and inferred type. Pure data shape matching the original LLM-output type. Zero domain imports.
+
+```typescript
+import { z } from "zod";
+
+export const ProfileIdentitySchema = z.object({
+  name: z.string(),
+  bio: z.string(),
+  location: z.string(),
+});
+
+export const ProfileNarrativeSchema = z.object({
+  context: z.string(),
+});
+
+export const ProfileAttributesSchema = z.object({
+  interests: z.array(z.string()),
+  skills: z.array(z.string()),
+});
+
+export const ProfileDocumentSchema = z.object({
+  userId: z.string(),
+  identity: ProfileIdentitySchema,
+  narrative: ProfileNarrativeSchema,
+  attributes: ProfileAttributesSchema,
+});
+
+export type ProfileDocument = z.infer<typeof ProfileDocumentSchema>;
+```
+
+#### 2. New schema: discovery-question.schema.ts
+**File**: `packages/protocol/src/shared/schemas/discovery-question.schema.ts`
+**Changes**: NEW — All discovery question leaf types (NegotiationRole, DiscoveryTurn, DiscoveryOutcome, DiscoveryNegotiation, DiscoverySummary, DiscoverySourceProfile) as Zod schemas + inferred types. Composite DiscoveryQuestionInput as pure interface.
+
+```typescript
+import { z } from "zod";
+import type { DiscoveryNegotiationDigest } from "./negotiation-digest.schema.js";
+import type { ChatContextDigest } from "./chat-context.schema.js";
+
+export const NegotiationRoleSchema = z.enum(["agent", "patient", "peer"]);
+export type NegotiationRole = z.infer<typeof NegotiationRoleSchema>;
+
+export const DiscoveryTurnSchema = z.object({
+  action: z.enum(["propose", "accept", "reject", "counter", "question"]),
+  reasoning: z.string(),
+  suggestedRoles: z.object({
+    ownUser: NegotiationRoleSchema,
+    otherUser: NegotiationRoleSchema,
+  }),
+});
+export type DiscoveryTurn = z.infer<typeof DiscoveryTurnSchema>;
+
+export const DiscoveryOutcomeSchema = z.object({
+  hasOpportunity: z.boolean(),
+  reasoning: z.string(),
+  agreedRoles: z.array(z.object({
+    userId: z.string(),
+    role: NegotiationRoleSchema,
+  })).optional(),
+  reason: z.enum(["turn_cap", "timeout"]).optional(),
+});
+export type DiscoveryOutcome = z.infer<typeof DiscoveryOutcomeSchema>;
+
+export const DiscoveryNegotiationSchema = z.object({
+  counterpartyId: z.string(),
+  counterpartyHint: z.string(),
+  indexContext: z.string(),
+  turns: z.array(DiscoveryTurnSchema),
+  outcome: DiscoveryOutcomeSchema,
+  seedAssessmentScore: z.number().optional(),
+});
+export type DiscoveryNegotiation = z.infer<typeof DiscoveryNegotiationSchema>;
+
+export const DiscoverySummarySchema = z.object({
+  totalCandidates: z.number(),
+  opportunitiesFound: z.number(),
+  noOpportunityCount: z.number(),
+  timeoutCount: z.number(),
+  roleDistribution: z.record(z.string(), z.number()).optional(),
+});
+export type DiscoverySummary = {
+  totalCandidates: number;
+  opportunitiesFound: number;
+  noOpportunityCount: number;
+  timeoutCount: number;
+  roleDistribution?: Partial<Record<NegotiationRole, number>>;
+};
+
+export const DiscoverySourceProfileSchema = z.object({
+  name: z.string().optional(),
+  bio: z.string().optional(),
+  location: z.string().optional(),
+  skills: z.array(z.string()).optional(),
+  interests: z.array(z.string()).optional(),
+});
+export type DiscoverySourceProfile = z.infer<typeof DiscoverySourceProfileSchema>;
+
+export interface DiscoveryQuestionInput {
+  query: string;
+  sourceProfile: DiscoverySourceProfile;
+  negotiationDigests: DiscoveryNegotiationDigest[];
+  summary: DiscoverySummary;
+  chatContext?: ChatContextDigest;
+  now: string;
+}
+```
+
+#### 3. Update database.interface.ts import
+**File**: `packages/protocol/src/shared/interfaces/database.interface.ts`
+**Changes**: Change `import { ProfileDocument }` from `../../profile/profile.generator.js` to `../schemas/profile.schema.js`
+
+```typescript
+// BEFORE:
+// import { ProfileDocument } from '../../profile/profile.generator.js';
+// AFTER:
+import { ProfileDocument } from '../schemas/profile.schema.js';
+```
+
+#### 4. Update tool.helpers.ts import
+**File**: `packages/protocol/src/shared/agent/tool.helpers.ts`
+**Changes**: Change `import type { ProfileDocument }` from `../../profile/profile.generator.js` to `../schemas/profile.schema.js`
+
+```typescript
+// BEFORE:
+// import type { ProfileDocument } from "../../profile/profile.generator.js";
+// AFTER:
+import type { ProfileDocument } from "../schemas/profile.schema.js";
+```
+
+#### 5. Update question-generator.interface.ts import
+**File**: `packages/protocol/src/shared/interfaces/question-generator.interface.ts`
+**Changes**: Change `import type { DiscoveryQuestionInput }` from `../../opportunity/question.prompt.js` to `../schemas/discovery-question.schema.js`
+
+```typescript
+// BEFORE:
+// import type { DiscoveryQuestionInput } from "../../opportunity/question.prompt.js";
+// AFTER:
+import type { DiscoveryQuestionInput } from "../schemas/discovery-question.schema.js";
+```
+
+#### 6. Update index.ts — add schema re-exports
+**File**: `packages/protocol/src/index.ts`
+**Changes**: Add profile.schema and discovery-question.schema re-exports. Remove old re-exports from `./opportunity/question.prompt.js`.
+
+```typescript
+// Add after the PendingQuestionSummary export:
+export {
+  ProfileIdentitySchema,
+  ProfileNarrativeSchema,
+  ProfileAttributesSchema,
+  ProfileDocumentSchema,
+  type ProfileDocument,
+} from "./shared/schemas/profile.schema.js";
+export type {
+  DiscoverySourceProfile,
+  DiscoverySummary,
+  DiscoveryNegotiation,
+  DiscoveryTurn,
+  DiscoveryOutcome,
+  DiscoveryQuestionInput,
+  NegotiationRole,
+} from "./shared/schemas/discovery-question.schema.js";
+
+// REMOVE old re-exports from "./opportunity/question.prompt.js":
+// export type { DiscoveryQuestionInput, DiscoveryNegotiation, ... };
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Type checking passes: `cd packages/protocol && bun run build`
+- [ ] Tests pass: `cd packages/protocol && bun test`
+- [ ] No imports from `profile/profile.generator.ts` or `opportunity/question.prompt.ts` remain in `shared/interfaces/database.interface.ts`
+- [ ] No imports from `profile/profile.generator.ts` remain in `shared/agent/tool.helpers.ts`
+
+#### Manual Verification:
+- [ ] `profile.schema.ts` defines `ProfileDocument` as a pure Zod-inferred type without LangChain or model imports
+- [ ] `discovery-question.schema.ts` defines all discovery question types without domain implementation imports
+- [ ] `database.interface.ts` imports `ProfileDocument` from `../schemas/profile.schema.js` not from `../../profile/profile.generator.js`
+- [ ] `tool.helpers.ts` imports `ProfileDocument` from `../schemas/profile.schema.js` not from `../../profile/profile.generator.js`
+
+---
+
+## Phase 2: Negotiation State DTO Extraction
+
+### Overview
+Extract NegotiationTurn, UserNegotiationContext, SeedAssessment to shared/schemas/ as pure interfaces. Update agent-dispatcher.interface.ts and index.ts imports.
+
+### Changes Required:
+
+#### 1. New schema: negotiation-state.schema.ts
+**File**: `packages/protocol/src/shared/schemas/negotiation-state.schema.ts`
+**Changes**: NEW — Pure interface definitions for NegotiationTurn, UserNegotiationContext, SeedAssessment (used by agent-dispatcher.interface.ts). Also includes NegotiationTurnSchema + NegotiationOutcomeSchema as Zod schemas.
+
+```typescript
+import { z } from "zod";
+
+export const NegotiationTurnSchema = z.object({
+  action: z.enum(["propose", "accept", "reject", "counter", "question"]),
+  assessment: z.object({
+    reasoning: z.string(),
+    suggestedRoles: z.object({
+      ownUser: z.enum(["agent", "patient", "peer"]),
+      otherUser: z.enum(["agent", "patient", "peer"]),
+    }),
+  }),
+  message: z.string().nullable().optional(),
+});
+export type NegotiationTurn = z.infer<typeof NegotiationTurnSchema>;
+
+export const NegotiationOutcomeSchema = z.object({
+  hasOpportunity: z.boolean(),
+  agreedRoles: z.array(z.object({
+    userId: z.string(),
+    role: z.enum(["agent", "patient", "peer"]),
+  })),
+  reasoning: z.string(),
+  turnCount: z.number(),
+  reason: z.enum(["turn_cap", "timeout"]).optional(),
+});
+export type NegotiationOutcome = z.infer<typeof NegotiationOutcomeSchema>;
+
+export interface UserNegotiationContext {
+  id: string;
+  intents: Array<{ id: string; title: string; description: string; confidence: number }>;
+  profile: { name?: string; bio?: string; location?: string; interests?: string[]; skills?: string[] };
+}
+
+export interface SeedAssessment {
+  reasoning: string;
+  valencyRole: string;
+  actors?: Array<{ userId: string; role: string }>;
+}
+```
+
+#### 2. Update agent-dispatcher.interface.ts import
+**File**: `packages/protocol/src/shared/interfaces/agent-dispatcher.interface.ts`
+**Changes**: Change import from `../../negotiation/negotiation.state.js` to `../schemas/negotiation-state.schema.js`
+
+```typescript
+// BEFORE:
+// import type { NegotiationTurn, UserNegotiationContext, SeedAssessment } from '../../negotiation/negotiation.state.js';
+// AFTER:
+import type { NegotiationTurn, UserNegotiationContext, SeedAssessment } from '../schemas/negotiation-state.schema.js';
+```
+
+#### 3. Update index.ts — negotiation state re-exports
+**File**: `packages/protocol/src/index.ts`
+**Changes**: Re-export negotiation types from shared schema instead of domain state module.
+
+```typescript
+// BEFORE:
+// export type { NegotiationTurn, UserNegotiationContext, SeedAssessment, NegotiationGraphLike } from "./negotiation/negotiation.state.js";
+// AFTER:
+export type {
+  UserNegotiationContext,
+  NegotiationTurn,
+  NegotiationOutcome,
+  SeedAssessment,
+} from "./shared/schemas/negotiation-state.schema.js";
+export type { NegotiationGraphLike } from "./negotiation/negotiation.state.js";
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Type checking passes: `cd packages/protocol && bun run build`
+- [ ] Tests pass: `cd packages/protocol && bun test`
+- [ ] No imports from `negotiation/negotiation.state.ts` remain in `shared/interfaces/agent-dispatcher.interface.ts`
+
+#### Manual Verification:
+- [ ] `negotiation-state.schema.ts` defines `NegotiationTurn` as a pure static interface (not `z.infer`)
+- [ ] `negotiation.state.ts` defines `NegotiationTurn`, `NegotiationOutcome`, `UserNegotiationContext`, `SeedAssessment` structurally identical to the shared schema (dual definitions — schema is canonical for shared interfaces; domain file keeps local copies for graph internals)
+- [ ] `agent-dispatcher.interface.ts` imports negotiation types from `../schemas/negotiation-state.schema.js`
+
+---
+
+## Phase 3: Public API Narrowing
+
+### Overview
+Remove `DefineTool`, `ToolRegistry`, `ToolErrorReport` from root barrel — zero external consumers. Keep `RawToolDefinition`, `CompiledGraph`, `ToolDeps` (used by backend queues and composition roots). `export type * from database.interface.js` kept as-is for now.
+
+### Changes Required:
+
+#### 1. Update index.ts — remove internal types
+**File**: `packages/protocol/src/index.ts`
+**Changes**: Remove `DefineTool`, `ToolRegistry`, `ToolErrorReport` from the tool.helpers.js re-export group.
+
+```typescript
+// BEFORE:
+// export type {
+//   ToolContext,
+//   ToolErrorReport,
+//   ResolvedToolContext,
+//   ToolDeps,
+//   ProtocolDeps,
+//   DefineTool,
+//   RawToolDefinition,
+//   CompiledGraph,
+//   ToolRegistry,
+// } from "./shared/agent/tool.helpers.js";
+
+// AFTER:
+export type {
+  ToolContext,
+  ResolvedToolContext,
+  ToolDeps,
+  ProtocolDeps,
+  RawToolDefinition,
+  CompiledGraph,
+} from "./shared/agent/tool.helpers.js";
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Type checking passes: `cd packages/protocol && bun run build`
+- [ ] No references to `DefineTool`, `RawToolDefinition`, or `ToolRegistry` remain in `index.ts` as root exports
+
+#### Manual Verification:
+- [ ] Backend code (`mcp.controller.ts`, `tool.service.ts`) still compiles without root imports of removed types
+- [ ] Negotiation state types are re-exported from schemas, not from `negotiation/negotiation.state.js`
+
+---
+
+## Phase 4: Premise Cast Fix + Postgres Dep Removal
+
+### Overview
+Add 5 premise CRUD methods to ChatGraphCompositeDatabase. Remove `as unknown as PremiseGraphDatabase` casts from tool.factory.ts and premise.tools.ts. Remove unused Postgres checkpoint dependency from package.json.
+
+### Changes Required:
+
+#### 1. Add premise CRUD methods to ChatGraphCompositeDatabase
+**File**: `packages/protocol/src/shared/interfaces/database.interface.ts`
+**Changes**: Add `createPremise`, `getPremise`, `updatePremise`, `assignPremiseToNetwork`, `getPremiseNetworks` to the `ChatGraphCompositeDatabase` Pick<> union under the existing premise section.
+
+```typescript
+// In ChatGraphCompositeDatabase, under // ProfileGraph aggregate mode section:
+  // ProfileGraph aggregate mode (premise-to-profile materialization)
+  // Premise lifecycle (CRUD + network assignment)
+  | 'getPremisesForUser'
+  | 'getPremisesForUserInNetworks'
+  | 'createPremise'
+  | 'getPremise'
+  | 'updatePremise'
+  | 'assignPremiseToNetwork'
+  | 'getPremiseNetworks'
+```
+
+#### 2. Remove cast in tool.factory.ts
+**File**: `packages/protocol/src/shared/agent/tool.factory.ts`
+**Changes**: Change `as unknown as PremiseGraphDatabase` to `as PremiseGraphDatabase`.
+
+```typescript
+// BEFORE:
+// const premiseGraph = new PremiseGraphFactory(database as unknown as PremiseGraphDatabase, embedder).createGraph();
+// AFTER:
+const premiseGraph = new PremiseGraphFactory(database as PremiseGraphDatabase, embedder).createGraph();
+```
+
+#### 3. Remove cast in premise.tools.ts
+**File**: `packages/protocol/src/premise/premise.tools.ts`
+**Changes**: Change `as unknown as PremiseGraphDatabase` to `as PremiseGraphDatabase`.
+
+```typescript
+// BEFORE:
+// const database = deps.database as unknown as PremiseGraphDatabase;
+// AFTER:
+const database = deps.database as PremiseGraphDatabase;
+```
+
+#### 4. Remove Postgres checkpoint dependency
+**File**: `packages/protocol/package.json`
+**Changes**: Remove `@langchain/langgraph-checkpoint-postgres` from dependencies.
+
+```json
+// BEFORE:
+// "@langchain/core": "^1.1.17",
+// "@langchain/langgraph": "^1.1.2",
+// "@langchain/langgraph-checkpoint-postgres": "^1.0.0",
+// "@langchain/openai": "^1.2.3",
+
+// AFTER:
+"@langchain/core": "^1.1.17",
+"@langchain/langgraph": "^1.1.2",
+"@langchain/openai": "^1.2.3",
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Type checking passes: `cd packages/protocol && bun run build`
+- [ ] Tests pass: `cd packages/protocol && bun test`
+- [ ] No `as unknown as PremiseGraphDatabase` casts remain in `tool.factory.ts` or `premise.tools.ts` (production code; test stubs exempt)
+- [ ] `@langchain/langgraph-checkpoint-postgres` is removed from `package.json`
+
+#### Manual Verification:
+- [ ] `ChatGraphCompositeDatabase` includes `createPremise`, `getPremise`, `updatePremise`, `assignPremiseToNetwork`, `getPremiseNetworks`
+- [ ] `tool.factory.ts:130` uses `database as PremiseGraphDatabase` (no `as unknown as`)
+- [ ] `premise.tools.ts:12` uses `deps.database` matching `PremiseGraphDatabase` (no `as unknown as`)
+
+---
+
+## Phase 5: MCP Auth DTO Refactor
+
+### Overview
+Create McpAuthInput DTO. Change McpAuthResolver.resolveIdentity signature from `Request` to `McpAuthInput`. Update MCP server to extract DTO from HTTP request at transport edge. Update backend resolver implementation.
+
+### Changes Required:
+
+#### 1. New schema: mcp-auth.schema.ts
+**File**: `packages/protocol/src/shared/schemas/mcp-auth.schema.ts`
+**Changes**: NEW — McpAuthInput interface with typed credential fields (transport-neutral).
+
+```typescript
+export interface McpAuthInput {
+  bearerToken?: string;
+  apiKey?: string;
+  clientSurface?: 'telegram' | 'web';
+  telegramHandle?: string;
+  telegramUsername?: string;
+}
+```
+
+#### 2. Update auth.interface.ts signature
+**File**: `packages/protocol/src/shared/interfaces/auth.interface.ts`
+**Changes**: Change `resolveIdentity` parameter from `Request` to `McpAuthInput`. Add McpAuthInput import. Update JSDoc.
+
+```typescript
+import type { McpAuthInput } from '../schemas/mcp-auth.schema.js';
+
+export interface McpAuthResolver {
+  resolveIdentity(input: McpAuthInput): Promise<{
+    userId: string;
+    agentId?: string;
+    isSessionAuth?: boolean;
+    networkScopeId?: string | null;
+    clientSurface?: 'telegram' | 'web';
+  }>;
+  // deprecated resolveUserId remains unchanged
+}
+```
+
+#### 3. Update mcp.server.ts — extract McpAuthInput
+**File**: `packages/protocol/src/mcp/mcp.server.ts`
+**Changes**: Import McpAuthInput type. Extract DTO from HTTP request headers before calling resolveIdentity. Add extractBearerToken() and parseClientSurface() helpers.
+
+```typescript
+import type { McpAuthResolver } from '../shared/interfaces/auth.interface.js';
+import type { McpAuthInput } from '../shared/schemas/mcp-auth.schema.js';
+
+// Inside the per-tool handler, after extracting httpReq:
+const mcpAuthInput: McpAuthInput = {
+  bearerToken: extractBearerToken(httpReq),
+  apiKey: httpReq.headers.get('x-api-key') ?? undefined,
+  clientSurface: parseClientSurface(httpReq.headers.get('x-index-surface')),
+  telegramHandle: httpReq.headers.get('x-index-telegram-handle') ?? undefined,
+  telegramUsername: httpReq.headers.get('x-index-telegram-username') ?? undefined,
+};
+const { userId, agentId, isSessionAuth, networkScopeId, clientSurface } = await authResolver.resolveIdentity(mcpAuthInput);
+
+// Module-level helpers:
+function extractBearerToken(req: Request): string | undefined {
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader) return undefined;
+  const [scheme, token] = authHeader.split(/\s+/, 2);
+  if (scheme?.toLowerCase() === 'bearer' && token) return token;
+  return undefined;
+}
+
+const seenInvalidSurfaces = new Set<string>();
+function parseClientSurface(raw: string | null): 'telegram' | 'web' {
+  if (raw === null || raw === '') return 'web';
+  const trimmed = raw.trim().toLowerCase();
+  if (trimmed === 'telegram') return 'telegram';
+  if (trimmed === 'web') return 'web';
+  if (!seenInvalidSurfaces.has(trimmed)) {
+    seenInvalidSurfaces.add(trimmed);
+    logger.warn(`Unknown x-index-surface value: "${trimmed}" (collapsing to web; seen once per process)`);
+  }
+  return 'web';
+}
+```
+
+#### 4. Update backend mcp.controller.ts resolver
+**File**: `backend/src/controllers/mcp.controller.ts`
+**Changes**: Import `McpAuthInput` from `@indexnetwork/protocol`. Change resolver signature. Replace header reads with DTO field reads. Update finalizeMcpIdentity to accept telegram handle directly.
+
+```typescript
+import type { ..., McpAuthInput } from '@indexnetwork/protocol';
+
+// In authResolver:
+const authResolver: McpAuthResolver = {
+  async resolveIdentity(input: McpAuthInput): Promise<ResolvedMcpIdentity> {
+    const clientSurface = input.clientSurface ?? 'web';
+
+    if (input.bearerToken) {
+      // JWT or opaque token auth — same logic, reads input.bearerToken instead of headers
+      // ...
+    }
+
+    if (input.apiKey) {
+      // API key auth — reads input.apiKey instead of headers
+      // ...
+    }
+
+    throw new Error('Authentication required');
+  },
+};
+
+// finalizeMcpIdentity now accepts telegramHandle directly:
+async function finalizeMcpIdentity(telegramHandle: string | undefined, identity: ResolvedMcpIdentity): Promise<ResolvedMcpIdentity> {
+  if (identity.clientSurface !== 'telegram' || !telegramHandle) return identity;
+  // ... (rest unchanged)
+}
+```
+
+#### 5. Add McpAuthInput export to index.ts
+**File**: `packages/protocol/src/index.ts`
+**Changes**: Add `export type { McpAuthInput }` from the new schema.
+
+```typescript
+export type { McpAuthInput } from "./shared/schemas/mcp-auth.schema.js";
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Type checking passes at both protocol and backend levels: `cd packages/protocol && bun run build` and `cd backend && bun run build`
+- [ ] `McpAuthResolver.resolveIdentity` no longer accepts `Request` — accepts `McpAuthInput` instead
+- [ ] `mcp.server.ts` extracts `McpAuthInput` from `ctx.http?.req` before calling `resolveIdentity`
+
+#### Manual Verification:
+- [ ] `mcp-auth.schema.ts` defines `McpAuthInput` with typed fields for authorization, API key, surface, and telegram headers
+- [ ] Backend `mcp.controller.ts` extracts `McpAuthInput` from the HTTP Request before passing to the resolver
+- [ ] `mcp.server.ts` no longer passes raw `Request` to `authResolver`
+
+---
+
+## Testing Strategy
+
+### Automated:
+- `cd packages/protocol && bun run build` — type checking after each phase
+- `cd packages/protocol && bun test` — unit/integration tests after Phase 1, 2, 4
+- `cd backend && bun run build` — full stack type check after Phase 5
+- Verification grep commands from success criteria
+
+### Manual Testing Steps:
+1. Verify `database.interface.ts` no longer imports from `profile/profile.generator.ts`
+2. Verify `agent-dispatcher.interface.ts` no longer imports from `negotiation/negotiation.state.ts`
+3. Verify `index.ts` has no `DefineTool`, `RawToolDefinition`, `ToolRegistry` exports
+4. Verify `grep -r "as unknown as PremiseGraphDatabase" packages/protocol/src/` (excluding tests) returns 0
+5. Verify `grep -r "langgraph-checkpoint-postgres" packages/protocol/package.json` returns 0
+
+## Performance Considerations
+
+All changes are compile-time / import-level — no runtime performance impact. DTO extraction moves type definitions but does not change runtime behavior. Removal of Postgres dep marginally reduces `node_modules` size.
+
+## Migration Notes
+
+Not applicable — all changes are backward-compatible import refactors. No data schema or persisted format changes. Old domain imports remain viable if consumers haven't been updated (domain modules re-export from schemas where needed).
+
+## Developer Context
+
+(Reserved for Step 4 review findings triage.)
+
+## References
+
+- Design: `.rpiv/artifacts/designs/2026-06-09_11-18-44_protocol-package-violations.md`
+- Research: `.rpiv/artifacts/research/2026-06-09_10-42-15_protocol-package-violations.md`

--- a/.rpiv/artifacts/research/2026-06-09_10-42-15_protocol-package-violations.md
+++ b/.rpiv/artifacts/research/2026-06-09_10-42-15_protocol-package-violations.md
@@ -1,0 +1,286 @@
+---
+date: 2026-06-09T10:42:15+0300
+author: Yankı Ekin Yüksel
+commit: c43ab654f
+branch: dev
+repository: index
+topic: "protocol package. Detect violations."
+tags: [research, codebase, protocol, boundaries, interfaces, mcp, tools]
+status: complete
+last_updated: 2026-06-09T10:42:15+0300
+last_updated_by: Yankı Ekin Yüksel
+---
+
+# Research: protocol package. Detect violations.
+
+## Research Question
+Detect boundary and architecture violations in the `packages/protocol` package, especially around protocol purity, shared interfaces, tool composition, MCP transport/auth, runtime configuration, and public exports.
+
+## Summary
+The protocol package has no direct imports from backend/frontend/adapters in the investigated paths, so the primary violations are not hard app-layer imports. The strongest violations are shared contract files depending on domain implementation/state modules, especially `ProfileDocument` from `profile.generator.ts` and negotiation state types from `negotiation.state.ts`. The persistence/tool seam remains adapter-free through injection, but `ChatGraphCompositeDatabase` is broad, deprecated raw DB access is still required, and premise tooling uses unsafe casts to methods not promised by the declared composite type. MCP auth is intentionally confined to the MCP HTTP transport, but `McpAuthResolver.resolveIdentity(request: Request)` couples a shared interface to a platform request object and should eventually be narrowed to a plain auth DTO. Public exports mix stable contracts, tolerated host composition seams, and internal runtime/registry/database surfaces, making boundary violations harder to detect downstream.
+
+## Detailed Findings
+
+### Shared interface dependencies leak domain implementation modules
+- `packages/protocol/src/shared/interfaces/database.interface.ts:1` imports `ProfileDocument` from `packages/protocol/src/profile/profile.generator.ts:37`, but `profile.generator.ts` also imports LangChain/Zod runtime code and constructs an LLM model at `packages/protocol/src/profile/profile.generator.ts:1-7` and `packages/protocol/src/profile/profile.generator.ts:39-45`.
+- The generator-derived `ProfileDocument` is exposed through shared persistence methods: `Database.getProfile()` and `saveProfile()` at `packages/protocol/src/shared/interfaces/database.interface.ts:530-537`.
+- `packages/protocol/src/shared/agent/tool.helpers.ts:3` imports the same profile type, aliases it as `ProfileContext` at `packages/protocol/src/shared/agent/tool.helpers.ts:36`, and places it on `ResolvedToolContext.userProfile` at `packages/protocol/src/shared/agent/tool.helpers.ts:75`.
+- `packages/protocol/src/shared/interfaces/agent-dispatcher.interface.ts:9` imports `NegotiationTurn`, `UserNegotiationContext`, and `SeedAssessment` from `packages/protocol/src/negotiation/negotiation.state.ts`, which contains LangGraph/Zod graph-state implementation at `packages/protocol/src/negotiation/negotiation.state.ts:1-2` and `packages/protocol/src/negotiation/negotiation.state.ts:104`.
+- `packages/protocol/src/shared/interfaces/question-generator.interface.ts:10` imports `DiscoveryQuestionInput` from `packages/protocol/src/opportunity/question.prompt.ts`; this is milder because the file is pure/no-I/O, but it still mixes DTOs with prompt text and rendering at `packages/protocol/src/opportunity/question.prompt.ts:92` and `packages/protocol/src/opportunity/question.prompt.ts:129`.
+- Classification: strong violation for `ProfileDocument` and negotiation state imports; medium violation for discovery question input location.
+
+### Persistence port is adapter-free but over-broad and partially unsafe
+- The canonical `Database` interface starts at `packages/protocol/src/shared/interfaces/database.interface.ts:520` and spans profiles, intents, opportunities, premises, user contexts, search, and more through `packages/protocol/src/shared/interfaces/database.interface.ts:1566`.
+- The file documents `Pick<>`-based graph aliases as interface segregation at `packages/protocol/src/shared/interfaces/database.interface.ts:1933-1948`, so some centralization is intentional.
+- `ChatGraphCompositeDatabase` begins at `packages/protocol/src/shared/interfaces/database.interface.ts:1982` and includes methods across many subgraphs through `packages/protocol/src/shared/interfaces/database.interface.ts:2065`; this is a composite host contract, not a narrow graph port.
+- `ToolContext.database` remains required but deprecated at `packages/protocol/src/shared/agent/tool.helpers.ts:124-125`, and `ToolDeps.database` keeps raw DB access available at `packages/protocol/src/shared/agent/tool.helpers.ts:421-422`.
+- `PremiseGraphDatabase` requires lifecycle methods at `packages/protocol/src/shared/interfaces/database.interface.ts:1968-1970`, but `ChatGraphCompositeDatabase` only includes premise aggregate/discovery methods at `packages/protocol/src/shared/interfaces/database.interface.ts:2053-2058`.
+- `packages/protocol/src/shared/agent/tool.factory.ts:130` casts the composite DB to `PremiseGraphDatabase`, and `packages/protocol/src/premise/premise.tools.ts:12` repeats the cast. This is a concrete type-contract violation hidden by `as unknown as`.
+- `OpportunityControllerDatabase` at `packages/protocol/src/shared/interfaces/database.interface.ts:2245-2276` is explicitly service/controller-shaped, including DM/conversation operations kept there because services cannot import other services.
+
+### Tool dependency injection remains adapter-free, but protocol owns a hidden composition root
+- `createChatTools()` receives injected dependencies rather than importing concrete adapters, as documented at `packages/protocol/src/shared/agent/tool.factory.ts:54-58`.
+- It still compiles all major subgraphs internally at `packages/protocol/src/shared/agent/tool.factory.ts:129-162`, creates scoped `userDb`/`systemDb` from host-provided callbacks at `packages/protocol/src/shared/agent/tool.factory.ts:175-176`, and assembles a large `ToolDeps` object at `packages/protocol/src/shared/agent/tool.factory.ts:181-218`.
+- `ToolContext` comments say `userDb` and `systemDb` may be created internally from a singleton path at `packages/protocol/src/shared/agent/tool.helpers.ts:115-120`, preserving a legacy raw-DB seam.
+- Backend wiring confirms concrete adapters are injected from the composition root: `backend/src/controllers/mcp.controller.ts:92-110` supplies `database`, `createUserDatabase`, and `createSystemDatabase`.
+- Classification: not an app-layer import violation, but a composition-boundary risk because broad raw DB access and factory callbacks make protocol responsible for orchestration that is duplicated elsewhere.
+
+### Tool registry split is intentional, with runtime and tool-set divergence risk
+- `packages/protocol/src/shared/agent/tool.factory.ts:57` implements the LangChain/chat path and wraps handlers in `invokeToolRuntime()` at `packages/protocol/src/shared/agent/tool.factory.ts:99-105`.
+- `packages/protocol/src/shared/agent/tool.registry.ts:30` implements the raw registry path; it registers raw handlers and explicitly documents that they are not LangChain wrappers at `packages/protocol/src/shared/agent/tool.registry.ts:21-24`.
+- MCP correctly wraps raw registry execution in `invokeToolRuntime()` at `packages/protocol/src/mcp/mcp.server.ts:595-601`, and the backend direct tool service does the same at `backend/src/services/tool.service.ts:130-134`.
+- The registry handler catches ordinary errors internally at `packages/protocol/src/shared/agent/tool.registry.ts:49-59`, while chat catches outside the runtime wrapper at `packages/protocol/src/shared/agent/tool.factory.ts:99-112`, so reporting and thrown-error behavior can differ.
+- Chat explicitly excludes `confirm_opportunity_delivery` at `packages/protocol/src/shared/agent/tool.factory.ts:237-245`, while the raw registry exposes the opportunity tool set returned by `packages/protocol/src/opportunity/opportunity.tools.ts:2088-2095`.
+- Backend raw callers duplicate graph assembly in `backend/src/controllers/mcp.controller.ts:160-184` and `backend/src/services/tool.service.ts:224-256`, creating drift from canonical chat graph assembly.
+- Classification: intentional transport split, not a package-boundary violation, but runtime/tool availability divergence is a real consistency risk.
+
+### MCP auth boundary is HTTP-coupled but confined
+- `McpAuthResolver` is defined in `packages/protocol/src/shared/interfaces/auth.interface.ts:6`, and `resolveIdentity(request: Request)` accepts a platform `Request` at `packages/protocol/src/shared/interfaces/auth.interface.ts:29`.
+- `createMcpServer()` extracts `ctx.http?.req` at `packages/protocol/src/mcp/mcp.server.ts:450` and passes it to the resolver at `packages/protocol/src/mcp/mcp.server.ts:459`.
+- The resolver returns plain identity fields (`userId`, optional `agentId`, session/scoped identity, client surface) at `packages/protocol/src/shared/interfaces/auth.interface.ts:30-35`; HTTP responses remain in backend controller code at `backend/src/controllers/mcp.controller.ts:751-788` and `backend/src/controllers/mcp.controller.ts:812-840`.
+- Scope handling after auth is plain context manipulation: `ScopedDepsFactory` is defined at `packages/protocol/src/mcp/mcp.server.ts:198-200`, `computeAgentIndexScope()` at `packages/protocol/src/mcp/mcp.server.ts:209-219`, and `applyNetworkScopeToContext()` at `packages/protocol/src/mcp/mcp.server.ts:235-262`.
+- Classification: tolerated MCP transport exception today, but the shared auth port is not transport-agnostic. The future direction is to replace the `Request` parameter with a small plain auth input extracted at the transport edge.
+
+### Runtime config is intentionally env-backed, while checkpoint Postgres dependency is adapter-specific
+- `ModelConfig` is defined at `packages/protocol/src/shared/agent/model.config.ts:19-27` and explicitly falls back to env according to `packages/protocol/src/shared/agent/model.config.ts:17`.
+- `createModel()` reads `OPENROUTER_API_KEY`, `OPENROUTER_REQUEST_TIMEOUT_MS`, `OPENROUTER_MAX_RETRIES`, and `OPENROUTER_BASE_URL` at `packages/protocol/src/shared/agent/model.config.ts:82`, `packages/protocol/src/shared/agent/model.config.ts:91`, `packages/protocol/src/shared/agent/model.config.ts:98`, and `packages/protocol/src/shared/agent/model.config.ts:103`.
+- `createModel()` directly constructs `ChatOpenAI` at `packages/protocol/src/shared/agent/model.config.ts:100-110`, so model provider construction is owned by protocol runtime rather than the host.
+- Chat can receive `ToolContext.modelConfig` at `packages/protocol/src/shared/agent/tool.helpers.ts:194`, and `ChatAgent` passes it to `createModel("chat", modelConfig)` at `packages/protocol/src/chat/chat.agent.ts:229-234`.
+- Non-chat agents commonly call `createModel()` without config, such as HyDE generator at `packages/protocol/src/shared/hyde/hyde.generator.ts:32`, opportunity evaluator at `packages/protocol/src/opportunity/opportunity.evaluator.ts:15`, and intent verifier at `packages/protocol/src/intent/intent.verifier.ts:21`.
+- Checkpointing is source-level injected through `BaseCheckpointSaver`: `packages/protocol/src/chat/chat.graph.ts:81-86` and `packages/protocol/src/chat/chat.streamer.ts:156-161` accept/checkpoint via abstraction.
+- `packages/protocol/package.json:25` still depends on `@langchain/langgraph-checkpoint-postgres`, while actual Postgres usage is in backend at `backend/src/adapters/checkpointer.adapter.ts:18`. This package dependency is an adapter-specific purity violation.
+
+### Public API mixes stable contracts, host seams, and internals
+- The package export map exposes only root `.` at `packages/protocol/package.json:7-10`, so everything in `packages/protocol/src/index.ts` is canonical public API.
+- `packages/protocol/src/index.ts:8-16` exports internal tool orchestration types such as `ToolDeps`, `DefineTool`, `RawToolDefinition`, `CompiledGraph`, and `ToolRegistry`.
+- `packages/protocol/src/index.ts:19-25` exports raw runtime/control-plane utilities such as `requestContext` and `invokeToolRuntime`.
+- `packages/protocol/src/index.ts:47` broadly re-exports all types from `database.interface.ts`, including the full `Database`, graph DB slices, storage-shaped records, and domain lifecycle types.
+- `packages/protocol/src/index.ts:103-119` exports graph factories. Per developer checkpoint, these should be classified with split severity: tolerated host composition seams, not the primary violation.
+- Downstream backend code uses the root exports for manual orchestration and casts: `backend/src/services/tool.service.ts:17`, `backend/src/services/tool.service.ts:87`, `backend/src/services/tool.service.ts:227`, `backend/src/services/tool.service.ts:241`, and `backend/src/services/tool.service.ts:256`.
+- Classification: graph factories are tolerated host seams, but raw runtime/registry types and broad DB exports are public-surface violations or high-risk leaks.
+
+## Code References
+- `packages/protocol/src/profile/profile.generator.ts:1-7` — Profile generator imports runtime LangChain/Zod/model helpers.
+- `packages/protocol/src/profile/profile.generator.ts:37` — Canonical `ProfileDocument` type is inferred from generator response schema.
+- `packages/protocol/src/shared/interfaces/database.interface.ts:1` — Shared DB interface imports `ProfileDocument` from domain generator.
+- `packages/protocol/src/shared/interfaces/database.interface.ts:520-537` — Canonical broad `Database` interface exposes profile persistence using `ProfileDocument`.
+- `packages/protocol/src/shared/interfaces/database.interface.ts:1933-1948` — Comments document `Pick<>`-based graph alias strategy.
+- `packages/protocol/src/shared/interfaces/database.interface.ts:1968-1970` — `PremiseGraphDatabase` requires premise lifecycle methods.
+- `packages/protocol/src/shared/interfaces/database.interface.ts:1982-2065` — `ChatGraphCompositeDatabase` broad composite methods.
+- `packages/protocol/src/shared/interfaces/database.interface.ts:2245-2276` — `OpportunityControllerDatabase` service/controller-shaped contract.
+- `packages/protocol/src/shared/agent/tool.helpers.ts:115-125` — Tool context comments and deprecated raw `database` field.
+- `packages/protocol/src/shared/agent/tool.helpers.ts:190-194` — Factory callbacks and optional model config in `ToolContext`.
+- `packages/protocol/src/shared/agent/tool.factory.ts:129-176` — `createChatTools()` compiles subgraphs and creates scoped DBs internally.
+- `packages/protocol/src/shared/agent/tool.factory.ts:181-218` — Large `ToolDeps` assembly.
+- `packages/protocol/src/shared/agent/tool.registry.ts:21-30` — Raw registry path documentation and entry point.
+- `packages/protocol/src/shared/agent/tool.registry.ts:49-59` — Raw registry catches handler exceptions internally.
+- `packages/protocol/src/mcp/mcp.server.ts:450-459` — MCP handler extracts HTTP request and resolves identity.
+- `packages/protocol/src/mcp/mcp.server.ts:565-572` — MCP creates scoped deps and rebuilds registry per request.
+- `packages/protocol/src/shared/interfaces/auth.interface.ts:29-35` — Auth interface accepts `Request` but returns plain identity.
+- `packages/protocol/src/shared/agent/model.config.ts:82-110` — Env-backed OpenRouter/ChatOpenAI construction.
+- `packages/protocol/src/chat/chat.graph.ts:81-86` — Chat graph accepts injected `BaseCheckpointSaver`.
+- `packages/protocol/package.json:25` — Protocol package depends on Postgres checkpoint adapter.
+- `packages/protocol/src/index.ts:8-25` — Root exports tool/runtime internals.
+- `packages/protocol/src/index.ts:47` — Root exports all database interface types.
+- `packages/protocol/src/index.ts:103-119` — Root exports graph factories, classified as tolerated host seams.
+- `backend/src/controllers/mcp.controller.ts:92-110` — Backend injects concrete protocol deps and scoped DB factories.
+- `backend/src/controllers/mcp.controller.ts:160-184` — Backend MCP path manually compiles protocol graphs.
+- `backend/src/services/tool.service.ts:224-256` — Backend direct tool service manually compiles protocol graphs.
+
+## Integration Points
+
+### Inbound References
+- `backend/src/controllers/mcp.controller.ts:54-55` — Backend MCP composition root imports protocol graph/tool types from package root.
+- `backend/src/controllers/mcp.controller.ts:92-110` — Backend provides `ProtocolDeps`, raw DB, and scoped DB factory callbacks.
+- `backend/src/controllers/mcp.controller.ts:425-426` — Backend implements `McpAuthResolver.resolveIdentity(request: Request)`.
+- `backend/src/controllers/mcp.controller.ts:648-657` — Backend provides `ScopedDepsFactory` to protocol MCP server.
+- `backend/src/services/tool.service.ts:17` — Backend direct tool service imports graph factories, registry, context resolver, and runtime utilities from root API.
+- `backend/src/services/agent-dispatcher.service.ts:1-5` — Backend imports `AgentDispatcher`, `AgentDispatchResult`, and `NegotiationTurnPayload` from protocol root.
+- `backend/src/adapters/database.adapter.ts:872-883` — Backend structurally implements profile reads with local profile row shapes.
+- `backend/src/adapters/database.adapter.ts:6636` — Backend creates user-scoped database wrapper.
+- `backend/src/adapters/database.adapter.ts:6795` — Backend creates system-scoped database wrapper.
+- `backend/src/adapters/checkpointer.adapter.ts:18` — Backend owns actual Postgres checkpoint adapter usage.
+
+### Outbound Dependencies
+- `packages/protocol/src/profile/profile.generator.ts:1-7` — Profile generator depends on LangChain/Zod/model runtime.
+- `packages/protocol/src/negotiation/negotiation.state.ts:1-2` — Negotiation state depends on LangGraph `Annotation` and Zod.
+- `packages/protocol/src/shared/agent/model.config.ts:1` — Protocol model config depends directly on `@langchain/openai`.
+- `packages/protocol/src/mcp/mcp.server.ts:10` — MCP server depends on MCP SDK `ServerContext`.
+- `packages/protocol/src/chat/chat.graph.ts:1` — Chat graph depends on LangGraph `BaseCheckpointSaver` abstraction.
+
+### Infrastructure Wiring
+- `packages/protocol/src/shared/agent/tool.factory.ts:57-58` — Chat tool factory is the main LangChain tool composition entry point.
+- `packages/protocol/src/shared/agent/tool.registry.ts:30` — Raw registry entry point for MCP/direct HTTP invocation.
+- `packages/protocol/src/mcp/mcp.server.ts:416` — MCP server factory composes auth, context, registry, runtime, and scoped DBs.
+- `packages/protocol/src/index.ts:3-119` — Package root exports public tool, interface, runtime, and graph surfaces.
+- `packages/protocol/package.json:7-10` — Package export map exposes only the root entry point.
+
+## Architecture Insights
+- Shared interfaces can reference stable protocol DTOs, but those DTOs should live in shared schema/interface modules, not in generator, prompt, or LangGraph state modules.
+- The protocol package is adapter-free in the strict import sense, but broad structural interfaces plus `as unknown as` casts can defeat compile-time boundary guarantees.
+- `createChatTools()` is an internal protocol composition root; this is manageable only if raw DB access continues to shrink and backend graph assembly does not drift.
+- The raw registry/LangChain factory split is a valid transport separation, but callers must consistently wrap raw handlers with `invokeToolRuntime()`.
+- MCP auth currently returns plain values and keeps HTTP response creation in backend, but accepting `Request` in a shared interface is a transport-coupling exception. A plain auth DTO would preserve the same behavior with less platform coupling.
+- `BaseCheckpointSaver` injection is the positive pattern for adapter-specific infrastructure; `@langchain/langgraph-checkpoint-postgres` in protocol package dependencies violates that pattern at package metadata level.
+- Per developer checkpoint, graph factory root exports are tolerated as host composition seams, while raw runtime/registry and broad DB exports remain violations or high-risk public surface.
+
+## Precedents & Lessons
+7 similar past change clusters analyzed.
+
+### Precedent: Removed protocol global config and public `configureProtocol`
+**Commit(s)**: `8699e86c2` — "refactor(protocol): remove _activeConfig global state and configureProtocol" (2026-06-08); `4416cffb0` — "refactor(protocol): remove configureProtocol side-effect from createChatTools" (2026-06-08); `deda68764` — "refactor(protocol): thread ModelConfig through ChatAgent constructor" (2026-06-08); `ea401abd9` — "feat(protocol)!: remove configureProtocol from public API" (2026-06-08)
+**Blast radius**: 4 files across 3 layers
+  protocol shared/agent — removed global model config state and factory side effect
+  protocol chat/domain — threaded `ModelConfig` explicitly into `ChatAgent`
+  public API — changed `packages/protocol/src/index.ts` exports
+
+**Follow-up fixes**:
+- `32985bc92` — "docs: update stale configureProtocol references after removal" (2026-06-08) — stale public guidance remained
+- `28499709b` — "docs(protocol): clarify ModelConfig scope — only ChatAgent honors ToolContext.modelConfig" (2026-06-08) — config ownership was ambiguous
+- `c28b99c74` — "docs(protocol): fix OPENROUTER_API_KEY requirement wording in README and createModel error" (2026-06-08) — env requirement wording was corrected
+
+**Lessons from docs**:
+- No relevant `.rpiv/artifacts/` documents found; directory is absent.
+
+**Takeaway**: Public API/config changes easily leave stale docs and hidden import-time assumptions.
+
+### Precedent: Added async MCP tool runs and shared runtime timeouts
+**Commit(s)**: `56317354d` — "fix(protocol): add shared MCP tool runtime timeouts" (2026-06-01); `0da6ce383` — "feat(protocol): queue async MCP discovery runs" (2026-06-01); `d4f9f6ba0` — "feat(protocol): queue async MCP profile runs" (2026-06-03)
+**Blast radius**: 39 files across 12 layers
+  protocol MCP — server response and polling behavior changed
+  protocol shared/agent — tool runtime, helpers, factory exports changed
+  protocol domain — opportunity/profile tools moved to async run lifecycle
+  backend database/queues/controllers/adapters — persisted and processed run records
+
+**Follow-up fixes**:
+- `6d83cdd10` — "fix(protocol): preserve typed MCP cancellation errors" (2026-06-01) — cancellation typing was lost
+- `c55bbf326` — "fix(protocol): propagate MCP cancellation to model calls" (2026-06-01) — abort signal did not reach model calls
+- `0c62370c2` — "fix(protocol,backend): coalesce MCP discovery runs and throttle the MCP transport" (2026-06-08) — repeated MCP calls caused duplicate work/rate pressure
+- `55fb54f5c` — "fix(protocol): scope discovery polling hint to discover_opportunities rate-limit errors" (2026-06-08) — generic polling hint leaked into wrong errors
+
+**Lessons from docs**:
+- No relevant `.rpiv/artifacts/` documents found; directory is absent.
+
+**Takeaway**: Async MCP paths need cancellation, coalescing, throttling, and scoped error messages from the start.
+
+### Precedent: Introduced agent registry/auth transport cutover
+**Commit(s)**: `ee6fc7aab` — "feat(agent): agent registry with transport cutover" (2026-04-09)
+**Blast radius**: 38 files across 11 layers
+  protocol shared/agent — registered agent tools and deps
+  protocol MCP/auth — MCP server and auth identity contract changed
+  public API — exported agent tooling
+  backend database/controllers/services/adapters — agent storage, auth, delivery services
+  renderer/docs — agent management UI and specs
+
+**Follow-up fixes**:
+- `6e312398f` — "fix(protocol/mcp): correct tool name read_indexes → read_networks" (2026-04-10) — MCP instruction/tool naming drifted
+- `0f1201e5b` — "fix(protocol): redact sensitive fields from tool registry logs" (2026-04-11) — registry logging exposed sensitive inputs
+- `7da939c2e` — "fix(mcp): OAuth sessions bypass agent-registration gate; wire chatSession in MCP handler" (2026-04-14) — auth gate handled the wrong identity class
+- `787240afd` — "fix(mcp): strip debugSteps from MCP responses to prevent data leaks" (2026-04-20) — debug internals leaked through MCP responses
+
+**Lessons from docs**:
+- No relevant `.rpiv/artifacts/` documents found; directory is absent.
+
+**Takeaway**: Auth/tool-registry changes repeatedly risk wrong gate semantics, stale tool names, and data leaks.
+
+### Precedent: Added Questioner/Premise ToolDeps and tool registrations
+**Commit(s)**: `03ca1300c` — "feat(protocol): add QuestionGeneratorReader interface + ToolContext slot" (2026-05-15); `262bc51d8` — "feat: migrate discovery question generation to async QuestionerQueue path" (2026-05-25); `edaeef0b0` — "feat: wire premise lifecycle events through ToolDeps callbacks" (2026-05-25); `02e0fe65f` — "feat: register premise tools and wire PremiseGraphFactory into all graph assembly points" (2026-05-24)
+**Blast radius**: 11 files across 6 layers
+  protocol shared/agent — `ToolDeps`/`ToolContext` callbacks expanded
+  protocol registry/factory — new tools registered and wired
+  protocol domain — questioner/premise tools consumed callbacks
+  backend controllers/services — host deps passed into protocol
+
+**Follow-up fixes**:
+- `b085e5a12` — "fix(tool-factory): forward chatSummary + questionGenerator into toolDeps" (2026-05-15) — new deps were not forwarded
+- `400e2d431` — "fix(protocol): address review feedback on premise tools" (2026-05-25) — premise tool behavior needed review cleanup
+- `6bf468832` — "fix(protocol): pass questionerEnqueue to IntentGraphFactory in tool.factory" (2026-05-25) — factory wiring missed a consumer
+- `9215fcad3` — "fix: pass sessionAwareEnqueue to NegotiationGraphFactory and toolDeps" (2026-05-26) — enqueue dependency was not consistently threaded
+
+**Lessons from docs**:
+- No relevant `.rpiv/artifacts/` documents found; directory is absent.
+
+**Takeaway**: Every new `ToolDeps` field must be threaded through all factories, graph constructors, tests, and backend composition roots.
+
+### Precedent: Expanded discovery/database contracts for context search
+**Commit(s)**: `1c9a3470d` — "feat: add searchIntentsByContextEmbedding and context CRUD to database interface" (2026-05-27); `52a026008` — "feat: add context-to-intent discovery strategy to opportunity graph" (2026-05-27); `44577b3ee` — "feat: add HyDE generation for user contexts to achieve discovery parity" (2026-05-27)
+**Blast radius**: 10 files across 6 layers
+  protocol interfaces — `database.interface.ts` contract expanded
+  protocol domain — opportunity graph/state added context discovery
+  backend adapter/database — host implementation updated
+  backend CLI/main — generation/backfill paths wired
+
+**Follow-up fixes**:
+- `1abbeff91` — "fix: address code review findings from Copilot" (2026-05-27) — export/review cleanup followed immediately
+- `829c0d213` — "fix: address second round of Copilot review findings" (2026-05-27) — context generator/opportunity graph cleanup
+- `f13a88aef` — "fix(protocol): cap premise discovery fan-out (#888)" (2026-06-03) — discovery contract enabled excessive fan-out
+
+**Lessons from docs**:
+- No relevant `.rpiv/artifacts/` documents found; directory is absent.
+
+**Takeaway**: Database-interface expansion must include backend adapter limits and fan-out guardrails.
+
+### Precedent: Added network/index scope propagation into MCP and ToolContext
+**Commit(s)**: `8fe10eae9` — "feat(protocol): add indexScope to ResolvedToolContext" (2026-05-19); `423ec825a` — "feat(protocol): populate context.indexScope from network scope" (2026-05-19); `302a8054c` — "feat(db): add getActiveIntentsAcrossIndexes for scope-aware reads" (2026-05-19); `561602989` — "feat(mcp): clamp indexScope for network-scoped agents" (2026-05-07)
+**Blast radius**: 12 files across 5 layers
+  protocol shared/agent — context resolution added scope
+  protocol MCP/auth — scoped agent identity affected context
+  protocol interfaces — scope-aware database reads added
+  backend adapter/guards — scope enforcement implemented
+
+**Follow-up fixes**:
+- `96d4853c0` — "fix(mcp): propagate network-scoped agent into context.networkId" (2026-05-07) — scoped agent did not reach tool context
+- `d2113c2bd` — "fix: clamp indexScope in resolveChatContext when networkId is set" (2026-05-20) — context resolution allowed scope override violation
+- `071a9fa23` — "fix(protocol): add indexScope to ToolContext and ResolvedToolContext" (2026-05-20) — type contract was incomplete
+- `3067713ea` — "docs(protocol): clarify ToolContext.indexScope override flow" (2026-05-20) — override semantics were unclear
+
+**Lessons from docs**:
+- No relevant `.rpiv/artifacts/` documents found; directory is absent.
+
+**Takeaway**: Scope/auth changes must fail closed and clamp context in both MCP identity handling and shared helper resolution.
+
+### Composite Lessons
+- Most recurring violation pattern: new protocol contracts are added but not threaded through every factory, graph, backend adapter, and test stub.
+- MCP/auth changes repeatedly risk data leaks or gate mistakes: redact logs, strip debug internals, and test OAuth/API-key/scoped-agent paths.
+- Async MCP tools need cancellation propagation, coalescing, throttling, and precise polling/error messaging.
+- Database-interface expansions need bounded fan-out and backend adapter implementation in the same change set.
+- Public API/model-config changes require immediate docs/export cleanup because stale guidance appears quickly.
+
+## Historical Context (from `.rpiv/artifacts/`)
+- No prior `.rpiv/artifacts/` research/design/plan/review documents were present in this working tree.
+
+## Developer Context
+**Q (`packages/protocol/src/index.ts:103-119`, `backend/src/services/tool.service.ts:17`): Should graph factory root exports used by backend host composition be classified as sanctioned seams or public-surface violations?**
+A: Split severity. Treat graph factories as tolerated host seams, but flag raw runtime/registry and broad database exports as violations or risks.
+
+**Q (`packages/protocol/src/shared/interfaces/auth.interface.ts:29`, `packages/protocol/src/mcp/mcp.server.ts:450-459`): Should `Request` in `McpAuthResolver` be treated as an allowed MCP transport exception or protocol port violation?**
+A: Developer asked, "How to fix it?" Classification used here: tolerated today but needs refactor note. Fix direction is to replace the `Request` parameter with a small plain auth input DTO extracted at the MCP transport edge.
+
+**Q (`scan complete`): Write the doc, add an area, or correct a finding?**
+A: Write the doc.
+
+## Related Research
+- None found.
+
+## Open Questions
+- None for violation classification. Implementation priority and exact refactor sequencing should be decided in a follow-up design or blueprint.

--- a/.rpiv/artifacts/research/2026-06-09_11-18-58_connect-links-auth-redirect.md
+++ b/.rpiv/artifacts/research/2026-06-09_11-18-58_connect-links-auth-redirect.md
@@ -1,0 +1,194 @@
+---
+date: 2026-06-09T11:18:58+0300
+author: Yankı Ekin Yüksel
+commit: cc4ceda7a
+branch: dev
+repository: index
+topic: "Connect links unauthenticated auth redirect — research"
+tags: [research, frontend, auth, connect-links, chat]
+status: complete
+last_updated: 2026-06-09T11:18:58+0300
+last_updated_by: Yankı Ekin Yüksel
+---
+
+# Research: Connect links unauthenticated auth redirect
+
+## Research Question
+
+Trace the code paths for extending `AuthContext.openLoginModal()` to accept an optional `callbackURL` string parameter, replacing the ChatPage's hard `navigate('/')` bounce with an inline login modal. Cover: AuthContext signature change, backward compatibility with existing callers, end-to-end magic-link and Google OAuth callbackURL routing, email/password implicit URL preservation, dismiss behavior and ref gating, and the precedent landscape.
+
+## Summary
+
+The fix is clean and low-risk. `AuthModal` already accepts a `callbackURL` prop (`AuthModal.tsx:13`) used by magic-link (line 65) and Google OAuth (line 120), but `AuthContext` renders `<AuthModal>` at line 189-192 without passing any `callbackURL`. The gap is a single plumbing layer: add `pendingCallbackURL` state in `AuthContext`, thread it through `openLoginModal(callbackURL?)` to `<AuthModal callbackURL={pendingCallbackURL}>`. All 5 existing callers (Header, landing page, invitation page, index join page) pass zero arguments and remain unaffected. The Better Auth server correctly preserves `callbackURL` through both magic-link email links (embedded as query param) and Google OAuth (encrypted in server-side state), so passing `window.location.href` from the ChatPage `useEffect` correctly restores the full path including `?msg=...`.
+
+## Detailed Findings
+
+### AuthContext: openLoginModal signature and state wiring
+
+The `openLoginModal` function is defined at `AuthContext.tsx:18` as `openLoginModal: () => void`. The implementation at lines 45-47 simply calls `setLoginModalOpen(true)` with no parameter support. A new `pendingCallbackURL` state variable must be added alongside `loginModalOpen` (line 32), the type widened to `(callbackURL?: string) => void`, and the `useCallback` updated to set both states atomically. The `onClose` handler at line 191 must clear `pendingCallbackURL` alongside `loginModalOpen` to prevent stale state leaking between modal opens. No `useEffect` cleanup is needed between opens because each `openLoginModal()` call overwrites `pendingCallbackURL` immediately via the setter.
+
+### AuthModal: existing callbackURL plumbing
+
+`AuthModal.tsx:13` defines `callbackURL?: string` in `AuthModalProps`. Two of the three auth paths use it:
+
+- **Magic link** (line 63-66): `authClient.signIn.magicLink({ email, callbackURL })` — Better Auth server embeds `callbackURL` as a query parameter in the email verification URL and redirects there after token validation.
+- **Google OAuth** (line 118-120): `authClient.signIn.social({ provider: 'google', callbackURL })` — Better Auth stores `callbackURL` encrypted in the OAuth state (server-side `generateState` at `oauth2/state.mjs`), invisible to Google during the round-trip. On callback, parsed state restores `callbackURL` and the user is redirected there.
+- **Email/password** (line 96-99): does NOT accept or pass `callbackURL`. The session is established via XHR (`authClient.signIn.email({ email, password })`), the modal closes, and the user stays on the current page. URL unchanged.
+
+Both OAuth/magic-link paths have a fallback: `callbackURL ?? window.location.origin` (lines 65, 120). When `callbackURL` is `undefined` (current state from `openLoginModal()` path), the user lands at `/` after authentication. The fix overrides this fallback by providing `pendingCallbackURL`.
+
+### ChatPage: auth-guard replacement
+
+The auth-guard `useEffect` at `page.tsx:30-34` currently calls `navigate('/')` when `isAuthenticated` is `false`, discarding all URL state. The FRD proposes replacing it with `openLoginModal(window.location.href)`, gated by a `useRef` to fire exactly once per page load. `useRef` is already imported at line 1 and `opportunityAcceptedRef` is used at line 26 — an additional `loginPromptedRef` is the only new variable needed.
+
+Timeline after the change:
+1. `authLoading` transitions `true` → `false` (AuthContext resolved)
+2. Effect fires: `!authLoading && !isAuthenticated && !loginPromptedRef.current` → `true`
+3. `loginPromptedRef.current = true`, `openLoginModal(window.location.href)` called
+4. Modal opens over the spinner (AuthModal is sibling of children, `position: fixed`)
+5. User authenticates or dismisses
+
+After dismissal, the effect's dependencies (`authLoading`, `isAuthenticated`, `openLoginModal`) are unchanged — React does not re-invoke the callback. Even if a future state change triggered re-execution, `loginPromptedRef.current = true` blocks the body.
+
+### AuthContext redirect check compatibility
+
+`AuthContext.tsx:177-182` checks `shouldRedirectToHome` based on pathname. The `/u/` prefix is in `publicPrefixes` (line 133), so the global guard does NOT intercept unauthenticated visits to `/u/:id/chat`. This is correct — the chat page handles auth itself via the new modal pattern. No change needed to `publicPrefixes`.
+
+### Email/password: implicit URL preservation
+
+Email/password sign-in (`AuthModal.tsx:85-112`) does not navigate the browser. `authClient.signIn.email()` establishes a session via XHR, the modal closes via `onClose()` (line 106), and React re-renders: `isAuthenticated` flips to `true`, the fetchData `useEffect` (ChatPage.tsx:36-51) fires, `prefillMessage` is still in state from `searchParams.get('msg')` at line 19, and the ChatView renders with the prefilled message. Since `window.location.href` was never modified, the URL path and `?msg=...` survive intact without any `callbackURL` involvement.
+
+### Spinner persistence after dismiss
+
+After the user dismisses the modal without authenticating, `loginModalOpen` is `false`, `isAuthenticated` is still `false`. The ChatPage's local `isLoading` (line 30, default `true`) never transitions to `false` because the fetchData effect (line 36) returns early when `isAuthenticated` is false. The spinner at lines 85-90 renders. This satisfies FRD requirement #4 (stay on page, no redirect).
+
+### Backward compatibility with existing callers
+
+All 5 existing callers pass zero arguments to `openLoginModal()`:
+- `Header.tsx:35` — calls `openLoginModal()`, has its own post-auth `useEffect` that navigates to `/`
+- `landing/page.tsx:313` and `332` — calls `openLoginModal()`, no post-auth redirect (user stays on landing)
+- `l/[code]/page.tsx:145` — calls `openLoginModal()`, relies on `useEffect` reload loop after auth
+- `index/[indexId]/page.tsx:161` — stores `pending_network_join` in localStorage, then calls `openLoginModal()`, `IndexesContext.tsx:82-88` reads it after auth
+
+Because the parameter is optional (`callbackURL?: string`), all callers continue to work: `openLoginModal()` desugars to `openLoginModal(undefined)`, setting `pendingCallbackURL = undefined` with zero behavioral change. No code changes needed in any existing caller.
+
+## Code References
+
+- `frontend/src/contexts/AuthContext.tsx:18` — `openLoginModal: () => void` type definition (widen to `(callbackURL?: string) => void`)
+- `frontend/src/contexts/AuthContext.tsx:45-47` — `useCallback` implementation (add `pendingCallbackURL`+`loginModalOpen` atomic set)
+- `frontend/src/contexts/AuthContext.tsx:32` — `loginModalOpen` state (add `pendingCallbackURL` alongside)
+- `frontend/src/contexts/AuthContext.tsx:189-192` — `<AuthModal>` rendering (add `callbackURL={pendingCallbackURL}`)
+- `frontend/src/contexts/AuthContext.tsx:115-120` — auto-close modal on auth (no change needed, `pendingCallbackURL` not cleared intentionally)
+- `frontend/src/components/AuthModal.tsx:13` — `callbackURL?: string` prop definition
+- `frontend/src/components/AuthModal.tsx:63-66` — magic-link `callbackURL` usage
+- `frontend/src/components/AuthModal.tsx:118-120` — Google OAuth `callbackURL` usage
+- `frontend/src/components/AuthModal.tsx:85-106` — email/password sign-in (no callbackURL)
+- `frontend/src/app/u/[id]/chat/page.tsx:30-34` — auth-guard `useEffect` (target for replacement)
+- `frontend/src/app/u/[id]/chat/page.tsx:1` — `useRef` already imported
+- `frontend/src/app/u/[id]/chat/page.tsx:26` — `opportunityAcceptedRef` usage (pattern for `loginPromptedRef`)
+- `frontend/src/app/u/[id]/chat/page.tsx:19` — `prefillMessage` from `searchParams.get('msg')`
+- `frontend/src/app/u/[id]/chat/page.tsx:85-90` — spinner render (modal overlays this)
+- `frontend/src/contexts/AuthContext.tsx:133` — `publicPrefixes` including `/u/`
+- `frontend/src/lib/auth-client.ts:8` — Better Auth client with `magicLinkClient()`
+- `backend/src/lib/betterauth/betterauth.ts:154-158` — magic-link plugin config
+
+## Integration Points
+
+### Inbound References
+- `frontend/src/components/Header.tsx:35` — calls `openLoginModal()` (zero args)
+- `frontend/src/app/landing/page.tsx:313,332` — calls `openLoginModal()` (zero args)
+- `frontend/src/app/l/[code]/page.tsx:145` — calls `openLoginModal()` (zero args)
+- `frontend/src/app/index/[indexId]/page.tsx:161` — calls `openLoginModal()` (zero args)
+
+### Outbound Dependencies
+- `frontend/src/lib/auth-client.ts:8` — `authClient.signIn.magicLink()` and `authClient.signIn.social()` consume `callbackURL`
+- `backend/src/lib/betterauth/betterauth.ts:154-158` — Better Auth server config for magic-link plugin
+
+### Infrastructure Wiring
+- `AuthContext.tsx:189-192` — React rendering of `<AuthModal>` (the wiring point for `callbackURL`)
+- `AuthContext.tsx:45-47` — `useCallback` defining `openLoginModal` (the injection point for `callbackURL`)
+
+## Architecture Insights
+
+- **Three-tier redirect contract**: `AuthModal` handles the per-auth-method redirect logic (magic-link email URL construction, Google OAuth state), `AuthContext` provides the modal state and URL plumbing, and individual pages/components trigger the flow. No page-level useEffect knows about the underlying redirect mechanism — only AuthModal does. The FRD keeps this layering intact.
+- **Redirect vs stay distinction**: For flows where the browser navigates away (magic-link email click, Google OAuth), `callbackURL` is essential. For flows where the browser stays (email/password XHR), no redirect mechanism is needed — URL preservation is automatic. The FRD correctly handles both via the same `pendingCallbackURL` state.
+- **No generic returnTo infrastructure**: The FRD intentionally avoids building a site-wide return-URL pattern. The three existing redirect patterns (Header: navigate to `/`; landing: stay; invitation: reload) are each caller-managed via their own useEffects or localStorage. The FRD's change is a targeted `callbackURL` generalization that only the ChatPage uses, keeping the existing patterns untouched.
+
+## Precedents & Lessons
+
+5 similar past changes analyzed.
+
+### Precedent: Intent-sharing connect flow — public /i/ routes with inline login modal
+**Commit(s)**: `6bbfb7f8e` — "feat(intent-sharing): redesign shared intent page with public access and connect flow" (2026-03-25)
+**Blast radius**: 5 files across 2 layers
+  frontend/src/app/i/[token]/page.tsx — redesign + connect flow
+  frontend/src/components/Header.tsx — Login button for logged-out visitors
+  frontend/src/contexts/AuthContext.tsx — made /i/ routes public
+
+**Follow-up fixes**:
+- `c78ed185e` — "fix: allow found-in-translation routes without authentication" (2026-03-31) — the `isPublicPage` list in AuthContext didn't include `/found-in-translation`
+- `0249a5fab` — "Add header to /i page and suppress header on /i routes"
+
+**Takeaway**: When making a page public with inline login, update the `isPublicPage` array in AuthContext or the global auth guard bounces visitors. `/u/` is already in the list — no change needed.
+
+### Precedent: AuthModal callbackURL prop for OAuth login bridge
+**Commit(s)**: `0132fd90e` — "feat: add callbackURL prop to AuthModal for oauth login bridge" (2026-04-03)
+**Blast radius**: 1 file, 1 layer — `frontend/src/components/AuthModal.tsx`
+
+**Follow-up fixes**:
+- `3e3a56c47` — "fix(frontend): use VITE_PROTOCOL_URL for auth providers fetch in AuthModal" (2026-04-09) — hardcoded `/api` broke in production
+
+**Takeaway**: AuthModal URL config must use `VITE_PROTOCOL_URL`, not hardcoded values.
+
+### Precedent: Persist pending index and auto-join on login
+**Commit(s)**: `72dd330a9` — "Persist pending index and auto-join on login" (2026-02-25)
+**Blast radius**: 3 files — `index/[indexId]/page.tsx`, `AuthModal.tsx`, `IndexesContext.tsx`
+
+**Takeaway**: localStorage pending-state pattern works reliably (no follow-up bugs in 30 days).
+
+### Precedent: Persist invite code and accept after onboarding
+**Commit(s)**: `08cae54f9` — "Persist invite code and accept after onboarding" (2026-03-13)
+**Blast radius**: 2 files — `l/[code]/page.tsx`, `onboarding/page.tsx`
+
+**Takeaway**: Second successful localStorage deferred-join precedent, no follow-up bugs.
+
+### Precedent: Ghost user chat page with prefill message
+**Commit(s)**: `f8de285f9` — "feat(frontend): differentiate CTA for ghost vs onboarded users with prefill invite flow" (2026-03-14)
+**Blast radius**: 5 files — `chat/page.tsx`, `ChatContent.tsx`, `ChatView.tsx`, `OpportunityCardInChat.tsx`, `opportunities.ts`
+
+**Follow-up fixes**:
+- `a0d830109` — "fix: ghost user claim via session hook + disable email/password in prod" (2026-03-22) — ghost users were never de-ghosted because `findUserByEmail` runs before `createUser`
+
+**Takeaway**: Chat page auth guard `navigate('/')` has no `{ replace: true }`, creating a back-button redirect loop. The inline modal replacement naturally solves this.
+
+### Composite Lessons
+- **Route visibility list is brittle**: Every new public page must be added to the `isPublicPage` array in `AuthContext.tsx:133`. `/u/` is already present — no change needed for this fix.
+- **AuthModal URL config breaks in production**: Twice the source of production-only bugs (`72dd330a9` hardcoded `http://localhost:3000`, `3e3a56c47` hardcoded `/api`). All fetch/redirect URLs must use `VITE_PROTOCOL_URL` or `window.location.origin`.
+- **localStorage pending-state pattern works reliably**: Three precedents used localStorage for deferred auth actions with zero follow-up bugs.
+- **AuthModal `callbackURL` prop exists but is unwired**: The prop at `AuthModal.tsx:13` is only used by the standalone `/login` page. `AuthContext` at line 189-192 does not pass it. This is the exact plumbing gap the planned change fills.
+
+## Historical Context (from `.rpiv/artifacts/`)
+- `.rpiv/artifacts/discover/2026-06-09_11-05-29_connect-links-auth-redirect.md` — Feature requirements: extend openLoginModal(), pass callbackURL, replace ChatPage navigate('/')
+
+## Developer Context
+**Q (discover: Mechanism: inline login modal vs. redirect to /login): What mechanism should the chat page use to handle unauthenticated visitors?**
+A: Use `openLoginModal()` inline with `callbackURL = window.location.href`
+
+**Q (discover: Modal dismiss behavior): If the user dismisses the login modal without authenticating, what should happen?**
+A: Stay on page when dismissed
+
+**Q (discover: Pre-resolution: AuthModal callbackURL plumbing): Pre-resolved from codebase evidence**
+A: Confirmed — `AuthModal.tsx:12-13` prop exists, `AuthContext.tsx:189-192` doesn't wire it
+
+**Q (discover: Pre-resolution: No generic returnTo convention): Pre-resolved from codebase evidence**
+A: Confirmed — `AuthContext.tsx:136-139` hardcodes `navigate('/')`
+
+**Q (discover: Pre-resolution: Backend URLs already correct): Pre-resolved from codebase evidence**
+A: Confirmed — `connect-link.controller.ts:173-174` builds correct URLs
+
+## Related Research
+- None — this is the first research artifact for this area.
+
+## Open Questions
+
+None.

--- a/.rpiv/artifacts/validation/2026-06-09_13-10-12_ind-354-connect-links-auth-redirect.md
+++ b/.rpiv/artifacts/validation/2026-06-09_13-10-12_ind-354-connect-links-auth-redirect.md
@@ -1,0 +1,65 @@
+---
+template_version: 1
+date: 2026-06-09T13:10:12+0300
+author: Yankı Ekin Yüksel
+commit: cc4ceda7a
+branch: dev
+repository: index
+topic: "Validation of IND-354: Connect links unauthenticated auth redirect"
+status: complete
+parent: .rpiv/artifacts/plans/2026-06-09_12-54-22_ind-354-connect-links-auth-redirect.md
+tags: [validation, frontend, auth, connect-links, chat]
+last_updated: 2026-06-09T13:10:12+0300
+---
+
+## Validation Report: IND-354: Connect links unauthenticated auth redirect
+
+### Implementation Status
+
+- ✓ Phase 1: AuthContext Extension — Fully implemented
+- ✓ Phase 2: ChatPage Replacement — Fully implemented
+
+### Automated Verification Results
+
+- ✓ TypeScript type check: `bunx tsc --noEmit --pretty` — No new type errors; only pre-existing TS2305 import errors unrelated to this change
+- ✓ `openLoginModal` type widened — All 5 existing callers pass zero args, backward compatible via optional `?` parameter
+- ✓ `navigate('/')` removed from auth-guard `useEffect` — Remaining `navigate('/')` calls in `handleClose` (line 69), error button (line 90) and `handleBack` (line 73) are correct and unchanged
+- ✓ No regressions detected
+
+### Code Review Findings
+
+#### Matches Plan:
+
+- `frontend/src/contexts/AuthContext.tsx:14` — `openLoginModal: (callbackURL?: string) => void;` type widened per plan
+- `frontend/src/contexts/AuthContext.tsx:28` — `const [pendingCallbackURL, setPendingCallbackURL] = useState<string | undefined>(undefined);` state added
+- `frontend/src/contexts/AuthContext.tsx:35-38` — `useCallback` accepts `callbackURL?`, stores via `setPendingCallbackURL`, opens modal
+- `frontend/src/contexts/AuthContext.tsx:119` — `onClose` clears both `pendingCallbackURL` and `loginModalOpen`
+- `frontend/src/contexts/AuthContext.tsx:120` — `<AuthModal callbackURL={pendingCallbackURL}>` prop wired
+- `frontend/src/contexts/AuthContext.tsx:76-79` — Auto-close `useEffect` preserves `pendingCallbackURL` (by design, not cleared)
+- `frontend/src/app/u/[id]/chat/page.tsx:17` — `openLoginModal` destructured from `useAuthContext()`
+- `frontend/src/app/u/[id]/chat/page.tsx:22` — `const loginPromptedRef = useRef(false);` declared
+- `frontend/src/app/u/[id]/chat/page.tsx:27-31` — Auth-guard `useEffect` calls `openLoginModal(window.location.href)` gated by `!loginPromptedRef.current`
+- `frontend/src/app/u/[id]/chat/page.tsx:31` — Dependencies: `[authLoading, isAuthenticated, openLoginModal]`
+
+#### Deviations from Plan:
+
+None. Implementation is a faithful realization of the plan.
+
+### Manual Testing Required:
+
+1. Open connect short-link (requires backend running):
+   - [ ] Open `https://protocol.index.network/c/UvThrrgHxC?link_preview=false` in logged-out browser → login modal appears instead of homepage redirect
+   - [ ] Sign in via email/password → lands on `/u/:id/chat` with prefilled message in input
+   - [ ] Sign in via magic-link → email returns to `/u/:id/chat?msg=...` with prefilled message
+   - [ ] Sign in via Google OAuth → redirect returns to `/u/:id/chat?msg=...` with prefilled message
+   - [ ] Dismiss login modal (×) → stays on `/u/:id/chat` page, spinner visible, no redirect
+   - [ ] Authenticated user opening connect link → goes directly to chat (no modal)
+
+2. Verify backward compatibility:
+   - [ ] Click Header "Login" button → modal appears with default behavior (no callbackURL, lands at `/` after auth)
+   - [ ] Navigate to landing page → sign-in opens modal (no callbackURL)
+   - [ ] Navigate to invitation page `/l/[code]` in logged-out browser → existing localStorage flow works unchanged
+
+### Recommendations:
+
+- Ready to commit — implementation is complete and validated. Both phases verified by codebase-analyzer agents (zero discrepancies), TypeScript type checks pass (no new errors), and code structure follows established patterns (`Header.tsx:36-47` ref-gating, `NotificationContext.tsx:58` optional params).

--- a/.rpiv/artifacts/validation/2026-06-09_13-55-40_protocol-package-violations.md
+++ b/.rpiv/artifacts/validation/2026-06-09_13-55-40_protocol-package-violations.md
@@ -1,0 +1,120 @@
+---
+date: 2026-06-09T13:55:40+0300
+author: Yankı Ekin Yüksel
+commit: 2c849825f
+branch: dev
+repository: index
+topic: "Validation of Fix protocol package boundary violations"
+tags: [validation, protocol, boundaries, interfaces, mcp, tools, schemas]
+status: complete
+parent: .rpiv/artifacts/plans/2026-06-09_13-10-22_protocol-package-violations.md
+last_updated: 2026-06-09T13:55:40+0300
+last_updated_by: Yankı Ekin Yüksel
+---
+
+# Validation: Fix protocol package boundary violations
+
+## Summary
+
+All 5 phases implemented and verified. 16 file changes (4 new, 12 modified). Typescript builds pass at both protocol and backend levels. All schema tests pass. All grep-based verification checks pass. Protocol test suite shows 1166 pass / 232 fail (all failures pre-existing LLM-related tests, unrelated to this change set).
+
+## Validation Results
+
+| Phase | Automated | Manual | Status |
+|-------|-----------|--------|--------|
+| 1: Profile + DiscoveryQuestion DTO extraction | 4/4 pass | 4/4 pass | ✅ |
+| 2: Negotiation state DTO extraction | 4/4 pass | 3/3 pass | ✅ |
+| 3: Public API narrowing | 3/3 pass | 3/3 pass | ✅ |
+| 4: Premise cast fix + Postgres dep removal | 4/4 pass | 4/4 pass | ✅ |
+| 5: MCP auth DTO refactor | 5/5 pass | 4/4 pass | ✅ |
+
+### Phase 1: Profile + DiscoveryQuestion DTO Extraction
+
+**Automated Verification:**
+- [✅] Type checking passes: `cd packages/protocol && bun run build` — passes
+- [✅] Tests pass: `cd packages/protocol && bun test` — 53 schema tests pass; overall 1166/1399 pass (pre-existing LLM failures)
+- [✅] No imports from `profile/profile.generator.ts` in `shared/interfaces/database.interface.ts` — confirmed (grep returns 0)
+- [✅] No imports from `profile/profile.generator.ts` in `shared/agent/tool.helpers.ts` — confirmed (grep returns 0)
+
+**Manual Verification:**
+- [✅] `profile.schema.ts` defines `ProfileDocument` as pure Zod-inferred type — confirmed: only `{ z } from "zod"` imported
+- [✅] `discovery-question.schema.ts` defines all types without domain imports — confirmed: only `z` and sibling schema types imported
+- [✅] `database.interface.ts` imports from `../schemas/profile.schema.js` — confirmed
+- [✅] `tool.helpers.ts` imports from `../schemas/profile.schema.js` — confirmed
+
+### Phase 2: Negotiation State DTO Extraction
+
+**Automated Verification:**
+- [✅] Type checking passes — confirmed
+- [✅] Tests pass — confirmed
+- [✅] No imports from `negotiation/negotiation.state.ts` in `shared/interfaces/agent-dispatcher.interface.ts` — confirmed: imports from `../schemas/negotiation-state.schema.js`
+- [✅] Structural parity — TypeScript build confirms structural compatibility; diff on export lists shows expected differences (domain file has additional graph-specific exports not in the shared schema)
+
+**Manual Verification:**
+- [✅] `negotiation-state.schema.ts` defines shared types — confirmed
+- [✅] Dual definitions structurally identical — confirmed by successful TypeScript build
+- [✅] `agent-dispatcher.interface.ts` imports from schemas — confirmed
+
+### Phase 3: Public API Narrowing
+
+**Automated Verification:**
+- [✅] Type checking passes — confirmed
+- [✅] Tests pass — confirmed
+- [✅] No `DefineTool` references in `index.ts` — 0
+- [✅] No `ToolRegistry` type references in `index.ts` — 0 (only `createToolRegistry` function export exists, not the type)
+- [✅] No `ToolErrorReport` references in `index.ts` — 0
+
+**Manual Verification:**
+- [✅] Backend code compiles without removed types — confirmed (`cd backend && bun run build` passes, ignoring pre-existing Sentry errors)
+- [✅] Negotiation state types re-exported from schemas — confirmed
+- [✅] README/docs references to removed exports noted — protocol package CLAUDE.md in .rpiv/guidance/ does not reference these types
+
+### Phase 4: Premise Cast Fix + Postgres Dep Removal
+
+**Automated Verification:**
+- [✅] Type checking passes — confirmed
+- [✅] Tests pass — confirmed
+- [✅] No `as unknown as PremiseGraphDatabase` casts in production code — confirmed (only 1 in test stub, which is expected)
+- [✅] `@langchain/langgraph-checkpoint-postgres` removed from `package.json` — confirmed (grep returns 0)
+
+**Manual Verification:**
+- [✅] `ChatGraphCompositeDatabase` includes premise CRUD methods — confirmed (`createPremise`, `getPremise`, `updatePremise`, `assignPremiseToNetwork`, `getPremiseNetworks` present in Pick list)
+- [✅] `tool.factory.ts:130` uses `database as PremiseGraphDatabase` — no `as unknown as`
+- [✅] `premise.tools.ts:12` uses `deps.database` cast — no `as unknown as`
+- [✅] Backend adapter already implements premise CRUD methods — confirmed: the `Database` interface already defines these methods; only `ChatGraphCompositeDatabase` Pick list was incomplete
+
+### Phase 5: MCP Auth DTO Refactor
+
+**Automated Verification:**
+- [✅] Protocol build passes — `cd packages/protocol && bun run build`
+- [✅] Backend build passes — `cd backend && bun run build` (pre-existing Sentry errors unrelated)
+- [✅] Tests pass — confirmed
+- [✅] `McpAuthResolver.resolveIdentity` accepts `McpAuthInput` not `Request` — confirmed at `auth.interface.ts`
+- [✅] `mcp.server.ts` extracts `McpAuthInput` before `resolveIdentity` — confirmed at lines 489-496 of `mcp.server.ts`
+- [✅] No auth credentials logged — confirmed: `bearerToken` and `apiKey` only appear in extraction lines, not logging lines
+
+**Manual Verification:**
+- [✅] `mcp-auth.schema.ts` defines `McpAuthInput` — confirmed
+- [✅] Backend `mcp.controller.ts` uses `McpAuthInput` — confirmed
+- [✅] `mcp.server.ts` no longer passes raw `Request` to `authResolver` — confirmed
+
+## Deviations from Plan
+
+None. All changes match the plan exactly.
+
+## Potential Issues
+
+1. **Dual-definition maintenance burden**: `negotiation.state.ts` and `negotiation-state.schema.ts` define structurally identical types for `NegotiationTurn`, `NegotiationOutcome`, `UserNegotiationContext`, `SeedAssessment`, and their Zod schemas. A future edit to one file without the other will cause silent drift detectable only at compile time. The current plan addresses this with a manual check only; no automated CI guard was added. Consider adding a CI diff or TypeScript structural type test in a follow-up.
+
+2. **Pre-existing test failures**: 232 tests fail across HydeGenerator, LensInferrer, ChatAgent hallucination, MCP connect-link wiring, and SemanticVerifier. These predate this change set and are unrelated. No regressions were introduced.
+
+3. **`RawToolDefinition` type still in barrel**: The design originally planned to remove `RawToolDefinition`, but it was kept because backend queues (`discovery-run.queue.ts`, `profile-run.queue.ts`) import it. This is documented in the design's Developer Context and the plan's scope section.
+
+## Findings Summary
+
+| Category | Count | Details |
+|----------|-------|---------|
+| ✅ Passed automated checks | 20/20 | All phase-level automated criteria verified |
+| ✅ Passed manual checks | 18/18 | All phase-level manual criteria verified |
+| ⚠️ Pre-existing failures | 232 | All unrelated LLM-based test failures |
+| ❌ New failures | 0 | No regressions introduced |

--- a/.rpiv/guidance/architecture.md
+++ b/.rpiv/guidance/architecture.md
@@ -1,0 +1,62 @@
+# Project Overview
+Index Network is a Bun/TypeScript monorepo for an intent-driven discovery protocol: backend API/workers, React frontend, protocol package, CLI, and Claude plugin. PostgreSQL/Drizzle, BullMQ/Redis, LangChain/LangGraph, and React Router shape most implementation patterns.
+
+# Architecture
+```
+index/
+├── backend/                 # Bun HTTP API, composition root, services/adapters/queues
+├── frontend/                # Vite + React Router SPA
+├── packages/protocol/       # Adapter-free LangGraph agents/tools/interfaces
+├── packages/cli/            # npm `index` terminal client
+├── packages/claude-plugin/  # static Claude/Codex plugin distribution
+└── scripts/                 # worktree, skill generation, release helpers
+```
+
+Dependency flow:
+```
+frontend/cli/plugin → backend HTTP/MCP → backend controllers → services → adapters/schema
+backend composition root → packages/protocol factories/tools via injected interfaces
+packages/protocol → shared interfaces only; never imports backend/frontend
+```
+
+# Commands
+| Area | Command | Purpose |
+|---|---|---|
+| root | `bun install` | install workspaces |
+| root | `bun run dev` | interactive dev launcher |
+| backend | `cd backend && bun run dev` | API server on port 3001 |
+| backend | `cd backend && bun test path/to/test.ts` | targeted tests |
+| backend | `cd backend && bun run db:generate && bun run db:migrate` | schema migration flow |
+| frontend | `cd frontend && bun run dev` | Vite frontend |
+| frontend | `cd frontend && bun run build` | production frontend build |
+| CLI | `cd packages/cli && bun src/main.ts conversation` | run CLI from source |
+| protocol | `cd packages/protocol && bun run build` | compile protocol package |
+| skills | `bun run build:skills` | regenerate Claude plugin skill outputs |
+
+# Business Context
+Users define signals/intents and indexes; autonomous agents discover relevant people, negotiate possible opportunities, and surface introductions through chat, CLI, MCP, and plugin skills.
+
+<important if="you are adding a cross-layer feature">
+- Start from the owning protocol/domain surface when agents or MCP tools are involved; see `.rpiv/guidance/packages/protocol/architecture.md`.
+- Add backend persistence/API wiring in the appropriate controller/service/adapter guidance files under `.rpiv/guidance/backend/src/`.
+- Add frontend pages/services/components by following `.rpiv/guidance/frontend/src/app/architecture.md`, `.rpiv/guidance/frontend/src/services/architecture.md`, and `.rpiv/guidance/frontend/src/components/architecture.md`.
+- Add CLI exposure by following `.rpiv/guidance/packages/cli/src/architecture.md`.
+</important>
+
+<important if="you are changing database schema">
+- Canonical schema is `backend/src/schemas/database.schema.ts`; do not introduce parallel schema definitions.
+- Generate migrations with Drizzle, rename SQL files to `{NNNN}_{action}_{target}.sql`, and update `drizzle/meta/_journal.json` tag.
+- Verify with a second `bun run db:generate` showing no pending schema changes.
+</important>
+
+<important if="you are changing generated Claude plugin skills">
+- Edit `packages/protocol/skills/claude-plugin/*.template.md` or `packages/protocol/skills/core-guidance.partial.md`.
+- Run `bun run build:skills` and commit both template/partial changes and generated `packages/claude-plugin/skills/**/SKILL.md` outputs.
+- Do not hand-edit generated skill files as the source of truth.
+</important>
+
+<important if="you are running tests">
+- Prefer targeted tests (`bun test path/to/spec.ts`) over full suites.
+- Use Bun test imports and mock external systems at the boundary being tested.
+- For backend/protocol graph tests, inject adapters/models rather than connecting to live services.
+</important>

--- a/.rpiv/guidance/backend/architecture.md
+++ b/.rpiv/guidance/backend/architecture.md
@@ -1,0 +1,71 @@
+# Backend
+
+## Responsibility
+Bun HTTP server and application host for REST APIs, MCP, auth, queues, events, gateways, and protocol graph wiring. `src/main.ts` is the composition root and runtime lifecycle owner.
+
+## Dependencies
+- **Bun.serve**: request dispatch and server lifecycle.
+- **Better Auth**: session/auth route integration.
+- **Drizzle/PostgreSQL**: persistence via adapters and schema.
+- **BullMQ/Redis**: async workers and queue UI.
+- **@indexnetwork/protocol**: graph/tool factories injected with backend adapters.
+
+## Consumers
+- **Frontend/CLI/Claude plugin/MCP clients**: call backend HTTP and `/mcp` endpoints.
+- **Workers/scripts**: reuse services, adapters, queues, and schema.
+
+## Module Structure
+```
+backend/
+├── src/main.ts                 # composition root, server, queue/event wiring
+├── src/controllers/            # HTTP/MCP request boundary
+├── src/services/               # application orchestration
+├── src/adapters/               # Drizzle/external infrastructure adapters
+├── src/queues/, src/events/    # async work and lifecycle hooks
+├── src/schemas/                # canonical Drizzle schema
+└── src/lib/                    # shared infrastructure helpers
+```
+
+## Composition Root Wiring
+```ts
+// main.ts shape: instantiate app boundaries and wire side effects once.
+import { RouteRegistry } from './lib/router/registry';
+import { intentQueue } from './queues/intent.queue';
+import { IntentEvents } from './events/intent.event';
+
+IntentEvents.onCreated = ({ intentId, userId }) => {
+  void intentQueue.addGenerateHydeJob({ intentId, userId });
+};
+
+const server = Bun.serve({
+  async fetch(req) {
+    // route registry, Better Auth, MCP, dev queue UI live here
+    return RouteRegistry.handle(req);
+  },
+});
+```
+
+## Layer Boundary Pattern
+```ts
+// Controller -> Service -> Adapter. Protocol deps are assembled at composition roots.
+class NetworkController {
+  constructor(private readonly service: NetworkService) {}
+  async create(req: Request) { return this.service.create(await req.json()); }
+}
+
+class NetworkService {
+  constructor(private readonly db: NetworkDatabaseAdapter) {}
+  async create(input: CreateNetworkInput) { return this.db.createNetwork(input); }
+}
+```
+
+## Boundary Rules
+- Controllers do not import adapters except explicit composition roots such as MCP wiring.
+- Services may call adapters, queues, and events; avoid service-to-service coupling.
+- Protocol package receives backend implementations through constructor/interface injection.
+
+<important if="you are adding backend runtime wiring">
+1. Add implementation in the owning layer first (controller/service/adapter/queue/event).
+2. Register controllers or queue workers in `src/main.ts` only after implementation is testable.
+3. Keep shutdown/close handling symmetrical for every worker or external connection.
+</important>

--- a/.rpiv/guidance/backend/src/adapters/architecture.md
+++ b/.rpiv/guidance/backend/src/adapters/architecture.md
@@ -1,0 +1,58 @@
+# Backend Adapters
+
+## Responsibility
+Infrastructure boundary for databases, cache, storage, scraping, email, and external APIs. Adapters implement backend persistence and structurally satisfy protocol interfaces without importing protocol adapter implementations.
+
+## Dependencies
+- **Drizzle/PostgreSQL**: typed SQL and schema mapping.
+- **Redis/cache clients**: shared cache/queue storage where applicable.
+- **External SDKs/APIs**: isolated behind adapter methods.
+
+## Consumers
+- **Services and queues**: call adapters for IO.
+- **MCP/protocol composition roots**: inject adapters into protocol factories.
+
+## Module Structure
+```
+adapters/
+├── *.adapter.ts              # infrastructure adapter by concept, not vendor
+├── *.database.adapter.ts     # Drizzle-backed domain persistence
+├── cache/storage/email/etc.  # external IO boundaries
+└── tests/                    # adapter contract/integration tests
+```
+
+## Plain Return Repository Boundary
+```ts
+export class WidgetDatabaseAdapter {
+  async getWidget(id: string): Promise<Widget | null> {
+    const [row] = await db.select().from(widgets).where(eq(widgets.id, id)).limit(1);
+    return row ? toWidget(row) : null; // not Result<T>
+  }
+
+  async createWidget(input: CreateWidgetInput): Promise<Widget> {
+    const [row] = await db.insert(widgets).values(input).returning();
+    if (!row) throw new Error('createWidget: no row returned');
+    return toWidget(row);
+  }
+}
+```
+
+## Protocol Interface Implementation
+```ts
+// Protocol defines the narrow contract; backend adapter implements structurally.
+type ProtocolNeeds = Pick<DatabaseAdapter, 'getUser' | 'searchIntentsByEmbedding'>;
+
+const deps: ProtocolNeeds = databaseAdapter;
+```
+
+## Boundary Rules
+- Return `T`, `T | null`, arrays, booleans, or throw for invariants; do not wrap DB calls in HTTP responses.
+- Map DB rows to domain DTOs at the adapter boundary.
+- Keep auth/scope-specific reads explicit; do not hide broad queries behind unsafe helpers.
+
+<important if="you are adding adapter methods">
+1. Add the narrow method required by the service/protocol interface.
+2. Use canonical schema from `backend/src/schemas/database.schema.ts`.
+3. Return plain values/null and throw only for invariant failures.
+4. Add tests for not-found, empty result, scope/visibility, and successful mapping.
+</important>

--- a/.rpiv/guidance/backend/src/controllers/architecture.md
+++ b/.rpiv/guidance/backend/src/controllers/architecture.md
@@ -1,0 +1,67 @@
+# Backend Controllers
+
+## Responsibility
+HTTP and MCP request boundary. Controllers parse/validate input, run guards, call services or protocol composition roots, and convert results to HTTP responses.
+
+## Dependencies
+- **Route decorators/registry**: `@Controller`, `@Get`, `@Post`, `@UseGuards` define routes.
+- **Guards/rate limiter**: auth, API key, scope, and rate-limit boundaries.
+- **Zod/manual parsing**: request validation before service calls.
+
+## Consumers
+- **`backend/src/main.ts`**: imports/registers controllers.
+- **HTTP clients**: frontend, CLI, MCP clients through API routes.
+
+## Module Structure
+```
+controllers/
+├── *.controller.ts       # one resource/API boundary per domain
+├── mcp.controller.ts     # composition root exception for protocol deps
+└── tests/                # controller/request behavior specs
+```
+
+## Decorated Request Boundary
+```ts
+@Controller('/api/widgets')
+export class WidgetController {
+  constructor(private readonly service = widgetService) {}
+
+  @Get('/')
+  @UseGuards(RateLimit('read'), AuthOrApiKeyGuard)
+  async list(req: Request) {
+    const userId = requireUser(req);
+    const result = await this.service.list(userId);
+    return Response.json({ widgets: result });
+  }
+
+  @Post('/')
+  @UseGuards(RateLimit('write'), AuthOrApiKeyGuard)
+  async create(req: Request) {
+    const body = CreateWidgetSchema.parse(await req.json());
+    return Response.json({ widget: await this.service.create(body) }, { status: 201 });
+  }
+}
+```
+
+## MCP Composition Root Exception
+```ts
+// mcp.controller.ts may assemble protocol deps; normal controllers should not.
+const deps: ProtocolDeps = {
+  database: databaseAdapter,
+  embedder: embedderAdapter,
+  questionerEnqueue: questionerQueue.addJob.bind(questionerQueue),
+};
+```
+
+## Boundary Rules
+- Do not put business persistence in controllers.
+- Put `RateLimit(...)` before auth guards so throttling happens before DB work.
+- Use `assertAgentNetworkScope` or scoped service filters on agent-facing routes.
+
+<important if="you are adding a new endpoint">
+1. Add/extend service method first.
+2. Add controller method with guard order: rate limit, then auth/scope guard.
+3. Parse params/body explicitly or with Zod.
+4. Return response envelopes matching nearby endpoints.
+5. Add targeted controller tests for validation, auth/scope, and success.
+</important>

--- a/.rpiv/guidance/backend/src/events/architecture.md
+++ b/.rpiv/guidance/backend/src/events/architecture.md
@@ -1,0 +1,64 @@
+# Backend Events
+
+## Responsibility
+In-process lifecycle hook layer. Events decouple post-persistence producers from downstream queues/services without introducing a broker abstraction.
+
+## Dependencies
+- **TypeScript object hooks**: mutable callback registries with no-op/null defaults.
+- **Injected handler factories**: question-answer reactions depend on supplied functions, not direct DB/queue imports.
+
+## Consumers
+- **`main.ts`**: assigns hook implementations.
+- **Services/adapters/queues**: emit lifecycle events after state changes.
+
+## Module Structure
+```
+events/
+├── *.event.ts                  # one exported hook object per domain lifecycle
+├── handlers/                   # event reaction dispatchers/factories
+├── tests/                      # event contract specs
+└── handlers/tests/             # handler/factory tests
+```
+
+## Mutable Hook Contract
+```ts
+export const IntentEvents = {
+  onCreated: (_: { intentId: string; userId: string }) => {},
+  onUpdated: (_: { intentId: string; userId: string }) => {},
+  onArchived: (_: { intentId: string; userId: string }) => {},
+};
+
+// main.ts wires side effects once.
+IntentEvents.onCreated = ({ intentId, userId }) => {
+  void intentQueue.addGenerateHydeJob({ intentId, userId });
+};
+```
+
+## Injected Reaction Handler
+```ts
+export interface AnswerDeps {
+  createPremiseFromAnswer(input: AnswerPayload): Promise<void>;
+  enqueueIntentRefinement(input: AnswerPayload): Promise<void>;
+}
+
+export async function handleQuestionAnswered(payload: AnswerPayload, deps: AnswerDeps) {
+  try {
+    if (payload.mode === 'profile') await deps.createPremiseFromAnswer(payload);
+    if (payload.mode === 'intent') await deps.enqueueIntentRefinement(payload);
+  } catch (error) {
+    log.warn('question answer reaction failed', { error });
+  }
+}
+```
+
+## Boundary Rules
+- Events are process-local hooks, not durable queues.
+- Emit after persistence succeeds.
+- Handler modules should use dependency interfaces/factories rather than importing adapters or queues directly.
+
+<important if="you are adding a lifecycle event">
+1. Add `<domain>.event.ts` with a no-op hook object or nullable hook if absence is meaningful.
+2. Emit from the producer after the DB state change.
+3. Wire side effects in `main.ts`.
+4. Add tests for default no-op behavior and wired behavior.
+</important>

--- a/.rpiv/guidance/backend/src/lib/architecture.md
+++ b/.rpiv/guidance/backend/src/lib/architecture.md
@@ -1,0 +1,59 @@
+# Backend Lib
+
+## Responsibility
+Shared infrastructure utilities for backend runtime: routing, auth, database/client singletons, BullMQ, logging, limiting, email, uploads, Sentry, protocol URL helpers, and external SDK glue.
+
+## Dependencies
+- **Router decorators/registry**: controller discovery and dispatch.
+- **Better Auth/JWT/API key helpers**: identity and trusted-origin behavior.
+- **Drizzle/BullMQ/Redis clients**: shared infrastructure singletons.
+- **Sentry/logging/limiter**: cross-cutting runtime instrumentation.
+
+## Consumers
+- **Controllers/services/queues/adapters/main.ts**: import infrastructure helpers.
+- **Tests**: mock or instantiate focused utilities.
+
+## Module Structure
+```
+lib/
+├── router/, auth/, apikey/       # request identity and routing infrastructure
+├── drizzle/, bullmq/, limiter/   # shared runtime clients/factories
+├── email/, upload/, storage/     # IO helper sublayers
+├── log*, sentry*                 # observability
+└── protocol-url, utils           # cross-cutting helpers
+```
+
+## Decorator Registry Pattern
+```ts
+export function Controller(prefix: string) {
+  return (target: Function) => RouteRegistry.registerController(target, prefix);
+}
+
+export function Get(path: string) {
+  return (target: object, key: string) => RouteRegistry.registerRoute(target, key, 'GET', path);
+}
+```
+
+## Shared Factory Boundary
+```ts
+export class QueueFactory {
+  static createQueue<T>(name: string) {
+    return new Queue<T>(name, { connection: getRedisConnection(), defaultJobOptions });
+  }
+
+  static createWorker<T>(name: string, processor: Processor<T>) {
+    return new Worker<T>(name, traceProcessor(processor), { connection: getRedisConnection() });
+  }
+}
+```
+
+## Boundary Rules
+- Keep `lib/` infrastructure-oriented; domain workflows belong in services/protocol.
+- Shared factories should centralize retry, connection, tracing, and environment fallback behavior.
+- Identity helpers should fail closed on ambiguous principals.
+
+<important if="you are adding shared infrastructure">
+1. Place it under a focused subfolder (`auth/`, `limiter/`, `bullmq/`, etc.).
+2. Keep public API small and documented enough for controllers/queues to use safely.
+3. Add unit tests for fallback/error behavior because many callers will share it.
+</important>

--- a/.rpiv/guidance/backend/src/queues/architecture.md
+++ b/.rpiv/guidance/backend/src/queues/architecture.md
@@ -1,0 +1,69 @@
+# Backend Queues
+
+## Responsibility
+Asynchronous work orchestration with BullMQ workers and cron-style maintenance. Queues enqueue heavy work from services/controllers and run protocol graphs/adapters outside the request cycle.
+
+## Dependencies
+- **BullMQ via QueueFactory**: queue/worker creation, retries, concurrency, tracing.
+- **node-cron**: maintenance jobs without BullMQ where appropriate.
+- **Injected adapters/protocol deps**: canonical access to persistence and graph work.
+
+## Consumers
+- **`main.ts`**: starts workers/crons and closes queues.
+- **Services/controllers/events**: enqueue jobs as producers.
+- **Dev queue UI**: reads queue singletons for Bull Board.
+
+## Module Structure
+```
+queues/
+├── *.queue.ts              # one domain/workflow queue class + singleton
+├── opportunity/            # opportunity discovery/expiration workflows
+├── negotiations/           # negotiation timeout/run workflows
+└── tests/                  # queue class tests with mocked deps/factory
+```
+
+## Queue Class Pattern
+```ts
+export interface WidgetJobData { widgetId: string; userId: string }
+export interface WidgetQueueDeps { database: WidgetDatabase; graph: WidgetGraph }
+
+export class WidgetQueue {
+  readonly queue = QueueFactory.createQueue<WidgetJobData>('widget-queue');
+  private worker?: Worker<WidgetJobData>;
+
+  constructor(private readonly deps: WidgetQueueDeps) {}
+
+  addJob(data: WidgetJobData) {
+    return this.queue.add('process_widget', data, { jobId: `widget-${data.widgetId}` });
+  }
+
+  startWorker() {
+    this.worker = QueueFactory.createWorker('widget-queue', (job) => this.processJob(job));
+  }
+
+  async processJob(job: Job<WidgetJobData>) {
+    const widget = await this.deps.database.getWidget(job.data.widgetId);
+    if (!widget) return;
+    await this.deps.graph.invoke({ widget, userId: job.data.userId });
+  }
+}
+```
+
+## Producer Boundary
+```ts
+// Producers enqueue only; they do not call worker internals.
+await widgetQueue.addJob({ widgetId, userId });
+```
+
+## Boundary Rules
+- New queue code should use injected adapters/deps; direct Drizzle/schema imports are legacy and should not be copied.
+- Workers start from `main.ts`, not at module import time.
+- Queues may enqueue downstream queues, but only via public enqueue methods.
+
+<important if="you are adding a new queue">
+1. Define `*JobData`, optional `*QueueDeps`, class, singleton export, and public enqueue method.
+2. Use `QueueFactory.createQueue/createWorker`; keep job names stable.
+3. Inject adapters/protocol deps for worker logic.
+4. Register `startWorker/startCrons` and `close` in `main.ts`.
+5. Add queue tests that instantiate the class with mocked deps and call `processJob`.
+</important>

--- a/.rpiv/guidance/backend/src/schemas/architecture.md
+++ b/.rpiv/guidance/backend/src/schemas/architecture.md
@@ -1,0 +1,56 @@
+# Backend Schemas
+
+## Responsibility
+Canonical database contract layer for Drizzle tables, enums, relations, and inferred row/insert types. All backend persistence should import schema from here.
+
+## Dependencies
+- **Drizzle pg-core/relations**: table, enum, index, relation definitions.
+- **Zod where needed**: runtime validation for selected schema-adjacent contracts.
+
+## Consumers
+- **Adapters/services/queues/tests**: import tables, enums, relations, and inferred types.
+- **Drizzle Kit**: generates SQL migrations from this file.
+
+## Module Structure
+```
+schemas/
+├── database.schema.ts       # canonical table/enums/relations/types
+├── conversation.schema.ts   # conversation/task schema split where present
+└── migrations via drizzle/  # generated SQL lives outside this folder
+```
+
+## Drizzle Table Contract
+```ts
+export const widgetStatus = pgEnum('widget_status', ['active', 'archived']);
+
+export const widgets = pgTable('widgets', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  ownerId: uuid('owner_id').notNull().references(() => users.id),
+  title: text('title').notNull(),
+  status: widgetStatus('status').notNull().default('active'),
+  deletedAt: timestamp('deleted_at'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+});
+
+export type Widget = typeof widgets.$inferSelect;
+export type NewWidget = typeof widgets.$inferInsert;
+```
+
+## Relation Definition Pattern
+```ts
+export const widgetsRelations = relations(widgets, ({ one }) => ({
+  owner: one(users, { fields: [widgets.ownerId], references: [users.id] }),
+}));
+```
+
+## Boundary Rules
+- Do not create alternate schema modules in `lib/schema` or feature folders.
+- Prefer soft-delete columns (`deletedAt`) over hard deletion where domain data may be referenced.
+- Keep schema changes paired with generated migrations and journal updates.
+
+<important if="you are changing schema">
+1. Edit `backend/src/schemas/database.schema.ts` or the owning canonical schema file.
+2. Run `cd backend && bun run db:generate`.
+3. Rename generated SQL to `{NNNN}_{action}_{target}.sql` and update `_journal.json` tag.
+4. Run `bun run db:migrate` and verify a second generate has no diff.
+</important>

--- a/.rpiv/guidance/backend/src/services/architecture.md
+++ b/.rpiv/guidance/backend/src/services/architecture.md
@@ -1,0 +1,62 @@
+# Backend Services
+
+## Responsibility
+Application orchestration layer. Services coordinate adapters, queues, events, and protocol graph factories while keeping HTTP and DB implementation details out of business flows.
+
+## Dependencies
+- **Adapters**: persistence/external IO through backend adapter classes.
+- **Queues/events**: async work and decoupled lifecycle side effects.
+- **Protocol factories**: invoked through injected or composition-root-created deps.
+
+## Consumers
+- **Controllers**: primary callers.
+- **Queues/CLI scripts**: reuse service workflows for maintenance/backfills.
+
+## Module Structure
+```
+services/
+├── *.service.ts          # one application service per domain/capability
+├── *-token.service.ts    # focused utility services
+└── tests/                # service-level behavior specs with mocked adapters/queues
+```
+
+## Service Orchestration Pattern
+```ts
+export class IntentService {
+  constructor(
+    private readonly db: IntentDatabaseAdapter,
+    private readonly queue = intentQueue,
+  ) {}
+
+  async create(userId: string, input: CreateIntentInput) {
+    const intent = await this.db.createIntent({ ...input, userId });
+
+    // Emit or enqueue after persistence succeeds.
+    IntentEvents.onCreated({ intentId: intent.id, userId });
+    await this.queue.addGenerateHydeJob({ intentId: intent.id, userId });
+
+    return intent; // plain domain DTO, controller formats HTTP response
+  }
+}
+```
+
+## Adapter + Queue Boundary
+```ts
+// Services import queues as producers only; workers own processing.
+await enrichmentQueue.addEnsureProfileHydeJob({ userId, networkId });
+
+// Services call adapters, not Drizzle directly.
+const profile = await profileAdapter.getProfile(userId);
+```
+
+## Boundary Rules
+- Avoid service-to-service imports; use events, queues, or shared pure helpers instead.
+- Keep HTTP `Request/Response` out of services.
+- Services may enforce domain invariants and emit lifecycle hooks after DB writes.
+
+<important if="you are adding a service workflow">
+1. Define adapter methods needed for persistence.
+2. Keep method inputs as domain DTOs, not raw `Request` objects.
+3. Persist first; enqueue/emit side effects after successful state changes.
+4. Mock adapters/queues/events in targeted service tests.
+</important>

--- a/.rpiv/guidance/frontend/architecture.md
+++ b/.rpiv/guidance/frontend/architecture.md
@@ -1,0 +1,67 @@
+# Frontend
+
+## Responsibility
+Vite + React Router SPA for chat, discovery, settings, profiles, networks, and public/shared flows. It consumes backend `/api` endpoints through typed services and app-wide contexts.
+
+## Dependencies
+- **React 19**: functional components and hooks.
+- **React Router v7**: lazy route modules and navigation.
+- **Tailwind CSS/Radix UI**: styling and accessible primitives.
+- **Vite**: dev server/build and API proxy.
+
+## Consumers
+- **Users/browser**: primary UI.
+- **Backend**: served/API-proxied against protocol backend in development.
+
+## Module Structure
+```
+frontend/
+├── src/routes.tsx, main.tsx      # router/provider bootstrap
+├── src/app/                      # lazy route page modules
+├── src/components/               # app shell, feature UI, primitives
+├── src/contexts/                 # global state/service providers
+├── src/services/                 # typed backend API wrappers
+└── src/lib/                      # API client and UI utilities
+```
+
+## Provider + Router Bootstrap
+```tsx
+const router = createBrowserRouter([
+  {
+    element: <ClientWrapper />,
+    children: [{ path: '/', lazy: () => import('@/app/page') }],
+  },
+]);
+
+createRoot(root).render(
+  <TooltipProvider>
+    <RouterProvider router={router} />
+  </TooltipProvider>,
+);
+```
+
+## API Consumption Boundary
+```tsx
+function FeatureContainer() {
+  const { networks } = useAPI();
+  const [items, setItems] = useState<Network[]>([]);
+
+  useEffect(() => {
+    void networks.list().then(setItems);
+  }, [networks]);
+
+  return <NetworkList items={items} />; // leaf receives props
+}
+```
+
+## Boundary Rules
+- Containers/pages/contexts may call services; reusable leaf components and `components/ui` should be prop-driven.
+- Keep route registration in `routes.tsx`; folder names may be Next-style but paths are React Router paths.
+- Service functions should own URL/query construction, not components.
+
+<important if="you are adding frontend capability">
+1. Add/extend service methods in `src/services/`.
+2. Add context state only if multiple routes/components share it.
+3. Add page under `src/app/**/page.tsx` and lazy route in `routes.tsx`.
+4. Build UI from container components plus prop-driven leaf/UI components.
+</important>

--- a/.rpiv/guidance/frontend/src/app/architecture.md
+++ b/.rpiv/guidance/frontend/src/app/architecture.md
@@ -1,0 +1,60 @@
+# Frontend App Routes
+
+## Responsibility
+Lazy route modules for the React Router SPA. Route folders describe URL shape, while `routes.tsx` maps those modules into actual paths.
+
+## Dependencies
+- **React Router lazy routes**: page modules loaded through `lazy: () => import(...)`.
+- **React components/contexts/services**: route modules compose application UI.
+
+## Consumers
+- **`src/routes.tsx`**: imports page modules lazily.
+- **`ClientWrapper`**: determines app/public/bare shell behavior by pathname.
+
+## Module Structure
+```
+app/
+├── page.tsx                       # root chat/home route
+├── d/[id]/, u/[id]/, s/[token]/   # dynamic route folders; Router uses :id/:token
+├── settings/, networks/, agents/  # authenticated feature pages
+├── landing/, login/, l/[code]/    # public/bare flows
+└── */page.tsx                     # route module convention
+```
+
+## Lazy Route Module Pattern
+```tsx
+// src/app/features/[id]/page.tsx
+export function Component() {
+  const { id } = useParams();
+  return <FeaturePage id={id!} />;
+}
+
+export default Component;
+
+// src/routes.tsx
+{
+  path: '/features/:id',
+  lazy: () => import('@/app/features/[id]/page'),
+}
+```
+
+## Shell Classification Pattern
+```tsx
+// ClientWrapper owns layout selection, not each page.
+const bareRoutes = ['/login', '/cli-auth'];
+const publicPrefixes = ['/s/', '/l/'];
+
+return isBare ? <Outlet /> : isPublic ? <PublicLayout /> : <ClientLayout />;
+```
+
+## Boundary Rules
+- Folder `[id]` is a naming convention only; React Router path uses `:id`.
+- Update `ClientWrapper` when a new route needs bare/public/authenticated shell behavior.
+- Keep heavy shared state in contexts, not duplicated across pages.
+
+<important if="you are adding a route">
+1. Create `src/app/<route>/page.tsx` with `Component` and default export.
+2. Register the path in `src/routes.tsx` with `lazy` import.
+3. If shell behavior differs, update `ClientWrapper` route lists.
+4. Add route tests for auth/public/bare behavior if classification changes.
+</important>

--- a/.rpiv/guidance/frontend/src/components/architecture.md
+++ b/.rpiv/guidance/frontend/src/components/architecture.md
@@ -1,0 +1,67 @@
+# Frontend Components
+
+## Responsibility
+React UI layer for app shell, chat rendering, settings panels, modals, domain widgets, and low-level primitives. Feature containers may use contexts/services; reusable leaf components should stay prop-driven.
+
+## Dependencies
+- **React hooks/components**: component state and rendering.
+- **React Router**: navigation in shell/route-aware components.
+- **Radix UI/Tailwind**: modals, tabs, tooltips, and styling primitives.
+- **Context hooks/services**: allowed in containers, not low-level primitives.
+
+## Consumers
+- **Route pages**: compose feature components.
+- **Contexts**: may render global modals/questions.
+- **Components**: compose primitives and feature widgets.
+
+## Module Structure
+```
+components/
+├── *.tsx                         # shell/domain widgets and containers
+├── chat/                         # streamed chat cards/timeline/trace renderers
+├── settings/, modals/            # workflow UI grouped by feature
+├── PendingQuestions/, InjectedQuestions/, DecisionQuestions/
+└── ui/, layout/                  # prop-driven primitives and layout helpers
+```
+
+## Container vs Leaf Component Pattern
+```tsx
+export function NetworkSettingsContainer({ networkId }: { networkId: string }) {
+  const { networks } = useAPI();
+  const [network, setNetwork] = useState<Network | null>(null);
+  useEffect(() => { void networks.get(networkId).then(setNetwork); }, [networks, networkId]);
+  return network ? <NetworkSettingsPanel network={network} onSave={networks.update} /> : null;
+}
+
+export function NetworkSettingsPanel(props: {
+  network: Network;
+  onSave(id: string, input: UpdateNetworkInput): Promise<void>;
+}) {
+  return <SettingsTab network={props.network} onSave={props.onSave} />;
+}
+```
+
+## UI Primitive Pattern
+```tsx
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'default' | 'ghost';
+}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = 'default', ...props }, ref) => (
+    <button ref={ref} className={cn(buttonVariants({ variant }), className)} {...props} />
+  ),
+);
+```
+
+## Boundary Rules
+- `components/ui` and reusable leaf widgets should not fetch data or import services.
+- Chat renderers must preserve backend/protocol streamed fenced block contracts.
+- Controlled modals receive open/submission state from parents unless they are global context modals.
+
+<important if="you are adding a component">
+1. Decide whether it is a container or reusable leaf.
+2. Containers may use context/service hooks; leaves take typed props/callbacks.
+3. Use existing `ui/` primitives and `cn` for styling composition.
+4. Add tests for non-trivial behavior, parsing, or state transitions.
+</important>

--- a/.rpiv/guidance/frontend/src/contexts/architecture.md
+++ b/.rpiv/guidance/frontend/src/contexts/architecture.md
@@ -1,0 +1,73 @@
+# Frontend Contexts
+
+## Responsibility
+Typed React providers for cross-route state: auth, API service injection, chat/session state, networks, filters, conversations, notifications, questions, and save-bar behavior.
+
+## Dependencies
+- **React Context/hooks**: provider + guarded hook pattern.
+- **Services/API client**: contexts orchestrate data loading and mutations.
+- **React Router/browser APIs**: navigation, redirects, storage, polling/SSE where needed.
+
+## Consumers
+- **Components/pages**: use exported `use*` hooks.
+- **Provider tree**: registers contexts around app routes.
+
+## Module Structure
+```
+contexts/
+├── *Context.tsx          # provider + use hook + state orchestration
+├── APIContext.tsx        # service factory injection
+├── AuthContext.tsx       # auth/session and global auth modal
+└── tests/                # provider/hook behavior tests where present
+```
+
+## Guarded Context Pattern
+```tsx
+interface FeatureContextValue {
+  items: Item[];
+  refresh(): Promise<void>;
+}
+
+const FeatureContext = createContext<FeatureContextValue | null>(null);
+
+export function FeatureProvider({ children }: { children: ReactNode }) {
+  const { featureService } = useAPI();
+  const [items, setItems] = useState<Item[]>([]);
+
+  const refresh = useCallback(async () => {
+    setItems(await featureService.list());
+  }, [featureService]);
+
+  return <FeatureContext.Provider value={{ items, refresh }}>{children}</FeatureContext.Provider>;
+}
+
+export function useFeature() {
+  const value = useContext(FeatureContext);
+  if (!value) throw new Error('useFeature must be used within FeatureProvider');
+  return value;
+}
+```
+
+## Provider Composition Pattern
+```tsx
+<APIProvider>
+  <AuthProvider>
+    <NetworksProvider>
+      <ConversationProvider>{children}</ConversationProvider>
+    </NetworksProvider>
+  </AuthProvider>
+</APIProvider>
+```
+
+## Boundary Rules
+- Contexts own shared state and side effects; leaf components should not duplicate global fetching.
+- Keep service construction in `APIContext`; feature contexts consume those services.
+- Clean up polling/SSE subscriptions in effects.
+
+<important if="you are adding a context">
+1. Define a narrow value interface.
+2. Export provider and guarded `useX` hook from the same file.
+3. Load/mutate through services from `APIContext`.
+4. Register provider only as high as necessary in the tree.
+5. Add tests or mocks for provider behavior if it owns async state.
+</important>

--- a/.rpiv/guidance/frontend/src/services/architecture.md
+++ b/.rpiv/guidance/frontend/src/services/architecture.md
@@ -1,0 +1,65 @@
+# Frontend Services
+
+## Responsibility
+Typed HTTP wrappers around the frontend API client. Services construct URLs/query strings, normalize response envelopes, and provide stable methods to contexts/pages/components.
+
+## Dependencies
+- **Authenticated API client**: central `get/post/patch/delete` boundary.
+- **TypeScript DTOs**: request/response shapes shared with UI code.
+- **URLSearchParams**: optional query construction.
+
+## Consumers
+- **APIContext**: instantiates service factories.
+- **Contexts/components/pages**: call services through context hooks.
+
+## Module Structure
+```
+services/
+├── *.ts                # one service factory per backend resource/capability
+├── shared DTO types    # colocated interfaces per service
+└── small caches/maps   # only for dedupe or in-flight request sharing
+```
+
+## Service Factory Pattern
+```ts
+export interface FeatureItem { id: string; title: string }
+export interface ListOptions { networkId?: string; limit?: number }
+
+export const createFeatureService = (api: APIClient) => ({
+  async list(options: ListOptions = {}): Promise<FeatureItem[]> {
+    const params = new URLSearchParams();
+    if (options.networkId) params.set('networkId', options.networkId);
+    if (options.limit) params.set('limit', String(options.limit));
+
+    const qs = params.toString();
+    const res = await api.get<{ items: FeatureItem[] }>(qs ? `/features?${qs}` : '/features');
+    return res.items ?? [];
+  },
+
+  async update(id: string, input: Partial<FeatureItem>): Promise<FeatureItem> {
+    const res = await api.patch<{ item: FeatureItem }>(`/features/${id}`, input);
+    return res.item;
+  },
+});
+```
+
+## APIContext Registration Pattern
+```tsx
+const services = useMemo(() => ({
+  features: createFeatureService(api),
+  networks: createNetworkService(api),
+}), [api]);
+```
+
+## Boundary Rules
+- Components should not hand-build API URLs when a service method exists.
+- Throw `APIError`/propagate API client errors; UI layers decide presentation.
+- Keep services mostly stateless; only cache/dedupe when there is a clear UX need.
+
+<important if="you are adding a service method">
+1. Add typed request/response interfaces.
+2. Build optional query params with `URLSearchParams`.
+3. Normalize backend envelopes before returning.
+4. Register new service factories in `APIContext` if consumers need hook access.
+5. Add tests/mocks for error and success paths when behavior is non-trivial.
+</important>

--- a/.rpiv/guidance/packages/claude-plugin/architecture.md
+++ b/.rpiv/guidance/packages/claude-plugin/architecture.md
@@ -1,0 +1,75 @@
+# Claude Plugin Package
+
+## Responsibility
+Static plugin distribution package for Claude Code/Codex-style clients. It ships plugin manifests, MCP endpoint configuration, and generated Index Network skill instructions; it does not implement backend business logic.
+
+## Dependencies
+- **Claude/Codex plugin manifests**: host-specific metadata and capabilities.
+- **Remote Index MCP server**: `https://protocol.index.network/mcp` implements tools.
+- **Protocol skill templates**: canonical source for generated `skills/**/SKILL.md`.
+
+## Consumers
+- **Claude Code users**: install via `/plugin install indexnetwork/claude-plugin`.
+- **Codex-style clients**: read `.codex-plugin/plugin.json`, `skills/`, and `mcp.json`.
+- **Subtree sync**: publishes `packages/claude-plugin` to external plugin repo.
+
+## Module Structure
+```
+packages/claude-plugin/
+├── package.json, README.md
+├── mcp.json                         # plain MCP server config
+├── .claude-plugin/plugin.json       # Claude manifest + API key config
+├── .claude-plugin/marketplace.json  # marketplace metadata
+├── .codex-plugin/plugin.json        # Codex manifest
+└── skills/<skill>/SKILL.md          # generated skill outputs
+```
+
+## MCP Manifest Pattern
+```json
+{
+  "userConfig": {
+    "apiKey": { "type": "string", "sensitive": true }
+  },
+  "mcpServers": {
+    "index-network": {
+      "type": "http",
+      "url": "https://protocol.index.network/mcp",
+      "headers": { "x-api-key": "${user_config.apiKey}" }
+    }
+  }
+}
+```
+
+## Generated Skill Template Pattern
+```md
+---
+name: index-orchestrator
+description: Use when the user asks about finding people...
+---
+
+# Index Network — Orchestrator
+
+{{CORE_GUIDANCE}}
+
+## Setup
+On activation, call the relevant MCP read tools.
+```
+
+## Boundary Rules
+- Do not edit generated `packages/claude-plugin/skills/**/SKILL.md` as the source of truth.
+- Keep orchestration guidance in skills; MCP tools remain single-purpose primitives implemented by protocol/backend.
+- Do not add repositories/services/controllers/components here; add execution logic in protocol/backend/frontend packages.
+
+<important if="you are updating plugin skills">
+1. Edit `packages/protocol/skills/claude-plugin/*.template.md` or `packages/protocol/skills/core-guidance.partial.md`.
+2. Run `bun run build:skills`.
+3. Commit both canonical templates/partials and generated `packages/claude-plugin/skills/**/SKILL.md`.
+4. Run `bun test scripts/tests/build-skills.spec.ts` when template injection behavior changes.
+</important>
+
+<important if="you are changing plugin distribution metadata">
+1. Update `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, `mcp.json`, or marketplace metadata as appropriate.
+2. Mark secrets in `userConfig` with `sensitive: true`.
+3. Bump `packages/claude-plugin/package.json` for package changes.
+4. Keep README install/auth instructions aligned.
+</important>

--- a/.rpiv/guidance/packages/cli/architecture.md
+++ b/.rpiv/guidance/packages/cli/architecture.md
@@ -1,0 +1,61 @@
+# CLI Package
+
+## Responsibility
+Standalone npm-distributed `index` terminal client. It packages a CJS shim, platform binaries/JS fallback, build/publish scripts, and TypeScript CLI source under `src/`.
+
+## Dependencies
+- **Node/Bun runtime APIs**: binary execution, HTTP callback server, filesystem, readline, build scripts.
+- **Remote backend API/MCP tools**: all domain behavior is accessed over HTTP/SSE/tool endpoints.
+- **npm optionalDependencies**: platform-specific binary packages.
+
+## Consumers
+- **End users**: install/use the `index` binary.
+- **Tests/build scripts**: import source modules and packaging helpers.
+
+## Module Structure
+```
+packages/cli/
+├── bin/index.cjs              # plain CJS npm shim
+├── npm/<os>-<arch>/           # optional platform packages
+├── scripts/build.ts,publish.ts# Bun build/release orchestration
+├── src/                       # CLI runtime application
+└── tests/                     # parser/client/command/output/package tests
+```
+
+## Bin Shim + Platform Package Pattern
+```js
+const pkg = `@indexnetwork/cli-${process.platform}-${process.arch}`;
+try {
+  const pkgJson = require.resolve(`${pkg}/package.json`);
+  const binary = path.join(path.dirname(pkgJson), 'bin', 'index');
+  if (existsSync(binary)) execFileSync(binary, process.argv.slice(2), { stdio: 'inherit' });
+} catch {
+  const fallback = path.join(__dirname, '..', 'dist', 'index.js');
+  execFileSync(resolveRuntime(), [fallback, ...process.argv.slice(2)], { stdio: 'inherit' });
+}
+```
+
+## Build Matrix Pattern
+```ts
+const TARGETS = [
+  { bunTarget: 'bun-linux-x64', npmDir: 'linux-x64', outName: 'index-linux-x64' },
+  { bunTarget: 'bun-darwin-arm64', npmDir: 'darwin-arm64', outName: 'index-darwin-arm64' },
+];
+
+for (const target of TARGETS) {
+  await $`bun build src/main.ts --compile --target=${target.bunTarget} --outfile dist/${target.outName}`;
+  await copyFile(`dist/${target.outName}`, `npm/${target.npmDir}/bin/index`);
+}
+```
+
+## Boundary Rules
+- `bin/index.cjs` must remain plain CommonJS and executable without TypeScript build support.
+- Platform package versions and main package optional dependency versions must stay aligned.
+- Publish platform packages before the main package.
+
+<important if="you are adding a platform target">
+1. Add `npm/<os>-<arch>/package.json` with correct `os/cpu` metadata.
+2. Add optional dependency in main `package.json`.
+3. Add target to `scripts/build.ts` and publish list.
+4. Extend package/build tests for the new target.
+</important>

--- a/.rpiv/guidance/packages/cli/src/architecture.md
+++ b/.rpiv/guidance/packages/cli/src/architecture.md
@@ -1,0 +1,78 @@
+# CLI Source
+
+## Responsibility
+Flat TypeScript CLI application: parse `index ...`, handle public auth commands, construct authenticated `ApiClient`, dispatch to command modules, and render JSON or terminal output.
+
+## Dependencies
+- **Node built-ins**: filesystem credentials, local login callback, browser open, readline REPL.
+- **Global fetch/SSE streams**: backend REST and streaming chat.
+- **Output facade**: centralized ANSI, tables/cards, markdown streaming.
+
+## Consumers
+- **`bin`/build scripts**: compile or execute `src/main.ts`.
+- **Tests**: import parser, ApiClient, handlers, output renderers.
+
+## Module Structure
+```
+src/
+├── main.ts                 # auth boundary and command dispatcher
+├── args.parser.ts          # plain ParsedCommand parser
+├── api.client.ts           # REST/SSE/tool HTTP boundary
+├── auth.store.ts, login.command.ts
+├── *.command.ts            # one top-level command family per file
+├── output/                 # terminal formatting and MarkdownRenderer
+└── types.ts, sse.parser.ts # shared DTOs and parsing helpers
+```
+
+## Command Handler Pattern
+```ts
+export async function handleWidget(
+  client: ApiClient,
+  subcommand: string | undefined,
+  positionals: string[],
+  options: { json?: boolean; limit?: number },
+): Promise<void> {
+  switch (subcommand) {
+    case 'list': {
+      const widgets = await client.listWidgets({ limit: options.limit });
+      if (options.json) return console.log(JSON.stringify(widgets));
+      output.widgetTable(widgets);
+      return;
+    }
+    default:
+      output.error(`Unknown widget subcommand: ${subcommand}`, 1);
+  }
+}
+```
+
+## ApiClient Boundary
+```ts
+class ApiClient {
+  constructor(private readonly baseUrl: string, private readonly token: string) {}
+
+  async callTool(toolName: string, query: Record<string, unknown> = {}): Promise<ToolResult> {
+    const res = await this.post(`/api/tools/${toolName}`, { query });
+    return (await res.json()) as ToolResult; // command checks success envelope
+  }
+
+  private async get(path: string) {
+    const res = await fetch(`${this.baseUrl}${path}`, { headers: { Authorization: `Bearer ${this.token}` } });
+    if (!res.ok) await this.handleError(res); // throws HTTP errors
+    return res;
+  }
+}
+```
+
+## Boundary Rules
+- `parseArgs()` returns a plain DTO; no IO or API calls.
+- `main.ts` owns auth; command modules receive an authenticated `ApiClient`.
+- REST methods throw on HTTP errors; tool methods return `ToolResult` and commands must check `success`.
+- `--json` prints raw DTO/tool envelopes and skips ANSI/progress output.
+
+<important if="you are adding a CLI command">
+1. Add command/subcommands to `ParsedCommand` and `KNOWN_COMMANDS` in `args.parser.ts`.
+2. Create `src/<command>.command.ts` exporting `handleX`.
+3. Add `ApiClient` methods or `callTool` usage; do not call `fetch` in command modules.
+4. Import/dispatch from `main.ts` and add output formatters if needed.
+5. Add parser, API client, command, and output tests.
+</important>

--- a/.rpiv/guidance/packages/protocol/architecture.md
+++ b/.rpiv/guidance/packages/protocol/architecture.md
@@ -1,0 +1,70 @@
+# Protocol Package
+
+## Responsibility
+Adapter-free protocol layer: LangGraph workflows, structured LLM agents, MCP/chat tools, schemas, and TypeScript interfaces. Host applications inject infrastructure through constructor/interface deps.
+
+## Dependencies
+- **LangGraph**: graph state, nodes, edges, compiled workflows.
+- **LangChain/OpenRouter model config**: structured LLM invocation.
+- **Zod**: runtime schemas for tools and agent outputs.
+- **Shared interfaces**: DB/cache/embedder/dispatcher ports.
+
+## Consumers
+- **Backend**: imports factories/tools/interfaces and injects adapters.
+- **CLI/plugin/frontend indirectly**: consume protocol behavior through backend APIs/MCP.
+
+## Module Structure
+```
+packages/protocol/
+├── src/index.ts                  # public package barrel
+├── src/shared/                   # interfaces, tools, model config, schemas
+├── src/chat/, intent/            # chat and intent workflows
+├── src/opportunity/, negotiation/# discovery and negotiation domains
+├── src/questioner/, hyde/, etc.  # supporting protocol domains
+└── skills/                       # Claude plugin skill templates/partials
+```
+
+## Adapter-Free Factory Pattern
+```ts
+export interface FeatureDatabase {
+  getFeature(id: string): Promise<Feature | null>;
+  createFeature(input: CreateFeature): Promise<Feature>;
+}
+
+export class FeatureGraphFactory {
+  constructor(private readonly database: FeatureDatabase, private readonly embedder: Embedder) {}
+
+  createGraph() {
+    return new StateGraph(FeatureState)
+      .addNode('load', async (state) => ({ feature: await this.database.getFeature(state.id) }))
+      .compile();
+  }
+}
+```
+
+## Tool Factory Pattern
+```ts
+export function createFeatureTools(defineTool: DefineTool, deps: ToolDeps) {
+  return [defineTool({
+    name: 'read_features',
+    querySchema: z.object({ id: z.string().optional() }),
+    handler: async ({ context, query }) => {
+      const result = await deps.database.getFeature(query.id ?? context.userId);
+      return result ? success({ feature: result }) : error('Feature not found');
+    },
+  })];
+}
+```
+
+## Boundary Rules
+- Never import backend adapters, controllers, services, Drizzle schema, or frontend code.
+- Ports return plain values/null/arrays or throw for invariants; not HTTP responses.
+- User-facing LLM output must be schema-validated and sanitized where IDs/internal data could leak.
+
+<important if="you are adding protocol capability">
+1. Define narrow interfaces/types in the owning module or `shared/interfaces`.
+2. Implement graph/agent/tool with injected deps and Zod schemas.
+3. Export the public surface from `src/index.ts` only when host packages need it.
+4. Implement backend adapter/wiring separately.
+5. Add protocol unit tests with stubbed deps/models.
+</important>

--- a/.rpiv/guidance/packages/protocol/src/chat/architecture.md
+++ b/.rpiv/guidance/packages/protocol/src/chat/architecture.md
@@ -1,0 +1,65 @@
+# Protocol Chat
+
+## Responsibility
+Chat orchestration layer: constructs chat graphs, binds tools, streams assistant/tool events, and manages ReAct-style model interaction for user sessions.
+
+## Dependencies
+- **LangGraph/LangChain**: graph/agent message flow.
+- **Shared tool factory/registry**: binds protocol tools into chat agents.
+- **Model config/request context**: model selection, abort signals, trace events.
+
+## Consumers
+- **Backend MCP/chat controllers and services**: instantiate `ChatGraphFactory` and sessions.
+- **Protocol tool factory**: shares tool/context contracts.
+
+## Module Structure
+```
+chat/
+├── chat.graph.ts        # graph factory and streaming orchestration
+├── chat.agent.ts        # ChatAgent.create and model/tool binding
+├── chat.state.ts        # graph state contracts
+├── tools/context files  # chat-specific tool context helpers
+└── tests/               # graph/agent behavior specs
+```
+
+## Private Factory Agent Pattern
+```ts
+export class ChatAgent {
+  private constructor(private readonly model: ChatModel, private readonly tools: Tool[]) {}
+
+  static create(context: ToolContext) {
+    const model = createModel('chat', context.modelConfig).bindTools(context.tools);
+    return new ChatAgent(model, context.tools);
+  }
+
+  async invoke(messages: BaseMessage[], options?: { signal?: AbortSignal }) {
+    return invokeWithAbortSignal(this.model, messages, options?.signal);
+  }
+}
+```
+
+## Trace Event Pattern
+```ts
+const emit = requestContext.getStore()?.traceEmitter;
+emit?.({ type: 'agent_start', agent: 'chat-agent', sessionId });
+try {
+  const response = await agent.invoke(messages, { signal });
+  emit?.({ type: 'agent_end', agent: 'chat-agent', ok: true });
+  return response;
+} catch (error) {
+  emit?.({ type: 'agent_end', agent: 'chat-agent', ok: false });
+  throw error;
+}
+```
+
+## Boundary Rules
+- Chat binds tools; individual tool logic belongs in domain tool factories.
+- Preserve streaming event contracts consumed by frontend/CLI renderers.
+- Only `ChatAgent` reads per-request `ModelConfig` from `ToolContext`.
+
+<important if="you are adding chat-visible tool behavior">
+1. Add the domain tool in its owning package folder.
+2. Register it through shared tool factory/registry.
+3. Ensure streaming/tool activity events remain stable for frontend and CLI.
+4. Add tests for tool binding and response/reset behavior if streaming changes.
+</important>

--- a/.rpiv/guidance/packages/protocol/src/intent/architecture.md
+++ b/.rpiv/guidance/packages/protocol/src/intent/architecture.md
@@ -1,0 +1,65 @@
+# Protocol Intent
+
+## Responsibility
+Intent/signal agent domain. It infers, verifies, reconciles, indexes, and executes intent operations through LangGraph workflows and structured LLM agents.
+
+## Dependencies
+- **LangGraph**: stateful workflow nodes and routing.
+- **Zod + structured LLM output**: inference/verification/reconciliation contracts.
+- **Shared database/embedder/HyDE interfaces**: injected persistence and semantic search.
+
+## Consumers
+- **Backend intent queues/tools/services**: run HyDE/indexing and CRUD tool flows.
+- **Opportunity discovery**: uses intent/index fit and embeddings.
+
+## Module Structure
+```
+intent/
+├── intent.state.ts       # graph state and operation contracts
+├── intent.graph.ts       # prep/query/infer/verify/reconcile/execute workflow
+├── *.agent.ts            # structured LLM sub-agents
+├── *.tools.ts            # MCP/chat tool surface where present
+└── tests/                # graph and agent unit specs
+```
+
+## Structured Agent Pattern
+```ts
+const OutputSchema = z.object({
+  description: z.string(),
+  confidence: z.number().min(0).max(1),
+  inferenceType: z.enum(['explicit', 'implicit']),
+});
+
+export class IntentInferrer {
+  private readonly model = createModel('intentInferrer').withStructuredOutput(OutputSchema, {
+    name: 'intent_inference',
+  });
+
+  async invoke(input: InferIntentInput) {
+    const raw = await invokeWithAbortSignal(this.model, renderMessages(input));
+    return OutputSchema.parse(raw);
+  }
+}
+```
+
+## Graph Node Pattern
+```ts
+const inferNode = async (state: IntentGraphState) => {
+  if (!state.query) return { error: 'Missing intent query' };
+  const inferred = await inferrer.invoke({ query: state.query, profile: state.profile });
+  return { inferredIntent: inferred, trace: [...state.trace, 'inferred'] };
+};
+```
+
+## Boundary Rules
+- Keep DB/embedder access behind injected interfaces.
+- Use Zod schemas as the public LLM output contract.
+- Regenerate HyDE/indexing asynchronously; do not block HTTP flows with heavy work unless explicitly required.
+
+<important if="you are adding intent graph behavior">
+1. Add state fields with reducers/defaults.
+2. Add a focused node or structured agent.
+3. Validate LLM outputs with Zod and decide fallback/null/throw policy.
+4. Wire backend queue/tool invocation separately.
+5. Add graph tests with stubbed agents/interfaces.
+</important>

--- a/.rpiv/guidance/packages/protocol/src/negotiation/architecture.md
+++ b/.rpiv/guidance/packages/protocol/src/negotiation/architecture.md
@@ -1,0 +1,78 @@
+# Protocol Negotiation
+
+## Responsibility
+Bilateral agent negotiation domain. Defines turn/outcome schemas, runs `init → turn → finalize`, dispatches personal agents before system fallback, exposes negotiation MCP tools, and summarizes outcomes.
+
+## Dependencies
+- **LangGraph**: negotiation state machine.
+- **Zod**: turn/outcome/tool schemas.
+- **AgentDispatcher interface**: personal-agent transport boundary.
+- **Structured LLM models**: `IndexNegotiator`, summarizer, insights generator.
+
+## Consumers
+- **Opportunity graph**: negotiates candidates and existing opportunities.
+- **Backend queues/services/MCP**: run background negotiation and external-agent tools.
+
+## Module Structure
+```
+negotiation/
+├── negotiation.state.ts       # Zod schemas, state annotations, public types
+├── negotiation.graph.ts       # graph factory and candidate fan-out
+├── negotiation.agent.ts       # system fallback negotiator
+├── negotiation.tools.ts       # list/get/respond tools
+├── summarizer/insight files   # downstream compression/narrative helpers
+└── tests/                     # graph, tools, timeout, summarizer specs
+```
+
+## Schema-First Turn Contract
+```ts
+export const NegotiationTurnSchema = z.object({
+  action: z.enum(['propose', 'accept', 'reject', 'counter', 'question']),
+  assessment: z.object({
+    reasoning: z.string(),
+    suggestedRoles: z.object({ ownUser: RoleSchema, otherUser: RoleSchema }),
+  }),
+  message: z.string().nullable().optional(),
+});
+
+export const SystemNegotiationTurnSchema = NegotiationTurnSchema.extend({
+  action: z.enum(['propose', 'accept', 'reject', 'counter']),
+});
+```
+
+## Dispatcher-First Turn Node
+```ts
+const dispatched = await dispatcher.dispatch(ownUser.id, scope, payload, { timeoutMs });
+
+if (dispatched.handled) turn = dispatched.turn;
+else if (dispatched.reason === 'waiting') {
+  await database.setTaskTurnContext(taskId, absoluteSourceCandidateContext);
+  await database.updateTaskState(taskId, 'waiting_for_agent');
+  return { status: 'waiting_for_agent' };
+} else {
+  turn = await new IndexNegotiator().invoke(payload); // system fallback
+}
+```
+
+## A2A DataPart Persistence
+```ts
+await database.createMessage({
+  conversationId,
+  senderId: `agent:${ownUser.id}`,
+  role: 'agent',
+  parts: [{ kind: 'data', data: turn }],
+  taskId,
+});
+```
+
+## Boundary Rules
+- Store parked context in absolute `source/candidate` terms; project to caller-relative `own/other` in tools.
+- First non-continuation graph turn must be `propose`; final system turn is only `accept|reject`.
+- Tools must enforce network scope, participant access, task state, and turn parity before responding.
+
+<important if="you are adding negotiation behavior">
+1. Update Zod schemas first, then inferred types and prompts.
+2. Update graph routing/finalization and `respond_to_negotiation` tool validation together.
+3. Preserve DataPart message envelope and `negotiation-outcome` artifact shape.
+4. Add tests for schema, graph routing, external tool response, and timeout/fallback paths.
+</important>

--- a/.rpiv/guidance/packages/protocol/src/opportunity/architecture.md
+++ b/.rpiv/guidance/packages/protocol/src/opportunity/architecture.md
@@ -1,0 +1,82 @@
+# Protocol Opportunity
+
+## Responsibility
+Connection-opportunity domain: discovers candidates, evaluates matches, persists/enriches opportunities, presents cards/feed sections, exposes tools, and hands accepted candidates into negotiation.
+
+## Dependencies
+- **LangGraph**: `OpportunityGraphFactory` and home/feed graph workflows.
+- **Structured LLM agents**: evaluator, presenter, categorizer, question generator.
+- **Injected database/cache/embedder/queue interfaces**: adapter-free persistence and async boundaries.
+- **Zod tools**: MCP/chat tool validation and success/error envelopes.
+
+## Consumers
+- **Backend opportunity services/queues/MCP**: instantiate graphs/tools.
+- **Negotiation/questioner/maintenance**: consume opportunity outputs and helper contracts.
+
+## Module Structure
+```
+opportunity/
+├── opportunity.state.ts, opportunity.graph.ts   # main discovery lifecycle
+├── opportunity.tools.ts                         # discover/list/update/poll tools
+├── evaluator/presenter/persist/utils files      # LLM, persistence, pure helpers
+├── feed/                                        # home feed projection graph
+└── tests/                                       # graph/tool/feed/presenter specs
+```
+
+## Graph Factory + Scope Pattern
+```ts
+export class OpportunityGraphFactory {
+  constructor(private readonly deps: OpportunityDeps) {}
+
+  createGraph() {
+    return new StateGraph(OpportunityGraphState)
+      .addNode('scope', async (s) => {
+        const memberships = await this.deps.database.getNetworkMemberships(s.userId);
+        const allowed = intersectScope(s.indexScope, memberships.map(m => m.networkId));
+        return allowed.length ? { indexScope: allowed } : { error: 'No accessible indexes' };
+      })
+      .addNode('discover', discoverNode)
+      .addNode('persist', persistNode)
+      .compile();
+  }
+}
+```
+
+## Visibility/Actionability Matrix
+```ts
+export function canUserSeeOpportunity(actors: Actor[], status: OpportunityStatus, viewerId: string) {
+  const roles = actors.filter(a => a.userId === viewerId).map(a => a.role);
+  if (roles.length === 0) return false;
+  return roles.some(role => role === 'introducer' || role === 'peer' || status !== 'latent');
+}
+
+export function isActionableForViewer(opp: Opportunity, viewerId: string) {
+  return canUserSeeOpportunity(opp.actors, opp.status, viewerId) && !['expired', 'rejected'].includes(opp.status);
+}
+```
+
+## Tool + Coalescing Pattern
+```ts
+const discover = defineTool({
+  name: 'discover_opportunities',
+  querySchema: DiscoverSchema,
+  handler: async ({ context, query }) => {
+    if (context.networkId && query.networkId !== context.networkId) return error('Scope denied');
+    const active = await deps.discoveryRuns.findEquivalent(context.userId, stableSignature(query));
+    if (active) return success({ discoveryRunId: active.id, coalesced: true });
+    return success(await runDiscoverFromQuery({ graph: deps.graphs.opportunity, userId: context.userId, query }));
+  },
+});
+```
+
+## Boundary Rules
+- Scope/membership intersection must happen before discovery searches.
+- User-facing card text goes through presenter/fallback and ID sanitizers.
+- Status changes require updating visibility/actionability, feed filters, mutation guards, and cache keys.
+
+<important if="you are adding opportunity status or action">
+1. Update status schemas/types and default filters.
+2. Update `canUserSeeOpportunity`, `isActionableForViewer`, labels, and blocked mutation statuses.
+3. Update presenter/feed behavior and cache key/skipping rules.
+4. Add tests for visibility, list/home inclusion, mutation, and card rendering.
+</important>

--- a/.rpiv/guidance/packages/protocol/src/shared/architecture.md
+++ b/.rpiv/guidance/packages/protocol/src/shared/architecture.md
@@ -1,0 +1,61 @@
+# Protocol Shared
+
+## Responsibility
+Cross-domain protocol primitives: model config, tool registry/factory, request context/observability, schemas, utility functions, and reusable interfaces.
+
+## Dependencies
+- **LangChain/LangGraph contracts**: shared tool/model invocation patterns.
+- **Zod**: common validation and tool schemas.
+- **Async request context**: trace/event propagation.
+
+## Consumers
+- **Protocol domains**: chat, intent, opportunity, negotiation, questioner, maintenance.
+- **Backend**: imports shared interfaces and tool factories for composition.
+
+## Module Structure
+```
+shared/
+├── agent/                # model config, tool factory/registry, invocation helpers
+├── interfaces/           # host-implemented ports/contracts
+├── schemas/              # shared Zod schemas and DTO contracts
+├── observability/logging # request context, traces, timing helpers
+└── utils                 # pure helpers used across protocol domains
+```
+
+## Shared Model Invocation Pattern
+```ts
+const model = createModel('featureAgent').withStructuredOutput(OutputSchema, {
+  name: 'feature_agent_output',
+});
+
+const raw = await invokeWithAbortSignal(model, [
+  new SystemMessage(SYSTEM_PROMPT),
+  new HumanMessage(renderInput(input)),
+], options?.signal);
+
+const parsed = OutputSchema.safeParse(raw);
+return parsed.success ? parsed.data : null;
+```
+
+## Tool Registry Pattern
+```ts
+export function createToolSet(defineTool: DefineTool, deps: ToolDeps) {
+  return [
+    ...createIntentTools(defineTool, deps),
+    ...createOpportunityTools(defineTool, deps),
+    ...(deps.agentDispatcher ? createNegotiationTools(defineTool, deps) : []),
+  ];
+}
+```
+
+## Boundary Rules
+- Add shared code only when at least two protocol domains need it.
+- Keep helpers pure unless the folder explicitly owns runtime context/model/tool behavior.
+- Avoid creating broad god interfaces; prefer focused contracts in domain modules.
+
+<important if="you are adding shared protocol utilities">
+1. Verify the helper is cross-domain; otherwise keep it in the owning domain folder.
+2. Prefer pure functions with unit tests.
+3. If adding model/tool behavior, preserve abort-signal and trace conventions.
+4. Re-export only stable public contracts from package root.
+</important>

--- a/.rpiv/guidance/packages/protocol/src/shared/interfaces/architecture.md
+++ b/.rpiv/guidance/packages/protocol/src/shared/interfaces/architecture.md
@@ -1,0 +1,55 @@
+# Protocol Shared Interfaces
+
+## Responsibility
+Port/contract layer for host-provided persistence, cache, embedder, dispatcher, tool deps, and protocol data shapes. Backend implements these structurally.
+
+## Dependencies
+- **TypeScript interfaces/types**: compile-time contracts.
+- **Protocol DTOs**: shared data shapes used by graphs/tools.
+
+## Consumers
+- **Protocol factories/tools**: depend on these contracts.
+- **Backend adapters**: implement matching methods without importing implementation code.
+
+## Module Structure
+```
+interfaces/
+├── database.interface.ts        # graph/tool persistence contracts and DTOs
+├── cache/embedder/etc.          # infrastructure ports
+├── agent-dispatcher.interface.ts# personal-agent transport boundary
+└── tool-related contracts       # ToolDeps and call context shapes
+```
+
+## Narrow Port Pattern
+```ts
+export interface OpportunityReader {
+  getOpportunity(id: string): Promise<Opportunity | null>;
+  getOpportunitiesForUser(userId: string, opts?: OpportunityFilter): Promise<Opportunity[]>;
+}
+
+export interface OpportunityWriter {
+  createOpportunity(input: CreateOpportunity): Promise<Opportunity>;
+  updateOpportunityStatus(id: string, status: OpportunityStatus): Promise<Opportunity | null>;
+}
+```
+
+## Backend Structural Implementation
+```ts
+class DatabaseAdapter implements OpportunityReader, OpportunityWriter {
+  async getOpportunity(id: string): Promise<Opportunity | null> { /* Drizzle mapping */ }
+  async createOpportunity(input: CreateOpportunity): Promise<Opportunity> { /* insert */ }
+  async updateOpportunityStatus(id: string, status: OpportunityStatus) { /* update */ }
+}
+```
+
+## Boundary Rules
+- Interfaces should be narrow enough for tests to stub easily.
+- Return plain domain values, null, arrays, booleans, or throw; never HTTP `Response`.
+- Do not import backend schema/adapters in this folder.
+
+<important if="you are extending protocol interfaces">
+1. Add the smallest method/type needed by the graph/tool.
+2. Update backend adapter implementation in a separate backend change.
+3. Update test stubs wherever the interface is consumed.
+4. Prefer local `Pick<>`-style interfaces in domain modules for one-off needs.
+</important>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ git push <indexnetwork-remote> main
 
 ### Subtrees
 
-The following packages are git subtrees tracked to external repos. **Syncing is automatic for Index-owned subtrees** — the `.github/workflows/sync-subtrees.yml` workflow runs on every push to `dev` or `main` of the canonical `indexnetwork/index` repo (including PR merges), splitting each prefix and force-pushing to the corresponding subtree repo with the `SUBTREE_SYNC_PAT` secret. Subtree branches stay aligned with the monorepo branch (`dev` -> `dev`, `main` -> `main`). AgentVillage is Edge-City-owned and is mounted as a git submodule at `packages/agentvillage`; `Edge-City/agentvillage` is canonical. The local `scripts/hooks/pre-push` hook still regenerates SKILL.md files before push, but no longer runs subtree push.
+The following packages are git subtrees tracked to external repos. **Syncing is automatic for Index-owned subtrees** — the `.github/workflows/sync-subtrees.yml` workflow runs on every push to `dev` or `main` of the canonical `indexnetwork/index` repo (including PR merges), splitting each prefix and force-pushing to the corresponding subtree repo with the `SUBTREE_SYNC_PAT` secret. Subtree branches stay aligned with the monorepo branch (`dev` -> `dev`, `main` -> `main`). AgentVillage is Edge-City-owned and is mounted as a git submodule at `packages/edge-city/agentvillage`; `Edge-City/agentvillage` is canonical. The local `scripts/hooks/pre-push` hook still regenerates SKILL.md files before push, but no longer runs subtree push.
 
 #### packages/protocol/ → indexnetwork/protocol
 
@@ -135,24 +135,24 @@ git subtree push --prefix=packages/claude-plugin https://github.com/indexnetwork
 git subtree pull --squash --prefix=packages/claude-plugin https://github.com/indexnetwork/claude-plugin.git <branch>
 ```
 
-#### packages/agentvillage/ → Edge-City/agentvillage submodule
+#### packages/edge-city/agentvillage/ → Edge-City/agentvillage submodule
 
 The `@edge-city/agentvillage` Agent Village workspace, skills, and installer. Includes skills for edge-esmeralda, index-network, edgeos, and geo-esmeralda. This package is Edge-City-owned; `Edge-City/agentvillage` is canonical and this monorepo records a submodule pointer for local context only. See `docs/guides/agentvillage-submodule.md` for the workflow and migration preservation note. Do not use subtree push/pull for AgentVillage anymore. Make AgentVillage changes inside the submodule, push a branch/fork to `Edge-City/agentvillage`, open the PR there, then update this monorepo's submodule pointer after the canonical PR merges. The nested `skills/` directory syncs from `Edge-City/agentvillage` to `Edge-City/agentvillage-skills` via that repo's workflow.
 
 ```bash
 # First clone or after switching branches
-git submodule update --init packages/agentvillage
+git submodule update --init packages/edge-city/agentvillage
 
 # Work on AgentVillage against the canonical repository
-cd packages/agentvillage
+cd packages/edge-city/agentvillage
 git checkout -b <branch>
 # edit, commit, push to a fork/branch, then open a PR against Edge-City/agentvillage:main
 
-# After the Edge-City PR merges, update the pointer in this monorepo
-cd ../..
-git -C packages/agentvillage fetch origin main
-git -C packages/agentvillage checkout origin/main
-git add packages/agentvillage
+# After the Edge-City PR merges, update this monorepo's pointer
+cd ../../..
+git -C packages/edge-city/agentvillage fetch origin main
+git -C packages/edge-city/agentvillage checkout origin/main
+git add packages/edge-city/agentvillage
 ```
 
 ### Root
@@ -179,7 +179,7 @@ index/
 │   ├── protocol/        # @indexnetwork/protocol NPM package — subtree → indexnetwork/protocol
 │   ├── cli/             # @indexnetwork/cli — Bun, TypeScript — subtree → indexnetwork/cli
 │   ├── claude-plugin/   # @indexnetwork/claude-plugin — index-orchestrator and index-negotiator skills, subtree → indexnetwork/claude-plugin
-│   └── agentvillage/    # @edge-city/agentvillage — git submodule → Edge-City/agentvillage (canonical)
+│   └── edge-city/       # Edge-City submodules: agentvillage, landing, controlplane
 ├── frontend/          # Vite + React Router v7 SPA with React 19
 ├── docs/              # Project documentation (design/, domain/, guides/, specs/)
 └── scripts/           # Worktree helpers, hooks, dev launcher

--- a/backend/src/controllers/mcp.controller.ts
+++ b/backend/src/controllers/mcp.controller.ts
@@ -52,7 +52,7 @@ import { mintConnectLink as mintConnectLinkSvc, buildConnectShortUrl } from '../
 import { resolveProtocolBaseUrl } from '../lib/protocol-url';
 
 import { IntentGraphFactory, ProfileGraphFactory, OpportunityGraphFactory, HydeGraphFactory, NetworkGraphFactory, NetworkMembershipGraphFactory, IntentNetworkGraphFactory, NegotiationGraphFactory, HydeGenerator, LensInferrer, IntentIndexer, createMcpServer, ChatGraphFactory, PremiseGraphFactory } from '@indexnetwork/protocol';
-import type { HydeGraphDatabase, PremiseGraphDatabase, ToolDeps, McpAuthResolver, ScopedDepsFactory, Embedder, ChatGraphCompositeDatabase, QuestionerEnqueuePayload, PendingQuestionSummary } from '@indexnetwork/protocol';
+import type { HydeGraphDatabase, PremiseGraphDatabase, ToolDeps, McpAuthResolver, ScopedDepsFactory, Embedder, ChatGraphCompositeDatabase, QuestionerEnqueuePayload, PendingQuestionSummary, McpAuthInput } from '@indexnetwork/protocol';
 
 import { BASE_URL, JWT_AUDIENCE } from '../lib/betterauth/betterauth';
 import { log } from '../lib/log';
@@ -265,6 +265,10 @@ export function telegramHandleFromRequest(request: Request): string | null {
   );
 }
 
+function telegramHandleFromAuthInput(input: McpAuthInput): string | undefined {
+  return normalizeTelegramHeader(input.telegramUsername ?? input.telegramHandle) ?? undefined;
+}
+
 function normalizeTelegramHandleForComparison(raw: string): string | null {
   return normalizeTelegramHeader(raw)?.toLowerCase() ?? null;
 }
@@ -341,10 +345,8 @@ class TelegramIdentityError extends Error {
   }
 }
 
-async function finalizeMcpIdentity(request: Request, identity: ResolvedMcpIdentity): Promise<ResolvedMcpIdentity> {
-  if (identity.clientSurface !== 'telegram') return identity;
-  const telegramHandle = telegramHandleFromRequest(request);
-  if (!telegramHandle) return identity;
+async function finalizeMcpIdentity(telegramHandle: string | undefined, identity: ResolvedMcpIdentity): Promise<ResolvedMcpIdentity> {
+  if (identity.clientSurface !== 'telegram' || !telegramHandle) return identity;
 
   let existingSocials: TelegramSocial[];
   let matchingTelegramSocials: TelegramSocial[];
@@ -423,23 +425,18 @@ export function parseClientSurface(raw: string | null): 'telegram' | 'web' {
 }
 
 const authResolver: McpAuthResolver = {
-  async resolveIdentity(request: Request): Promise<ResolvedMcpIdentity> {
-    const clientSurface = parseClientSurface(request.headers.get('x-index-surface'));
-    const authHeader = request.headers.get('Authorization');
-    const [scheme, token] = authHeader?.split(/\s+/, 2) ?? [];
+  async resolveIdentity(input: McpAuthInput): Promise<ResolvedMcpIdentity> {
+    const clientSurface = input.clientSurface ?? 'web';
 
-    if (scheme?.toLowerCase() === 'bearer' && token) {
-      const isJwt = token.split('.').length === 3;
+    if (input.bearerToken) {
+      const isJwt = input.bearerToken.split('.').length === 3;
 
       if (isJwt) {
-        // JWT path: verify with JWKS (issued by the jwt() plugin for CLI/API use).
-        // JWTs don't carry an agentId — they authenticate users, not agents — so
-        // there is no network scope to compute; the field is explicitly null
-        // (not omitted) so callers cannot conflate "no scope" with "scope unset".
+        // JWT path
         try {
-          const { payload } = await jwtVerify(token, JWKS, { issuer: BASE_URL, audience: JWT_AUDIENCE });
-          if (typeof payload.id === 'string') return finalizeMcpIdentity(request, { userId: payload.id, isSessionAuth: true, networkScopeId: null, clientSurface });
-          if (typeof payload.sub === 'string') return finalizeMcpIdentity(request, { userId: payload.sub, isSessionAuth: true, networkScopeId: null, clientSurface });
+          const { payload } = await jwtVerify(input.bearerToken, JWKS, { issuer: BASE_URL, audience: JWT_AUDIENCE });
+          if (typeof payload.id === 'string') return finalizeMcpIdentity(telegramHandleFromAuthInput(input), { userId: payload.id, isSessionAuth: true, networkScopeId: null, clientSurface });
+          if (typeof payload.sub === 'string') return finalizeMcpIdentity(telegramHandleFromAuthInput(input), { userId: payload.sub, isSessionAuth: true, networkScopeId: null, clientSurface });
           throw new Error('JWT payload missing user ID');
         } catch (err) {
           if (err instanceof TelegramIdentityError) throw err;
@@ -450,16 +447,15 @@ const authResolver: McpAuthResolver = {
           throw new Error(`Invalid or expired access token: ${msg}`, { cause: err });
         }
       } else {
-        // Opaque token path: issued by the mcp() plugin via OAuth flow — also
-        // session-auth, no agent identity, so network scope is always null.
+        // Opaque token path
         try {
           const res = await fetch(`${BASE_URL}/api/auth/mcp/get-session`, {
-            headers: { Authorization: `Bearer ${token}` },
+            headers: { Authorization: `Bearer ${input.bearerToken}` },
             signal: AbortSignal.timeout(5000),
           });
           if (res.ok) {
             const data = await res.json() as { userId?: string } | null;
-            if (data?.userId) return finalizeMcpIdentity(request, { userId: data.userId, isSessionAuth: true, networkScopeId: null, clientSurface });
+            if (data?.userId) return finalizeMcpIdentity(telegramHandleFromAuthInput(input), { userId: data.userId, isSessionAuth: true, networkScopeId: null, clientSurface });
           }
         } catch (err) {
           if (err instanceof TelegramIdentityError) throw err;
@@ -470,13 +466,12 @@ const authResolver: McpAuthResolver = {
       }
     }
 
-    const apiKey = request.headers.get('x-api-key');
-    if (apiKey) {
+    if (input.apiKey) {
       let sessionUserId: string | undefined;
 
       try {
         const sessionRes = await fetch(`${BASE_URL}/api/auth/get-session`, {
-          headers: { 'x-api-key': apiKey },
+          headers: { 'x-api-key': input.apiKey },
           signal: AbortSignal.timeout(5000),
         });
         if (sessionRes.ok) {
@@ -488,7 +483,7 @@ const authResolver: McpAuthResolver = {
       } catch { /* session lookup failed, try direct DB */ }
 
       try {
-        const hashBuffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(apiKey));
+        const hashBuffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input.apiKey));
         const hashed = btoa(String.fromCharCode(...new Uint8Array(hashBuffer)))
           .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
         const drizzle = await import('../lib/drizzle/drizzle');
@@ -528,12 +523,10 @@ const authResolver: McpAuthResolver = {
           }
 
           if (principal) {
-            // For network-scoped agents, resolve the bound network scope so the
-            // MCP server can clamp `indexScope` to that single network downstream.
             const networkScopeId = principal.agentId
               ? await resolveAgentNetworkScopeById(principal.agentId)
               : null;
-            return finalizeMcpIdentity(request, {
+            return finalizeMcpIdentity(telegramHandleFromAuthInput(input), {
               userId: principal.userId,
               ...(principal.agentId ? { agentId: principal.agentId } : {}),
               networkScopeId,
@@ -543,7 +536,7 @@ const authResolver: McpAuthResolver = {
         }
 
         if (sessionUserId) {
-          return finalizeMcpIdentity(request, { userId: sessionUserId, networkScopeId: null, clientSurface });
+          return finalizeMcpIdentity(telegramHandleFromAuthInput(input), { userId: sessionUserId, networkScopeId: null, clientSurface });
         }
       } catch (err) {
         if (err instanceof TelegramIdentityError) throw err;
@@ -561,7 +554,21 @@ const authResolver: McpAuthResolver = {
   },
 
   async resolveUserId(request: Request): Promise<string> {
-    const { userId } = await authResolver.resolveIdentity(request);
+    // Deprecated bridge: extract McpAuthInput from Request using the same
+    // edge semantics as the protocol MCP transport.
+    const input: McpAuthInput = {
+      bearerToken: (() => {
+        const auth = request.headers.get('Authorization');
+        if (!auth) return undefined;
+        const [scheme, token] = auth.trim().split(/\s+/, 2);
+        return scheme?.toLowerCase() === 'bearer' && token ? token : undefined;
+      })(),
+      apiKey: request.headers.get('x-api-key') ?? undefined,
+      clientSurface: request.headers.get('x-index-surface')?.trim().toLowerCase() === 'telegram' ? 'telegram' : 'web',
+      telegramHandle: request.headers.get('x-index-telegram-handle') ?? undefined,
+      telegramUsername: request.headers.get('x-index-telegram-username') ?? undefined,
+    };
+    const { userId } = await authResolver.resolveIdentity(input);
     return userId;
   },
 };

--- a/backend/src/services/connect-link.service.ts
+++ b/backend/src/services/connect-link.service.ts
@@ -236,8 +236,9 @@ async function resolveOpportunityForLink(
 }
 
 /**
- * Resolve a short code to its row. Self-heals expired codes by extending
- * TTL when the underlying opportunity is still actionable.
+ * Resolve a short code to its row. Returns null for terminal-status opportunities
+ * regardless of link freshness. Self-heals stale codes by extending TTL when
+ * the underlying opportunity is still actionable.
  *
  * @param code - The 10-char base62 short code.
  * @returns The resolved link row, or `null` for unknown codes or codes
@@ -255,13 +256,12 @@ export async function resolveConnectLink(code: string): Promise<ResolvedLink | n
   const opp = await resolveOpportunityForLink(row.opportunityId, row.userId);
   if (!opp) return null;
 
+  if (TERMINAL_STATUSES.has(opp.status)) return null;
+
   const resolvedLink = toResolvedLink(row, opp.id);
   if (row.expiresAt > now) {
     return resolvedLink;
   }
-
-  // Expired — check if the opportunity is still actionable.
-  if (TERMINAL_STATUSES.has(opp.status)) return null;
 
   // Extend TTL.
   const expiresAt = new Date(now.getTime() + TTL_DAYS * 24 * 60 * 60 * 1000);

--- a/backend/src/services/opportunity.service.ts
+++ b/backend/src/services/opportunity.service.ts
@@ -675,9 +675,9 @@ export class OpportunityService {
       });
       return { conversationId: conversation.id, counterpartUserId: counterpart.userId, opportunity: opp };
     }
-    if (opp.status !== 'pending' && opp.status !== 'draft') {
+    if (opp.status !== 'pending' && opp.status !== 'draft' && opp.status !== 'latent') {
       return {
-        error: `Cannot start chat on opportunity in status '${opp.status}'; must be pending or draft.`,
+        error: `Cannot start chat on opportunity in status '${opp.status}'; must be pending, draft, or latent.`,
         status: 400,
       };
     }
@@ -700,7 +700,7 @@ export class OpportunityService {
     }
 
     // Resolve the DM first — independent of opp state, safe to retry if it
-    // throws (opp is still pending/draft, button re-appears).
+    // throws (opp is still pending/draft/latent, button re-appears).
     let conversation: { id: string };
     try {
       conversation = await this.db.getOrCreateDM(userId, counterpart.userId);

--- a/bun.lock
+++ b/bun.lock
@@ -127,11 +127,10 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "1.26.9",
+      "version": "3.0.0",
       "dependencies": {
         "@langchain/core": "^1.1.17",
         "@langchain/langgraph": "^1.1.2",
-        "@langchain/langgraph-checkpoint-postgres": "^1.0.0",
         "@langchain/openai": "^1.2.3",
         "@modelcontextprotocol/server": "^2.0.0-alpha.2",
         "dotenv": "^16.3.1",

--- a/docs/guides/agentvillage-submodule.md
+++ b/docs/guides/agentvillage-submodule.md
@@ -1,13 +1,13 @@
 # AgentVillage submodule workflow
 
-`packages/agentvillage` is a git submodule whose canonical repository is `Edge-City/agentvillage`.
+`packages/edge-city/agentvillage` is a git submodule whose canonical repository is `Edge-City/agentvillage`.
 
 This monorepo keeps the submodule only so Index development has local AgentVillage context. Do not treat `indexnetwork/index` as the source of truth for AgentVillage file contents.
 
 ## Initial setup
 
 ```bash
-git submodule update --init packages/agentvillage
+git submodule update --init packages/edge-city/agentvillage
 ```
 
 ## Making AgentVillage changes
@@ -15,7 +15,7 @@ git submodule update --init packages/agentvillage
 1. Work inside the submodule:
 
    ```bash
-   cd packages/agentvillage
+   cd packages/edge-city/agentvillage
    git checkout main
    git pull origin main
    git checkout -b <branch>
@@ -25,16 +25,16 @@ git submodule update --init packages/agentvillage
 3. After the Edge-City PR merges, update this monorepo's pointer:
 
    ```bash
-   cd ../..
-   git -C packages/agentvillage fetch origin main
-   git -C packages/agentvillage checkout origin/main
-   git add packages/agentvillage
+   cd ../../..
+   git -C packages/edge-city/agentvillage fetch origin main
+   git -C packages/edge-city/agentvillage checkout origin/main
+   git add packages/edge-city/agentvillage
    git commit -m "chore(agentvillage): update submodule"
    ```
 
 ## Migration preservation note
 
-When `packages/agentvillage` was converted from tracked subtree files to a submodule, the tracked tree in `indexnetwork/index` matched `Edge-City/agentvillage@3831d4a790d75786fc36a7ad7049a04f459a89aa` exactly:
+When `packages/edge-city/agentvillage` was converted from tracked subtree files to a submodule, the tracked tree in `indexnetwork/index` matched `Edge-City/agentvillage@3831d4a790d75786fc36a7ad7049a04f459a89aa` exactly:
 
 ```text
 index tree: 0123d7e8541e55d9705aaccdf69b93edf79566dc

--- a/frontend/src/app/u/[id]/chat/page.tsx
+++ b/frontend/src/app/u/[id]/chat/page.tsx
@@ -20,20 +20,22 @@ export default function ChatPage() {
   const prefillMessage = initialState?.prefill ?? searchParams.get('msg') ?? undefined;
   const autoSend = initialState?.autoSend ?? false;
   const pendingOpportunityId = initialState?.opportunityId ?? undefined;
-  const { isAuthenticated, isLoading: authLoading } = useAuthContext();
+  const { isAuthenticated, isLoading: authLoading, openLoginModal } = useAuthContext();
   const usersService = useUsers();
   const opportunitiesService = useOpportunities();
   const opportunityAcceptedRef = useRef(false);
+  const loginPromptedRef = useRef(false);
 
   const [profileData, setProfileData] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!authLoading && !isAuthenticated) {
-      navigate('/');
+    if (!authLoading && !isAuthenticated && !loginPromptedRef.current) {
+      loginPromptedRef.current = true;
+      openLoginModal(window.location.href);
     }
-  }, [authLoading, isAuthenticated, navigate]);
+  }, [authLoading, isAuthenticated, openLoginModal]);
 
   useEffect(() => {
     const fetchData = async () => {

--- a/frontend/src/components/ChatContent.tsx
+++ b/frontend/src/components/ChatContent.tsx
@@ -1796,6 +1796,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
                           userId: draft.counterparty.userId,
                           name: draft.counterparty.name ?? "New connection",
                           mainText:
+                            draft.personalizedSummary ??
                             draft.opportunity.interpretation?.reasoning ??
                             "Accepted draft opportunity",
                           primaryActionLabel: "Start Chat",

--- a/frontend/src/contexts/AIChatContext.tsx
+++ b/frontend/src/contexts/AIChatContext.tsx
@@ -38,6 +38,7 @@ export interface StreamingDraft {
     interpretation?: { reasoning?: string };
     actors?: Array<{ userId: string; role?: string }>;
   };
+  personalizedSummary?: string;
   counterparty: {
     userId: string;
     name?: string;
@@ -790,6 +791,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
                     const draft: StreamingDraft = {
                       opportunityId: event.opportunityId,
                       opportunity: event.opportunity,
+                      personalizedSummary: event.personalizedSummary,
                       counterparty: event.counterparty,
                       receivedAt: Date.now(),
                     };

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -15,7 +15,7 @@ type AuthContextType = {
   error: string | null;
   refetchUser: () => Promise<void>;
   updateUser: (user: User) => void;
-  openLoginModal: () => void;
+  openLoginModal: (callbackURL?: string) => void;
   signOut: () => Promise<void>;
 };
 
@@ -30,6 +30,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [userFetchAttempted, setUserFetchAttempted] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [loginModalOpen, setLoginModalOpen] = useState(false);
+  const [pendingCallbackURL, setPendingCallbackURL] = useState<string | undefined>(undefined);
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const api = useAuthenticatedAPI();
@@ -42,7 +43,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUser(updatedUser);
   }, []);
 
-  const openLoginModal = useCallback(() => {
+  const openLoginModal = useCallback((callbackURL?: string) => {
+    setPendingCallbackURL(callbackURL);
     setLoginModalOpen(true);
   }, []);
 
@@ -188,7 +190,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       )}
       <AuthModal
         isOpen={loginModalOpen}
-        onClose={() => setLoginModalOpen(false)}
+        onClose={() => { setPendingCallbackURL(undefined); setLoginModalOpen(false); }}
+        callbackURL={pendingCallbackURL}
       />
     </AuthContext.Provider>
   );

--- a/packages/edge-city/README.md
+++ b/packages/edge-city/README.md
@@ -1,0 +1,58 @@
+# Edge-City submodules
+
+This directory contains Edge-City-owned repositories mounted as git submodules for local development context inside `indexnetwork/index`.
+
+## Submodules
+
+- `agentvillage` → `Edge-City/agentvillage`
+- `agentvillage-landing` → `Edge-City/agentvillage-landing`
+- `agentvillage-controlplane` → `Edge-City/agentvillage-controlplane`
+
+The monorepo stores only each submodule path, URL, and pinned commit SHA. Source contents remain owned by the Edge-City repositories, and private repositories require GitHub access.
+
+## Initialize
+
+After cloning `indexnetwork/index`, initialize all Edge-City submodules:
+
+```bash
+git submodule update --init packages/edge-city/agentvillage packages/edge-city/agentvillage-landing packages/edge-city/agentvillage-controlplane
+```
+
+Or initialize every submodule in the repository:
+
+```bash
+git submodule update --init --recursive
+```
+
+## Fetch latest upstream changes
+
+Submodules are pinned by commit. To update one pointer after upstream changes land:
+
+```bash
+git -C packages/edge-city/<repo> fetch origin main
+git -C packages/edge-city/<repo> checkout origin/main
+git add packages/edge-city/<repo>
+git commit -m "chore(edge-city): update <repo> submodule"
+```
+
+Replace `<repo>` with `agentvillage`, `agentvillage-landing`, or `agentvillage-controlplane`.
+
+## Make changes
+
+Do not treat `indexnetwork/index` as the source of truth for Edge-City code. Make code changes inside the submodule repository, then open a PR against the canonical Edge-City repo:
+
+```bash
+cd packages/edge-city/<repo>
+git checkout main
+git pull origin main
+git checkout -b <branch>
+# edit, test, commit, and push to a fork or branch
+gh pr create --repo Edge-City/<repo> --base main
+```
+
+After the Edge-City PR merges, update the pinned submodule commit in this monorepo using the fetch/latest flow above.
+
+## Notes
+
+- `agentvillage-landing` and `agentvillage-controlplane` are private repositories; CI and developers need explicit access.
+- Avoid editing submodule contents and committing only the parent pointer unless the corresponding Edge-City branch/PR already contains those commits.

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -22,7 +22,6 @@
   "dependencies": {
     "@langchain/core": "^1.1.17",
     "@langchain/langgraph": "^1.1.2",
-    "@langchain/langgraph-checkpoint-postgres": "^1.0.0",
     "@langchain/openai": "^1.2.3",
     "@modelcontextprotocol/server": "^2.0.0-alpha.2",
     "dotenv": "^16.3.1",

--- a/packages/protocol/src/chat/chat.agent.ts
+++ b/packages/protocol/src/chat/chat.agent.ts
@@ -89,6 +89,8 @@ export type AgentStreamEvent =
       type: "opportunity_draft_ready";
       opportunityId: string;
       opportunity: Opportunity;
+      /** Viewer-centric summary derived from interpretation.reasoning via viewerCentricCardSummary. */
+      personalizedSummary?: string;
       counterparty: {
         userId: string;
         name?: string;

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -6,14 +6,11 @@ export type { ChatTools } from "./shared/agent/tool.factory.js";
 export type { ModelConfig, ModelSettings } from "./shared/agent/model.config.js";
 export type {
   ToolContext,
-  ToolErrorReport,
   ResolvedToolContext,
   ToolDeps,
   ProtocolDeps,
-  DefineTool,
   RawToolDefinition,
   CompiledGraph,
-  ToolRegistry,
 } from "./shared/agent/tool.helpers.js";
 export { ChatContextAccessError, resolveChatContext } from "./shared/agent/tool.helpers.js";
 export { requestContext } from "./shared/observability/request-context.js";
@@ -97,6 +94,23 @@ export {
   type QuestionAnswer,
 } from "./shared/schemas/question.schema.js";
 export type { PendingQuestionSummary } from "./shared/schemas/pending-question.schema.js";
+export type { McpAuthInput } from "./shared/schemas/mcp-auth.schema.js";
+export {
+  ProfileIdentitySchema,
+  ProfileNarrativeSchema,
+  ProfileAttributesSchema,
+  ProfileDocumentSchema,
+  type ProfileDocument,
+} from "./shared/schemas/profile.schema.js";
+export type {
+  DiscoverySourceProfile,
+  DiscoverySummary,
+  DiscoveryNegotiation,
+  DiscoveryTurn,
+  DiscoveryOutcome,
+  DiscoveryQuestionInput,
+  NegotiationRole,
+} from "./shared/schemas/discovery-question.schema.js";
 
 // ─── Graph factories ──────────────────────────────────────────────────────────
 
@@ -166,15 +180,6 @@ export { createOpportunityTools } from "./opportunity/opportunity.tools.js";
 export { createProfileTools } from "./profile/profile.tools.js";
 export type { PresenterDatabase } from "./opportunity/opportunity.presenter.js";
 export { QuestionGenerator } from "./opportunity/question.generator.js";
-export type {
-  DiscoveryQuestionInput,
-  DiscoveryNegotiation,
-  DiscoveryOutcome,
-  DiscoveryTurn,
-  DiscoverySummary,
-  DiscoverySourceProfile,
-  NegotiationRole,
-} from "./opportunity/question.prompt.js";
 
 // ─── Support utilities ────────────────────────────────────────────────────────
 
@@ -236,8 +241,8 @@ export type {
   NegotiationTurn,
   NegotiationOutcome,
   SeedAssessment,
-  NegotiationGraphLike,
-} from "./negotiation/negotiation.state.js";
+} from "./shared/schemas/negotiation-state.schema.js";
+export type { NegotiationGraphLike } from "./negotiation/negotiation.state.js";
 
 // ─── Streamers ────────────────────────────────────────────────────────────────
 

--- a/packages/protocol/src/mcp/mcp.server.ts
+++ b/packages/protocol/src/mcp/mcp.server.ts
@@ -10,6 +10,7 @@ import { McpServer, fromJsonSchema } from '@modelcontextprotocol/server';
 import type { ServerContext, JsonSchemaType } from '@modelcontextprotocol/server';
 
 import type { McpAuthResolver } from '../shared/interfaces/auth.interface.js';
+import type { McpAuthInput } from '../shared/schemas/mcp-auth.schema.js';
 import type { ToolDeps, ResolvedToolContext } from '../shared/agent/tool.helpers.js';
 import { resolveChatContext } from '../shared/agent/tool.helpers.js';
 import type { Question } from '../shared/schemas/question.schema.js';
@@ -413,6 +414,35 @@ After \`discover_opportunities\`, the tool result may include a second text bloc
 **Elicitation-capable clients** (those that declared \`elicitation\` support in \`initialize\`): the server dispatches \`elicitation/create\` requests directly — answers are written back to the chat session automatically. You will not see the envelope as a follow-up task in that case.
 `.trim();
 
+/**
+ * Extracts a Bearer token from an HTTP Authorization header.
+ */
+export function extractBearerToken(req: Request): string | undefined {
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader) return undefined;
+  const [scheme, token] = authHeader.trim().split(/\s+/, 2);
+  if (scheme?.toLowerCase() === 'bearer' && token) return token;
+  return undefined;
+}
+
+/**
+ * Normalizes the x-index-surface header to a typed surface value.
+ * Unknown or absent values collapse to 'web'.
+ */
+let hasWarnedInvalidSurface = false;
+export function parseClientSurface(raw: string | null): 'telegram' | 'web' {
+  if (raw === null || raw === '') return 'web';
+  const trimmed = raw.trim().toLowerCase();
+  if (trimmed === '') return 'web';
+  if (trimmed === 'telegram') return 'telegram';
+  if (trimmed === 'web') return 'web';
+  if (!hasWarnedInvalidSurface) {
+    hasWarnedInvalidSurface = true;
+    logger.warn('Unknown x-index-surface value (collapsing to web; warning once per process)');
+  }
+  return 'web';
+}
+
 export function createMcpServer(
   deps: ToolDeps,
   authResolver: McpAuthResolver,
@@ -455,8 +485,17 @@ export function createMcpServer(
             };
           }
 
-          // Resolve authenticated identity (userId + optional agentId + optional network scope + optional surface)
-          const { userId, agentId, isSessionAuth, networkScopeId, clientSurface } = await authResolver.resolveIdentity(httpReq);
+          // Extract transport-neutral auth input DTO from the HTTP request
+          const mcpAuthInput: McpAuthInput = {
+            bearerToken: extractBearerToken(httpReq),
+            apiKey: httpReq.headers.get('x-api-key') ?? undefined,
+            clientSurface: parseClientSurface(httpReq.headers.get('x-index-surface')),
+            telegramHandle: httpReq.headers.get('x-index-telegram-handle') ?? undefined,
+            telegramUsername: httpReq.headers.get('x-index-telegram-username') ?? undefined,
+          };
+
+          // Resolve authenticated identity from the auth input DTO
+          const { userId, agentId, isSessionAuth, networkScopeId, clientSurface } = await authResolver.resolveIdentity(mcpAuthInput);
           reportUserId = userId;
 
           // Per-principal MCP throttle. Runs BEFORE any DB work so a throttled

--- a/packages/protocol/src/mcp/tests/mcp.server.spec.ts
+++ b/packages/protocol/src/mcp/tests/mcp.server.spec.ts
@@ -10,7 +10,7 @@ import { config } from "dotenv";
 config({ path: ".env.test", override: true });
 
 import { describe, test, expect } from "bun:test";
-import { MCP_INSTRUCTIONS, sanitizeMcpResult, buildMcpOnboardingMessage, ONBOARDING_ALLOWED, shouldReportMcpToolError } from "../mcp.server.js";
+import { MCP_INSTRUCTIONS, sanitizeMcpResult, buildMcpOnboardingMessage, ONBOARDING_ALLOWED, shouldReportMcpToolError, extractBearerToken, parseClientSurface } from "../mcp.server.js";
 import type { ResolvedToolContext } from "../../shared/agent/tool.helpers.js";
 import { ToolRuntimeError } from "../../shared/agent/tool.runtime.js";
 
@@ -210,6 +210,50 @@ describe("shouldReportMcpToolError", () => {
 
   test("reports unexpected tool failures", () => {
     expect(shouldReportMcpToolError(new Error("database unavailable"))).toBe(true);
+  });
+});
+
+describe("extractBearerToken", () => {
+  function requestWithAuthorization(value?: string): Request {
+    return new Request("https://example.test/mcp", {
+      headers: value === undefined ? undefined : { Authorization: value },
+    });
+  }
+
+  test("returns undefined when Authorization is missing", () => {
+    expect(extractBearerToken(requestWithAuthorization())).toBeUndefined();
+  });
+
+  test("extracts bearer token case-insensitively", () => {
+    expect(extractBearerToken(requestWithAuthorization("Bearer token-123"))).toBe("token-123");
+    expect(extractBearerToken(requestWithAuthorization("bearer token-456"))).toBe("token-456");
+  });
+
+  test("allows extra whitespace around bearer credentials", () => {
+    expect(extractBearerToken(requestWithAuthorization("  Bearer   spaced-token  "))).toBe("spaced-token");
+  });
+
+  test("rejects wrong schemes and missing tokens", () => {
+    expect(extractBearerToken(requestWithAuthorization("Basic token-123"))).toBeUndefined();
+    expect(extractBearerToken(requestWithAuthorization("Bearer"))).toBeUndefined();
+  });
+});
+
+describe("parseClientSurface", () => {
+  test("defaults absent, empty, and whitespace-only values to web", () => {
+    expect(parseClientSurface(null)).toBe("web");
+    expect(parseClientSurface("")).toBe("web");
+    expect(parseClientSurface("   ")).toBe("web");
+  });
+
+  test("normalizes known surfaces", () => {
+    expect(parseClientSurface("telegram")).toBe("telegram");
+    expect(parseClientSurface(" Telegram ")).toBe("telegram");
+    expect(parseClientSurface("WEB")).toBe("web");
+  });
+
+  test("coerces unknown surfaces to web", () => {
+    expect(parseClientSurface("slack")).toBe("web");
   });
 });
 

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -37,6 +37,7 @@ import type { OpportunityGraphDatabase } from '../shared/interfaces/database.int
 import { IntentIndexer } from '../intent/intent.indexer.js';
 import { getModelName } from '../shared/agent/model.config.js';
 import { validateOpportunityActors } from './opportunity.utils.js';
+import { viewerCentricCardSummary } from './opportunity.presentation.js';
 
 /** Optional evaluator for testing (avoids LLM calls). */
 export type OpportunityEvaluatorLike = {
@@ -2079,10 +2080,21 @@ export class OpportunityGraphFactory {
             });
           if (!updated || abortSignal?.aborted) return;
 
+          const counterpartName = candidate.candidateUser.profile?.name ?? '';
+          const viewerName = sourceUser.profile.name;
+          const rawReasoning = updated.interpretation?.reasoning ?? '';
+          const personalizedSummary = viewerCentricCardSummary(
+            rawReasoning,
+            counterpartName,
+            undefined,
+            viewerName,
+          );
+
           traceEmitter?.({
             type: 'opportunity_draft_ready',
             opportunityId: candidate.opportunityId,
             opportunity: updated,
+            personalizedSummary,
             counterparty: {
               userId: candidate.candidateUser.id,
               ...(candidate.candidateUser.profile?.name

--- a/packages/protocol/src/premise/premise.tools.ts
+++ b/packages/protocol/src/premise/premise.tools.ts
@@ -3,13 +3,13 @@ import { z } from "zod";
 import type { DefineTool, ToolDeps } from "../shared/agent/tool.helpers.js";
 import { success, error, UUID_REGEX } from "../shared/agent/tool.helpers.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
-import type { PremiseGraphDatabase, PremiseRecord, PremiseValidity } from "../shared/interfaces/database.interface.js";
+import type { PremiseRecord, PremiseValidity } from "../shared/interfaces/database.interface.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("ChatTools:Premise");
 
 export function createPremiseTools(defineTool: DefineTool, deps: ToolDeps) {
-  const database = deps.database as unknown as PremiseGraphDatabase;
+  const database = deps.database;
   const premiseGraph = deps.graphs.premise;
 
   // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/protocol/src/shared/agent/tool.factory.ts
+++ b/packages/protocol/src/shared/agent/tool.factory.ts
@@ -1,6 +1,6 @@
 import { tool } from "@langchain/core/tools";
 import { z } from "zod";
-import type { HydeGraphDatabase, PremiseGraphDatabase } from "../interfaces/database.interface.js";
+import type { HydeGraphDatabase } from "../interfaces/database.interface.js";
 import { IntentGraphFactory } from "../../intent/intent.graph.js";
 import { ProfileGraphFactory } from "../../profile/profile.graph.js";
 import { OpportunityGraphFactory } from "../../opportunity/opportunity.graph.js";
@@ -127,7 +127,7 @@ export async function createChatTools(
     : undefined;
 
   const intentGraph = new IntentGraphFactory(database, embedder, deps.intentQueue, sessionAwareEnqueue).createGraph();
-  const premiseGraph = new PremiseGraphFactory(database as unknown as PremiseGraphDatabase, embedder).createGraph();
+  const premiseGraph = new PremiseGraphFactory(database, embedder).createGraph();
   const profileGraph = new ProfileGraphFactory(database, scraper, deps.enricher, sessionAwareEnqueue, premiseGraph).createGraph();
   const hydeCache = deps.hydeCache;
   const lensInferrer = new LensInferrer();

--- a/packages/protocol/src/shared/agent/tool.helpers.ts
+++ b/packages/protocol/src/shared/agent/tool.helpers.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { ModelConfig } from "./model.config.js";
-import type { ProfileDocument } from "../../profile/profile.generator.js";
+import type { ProfileDocument } from "../schemas/profile.schema.js";
 import type {
   ChatGraphCompositeDatabase,
   NetworkMembership,

--- a/packages/protocol/src/shared/interfaces/agent-dispatcher.interface.ts
+++ b/packages/protocol/src/shared/interfaces/agent-dispatcher.interface.ts
@@ -6,7 +6,7 @@
  * The concrete implementation lives in the host application.
  */
 
-import type { NegotiationTurn, UserNegotiationContext, SeedAssessment } from '../../negotiation/negotiation.state.js';
+import type { NegotiationTurn, UserNegotiationContext, SeedAssessment } from '../schemas/negotiation-state.schema.js';
 
 /** Payload sent to the dispatcher for each negotiation turn. */
 export interface NegotiationTurnPayload {

--- a/packages/protocol/src/shared/interfaces/auth.interface.ts
+++ b/packages/protocol/src/shared/interfaces/auth.interface.ts
@@ -1,13 +1,18 @@
+import type { McpAuthInput } from '../schemas/mcp-auth.schema.js';
+
 /**
- * Resolves the authenticated MCP identity from an incoming request.
- * Injected into the MCP server factory so the protocol layer
- * stays independent of any specific auth implementation.
+ * Resolves the authenticated MCP identity from an auth input DTO.
+ * The DTO is extracted from the transport at the edge (e.g. from HTTP Request
+ * headers) before the protocol layer is called. New auth paths stay free of
+ * platform-specific `Request` coupling; `resolveUserId` remains only as a
+ * deprecated compatibility bridge while callers migrate to `resolveIdentity`.
  */
 export interface McpAuthResolver {
   /**
-   * Extracts and validates the authenticated identity from the request.
+   * Extracts and validates the authenticated identity from the auth input.
    *
-   * @param request - The incoming HTTP request
+   * @param input - Transport-neutral auth input DTO with credential fields
+   *   extracted at the MCP transport edge.
    * @returns The authenticated user's UUID, optional agent UUID, auth method,
    *   `networkScopeId` if the caller's API key is bound to a network-scoped
    *   agent, and `clientSurface` declaring which kind of UI is rendering the
@@ -20,13 +25,12 @@ export interface McpAuthResolver {
    *   `isSessionAuth` is true for OAuth/JWT bearer sessions — the agent-
    *   registration gate in the MCP server is skipped for these callers.
    *
-   *   `clientSurface` is read from the `x-index-surface` request header by the
-   *   backend implementation. Absent or unknown values collapse to `'web'`.
-   *   Only `'telegram'` activates the t.me redirect path on `/c/{code}` clicks.
+   *   `clientSurface` is passed through from the DTO. Only `'telegram'`
+   *   activates the t.me redirect path on `/c/{code}` clicks.
    *
    * @throws Error if authentication fails (no token, invalid token, etc.)
    */
-  resolveIdentity(request: Request): Promise<{
+  resolveIdentity(input: McpAuthInput): Promise<{
     userId: string;
     agentId?: string;
     isSessionAuth?: boolean;
@@ -35,6 +39,10 @@ export interface McpAuthResolver {
   }>;
 
   /**
+   * Deprecated HTTP Request bridge retained for compatibility with older
+   * callers. New transport code must extract `McpAuthInput` at the edge and
+   * call `resolveIdentity` instead.
+   *
    * @deprecated Use resolveIdentity instead.
    */
   resolveUserId(request: Request): Promise<string>;

--- a/packages/protocol/src/shared/interfaces/database.interface.ts
+++ b/packages/protocol/src/shared/interfaces/database.interface.ts
@@ -1,4 +1,4 @@
-import { ProfileDocument } from '../../profile/profile.generator.js';
+import type { ProfileDocument } from '../schemas/profile.schema.js';
 
 // ─── Inlined types (previously imported from outside the protocol lib) ───────
 
@@ -2050,8 +2050,14 @@ export type ChatGraphCompositeDatabase = Pick<
   | 'findDuplicateUser'
   | 'mergeGhostUser'
   // ProfileGraph aggregate mode (premise-to-profile materialization)
+  // Premise lifecycle (CRUD + network assignment)
   | 'getPremisesForUser'
   | 'getPremisesForUserInNetworks'
+  | 'createPremise'
+  | 'getPremise'
+  | 'updatePremise'
+  | 'assignPremiseToNetwork'
+  | 'getPremiseNetworks'
   // Premise-to-premise discovery (path D) in OpportunityGraph
   | 'searchPremisesBySimilarity'
   | 'searchPremisesBySimilarityBatch'

--- a/packages/protocol/src/shared/interfaces/question-generator.interface.ts
+++ b/packages/protocol/src/shared/interfaces/question-generator.interface.ts
@@ -7,7 +7,7 @@
  * its own LLM-bound `QuestionGenerator` — callers inject one (or `undefined` to
  * opt out).
  */
-import type { DiscoveryQuestionInput } from "../../opportunity/question.prompt.js";
+import type { DiscoveryQuestionInput } from "../schemas/discovery-question.schema.js";
 import type { QuestionGenerationResult } from "../schemas/question.schema.js";
 
 export interface QuestionGeneratorReader {

--- a/packages/protocol/src/shared/observability/request-context.ts
+++ b/packages/protocol/src/shared/observability/request-context.ts
@@ -27,6 +27,8 @@ export type TraceEmitter = (
         type: "opportunity_draft_ready";
         opportunityId: string;
         opportunity: Opportunity;
+        /** Viewer-centric summary derived from interpretation.reasoning. */
+        personalizedSummary?: string;
         /**
          * Minimal counterparty data for rendering the inline card without a
          * second-round-trip user lookup. Populated from the negotiation

--- a/packages/protocol/src/shared/schemas/discovery-question.schema.ts
+++ b/packages/protocol/src/shared/schemas/discovery-question.schema.ts
@@ -1,0 +1,85 @@
+/**
+ * DiscoveryQuestionInput and nested types.
+ * Leaf types have full Zod schemas. The composite DiscoveryQuestionInput is
+ * a pure interface referencing cross-schema types (DiscoveryNegotiationDigest,
+ * ChatContextDigest) to avoid Zod cross-schema runtime coupling.
+ */
+import { z } from "zod";
+import type { DiscoveryNegotiationDigest } from "./negotiation-digest.schema.js";
+import type { ChatContextDigest } from "./chat-context.schema.js";
+
+// ─── Primitives ───────────────────────────────────────────────────────────────
+
+export const NegotiationRoleSchema = z.enum(["agent", "patient", "peer"]);
+export type NegotiationRole = z.infer<typeof NegotiationRoleSchema>;
+
+export const DiscoveryTurnSchema = z.object({
+  action: z.enum(["propose", "accept", "reject", "counter", "question"]),
+  reasoning: z.string(),
+  suggestedRoles: z.object({
+    ownUser: NegotiationRoleSchema,
+    otherUser: NegotiationRoleSchema,
+  }),
+});
+export type DiscoveryTurn = z.infer<typeof DiscoveryTurnSchema>;
+
+export const DiscoveryOutcomeSchema = z.object({
+  hasOpportunity: z.boolean(),
+  reasoning: z.string(),
+  agreedRoles: z.array(z.object({
+    userId: z.string(),
+    role: NegotiationRoleSchema,
+  })).optional(),
+  reason: z.enum(["turn_cap", "timeout"]).optional(),
+});
+export type DiscoveryOutcome = z.infer<typeof DiscoveryOutcomeSchema>;
+
+export const DiscoveryNegotiationSchema = z.object({
+  counterpartyId: z.string(),
+  counterpartyHint: z.string(),
+  indexContext: z.string(),
+  turns: z.array(DiscoveryTurnSchema),
+  outcome: DiscoveryOutcomeSchema,
+  seedAssessmentScore: z.number().optional(),
+});
+export type DiscoveryNegotiation = z.infer<typeof DiscoveryNegotiationSchema>;
+
+export const DiscoverySummarySchema = z.object({
+  totalCandidates: z.number(),
+  opportunitiesFound: z.number(),
+  noOpportunityCount: z.number(),
+  timeoutCount: z.number(),
+  roleDistribution: z.record(NegotiationRoleSchema, z.number()),
+});
+export type DiscoverySummary = {
+  totalCandidates: number;
+  opportunitiesFound: number;
+  noOpportunityCount: number;
+  timeoutCount: number;
+  roleDistribution: Partial<Record<NegotiationRole, number>>;
+};
+
+export const DiscoverySourceProfileSchema = z.object({
+  name: z.string().optional(),
+  bio: z.string().optional(),
+  location: z.string().optional(),
+  skills: z.array(z.string()).optional(),
+  interests: z.array(z.string()).optional(),
+});
+export type DiscoverySourceProfile = z.infer<typeof DiscoverySourceProfileSchema>;
+
+// ─── Composite input (pure interface — references cross-schema types) ─────────
+
+/**
+ * Full input to the question generator.
+ * Defined as a pure interface so it can reference DiscoveryNegotiationDigest
+ * and ChatContextDigest from sibling schemas without Zod runtime coupling.
+ */
+export interface DiscoveryQuestionInput {
+  query: string;
+  sourceProfile: DiscoverySourceProfile;
+  negotiationDigests: DiscoveryNegotiationDigest[];
+  summary: DiscoverySummary;
+  chatContext?: ChatContextDigest;
+  now: string;
+}

--- a/packages/protocol/src/shared/schemas/mcp-auth.schema.ts
+++ b/packages/protocol/src/shared/schemas/mcp-auth.schema.ts
@@ -1,0 +1,17 @@
+/**
+ * McpAuthInput — plain DTO extracted from the MCP HTTP request at the transport
+ * edge before the protocol auth resolver is called. Keeps the shared auth
+ * interface free of platform-specific `Request` coupling.
+ */
+export interface McpAuthInput {
+  /** Authorization Bearer token (JWT or opaque session token). */
+  bearerToken?: string;
+  /** API key for agent/API-key authentication. */
+  apiKey?: string;
+  /** Client surface hint for UI branching (telegram vs web). */
+  clientSurface?: 'telegram' | 'web';
+  /** Telegram handle for identity verification (extracted from request headers). */
+  telegramHandle?: string;
+  /** Telegram username for identity verification (extracted from request headers). */
+  telegramUsername?: string;
+}

--- a/packages/protocol/src/shared/schemas/negotiation-state.schema.ts
+++ b/packages/protocol/src/shared/schemas/negotiation-state.schema.ts
@@ -1,0 +1,49 @@
+/**
+ * Negotiation state DTOs extracted from negotiation/negotiation.state.ts for
+ * consumption by shared interfaces. This shared module owns the DTO schemas;
+ * LangGraph Annotation.Root stays in the domain file.
+ */
+import { z } from "zod";
+
+// ─── Zod schemas (available for runtime validation) ───────────────────────────
+
+export const NegotiationTurnSchema = z.object({
+  action: z.enum(["propose", "accept", "reject", "counter", "question"]),
+  assessment: z.object({
+    reasoning: z.string(),
+    suggestedRoles: z.object({
+      ownUser: z.enum(["agent", "patient", "peer"]),
+      otherUser: z.enum(["agent", "patient", "peer"]),
+    }),
+  }),
+  message: z.string().nullable().optional(),
+});
+export type NegotiationTurn = z.infer<typeof NegotiationTurnSchema>;
+
+export const NegotiationOutcomeSchema = z.object({
+  hasOpportunity: z.boolean(),
+  agreedRoles: z.array(z.object({
+    userId: z.string(),
+    role: z.enum(["agent", "patient", "peer"]),
+  })),
+  reasoning: z.string(),
+  turnCount: z.number(),
+  reason: z.enum(["turn_cap", "timeout"]).optional(),
+});
+export type NegotiationOutcome = z.infer<typeof NegotiationOutcomeSchema>;
+
+// ─── Pure interfaces ──────────────────────────────────────────────────────────
+
+/** Context each agent receives about its user. */
+export interface UserNegotiationContext {
+  id: string;
+  intents: Array<{ id: string; title: string; description: string; confidence: number }>;
+  profile: { name?: string; bio?: string; location?: string; interests?: string[]; skills?: string[] };
+}
+
+/** Seed assessment from the evaluator pre-filter. */
+export interface SeedAssessment {
+  reasoning: string;
+  valencyRole: string;
+  actors?: Array<{ userId: string; role: string }>;
+}

--- a/packages/protocol/src/shared/schemas/profile.schema.ts
+++ b/packages/protocol/src/shared/schemas/profile.schema.ts
@@ -1,0 +1,31 @@
+/**
+ * ProfileDocument DTO — pure Zod schema and inferred type.
+ * Shared contract for the database/interface layer.
+ * The LLM-facing Zod schema with .describe() annotations lives in
+ * profile/profile.generator.ts alongside the generator itself.
+ */
+import { z } from "zod";
+
+export const ProfileIdentitySchema = z.object({
+  name: z.string(),
+  bio: z.string(),
+  location: z.string(),
+});
+
+export const ProfileNarrativeSchema = z.object({
+  context: z.string(),
+});
+
+export const ProfileAttributesSchema = z.object({
+  interests: z.array(z.string()),
+  skills: z.array(z.string()),
+});
+
+export const ProfileDocumentSchema = z.object({
+  userId: z.string(),
+  identity: ProfileIdentitySchema,
+  narrative: ProfileNarrativeSchema,
+  attributes: ProfileAttributesSchema,
+});
+
+export type ProfileDocument = z.infer<typeof ProfileDocumentSchema>;


### PR DESCRIPTION
## Release changelog

### Highlights
- Improves connect-link and chat handoff behavior: expired links now fail cleanly or forward to live replacements, latent replacements can start chat, viewer-facing opportunity cards use personalized summaries, and unauthenticated connect-link visitors keep their target chat URL plus prefilled `msg` through login.
- Cleans up protocol package boundaries by moving shared DTOs/schemas out of domain modules, narrowing public exports, removing platform `Request` coupling from MCP auth, and tightening premise/database interfaces.
- Adds rpiv architecture guidance, planning/validation artifacts, project MCP/pi configuration, and release/review workflow skills.
- Reorganizes Edge-City packages under `packages/edge-city/` and documents the submodule workflow.

### Changes

#### Bug Fixes
- fix(chat): use viewer-centric summary on orchestrator opportunity cards (`2fa20b60dd`)
- fix(backend): forward expired connect links to replacement opportunities and handle latent in startChat (`850b991c59`)
- fix(frontend): preserve deep-link URL and msg for unauthenticated connect-link visitors (`e6514ed99e`)

#### Refactors
- refactor(protocol): fix package boundary violations — DTO extraction, API narrowing, premise type safety, MCP auth refactor (#925) (`eba9fa8779`)

#### Documentation
- docs: add architecture guidance annotations (`c43ab654f5`)
- docs: add rpiv design artifacts for IND-354 connect-links auth redirect (`2c849825f7`)

#### Chores
- chore: relax Claude command permissions (`249dad0b84`)
- Revert "chore: relax Claude command permissions" (`efb2a5e16`)
- chore: relax Claude command permissions (`7100df3f16`)
- chore(edge-city): group Edge-City submodules (`53e3fec370`)
- chore: add project MCP config (`cc4ceda7aa`)
- Merge branch 'main' into dev (`fa65560c1b`)

### Issues and PRs
- GitHub PR [#925](https://github.com/indexnetwork/index/pull/925) — refactor(protocol): fix package boundary violations — DTO extraction, API narrowing, premise type safety, MCP auth refactor (merged)
- Linear [IND-354](https://linear.app/indexnetwork/issue/IND-354/connect-links-c-drop-unauthenticated-users-on-homepage-losing-chat) — Connect links (/c/...) drop unauthenticated users on homepage, losing chat + prefilled message (In Review)

### Diff summary
```text
 .claude/settings.json                              |  24 +-
 .gitignore                                         |  47 +-
 .gitmodules                                        |  12 +-
 .mcp.json                                          |  22 +
 .pi/npm/.gitignore                                 |   2 +
 .pi/settings.json                                  |  12 +
 .pi/skills/finish-pr/SKILL.md                      | 256 +++++++++
 .pi/skills/open-release-pr/SKILL.md                | 239 ++++++++
 .pi/skills/receiving-code-review/SKILL.md          | 274 +++++++++
 ...6-06-09_11-18-44_protocol-package-violations.md | 617 ++++++++++++++++++++
 ...6-06-09_11-48-41_connect-links-auth-redirect.md | 248 ++++++++
 ...6-06-09_11-05-29_connect-links-auth-redirect.md | 120 ++++
 ...12-54-22_ind-354-connect-links-auth-redirect.md | 189 ++++++
 ...6-06-09_13-10-22_protocol-package-violations.md | 633 +++++++++++++++++++++
 ...6-06-09_10-42-15_protocol-package-violations.md | 286 ++++++++++
 ...6-06-09_11-18-58_connect-links-auth-redirect.md | 194 +++++++
 ...13-10-12_ind-354-connect-links-auth-redirect.md |  65 +++
 ...6-06-09_13-55-40_protocol-package-violations.md | 120 ++++
 .rpiv/guidance/architecture.md                     |  62 ++
 .rpiv/guidance/backend/architecture.md             |  71 +++
 .../guidance/backend/src/adapters/architecture.md  |  58 ++
 .../backend/src/controllers/architecture.md        |  67 +++
 .rpiv/guidance/backend/src/events/architecture.md  |  64 +++
 .rpiv/guidance/backend/src/lib/architecture.md     |  59 ++
 .rpiv/guidance/backend/src/queues/architecture.md  |  69 +++
 .rpiv/guidance/backend/src/schemas/architecture.md |  56 ++
 .../guidance/backend/src/services/architecture.md  |  62 ++
 .rpiv/guidance/frontend/architecture.md            |  67 +++
 .rpiv/guidance/frontend/src/app/architecture.md    |  60 ++
 .../frontend/src/components/architecture.md        |  67 +++
 .../guidance/frontend/src/contexts/architecture.md |  73 +++
 .../guidance/frontend/src/services/architecture.md |  65 +++
 .../packages/claude-plugin/architecture.md         |  75 +++
 .rpiv/guidance/packages/cli/architecture.md        |  61 ++
 .rpiv/guidance/packages/cli/src/architecture.md    |  78 +++
 .rpiv/guidance/packages/protocol/architecture.md   |  70 +++
 .../packages/protocol/src/chat/architecture.md     |  65 +++
 .../packages/protocol/src/intent/architecture.md   |  65 +++
 .../protocol/src/negotiation/architecture.md       |  78 +++
 .../protocol/src/opportunity/architecture.md       |  82 +++
 .../packages/protocol/src/shared/architecture.md   |  61 ++
 .../protocol/src/shared/interfaces/architecture.md |  55 ++
 CLAUDE.md                                          |  20 +-
 backend/src/controllers/mcp.controller.ts          |  69 ++-
 bun.lock                                           |   3 +-
 docs/guides/agentvillage-submodule.md              |  16 +-
 frontend/src/app/u/[id]/chat/page.tsx              |  10 +-
 frontend/src/contexts/AuthContext.tsx              |   9 +-
 packages/edge-city/README.md                       |  58 ++
 packages/{ => edge-city}/agentvillage              |   0
 packages/edge-city/agentvillage-controlplane       |   1 +
 packages/edge-city/agentvillage-landing            |   1 +
 packages/protocol/package.json                     |   3 +-
 packages/protocol/src/index.ts                     |  33 +-
 packages/protocol/src/mcp/mcp.server.ts            |  43 +-
 packages/protocol/src/mcp/tests/mcp.server.spec.ts |  46 +-
 packages/protocol/src/premise/premise.tools.ts     |   4 +-
 packages/protocol/src/shared/agent/tool.factory.ts |   4 +-
 packages/protocol/src/shared/agent/tool.helpers.ts |   2 +-
 .../interfaces/agent-dispatcher.interface.ts       |   2 +-
 .../src/shared/interfaces/auth.interface.ts        |  26 +-
 .../src/shared/interfaces/database.interface.ts    |   8 +-
 .../interfaces/question-generator.interface.ts     |   2 +-
 .../shared/schemas/discovery-question.schema.ts    |  85 +++
 .../protocol/src/shared/schemas/mcp-auth.schema.ts |  17 +
 .../src/shared/schemas/negotiation-state.schema.ts |  49 ++
 .../protocol/src/shared/schemas/profile.schema.ts  |  31 +
 67 files changed, 5343 insertions(+), 149 deletions(-)
```

### Changed files
```text
M	.claude/settings.json
M	.gitignore
M	.gitmodules
A	.mcp.json
A	.pi/npm/.gitignore
A	.pi/settings.json
A	.pi/skills/finish-pr/SKILL.md
A	.pi/skills/open-release-pr/SKILL.md
A	.pi/skills/receiving-code-review/SKILL.md
A	.rpiv/artifacts/designs/2026-06-09_11-18-44_protocol-package-violations.md
A	.rpiv/artifacts/designs/2026-06-09_11-48-41_connect-links-auth-redirect.md
A	.rpiv/artifacts/discover/2026-06-09_11-05-29_connect-links-auth-redirect.md
A	.rpiv/artifacts/plans/2026-06-09_12-54-22_ind-354-connect-links-auth-redirect.md
A	.rpiv/artifacts/plans/2026-06-09_13-10-22_protocol-package-violations.md
A	.rpiv/artifacts/research/2026-06-09_10-42-15_protocol-package-violations.md
A	.rpiv/artifacts/research/2026-06-09_11-18-58_connect-links-auth-redirect.md
A	.rpiv/artifacts/validation/2026-06-09_13-10-12_ind-354-connect-links-auth-redirect.md
A	.rpiv/artifacts/validation/2026-06-09_13-55-40_protocol-package-violations.md
A	.rpiv/guidance/architecture.md
A	.rpiv/guidance/backend/architecture.md
A	.rpiv/guidance/backend/src/adapters/architecture.md
A	.rpiv/guidance/backend/src/controllers/architecture.md
A	.rpiv/guidance/backend/src/events/architecture.md
A	.rpiv/guidance/backend/src/lib/architecture.md
A	.rpiv/guidance/backend/src/queues/architecture.md
A	.rpiv/guidance/backend/src/schemas/architecture.md
A	.rpiv/guidance/backend/src/services/architecture.md
A	.rpiv/guidance/frontend/architecture.md
A	.rpiv/guidance/frontend/src/app/architecture.md
A	.rpiv/guidance/frontend/src/components/architecture.md
A	.rpiv/guidance/frontend/src/contexts/architecture.md
A	.rpiv/guidance/frontend/src/services/architecture.md
A	.rpiv/guidance/packages/claude-plugin/architecture.md
A	.rpiv/guidance/packages/cli/architecture.md
A	.rpiv/guidance/packages/cli/src/architecture.md
A	.rpiv/guidance/packages/protocol/architecture.md
A	.rpiv/guidance/packages/protocol/src/chat/architecture.md
A	.rpiv/guidance/packages/protocol/src/intent/architecture.md
A	.rpiv/guidance/packages/protocol/src/negotiation/architecture.md
A	.rpiv/guidance/packages/protocol/src/opportunity/architecture.md
A	.rpiv/guidance/packages/protocol/src/shared/architecture.md
A	.rpiv/guidance/packages/protocol/src/shared/interfaces/architecture.md
M	CLAUDE.md
M	backend/src/controllers/mcp.controller.ts
M	bun.lock
M	docs/guides/agentvillage-submodule.md
M	frontend/src/app/u/[id]/chat/page.tsx
M	frontend/src/contexts/AuthContext.tsx
A	packages/edge-city/README.md
R100	packages/agentvillage	packages/edge-city/agentvillage
A	packages/edge-city/agentvillage-controlplane
A	packages/edge-city/agentvillage-landing
M	packages/protocol/package.json
M	packages/protocol/src/index.ts
M	packages/protocol/src/mcp/mcp.server.ts
M	packages/protocol/src/mcp/tests/mcp.server.spec.ts
M	packages/protocol/src/premise/premise.tools.ts
M	packages/protocol/src/shared/agent/tool.factory.ts
M	packages/protocol/src/shared/agent/tool.helpers.ts
M	packages/protocol/src/shared/interfaces/agent-dispatcher.interface.ts
M	packages/protocol/src/shared/interfaces/auth.interface.ts
M	packages/protocol/src/shared/interfaces/database.interface.ts
M	packages/protocol/src/shared/interfaces/question-generator.interface.ts
A	packages/protocol/src/shared/schemas/discovery-question.schema.ts
A	packages/protocol/src/shared/schemas/mcp-auth.schema.ts
A	packages/protocol/src/shared/schemas/negotiation-state.schema.ts
A	packages/protocol/src/shared/schemas/profile.schema.ts
```

### Verification
- [x] Release branch created from `origin/dev` at `eba9fa87793ad561776435ee55d5eac5b0b01176`.
- [x] GitHub checks pass on this PR.
- [ ] Release PR reviewed and approved.

### Raw release range
- Base: `38d08875137d250c2c9b9a6e2768dbf409c380dc`
- Head: `eba9fa87793ad561776435ee55d5eac5b0b01176`
- Commits: `12`
