### PR TITLE
Require recipients for connect links

### DIFF
--- a/.rpiv/artifacts/designs/2026-06-10_00-15-03_recipient-bound-connect-links.md
+++ b/.rpiv/artifacts/designs/2026-06-10_00-15-03_recipient-bound-connect-links.md
@@ -1,0 +1,1410 @@
+---
+date: 2026-06-10T00:15:03+0300
+author: Yankı Ekin Yüksel
+commit: 2153450f65
+branch: main
+repository: index
+topic: "Recipient-bound connect links"
+tags: [design, connect-links, auth, opportunities, frontend]
+status: ready
+parent: /Users/aposto/Projects/index/.worktrees/research-recipient-bound-connect-links/.rpiv/artifacts/research/2026-06-09_23-41-51_recipient-bound-connect-links.md
+last_updated: 2026-06-10T00:15:03+0300
+last_updated_by: Yankı Ekin Yüksel
+---
+
+# Design: Recipient-bound Connect Links
+
+## Summary
+Recipient-bound connect links move the trust boundary from possession of a short code to an authenticated backend resolver. Public `/c/:code` no longer resolves the database row; it only bridges valid-looking codes to a frontend `/c/:code` continuation that preserves the opaque code through login and then calls authenticated `/api/c/:code/go`, where the backend compares `AuthenticatedUser.id` to `connect_links.user_id` before any greeting, approval, DM, or acceptance side effect.
+
+## Requirements
+- Require authentication before any short-link side effect for all connect-link kinds: `connect`, `send_direct`, `outreach`, and `approve_introduction`.
+- Compare the authenticated account to the resolved `connect_links.user_id`; only the intended recipient may proceed.
+- Preserve login continuity by carrying the short code through login instead of redirecting to a final `/u/:id/chat?msg=...` URL before recipient validation.
+- Preserve existing correct-recipient destinations: Telegram-preferred links still try `t.me`, web links still go to profile chat or conversation routes with greeting text.
+- Wrong-account, malformed, unknown, expired, and terminal links must present generic unavailable/not-found UX.
+- Avoid JWTs in callback URLs; use the frontend authenticated API client, which attaches `Authorization: Bearer <jwt>`.
+- Do not change schema or protocol/MCP link minting semantics; link rows already store recipient identity.
+
+## Current State Analysis
+The current short-link resolver is possession-based. Backend `/c/:code` and `/c/:code/go` are rate-limited but unauthenticated, resolve `connect_links.user_id`, and pass that stored recipient id into opportunity side-effect methods. The link rows already contain the intended recipient, but the browser account is never compared to that value.
+
+### Key Discoveries
+- `backend/src/controllers/connect-link.controller.ts:88-125` handles public `/c/:code`; it currently calls `resolveConnectLink(code)` and performs `approve_introduction` inline.
+- `backend/src/controllers/connect-link.controller.ts:133-199` handles `/c/:code/go`; it currently generates greetings, calls `startChat`, `approveIntroduction`, Telegram helpers, and conversation lookup using `link.userId` as actor.
+- `backend/src/services/connect-link.service.ts:183-193` returns a `ResolvedLink` containing stored `userId`, `opportunityId`, `kind`, `greeting`, and narrowed `preferredSurface`.
+- `backend/src/services/connect-link.service.ts:197-247` can resolve expired opportunities to recipient-visible replacements and can extend link TTL; unauthenticated `/c/:code` must not invoke this in the new flow.
+- `backend/src/guards/auth.guard.ts:26-43` verifies Better Auth JWTs from `Authorization: Bearer` or a query `token`; the chosen continuation avoids query tokens and uses bearer headers.
+- `backend/src/main.ts:489-493` rewrites backend-host `/c/*` to `/api/c/*` for controller dispatch.
+- `backend/src/main.ts:536-549` executes guards in order and passes the final guard result as the controller `user` argument.
+- `frontend/src/lib/api.ts:46-48` attaches a bearer JWT on authenticated API calls.
+- `frontend/src/contexts/AuthContext.tsx:32-47` supports `openLoginModal(callbackURL?)`; `frontend/src/components/AuthModal.tsx:57-66` and `frontend/src/components/AuthModal.tsx:114-121` pass callback URLs into magic-link and Google auth.
+- `frontend/src/contexts/AuthContext.tsx:129-140` redirects unauthenticated users away from non-public routes; `/c/` must be added as public or the short code is lost before route-level login can run.
+- `frontend/src/routes.tsx:1-153` has no `/c/:code` route today.
+- `frontend/src/app/u/[id]/chat/page.tsx:33-38` is the existing one-shot login-modal pattern that preserves `window.location.href` through auth.
+- `frontend/src/app/l/[code]/page.tsx:17-105` is the closest short-code route state-machine pattern for loading, auth-required, authenticated API, and error handling.
+
+## Scope
+### Building
+- Refactor backend `ConnectLinkController.resolve` into a no-DB public bridge for syntactically valid short codes.
+- Protect backend `ConnectLinkController.go` with `RateLimit('read'), AuthGuard` and recipient equality.
+- Return masked 404s for unknown, expired, terminal, malformed, and wrong-account resolver failures.
+- Preserve current destination construction after authorization for `connect`, `send_direct`, `outreach`, and `approve_introduction`.
+- Add a typed frontend `connect-links` service and `APIContext` hook.
+- Add frontend `/c/:code` continuation route that opens login with `window.location.href`, calls the authenticated resolver once authenticated, redirects to returned URLs, and renders confirmation/unavailable states.
+- Register `/c/:code` in React Router and add `/c/` to public route prefixes.
+- Add targeted backend and frontend regression tests for auth gating, wrong-account masking, route registration, public-prefix behavior, and link-kind preservation.
+
+### Not Building
+- No database schema changes; `connect_links.user_id` already stores recipient identity.
+- No protocol package changes; protocol/MCP already mints `acceptUrl` with `viewerId` and `preferredSurface`.
+- No JWTs in callback URLs or query params.
+- No Better Auth cookie-session support in `AuthGuard`; the frontend uses existing bearer-token API flow.
+- No changes to opportunity service semantics beyond making existing calls unreachable until recipient validation passes.
+- No redesign of final chat pages or Telegram URL behavior.
+
+## Decisions
+### Public short-link bridge does not resolve DB before auth
+**Ambiguity:** Public `/c/:code` could keep resolving rows before login for better dead-link UX, but `resolveConnectLink()` can also self-heal expired rows by extending TTL.
+
+**Explored:**
+- Option A — No DB before auth: public `/c/:code` validates only syntax and redirects/bridges the code to frontend continuation. This avoids public row lookup and TTL self-heal before account proof (`backend/src/services/connect-link.service.ts:237-247`).
+- Option B — Validate before login: public `/c/:code` keeps DB existence/expiry checks, preserving current dead-link UX but retaining unauthenticated resolve behavior (`backend/src/controllers/connect-link.controller.ts:106`).
+
+**Decision:** No DB before auth. For valid-looking codes, public `/c/:code` sends the browser to frontend `/c/:code`; authenticated `/c/:code/go` is the first DB trust point.
+
+### Wrong-account failures are masked at the backend boundary
+**Ambiguity:** The backend could return structured 403 while frontend masks it, or the backend itself could return 404 for mismatches.
+
+**Explored:**
+- Option A — Backend 404: wrong-account, missing, expired, and terminal links are indistinguishable at API boundary.
+- Option B — API 403, UI 404: clearer internal status but exposes recipient-mismatch semantics to any authenticated caller.
+
+**Decision:** Backend returns 404 for recipient mismatch. This matches the developer's Not Found UX decision and avoids a recipient oracle.
+
+### Frontend continuation uses a new connect-links service
+**Ambiguity:** The route could call `useAuthenticatedAPI()` directly like the invitation page, reuse `connectionsService`, or introduce a dedicated service.
+
+**Explored:**
+- Option A — New service: explicit `connect-links` domain boundary, typed response, and reusable hook via `APIContext`.
+- Option B — Route-local API: fewer files, but route owns URL construction.
+- Option C — Connections service: smaller than a new service, but mixes short-link continuation with connection-event actions.
+
+**Decision:** Add `frontend/src/services/connect-links.ts`, wire it through `APIContext`, and consume it via `useConnectLinks()` in the continuation route.
+
+### Existing opportunity side-effect methods remain the implementation surface
+`OpportunityService.startChat`, `approveIntroduction`, `getCounterpartTelegramHandle`, `getCounterpartTelegramHandleForOpp`, and `getConversationIdForOpp` already enforce actor/business invariants and preserve destination semantics once called with the true authenticated recipient (`backend/src/services/opportunity.service.ts:563-596`, `backend/src/services/opportunity.service.ts:640-754`, `backend/src/services/opportunity.service.ts:1141-1197`). The design changes only when and with which actor id these methods are invoked.
+
+## Architecture
+### backend/src/controllers/connect-link.controller.ts:1-199 — MODIFY
+Refactor public bridge and authenticated resolver.
+
+```ts
+import { AuthGuard, type AuthenticatedUser } from '../guards/auth.guard';
+import { RateLimit } from '../guards/limiter.guard';
+import { Controller, Get, UseGuards } from '../lib/router/router.decorators';
+import { resolveConnectLink } from '../services/connect-link.service';
+import { opportunityService } from '../services/opportunity.service';
+
+/** Route params when path has :code */
+type RouteParams = Record<string, string>;
+
+type ConnectLinkGoResponse =
+  | { url: string }
+  | { kind: 'approve_introduction' };
+
+const CODE_PATTERN = /^[A-Za-z0-9]{10}$/;
+
+const EXPIRED_HTML = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Unavailable</title></head>
+<body style="font-family:system-ui;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0">
+<div style="text-align:center"><h1 style="font-size:1.5rem">This opportunity is no longer available</h1>
+<p style="color:#666">The opportunity behind this link has expired or been closed.</p>
+</div></body></html>`;
+
+function getFrontendUrl(): string {
+  return (process.env.FRONTEND_URL || process.env.APP_URL || 'https://index.network').replace(/\/+$/, '');
+}
+
+function jsonError(message: string, status: number): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function notFoundJson(): Response {
+  return jsonError('Link not found', 404);
+}
+
+/**
+ * ConnectLinkController: opaque short-link dispatcher.
+ *
+ * Public `/c/:code` is only a bridge into the frontend continuation route. It
+ * deliberately does not resolve `connect_links` rows: account binding happens
+ * on authenticated `/c/:code/go`, where the JWT user must match the stored
+ * recipient before any opportunity side effect or destination lookup runs.
+ */
+@Controller('/c')
+export class ConnectLinkController {
+  /**
+   * GET /c/:code — public short-link bridge.
+   *
+   * Valid-looking short codes are redirected to the frontend continuation route
+   * with the same opaque code. The frontend preserves that URL through login and
+   * calls authenticated `/api/c/:code/go`. This route performs no DB lookup and
+   * no opportunity side effects.
+   */
+  @Get('/:code')
+  @UseGuards(RateLimit('read'))
+  async resolve(_req: Request, _user: unknown, params?: RouteParams) {
+    const code = params?.code;
+    if (!code) return new Response('Missing code', { status: 400 });
+
+    if (!CODE_PATTERN.test(code)) {
+      return new Response(EXPIRED_HTML, { status: 404, headers: { 'Content-Type': 'text/html' } });
+    }
+
+    return Response.redirect(`${getFrontendUrl()}/c/${code}`, 302);
+  }
+
+  /**
+   * GET /c/:code/go — authenticated JSON resolver.
+   *
+   * Resolves the short code, verifies the authenticated user is the stored
+   * recipient, then performs the kind-specific side effect and returns the final
+   * destination. Unknown, terminal, malformed, and wrong-account links are all
+   * masked as 404. No greeting generation, DM lookup, approval, or acceptance
+   * runs until the recipient check passes.
+   */
+  @Get('/:code/go')
+  @UseGuards(RateLimit('read'), AuthGuard)
+  async go(_req: Request, user: AuthenticatedUser, params?: RouteParams): Promise<Response> {
+    const code = params?.code;
+    if (!code) return jsonError('Missing code', 400);
+    if (!CODE_PATTERN.test(code)) return notFoundJson();
+
+    const link = await resolveConnectLink(code);
+    if (!link) return notFoundJson();
+    if (link.userId !== user.id) return notFoundJson();
+
+    const frontendUrl = getFrontendUrl();
+    const greetingForRecipient = async () => (
+      link.greeting ?? (await opportunityService.getGreetingForCard(link.opportunityId, user.id))
+    );
+
+    if (link.kind === 'approve_introduction') {
+      const result = await opportunityService.approveIntroduction(link.opportunityId, user.id);
+      if ('error' in result) return jsonError(result.error, result.status);
+      return Response.json({ kind: 'approve_introduction' } satisfies ConnectLinkGoResponse);
+    }
+
+    // `connect` (receiver flipping pending → accepted) and `send_direct`
+    // (sender flipping draft/latent → accepted) both want the chat open and the
+    // greeting ready to send. opportunityService.startChat handles both source
+    // statuses; the semantic difference lives in the matrix that picked `kind`.
+    if (link.kind === 'connect' || link.kind === 'send_direct') {
+      const result = await opportunityService.startChat(link.opportunityId, user.id);
+      if ('error' in result) return jsonError(result.error, result.status);
+
+      const greeting = await greetingForRecipient();
+
+      if (link.preferredSurface === 'telegram') {
+        const handle = await opportunityService.getCounterpartTelegramHandle(result.counterpartUserId);
+        const target = handle
+          ? (greeting ? `https://t.me/${handle}?text=${encodeURIComponent(greeting)}` : `https://t.me/${handle}`)
+          : (greeting
+              ? `${frontendUrl}/u/${result.counterpartUserId}/chat?msg=${encodeURIComponent(greeting)}`
+              : `${frontendUrl}/u/${result.counterpartUserId}/chat`);
+        return Response.json({ url: target } satisfies ConnectLinkGoResponse);
+      }
+
+      const target = greeting
+        ? `${frontendUrl}/u/${result.counterpartUserId}/chat?msg=${encodeURIComponent(greeting)}`
+        : `${frontendUrl}/u/${result.counterpartUserId}/chat`;
+      return Response.json({ url: target } satisfies ConnectLinkGoResponse);
+    }
+
+    if (link.kind === 'outreach') {
+      const greeting = await greetingForRecipient();
+
+      if (link.preferredSurface === 'telegram') {
+        const handle = await opportunityService.getCounterpartTelegramHandleForOpp(link.opportunityId, user.id);
+        if (handle) {
+          const target = greeting ? `https://t.me/${handle}?text=${encodeURIComponent(greeting)}` : `https://t.me/${handle}`;
+          return Response.json({ url: target } satisfies ConnectLinkGoResponse);
+        }
+      }
+      const conversationId = await opportunityService.getConversationIdForOpp(link.opportunityId, user.id);
+      const target = conversationId
+        ? `${frontendUrl}/conversations/${conversationId}${greeting ? `?msg=${encodeURIComponent(greeting)}` : ''}`
+        : frontendUrl;
+      return Response.json({ url: target } satisfies ConnectLinkGoResponse);
+    }
+
+    return jsonError('Unknown link kind', 400);
+  }
+}
+```
+
+### backend/tests/connect-link.e2e.spec.ts:1-127 — MODIFY
+Update public bridge/controller tests and add authenticated resolver checks.
+
+```ts
+import '../src/startup.env';
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+
+import { ConnectLinkController } from '../src/controllers/connect-link.controller';
+import type { AuthenticatedUser } from '../src/guards/auth.guard';
+import db from '../src/lib/drizzle/drizzle';
+import { connectLinks, opportunities, users } from '../src/schemas/database.schema';
+import { mintConnectLink } from '../src/services/connect-link.service';
+
+function makeRequest(path: string) {
+  return new Request(`http://localhost${path}`, { method: 'GET' });
+}
+
+const FRONTEND_URL = (process.env.FRONTEND_URL || process.env.APP_URL || 'https://index.network')
+  .replace(/\/+$/, '');
+
+const USER_ID = `cl-e2e-user-${Date.now()}`;
+const OTHER_USER_ID = `cl-e2e-other-${Date.now()}`;
+const OPP_ID = `cl-e2e-opp-${Date.now()}`;
+
+function mockUser(id: string = USER_ID): AuthenticatedUser {
+  return { id, email: `${id}@test`, name: 'CL E2E User' };
+}
+
+describe('GET /c/:code — connect-link controller', () => {
+  let controller: ConnectLinkController;
+
+  beforeAll(async () => {
+    controller = new ConnectLinkController();
+
+    await db.insert(users).values([
+      { id: USER_ID, email: `${USER_ID}@test`, name: 'CL E2E User' },
+      { id: OTHER_USER_ID, email: `${OTHER_USER_ID}@test`, name: 'CL E2E Other User' },
+    ]);
+
+    await db.insert(opportunities).values({
+      id: OPP_ID,
+      actors: [{ userId: USER_ID, networkId: 'n/a', role: 'seeker' }],
+      detection: { source: 'test', timestamp: new Date().toISOString(), createdBy: USER_ID },
+      interpretation: { category: 'test', reasoning: 'test', confidence: 0.9 },
+      context: { networkId: 'n/a' },
+      confidence: '0.9',
+      status: 'pending',
+    });
+  });
+
+  afterAll(async () => {
+    await db.delete(connectLinks).where(eq(connectLinks.userId, USER_ID));
+    await db.delete(opportunities).where(eq(opportunities.id, OPP_ID));
+    await db.delete(users).where(eq(users.id, USER_ID));
+    await db.delete(users).where(eq(users.id, OTHER_USER_ID));
+  });
+
+  test('unknown but well-formed public code redirects to frontend continuation without DB lookup', async () => {
+    const code = 'Aa0Bb1Cc2D';
+    const res = await controller.resolve(makeRequest(`/c/${code}`), undefined, { code });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe(`${FRONTEND_URL}/c/${code}`);
+  });
+
+  test('malformed public code (wrong length or non-base62) is rejected with 404 HTML', async () => {
+    let res = await controller.resolve(makeRequest('/c/TOOSHORT'), undefined, { code: 'TOOSHORT' });
+    expect(res.status).toBe(404);
+    expect(res.headers.get('content-type')).toMatch(/text\/html/);
+
+    res = await controller.resolve(makeRequest('/c/AAAA-BBBBB'), undefined, { code: 'AAAA-BBBBB' });
+    expect(res.status).toBe(404);
+  });
+
+  test('valid public connect code redirects to frontend continuation instead of resolving side effects', async () => {
+    const { code } = await mintConnectLink({
+      userId: USER_ID,
+      opportunityId: OPP_ID,
+      kind: 'connect',
+      greeting: 'Hi from e2e test.',
+    });
+
+    const res = await controller.resolve(makeRequest(`/c/${code}`), undefined, { code });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe(`${FRONTEND_URL}/c/${code}`);
+  });
+
+  test('valid public approve-introduction code redirects to frontend continuation without approving inline', async () => {
+    const { code } = await mintConnectLink({
+      userId: USER_ID,
+      opportunityId: OPP_ID,
+      kind: 'approve_introduction',
+      greeting: 'Approve from e2e test.',
+    });
+
+    const res = await controller.resolve(makeRequest(`/c/${code}`), undefined, { code });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe(`${FRONTEND_URL}/c/${code}`);
+  });
+
+  test('authenticated go masks unknown and malformed codes as 404', async () => {
+    let res = await controller.go(makeRequest('/c/Aa0Bb1Cc2D/go'), mockUser(), { code: 'Aa0Bb1Cc2D' });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Link not found' });
+
+    res = await controller.go(makeRequest('/c/AAAA-BBBBB/go'), mockUser(), { code: 'AAAA-BBBBB' });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Link not found' });
+  });
+
+  test('authenticated go masks wrong-account recipient mismatch as 404', async () => {
+    const { code } = await mintConnectLink({
+      userId: USER_ID,
+      opportunityId: OPP_ID,
+      kind: 'connect',
+      greeting: 'Hi from e2e test.',
+    });
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(OTHER_USER_ID), { code });
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Link not found' });
+  });
+});
+```
+
+### backend/tests/connect-link.surface.spec.ts:1-188 — MODIFY
+Update surface-aware redirect tests to pass an authenticated recipient and add wrong-account masking coverage.
+
+```ts
+import '../src/startup.env';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+
+import { ConnectLinkController } from '../src/controllers/connect-link.controller';
+import type { AuthenticatedUser } from '../src/guards/auth.guard';
+import db from '../src/lib/drizzle/drizzle';
+import {
+  connectLinks,
+  networkMembers,
+  networks,
+  opportunities,
+  personalNetworks,
+  userSocials,
+  users,
+} from '../src/schemas/database.schema';
+import { mintConnectLink } from '../src/services/connect-link.service';
+
+const FRONTEND_URL = (process.env.FRONTEND_URL || process.env.APP_URL || 'https://index.network')
+  .replace(/\/+$/, '');
+
+function makeRequest(path: string): Request {
+  return new Request(`http://localhost${path}`, { method: 'GET' });
+}
+
+const CALLER_ID = `cl-surface-caller-${Date.now()}`;
+const COUNTERPART_ID = `cl-surface-counterpart-${Date.now()}`;
+const OTHER_USER_ID = `cl-surface-other-${Date.now()}`;
+const OPP_ID = `cl-surface-opp-${Date.now()}`;
+const INTRO_OPP_ID = `cl-surface-intro-opp-${Date.now()}`;
+const OPP_ACTORS = [
+  { userId: CALLER_ID, networkId: 'n/a', role: 'seeker' },
+  { userId: COUNTERPART_ID, networkId: 'n/a', role: 'responder' },
+];
+const INTRO_ACTORS = [
+  { userId: CALLER_ID, networkId: 'n/a', role: 'introducer', approved: false },
+  { userId: COUNTERPART_ID, networkId: 'n/a', role: 'party' },
+];
+
+function mockUser(id: string = CALLER_ID): AuthenticatedUser {
+  return { id, email: `${id}@test`, name: 'CL Surface User' };
+}
+
+describe('GET /c/:code/go — surface-aware redirect', () => {
+  let controller: ConnectLinkController;
+
+  beforeAll(async () => {
+    controller = new ConnectLinkController();
+
+    await db.insert(users).values([
+      { id: CALLER_ID, email: `${CALLER_ID}@test`, name: 'CL Surface Caller' },
+      { id: COUNTERPART_ID, email: `${COUNTERPART_ID}@test`, name: 'CL Surface Counterpart' },
+      { id: OTHER_USER_ID, email: `${OTHER_USER_ID}@test`, name: 'CL Surface Other' },
+    ]);
+
+    await db.insert(opportunities).values({
+      id: OPP_ID,
+      actors: OPP_ACTORS,
+      detection: { source: 'test', timestamp: new Date().toISOString(), createdBy: CALLER_ID },
+      interpretation: { category: 'test', reasoning: 'surface-test', confidence: 0.9 },
+      context: { networkId: 'n/a' },
+      confidence: '0.9',
+      status: 'pending',
+    });
+    await db.insert(opportunities).values({
+      id: INTRO_OPP_ID,
+      actors: INTRO_ACTORS,
+      detection: { source: 'test', timestamp: new Date().toISOString(), createdBy: CALLER_ID },
+      interpretation: { category: 'test', reasoning: 'intro-test', confidence: 0.9 },
+      context: { networkId: 'n/a' },
+      confidence: '0.9',
+      status: 'latent',
+    });
+  });
+
+  afterAll(async () => {
+    await db.delete(connectLinks).where(eq(connectLinks.userId, CALLER_ID));
+    await db.delete(opportunities).where(eq(opportunities.id, OPP_ID));
+    await db.delete(opportunities).where(eq(opportunities.id, INTRO_OPP_ID));
+    await db.delete(userSocials).where(eq(userSocials.userId, COUNTERPART_ID));
+
+    const personalNetworkRows = await db
+      .select({ networkId: personalNetworks.networkId })
+      .from(personalNetworks)
+      .where(eq(personalNetworks.userId, CALLER_ID));
+    const counterpartPersonalNetworkRows = await db
+      .select({ networkId: personalNetworks.networkId })
+      .from(personalNetworks)
+      .where(eq(personalNetworks.userId, COUNTERPART_ID));
+
+    await db.delete(networkMembers).where(eq(networkMembers.userId, CALLER_ID));
+    await db.delete(networkMembers).where(eq(networkMembers.userId, COUNTERPART_ID));
+    await db.delete(personalNetworks).where(eq(personalNetworks.userId, CALLER_ID));
+    await db.delete(personalNetworks).where(eq(personalNetworks.userId, COUNTERPART_ID));
+
+    for (const { networkId } of [...personalNetworkRows, ...counterpartPersonalNetworkRows]) {
+      await db.delete(networkMembers).where(eq(networkMembers.networkId, networkId));
+      await db.delete(networks).where(eq(networks.id, networkId));
+    }
+
+    await db.delete(users).where(eq(users.id, CALLER_ID));
+    await db.delete(users).where(eq(users.id, COUNTERPART_ID));
+    await db.delete(users).where(eq(users.id, OTHER_USER_ID));
+  });
+
+  beforeEach(async () => {
+    await db.delete(connectLinks).where(eq(connectLinks.userId, CALLER_ID));
+    await db.delete(userSocials).where(eq(userSocials.userId, COUNTERPART_ID));
+    await db
+      .update(opportunities)
+      .set({ status: 'pending', actors: OPP_ACTORS })
+      .where(eq(opportunities.id, OPP_ID));
+    await db
+      .update(opportunities)
+      .set({ status: 'latent', actors: INTRO_ACTORS })
+      .where(eq(opportunities.id, INTRO_OPP_ID));
+  });
+
+  test('preferredSurface=telegram + counterpart has TG handle → t.me URL', async () => {
+    await db.insert(userSocials).values({
+      userId: COUNTERPART_ID,
+      label: 'telegram',
+      value: 'counterpart_handle',
+    });
+
+    const { code } = await mintConnectLink({
+      userId: CALLER_ID,
+      opportunityId: OPP_ID,
+      kind: 'connect',
+      greeting: 'hello there',
+      preferredSurface: 'telegram',
+    });
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(), { code });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { url: string };
+    expect(body.url).toMatch(/^https:\/\/t\.me\/counterpart_handle/);
+    expect(body.url).toContain('text=hello%20there');
+  });
+
+  test('preferredSurface=telegram + counterpart has no TG handle → web fallback', async () => {
+    const { code } = await mintConnectLink({
+      userId: CALLER_ID,
+      opportunityId: OPP_ID,
+      kind: 'connect',
+      greeting: 'hello there',
+      preferredSurface: 'telegram',
+    });
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(), { code });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { url: string };
+    expect(body.url).not.toMatch(/^https:\/\/t\.me/);
+    expect(body.url).toContain(`${FRONTEND_URL}/u/${COUNTERPART_ID}/chat`);
+    expect(body.url).toContain('msg=hello%20there');
+  });
+
+  test('preferredSurface unset + counterpart has TG handle → web URL', async () => {
+    await db.insert(userSocials).values({
+      userId: COUNTERPART_ID,
+      label: 'telegram',
+      value: 'counterpart_handle',
+    });
+
+    const { code } = await mintConnectLink({
+      userId: CALLER_ID,
+      opportunityId: OPP_ID,
+      kind: 'connect',
+      greeting: 'hello there',
+    });
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(), { code });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { url: string };
+    expect(body.url).not.toMatch(/^https:\/\/t\.me/);
+    expect(body.url).toContain(`${FRONTEND_URL}/u/${COUNTERPART_ID}/chat`);
+  });
+
+  test('send_direct uses authenticated recipient and opens the same web chat destination as connect', async () => {
+    const { code } = await mintConnectLink({
+      userId: CALLER_ID,
+      opportunityId: OPP_ID,
+      kind: 'send_direct',
+      greeting: 'hello direct',
+    });
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(), { code });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { url: string };
+    expect(body.url).toContain(`${FRONTEND_URL}/u/${COUNTERPART_ID}/chat`);
+    expect(body.url).toContain('msg=hello%20direct');
+  });
+
+  test('outreach uses authenticated recipient and returns conversation destination', async () => {
+    await db
+      .update(opportunities)
+      .set({ status: 'accepted', actors: OPP_ACTORS })
+      .where(eq(opportunities.id, OPP_ID));
+
+    const { code } = await mintConnectLink({
+      userId: CALLER_ID,
+      opportunityId: OPP_ID,
+      kind: 'outreach',
+      greeting: 'hello outreach',
+    });
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(), { code });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { url: string };
+    expect(body.url).toContain(`${FRONTEND_URL}/conversations/`);
+    expect(body.url).toContain('msg=hello%20outreach');
+  });
+
+  test('approve_introduction uses authenticated introducer and returns approval confirmation kind', async () => {
+    const { code } = await mintConnectLink({
+      userId: CALLER_ID,
+      opportunityId: INTRO_OPP_ID,
+      kind: 'approve_introduction',
+    });
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(), { code });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ kind: 'approve_introduction' });
+
+    const [after] = await db
+      .select({ status: opportunities.status, actors: opportunities.actors })
+      .from(opportunities)
+      .where(eq(opportunities.id, INTRO_OPP_ID))
+      .limit(1);
+    expect(after.status).toBe('pending');
+    expect(after.actors.some((actor) => actor.userId === CALLER_ID && actor.role === 'introducer' && actor.approved === true)).toBe(true);
+  });
+
+  test('wrong authenticated recipient is masked as 404 before destination side effects', async () => {
+    const { code } = await mintConnectLink({
+      userId: CALLER_ID,
+      opportunityId: OPP_ID,
+      kind: 'connect',
+      greeting: 'hello there',
+      preferredSurface: 'telegram',
+    });
+
+    const [before] = await db
+      .select({ status: opportunities.status })
+      .from(opportunities)
+      .where(eq(opportunities.id, OPP_ID))
+      .limit(1);
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(OTHER_USER_ID), { code });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Link not found' });
+
+    const [after] = await db
+      .select({ status: opportunities.status })
+      .from(opportunities)
+      .where(eq(opportunities.id, OPP_ID))
+      .limit(1);
+    expect(after.status).toBe(before.status);
+  });
+
+  test('wrong authenticated recipient is masked as 404 for every connect-link kind', async () => {
+    const cases = [
+      { kind: 'connect' as const, opportunityId: OPP_ID, status: 'pending' as const, actors: OPP_ACTORS },
+      { kind: 'send_direct' as const, opportunityId: OPP_ID, status: 'pending' as const, actors: OPP_ACTORS },
+      { kind: 'outreach' as const, opportunityId: OPP_ID, status: 'accepted' as const, actors: OPP_ACTORS },
+      { kind: 'approve_introduction' as const, opportunityId: INTRO_OPP_ID, status: 'latent' as const, actors: INTRO_ACTORS },
+    ];
+
+    for (const item of cases) {
+      await db.delete(connectLinks).where(eq(connectLinks.userId, CALLER_ID));
+      await db
+        .update(opportunities)
+        .set({ status: item.status, actors: item.actors })
+        .where(eq(opportunities.id, item.opportunityId));
+
+      const { code } = await mintConnectLink({
+        userId: CALLER_ID,
+        opportunityId: item.opportunityId,
+        kind: item.kind,
+        greeting: 'wrong account should not use this',
+        preferredSurface: 'telegram',
+      });
+
+      const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(OTHER_USER_ID), { code });
+      expect(res.status).toBe(404);
+      expect(await res.json()).toEqual({ error: 'Link not found' });
+
+      const [after] = await db
+        .select({ status: opportunities.status, actors: opportunities.actors })
+        .from(opportunities)
+        .where(eq(opportunities.id, item.opportunityId))
+        .limit(1);
+      expect(after.status).toBe(item.status);
+      if (item.kind === 'approve_introduction') {
+        expect(after.actors.some((actor) => actor.userId === CALLER_ID && actor.role === 'introducer' && actor.approved === true)).toBe(false);
+      }
+    }
+  });
+});
+```
+
+### frontend/src/services/connect-links.ts — NEW
+Typed frontend service for authenticated connect-link continuation.
+
+```ts
+export type ConnectLinkResolution =
+  | { url: string }
+  | { kind: 'approve_introduction' };
+
+/**
+ * Authenticated connect-link continuation API.
+ *
+ * The backend masks unknown, expired, terminal, and wrong-account links as 404.
+ * Callers should render the same unavailable UX for those failures.
+ */
+export const createConnectLinksService = (
+  api: ReturnType<typeof import('../lib/api').useAuthenticatedAPI>,
+) => ({
+  resolveConnectLink: async (
+    code: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<ConnectLinkResolution> => {
+    return api.get<ConnectLinkResolution>(`/c/${encodeURIComponent(code)}/go`, options);
+  },
+});
+```
+
+### frontend/src/contexts/APIContext.tsx:1-128 — MODIFY
+Wire the new connect-links service into the provider and export `useConnectLinks()`.
+
+```tsx
+import { createContext, useContext, useMemo, ReactNode } from 'react';
+import { useAuthenticatedAPI } from '@/lib/api';
+import { createIndexesService } from '@/services/networks';
+import { createIntentsService } from '@/services/intents';
+import { createConnectionsService } from '@/services/connections';
+import { createConnectLinksService } from '@/services/connect-links';
+import { createSynthesisService } from '@/services/synthesis';
+import { createDiscoverService } from '@/services/discover';
+import { createFilesService } from '@/services/files';
+import { createLinksService } from '@/services/links';
+import { createAuthService } from '@/services/auth';
+import { createIntegrationsService } from '@/services/integrations';
+import { createAdminService } from '@/services/admin';
+import { createUsersService } from '@/services/users';
+import { createOpportunitiesService } from '@/services/opportunities';
+import { createConversationService } from '@/services/conversation';
+import { createApiKeysService } from '@/services/api-keys';
+import { createAgentsService } from '@/services/agents';
+import { createQuestionsService } from '@/services/questions';
+
+export interface APIContextType {
+  indexesService: ReturnType<typeof createIndexesService>;
+  intentsService: ReturnType<typeof createIntentsService>;
+  connectionsService: ReturnType<typeof createConnectionsService>;
+  connectLinksService: ReturnType<typeof createConnectLinksService>;
+  synthesisService: ReturnType<typeof createSynthesisService>;
+  discoverService: ReturnType<typeof createDiscoverService>;
+  filesService: ReturnType<typeof createFilesService>;
+  linksService: ReturnType<typeof createLinksService>;
+  authService: ReturnType<typeof createAuthService>;
+  integrationsService: ReturnType<typeof createIntegrationsService>;
+  adminService: ReturnType<typeof createAdminService>;
+  usersService: ReturnType<typeof createUsersService>;
+  opportunitiesService: ReturnType<typeof createOpportunitiesService>;
+  conversationService: ReturnType<typeof createConversationService>;
+  apiKeysService: ReturnType<typeof createApiKeysService>;
+  agentsService: ReturnType<typeof createAgentsService>;
+  questionsService: ReturnType<typeof createQuestionsService>;
+}
+
+const APIContext = createContext<APIContextType | undefined>(undefined);
+
+export function APIProvider({ children }: { children: ReactNode }) {
+  const api = useAuthenticatedAPI();
+
+  const services = useMemo(() => ({
+    indexesService: createIndexesService(api),
+    intentsService: createIntentsService(api),
+    connectionsService: createConnectionsService(api),
+    connectLinksService: createConnectLinksService(api),
+    synthesisService: createSynthesisService(api),
+    discoverService: createDiscoverService(api),
+    filesService: createFilesService(api),
+    linksService: createLinksService(api),
+    authService: createAuthService(api),
+    integrationsService: createIntegrationsService(api),
+    adminService: createAdminService(api),
+    usersService: createUsersService(api),
+    opportunitiesService: createOpportunitiesService(api),
+    conversationService: createConversationService(api),
+    apiKeysService: createApiKeysService(api),
+    agentsService: createAgentsService(api),
+    questionsService: createQuestionsService(api),
+  }), [api]);
+
+  return (
+    <APIContext.Provider value={services}>
+      {children}
+    </APIContext.Provider>
+  );
+}
+
+export function useAPI() {
+  const context = useContext(APIContext);
+  if (context === undefined) {
+    throw new Error('useAPI must be used within an APIProvider');
+  }
+  return context;
+}
+
+export function useNetworks() {
+  const { indexesService } = useAPI();
+  return indexesService;
+}
+
+export function useIntents() {
+  const { intentsService } = useAPI();
+  return intentsService;
+}
+
+export function useConnections() {
+  const { connectionsService } = useAPI();
+  return connectionsService;
+}
+
+export function useConnectLinks() {
+  const { connectLinksService } = useAPI();
+  return connectLinksService;
+}
+
+export function useSynthesis() {
+  const { synthesisService } = useAPI();
+  return synthesisService;
+}
+
+export function useDiscover() {
+  const { discoverService } = useAPI();
+  return discoverService;
+}
+
+export function useFiles() {
+  const { filesService } = useAPI();
+  return filesService;
+}
+
+export function useLinks() {
+  const { linksService } = useAPI();
+  return linksService;
+}
+
+export function useAuth() {
+  const { authService } = useAPI();
+  return authService;
+}
+
+export function useAdmin() {
+  const { adminService } = useAPI();
+  return adminService;
+}
+
+export function useUsers() {
+  const { usersService } = useAPI();
+  return usersService;
+}
+
+export function useOpportunities() {
+  const { opportunitiesService } = useAPI();
+  return opportunitiesService;
+}
+
+export function useConversations() {
+  const { conversationService } = useAPI();
+  return conversationService;
+}
+
+export function useApiKeys() {
+  const { apiKeysService } = useAPI();
+  return apiKeysService;
+}
+
+export function useAgents() {
+  const { agentsService } = useAPI();
+  return agentsService;
+}
+
+export function useQuestionsService() {
+  const { questionsService } = useAPI();
+  return questionsService;
+}
+```
+
+### frontend/src/contexts/AuthContext.tsx:129-137 — MODIFY
+Add `/c/` to public route prefixes.
+
+```tsx
+const publicPrefixes = [
+  '/simulation', '/l', '/c/', '/index/', '/blog', '/pages', '/about',
+  '/login', '/s/', '/oauth/', '/found-in-translation', '/cli-auth', '/u/',
+];
+```
+
+### frontend/src/routes.tsx:75-168 — MODIFY
+Register `/c/:code` before the wildcard route.
+
+```tsx
+{
+  path: "/c/:code",
+  lazy: () => import("@/app/c/[code]/page"),
+},
+```
+
+### frontend/src/app/c/[code]/page.tsx — NEW
+Frontend continuation page that preserves login and calls the authenticated resolver.
+
+```tsx
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import { Loader2 } from 'lucide-react';
+
+import { useAuthContext } from '@/contexts/AuthContext';
+import { useConnectLinks } from '@/contexts/APIContext';
+import { APIError } from '@/lib/api';
+
+const CODE_PATTERN = /^[A-Za-z0-9]{10}$/;
+
+type PageStep = 'loading' | 'auth-required' | 'resolving' | 'approved' | 'unavailable' | 'error';
+
+interface PageState {
+  step: PageStep;
+  error: string | null;
+}
+
+function CenteredState({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-[#FDFDFD] px-6">
+      <div className="max-w-md text-center">{children}</div>
+    </div>
+  );
+}
+
+export default function ConnectLinkContinuationPage() {
+  const { code } = useParams();
+  const navigate = useNavigate();
+  const { isAuthenticated, isReady, isLoading: authLoading, openLoginModal } = useAuthContext();
+  const connectLinks = useConnectLinks();
+  const loginPromptedRef = useRef(false);
+  const attemptedCodeRef = useRef<string | null>(null);
+  const [state, setState] = useState<PageState>({ step: 'loading', error: null });
+
+  useEffect(() => {
+    if (!code || !CODE_PATTERN.test(code)) {
+      setState({ step: 'unavailable', error: null });
+      return;
+    }
+
+    if (!isReady || authLoading) {
+      setState({ step: 'loading', error: null });
+      return;
+    }
+
+    if (!isAuthenticated) {
+      attemptedCodeRef.current = null;
+      setState({ step: 'auth-required', error: null });
+      if (!loginPromptedRef.current && typeof window !== 'undefined') {
+        loginPromptedRef.current = true;
+        openLoginModal(window.location.href);
+      }
+      return;
+    }
+
+    if (attemptedCodeRef.current === code) return;
+    attemptedCodeRef.current = code;
+    setState({ step: 'resolving', error: null });
+
+    const controller = new AbortController();
+    connectLinks.resolveConnectLink(code, { signal: controller.signal })
+      .then((result) => {
+        if ('url' in result) {
+          window.location.replace(result.url);
+          return;
+        }
+        setState({ step: 'approved', error: null });
+      })
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) return;
+        if (error instanceof APIError && error.status === 404) {
+          setState({ step: 'unavailable', error: null });
+          return;
+        }
+        setState({
+          step: 'error',
+          error: error instanceof Error ? error.message : 'Could not open this link',
+        });
+      });
+
+    return () => controller.abort();
+  }, [authLoading, code, connectLinks, isAuthenticated, isReady, openLoginModal]);
+
+  const openLogin = () => {
+    if (typeof window !== 'undefined') {
+      openLoginModal(window.location.href);
+    } else {
+      openLoginModal();
+    }
+  };
+
+  if (state.step === 'loading' || state.step === 'resolving') {
+    return (
+      <CenteredState>
+        <Loader2 className="mx-auto mb-4 h-8 w-8 animate-spin text-gray-400" />
+        <h1 className="mb-2 text-xl font-semibold text-[#041729]">Connecting…</h1>
+        <p className="text-sm text-gray-600">Preparing your connection. This usually takes a few seconds.</p>
+      </CenteredState>
+    );
+  }
+
+  if (state.step === 'auth-required') {
+    return (
+      <CenteredState>
+        <h1 className="mb-2 text-xl font-semibold text-[#041729]">Sign in to continue</h1>
+        <p className="mb-6 text-sm text-gray-600">This link is tied to a specific Index Network account.</p>
+        <button
+          type="button"
+          onClick={openLogin}
+          className="rounded bg-[#041729] px-4 py-2 text-sm font-medium text-white hover:bg-[#0a2d4a]"
+        >
+          Sign in
+        </button>
+      </CenteredState>
+    );
+  }
+
+  if (state.step === 'approved') {
+    return (
+      <CenteredState>
+        <h1 className="mb-2 text-xl font-semibold text-[#041729]">Introduction approved</h1>
+        <p className="mb-6 text-sm text-gray-600">You approved the introduction. Both parties will be connected shortly.</p>
+        <button
+          type="button"
+          onClick={() => navigate('/')}
+          className="rounded bg-[#041729] px-4 py-2 text-sm font-medium text-white hover:bg-[#0a2d4a]"
+        >
+          Go home
+        </button>
+      </CenteredState>
+    );
+  }
+
+  if (state.step === 'unavailable') {
+    return (
+      <CenteredState>
+        <h1 className="mb-2 text-xl font-semibold text-[#041729]">This opportunity is no longer available</h1>
+        <p className="mb-6 text-sm text-gray-600">The opportunity behind this link has expired or been closed.</p>
+        <button
+          type="button"
+          onClick={() => navigate('/')}
+          className="rounded bg-[#041729] px-4 py-2 text-sm font-medium text-white hover:bg-[#0a2d4a]"
+        >
+          Go home
+        </button>
+      </CenteredState>
+    );
+  }
+
+  return (
+    <CenteredState>
+      <h1 className="mb-2 text-xl font-semibold text-[#041729]">Could not open this link</h1>
+      <p className="mb-6 text-sm text-gray-600">{state.error ?? 'Please try again, or contact support if this keeps happening.'}</p>
+      <button
+        type="button"
+        onClick={() => window.location.reload()}
+        className="rounded bg-[#041729] px-4 py-2 text-sm font-medium text-white hover:bg-[#0a2d4a]"
+      >
+        Try again
+      </button>
+    </CenteredState>
+  );
+}
+
+export const Component = ConnectLinkContinuationPage;
+```
+
+### frontend/tests/auth-context.test.tsx:1-86 — MODIFY
+Add public-prefix regression for `/c/:code`.
+
+```tsx
+test('allows unauthenticated users to stay on connect-link continuation routes', async () => {
+  mocks.useSession.mockReturnValue({ data: null, isPending: false });
+
+  renderAuthProviderAt('/c/Aa0Bb1Cc2D');
+
+  expect(await screen.findByTestId('location')).toHaveTextContent('/c/Aa0Bb1Cc2D');
+  expect(mocks.apiClient.get).not.toHaveBeenCalled();
+});
+```
+
+### frontend/tests/routes.test.tsx:1-406 — MODIFY
+Add route smoke coverage for `/c/:code`.
+
+```tsx
+// Add to the APIContext mock return object:
+useConnectLinks: () => noopService,
+
+// Add to Route rendering smoke tests:
+test('/c/:code — Connect-link continuation page renders without crashing', async () => {
+  const { Component } = await import('@/app/c/[code]/page');
+  const { container } = renderWithRouter(<Component />, {
+    route: '/c/Aa0Bb1Cc2D',
+  });
+  expect(container).toBeTruthy();
+});
+```
+
+### frontend/src/app/c/[code]/page.test.tsx — NEW
+Continuation-route unit tests for login prompt, correct-user redirect/confirmation, and unavailable states.
+
+```tsx
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router';
+
+const mocks = vi.hoisted(() => ({
+  authContext: {
+    isReady: true,
+    isLoading: false,
+    isAuthenticated: false,
+    openLoginModal: vi.fn(),
+  },
+  connectLinks: {
+    resolveConnectLink: vi.fn(),
+  },
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuthContext: () => mocks.authContext,
+}));
+
+vi.mock('@/contexts/APIContext', () => ({
+  useConnectLinks: () => mocks.connectLinks,
+}));
+
+vi.mock('@/lib/api', () => ({
+  APIError: class APIError extends Error {
+    constructor(
+      message: string,
+      public status: number,
+      public response?: unknown,
+    ) {
+      super(message);
+      this.name = 'APIError';
+    }
+  },
+}));
+
+import { APIError } from '@/lib/api';
+import { Component as ConnectLinkContinuationPage } from './page';
+
+function renderPage(route = '/c/Aa0Bb1Cc2D') {
+  window.history.pushState({}, '', route);
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <Routes>
+        <Route path="/c/:code" element={<ConnectLinkContinuationPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('ConnectLinkContinuationPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.authContext.isReady = true;
+    mocks.authContext.isLoading = false;
+    mocks.authContext.isAuthenticated = false;
+    mocks.connectLinks.resolveConnectLink.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('opens login with the current /c/:code URL when unauthenticated', async () => {
+    renderPage();
+
+    expect(await screen.findByText('Sign in to continue')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mocks.authContext.openLoginModal).toHaveBeenCalledWith(window.location.href);
+    });
+    expect(mocks.connectLinks.resolveConnectLink).not.toHaveBeenCalled();
+  });
+
+  test('calls the authenticated resolver once and redirects for URL responses', async () => {
+    mocks.authContext.isAuthenticated = true;
+    mocks.connectLinks.resolveConnectLink.mockResolvedValue({ url: 'https://example.com/next' });
+    const replaceSpy = vi.spyOn(window.location, 'replace').mockImplementation(() => undefined);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(mocks.connectLinks.resolveConnectLink).toHaveBeenCalledTimes(1);
+      expect(mocks.connectLinks.resolveConnectLink).toHaveBeenCalledWith('Aa0Bb1Cc2D', expect.objectContaining({ signal: expect.any(AbortSignal) }));
+      expect(replaceSpy).toHaveBeenCalledWith('https://example.com/next');
+    });
+  });
+
+  test('renders introduction-approved confirmation for approve responses', async () => {
+    mocks.authContext.isAuthenticated = true;
+    mocks.connectLinks.resolveConnectLink.mockResolvedValue({ kind: 'approve_introduction' });
+
+    renderPage();
+
+    expect(await screen.findByText('Introduction approved')).toBeInTheDocument();
+  });
+
+  test('renders unavailable state for backend 404 responses', async () => {
+    mocks.authContext.isAuthenticated = true;
+    mocks.connectLinks.resolveConnectLink.mockRejectedValue(new APIError('Link not found', 404));
+
+    renderPage();
+
+    expect(await screen.findByText('This opportunity is no longer available')).toBeInTheDocument();
+  });
+});
+```
+
+## Slices
+### Slice 1: Authenticated backend resolver
+
+**Files**: `backend/src/controllers/connect-link.controller.ts`, `backend/tests/connect-link.e2e.spec.ts`, `backend/tests/connect-link.surface.spec.ts`
+
+#### Automated Verification:
+- [ ] Backend connect-link tests pass: `cd backend && bun test tests/connect-link.e2e.spec.ts tests/connect-link.surface.spec.ts`
+- [ ] Guard order is present on the side-effecting resolver: `grep -n "@UseGuards(RateLimit('read'), AuthGuard)" backend/src/controllers/connect-link.controller.ts`
+- [ ] Public `/c/:code` no longer resolves DB rows: `grep -n "resolveConnectLink(code)" backend/src/controllers/connect-link.controller.ts` appears only inside `go`, not inside `resolve`
+
+#### Manual Verification:
+- [ ] Public `/c/:code` performs only code syntax validation and redirects to `${FRONTEND_URL}/c/:code` for well-formed codes.
+- [ ] Wrong-account `/c/:code/go` returns `{ "error": "Link not found" }` with 404 before greeting generation or opportunity side effects.
+- [ ] Correct-recipient Telegram/web destination behavior in existing surface-aware tests remains unchanged except authenticated user is now passed to `go`.
+- [ ] Ratify known Slice 1 atomicity tension: public `/c/:code` redirects to the frontend continuation route that is introduced in Slice 2; do not deploy Slice 1 alone unless a temporary frontend route exists.
+
+### Slice 2: Frontend continuation service and route
+
+**Files**: `frontend/src/services/connect-links.ts`, `frontend/src/contexts/APIContext.tsx`, `frontend/src/contexts/AuthContext.tsx`, `frontend/src/routes.tsx`, `frontend/src/app/c/[code]/page.tsx`
+
+#### Automated Verification:
+- [ ] Connect-link service is wired through APIContext: `grep -n "connectLinksService" frontend/src/contexts/APIContext.tsx`
+- [ ] Frontend `/c/:code` route is registered: `grep -n 'path: "/c/:code"' frontend/src/routes.tsx`
+- [ ] `/c/` is public for unauthenticated continuation: `grep -n "'/c/'" frontend/src/contexts/AuthContext.tsx`
+
+#### Manual Verification:
+- [ ] Logged-out visits to frontend `/c/:code` open the login modal with `window.location.href` as callback.
+- [ ] After login, the route calls `connectLinks.resolveConnectLink(code)` exactly once per code and redirects for `{ url }` responses.
+- [ ] `{ kind: 'approve_introduction' }` renders an in-app confirmation instead of redirecting.
+- [ ] Backend 404 responses render the generic unavailable/not-found state.
+
+### Slice 3: Frontend and auth-route regression coverage
+
+**Files**: `frontend/tests/auth-context.test.tsx`, `frontend/tests/routes.test.tsx`, `frontend/src/app/c/[code]/page.test.tsx`
+
+#### Automated Verification:
+- [ ] Frontend auth and route tests pass: `cd frontend && bun test tests/auth-context.test.tsx tests/routes.test.tsx src/app/c/[code]/page.test.tsx`
+- [ ] AuthContext test asserts `/c/:code` remains public for unauthenticated users: `grep -n "connect-link continuation" frontend/tests/auth-context.test.tsx`
+- [ ] Route smoke tests include `/c/:code`: `grep -n 'Connect-link continuation page' frontend/tests/routes.test.tsx`
+
+#### Manual Verification:
+- [ ] The continuation page test covers logged-out login callback preservation.
+- [ ] The continuation page test covers authenticated `{ url }` redirects.
+- [ ] The continuation page test covers `{ kind: 'approve_introduction' }` confirmation.
+- [ ] The continuation page test covers backend 404 rendering generic unavailable UX.
+
+### Slice 4: Verification hardening for all link kinds
+
+**Files**: `backend/tests/connect-link.e2e.spec.ts`, `backend/tests/connect-link.surface.spec.ts`
+
+#### Automated Verification:
+- [ ] Backend connect-link tests pass with all link kinds covered: `cd backend && bun test tests/connect-link.e2e.spec.ts tests/connect-link.surface.spec.ts`
+- [ ] Surface tests cover all authenticated resolver kinds: `grep -n "send_direct\|outreach\|approve_introduction" backend/tests/connect-link.surface.spec.ts`
+- [ ] Public e2e tests prove `approve_introduction` no longer approves inline: `grep -n "approve-introduction code redirects" backend/tests/connect-link.e2e.spec.ts`
+
+#### Manual Verification:
+- [ ] `connect` and `send_direct` both preserve web chat destination behavior for the correct recipient.
+- [ ] `outreach` remains behind the recipient check before conversation lookup.
+- [ ] `approve_introduction` mutates only through authenticated `/go` and returns `{ kind: 'approve_introduction' }`.
+- [ ] Wrong-account calls for all four link kinds return 404 and leave status/approval state unchanged.
+
+## Desired End State
+Correct recipient opening a daily-brief connect link while logged out:
+
+```text
+GET https://protocol.example/c/AbCd123456
+  -> backend validates code syntax only
+  -> 302 https://app.example/c/AbCd123456
+  -> frontend opens login with callbackURL=https://app.example/c/AbCd123456
+  -> after auth, frontend calls GET /api/c/AbCd123456/go with Authorization bearer
+  -> backend compares authenticated user.id to resolved connect_links.user_id
+  -> backend starts chat/builds destination and returns { url }
+  -> frontend window.location.replace(url)
+```
+
+Wrong account opening the same link:
+
+```text
+GET /api/c/AbCd123456/go with Authorization for other user
+  -> resolveConnectLink(code)
+  -> link.userId !== authenticated user.id
+  -> 404 { "error": "Link not found" }
+  -> frontend renders unavailable/not-found state
+  -> no greeting generation, startChat, approveIntroduction, or DM lookup occurs
+```
+
+Frontend service usage:
+
+```ts
+const connectLinks = useConnectLinks();
+const result = await connectLinks.resolveConnectLink(code);
+if (result.url) window.location.replace(result.url);
+```
+
+## File Map
+```text
+backend/src/controllers/connect-link.controller.ts          # MODIFY — no-DB public bridge, authenticated recipient-bound resolver
+backend/tests/connect-link.e2e.spec.ts                      # MODIFY — public bridge and authenticated resolver tests
+backend/tests/connect-link.surface.spec.ts                  # MODIFY — authenticated surface-aware redirect and mismatch tests
+frontend/src/services/connect-links.ts                      # NEW — typed continuation service
+frontend/src/contexts/APIContext.tsx                        # MODIFY — connectLinksService provider/hook
+frontend/src/contexts/AuthContext.tsx                       # MODIFY — `/c/` public prefix
+frontend/src/routes.tsx                                     # MODIFY — `/c/:code` route
+frontend/src/app/c/[code]/page.tsx                          # NEW — continuation route
+frontend/tests/auth-context.test.tsx                        # MODIFY — public-prefix regression
+frontend/tests/routes.test.tsx                              # MODIFY — route smoke regression
+frontend/src/app/c/[code]/page.test.tsx                     # NEW — continuation route behavior tests
+```
+
+## Ordering Constraints
+- Slice 1 must land first because frontend Slice 2 depends on authenticated `/api/c/:code/go` response semantics.
+- Slice 2 must land before frontend tests in Slice 3.
+- Slice 4 can be authored after Slice 1 but should be finalized after Slice 2 so test contracts and user-facing responses align.
+- No slices are parallel in this design; each slice builds on locked prior behavior.
+
+## Verification Notes
+- Verify public `/c/:code` no longer calls `resolveConnectLink()` or opportunity side-effect methods before auth.
+- Verify `GET /api/c/:code/go` has guard order `RateLimit('read'), AuthGuard`.
+- Verify recipient mismatch returns 404 before greeting generation, `startChat`, `approveIntroduction`, `getCounterpartTelegramHandleForOpp`, or `getConversationIdForOpp`.
+- Verify `approve_introduction` no longer mutates from public `/c/:code`; it is handled only by authenticated `/go`.
+- Verify `outreach` remains protected because `getConversationIdForOpp()` can create a DM.
+- Verify Telegram-preferred redirect behavior remains unchanged for the correct recipient.
+- Verify `/c/` is included in frontend public prefixes so unauthenticated users are not redirected home before login continuation.
+- Verify magic-link/Google callback URLs preserve frontend `/c/:code`, not final chat URLs.
+- Run targeted backend tests: `cd backend && bun test tests/connect-link.e2e.spec.ts tests/connect-link.surface.spec.ts`.
+- Run targeted frontend tests: `cd frontend && bun test tests/auth-context.test.tsx tests/routes.test.tsx src/app/c/[code]/page.test.tsx`.
+
+## Performance Considerations
+- The authenticated recipient comparison must happen before `getGreetingForCard()` to avoid unnecessary LLM/presenter work and opportunity context exposure.
+- Public `/c/:code` performs only syntax validation and string redirect construction, reducing public DB load and eliminating unauthenticated TTL self-heal writes.
+- The frontend continuation should guard against duplicate resolver calls with a `useRef`/abort pattern because React effects may re-run during auth/session refresh.
+
+## Migration Notes
+No schema migration is required. Existing links remain valid because their short codes and row shape are unchanged; the only behavior change is that resolving a link now requires signing into the stored recipient account.
+
+## Pattern References
+- `backend/src/controllers/opportunity.controller.ts:133-148` — authenticated GET pattern using `RateLimit('read'), AuthGuard` and service error mapping.
+- `backend/src/controllers/opportunity.controller.ts:279-296` — authenticated action endpoint pattern that resolves params and returns structured service errors.
+- `frontend/src/app/u/[id]/chat/page.tsx:33-38` — one-shot login modal preserving current URL.
+- `frontend/src/app/l/[code]/page.tsx:17-105` — short-code route state machine for loading/auth/error.
+- `frontend/src/services/opportunities.ts:129-204` — typed API service factory patterns.
+- `frontend/src/contexts/APIContext.tsx:1-128` — service provider/hook wiring pattern.
+- `backend/tests/connect-link.surface.spec.ts:30-163` — two-actor opportunity fixture and surface redirect assertions.
+- `frontend/tests/auth-context.test.tsx:1-86` — AuthProvider route behavior test pattern.
+- `frontend/tests/routes.test.tsx:1-406` — route smoke test pattern.
+
+## Developer Context
+**Q (discover: Intended user framing): For this connect-url login issue, what problem are you solving and who hits it?**
+A: Daily brief user.
+
+**Q (discover: Possession-based short links must change): From the probe I inferred that connect URLs are currently possession-based: `/c/:code` is unauthenticated, resolves `connect_links.user_id`, and calls `startChat(link.opportunityId, link.userId)` before web login can identify the browser account (`backend/src/controllers/connect-link.controller.ts:68,155`). Keep this behavior or change it?**
+A: Change it.
+
+**Q (discover: Preserve recipient binding through login): From the probe I inferred that after fallback to web chat, login returns to `/u/:id/chat?msg=...` and that URL has no connect code or intended-recipient user to compare against (`frontend/src/app/u/[id]/chat/page.tsx:34-36,102-110`). Should the feature preserve recipient binding through login?**
+A: Bind through login.
+
+**Q (discover: Scope across acceptance links): You clarified that nowhere should people accept other people's connections. Should this requirement cover only daily-brief `connect` links, or all short-link acceptance kinds the code supports?**
+A: All acceptance links.
+
+**Q (discover: Server-side recipient check): Where should the recipient check live for connect-link acceptance? Tradeoff: strongest server-side security vs smallest change to the existing redirect flow.**
+A: Server-gated links.
+
+**Q (discover: Wrong-account UX): What should users see when the link is opened by the wrong logged-in account or after logging in as the wrong account?**
+A: Not found.
+
+**Q (discover: Correct-recipient destination): For the correct recipient, what should happen after they authenticate through a connect link?**
+A: Preserve destination.
+
+**Q (discover: Include non-state-changing outreach links): Should non-state-changing short links, like `outreach` links that only redirect for an already-accepted opportunity, also require the same recipient-account check?**
+A: Yes, all links.
+
+**Q (`backend/src/controllers/connect-link.controller.ts:38`, `backend/src/guards/auth.guard.ts:26-43`, `frontend/src/lib/api.ts:46-48`): Static interstitial fetch omits credentials, AuthGuard requires bearer/query JWT, and the frontend API client attaches Authorization. Which continuation shape should the design prefer?**
+A: Frontend continuation. Use a frontend route/modal callback that preserves the short code and calls an authenticated backend resolver via the API client; avoid JWTs in URLs.
+
+**Q (design checkpoint: public `/c/:code` DB resolution): Backend `/c/:code` currently validates and resolves the DB row before returning HTML, and `resolveConnectLink()` can self-heal expired links by extending TTL (`backend/src/controllers/connect-link.controller.ts:106`, `backend/src/services/connect-link.service.ts:237`). For recipient-bound links, should unauthenticated `/c/:code` do any DB resolution before login?**
+A: No DB before auth.
+
+**Q (design checkpoint: wrong-account API status): After authenticated `/c/:code/go` resolves a link, if `AuthenticatedUser.id` differs from `connect_links.user_id`, should the backend itself return a masked 404 or return a structured 403 while the frontend displays generic Not Found? Evidence: auth errors are centrally structured (`backend/src/main.ts:602`), while your UX decision was “Not found.”**
+A: Backend 404.
+
+**Q (design checkpoint: frontend service placement): The frontend continuation route needs one authenticated call to `/api/c/:code/go`. Existing patterns include route-local `useAuthenticatedAPI()` in invitation flow (`frontend/src/app/l/[code]/page.tsx:33`) and typed service factories wired through `APIContext` (`frontend/src/contexts/APIContext.tsx:47`). Where should the connect-link continuation call live?**
+A: New service.
+
+**Q (design summary confirmation): Design summary above. Ready to proceed to decomposition?**
+A: Proceed.
+
+**Q (decomposition confirmation): 4 slices for recipient-bound connect links. Slice 1: authenticated backend resolver. Slice 2: frontend continuation route/service. Slice 3: frontend route/auth tests. Slice 4: backend all-kind hardening tests. Approve decomposition?**
+A: Approve.
+
+## Design History
+- Slice 1: Authenticated backend resolver — approved as generated; verifier atomicity finding surfaced and ratified (frontend `/c/:code` target lands in Slice 2)
+- Slice 2: Frontend continuation service and route — approved as generated
+- Slice 3: Frontend and auth-route regression coverage — approved as generated
+- Slice 4: Verification hardening for all link kinds — approved as generated
+
+## References
+- `/Users/aposto/Projects/index/.worktrees/research-recipient-bound-connect-links/.rpiv/artifacts/research/2026-06-09_23-41-51_recipient-bound-connect-links.md`
+- `.rpiv/artifacts/discover/2026-06-09_23-32-44_recipient-bound-connect-links.md`
+- `.rpiv/artifacts/research/2026-06-09_11-18-58_connect-links-auth-redirect.md`
+- `.rpiv/artifacts/designs/2026-06-09_11-48-41_connect-links-auth-redirect.md`
+- `.rpiv/artifacts/validation/2026-06-09_13-10-12_ind-354-connect-links-auth-redirect.md`

--- a/.rpiv/artifacts/discover/2026-06-09_23-32-44_recipient-bound-connect-links.md
+++ b/.rpiv/artifacts/discover/2026-06-09_23-32-44_recipient-bound-connect-links.md
@@ -1,0 +1,131 @@
+---
+date: 2026-06-09T23:32:44+0300
+author: Yankı Ekin Yüksel
+commit: 2153450f65
+branch: main
+repository: index
+topic: "Recipient-bound connect links"
+tags: [intent, frd, connect-links, opportunities, telegram, auth]
+status: ready
+last_updated: 2026-06-09T23:32:44+0300
+last_updated_by: Yankı Ekin Yüksel
+---
+
+# FRD: Recipient-bound connect links
+
+## Summary
+Connect and opportunity short links must be bound to the intended recipient account, including links delivered through AgentVillage Telegram daily briefs. If a logged-out user opens a valid link, the login flow must only allow the link recipient to complete the opportunity action and reach the opportunity chat; any other account should receive a generic not-found/unavailable result.
+
+## Problem & Intent
+The initial affected user is the **Daily brief user**: the intended recipient of a Telegram daily brief must be the only account that can open that specific opportunity chat after login.
+
+Developer clarification: "I think in nowhere in the system, other people should be able to accept other people's connections. This is a security issue."
+
+Original feature description: "Check the last features we implemented. In agentvillage telegram, I get my daily brief and click the connect url on one of the connections. If I am not logged in, the system allows me to login and redirects to the opportunity chat. But in the login phase, I can use any account I want, which is a problem. If User A received the connect url, only user a should be able to reach the opportunity via login, otherwise, we can just state Opportunity not found or something like that."
+
+## Goals
+- Ensure only the user recorded on a short link can use that link to accept, approve, or access the linked opportunity flow.
+- Preserve the existing successful destination behavior for the correct recipient: Telegram-preferred links should still deep-link to Telegram when possible, otherwise fall back to web chat with the prepared greeting.
+- Treat wrong-account access as a privacy/security failure and avoid revealing that the opportunity or link exists for another user.
+- Apply the recipient-account check consistently across all connect-link kinds, not only daily-brief `connect` links.
+
+## Non-Goals
+- Do not redesign opportunity discovery, daily brief generation, or how `acceptUrl` is minted.
+- Do not add a new user-facing account-switching UX that confirms the link belongs to another account.
+- Do not change the intended successful Telegram/web destination beyond inserting the required recipient authentication check.
+- Do not implement source changes in this FRD; downstream `research`, `design`, and `implement` should handle code changes.
+
+## Functional Requirements
+1. The system SHALL require an authenticated user before executing any `/c/:code` side effect or redirect that represents another user’s opportunity connection flow.
+2. The system SHALL compare the authenticated user id with the resolved `connect_links.user_id` before processing any valid short-link kind.
+3. The system SHALL deny wrong-account access with the same generic not-found/unavailable behavior used for missing or expired links.
+4. The system SHALL protect all short-link kinds, including state-changing `connect`, `send_direct`, and `approve_introduction` links, plus non-state-changing `outreach` links.
+5. The system SHALL preserve the short-link code through login so the backend can perform recipient verification after authentication rather than relying only on `/u/:id/chat?msg=...`.
+6. The system SHALL preserve current success destinations for the correct recipient: Telegram preferred surface should redirect to `t.me` when a handle exists, otherwise to the existing web chat fallback.
+7. The system SHALL avoid accepting or stamping an opportunity actor action before the recipient-account check passes.
+
+## Non-Functional Requirements
+- **Performance**: No special latency target beyond preserving the current short-link interstitial behavior; the added recipient check should be a lightweight auth/session and link-row comparison before existing work.
+- **Security**: Short-link possession alone is insufficient. Authorization must be account-bound, and wrong-account responses must not reveal whether a link is valid for another user.
+- **UX / Accessibility**: Logged-out correct recipients should be guided through login and then continue to the existing destination. Wrong-account users should see generic unavailable/not-found messaging, not a detailed account mismatch explanation.
+- **Reliability**: Login callbacks must preserve enough state to retry the link resolution after auth. Expired, malformed, missing, wrong-account, and already-invalid links should consistently fail without mutating opportunity state.
+
+## Constraints & Assumptions
+- The short URL currently contains only an opaque 10-character code; the intended recipient and opportunity are stored server-side in `connect_links`.
+- The backend connect-link controller currently has no auth guard because possession of the code was treated as authentication.
+- The frontend chat callback currently has no connect-link code or intended-recipient id, so a frontend-only guard cannot prevent server-side acceptance.
+- The implementation should keep controller/service layering intact: controllers enforce HTTP/auth boundaries and call services; services enforce opportunity invariants.
+- The implementation should add targeted tests rather than relying on the full test suite.
+
+## Acceptance Criteria
+- [ ] With a valid connect link for User A, opening `/c/<code>` while logged out prompts or redirects through login while preserving `<code>`; after authenticating as User A, the browser reaches the same Telegram or web chat destination the current flow would have produced.
+- [ ] With the same valid connect link for User A, authenticating as User B returns the generic not-found/unavailable response and does not call `startChat` or mutate opportunity actor state.
+- [ ] For `connect`, `send_direct`, and `approve_introduction` links, wrong-account requests return generic not-found/unavailable and leave opportunity status/actor action unchanged.
+- [ ] For `outreach` links, wrong-account requests return generic not-found/unavailable and do not reveal the counterpart chat/Telegram destination.
+- [ ] Existing malformed, expired, or missing code behavior remains generic and indistinguishable from wrong-account behavior from the user’s perspective.
+- [ ] Running the targeted backend connect-link tests, e.g. `cd backend && bun test src/controllers/tests/connect-link.controller.spec.ts`, exits 0 after implementation.
+- [ ] Running any affected frontend auth/callback test or build target chosen by implementation, e.g. `cd frontend && bun run build`, exits 0 after implementation.
+
+## Recommended Approach
+Move the security boundary to the backend short-link flow: require authentication before `/c/:code/go` performs link side effects, compare the authenticated user to `connect_links.user_id`, and only then call the existing opportunity service and destination-building logic. Preserve login continuity by returning/redirecting to an account-bound continuation that carries the short code, not just the final `/u/:id/chat?msg=...` URL.
+
+## Decisions
+
+### Intended user framing
+**Question**: For this connect-url login issue, what problem are you solving and who hits it?
+**Recommended**: n/a — `intent` question
+**Chosen**: Daily brief user.
+**Rationale**: Developer selected the daily brief recipient as the primary user and later clarified the broader security rule in their own words.
+
+### Possession-based short links must change
+**Question**: From the probe I inferred that connect URLs are currently possession-based: `/c/:code` is unauthenticated, resolves `connect_links.user_id`, and calls `startChat(link.opportunityId, link.userId)` before web login can identify the browser account (`backend/src/controllers/connect-link.controller.ts:68,155`). Keep this behavior or change it?
+**Recommended**: Change it.
+**Chosen**: Change it.
+**Rationale**: evidence: `backend/src/controllers/connect-link.controller.ts:68,155` + confirmed; possession-only access lets another account accept or reach the connection.
+
+### Preserve recipient binding through login
+**Question**: From the probe I inferred that after fallback to web chat, login returns to `/u/:id/chat?msg=...` and that URL has no connect code or intended-recipient user to compare against (`frontend/src/app/u/[id]/chat/page.tsx:34-36,102-110`). Should the feature preserve recipient binding through login?
+**Recommended**: Bind through login.
+**Chosen**: Bind through login.
+**Rationale**: evidence: `frontend/src/app/u/[id]/chat/page.tsx:34-36,102-110` + confirmed; the post-login account must be checked against the link recipient.
+
+### Scope across acceptance links
+**Question**: You clarified that nowhere should people accept other people's connections. Should this requirement cover only daily-brief `connect` links, or all short-link acceptance kinds the code supports?
+**Recommended**: All acceptance links.
+**Chosen**: All acceptance links.
+**Rationale**: The developer framed this as a general security invariant, not a daily-brief-only bug.
+
+### Server-side recipient check
+**Question**: Where should the recipient check live for connect-link acceptance? Tradeoff: strongest server-side security vs smallest change to the existing redirect flow.
+**Recommended**: Server-gated links.
+**Chosen**: Server-gated links.
+**Rationale**: Backend validation protects before state changes; frontend-only checks would happen after the current controller has already accepted as `link.userId`.
+
+### Wrong-account UX
+**Question**: What should users see when the link is opened by the wrong logged-in account or after logging in as the wrong account?
+**Recommended**: Not found.
+**Chosen**: Not found.
+**Rationale**: Generic not-found/unavailable messaging avoids leaking that an opportunity exists for another account.
+
+### Correct-recipient destination
+**Question**: For the correct recipient, what should happen after they authenticate through a connect link?
+**Recommended**: Preserve destination.
+**Chosen**: Preserve destination.
+**Rationale**: Keep the successful Telegram/web behavior already implemented in `backend/src/controllers/connect-link.controller.ts:162-175` while adding the security gate.
+
+### Include non-state-changing outreach links
+**Question**: Should non-state-changing short links, like `outreach` links that only redirect for an already-accepted opportunity, also require the same recipient-account check?
+**Recommended**: Yes, all links.
+**Chosen**: Yes, all links.
+**Rationale**: The developer wanted a system-wide rule that other people should not use another user’s connection links, including access-only redirects.
+
+## Open Questions
+- None explicitly deferred.
+
+## References
+- Skill input: free-text feature description provided at invocation.
+- `backend/src/controllers/connect-link.controller.ts`
+- `backend/src/services/connect-link.service.ts`
+- `backend/src/services/opportunity.service.ts`
+- `frontend/src/app/u/[id]/chat/page.tsx`
+- `packages/protocol/src/opportunity/opportunity.tools.ts`

--- a/.rpiv/artifacts/plans/2026-06-10_01-05-37_recipient-bound-connect-links.md
+++ b/.rpiv/artifacts/plans/2026-06-10_01-05-37_recipient-bound-connect-links.md
@@ -1,0 +1,1846 @@
+---
+date: 2026-06-10T01:05:37+0300
+author: Yankı Ekin Yüksel
+commit: 2153450f65
+branch: main
+repository: index
+topic: "Recipient-bound connect links"
+tags: [plan, connect-links, auth, opportunities, frontend]
+status: ready
+parent: "/Users/aposto/Projects/index/.worktrees/research-recipient-bound-connect-links/.rpiv/artifacts/designs/2026-06-10_00-15-03_recipient-bound-connect-links.md"
+phase_count: 4
+phases:
+  - { n: 1, title: Authenticated backend resolver }
+  - { n: 2, title: Frontend continuation service and route }
+  - { n: 3, title: Frontend and auth-route regression coverage }
+  - { n: 4, title: Verification hardening for all link kinds }
+last_updated: 2026-06-10T01:05:37+0300
+last_updated_by: Yankı Ekin Yüksel
+---
+
+# Recipient-bound Connect Links Implementation Plan
+
+## Overview
+
+Implement recipient-bound connect links from the design artifact by moving short-link side effects behind authenticated `/api/c/:code/go` resolution, preserving the opaque short code through frontend login, and adding targeted backend/frontend coverage. Phase boundaries are inherited 1:1 from the design slices; design decisions are fixed.
+
+## Desired End State
+
+Correct recipient opening a daily-brief connect link while logged out:
+
+```text
+GET https://protocol.example/c/AbCd123456
+  -> backend validates code syntax only
+  -> 302 https://app.example/c/AbCd123456
+  -> frontend opens login with callbackURL=https://app.example/c/AbCd123456
+  -> after auth, frontend calls GET /api/c/AbCd123456/go with Authorization bearer
+  -> backend compares authenticated user.id to resolved connect_links.user_id
+  -> backend starts chat/builds destination and returns { url }
+  -> frontend window.location.replace(url)
+```
+
+Wrong account opening the same link:
+
+```text
+GET /api/c/AbCd123456/go with Authorization for other user
+  -> resolveConnectLink(code)
+  -> link.userId !== authenticated user.id
+  -> 404 { "error": "Link not found" }
+  -> frontend renders unavailable/not-found state
+  -> no greeting generation, startChat, approveIntroduction, or DM lookup occurs
+```
+
+Frontend service usage:
+
+```ts
+const connectLinks = useConnectLinks();
+const result = await connectLinks.resolveConnectLink(code);
+if (result.url) window.location.replace(result.url);
+```
+
+## What We're NOT Doing
+
+- No database schema changes; `connect_links.user_id` already stores recipient identity.
+- No protocol package changes; protocol/MCP already mints `acceptUrl` with `viewerId` and `preferredSurface`.
+- No JWTs in callback URLs or query params.
+- No Better Auth cookie-session support in `AuthGuard`; the frontend uses existing bearer-token API flow.
+- No changes to opportunity service semantics beyond making existing calls unreachable until recipient validation passes.
+- No redesign of final chat pages or Telegram URL behavior.
+
+## Phase 1: Authenticated backend resolver
+
+### Overview
+Converts the backend public short-link route into a no-DB bridge and protects the side-effecting resolver with `AuthGuard` plus recipient equality checks.
+
+### Changes Required:
+
+#### 1. backend/src/controllers/connect-link.controller.ts
+**File**: `backend/src/controllers/connect-link.controller.ts`
+**Changes**: Refactor public `/c/:code` into syntax-only frontend bridge; protect `/c/:code/go` with `RateLimit` + `AuthGuard`; compare authenticated user to stored link recipient before any destination or side effect.
+
+```ts
+import { AuthGuard, type AuthenticatedUser } from '../guards/auth.guard';
+import { RateLimit } from '../guards/limiter.guard';
+import { Controller, Get, UseGuards } from '../lib/router/router.decorators';
+import { resolveConnectLinkForUser } from '../services/connect-link.service';
+import { opportunityService } from '../services/opportunity.service';
+
+/** Route params when path has :code */
+type RouteParams = Record<string, string>;
+
+type ConnectLinkGoResponse =
+  | { url: string }
+  | { kind: 'approve_introduction' };
+
+const CODE_PATTERN = /^[A-Za-z0-9]{10}$/;
+
+const EXPIRED_HTML = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Unavailable</title></head>
+<body style="font-family:system-ui;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0">
+<div style="text-align:center"><h1 style="font-size:1.5rem">This opportunity is no longer available</h1>
+<p style="color:#666">The opportunity behind this link has expired or been closed.</p>
+</div></body></html>`;
+
+function getFrontendUrl(): string {
+  return (process.env.FRONTEND_URL || process.env.APP_URL || 'https://index.network').replace(/\/+$/, '');
+}
+
+function jsonError(message: string, status: number): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function notFoundJson(): Response {
+  return jsonError('Link not found', 404);
+}
+
+/**
+ * ConnectLinkController: opaque short-link dispatcher.
+ *
+ * Public `/c/:code` is only a bridge into the frontend continuation route. It
+ * deliberately does not resolve `connect_links` rows: account binding happens
+ * on authenticated `/c/:code/go`, where the JWT user must match the stored
+ * recipient before any opportunity side effect or destination lookup runs.
+ */
+@Controller('/c')
+export class ConnectLinkController {
+  /**
+   * GET /c/:code — public short-link bridge.
+   *
+   * Valid-looking short codes are redirected to the frontend continuation route
+   * with the same opaque code. The frontend preserves that URL through login and
+   * calls authenticated `/api/c/:code/go`. This route performs no DB lookup and
+   * no opportunity side effects.
+   */
+  @Get('/:code')
+  @UseGuards(RateLimit('read'))
+  async resolve(_req: Request, _user: unknown, params?: RouteParams) {
+    const code = params?.code;
+    if (!code) return new Response('Missing code', { status: 400 });
+
+    if (!CODE_PATTERN.test(code)) {
+      return new Response(EXPIRED_HTML, { status: 404, headers: { 'Content-Type': 'text/html' } });
+    }
+
+    return Response.redirect(`${getFrontendUrl()}/c/${code}`, 302);
+  }
+
+  /**
+   * GET /c/:code/go — authenticated JSON resolver.
+   *
+   * Resolves the short code, verifies the authenticated user is the stored
+   * recipient, then performs the kind-specific side effect and returns the final
+   * destination. Unknown, terminal, malformed, and wrong-account links are all
+   * masked as 404. No greeting generation, DM lookup, approval, or acceptance
+   * runs until the recipient check passes.
+   */
+  @Get('/:code/go')
+  @UseGuards(RateLimit('read'), AuthGuard)
+  async go(_req: Request, user: AuthenticatedUser, params?: RouteParams): Promise<Response> {
+    const code = params?.code;
+    if (!code) return jsonError('Missing code', 400);
+    if (!CODE_PATTERN.test(code)) return notFoundJson();
+
+    const link = await resolveConnectLinkForUser(code, user.id);
+    if (!link) return notFoundJson();
+    if (link.userId !== user.id) return notFoundJson();
+
+    const frontendUrl = getFrontendUrl();
+    const greetingForRecipient = async () => (
+      link.greeting ?? (await opportunityService.getGreetingForCard(link.opportunityId, user.id))
+    );
+
+    if (link.kind === 'approve_introduction') {
+      const result = await opportunityService.approveIntroduction(link.opportunityId, user.id);
+      if ('error' in result) return jsonError(result.error, result.status);
+      return Response.json({ kind: 'approve_introduction' } satisfies ConnectLinkGoResponse);
+    }
+
+    // `connect` (receiver flipping pending → accepted) and `send_direct`
+    // (sender flipping draft/latent → accepted) both want the chat open and the
+    // greeting ready to send. opportunityService.startChat handles both source
+    // statuses; the semantic difference lives in the matrix that picked `kind`.
+    if (link.kind === 'connect' || link.kind === 'send_direct') {
+      const result = await opportunityService.startChat(link.opportunityId, user.id);
+      if ('error' in result) return jsonError(result.error, result.status);
+
+      const greeting = await greetingForRecipient();
+
+      if (link.preferredSurface === 'telegram') {
+        const handle = await opportunityService.getCounterpartTelegramHandle(result.counterpartUserId);
+        const target = handle
+          ? (greeting ? `https://t.me/${handle}?text=${encodeURIComponent(greeting)}` : `https://t.me/${handle}`)
+          : (greeting
+              ? `${frontendUrl}/u/${result.counterpartUserId}/chat?msg=${encodeURIComponent(greeting)}`
+              : `${frontendUrl}/u/${result.counterpartUserId}/chat`);
+        return Response.json({ url: target } satisfies ConnectLinkGoResponse);
+      }
+
+      const target = greeting
+        ? `${frontendUrl}/u/${result.counterpartUserId}/chat?msg=${encodeURIComponent(greeting)}`
+        : `${frontendUrl}/u/${result.counterpartUserId}/chat`;
+      return Response.json({ url: target } satisfies ConnectLinkGoResponse);
+    }
+
+    if (link.kind === 'outreach') {
+      const greeting = await greetingForRecipient();
+
+      if (link.preferredSurface === 'telegram') {
+        const handle = await opportunityService.getCounterpartTelegramHandleForOpp(link.opportunityId, user.id);
+        if (handle) {
+          const target = greeting ? `https://t.me/${handle}?text=${encodeURIComponent(greeting)}` : `https://t.me/${handle}`;
+          return Response.json({ url: target } satisfies ConnectLinkGoResponse);
+        }
+      }
+      const conversationId = await opportunityService.getConversationIdForOpp(link.opportunityId, user.id);
+      const target = conversationId
+        ? `${frontendUrl}/conversations/${conversationId}${greeting ? `?msg=${encodeURIComponent(greeting)}` : ''}`
+        : frontendUrl;
+      return Response.json({ url: target } satisfies ConnectLinkGoResponse);
+    }
+
+    return jsonError('Unknown link kind', 400);
+  }
+}
+```
+
+#### 2. backend/src/services/connect-link.service.ts
+**File**: `backend/src/services/connect-link.service.ts`
+**Changes**: Add a recipient-aware resolver for authenticated `/go` that filters by `(code, userId)` before opportunity replacement lookup or TTL extension, preventing wrong-account requests from self-healing link rows.
+
+```ts
+/**
+ * Resolve a short code for a specific authenticated recipient.
+ *
+ * This filters by `userId` before expired-opportunity replacement lookup or TTL
+ * extension, so wrong-account callers cannot mutate `connect_links` rows merely
+ * by probing another user's code.
+ *
+ * @param code - The 10-char base62 short code.
+ * @param userId - Authenticated recipient id that must own the link row.
+ * @returns The resolved link row, or `null` for unknown, wrong-recipient,
+ *   expired-terminal, or otherwise unavailable links.
+ */
+export async function resolveConnectLinkForUser(
+  code: string,
+  userId: string,
+): Promise<ResolvedLink | null> {
+  const [row] = await db
+    .select()
+    .from(connectLinks)
+    .where(and(eq(connectLinks.code, code), eq(connectLinks.userId, userId)))
+    .limit(1);
+  if (!row) return null;
+
+  const now = new Date();
+  const opp = await resolveOpportunityForLink(row.opportunityId, userId);
+  if (!opp) return null;
+
+  if (TERMINAL_STATUSES.has(opp.status)) return null;
+
+  const resolvedLink = toResolvedLink(row, opp.id);
+  if (row.expiresAt > now) {
+    return resolvedLink;
+  }
+
+  // Extend TTL only after the authenticated recipient has matched the row.
+  const expiresAt = new Date(now.getTime() + TTL_DAYS * 24 * 60 * 60 * 1000);
+  await db
+    .update(connectLinks)
+    .set({ expiresAt })
+    .where(and(eq(connectLinks.code, code), eq(connectLinks.userId, userId)));
+
+  return resolvedLink;
+}
+```
+
+#### 3. backend/tests/connect-link.e2e.spec.ts
+**File**: `backend/tests/connect-link.e2e.spec.ts`
+**Changes**: Cover public bridge behavior, malformed code handling, authenticated 404 masking, wrong-account rejection, and approve-introduction public redirect.
+
+```ts
+import '../src/startup.env';
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+
+import { ConnectLinkController } from '../src/controllers/connect-link.controller';
+import type { AuthenticatedUser } from '../src/guards/auth.guard';
+import db from '../src/lib/drizzle/drizzle';
+import { connectLinks, opportunities, users } from '../src/schemas/database.schema';
+import { mintConnectLink } from '../src/services/connect-link.service';
+
+function makeRequest(path: string) {
+  return new Request(`http://localhost${path}`, { method: 'GET' });
+}
+
+const FRONTEND_URL = (process.env.FRONTEND_URL || process.env.APP_URL || 'https://index.network')
+  .replace(/\/+$/, '');
+
+const USER_ID = `cl-e2e-user-${Date.now()}`;
+const OTHER_USER_ID = `cl-e2e-other-${Date.now()}`;
+const OPP_ID = `cl-e2e-opp-${Date.now()}`;
+
+function mockUser(id: string = USER_ID): AuthenticatedUser {
+  return { id, email: `${id}@test`, name: 'CL E2E User' };
+}
+
+describe('GET /c/:code — connect-link controller', () => {
+  let controller: ConnectLinkController;
+
+  beforeAll(async () => {
+    controller = new ConnectLinkController();
+
+    await db.insert(users).values([
+      { id: USER_ID, email: `${USER_ID}@test`, name: 'CL E2E User' },
+      { id: OTHER_USER_ID, email: `${OTHER_USER_ID}@test`, name: 'CL E2E Other User' },
+    ]);
+
+    await db.insert(opportunities).values({
+      id: OPP_ID,
+      actors: [{ userId: USER_ID, networkId: 'n/a', role: 'seeker' }],
+      detection: { source: 'test', timestamp: new Date().toISOString(), createdBy: USER_ID },
+      interpretation: { category: 'test', reasoning: 'test', confidence: 0.9 },
+      context: { networkId: 'n/a' },
+      confidence: '0.9',
+      status: 'pending',
+    });
+  });
+
+  afterAll(async () => {
+    await db.delete(connectLinks).where(eq(connectLinks.userId, USER_ID));
+    await db.delete(opportunities).where(eq(opportunities.id, OPP_ID));
+    await db.delete(users).where(eq(users.id, USER_ID));
+    await db.delete(users).where(eq(users.id, OTHER_USER_ID));
+  });
+
+  test('unknown but well-formed public code redirects to frontend continuation without DB lookup', async () => {
+    const code = 'Aa0Bb1Cc2D';
+    const res = await controller.resolve(makeRequest(`/c/${code}`), undefined, { code });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe(`${FRONTEND_URL}/c/${code}`);
+  });
+
+  test('malformed public code (wrong length or non-base62) is rejected with 404 HTML', async () => {
+    let res = await controller.resolve(makeRequest('/c/TOOSHORT'), undefined, { code: 'TOOSHORT' });
+    expect(res.status).toBe(404);
+    expect(res.headers.get('content-type')).toMatch(/text\/html/);
+
+    res = await controller.resolve(makeRequest('/c/AAAA-BBBBB'), undefined, { code: 'AAAA-BBBBB' });
+    expect(res.status).toBe(404);
+  });
+
+  test('valid public connect code redirects to frontend continuation instead of resolving side effects', async () => {
+    const { code } = await mintConnectLink({
+      userId: USER_ID,
+      opportunityId: OPP_ID,
+      kind: 'connect',
+      greeting: 'Hi from e2e test.',
+    });
+
+    const res = await controller.resolve(makeRequest(`/c/${code}`), undefined, { code });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe(`${FRONTEND_URL}/c/${code}`);
+  });
+
+  test('valid public approve-introduction code redirects to frontend continuation without approving inline', async () => {
+    const { code } = await mintConnectLink({
+      userId: USER_ID,
+      opportunityId: OPP_ID,
+      kind: 'approve_introduction',
+      greeting: 'Approve from e2e test.',
+    });
+
+    const res = await controller.resolve(makeRequest(`/c/${code}`), undefined, { code });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe(`${FRONTEND_URL}/c/${code}`);
+  });
+
+  test('authenticated go masks unknown and malformed codes as 404', async () => {
+    let res = await controller.go(makeRequest('/c/Aa0Bb1Cc2D/go'), mockUser(), { code: 'Aa0Bb1Cc2D' });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Link not found' });
+
+    res = await controller.go(makeRequest('/c/AAAA-BBBBB/go'), mockUser(), { code: 'AAAA-BBBBB' });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Link not found' });
+  });
+
+  test('authenticated go masks wrong-account recipient mismatch as 404', async () => {
+    const { code } = await mintConnectLink({
+      userId: USER_ID,
+      opportunityId: OPP_ID,
+      kind: 'connect',
+      greeting: 'Hi from e2e test.',
+    });
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(OTHER_USER_ID), { code });
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Link not found' });
+  });
+});
+```
+
+#### 4. backend/tests/connect-link.surface.spec.ts
+**File**: `backend/tests/connect-link.surface.spec.ts`
+**Changes**: Pass authenticated users into surface-aware resolver tests and cover correct-recipient destinations plus wrong-account non-mutation for all link kinds.
+
+```ts
+import '../src/startup.env';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+
+import { ConnectLinkController } from '../src/controllers/connect-link.controller';
+import type { AuthenticatedUser } from '../src/guards/auth.guard';
+import db from '../src/lib/drizzle/drizzle';
+import {
+  connectLinks,
+  networkMembers,
+  networks,
+  opportunities,
+  personalNetworks,
+  userSocials,
+  users,
+} from '../src/schemas/database.schema';
+import { mintConnectLink } from '../src/services/connect-link.service';
+
+const FRONTEND_URL = (process.env.FRONTEND_URL || process.env.APP_URL || 'https://index.network')
+  .replace(/\/+$/, '');
+
+function makeRequest(path: string): Request {
+  return new Request(`http://localhost${path}`, { method: 'GET' });
+}
+
+const CALLER_ID = `cl-surface-caller-${Date.now()}`;
+const COUNTERPART_ID = `cl-surface-counterpart-${Date.now()}`;
+const OTHER_USER_ID = `cl-surface-other-${Date.now()}`;
+const OPP_ID = `cl-surface-opp-${Date.now()}`;
+const INTRO_OPP_ID = `cl-surface-intro-opp-${Date.now()}`;
+const OPP_ACTORS = [
+  { userId: CALLER_ID, networkId: 'n/a', role: 'seeker' },
+  { userId: COUNTERPART_ID, networkId: 'n/a', role: 'responder' },
+];
+const INTRO_ACTORS = [
+  { userId: CALLER_ID, networkId: 'n/a', role: 'introducer', approved: false },
+  { userId: COUNTERPART_ID, networkId: 'n/a', role: 'party' },
+];
+
+function mockUser(id: string = CALLER_ID): AuthenticatedUser {
+  return { id, email: `${id}@test`, name: 'CL Surface User' };
+}
+
+describe('GET /c/:code/go — surface-aware redirect', () => {
+  let controller: ConnectLinkController;
+
+  beforeAll(async () => {
+    controller = new ConnectLinkController();
+
+    await db.insert(users).values([
+      { id: CALLER_ID, email: `${CALLER_ID}@test`, name: 'CL Surface Caller' },
+      { id: COUNTERPART_ID, email: `${COUNTERPART_ID}@test`, name: 'CL Surface Counterpart' },
+      { id: OTHER_USER_ID, email: `${OTHER_USER_ID}@test`, name: 'CL Surface Other' },
+    ]);
+
+    await db.insert(opportunities).values({
+      id: OPP_ID,
+      actors: OPP_ACTORS,
+      detection: { source: 'test', timestamp: new Date().toISOString(), createdBy: CALLER_ID },
+      interpretation: { category: 'test', reasoning: 'surface-test', confidence: 0.9 },
+      context: { networkId: 'n/a' },
+      confidence: '0.9',
+      status: 'pending',
+    });
+    await db.insert(opportunities).values({
+      id: INTRO_OPP_ID,
+      actors: INTRO_ACTORS,
+      detection: { source: 'test', timestamp: new Date().toISOString(), createdBy: CALLER_ID },
+      interpretation: { category: 'test', reasoning: 'intro-test', confidence: 0.9 },
+      context: { networkId: 'n/a' },
+      confidence: '0.9',
+      status: 'latent',
+    });
+  });
+
+  afterAll(async () => {
+    await db.delete(connectLinks).where(eq(connectLinks.userId, CALLER_ID));
+    await db.delete(opportunities).where(eq(opportunities.id, OPP_ID));
+    await db.delete(opportunities).where(eq(opportunities.id, INTRO_OPP_ID));
+    await db.delete(userSocials).where(eq(userSocials.userId, COUNTERPART_ID));
+
+    const personalNetworkRows = await db
+      .select({ networkId: personalNetworks.networkId })
+      .from(personalNetworks)
+      .where(eq(personalNetworks.userId, CALLER_ID));
+    const counterpartPersonalNetworkRows = await db
+      .select({ networkId: personalNetworks.networkId })
+      .from(personalNetworks)
+      .where(eq(personalNetworks.userId, COUNTERPART_ID));
+
+    await db.delete(networkMembers).where(eq(networkMembers.userId, CALLER_ID));
+    await db.delete(networkMembers).where(eq(networkMembers.userId, COUNTERPART_ID));
+    await db.delete(personalNetworks).where(eq(personalNetworks.userId, CALLER_ID));
+    await db.delete(personalNetworks).where(eq(personalNetworks.userId, COUNTERPART_ID));
+
+    for (const { networkId } of [...personalNetworkRows, ...counterpartPersonalNetworkRows]) {
+      await db.delete(networkMembers).where(eq(networkMembers.networkId, networkId));
+      await db.delete(networks).where(eq(networks.id, networkId));
+    }
+
+    await db.delete(users).where(eq(users.id, CALLER_ID));
+    await db.delete(users).where(eq(users.id, COUNTERPART_ID));
+    await db.delete(users).where(eq(users.id, OTHER_USER_ID));
+  });
+
+  beforeEach(async () => {
+    await db.delete(connectLinks).where(eq(connectLinks.userId, CALLER_ID));
+    await db.delete(userSocials).where(eq(userSocials.userId, COUNTERPART_ID));
+    await db
+      .update(opportunities)
+      .set({ status: 'pending', actors: OPP_ACTORS })
+      .where(eq(opportunities.id, OPP_ID));
+    await db
+      .update(opportunities)
+      .set({ status: 'latent', actors: INTRO_ACTORS })
+      .where(eq(opportunities.id, INTRO_OPP_ID));
+  });
+
+  test('preferredSurface=telegram + counterpart has TG handle → t.me URL', async () => {
+    await db.insert(userSocials).values({
+      userId: COUNTERPART_ID,
+      label: 'telegram',
+      value: 'counterpart_handle',
+    });
+
+    const { code } = await mintConnectLink({
+      userId: CALLER_ID,
+      opportunityId: OPP_ID,
+      kind: 'connect',
+      greeting: 'hello there',
+      preferredSurface: 'telegram',
+    });
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(), { code });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { url: string };
+    expect(body.url).toMatch(/^https:\/\/t\.me\/counterpart_handle/);
+    expect(body.url).toContain('text=hello%20there');
+  });
+
+  test('preferredSurface=telegram + counterpart has no TG handle → web fallback', async () => {
+    const { code } = await mintConnectLink({
+      userId: CALLER_ID,
+      opportunityId: OPP_ID,
+      kind: 'connect',
+      greeting: 'hello there',
+      preferredSurface: 'telegram',
+    });
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(), { code });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { url: string };
+    expect(body.url).not.toMatch(/^https:\/\/t\.me/);
+    expect(body.url).toContain(`${FRONTEND_URL}/u/${COUNTERPART_ID}/chat`);
+    expect(body.url).toContain('msg=hello%20there');
+  });
+
+  test('preferredSurface unset + counterpart has TG handle → web URL', async () => {
+    await db.insert(userSocials).values({
+      userId: COUNTERPART_ID,
+      label: 'telegram',
+      value: 'counterpart_handle',
+    });
+
+    const { code } = await mintConnectLink({
+      userId: CALLER_ID,
+      opportunityId: OPP_ID,
+      kind: 'connect',
+      greeting: 'hello there',
+    });
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(), { code });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { url: string };
+    expect(body.url).not.toMatch(/^https:\/\/t\.me/);
+    expect(body.url).toContain(`${FRONTEND_URL}/u/${COUNTERPART_ID}/chat`);
+  });
+
+  test('send_direct uses authenticated recipient and opens the same web chat destination as connect', async () => {
+    const { code } = await mintConnectLink({
+      userId: CALLER_ID,
+      opportunityId: OPP_ID,
+      kind: 'send_direct',
+      greeting: 'hello direct',
+    });
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(), { code });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { url: string };
+    expect(body.url).toContain(`${FRONTEND_URL}/u/${COUNTERPART_ID}/chat`);
+    expect(body.url).toContain('msg=hello%20direct');
+  });
+
+  test('outreach uses authenticated recipient and returns conversation destination', async () => {
+    await db
+      .update(opportunities)
+      .set({ status: 'accepted', actors: OPP_ACTORS })
+      .where(eq(opportunities.id, OPP_ID));
+
+    const { code } = await mintConnectLink({
+      userId: CALLER_ID,
+      opportunityId: OPP_ID,
+      kind: 'outreach',
+      greeting: 'hello outreach',
+    });
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(), { code });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { url: string };
+    expect(body.url).toContain(`${FRONTEND_URL}/conversations/`);
+    expect(body.url).toContain('msg=hello%20outreach');
+  });
+
+  test('approve_introduction uses authenticated introducer and returns approval confirmation kind', async () => {
+    const { code } = await mintConnectLink({
+      userId: CALLER_ID,
+      opportunityId: INTRO_OPP_ID,
+      kind: 'approve_introduction',
+    });
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(), { code });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ kind: 'approve_introduction' });
+
+    const [after] = await db
+      .select({ status: opportunities.status, actors: opportunities.actors })
+      .from(opportunities)
+      .where(eq(opportunities.id, INTRO_OPP_ID))
+      .limit(1);
+    expect(after.status).toBe('pending');
+    expect(after.actors.some((actor) => actor.userId === CALLER_ID && actor.role === 'introducer' && actor.approved === true)).toBe(true);
+  });
+
+  test('wrong authenticated recipient is masked as 404 before destination side effects', async () => {
+    const { code } = await mintConnectLink({
+      userId: CALLER_ID,
+      opportunityId: OPP_ID,
+      kind: 'connect',
+      greeting: 'hello there',
+      preferredSurface: 'telegram',
+    });
+
+    const [before] = await db
+      .select({ status: opportunities.status })
+      .from(opportunities)
+      .where(eq(opportunities.id, OPP_ID))
+      .limit(1);
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(OTHER_USER_ID), { code });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Link not found' });
+
+    const [after] = await db
+      .select({ status: opportunities.status })
+      .from(opportunities)
+      .where(eq(opportunities.id, OPP_ID))
+      .limit(1);
+    expect(after.status).toBe(before.status);
+  });
+
+  test('wrong authenticated recipient is masked as 404 for every connect-link kind', async () => {
+    const cases = [
+      { kind: 'connect' as const, opportunityId: OPP_ID, status: 'pending' as const, actors: OPP_ACTORS },
+      { kind: 'send_direct' as const, opportunityId: OPP_ID, status: 'pending' as const, actors: OPP_ACTORS },
+      { kind: 'outreach' as const, opportunityId: OPP_ID, status: 'accepted' as const, actors: OPP_ACTORS },
+      { kind: 'approve_introduction' as const, opportunityId: INTRO_OPP_ID, status: 'latent' as const, actors: INTRO_ACTORS },
+    ];
+
+    for (const item of cases) {
+      await db.delete(connectLinks).where(eq(connectLinks.userId, CALLER_ID));
+      await db
+        .update(opportunities)
+        .set({ status: item.status, actors: item.actors })
+        .where(eq(opportunities.id, item.opportunityId));
+
+      const { code } = await mintConnectLink({
+        userId: CALLER_ID,
+        opportunityId: item.opportunityId,
+        kind: item.kind,
+        greeting: 'wrong account should not use this',
+        preferredSurface: 'telegram',
+      });
+
+      const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(OTHER_USER_ID), { code });
+      expect(res.status).toBe(404);
+      expect(await res.json()).toEqual({ error: 'Link not found' });
+
+      const [after] = await db
+        .select({ status: opportunities.status, actors: opportunities.actors })
+        .from(opportunities)
+        .where(eq(opportunities.id, item.opportunityId))
+        .limit(1);
+      expect(after.status).toBe(item.status);
+      if (item.kind === 'approve_introduction') {
+        expect(after.actors.some((actor) => actor.userId === CALLER_ID && actor.role === 'introducer' && actor.approved === true)).toBe(false);
+      }
+    }
+  });
+});
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] Backend connect-link tests pass: `cd backend && bun test tests/connect-link.e2e.spec.ts tests/connect-link.surface.spec.ts`
+- [x] Guard order is present on the side-effecting resolver: `grep -n "@UseGuards(RateLimit('read'), AuthGuard)" backend/src/controllers/connect-link.controller.ts`
+- [x] Public `/c/:code` no longer resolves DB rows and authenticated `/go` uses recipient-aware resolution: `grep -n "resolveConnectLinkForUser(code, user.id)" backend/src/controllers/connect-link.controller.ts` appears inside `go`, while `grep -n "resolveConnectLink(code)" backend/src/controllers/connect-link.controller.ts` returns no matches
+
+#### Manual Verification:
+- [ ] Public `/c/:code` performs only code syntax validation and redirects to `${FRONTEND_URL}/c/:code` for well-formed codes.
+- [ ] Wrong-account `/c/:code/go` returns `{ "error": "Link not found" }` with 404 before greeting generation or opportunity side effects.
+- [ ] Correct-recipient Telegram/web destination behavior in existing surface-aware tests remains unchanged except authenticated user is now passed to `go`.
+- [ ] Ratify known Slice 1 atomicity tension: public `/c/:code` redirects to the frontend continuation route that is introduced in Slice 2; do not deploy Slice 1 alone unless a temporary frontend route exists.
+
+---
+
+## Phase 2: Frontend continuation service and route
+
+### Overview
+Adds the frontend account-bound continuation path: typed connect-link service, APIContext hook, public `/c/` prefix, route registration, and `/c/:code` page.
+
+### Changes Required:
+
+#### 1. frontend/src/services/connect-links.ts
+**File**: `frontend/src/services/connect-links.ts`
+**Changes**: Add typed authenticated service for resolving continuation codes through `/c/:code/go`.
+
+```ts
+export type ConnectLinkResolution =
+  | { url: string }
+  | { kind: 'approve_introduction' };
+
+/**
+ * Authenticated connect-link continuation API.
+ *
+ * The backend masks unknown, expired, terminal, and wrong-account links as 404.
+ * Callers should render the same unavailable UX for those failures.
+ */
+export const createConnectLinksService = (
+  api: ReturnType<typeof import('../lib/api').useAuthenticatedAPI>,
+) => ({
+  resolveConnectLink: async (
+    code: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<ConnectLinkResolution> => {
+    return api.get<ConnectLinkResolution>(`/c/${encodeURIComponent(code)}/go`, options);
+  },
+});
+```
+
+#### 2. frontend/src/contexts/APIContext.tsx
+**File**: `frontend/src/contexts/APIContext.tsx`
+**Changes**: Create and expose `connectLinksService` via APIProvider and `useConnectLinks()`.
+
+```tsx
+import { createContext, useContext, useMemo, ReactNode } from 'react';
+import { useAuthenticatedAPI } from '@/lib/api';
+import { createIndexesService } from '@/services/networks';
+import { createIntentsService } from '@/services/intents';
+import { createConnectionsService } from '@/services/connections';
+import { createConnectLinksService } from '@/services/connect-links';
+import { createSynthesisService } from '@/services/synthesis';
+import { createDiscoverService } from '@/services/discover';
+import { createFilesService } from '@/services/files';
+import { createLinksService } from '@/services/links';
+import { createAuthService } from '@/services/auth';
+import { createIntegrationsService } from '@/services/integrations';
+import { createAdminService } from '@/services/admin';
+import { createUsersService } from '@/services/users';
+import { createOpportunitiesService } from '@/services/opportunities';
+import { createConversationService } from '@/services/conversation';
+import { createApiKeysService } from '@/services/api-keys';
+import { createAgentsService } from '@/services/agents';
+import { createQuestionsService } from '@/services/questions';
+
+export interface APIContextType {
+  indexesService: ReturnType<typeof createIndexesService>;
+  intentsService: ReturnType<typeof createIntentsService>;
+  connectionsService: ReturnType<typeof createConnectionsService>;
+  connectLinksService: ReturnType<typeof createConnectLinksService>;
+  synthesisService: ReturnType<typeof createSynthesisService>;
+  discoverService: ReturnType<typeof createDiscoverService>;
+  filesService: ReturnType<typeof createFilesService>;
+  linksService: ReturnType<typeof createLinksService>;
+  authService: ReturnType<typeof createAuthService>;
+  integrationsService: ReturnType<typeof createIntegrationsService>;
+  adminService: ReturnType<typeof createAdminService>;
+  usersService: ReturnType<typeof createUsersService>;
+  opportunitiesService: ReturnType<typeof createOpportunitiesService>;
+  conversationService: ReturnType<typeof createConversationService>;
+  apiKeysService: ReturnType<typeof createApiKeysService>;
+  agentsService: ReturnType<typeof createAgentsService>;
+  questionsService: ReturnType<typeof createQuestionsService>;
+}
+
+const APIContext = createContext<APIContextType | undefined>(undefined);
+
+export function APIProvider({ children }: { children: ReactNode }) {
+  const api = useAuthenticatedAPI();
+
+  const services = useMemo(() => ({
+    indexesService: createIndexesService(api),
+    intentsService: createIntentsService(api),
+    connectionsService: createConnectionsService(api),
+    connectLinksService: createConnectLinksService(api),
+    synthesisService: createSynthesisService(api),
+    discoverService: createDiscoverService(api),
+    filesService: createFilesService(api),
+    linksService: createLinksService(api),
+    authService: createAuthService(api),
+    integrationsService: createIntegrationsService(api),
+    adminService: createAdminService(api),
+    usersService: createUsersService(api),
+    opportunitiesService: createOpportunitiesService(api),
+    conversationService: createConversationService(api),
+    apiKeysService: createApiKeysService(api),
+    agentsService: createAgentsService(api),
+    questionsService: createQuestionsService(api),
+  }), [api]);
+
+  return (
+    <APIContext.Provider value={services}>
+      {children}
+    </APIContext.Provider>
+  );
+}
+
+export function useAPI() {
+  const context = useContext(APIContext);
+  if (context === undefined) {
+    throw new Error('useAPI must be used within an APIProvider');
+  }
+  return context;
+}
+
+export function useNetworks() {
+  const { indexesService } = useAPI();
+  return indexesService;
+}
+
+export function useIntents() {
+  const { intentsService } = useAPI();
+  return intentsService;
+}
+
+export function useConnections() {
+  const { connectionsService } = useAPI();
+  return connectionsService;
+}
+
+export function useConnectLinks() {
+  const { connectLinksService } = useAPI();
+  return connectLinksService;
+}
+
+export function useSynthesis() {
+  const { synthesisService } = useAPI();
+  return synthesisService;
+}
+
+export function useDiscover() {
+  const { discoverService } = useAPI();
+  return discoverService;
+}
+
+export function useFiles() {
+  const { filesService } = useAPI();
+  return filesService;
+}
+
+export function useLinks() {
+  const { linksService } = useAPI();
+  return linksService;
+}
+
+export function useAuth() {
+  const { authService } = useAPI();
+  return authService;
+}
+
+export function useAdmin() {
+  const { adminService } = useAPI();
+  return adminService;
+}
+
+export function useUsers() {
+  const { usersService } = useAPI();
+  return usersService;
+}
+
+export function useOpportunities() {
+  const { opportunitiesService } = useAPI();
+  return opportunitiesService;
+}
+
+export function useConversations() {
+  const { conversationService } = useAPI();
+  return conversationService;
+}
+
+export function useApiKeys() {
+  const { apiKeysService } = useAPI();
+  return apiKeysService;
+}
+
+export function useAgents() {
+  const { agentsService } = useAPI();
+  return agentsService;
+}
+
+export function useQuestionsService() {
+  const { questionsService } = useAPI();
+  return questionsService;
+}
+```
+
+#### 3. frontend/src/contexts/AuthContext.tsx
+**File**: `frontend/src/contexts/AuthContext.tsx`
+**Changes**: Add `/c/` to public prefixes so unauthenticated continuation routes can open the login modal.
+
+```tsx
+const publicPrefixes = [
+  '/simulation', '/l', '/c/', '/index/', '/blog', '/pages', '/about',
+  '/login', '/s/', '/oauth/', '/found-in-translation', '/cli-auth', '/u/',
+];
+```
+
+#### 4. frontend/src/routes.tsx
+**File**: `frontend/src/routes.tsx`
+**Changes**: Register `/c/:code` before wildcard route handling.
+
+```tsx
+{
+  path: "/c/:code",
+  lazy: () => import("@/app/c/[code]/page"),
+},
+```
+
+#### 5. frontend/src/app/c/[code]/page.tsx
+**File**: `frontend/src/app/c/[code]/page.tsx`
+**Changes**: Add continuation state machine that preserves login callback, resolves once authenticated, redirects URLs, and renders approval/unavailable/error states.
+
+```tsx
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import { Loader2 } from 'lucide-react';
+
+import { useAuthContext } from '@/contexts/AuthContext';
+import { useConnectLinks } from '@/contexts/APIContext';
+import { APIError } from '@/lib/api';
+
+const CODE_PATTERN = /^[A-Za-z0-9]{10}$/;
+
+type PageStep = 'loading' | 'auth-required' | 'resolving' | 'approved' | 'unavailable' | 'error';
+
+interface PageState {
+  step: PageStep;
+  error: string | null;
+}
+
+function CenteredState({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-[#FDFDFD] px-6">
+      <div className="max-w-md text-center">{children}</div>
+    </div>
+  );
+}
+
+export default function ConnectLinkContinuationPage() {
+  const { code } = useParams();
+  const navigate = useNavigate();
+  const { isAuthenticated, isReady, isLoading: authLoading, openLoginModal } = useAuthContext();
+  const connectLinks = useConnectLinks();
+  const loginPromptedRef = useRef(false);
+  const attemptedCodeRef = useRef<string | null>(null);
+  const [state, setState] = useState<PageState>({ step: 'loading', error: null });
+
+  useEffect(() => {
+    if (!code || !CODE_PATTERN.test(code)) {
+      setState({ step: 'unavailable', error: null });
+      return;
+    }
+
+    if (!isReady || authLoading) {
+      setState({ step: 'loading', error: null });
+      return;
+    }
+
+    if (!isAuthenticated) {
+      attemptedCodeRef.current = null;
+      setState({ step: 'auth-required', error: null });
+      if (!loginPromptedRef.current && typeof window !== 'undefined') {
+        loginPromptedRef.current = true;
+        openLoginModal(window.location.href);
+      }
+      return;
+    }
+
+    if (attemptedCodeRef.current === code) return;
+    attemptedCodeRef.current = code;
+    setState({ step: 'resolving', error: null });
+
+    const controller = new AbortController();
+    let completed = false;
+
+    connectLinks.resolveConnectLink(code, { signal: controller.signal })
+      .then((result) => {
+        completed = true;
+        if ('url' in result) {
+          window.location.replace(result.url);
+          return;
+        }
+        setState({ step: 'approved', error: null });
+      })
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) return;
+        completed = true;
+        if (error instanceof APIError && error.status === 404) {
+          setState({ step: 'unavailable', error: null });
+          return;
+        }
+        setState({
+          step: 'error',
+          error: error instanceof Error ? error.message : 'Could not open this link',
+        });
+      });
+
+    return () => {
+      controller.abort();
+      if (!completed && attemptedCodeRef.current === code) {
+        attemptedCodeRef.current = null;
+      }
+    };
+  }, [authLoading, code, connectLinks, isAuthenticated, isReady, openLoginModal]);
+
+  const openLogin = () => {
+    if (typeof window !== 'undefined') {
+      openLoginModal(window.location.href);
+    } else {
+      openLoginModal();
+    }
+  };
+
+  if (state.step === 'loading' || state.step === 'resolving') {
+    return (
+      <CenteredState>
+        <Loader2 className="mx-auto mb-4 h-8 w-8 animate-spin text-gray-400" />
+        <h1 className="mb-2 text-xl font-semibold text-[#041729]">Connecting…</h1>
+        <p className="text-sm text-gray-600">Preparing your connection. This usually takes a few seconds.</p>
+      </CenteredState>
+    );
+  }
+
+  if (state.step === 'auth-required') {
+    return (
+      <CenteredState>
+        <h1 className="mb-2 text-xl font-semibold text-[#041729]">Sign in to continue</h1>
+        <p className="mb-6 text-sm text-gray-600">This link is tied to a specific Index Network account.</p>
+        <button
+          type="button"
+          onClick={openLogin}
+          className="rounded bg-[#041729] px-4 py-2 text-sm font-medium text-white hover:bg-[#0a2d4a]"
+        >
+          Sign in
+        </button>
+      </CenteredState>
+    );
+  }
+
+  if (state.step === 'approved') {
+    return (
+      <CenteredState>
+        <h1 className="mb-2 text-xl font-semibold text-[#041729]">Introduction approved</h1>
+        <p className="mb-6 text-sm text-gray-600">You approved the introduction. Both parties will be connected shortly.</p>
+        <button
+          type="button"
+          onClick={() => navigate('/')}
+          className="rounded bg-[#041729] px-4 py-2 text-sm font-medium text-white hover:bg-[#0a2d4a]"
+        >
+          Go home
+        </button>
+      </CenteredState>
+    );
+  }
+
+  if (state.step === 'unavailable') {
+    return (
+      <CenteredState>
+        <h1 className="mb-2 text-xl font-semibold text-[#041729]">This opportunity is no longer available</h1>
+        <p className="mb-6 text-sm text-gray-600">The opportunity behind this link has expired or been closed.</p>
+        <button
+          type="button"
+          onClick={() => navigate('/')}
+          className="rounded bg-[#041729] px-4 py-2 text-sm font-medium text-white hover:bg-[#0a2d4a]"
+        >
+          Go home
+        </button>
+      </CenteredState>
+    );
+  }
+
+  return (
+    <CenteredState>
+      <h1 className="mb-2 text-xl font-semibold text-[#041729]">Could not open this link</h1>
+      <p className="mb-6 text-sm text-gray-600">{state.error ?? 'Please try again, or contact support if this keeps happening.'}</p>
+      <button
+        type="button"
+        onClick={() => window.location.reload()}
+        className="rounded bg-[#041729] px-4 py-2 text-sm font-medium text-white hover:bg-[#0a2d4a]"
+      >
+        Try again
+      </button>
+    </CenteredState>
+  );
+}
+
+export const Component = ConnectLinkContinuationPage;
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Connect-link service is wired through APIContext: `grep -n "connectLinksService" frontend/src/contexts/APIContext.tsx`
+- [ ] Frontend `/c/:code` route is registered: `grep -n 'path: "/c/:code"' frontend/src/routes.tsx`
+- [ ] `/c/` is public for unauthenticated continuation: `grep -n "'/c/'" frontend/src/contexts/AuthContext.tsx`
+
+#### Manual Verification:
+- [ ] Logged-out visits to frontend `/c/:code` open the login modal with `window.location.href` as callback.
+- [ ] After login, the route calls `connectLinks.resolveConnectLink(code)` exactly once per code and redirects for `{ url }` responses.
+- [ ] `{ kind: 'approve_introduction' }` renders an in-app confirmation instead of redirecting.
+- [ ] Backend 404 responses render the generic unavailable/not-found state.
+
+---
+
+## Phase 3: Frontend and auth-route regression coverage
+
+### Overview
+Adds frontend regression tests for public-route auth behavior, route registration, and continuation-page outcomes.
+
+### Changes Required:
+
+#### 1. frontend/tests/auth-context.test.tsx
+**File**: `frontend/tests/auth-context.test.tsx`
+**Changes**: Assert unauthenticated `/c/:code` remains on the continuation route without API calls.
+
+```tsx
+test('allows unauthenticated users to stay on connect-link continuation routes', async () => {
+  mocks.useSession.mockReturnValue({ data: null, isPending: false });
+
+  renderAuthProviderAt('/c/Aa0Bb1Cc2D');
+
+  expect(await screen.findByTestId('location')).toHaveTextContent('/c/Aa0Bb1Cc2D');
+  expect(mocks.apiClient.get).not.toHaveBeenCalled();
+});
+```
+
+#### 2. frontend/tests/routes.test.tsx
+**File**: `frontend/tests/routes.test.tsx`
+**Changes**: Add APIContext mock hook and smoke-render the `/c/:code` route.
+
+```tsx
+// Add to the APIContext mock return object:
+useConnectLinks: () => noopService,
+
+// Add to Route rendering smoke tests:
+test('/c/:code — Connect-link continuation page renders without crashing', async () => {
+  const { Component } = await import('@/app/c/[code]/page');
+  const { container } = renderWithRouter(<Component />, {
+    route: '/c/Aa0Bb1Cc2D',
+  });
+  expect(container).toBeTruthy();
+});
+```
+
+#### 3. frontend/src/app/c/[code]/page.test.tsx
+**File**: `frontend/src/app/c/[code]/page.test.tsx`
+**Changes**: Add unit coverage for login callback preservation, authenticated URL redirect, approval confirmation, and backend 404 unavailable UX.
+
+```tsx
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router';
+
+const mocks = vi.hoisted(() => ({
+  authContext: {
+    isReady: true,
+    isLoading: false,
+    isAuthenticated: false,
+    openLoginModal: vi.fn(),
+  },
+  connectLinks: {
+    resolveConnectLink: vi.fn(),
+  },
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuthContext: () => mocks.authContext,
+}));
+
+vi.mock('@/contexts/APIContext', () => ({
+  useConnectLinks: () => mocks.connectLinks,
+}));
+
+vi.mock('@/lib/api', () => ({
+  APIError: class APIError extends Error {
+    constructor(
+      message: string,
+      public status: number,
+      public response?: unknown,
+    ) {
+      super(message);
+      this.name = 'APIError';
+    }
+  },
+}));
+
+import { APIError } from '@/lib/api';
+import { Component as ConnectLinkContinuationPage } from './page';
+
+function renderPage(route = '/c/Aa0Bb1Cc2D') {
+  window.history.pushState({}, '', route);
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <Routes>
+        <Route path="/c/:code" element={<ConnectLinkContinuationPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('ConnectLinkContinuationPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.authContext.isReady = true;
+    mocks.authContext.isLoading = false;
+    mocks.authContext.isAuthenticated = false;
+    mocks.connectLinks.resolveConnectLink.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('opens login with the current /c/:code URL when unauthenticated', async () => {
+    renderPage();
+
+    expect(await screen.findByText('Sign in to continue')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mocks.authContext.openLoginModal).toHaveBeenCalledWith(window.location.href);
+    });
+    expect(mocks.connectLinks.resolveConnectLink).not.toHaveBeenCalled();
+  });
+
+  test('calls the authenticated resolver once and redirects for URL responses', async () => {
+    mocks.authContext.isAuthenticated = true;
+    mocks.connectLinks.resolveConnectLink.mockResolvedValue({ url: 'https://example.com/next' });
+    const replaceSpy = vi.spyOn(window.location, 'replace').mockImplementation(() => undefined);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(mocks.connectLinks.resolveConnectLink).toHaveBeenCalledTimes(1);
+      expect(mocks.connectLinks.resolveConnectLink).toHaveBeenCalledWith('Aa0Bb1Cc2D', expect.objectContaining({ signal: expect.any(AbortSignal) }));
+      expect(replaceSpy).toHaveBeenCalledWith('https://example.com/next');
+    });
+  });
+
+  test('renders introduction-approved confirmation for approve responses', async () => {
+    mocks.authContext.isAuthenticated = true;
+    mocks.connectLinks.resolveConnectLink.mockResolvedValue({ kind: 'approve_introduction' });
+
+    renderPage();
+
+    expect(await screen.findByText('Introduction approved')).toBeInTheDocument();
+  });
+
+  test('renders unavailable state for backend 404 responses', async () => {
+    mocks.authContext.isAuthenticated = true;
+    mocks.connectLinks.resolveConnectLink.mockRejectedValue(new APIError('Link not found', 404));
+
+    renderPage();
+
+    expect(await screen.findByText('This opportunity is no longer available')).toBeInTheDocument();
+  });
+});
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Frontend auth and route tests pass: `cd frontend && bun test tests/auth-context.test.tsx tests/routes.test.tsx src/app/c/[code]/page.test.tsx`
+- [ ] AuthContext test asserts `/c/:code` remains public for unauthenticated users: `grep -n "connect-link continuation" frontend/tests/auth-context.test.tsx`
+- [ ] Route smoke tests include `/c/:code`: `grep -n 'Connect-link continuation page' frontend/tests/routes.test.tsx`
+
+#### Manual Verification:
+- [ ] The continuation page test covers logged-out login callback preservation.
+- [ ] The continuation page test covers authenticated `{ url }` redirects.
+- [ ] The continuation page test covers `{ kind: 'approve_introduction' }` confirmation.
+- [ ] The continuation page test covers backend 404 rendering generic unavailable UX.
+
+---
+
+## Phase 4: Verification hardening for all link kinds
+
+### Overview
+Hardens backend coverage across every connect-link kind, including public approve-introduction behavior and wrong-account masking.
+
+### Changes Required:
+
+#### 1. backend/tests/connect-link.e2e.spec.ts
+**File**: `backend/tests/connect-link.e2e.spec.ts`
+**Changes**: Cover public bridge behavior, malformed code handling, authenticated 404 masking, wrong-account rejection, and approve-introduction public redirect.
+
+```ts
+import '../src/startup.env';
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+
+import { ConnectLinkController } from '../src/controllers/connect-link.controller';
+import type { AuthenticatedUser } from '../src/guards/auth.guard';
+import db from '../src/lib/drizzle/drizzle';
+import { connectLinks, opportunities, users } from '../src/schemas/database.schema';
+import { mintConnectLink } from '../src/services/connect-link.service';
+
+function makeRequest(path: string) {
+  return new Request(`http://localhost${path}`, { method: 'GET' });
+}
+
+const FRONTEND_URL = (process.env.FRONTEND_URL || process.env.APP_URL || 'https://index.network')
+  .replace(/\/+$/, '');
+
+const USER_ID = `cl-e2e-user-${Date.now()}`;
+const OTHER_USER_ID = `cl-e2e-other-${Date.now()}`;
+const OPP_ID = `cl-e2e-opp-${Date.now()}`;
+
+function mockUser(id: string = USER_ID): AuthenticatedUser {
+  return { id, email: `${id}@test`, name: 'CL E2E User' };
+}
+
+describe('GET /c/:code — connect-link controller', () => {
+  let controller: ConnectLinkController;
+
+  beforeAll(async () => {
+    controller = new ConnectLinkController();
+
+    await db.insert(users).values([
+      { id: USER_ID, email: `${USER_ID}@test`, name: 'CL E2E User' },
+      { id: OTHER_USER_ID, email: `${OTHER_USER_ID}@test`, name: 'CL E2E Other User' },
+    ]);
+
+    await db.insert(opportunities).values({
+      id: OPP_ID,
+      actors: [{ userId: USER_ID, networkId: 'n/a', role: 'seeker' }],
+      detection: { source: 'test', timestamp: new Date().toISOString(), createdBy: USER_ID },
+      interpretation: { category: 'test', reasoning: 'test', confidence: 0.9 },
+      context: { networkId: 'n/a' },
+      confidence: '0.9',
+      status: 'pending',
+    });
+  });
+
+  afterAll(async () => {
+    await db.delete(connectLinks).where(eq(connectLinks.userId, USER_ID));
+    await db.delete(opportunities).where(eq(opportunities.id, OPP_ID));
+    await db.delete(users).where(eq(users.id, USER_ID));
+    await db.delete(users).where(eq(users.id, OTHER_USER_ID));
+  });
+
+  test('unknown but well-formed public code redirects to frontend continuation without DB lookup', async () => {
+    const code = 'Aa0Bb1Cc2D';
+    const res = await controller.resolve(makeRequest(`/c/${code}`), undefined, { code });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe(`${FRONTEND_URL}/c/${code}`);
+  });
+
+  test('malformed public code (wrong length or non-base62) is rejected with 404 HTML', async () => {
+    let res = await controller.resolve(makeRequest('/c/TOOSHORT'), undefined, { code: 'TOOSHORT' });
+    expect(res.status).toBe(404);
+    expect(res.headers.get('content-type')).toMatch(/text\/html/);
+
+    res = await controller.resolve(makeRequest('/c/AAAA-BBBBB'), undefined, { code: 'AAAA-BBBBB' });
+    expect(res.status).toBe(404);
+  });
+
+  test('valid public connect code redirects to frontend continuation instead of resolving side effects', async () => {
+    const { code } = await mintConnectLink({
+      userId: USER_ID,
+      opportunityId: OPP_ID,
+      kind: 'connect',
+      greeting: 'Hi from e2e test.',
+    });
+
+    const res = await controller.resolve(makeRequest(`/c/${code}`), undefined, { code });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe(`${FRONTEND_URL}/c/${code}`);
+  });
+
+  test('valid public approve-introduction code redirects to frontend continuation without approving inline', async () => {
+    const { code } = await mintConnectLink({
+      userId: USER_ID,
+      opportunityId: OPP_ID,
+      kind: 'approve_introduction',
+      greeting: 'Approve from e2e test.',
+    });
+
+    const res = await controller.resolve(makeRequest(`/c/${code}`), undefined, { code });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe(`${FRONTEND_URL}/c/${code}`);
+  });
+
+  test('authenticated go masks unknown and malformed codes as 404', async () => {
+    let res = await controller.go(makeRequest('/c/Aa0Bb1Cc2D/go'), mockUser(), { code: 'Aa0Bb1Cc2D' });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Link not found' });
+
+    res = await controller.go(makeRequest('/c/AAAA-BBBBB/go'), mockUser(), { code: 'AAAA-BBBBB' });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Link not found' });
+  });
+
+  test('authenticated go masks wrong-account recipient mismatch as 404', async () => {
+    const { code } = await mintConnectLink({
+      userId: USER_ID,
+      opportunityId: OPP_ID,
+      kind: 'connect',
+      greeting: 'Hi from e2e test.',
+    });
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(OTHER_USER_ID), { code });
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Link not found' });
+  });
+});
+```
+
+#### 2. backend/tests/connect-link.surface.spec.ts
+**File**: `backend/tests/connect-link.surface.spec.ts`
+**Changes**: Pass authenticated users into surface-aware resolver tests and cover correct-recipient destinations plus wrong-account non-mutation for all link kinds.
+
+```ts
+import '../src/startup.env';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+
+import { ConnectLinkController } from '../src/controllers/connect-link.controller';
+import type { AuthenticatedUser } from '../src/guards/auth.guard';
+import db from '../src/lib/drizzle/drizzle';
+import {
+  connectLinks,
+  networkMembers,
+  networks,
+  opportunities,
+  personalNetworks,
+  userSocials,
+  users,
+} from '../src/schemas/database.schema';
+import { mintConnectLink } from '../src/services/connect-link.service';
+
+const FRONTEND_URL = (process.env.FRONTEND_URL || process.env.APP_URL || 'https://index.network')
+  .replace(/\/+$/, '');
+
+function makeRequest(path: string): Request {
+  return new Request(`http://localhost${path}`, { method: 'GET' });
+}
+
+const CALLER_ID = `cl-surface-caller-${Date.now()}`;
+const COUNTERPART_ID = `cl-surface-counterpart-${Date.now()}`;
+const OTHER_USER_ID = `cl-surface-other-${Date.now()}`;
+const OPP_ID = `cl-surface-opp-${Date.now()}`;
+const INTRO_OPP_ID = `cl-surface-intro-opp-${Date.now()}`;
+const OPP_ACTORS = [
+  { userId: CALLER_ID, networkId: 'n/a', role: 'seeker' },
+  { userId: COUNTERPART_ID, networkId: 'n/a', role: 'responder' },
+];
+const INTRO_ACTORS = [
+  { userId: CALLER_ID, networkId: 'n/a', role: 'introducer', approved: false },
+  { userId: COUNTERPART_ID, networkId: 'n/a', role: 'party' },
+];
+
+function mockUser(id: string = CALLER_ID): AuthenticatedUser {
+  return { id, email: `${id}@test`, name: 'CL Surface User' };
+}
+
+describe('GET /c/:code/go — surface-aware redirect', () => {
+  let controller: ConnectLinkController;
+
+  beforeAll(async () => {
+    controller = new ConnectLinkController();
+
+    await db.insert(users).values([
+      { id: CALLER_ID, email: `${CALLER_ID}@test`, name: 'CL Surface Caller' },
+      { id: COUNTERPART_ID, email: `${COUNTERPART_ID}@test`, name: 'CL Surface Counterpart' },
+      { id: OTHER_USER_ID, email: `${OTHER_USER_ID}@test`, name: 'CL Surface Other' },
+    ]);
+
+    await db.insert(opportunities).values({
+      id: OPP_ID,
+      actors: OPP_ACTORS,
+      detection: { source: 'test', timestamp: new Date().toISOString(), createdBy: CALLER_ID },
+      interpretation: { category: 'test', reasoning: 'surface-test', confidence: 0.9 },
+      context: { networkId: 'n/a' },
+      confidence: '0.9',
+      status: 'pending',
+    });
+    await db.insert(opportunities).values({
+      id: INTRO_OPP_ID,
+      actors: INTRO_ACTORS,
+      detection: { source: 'test', timestamp: new Date().toISOString(), createdBy: CALLER_ID },
+      interpretation: { category: 'test', reasoning: 'intro-test', confidence: 0.9 },
+      context: { networkId: 'n/a' },
+      confidence: '0.9',
+      status: 'latent',
+    });
+  });
+
+  afterAll(async () => {
+    await db.delete(connectLinks).where(eq(connectLinks.userId, CALLER_ID));
+    await db.delete(opportunities).where(eq(opportunities.id, OPP_ID));
+    await db.delete(opportunities).where(eq(opportunities.id, INTRO_OPP_ID));
+    await db.delete(userSocials).where(eq(userSocials.userId, COUNTERPART_ID));
+
+    const personalNetworkRows = await db
+      .select({ networkId: personalNetworks.networkId })
+      .from(personalNetworks)
+      .where(eq(personalNetworks.userId, CALLER_ID));
+    const counterpartPersonalNetworkRows = await db
+      .select({ networkId: personalNetworks.networkId })
+      .from(personalNetworks)
+      .where(eq(personalNetworks.userId, COUNTERPART_ID));
+
+    await db.delete(networkMembers).where(eq(networkMembers.userId, CALLER_ID));
+    await db.delete(networkMembers).where(eq(networkMembers.userId, COUNTERPART_ID));
+    await db.delete(personalNetworks).where(eq(personalNetworks.userId, CALLER_ID));
+    await db.delete(personalNetworks).where(eq(personalNetworks.userId, COUNTERPART_ID));
+
+    for (const { networkId } of [...personalNetworkRows, ...counterpartPersonalNetworkRows]) {
+      await db.delete(networkMembers).where(eq(networkMembers.networkId, networkId));
+      await db.delete(networks).where(eq(networks.id, networkId));
+    }
+
+    await db.delete(users).where(eq(users.id, CALLER_ID));
+    await db.delete(users).where(eq(users.id, COUNTERPART_ID));
+    await db.delete(users).where(eq(users.id, OTHER_USER_ID));
+  });
+
+  beforeEach(async () => {
+    await db.delete(connectLinks).where(eq(connectLinks.userId, CALLER_ID));
+    await db.delete(userSocials).where(eq(userSocials.userId, COUNTERPART_ID));
+    await db
+      .update(opportunities)
+      .set({ status: 'pending', actors: OPP_ACTORS })
+      .where(eq(opportunities.id, OPP_ID));
+    await db
+      .update(opportunities)
+      .set({ status: 'latent', actors: INTRO_ACTORS })
+      .where(eq(opportunities.id, INTRO_OPP_ID));
+  });
+
+  test('preferredSurface=telegram + counterpart has TG handle → t.me URL', async () => {
+    await db.insert(userSocials).values({
+      userId: COUNTERPART_ID,
+      label: 'telegram',
+      value: 'counterpart_handle',
+    });
+
+    const { code } = await mintConnectLink({
+      userId: CALLER_ID,
+      opportunityId: OPP_ID,
+      kind: 'connect',
+      greeting: 'hello there',
+      preferredSurface: 'telegram',
+    });
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(), { code });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { url: string };
+    expect(body.url).toMatch(/^https:\/\/t\.me\/counterpart_handle/);
+    expect(body.url).toContain('text=hello%20there');
+  });
+
+  test('preferredSurface=telegram + counterpart has no TG handle → web fallback', async () => {
+    const { code } = await mintConnectLink({
+      userId: CALLER_ID,
+      opportunityId: OPP_ID,
+      kind: 'connect',
+      greeting: 'hello there',
+      preferredSurface: 'telegram',
+    });
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(), { code });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { url: string };
+    expect(body.url).not.toMatch(/^https:\/\/t\.me/);
+    expect(body.url).toContain(`${FRONTEND_URL}/u/${COUNTERPART_ID}/chat`);
+    expect(body.url).toContain('msg=hello%20there');
+  });
+
+  test('preferredSurface unset + counterpart has TG handle → web URL', async () => {
+    await db.insert(userSocials).values({
+      userId: COUNTERPART_ID,
+      label: 'telegram',
+      value: 'counterpart_handle',
+    });
+
+    const { code } = await mintConnectLink({
+      userId: CALLER_ID,
+      opportunityId: OPP_ID,
+      kind: 'connect',
+      greeting: 'hello there',
+    });
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(), { code });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { url: string };
+    expect(body.url).not.toMatch(/^https:\/\/t\.me/);
+    expect(body.url).toContain(`${FRONTEND_URL}/u/${COUNTERPART_ID}/chat`);
+  });
+
+  test('send_direct uses authenticated recipient and opens the same web chat destination as connect', async () => {
+    const { code } = await mintConnectLink({
+      userId: CALLER_ID,
+      opportunityId: OPP_ID,
+      kind: 'send_direct',
+      greeting: 'hello direct',
+    });
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(), { code });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { url: string };
+    expect(body.url).toContain(`${FRONTEND_URL}/u/${COUNTERPART_ID}/chat`);
+    expect(body.url).toContain('msg=hello%20direct');
+  });
+
+  test('outreach uses authenticated recipient and returns conversation destination', async () => {
+    await db
+      .update(opportunities)
+      .set({ status: 'accepted', actors: OPP_ACTORS })
+      .where(eq(opportunities.id, OPP_ID));
+
+    const { code } = await mintConnectLink({
+      userId: CALLER_ID,
+      opportunityId: OPP_ID,
+      kind: 'outreach',
+      greeting: 'hello outreach',
+    });
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(), { code });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { url: string };
+    expect(body.url).toContain(`${FRONTEND_URL}/conversations/`);
+    expect(body.url).toContain('msg=hello%20outreach');
+  });
+
+  test('approve_introduction uses authenticated introducer and returns approval confirmation kind', async () => {
+    const { code } = await mintConnectLink({
+      userId: CALLER_ID,
+      opportunityId: INTRO_OPP_ID,
+      kind: 'approve_introduction',
+    });
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(), { code });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ kind: 'approve_introduction' });
+
+    const [after] = await db
+      .select({ status: opportunities.status, actors: opportunities.actors })
+      .from(opportunities)
+      .where(eq(opportunities.id, INTRO_OPP_ID))
+      .limit(1);
+    expect(after.status).toBe('pending');
+    expect(after.actors.some((actor) => actor.userId === CALLER_ID && actor.role === 'introducer' && actor.approved === true)).toBe(true);
+  });
+
+  test('wrong authenticated recipient is masked as 404 before destination side effects', async () => {
+    const { code } = await mintConnectLink({
+      userId: CALLER_ID,
+      opportunityId: OPP_ID,
+      kind: 'connect',
+      greeting: 'hello there',
+      preferredSurface: 'telegram',
+    });
+
+    const [before] = await db
+      .select({ status: opportunities.status })
+      .from(opportunities)
+      .where(eq(opportunities.id, OPP_ID))
+      .limit(1);
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(OTHER_USER_ID), { code });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Link not found' });
+
+    const [after] = await db
+      .select({ status: opportunities.status })
+      .from(opportunities)
+      .where(eq(opportunities.id, OPP_ID))
+      .limit(1);
+    expect(after.status).toBe(before.status);
+  });
+
+  test('wrong authenticated recipient is masked as 404 for every connect-link kind', async () => {
+    const cases = [
+      { kind: 'connect' as const, opportunityId: OPP_ID, status: 'pending' as const, actors: OPP_ACTORS },
+      { kind: 'send_direct' as const, opportunityId: OPP_ID, status: 'pending' as const, actors: OPP_ACTORS },
+      { kind: 'outreach' as const, opportunityId: OPP_ID, status: 'accepted' as const, actors: OPP_ACTORS },
+      { kind: 'approve_introduction' as const, opportunityId: INTRO_OPP_ID, status: 'latent' as const, actors: INTRO_ACTORS },
+    ];
+
+    for (const item of cases) {
+      await db.delete(connectLinks).where(eq(connectLinks.userId, CALLER_ID));
+      await db
+        .update(opportunities)
+        .set({ status: item.status, actors: item.actors })
+        .where(eq(opportunities.id, item.opportunityId));
+
+      const { code } = await mintConnectLink({
+        userId: CALLER_ID,
+        opportunityId: item.opportunityId,
+        kind: item.kind,
+        greeting: 'wrong account should not use this',
+        preferredSurface: 'telegram',
+      });
+
+      const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(OTHER_USER_ID), { code });
+      expect(res.status).toBe(404);
+      expect(await res.json()).toEqual({ error: 'Link not found' });
+
+      const [after] = await db
+        .select({ status: opportunities.status, actors: opportunities.actors })
+        .from(opportunities)
+        .where(eq(opportunities.id, item.opportunityId))
+        .limit(1);
+      expect(after.status).toBe(item.status);
+      if (item.kind === 'approve_introduction') {
+        expect(after.actors.some((actor) => actor.userId === CALLER_ID && actor.role === 'introducer' && actor.approved === true)).toBe(false);
+      }
+    }
+  });
+});
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Backend connect-link tests pass with all link kinds covered: `cd backend && bun test tests/connect-link.e2e.spec.ts tests/connect-link.surface.spec.ts`
+- [ ] Surface tests cover all authenticated resolver kinds: `grep -n "send_direct\|outreach\|approve_introduction" backend/tests/connect-link.surface.spec.ts`
+- [ ] Public e2e tests prove `approve_introduction` no longer approves inline: `grep -n "approve-introduction code redirects" backend/tests/connect-link.e2e.spec.ts`
+
+#### Manual Verification:
+- [ ] `connect` and `send_direct` both preserve web chat destination behavior for the correct recipient.
+- [ ] `outreach` remains behind the recipient check before conversation lookup.
+- [ ] `approve_introduction` mutates only through authenticated `/go` and returns `{ kind: 'approve_introduction' }`.
+- [ ] Wrong-account calls for all four link kinds return 404 and leave status/approval state unchanged.
+
+---
+
+## Testing Strategy
+
+### Automated:
+- [ ] Backend connect-link tests pass: `cd backend && bun test tests/connect-link.e2e.spec.ts tests/connect-link.surface.spec.ts`
+- [ ] Guard order is present on the side-effecting resolver: `grep -n "@UseGuards(RateLimit('read'), AuthGuard)" backend/src/controllers/connect-link.controller.ts`
+- [ ] Public `/c/:code` no longer resolves DB rows and authenticated `/go` uses recipient-aware resolution: `grep -n "resolveConnectLinkForUser(code, user.id)" backend/src/controllers/connect-link.controller.ts` appears inside `go`, while `grep -n "resolveConnectLink(code)" backend/src/controllers/connect-link.controller.ts` returns no matches
+- [ ] Public `/c/:code` performs only code syntax validation and redirects to `${FRONTEND_URL}/c/:code` for well-formed codes.
+- [ ] Wrong-account `/c/:code/go` returns `{ "error": "Link not found" }` with 404 before greeting generation or opportunity side effects.
+- [ ] Correct-recipient Telegram/web destination behavior in existing surface-aware tests remains unchanged except authenticated user is now passed to `go`.
+- [ ] Ratify known Slice 1 atomicity tension: public `/c/:code` redirects to the frontend continuation route that is introduced in Slice 2; do not deploy Slice 1 alone unless a temporary frontend route exists.
+- [ ] Connect-link service is wired through APIContext: `grep -n "connectLinksService" frontend/src/contexts/APIContext.tsx`
+- [ ] Frontend `/c/:code` route is registered: `grep -n 'path: "/c/:code"' frontend/src/routes.tsx`
+- [ ] `/c/` is public for unauthenticated continuation: `grep -n "'/c/'" frontend/src/contexts/AuthContext.tsx`
+- [ ] Logged-out visits to frontend `/c/:code` open the login modal with `window.location.href` as callback.
+- [ ] After login, the route calls `connectLinks.resolveConnectLink(code)` exactly once per code and redirects for `{ url }` responses.
+- [ ] `{ kind: 'approve_introduction' }` renders an in-app confirmation instead of redirecting.
+- [ ] Frontend auth and route tests pass: `cd frontend && bun test tests/auth-context.test.tsx tests/routes.test.tsx src/app/c/[code]/page.test.tsx`
+- [ ] AuthContext test asserts `/c/:code` remains public for unauthenticated users: `grep -n "connect-link continuation" frontend/tests/auth-context.test.tsx`
+- [ ] Route smoke tests include `/c/:code`: `grep -n 'Connect-link continuation page' frontend/tests/routes.test.tsx`
+- [ ] The continuation page test covers authenticated `{ url }` redirects.
+- [ ] The continuation page test covers `{ kind: 'approve_introduction' }` confirmation.
+- [ ] Backend connect-link tests pass with all link kinds covered: `cd backend && bun test tests/connect-link.e2e.spec.ts tests/connect-link.surface.spec.ts`
+- [ ] Surface tests cover all authenticated resolver kinds: `grep -n "send_direct\|outreach\|approve_introduction" backend/tests/connect-link.surface.spec.ts`
+- [ ] Public e2e tests prove `approve_introduction` no longer approves inline: `grep -n "approve-introduction code redirects" backend/tests/connect-link.e2e.spec.ts`
+- [ ] `connect` and `send_direct` both preserve web chat destination behavior for the correct recipient.
+- [ ] `outreach` remains behind the recipient check before conversation lookup.
+- [ ] `approve_introduction` mutates only through authenticated `/go` and returns `{ kind: 'approve_introduction' }`.
+
+### Manual Testing Steps:
+1. Verify public `/c/:code` no longer calls `resolveConnectLink()` or opportunity side-effect methods before auth.
+2. Verify `GET /api/c/:code/go` has guard order `RateLimit('read'), AuthGuard`.
+3. Verify recipient mismatch returns 404 before greeting generation, `startChat`, `approveIntroduction`, `getCounterpartTelegramHandleForOpp`, or `getConversationIdForOpp`.
+4. Verify `approve_introduction` no longer mutates from public `/c/:code`; it is handled only by authenticated `/go`.
+5. Verify `outreach` remains protected because `getConversationIdForOpp()` can create a DM.
+6. Verify Telegram-preferred redirect behavior remains unchanged for the correct recipient.
+7. Verify `/c/` is included in frontend public prefixes so unauthenticated users are not redirected home before login continuation.
+8. Verify magic-link/Google callback URLs preserve frontend `/c/:code`, not final chat URLs.
+9. Run targeted backend tests: `cd backend && bun test tests/connect-link.e2e.spec.ts tests/connect-link.surface.spec.ts`.
+10. Run targeted frontend tests: `cd frontend && bun test tests/auth-context.test.tsx tests/routes.test.tsx src/app/c/[code]/page.test.tsx`.
+
+## Performance Considerations
+
+- The authenticated recipient comparison must happen before `getGreetingForCard()` to avoid unnecessary LLM/presenter work and opportunity context exposure.
+- Public `/c/:code` performs only syntax validation and string redirect construction, reducing public DB load and eliminating unauthenticated TTL self-heal writes.
+- The frontend continuation should guard against duplicate resolver calls with a `useRef`/abort pattern because React effects may re-run during auth/session refresh.
+
+## Migration Notes
+
+No schema migration is required. Existing links remain valid because their short codes and row shape are unchanged; the only behavior change is that resolving a link now requires signing into the stored recipient account.
+
+## Developer Context
+
+
+## References
+
+- Design: `/Users/aposto/Projects/index/.worktrees/research-recipient-bound-connect-links/.rpiv/artifacts/designs/2026-06-10_00-15-03_recipient-bound-connect-links.md`
+- `/Users/aposto/Projects/index/.worktrees/research-recipient-bound-connect-links/.rpiv/artifacts/research/2026-06-09_23-41-51_recipient-bound-connect-links.md`
+- `.rpiv/artifacts/discover/2026-06-09_23-32-44_recipient-bound-connect-links.md`
+- `.rpiv/artifacts/research/2026-06-09_11-18-58_connect-links-auth-redirect.md`
+- `.rpiv/artifacts/designs/2026-06-09_11-48-41_connect-links-auth-redirect.md`
+- `.rpiv/artifacts/validation/2026-06-09_13-10-12_ind-354-connect-links-auth-redirect.md`
+
+## Plan Review (Step 4)
+
+_Independent post-finalization review by artifact-code-reviewer and artifact-coverage-reviewer subagents. Findings triaged at Step 5._
+
+| source | plan-loc | codebase-loc | severity | dimension | finding | recommendation | resolution |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| code | Phase 1 §1 (connect-link.controller.ts) | backend/src/services/connect-link.service.ts:266-271 | concern | code-quality | `go` calls `resolveConnectLink(code)` before `link.userId !== user.id`, but the live resolver self-heals expired rows by updating `expiresAt`, so wrong-account requests can still mutate `connect_links` before recipient validation | Add a recipient-aware resolver path that checks the stored `userId` before any TTL extension, and use it from authenticated `/c/:code/go` | applied: added Phase 1 `resolveConnectLinkForUser(code, user.id)` service change and updated controller to use it before TTL self-heal; plan-local design follow-up: `/Users/aposto/Projects/index/.worktrees/research-recipient-bound-connect-links/.rpiv/artifacts/designs/2026-06-10_00-15-03_recipient-bound-connect-links.md` |
+| code | Phase 2 §5 (page.tsx) | frontend/src/main.tsx:10-15 | concern | codebase-fit | The page sets `attemptedCodeRef.current = code` before the fetch completes, but the app runs under `StrictMode`, whose dev effect cleanup can abort the first request and leave the second effect run suppressed by `attemptedCodeRef.current === code` | Reset `attemptedCodeRef.current` when aborting or only mark the code as attempted after a non-aborted resolver completion | applied: route cleanup now aborts and clears `attemptedCodeRef` when a resolver call did not complete, allowing StrictMode's second effect run to retry |

--- a/.rpiv/artifacts/research/2026-06-09_23-41-51_recipient-bound-connect-links.md
+++ b/.rpiv/artifacts/research/2026-06-09_23-41-51_recipient-bound-connect-links.md
@@ -1,0 +1,261 @@
+---
+date: 2026-06-09T23:41:51+0300
+author: Yankı Ekin Yüksel
+commit: 2153450f65
+branch: main
+repository: index
+topic: "Recipient-bound connect links"
+tags: [research, codebase, connect-links, auth, opportunities, telegram]
+status: ready
+last_updated: 2026-06-09T23:41:51+0300
+last_updated_by: Yankı Ekin Yüksel
+---
+
+# Research: Recipient-bound connect links
+
+## Research Question
+Move the security boundary to the backend short-link flow: require authentication before `/c/:code/go` performs link side effects, compare the authenticated user to `connect_links.user_id`, and only then call the existing opportunity service and destination-building logic. Preserve login continuity by returning/redirecting to an account-bound continuation that carries the short code, not just the final `/u/:id/chat?msg=...` URL.
+
+## Summary
+The current short-link resolver is bearer-by-possession: `/c/:code` and `/c/:code/go` are rate-limited but unauthenticated, resolve `connect_links.user_id`, then execute opportunity side effects as that stored user. The link rows already contain the correct recipient identity because MCP/daily-brief `acceptUrl` generation mints links with `userId: viewerId`; the missing piece is enforcement at resolve time. The safest shape is a frontend continuation route that preserves the short code through login, then calls an authenticated backend resolver with the existing API client authorization header before any greeting generation, `startChat`, `approveIntroduction`, or outreach destination lookup runs.
+
+## Detailed Findings
+
+### Backend short-link resolver is the current security boundary gap
+- `ConnectLinkController` explicitly documents that there is no guard and that authentication is currently possession of the short code (`backend/src/controllers/connect-link.controller.ts:68`).
+- The browser entry route validates the 10-character code, resolves the link row, and handles `approve_introduction` inline by calling `opportunityService.approveIntroduction(link.opportunityId, link.userId)` without an authenticated user (`backend/src/controllers/connect-link.controller.ts:88-114`).
+- The interstitial route fetches `/c/:code/go` with `credentials: 'omit'`, so even a cookie/session-capable auth scheme would not currently be sent by this HTML fetch (`backend/src/controllers/connect-link.controller.ts:26-49`).
+- `/c/:code/go` resolves the same link, computes the greeting before the `connect`/`send_direct` branch, then calls `opportunityService.startChat(link.opportunityId, link.userId)` (`backend/src/controllers/connect-link.controller.ts:133-155`). This is the main mutation bug: the controller supplies the actor from the link row, not from a verified session.
+- Correct-recipient destination behavior is already contained after `startChat`: Telegram-preferred links try `getCounterpartTelegramHandle`, otherwise fall back to `/u/:counterpart/chat?msg=...`; web links directly build that chat URL (`backend/src/controllers/connect-link.controller.ts:162-175`). Preserve this logic after the account check.
+- `outreach` also reveals or creates access to a destination: it may fetch a Telegram handle for the opportunity or call `getConversationIdForOpp` and return `/conversations/:id` (`backend/src/controllers/connect-link.controller.ts:179-189`). The FRD decision to protect all link kinds should include this branch.
+
+### Link rows already store recipient identity
+- `connect_links` stores `code`, `user_id`, `opportunity_id`, `kind`, optional `greeting`, optional `preferred_surface`, and `expires_at` (`backend/src/schemas/database.schema.ts:121-134`).
+- The schema enforces one row per `(opportunityId, userId, kind)`, so the row is explicitly per-recipient and per-action (`backend/src/schemas/database.schema.ts:138-142`).
+- `mintConnectLink` either reuses a fresh row or rotates an expired row for the same `(opportunityId, userId, kind)` tuple (`backend/src/services/connect-link.service.ts:74-171`).
+- `resolveConnectLink` returns a `ResolvedLink` containing `userId`, `opportunityId`, `kind`, `greeting`, and narrowed `preferredSurface`; it also handles expired opportunity replacement/self-healing before returning the resolved opportunity id (`backend/src/services/connect-link.service.ts:183-193`, `backend/src/services/connect-link.service.ts:197-247`, `backend/src/services/connect-link.service.ts:247-271`).
+- Because `resolveConnectLink` may rewrite an expired link to a visible replacement for the stored recipient, recipient validation must compare authenticated user to the resolved row’s `userId` before trusting the replacement destination (`backend/src/services/connect-link.service.ts:197-247`).
+
+### Existing AuthGuard cannot be used by static interstitial fetch as-is
+- `AuthGuard` only accepts an `Authorization: Bearer <jwt>` header or a `token` query parameter; it does not read Better Auth cookies (`backend/src/guards/auth.guard.ts:26-43`).
+- Route registry runs each guard and passes the last guard result into the handler’s `user` parameter (`backend/src/main.ts:538-549`). Adding `AuthGuard` after `RateLimit('read')` would make the handler receive `AuthenticatedUser`, but only if the request carries bearer/query token.
+- Guard failures with messages like `Access token required` map to HTTP 401 in the central error handler (`backend/src/main.ts:602-608`). That is useful for an API resolver but not sufficient for raw `/c/:code` HTML because the HTML fetch does not attach a token.
+- Frontend authenticated API calls already attach bearer JWT via `getJwtToken()` and `Authorization` unless `skipAuth` is set (`frontend/src/lib/api.ts:46-48`). Developer checkpoint selected this as the preferred continuation path rather than putting JWTs in callback URLs or adding cookie-session guard behavior.
+
+### Login continuation plumbing exists but currently targets final chat URL
+- `AuthContext.openLoginModal(callbackURL?)` stores a pending callback URL and opens the global auth modal (`frontend/src/contexts/AuthContext.tsx:32-47`).
+- `AuthModal` accepts `callbackURL` and passes it to magic-link sign-in and Google OAuth sign-in (`frontend/src/components/AuthModal.tsx:9-13`, `frontend/src/components/AuthModal.tsx:57-66`, `frontend/src/components/AuthModal.tsx:114-121`).
+- On successful in-app auth, `AuthContext` closes the modal; the actual redirect for magic link / Google is delegated to Better Auth via `callbackURL` (`frontend/src/contexts/AuthContext.tsx:119-122`).
+- The prior chat-page behavior opens login for unauthenticated `/u/:id/chat` visitors with `window.location.href` as callback, preserving final URL and `msg` (`frontend/src/app/u/[id]/chat/page.tsx:33-38`).
+- For recipient-bound links, that callback target should become a short-code continuation route rather than `/u/:id/chat?msg=...`, because final chat URLs have no `connect_links.user_id` to compare (`frontend/src/app/u/[id]/chat/page.tsx:20-23`, `frontend/src/app/u/[id]/chat/page.tsx:102-110`).
+- `AuthContext` treats `/u/` as public so unauthenticated users can reach the chat page and trigger inline login (`frontend/src/contexts/AuthContext.tsx:129-137`). A new frontend continuation route would need equivalent public-route classification if it is not under an existing public prefix.
+
+### Opportunity mutation is correctly guarded inside service, but controller passes the wrong actor source
+- `OpportunityService.startChat` is designed around an authenticated caller id: it checks opportunity existence, accepted-state actor membership, pending/draft/latent status, caller actor membership, and self-accept guard (`backend/src/services/opportunity.service.ts:640-697`).
+- It resolves or creates the DM before mutating opportunity state, then un-hides the conversation for the caller (`backend/src/services/opportunity.service.ts:703-724`).
+- It stamps the actor action with `stampOpportunityActorAction(opportunityId, userId, 'accepted', userId)` after the DM exists (`backend/src/services/opportunity.service.ts:729`).
+- Best-effort sibling opportunity acceptance and contact membership writes run after the status flip (`backend/src/services/opportunity.service.ts:737-754`). These must also remain unreachable for wrong-account link users.
+- The service’s existing actor checks do not solve this bug because `ConnectLinkController.go` supplies `link.userId`; a stolen/forwarded link therefore runs the service as the intended recipient (`backend/src/controllers/connect-link.controller.ts:154-155`).
+- `approveIntroduction` and outreach helper paths also take a `userId` parameter and should receive the authenticated recipient only after comparison with `link.userId` (`backend/src/services/opportunity.service.ts:563-596`, `backend/src/services/opportunity.service.ts:1141-1197`).
+
+### MCP and daily brief generation already mint account-bound links
+- Protocol cards call `attachActionableLinks` when an MCP context and `mintConnectLink` dependency are present (`packages/protocol/src/opportunity/opportunity.tools.ts:947-958`, `packages/protocol/src/opportunity/opportunity.tools.ts:1281-1296`, `packages/protocol/src/opportunity/opportunity.tools.ts:1762-1775`, `packages/protocol/src/opportunity/opportunity.tools.ts:1881-1895`).
+- `attachActionableLinks` passes `userId: opts.viewerId`, `opportunityId`, resolved `kind`, `greeting: null`, and `preferredSurface` to `mintConnectLink`, then puts the returned URL on `card.acceptUrl` (`packages/protocol/src/opportunity/opportunity.tools.ts:119-167`).
+- The backend MCP adapter delegates to `mintConnectLinkSvc` and returns `buildConnectShortUrl(apiBaseUrl, code)` (`backend/src/controllers/mcp.controller.ts:81-89`).
+- MCP identity normalizes `x-index-surface` into `clientSurface` and forwards it into protocol context, which later becomes `preferredSurface` for minting (`backend/src/controllers/mcp.controller.ts:401-429`, `backend/src/controllers/mcp.controller.ts:567`, `packages/protocol/src/opportunity/opportunity.tools.ts:667`).
+- Therefore daily brief links are already account-bound in persistence; resolver enforcement should not require changes to protocol card rendering or link minting except tests if behavior/copy changes.
+
+### Test surface is split across service, protocol, controller, and frontend auth
+- `connect-link.service.spec.ts` covers mint code shape, idempotency per `(opp,user,kind)`, per-kind code differences, valid/unknown resolve, expiry rotation, and expired/replacement behavior (`backend/src/services/tests/connect-link.service.spec.ts:72-142`, `backend/src/services/tests/connect-link.service.spec.ts:146-233`).
+- `opportunity.tools.spec.ts` covers action-kind selection and `attachActionableLinks` mints `connect`, `outreach`, `approve_introduction`, and `send_direct` with `viewerId` and `acceptUrl` fields (`packages/protocol/src/opportunity/tests/opportunity.tools.spec.ts:180-188`, `packages/protocol/src/opportunity/tests/opportunity.tools.spec.ts:276-348`).
+- `opportunity.service.startChat.spec.ts` already verifies `startChat` flips pending/draft to accepted, idempotently returns accepted conversations, rejects non-actors, and stamps the actor action with the passed user id (`backend/src/services/tests/opportunity.service.startChat.spec.ts:64-143`).
+- `opportunity.controller.spec.ts` covers authenticated opportunity status controller behavior and can be used as a controller-test pattern, but it does not cover `ConnectLinkController.go` branches (`backend/src/controllers/tests/opportunity.controller.spec.ts:294-337`).
+- There is no surfaced connect-link controller test covering unauthenticated continuation, wrong-account denial, right-account destination, or all four link kinds; this should be the main targeted backend test addition (`backend/src/controllers/connect-link.controller.ts:133-199`).
+- Frontend tests should focus on the new continuation route/modal callback and authenticated API call. Existing behavior to preserve is `AuthModal` forwarding callback URLs for magic link and Google (`frontend/src/components/AuthModal.tsx:63-120`) and `ChatPage` preserving final chat `msg` when users enter via old `/u/:id/chat` (`frontend/src/app/u/[id]/chat/page.tsx:33-38`).
+
+## Code References
+- `backend/src/controllers/connect-link.controller.ts:26-49` — Interstitial HTML fetches `/go` without credentials.
+- `backend/src/controllers/connect-link.controller.ts:68` — Current no-guard, possession-based auth documentation.
+- `backend/src/controllers/connect-link.controller.ts:88-114` — `/c/:code` entry validates code, resolves row, and currently approves introductions inline.
+- `backend/src/controllers/connect-link.controller.ts:133-199` — `/c/:code/go` side-effecting resolver for connect/send_direct/outreach/approve_introduction.
+- `backend/src/services/connect-link.service.ts:53-55` — Short URL shape `/c/:code?link_preview=false`.
+- `backend/src/services/connect-link.service.ts:74-171` — Idempotent mint and expired-row rotation per recipient/opportunity/kind.
+- `backend/src/services/connect-link.service.ts:183-193` — `ResolvedLink` includes stored `userId` and narrowed `preferredSurface`.
+- `backend/src/services/connect-link.service.ts:197-247` — Expired opportunity replacement lookup scoped to stored user visibility.
+- `backend/src/services/connect-link.service.ts:247-271` — `resolveConnectLink` returns null for invalid/terminal links or resolved replacement link.
+- `backend/src/schemas/database.schema.ts:121-142` — `connect_links` schema and unique recipient/action constraint.
+- `backend/src/guards/auth.guard.ts:26-43` — JWT-only `AuthGuard` contract.
+- `backend/src/main.ts:538-549` — Route guard result becomes handler `user` argument.
+- `backend/src/main.ts:602-608` — Auth guard failures become 401 responses.
+- `backend/src/services/opportunity.service.ts:640-754` — `startChat` actor checks, DM creation, actor stamping, and side effects.
+- `backend/src/services/opportunity.service.ts:563-596` — Introducer approval mutation path.
+- `backend/src/services/opportunity.service.ts:1141-1197` — Telegram/conversation destination helpers for connect/outreach branches.
+- `frontend/src/lib/api.ts:46-48` — Authenticated frontend API requests attach bearer JWT.
+- `frontend/src/contexts/AuthContext.tsx:32-47` — Pending callback URL and `openLoginModal` state.
+- `frontend/src/contexts/AuthContext.tsx:129-137` — Public route prefix classification includes `/u/`.
+- `frontend/src/components/AuthModal.tsx:57-66` — Magic-link sign-in uses `callbackURL`.
+- `frontend/src/components/AuthModal.tsx:114-121` — Google sign-in uses `callbackURL`.
+- `frontend/src/app/u/[id]/chat/page.tsx:33-38` — Logged-out chat route opens login with current URL.
+- `packages/protocol/src/opportunity/opportunity.tools.ts:119-167` — `attachActionableLinks` mints `acceptUrl` with `viewerId`.
+- `backend/src/controllers/mcp.controller.ts:81-89` — Backend MCP `mintConnectLink` wrapper returns short URL.
+- `backend/src/controllers/mcp.controller.ts:401-429` — MCP client surface normalization.
+- `backend/src/controllers/mcp.controller.ts:567` — `x-index-surface` request header mapped to `clientSurface`.
+- `backend/src/services/tests/connect-link.service.spec.ts:72-233` — Current service tests for mint/resolve/expiry.
+- `packages/protocol/src/opportunity/tests/opportunity.tools.spec.ts:180-348` — Current protocol tests for actionable link kind and mint calls.
+- `backend/src/services/tests/opportunity.service.startChat.spec.ts:64-143` — Current service tests for startChat actor/mutation behavior.
+
+## Integration Points
+
+### Inbound References
+- `packages/protocol/src/opportunity/opportunity.tools.ts:947-958` — MCP list/details path attaches actionable links to cards for the current context user.
+- `packages/protocol/src/opportunity/opportunity.tools.ts:1281-1296` — Additional opportunity tool path attaches actionable links with context user and preferred surface.
+- `packages/protocol/src/opportunity/opportunity.tools.ts:1762-1775` — Later card rendering path attaches actionable links for MCP contexts.
+- `packages/protocol/src/opportunity/opportunity.tools.ts:1881-1895` — Feed/card path attaches actionable links with the same dependency.
+- `frontend/src/app/u/[id]/chat/page.tsx:33-38` — Final chat page currently handles unauthenticated users and preserved `msg` after login.
+- `frontend/src/contexts/AuthContext.tsx:191-195` — Global auth modal receives pending callback URL from route-level callers.
+
+### Outbound Dependencies
+- `backend/src/controllers/connect-link.controller.ts:101-107` — `/c/:code` depends on `resolveConnectLink` and `approveIntroduction`.
+- `backend/src/controllers/connect-link.controller.ts:140-155` — `/c/:code/go` depends on `resolveConnectLink`, `getGreetingForCard`, and `startChat`.
+- `backend/src/controllers/connect-link.controller.ts:162-189` — Resolver depends on opportunity service helpers for Telegram handles and conversation ids.
+- `backend/src/services/connect-link.service.ts:1-4` — Connect-link service depends directly on Drizzle, `connectLinks`, and `opportunities`.
+- `frontend/src/lib/api.ts:46-48` — New frontend continuation should depend on the existing authenticated API client for bearer JWT.
+
+### Infrastructure Wiring
+- `backend/src/main.ts:489-493` — Top-level `/c/:code` requests are rewritten to `/api/c/:code` before route handling.
+- `backend/src/main.ts:538-549` — Decorator guard output is wired to controller handler user parameter.
+- `backend/src/main.ts:602-608` — Auth guard errors are centrally mapped to 401 JSON.
+- `backend/src/controllers/connect-link.controller.ts:88-89` and `backend/src/controllers/connect-link.controller.ts:133-134` — Current guard order is only `RateLimit('read')`; any authenticated API resolver should use `RateLimit('read')` before `AuthGuard`.
+- `frontend/src/contexts/AuthContext.tsx:129-137` — Any new frontend continuation route must be public or it will redirect unauthenticated users home before opening login.
+- `backend/src/controllers/mcp.controller.ts:81-89` and `backend/src/controllers/mcp.controller.ts:127` — MCP dependency injection surfaces backend short-link minting to protocol tools.
+
+## Architecture Insights
+- The link row should remain the authority for intended recipient and opportunity; the authenticated session should only prove that the browser user equals `connect_links.user_id` before using the row.
+- Avoid putting bearer JWTs in callback URLs even though `AuthGuard` supports `token`; the existing frontend API client already supplies bearer headers and the developer chose that path.
+- The correct recipient check belongs before greeting generation as well as before mutation. Greeting generation can be expensive and may reveal opportunity context through downstream redirect text.
+- `startChat` is already safe when called with the true authenticated user; the bug is the controller’s actor source, not the service’s actor validation.
+- Existing protocol/MCP minting already passes `viewerId`, so changing resolver authorization should not require changing `acceptUrl` generation semantics.
+- Wrong-account, malformed, expired, and missing-link responses should converge to generic unavailable/not-found UX, but API-level status codes can still be structured internally if the frontend masks them.
+- `approve_introduction` currently runs on `/c/:code` directly while other link kinds defer work to `/go`; protecting all link kinds likely requires moving approval side effects behind the authenticated continuation too.
+
+## Precedents & Lessons
+4 similar past change clusters analyzed.
+
+### Precedent: Preserve connect-link deep-link URL through login
+**Commit(s)**: `e6514ed99e` — "fix(frontend): preserve deep-link URL and msg for unauthenticated connect-link visitors" (2026-06-09); `0132fd90e1` — "feat: add callbackURL prop to AuthModal for oauth login bridge" (2026-04-03); `6d96cd5fe1` — "Include '/u/' in public route prefixes" (2026-05-25)
+**Blast radius**: 4 files across 2 layers
+  frontend/auth — `AuthContext.tsx`, `AuthModal.tsx`: callbackURL plumbing and public route behavior
+  frontend/chat — `frontend/src/app/u/[id]/chat/page.tsx`: preserved deep-link and `msg` for unauthenticated entry
+
+**Follow-up fixes**:
+- `25318cb61e` — "fix(frontend): clear stale auth sessions" (2026-06-01) — auth state could remain stale.
+- `e6514ed99e` — "fix(frontend): preserve deep-link URL and msg for unauthenticated connect-link visitors" (2026-06-09) — unauthenticated connect-link users were dropped to home, losing chat continuation.
+
+**Lessons from docs**:
+- `.rpiv/artifacts/research/2026-06-09_11-18-58_connect-links-auth-redirect.md` — prior auth-continuation research.
+- `.rpiv/artifacts/designs/2026-06-09_11-48-41_connect-links-auth-redirect.md` — prior design for `/u/` public route and chat-page login prompt.
+- `.rpiv/artifacts/validation/2026-06-09_13-10-12_ind-354-connect-links-auth-redirect.md` — validation matrix for magic-link, Google OAuth, email/password, dismiss, and authenticated flows.
+
+**Takeaway**: Preserve URL state through auth, but for this feature preserve the short code rather than the final chat URL.
+
+### Precedent: Initial short connect-link mint/resolve and MCP surfacing
+**Commit(s)**: `2fc234c3ea` — "feat(connect-links): mint and resolve service with idempotent (opp,user,kind)" (2026-05-08); `214537daea` — "feat(connect-links): GET /c/:code dispatches per-kind redirects" (2026-05-08); `95b6ebe6a4` — "feat(connect-links): POST /opportunities/:id/connect-link mints short URL with backend greeting" (2026-05-08); `6af43dbc50` — "feat(connect-links): MCP list_opportunities surfaces short URL; drop &msg= clause" (2026-05-08)
+**Blast radius**: 11 files across 4 layers
+  backend/controller — `/c/:code` resolver and opportunity connect-link endpoint
+  backend/service — connect-link idempotency and opportunity start-chat support
+  protocol — opportunity tools and shared connect-link interface
+  tests/init — service/e2e tests and protocol-init wiring
+
+**Follow-up fixes**:
+- `f3ee1435b3` — "fix(connect-links): address Copilot review on PR #759" (2026-05-08) — controller/service/test hardening after review.
+- `00a5055bcd` — "fix(protocol): surface connector-flow opps in chat tool" (2026-05-09) — protocol tool missed connector-flow opportunities.
+- `76e3f6d168` — "fix(backend): interstitial HTML on /c/<code> for visible loading state" (2026-05-12) — direct redirect lacked visible loading state.
+
+**Lessons from docs**:
+- `.rpiv/artifacts/discover/2026-06-09_11-05-29_connect-links-auth-redirect.md` — prior discover artifact for auth redirect behavior.
+
+**Takeaway**: Connect-link changes cross backend resolver, opportunity service, protocol tools, and frontend continuation; test all entry surfaces.
+
+### Precedent: Surface-aware connect-link redirects
+**Commit(s)**: `83bca6fe3b` — "feat(connect-link): persist preferredSurface at mint time" (2026-05-15); `472ef61d1a` — "feat(connect-link): branch click redirect on link.preferredSurface" (2026-05-15); `84a99f7b2e` — "feat(protocol): forward clientSurface into mintConnectLink calls" (2026-05-15)
+**Blast radius**: 4 files across 3 layers
+  backend/controller — redirect branch based on preferred surface
+  backend/service — persisted/narrowed preferredSurface
+  protocol — forwarded clientSurface from tool calls
+
+**Follow-up fixes**:
+- `f90da6906a` — "fix(connect-link): narrow preferredSurface defensively + test cleanup" (2026-05-15) — preferredSurface needed defensive validation.
+- `bd769f2018` — "fix(protocol): profileUrl is always the Index web profile, never t.me" (2026-06-01) — surface-specific URL semantics regressed.
+
+**Lessons from docs**:
+- `.rpiv/artifacts/research/2026-06-09_11-18-58_connect-links-auth-redirect.md` — prior research context.
+
+**Takeaway**: Treat recipient/surface metadata as untrusted at resolve time; defensively narrow before branching.
+
+### Precedent: Expired connect-link replacement/self-healing
+**Commit(s)**: `d4946436fb` — "feat: self-heal expired connect links when opportunity is actionable" (2026-05-25); `2a40fe14b9` — "fix(connect-links): resolve expired opportunity replacements" (2026-06-01)
+**Blast radius**: 5 files across 2 layers
+  backend/service — connect-link replacement resolution and opportunity replacement lookup
+  backend/controller — expired-link messaging
+
+**Follow-up fixes**:
+- `50a612bf44` — "fix: update expired-link message to reflect self-healing behavior" (2026-05-25) — UX copy lagged behavior.
+- `1c7cf9e87d` — "fix(opportunities): resolve enriched replacements" (2026-06-01) — replacement lookup failed for enriched opportunities.
+- `38d0887513` — "fix(backend): forward expired connect links to replacement opportunities and handle latent in startChat" (2026-06-08) — expired links still needed forwarding; latent handling was incomplete.
+
+**Lessons from docs**:
+- `.rpiv/artifacts/plans/2026-06-09_12-54-22_ind-354-connect-links-auth-redirect.md` — prior implementation-plan context.
+
+**Takeaway**: Explicitly test recipient-bound behavior when links resolve to expired, replacement, or latent opportunities.
+
+### Composite Lessons
+- Connect-link continuation commonly breaks at boundaries: backend `/c` resolver → frontend route → auth modal callbackURL → protocol minting.
+- Preserve URL state through auth; for this feature the preserved state should be the opaque short code, not the final chat destination.
+- Validate recipient, surface, and link metadata at resolve time, not only at mint time.
+- Expired/replaced/latent opportunity handling has had multiple follow-up fixes; include it in design/test scope.
+- Include auth matrix coverage for logged-out, authenticated correct user, authenticated wrong user, magic link, Google OAuth, email/password, and modal dismiss.
+
+## Historical Context (from `.rpiv/artifacts/`)
+- `.rpiv/artifacts/discover/2026-06-09_23-32-44_recipient-bound-connect-links.md` — source FRD for this research.
+- `.rpiv/artifacts/discover/2026-06-09_11-05-29_connect-links-auth-redirect.md` — prior discover artifact for preserving connect-link redirects through auth.
+- `.rpiv/artifacts/research/2026-06-09_11-18-58_connect-links-auth-redirect.md` — prior research on connect-link auth redirect behavior.
+- `.rpiv/artifacts/designs/2026-06-09_11-48-41_connect-links-auth-redirect.md` — prior design for frontend login continuation.
+- `.rpiv/artifacts/plans/2026-06-09_12-54-22_ind-354-connect-links-auth-redirect.md` — prior implementation plan for connect-link auth redirect.
+- `.rpiv/artifacts/validation/2026-06-09_13-10-12_ind-354-connect-links-auth-redirect.md` — prior validation artifact for auth redirect behavior.
+
+## Developer Context
+**Q (discover: Intended user framing): For this connect-url login issue, what problem are you solving and who hits it?**
+A: Daily brief user.
+
+**Q (discover: Possession-based short links must change): From the probe I inferred that connect URLs are currently possession-based: `/c/:code` is unauthenticated, resolves `connect_links.user_id`, and calls `startChat(link.opportunityId, link.userId)` before web login can identify the browser account (`backend/src/controllers/connect-link.controller.ts:68,155`). Keep this behavior or change it?**
+A: Change it.
+
+**Q (discover: Preserve recipient binding through login): From the probe I inferred that after fallback to web chat, login returns to `/u/:id/chat?msg=...` and that URL has no connect code or intended-recipient user to compare against (`frontend/src/app/u/[id]/chat/page.tsx:34-36,102-110`). Should the feature preserve recipient binding through login?**
+A: Bind through login.
+
+**Q (discover: Scope across acceptance links): You clarified that nowhere should people accept other people's connections. Should this requirement cover only daily-brief `connect` links, or all short-link acceptance kinds the code supports?**
+A: All acceptance links.
+
+**Q (discover: Server-side recipient check): Where should the recipient check live for connect-link acceptance? Tradeoff: strongest server-side security vs smallest change to the existing redirect flow.**
+A: Server-gated links.
+
+**Q (discover: Wrong-account UX): What should users see when the link is opened by the wrong logged-in account or after logging in as the wrong account?**
+A: Not found.
+
+**Q (discover: Correct-recipient destination): For the correct recipient, what should happen after they authenticate through a connect link?**
+A: Preserve destination.
+
+**Q (discover: Include non-state-changing outreach links): Should non-state-changing short links, like `outreach` links that only redirect for an already-accepted opportunity, also require the same recipient-account check?**
+A: Yes, all links.
+
+**Q (`backend/src/controllers/connect-link.controller.ts:38`, `backend/src/guards/auth.guard.ts:26-43`, `frontend/src/lib/api.ts:46-48`): Static interstitial fetch omits credentials, AuthGuard requires bearer/query JWT, and the frontend API client attaches Authorization. Which continuation shape should the design prefer?**
+A: Frontend continuation. Use a frontend route/modal callback that preserves the short code and calls an authenticated backend resolver via the API client; avoid JWTs in URLs.
+
+**Q (research checkpoint): Scan complete — write the doc, or adjust first?**
+A: Write the doc.
+
+## Related Research
+- `.rpiv/artifacts/research/2026-06-09_11-18-58_connect-links-auth-redirect.md`
+
+## Open Questions
+None.

--- a/.rpiv/artifacts/validation/2026-06-10_01-25-02_recipient-bound-connect-links.md
+++ b/.rpiv/artifacts/validation/2026-06-10_01-25-02_recipient-bound-connect-links.md
@@ -1,0 +1,65 @@
+---
+template_version: 1
+date: 2026-06-10T01:25:02+0300
+author: Yankı Ekin Yüksel
+commit: 2153450f65
+branch: main
+repository: index
+topic: "Validation of Recipient-bound connect links"
+status: ready
+verdict: pass
+parent: "/Users/aposto/Projects/index/.worktrees/research-recipient-bound-connect-links/.rpiv/artifacts/plans/2026-06-10_01-05-37_recipient-bound-connect-links.md"
+tags: [validation, connect-links, auth, opportunities, frontend]
+last_updated: 2026-06-10T01:25:02+0300
+---
+
+## Validation Report: Recipient-bound connect links
+
+### Implementation Status
+
+- ✓ Phase 1: Authenticated backend resolver — Fully implemented and verified against all checked criteria.
+- ○ Phase 2: Frontend continuation service and route — Not implemented; not marked complete in the plan and not included in this validation verdict.
+- ○ Phase 3: Frontend and auth-route regression coverage — Not implemented; not marked complete in the plan and not included in this validation verdict.
+- ○ Phase 4: Verification hardening for all link kinds — Not separately marked complete; Phase 1's backend test updates already cover all backend link kinds, but the Phase 4 checklist remains unchecked and outside this validation verdict.
+
+### Automated Verification Results
+
+- ✓ Backend connect-link tests pass: `cd backend && bun test tests/connect-link.e2e.spec.ts tests/connect-link.surface.spec.ts` — 14 pass, 0 fail, 51 assertions.
+- ✓ Guard order is present on the side-effecting resolver: `grep -n "@UseGuards(RateLimit('read'), AuthGuard)" backend/src/controllers/connect-link.controller.ts` — found at `backend/src/controllers/connect-link.controller.ts:78`.
+- ✓ Authenticated `/go` uses recipient-aware resolution and public controller has no `resolveConnectLink(code)` call: `grep -n "resolveConnectLinkForUser(code, user.id)" backend/src/controllers/connect-link.controller.ts` appears at `backend/src/controllers/connect-link.controller.ts:84`; `grep -n "resolveConnectLink(code)" backend/src/controllers/connect-link.controller.ts` returned no matches.
+- ✓ No regressions detected in the completed Phase 1 validation surface.
+
+### Code Review Findings
+
+#### Matches Plan:
+
+- `backend/src/controllers/connect-link.controller.ts:55-65` — public `/c/:code` performs presence/syntax validation only and redirects valid-looking codes to `${FRONTEND_URL}/c/:code` without calling DB-backed link resolution or opportunity side effects.
+- `backend/src/controllers/connect-link.controller.ts:77-86` — authenticated `/c/:code/go` uses `@UseGuards(RateLimit('read'), AuthGuard)`, masks malformed/unresolved/wrong-recipient cases as 404, and calls `resolveConnectLinkForUser(code, user.id)` before any opportunity work.
+- `backend/src/controllers/connect-link.controller.ts:88-139` — greeting generation, `approveIntroduction`, `startChat`, Telegram lookup, and conversation lookup are all below the recipient-aware resolution/null-return guard.
+- `backend/src/services/connect-link.service.ts:288-318` — `resolveConnectLinkForUser` filters by both `connect_links.code` and `connect_links.user_id` before opportunity replacement lookup and scopes TTL extension by the same pair.
+- `backend/tests/connect-link.e2e.spec.ts:64-123` — e2e coverage verifies malformed public links, public redirect for connect and approve-introduction codes, authenticated 404 masking, and wrong-account masking.
+- `backend/tests/connect-link.surface.spec.ts:121-300` — surface tests pass authenticated users into `go`, preserve correct-recipient Telegram/web destinations, verify `send_direct`, `outreach`, and `approve_introduction`, and assert wrong-account calls leave status/approval state unchanged.
+
+#### Deviations from Plan:
+
+None. Implementation is a faithful realization of the completed Phase 1 plan. Later phases remain intentionally unchecked and unimplemented.
+
+#### Pattern Conformance:
+
+- ✓ Decorator and guard ordering follows existing controller conventions, with `RateLimit('read')` before `AuthGuard` on the authenticated resolver.
+- ✓ Backend tests follow repository patterns: env loaded first, destructured `bun:test` imports, direct controller integration coverage, and cleanup in `afterAll`/`beforeEach` where mutable rows are created.
+- ✓ Explicit `TEST_TIMEOUT_MS = 15_000` in `backend/tests/connect-link.surface.spec.ts` is consistent with repo guidance to set timeouts for slower backend/integration tests.
+- Minor observation: `ConnectLinkController.go` continues to orchestrate destination construction in-controller. This is an acceptable variation, not a Phase 1 deviation, because the pre-existing controller owned this flow and the plan explicitly scoped only recipient binding and public/auth route separation.
+
+### Manual Testing Required:
+
+1. Phase 1 backend behavior:
+   - [ ] Public `/c/:code` performs only code syntax validation and redirects to `${FRONTEND_URL}/c/:code` for well-formed codes.
+   - [ ] Wrong-account `/c/:code/go` returns `{ "error": "Link not found" }` with 404 before greeting generation or opportunity side effects.
+   - [ ] Correct-recipient Telegram/web destination behavior remains unchanged except authenticated user is now passed to `go`.
+   - [ ] Ratify the known Slice 1 atomicity tension: public `/c/:code` redirects to the frontend continuation route introduced in Phase 2, so do not deploy Phase 1 alone unless a temporary frontend route exists.
+
+### Recommendations:
+
+- Ready to commit Phase 1 backend changes — the completed, checked plan criteria are implemented and validated.
+- Continue with Phase 2 before deployment so public `/c/:code` has the frontend continuation route it now redirects to.

--- a/backend/src/controllers/connect-link.controller.ts
+++ b/backend/src/controllers/connect-link.controller.ts
@@ -83,7 +83,6 @@ export class ConnectLinkController {
 
     const link = await resolveConnectLinkForUser(code, user.id);
     if (!link) return notFoundJson();
-    if (link.userId !== user.id) return notFoundJson();
 
     const frontendUrl = getFrontendUrl();
     const greetingForRecipient = async () => (
@@ -101,10 +100,9 @@ export class ConnectLinkController {
     // greeting ready to send. opportunityService.startChat handles both source
     // statuses; the semantic difference lives in the matrix that picked `kind`.
     if (link.kind === 'connect' || link.kind === 'send_direct') {
+      const greeting = await greetingForRecipient();
       const result = await opportunityService.startChat(link.opportunityId, user.id);
       if ('error' in result) return jsonError(result.error, result.status);
-
-      const greeting = await greetingForRecipient();
 
       if (link.preferredSurface === 'telegram') {
         const handle = await opportunityService.getCounterpartTelegramHandle(result.counterpartUserId);

--- a/backend/src/controllers/connect-link.controller.ts
+++ b/backend/src/controllers/connect-link.controller.ts
@@ -1,10 +1,17 @@
+import { AuthGuard, type AuthenticatedUser } from '../guards/auth.guard';
 import { RateLimit } from '../guards/limiter.guard';
 import { Controller, Get, UseGuards } from '../lib/router/router.decorators';
-import { resolveConnectLink } from '../services/connect-link.service';
+import { resolveConnectLinkForUser } from '../services/connect-link.service';
 import { opportunityService } from '../services/opportunity.service';
 
 /** Route params when path has :code */
 type RouteParams = Record<string, string>;
+
+type ConnectLinkGoResponse =
+  | { url: string }
+  | { kind: 'approve_introduction' };
+
+const CODE_PATTERN = /^[A-Za-z0-9]{10}$/;
 
 const EXPIRED_HTML = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Unavailable</title></head>
 <body style="font-family:system-ui;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0">
@@ -12,40 +19,9 @@ const EXPIRED_HTML = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Un
 <p style="color:#666">The opportunity behind this link has expired or been closed.</p>
 </div></body></html>`;
 
-const APPROVED_HTML = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Introduction Approved</title></head>
-<body style="font-family:system-ui;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0">
-<div style="text-align:center"><h1 style="font-size:1.5rem">Introduction approved</h1>
-<p style="color:#666">You approved the introduction. Both parties will be connected shortly.</p>
-</div></body></html>`;
-
-// Connect/outreach flows trigger an inline LLM call to generate a personalized
-// greeting (see opportunityService.getGreetingForCard). That call has a 20s
-// timeout and the user otherwise stares at a blank tab while it runs. Serve
-// this interstitial immediately, then fetch the resolved URL via /c/:code/go
-// and redirect client-side so the wait is visible.
-const INTERSTITIAL_HTML = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Connecting…</title><meta name="robots" content="noindex"></head>
-<body style="font-family:system-ui;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;color:#333">
-<div id="state" style="text-align:center">
-<div style="display:inline-block;width:32px;height:32px;border:3px solid #e5e7eb;border-top-color:#3b82f6;border-radius:50%;animation:spin 1s linear infinite"></div>
-<h1 style="font-size:1.25rem;margin:1rem 0 0.5rem">Connecting…</h1>
-<p style="color:#666;margin:0">Preparing your message. This usually takes a few seconds.</p>
-</div>
-<style>@keyframes spin{to{transform:rotate(360deg)}}</style>
-<script>
-(async()=>{
-  const fail = (h)=>{document.getElementById('state').innerHTML=h};
-  try {
-    const r = await fetch(window.location.pathname.replace(/\\/$/, '') + '/go', { credentials: 'omit' });
-    if (!r.ok) return fail('<h1 style="font-size:1.25rem">Could not open conversation</h1><p style="color:#666">Please try again, or contact support if this keeps happening.</p>');
-    const j = await r.json();
-    if (j.url) window.location.replace(j.url);
-    else fail('<h1 style="font-size:1.25rem">Done</h1><p style="color:#666">You can close this tab.</p>');
-  } catch (e) {
-    fail('<h1 style="font-size:1.25rem">Connection failed</h1><p style="color:#666">Please try again.</p>');
-  }
-})();
-</script>
-</body></html>`;
+function getFrontendUrl(): string {
+  return (process.env.FRONTEND_URL || process.env.APP_URL || 'https://index.network').replace(/\/+$/, '');
+}
 
 function jsonError(message: string, status: number): Response {
   return new Response(JSON.stringify({ error: message }), {
@@ -54,36 +30,27 @@ function jsonError(message: string, status: number): Response {
   });
 }
 
+function notFoundJson(): Response {
+  return jsonError('Link not found', 404);
+}
+
 /**
  * ConnectLinkController: opaque short-link dispatcher.
  *
- * Resolves a base62 short code minted by `connect-link.service.ts` and performs
- * the kind-appropriate side effect: `connect` accepts the opportunity and
- * redirects to Telegram (or web chat); `approve_introduction` flips the
- * introducer's approved flag and renders an inline HTML confirmation;
- * `outreach` redirects to a Telegram DM (or fallback chat URL) for an
- * already-accepted opportunity. Greeting is pulled from the connect-link row
- * and URI-encoded into the redirect target.
- *
- * No guard: authentication is via possession of the short code itself.
+ * Public `/c/:code` is only a bridge into the frontend continuation route. It
+ * deliberately does not resolve `connect_links` rows: account binding happens
+ * on authenticated `/c/:code/go`, where the JWT user must match the stored
+ * recipient before any opportunity side effect or destination lookup runs.
  */
 @Controller('/c')
 export class ConnectLinkController {
   /**
-   * GET /c/:code — opaque short-link dispatcher.
+   * GET /c/:code — public short-link bridge.
    *
-   * Browser entry point. For approve_introduction (synchronous-light, no LLM)
-   * we do the work inline and return the confirmation HTML. For connect and
-   * outreach (which trigger a 20s-tail LLM greeting call inside
-   * getGreetingForCard), we return an interstitial HTML page that fetches
-   * `/c/:code/go` and redirects client-side — the user sees a loading state
-   * instead of a blank tab while the LLM runs.
-   *
-   * @param _req - The incoming request (unused; code is in path params).
-   * @param _user - Unauthenticated route; no user context.
-   * @param params - Path params, must contain `code`.
-   * @returns Interstitial HTML 200 for connect/outreach; confirmation HTML 200
-   *   for approve_introduction; expired HTML 404 if the code is unknown.
+   * Valid-looking short codes are redirected to the frontend continuation route
+   * with the same opaque code. The frontend preserves that URL through login and
+   * calls authenticated `/api/c/:code/go`. This route performs no DB lookup and
+   * no opportunity side effects.
    */
   @Get('/:code')
   @UseGuards(RateLimit('read'))
@@ -91,74 +58,54 @@ export class ConnectLinkController {
     const code = params?.code;
     if (!code) return new Response('Missing code', { status: 400 });
 
-    // Codes are 10-char base62 by construction (see connect-link.service.ts).
-    // Reject malformed codes before hitting the DB to avoid wasted lookups
-    // and make brute-force scanning more expensive.
-    if (!/^[A-Za-z0-9]{10}$/.test(code)) {
+    if (!CODE_PATTERN.test(code)) {
       return new Response(EXPIRED_HTML, { status: 404, headers: { 'Content-Type': 'text/html' } });
     }
 
-    const link = await resolveConnectLink(code);
-    if (!link) {
-      return new Response(EXPIRED_HTML, { status: 404, headers: { 'Content-Type': 'text/html' } });
-    }
-
-    if (link.kind === 'approve_introduction') {
-      const result = await opportunityService.approveIntroduction(link.opportunityId, link.userId);
-      if ('error' in result) {
-        return new Response(result.error, { status: result.status });
-      }
-      return new Response(APPROVED_HTML, { status: 200, headers: { 'Content-Type': 'text/html' } });
-    }
-
-    return new Response(INTERSTITIAL_HTML, {
-      status: 200,
-      headers: { 'Content-Type': 'text/html' },
-    });
+    return Response.redirect(`${getFrontendUrl()}/c/${code}`, 302);
   }
 
   /**
-   * GET /c/:code/go — JSON resolver invoked by the interstitial HTML.
+   * GET /c/:code/go — authenticated JSON resolver.
    *
-   * Does the side-effecting work (resolve, optionally startChat, generate
-   * greeting via LLM, look up Telegram handle / conversation) and returns the
-   * final redirect URL as JSON. The client-side script in INTERSTITIAL_HTML
-   * calls this endpoint and `location.replace`s on success.
-   *
-   * @returns `{ url: string }` for connect/outreach success; `{ error }` with
-   *   appropriate status for any failure path. approve_introduction is handled
-   *   inline on `/c/:code`; if this endpoint receives one, it executes the
-   *   approval and returns `{ kind: 'approve_introduction' }` for completeness.
+   * Resolves the short code, verifies the authenticated user is the stored
+   * recipient, then performs the kind-specific side effect and returns the final
+   * destination. Unknown, terminal, malformed, and wrong-account links are all
+   * masked as 404. No greeting generation, DM lookup, approval, or acceptance
+   * runs until the recipient check passes.
    */
   @Get('/:code/go')
-  @UseGuards(RateLimit('read'))
-  async go(_req: Request, _user: unknown, params?: RouteParams) {
+  @UseGuards(RateLimit('read'), AuthGuard)
+  async go(_req: Request, user: AuthenticatedUser, params?: RouteParams): Promise<Response> {
     const code = params?.code;
     if (!code) return jsonError('Missing code', 400);
-    if (!/^[A-Za-z0-9]{10}$/.test(code)) return jsonError('Invalid code', 404);
+    if (!CODE_PATTERN.test(code)) return notFoundJson();
 
-    const link = await resolveConnectLink(code);
-    if (!link) return jsonError('Link expired', 404);
+    const link = await resolveConnectLinkForUser(code, user.id);
+    if (!link) return notFoundJson();
+    if (link.userId !== user.id) return notFoundJson();
 
-    const frontendUrl = (process.env.FRONTEND_URL || process.env.APP_URL || 'https://index.network').replace(/\/+$/, '');
-    const greeting = link.greeting
-      ?? (await opportunityService.getGreetingForCard(link.opportunityId, link.userId));
+    const frontendUrl = getFrontendUrl();
+    const greetingForRecipient = async () => (
+      link.greeting ?? (await opportunityService.getGreetingForCard(link.opportunityId, user.id))
+    );
+
+    if (link.kind === 'approve_introduction') {
+      const result = await opportunityService.approveIntroduction(link.opportunityId, user.id);
+      if ('error' in result) return jsonError(result.error, result.status);
+      return Response.json({ kind: 'approve_introduction' } satisfies ConnectLinkGoResponse);
+    }
 
     // `connect` (receiver flipping pending → accepted) and `send_direct`
-    // (sender flipping draft/latent → accepted) both want the same thing
-    // once they land: the chat is open and the greeting is ready to send.
-    // opportunityService.startChat already handles both source statuses —
-    // see its docstring — so the two kinds share one handler body. The
-    // semantic difference (who's consenting first vs. second) lives in the
-    // matrix that picked the kind, not here.
+    // (sender flipping draft/latent → accepted) both want the chat open and the
+    // greeting ready to send. opportunityService.startChat handles both source
+    // statuses; the semantic difference lives in the matrix that picked `kind`.
     if (link.kind === 'connect' || link.kind === 'send_direct') {
-      const result = await opportunityService.startChat(link.opportunityId, link.userId);
+      const result = await opportunityService.startChat(link.opportunityId, user.id);
       if ('error' in result) return jsonError(result.error, result.status);
 
-      // Receiver surface determines redirect target. preferredSurface = 'telegram'
-      // means the click came from a Telegram-rendering MCP client and
-      // we should attempt the t.me deep link. Anything else (including NULL on
-      // pre-rollout rows) goes to the web frontend.
+      const greeting = await greetingForRecipient();
+
       if (link.preferredSurface === 'telegram') {
         const handle = await opportunityService.getCounterpartTelegramHandle(result.counterpartUserId);
         const target = handle
@@ -166,34 +113,30 @@ export class ConnectLinkController {
           : (greeting
               ? `${frontendUrl}/u/${result.counterpartUserId}/chat?msg=${encodeURIComponent(greeting)}`
               : `${frontendUrl}/u/${result.counterpartUserId}/chat`);
-        return Response.json({ url: target });
+        return Response.json({ url: target } satisfies ConnectLinkGoResponse);
       }
 
       const target = greeting
         ? `${frontendUrl}/u/${result.counterpartUserId}/chat?msg=${encodeURIComponent(greeting)}`
         : `${frontendUrl}/u/${result.counterpartUserId}/chat`;
-      return Response.json({ url: target });
+      return Response.json({ url: target } satisfies ConnectLinkGoResponse);
     }
 
     if (link.kind === 'outreach') {
+      const greeting = await greetingForRecipient();
+
       if (link.preferredSurface === 'telegram') {
-        const handle = await opportunityService.getCounterpartTelegramHandleForOpp(link.opportunityId, link.userId);
+        const handle = await opportunityService.getCounterpartTelegramHandleForOpp(link.opportunityId, user.id);
         if (handle) {
           const target = greeting ? `https://t.me/${handle}?text=${encodeURIComponent(greeting)}` : `https://t.me/${handle}`;
-          return Response.json({ url: target });
+          return Response.json({ url: target } satisfies ConnectLinkGoResponse);
         }
       }
-      const conversationId = await opportunityService.getConversationIdForOpp(link.opportunityId, link.userId);
+      const conversationId = await opportunityService.getConversationIdForOpp(link.opportunityId, user.id);
       const target = conversationId
         ? `${frontendUrl}/conversations/${conversationId}${greeting ? `?msg=${encodeURIComponent(greeting)}` : ''}`
         : frontendUrl;
-      return Response.json({ url: target });
-    }
-
-    if (link.kind === 'approve_introduction') {
-      const result = await opportunityService.approveIntroduction(link.opportunityId, link.userId);
-      if ('error' in result) return jsonError(result.error, result.status);
-      return Response.json({ kind: 'approve_introduction' });
+      return Response.json({ url: target } satisfies ConnectLinkGoResponse);
     }
 
     return jsonError('Unknown link kind', 400);

--- a/backend/src/services/connect-link.service.ts
+++ b/backend/src/services/connect-link.service.ts
@@ -273,3 +273,47 @@ export async function resolveConnectLink(code: string): Promise<ResolvedLink | n
   return resolvedLink;
 }
 
+/**
+ * Resolve a short code for a specific authenticated recipient.
+ *
+ * This filters by `userId` before expired-opportunity replacement lookup or TTL
+ * extension, so wrong-account callers cannot mutate `connect_links` rows merely
+ * by probing another user's code.
+ *
+ * @param code - The 10-char base62 short code.
+ * @param userId - Authenticated recipient id that must own the link row.
+ * @returns The resolved link row, or `null` for unknown, wrong-recipient,
+ *   expired-terminal, or otherwise unavailable links.
+ */
+export async function resolveConnectLinkForUser(
+  code: string,
+  userId: string,
+): Promise<ResolvedLink | null> {
+  const [row] = await db
+    .select()
+    .from(connectLinks)
+    .where(and(eq(connectLinks.code, code), eq(connectLinks.userId, userId)))
+    .limit(1);
+  if (!row) return null;
+
+  const now = new Date();
+  const opp = await resolveOpportunityForLink(row.opportunityId, userId);
+  if (!opp) return null;
+
+  if (TERMINAL_STATUSES.has(opp.status)) return null;
+
+  const resolvedLink = toResolvedLink(row, opp.id);
+  if (row.expiresAt > now) {
+    return resolvedLink;
+  }
+
+  // Extend TTL only after the authenticated recipient has matched the row.
+  const expiresAt = new Date(now.getTime() + TTL_DAYS * 24 * 60 * 60 * 1000);
+  await db
+    .update(connectLinks)
+    .set({ expiresAt })
+    .where(and(eq(connectLinks.code, code), eq(connectLinks.userId, userId)));
+
+  return resolvedLink;
+}
+

--- a/backend/tests/connect-link.e2e.spec.ts
+++ b/backend/tests/connect-link.e2e.spec.ts
@@ -4,25 +4,25 @@ import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { eq } from 'drizzle-orm';
 
 import { ConnectLinkController } from '../src/controllers/connect-link.controller';
+import type { AuthenticatedUser } from '../src/guards/auth.guard';
 import db from '../src/lib/drizzle/drizzle';
 import { connectLinks, opportunities, users } from '../src/schemas/database.schema';
 import { mintConnectLink } from '../src/services/connect-link.service';
-
-// ---------------------------------------------------------------------------
-// Helpers — in-process controller invocation, mirrors the pattern used in
-// agent-test-message.e2e.spec.ts (no running dev server required).
-// ---------------------------------------------------------------------------
 
 function makeRequest(path: string) {
   return new Request(`http://localhost${path}`, { method: 'GET' });
 }
 
+const FRONTEND_URL = (process.env.FRONTEND_URL || process.env.APP_URL || 'https://index.network')
+  .replace(/\/+$/, '');
+
 const USER_ID = `cl-e2e-user-${Date.now()}`;
+const OTHER_USER_ID = `cl-e2e-other-${Date.now()}`;
 const OPP_ID = `cl-e2e-opp-${Date.now()}`;
 
-// ---------------------------------------------------------------------------
-// Fixtures
-// ---------------------------------------------------------------------------
+function mockUser(id: string = USER_ID): AuthenticatedUser {
+  return { id, email: `${id}@test`, name: 'CL E2E User' };
+}
 
 describe('GET /c/:code — connect-link controller', () => {
   let controller: ConnectLinkController;
@@ -30,14 +30,11 @@ describe('GET /c/:code — connect-link controller', () => {
   beforeAll(async () => {
     controller = new ConnectLinkController();
 
-    await db.insert(users).values({
-      id: USER_ID,
-      email: `${USER_ID}@test`,
-      name: 'CL E2E User',
-    });
+    await db.insert(users).values([
+      { id: USER_ID, email: `${USER_ID}@test`, name: 'CL E2E User' },
+      { id: OTHER_USER_ID, email: `${OTHER_USER_ID}@test`, name: 'CL E2E Other User' },
+    ]);
 
-    // Minimal opportunity row matching the shape used in
-    // backend/src/services/tests/connect-link.service.spec.ts
     await db.insert(opportunities).values({
       id: OPP_ID,
       actors: [{ userId: USER_ID, networkId: 'n/a', role: 'seeker' }],
@@ -53,41 +50,27 @@ describe('GET /c/:code — connect-link controller', () => {
     await db.delete(connectLinks).where(eq(connectLinks.userId, USER_ID));
     await db.delete(opportunities).where(eq(opportunities.id, OPP_ID));
     await db.delete(users).where(eq(users.id, USER_ID));
+    await db.delete(users).where(eq(users.id, OTHER_USER_ID));
   });
 
-  test('unknown but well-formed code returns 404 with HTML body', async () => {
-    const res = await controller.resolve(
-      makeRequest('/c/Aa0Bb1Cc2D'),
-      undefined,
-      { code: 'Aa0Bb1Cc2D' },
-    );
+  test('unknown but well-formed public code redirects to frontend continuation without DB lookup', async () => {
+    const code = 'Aa0Bb1Cc2D';
+    const res = await controller.resolve(makeRequest(`/c/${code}`), undefined, { code });
 
-    expect(res.status).toBe(404);
-    expect(res.headers.get('content-type')).toMatch(/text\/html/);
-    const body = await res.text();
-    expect(body.length).toBeGreaterThan(0);
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe(`${FRONTEND_URL}/c/${code}`);
   });
 
-  test('malformed code (wrong length or non-base62) is rejected with 404', async () => {
-    // Wrong length
-    let res = await controller.resolve(
-      makeRequest('/c/TOOSHORT'),
-      undefined,
-      { code: 'TOOSHORT' },
-    );
+  test('malformed public code (wrong length or non-base62) is rejected with 404 HTML', async () => {
+    let res = await controller.resolve(makeRequest('/c/TOOSHORT'), undefined, { code: 'TOOSHORT' });
     expect(res.status).toBe(404);
     expect(res.headers.get('content-type')).toMatch(/text\/html/);
 
-    // Non-base62 characters
-    res = await controller.resolve(
-      makeRequest('/c/AAAA-BBBBB'),
-      undefined,
-      { code: 'AAAA-BBBBB' },
-    );
+    res = await controller.resolve(makeRequest('/c/AAAA-BBBBB'), undefined, { code: 'AAAA-BBBBB' });
     expect(res.status).toBe(404);
   });
 
-  test('valid connect code is reachable (controller resolves the link)', async () => {
+  test('valid public connect code redirects to frontend continuation instead of resolving side effects', async () => {
     const { code } = await mintConnectLink({
       userId: USER_ID,
       opportunityId: OPP_ID,
@@ -95,18 +78,47 @@ describe('GET /c/:code — connect-link controller', () => {
       greeting: 'Hi from e2e test.',
     });
 
-    const res = await controller.resolve(
-      makeRequest(`/c/${code}`),
-      undefined,
-      { code },
-    );
+    const res = await controller.resolve(makeRequest(`/c/${code}`), undefined, { code });
 
-    // The synthetic opportunity may or may not satisfy `startChat`'s actor
-    // resolution; we only need to confirm the route is wired and the link
-    // resolved (i.e. NOT a 404 expired-page and NOT a 5xx). 302 on success,
-    // 4xx if startChat rejects.
-    expect(res.status).toBeGreaterThanOrEqual(200);
-    expect(res.status).toBeLessThan(500);
-    expect(res.status).not.toBe(404);
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe(`${FRONTEND_URL}/c/${code}`);
+  });
+
+  test('valid public approve-introduction code redirects to frontend continuation without approving inline', async () => {
+    const { code } = await mintConnectLink({
+      userId: USER_ID,
+      opportunityId: OPP_ID,
+      kind: 'approve_introduction',
+      greeting: 'Approve from e2e test.',
+    });
+
+    const res = await controller.resolve(makeRequest(`/c/${code}`), undefined, { code });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe(`${FRONTEND_URL}/c/${code}`);
+  });
+
+  test('authenticated go masks unknown and malformed codes as 404', async () => {
+    let res = await controller.go(makeRequest('/c/Aa0Bb1Cc2D/go'), mockUser(), { code: 'Aa0Bb1Cc2D' });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Link not found' });
+
+    res = await controller.go(makeRequest('/c/AAAA-BBBBB/go'), mockUser(), { code: 'AAAA-BBBBB' });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Link not found' });
+  });
+
+  test('authenticated go masks wrong-account recipient mismatch as 404', async () => {
+    const { code } = await mintConnectLink({
+      userId: USER_ID,
+      opportunityId: OPP_ID,
+      kind: 'connect',
+      greeting: 'Hi from e2e test.',
+    });
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(OTHER_USER_ID), { code });
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Link not found' });
   });
 });

--- a/backend/tests/connect-link.surface.spec.ts
+++ b/backend/tests/connect-link.surface.spec.ts
@@ -1,9 +1,10 @@
 import '../src/startup.env';
 
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
-import { and, eq } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 
 import { ConnectLinkController } from '../src/controllers/connect-link.controller';
+import type { AuthenticatedUser } from '../src/guards/auth.guard';
 import db from '../src/lib/drizzle/drizzle';
 import {
   connectLinks,
@@ -25,7 +26,22 @@ function makeRequest(path: string): Request {
 
 const CALLER_ID = `cl-surface-caller-${Date.now()}`;
 const COUNTERPART_ID = `cl-surface-counterpart-${Date.now()}`;
+const OTHER_USER_ID = `cl-surface-other-${Date.now()}`;
 const OPP_ID = `cl-surface-opp-${Date.now()}`;
+const INTRO_OPP_ID = `cl-surface-intro-opp-${Date.now()}`;
+const OPP_ACTORS = [
+  { userId: CALLER_ID, networkId: 'n/a', role: 'seeker' },
+  { userId: COUNTERPART_ID, networkId: 'n/a', role: 'responder' },
+];
+const INTRO_ACTORS = [
+  { userId: CALLER_ID, networkId: 'n/a', role: 'introducer', approved: false },
+  { userId: COUNTERPART_ID, networkId: 'n/a', role: 'party' },
+];
+const TEST_TIMEOUT_MS = 15_000;
+
+function mockUser(id: string = CALLER_ID): AuthenticatedUser {
+  return { id, email: `${id}@test`, name: 'CL Surface User' };
+}
 
 describe('GET /c/:code/go — surface-aware redirect', () => {
   let controller: ConnectLinkController;
@@ -36,32 +52,35 @@ describe('GET /c/:code/go — surface-aware redirect', () => {
     await db.insert(users).values([
       { id: CALLER_ID, email: `${CALLER_ID}@test`, name: 'CL Surface Caller' },
       { id: COUNTERPART_ID, email: `${COUNTERPART_ID}@test`, name: 'CL Surface Counterpart' },
+      { id: OTHER_USER_ID, email: `${OTHER_USER_ID}@test`, name: 'CL Surface Other' },
     ]);
 
     await db.insert(opportunities).values({
       id: OPP_ID,
-      // Two actors so startChat can resolve a counterpart.
-      actors: [
-        { userId: CALLER_ID, networkId: 'n/a', role: 'seeker' },
-        { userId: COUNTERPART_ID, networkId: 'n/a', role: 'responder' },
-      ],
+      actors: OPP_ACTORS,
       detection: { source: 'test', timestamp: new Date().toISOString(), createdBy: CALLER_ID },
       interpretation: { category: 'test', reasoning: 'surface-test', confidence: 0.9 },
       context: { networkId: 'n/a' },
       confidence: '0.9',
       status: 'pending',
     });
+    await db.insert(opportunities).values({
+      id: INTRO_OPP_ID,
+      actors: INTRO_ACTORS,
+      detection: { source: 'test', timestamp: new Date().toISOString(), createdBy: CALLER_ID },
+      interpretation: { category: 'test', reasoning: 'intro-test', confidence: 0.9 },
+      context: { networkId: 'n/a' },
+      confidence: '0.9',
+      status: 'latent',
+    });
   });
 
   afterAll(async () => {
     await db.delete(connectLinks).where(eq(connectLinks.userId, CALLER_ID));
     await db.delete(opportunities).where(eq(opportunities.id, OPP_ID));
+    await db.delete(opportunities).where(eq(opportunities.id, INTRO_OPP_ID));
     await db.delete(userSocials).where(eq(userSocials.userId, COUNTERPART_ID));
 
-    // startChat → upsertContactMembership → ensurePersonalNetwork creates
-    // personal_networks + networks + network_members for each actor. Delete
-    // these child rows before the users rows to satisfy FK constraints.
-    // Collect the personal network IDs so we can drop the networks row too.
     const personalNetworkRows = await db
       .select({ networkId: personalNetworks.networkId })
       .from(personalNetworks)
@@ -76,8 +95,6 @@ describe('GET /c/:code/go — surface-aware redirect', () => {
     await db.delete(personalNetworks).where(eq(personalNetworks.userId, CALLER_ID));
     await db.delete(personalNetworks).where(eq(personalNetworks.userId, COUNTERPART_ID));
 
-    // Also drop the personal network rows themselves and any network_members
-    // that reference them (e.g. the counterpart added as a contact).
     for (const { networkId } of [...personalNetworkRows, ...counterpartPersonalNetworkRows]) {
       await db.delete(networkMembers).where(eq(networkMembers.networkId, networkId));
       await db.delete(networks).where(eq(networks.id, networkId));
@@ -85,21 +102,21 @@ describe('GET /c/:code/go — surface-aware redirect', () => {
 
     await db.delete(users).where(eq(users.id, CALLER_ID));
     await db.delete(users).where(eq(users.id, COUNTERPART_ID));
+    await db.delete(users).where(eq(users.id, OTHER_USER_ID));
   });
 
-  // `mintConnectLink` has a unique index on (opportunityId, userId, kind), so
-  // each test reuses or rotates the same row. Wipe the row before each test
-  // so the surface stamp is exactly what the test sets — first-mint-wins
-  // would otherwise let an earlier test's surface leak.
   beforeEach(async () => {
-    await db.delete(connectLinks).where(
-      and(
-        eq(connectLinks.opportunityId, OPP_ID),
-        eq(connectLinks.userId, CALLER_ID),
-      ),
-    );
+    await db.delete(connectLinks).where(eq(connectLinks.userId, CALLER_ID));
     await db.delete(userSocials).where(eq(userSocials.userId, COUNTERPART_ID));
-  });
+    await db
+      .update(opportunities)
+      .set({ status: 'pending', actors: OPP_ACTORS })
+      .where(eq(opportunities.id, OPP_ID));
+    await db
+      .update(opportunities)
+      .set({ status: 'latent', actors: INTRO_ACTORS })
+      .where(eq(opportunities.id, INTRO_OPP_ID));
+  }, TEST_TIMEOUT_MS);
 
   test('preferredSurface=telegram + counterpart has TG handle → t.me URL', async () => {
     await db.insert(userSocials).values({
@@ -116,16 +133,14 @@ describe('GET /c/:code/go — surface-aware redirect', () => {
       preferredSurface: 'telegram',
     });
 
-    const res = await controller.go(makeRequest(`/c/${code}/go`), undefined, { code });
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(), { code });
     expect(res.status).toBe(200);
     const body = (await res.json()) as { url: string };
     expect(body.url).toMatch(/^https:\/\/t\.me\/counterpart_handle/);
     expect(body.url).toContain('text=hello%20there');
-  });
+  }, TEST_TIMEOUT_MS);
 
   test('preferredSurface=telegram + counterpart has no TG handle → web fallback', async () => {
-    // No userSocials row — the beforeEach wiped it.
-
     const { code } = await mintConnectLink({
       userId: CALLER_ID,
       opportunityId: OPP_ID,
@@ -134,15 +149,15 @@ describe('GET /c/:code/go — surface-aware redirect', () => {
       preferredSurface: 'telegram',
     });
 
-    const res = await controller.go(makeRequest(`/c/${code}/go`), undefined, { code });
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(), { code });
     expect(res.status).toBe(200);
     const body = (await res.json()) as { url: string };
     expect(body.url).not.toMatch(/^https:\/\/t\.me/);
     expect(body.url).toContain(`${FRONTEND_URL}/u/${COUNTERPART_ID}/chat`);
     expect(body.url).toContain('msg=hello%20there');
-  });
+  }, TEST_TIMEOUT_MS);
 
-  test('preferredSurface unset + counterpart has TG handle → web URL (behavior change)', async () => {
+  test('preferredSurface unset + counterpart has TG handle → web URL', async () => {
     await db.insert(userSocials).values({
       userId: COUNTERPART_ID,
       label: 'telegram',
@@ -154,13 +169,133 @@ describe('GET /c/:code/go — surface-aware redirect', () => {
       opportunityId: OPP_ID,
       kind: 'connect',
       greeting: 'hello there',
-      // preferredSurface omitted — persists as NULL, treated as web.
     });
 
-    const res = await controller.go(makeRequest(`/c/${code}/go`), undefined, { code });
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(), { code });
     expect(res.status).toBe(200);
     const body = (await res.json()) as { url: string };
     expect(body.url).not.toMatch(/^https:\/\/t\.me/);
     expect(body.url).toContain(`${FRONTEND_URL}/u/${COUNTERPART_ID}/chat`);
-  });
+  }, TEST_TIMEOUT_MS);
+
+  test('send_direct uses authenticated recipient and opens the same web chat destination as connect', async () => {
+    const { code } = await mintConnectLink({
+      userId: CALLER_ID,
+      opportunityId: OPP_ID,
+      kind: 'send_direct',
+      greeting: 'hello direct',
+    });
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(), { code });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { url: string };
+    expect(body.url).toContain(`${FRONTEND_URL}/u/${COUNTERPART_ID}/chat`);
+    expect(body.url).toContain('msg=hello%20direct');
+  }, TEST_TIMEOUT_MS);
+
+  test('outreach uses authenticated recipient and returns conversation destination', async () => {
+    await db
+      .update(opportunities)
+      .set({ status: 'accepted', actors: OPP_ACTORS })
+      .where(eq(opportunities.id, OPP_ID));
+
+    const { code } = await mintConnectLink({
+      userId: CALLER_ID,
+      opportunityId: OPP_ID,
+      kind: 'outreach',
+      greeting: 'hello outreach',
+    });
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(), { code });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { url: string };
+    expect(body.url).toContain(`${FRONTEND_URL}/conversations/`);
+    expect(body.url).toContain('msg=hello%20outreach');
+  }, TEST_TIMEOUT_MS);
+
+  test('approve_introduction uses authenticated introducer and returns approval confirmation kind', async () => {
+    const { code } = await mintConnectLink({
+      userId: CALLER_ID,
+      opportunityId: INTRO_OPP_ID,
+      kind: 'approve_introduction',
+    });
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(), { code });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ kind: 'approve_introduction' });
+
+    const [after] = await db
+      .select({ status: opportunities.status, actors: opportunities.actors })
+      .from(opportunities)
+      .where(eq(opportunities.id, INTRO_OPP_ID))
+      .limit(1);
+    expect(after.status).toBe('pending');
+    expect(after.actors.some((actor) => actor.userId === CALLER_ID && actor.role === 'introducer' && actor.approved === true)).toBe(true);
+  }, TEST_TIMEOUT_MS);
+
+  test('wrong authenticated recipient is masked as 404 before destination side effects', async () => {
+    const { code } = await mintConnectLink({
+      userId: CALLER_ID,
+      opportunityId: OPP_ID,
+      kind: 'connect',
+      greeting: 'hello there',
+      preferredSurface: 'telegram',
+    });
+
+    const [before] = await db
+      .select({ status: opportunities.status })
+      .from(opportunities)
+      .where(eq(opportunities.id, OPP_ID))
+      .limit(1);
+
+    const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(OTHER_USER_ID), { code });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Link not found' });
+
+    const [after] = await db
+      .select({ status: opportunities.status })
+      .from(opportunities)
+      .where(eq(opportunities.id, OPP_ID))
+      .limit(1);
+    expect(after.status).toBe(before.status);
+  }, TEST_TIMEOUT_MS);
+
+  test('wrong authenticated recipient is masked as 404 for every connect-link kind', async () => {
+    const cases = [
+      { kind: 'connect' as const, opportunityId: OPP_ID, status: 'pending' as const, actors: OPP_ACTORS },
+      { kind: 'send_direct' as const, opportunityId: OPP_ID, status: 'pending' as const, actors: OPP_ACTORS },
+      { kind: 'outreach' as const, opportunityId: OPP_ID, status: 'accepted' as const, actors: OPP_ACTORS },
+      { kind: 'approve_introduction' as const, opportunityId: INTRO_OPP_ID, status: 'latent' as const, actors: INTRO_ACTORS },
+    ];
+
+    for (const item of cases) {
+      await db.delete(connectLinks).where(eq(connectLinks.userId, CALLER_ID));
+      await db
+        .update(opportunities)
+        .set({ status: item.status, actors: item.actors })
+        .where(eq(opportunities.id, item.opportunityId));
+
+      const { code } = await mintConnectLink({
+        userId: CALLER_ID,
+        opportunityId: item.opportunityId,
+        kind: item.kind,
+        greeting: 'wrong account should not use this',
+        preferredSurface: 'telegram',
+      });
+
+      const res = await controller.go(makeRequest(`/c/${code}/go`), mockUser(OTHER_USER_ID), { code });
+      expect(res.status).toBe(404);
+      expect(await res.json()).toEqual({ error: 'Link not found' });
+
+      const [after] = await db
+        .select({ status: opportunities.status, actors: opportunities.actors })
+        .from(opportunities)
+        .where(eq(opportunities.id, item.opportunityId))
+        .limit(1);
+      expect(after.status).toBe(item.status);
+      if (item.kind === 'approve_introduction') {
+        expect(after.actors.some((actor) => actor.userId === CALLER_ID && actor.role === 'introducer' && actor.approved === true)).toBe(false);
+      }
+    }
+  }, TEST_TIMEOUT_MS);
 });


### PR DESCRIPTION
## Summary
- make public `/c/:code` a syntax-only bridge to the frontend continuation route
- add authenticated recipient-aware `/c/:code/go` resolution before connect-link side effects
- cover wrong-account masking and all backend connect-link kinds in targeted tests
- add discover/research/design/plan/validation artifacts for the change

## Validation
- `cd backend && bun test tests/connect-link.e2e.spec.ts tests/connect-link.surface.spec.ts` — 14 pass, 0 fail
- `grep -n "@UseGuards(RateLimit('read'), AuthGuard)" backend/src/controllers/connect-link.controller.ts`\n- `grep -n "resolveConnectLinkForUser(code, user.id)" backend/src/controllers/connect-link.controller.ts`\n- `grep -n "resolveConnectLink(code)" backend/src/controllers/connect-link.controller.ts` returns no matches\n\n## Notes\n- This PR implements Phase 1 only from the approved plan. Frontend continuation remains a follow-up phase before deploy.