### PR TITLE
fix: normalize null-like specificity warning strings at protocol output and card display

### DIFF
--- a/frontend/src/components/chat/IntentProposalCard.tsx
+++ b/frontend/src/components/chat/IntentProposalCard.tsx
@@ -49,6 +49,14 @@ const COUNTDOWN_SECONDS = 5;
 const DEFAULT_SPECIFICITY_WARNING =
   "This signal is broad and may produce many weak matches. Add a more concrete role, outcome, location, timeframe, domain, or specific need to get better recommendations.";
 
+const NULL_LIKE_SPECIFICITY_WARNING_VALUES = new Set(["null", "undefined"]);
+
+function normalizeSpecificityWarning(value: string | null | undefined): string | null {
+  const warning = value?.trim();
+  if (!warning) return null;
+  return NULL_LIKE_SPECIFICITY_WARNING_VALUES.has(warning.toLowerCase()) ? null : warning;
+}
+
 /**
  * Auto-save card for intent creation in chat.
  * Countdown from 5 with Skip option; auto-saves after countdown; Undo after save.
@@ -73,7 +81,7 @@ export default function IntentProposalCard({
   const statusResolved = currentStatus !== undefined;
   const effectiveStatus = currentStatus ?? (actionTaken ? actionTaken : "pending");
   const isPending = statusResolved && effectiveStatus === "pending" && !actionTaken && !actionError;
-  const specificityWarning = card.specificityWarning?.trim();
+  const specificityWarning = normalizeSpecificityWarning(card.specificityWarning);
   const requiresManualApproval = Boolean(specificityWarning || card.referentialBreadth === "broad");
   // When manual approval is required, always show a warning banner — fall back to
   // the default if the backend sent a broad breadth without a specific message, so

--- a/frontend/src/components/chat/__tests__/IntentProposalCard.test.tsx
+++ b/frontend/src/components/chat/__tests__/IntentProposalCard.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import IntentProposalCard, { type IntentProposalData } from "../IntentProposalCard";
+
+const baseCard: IntentProposalData = {
+  proposalId: "proposal-1",
+  description: "Find agent builders for TypeScript protocol tooling",
+};
+
+describe("IntentProposalCard", () => {
+  it("treats null-like warning strings as absent for non-broad proposals", () => {
+    render(
+      <IntentProposalCard
+        card={{
+          ...baseCard,
+          referentialBreadth: "narrow",
+          specificityWarning: " NuLl ",
+        }}
+        currentStatus="pending"
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText(/^null$/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /create anyway/i })).not.toBeInTheDocument();
+    expect(screen.getByTitle("Create now")).toBeInTheDocument();
+  });
+
+  it("falls back to the default warning for broad proposals with null-like warning strings", () => {
+    render(
+      <IntentProposalCard
+        card={{
+          ...baseCard,
+          referentialBreadth: "broad",
+          specificityWarning: "undefined",
+        }}
+        currentStatus="pending"
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText(/^undefined$/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/This signal is broad and may produce many weak matches/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /create anyway/i })).toBeInTheDocument();
+  });
+});

--- a/packages/protocol/src/intent/intent.tools.ts
+++ b/packages/protocol/src/intent/intent.tools.ts
@@ -53,9 +53,16 @@ function isBroadAttributiveIntent(intent: VerifiedIntent): boolean {
   return intent.verification?.referential_breadth === "broad";
 }
 
+const NULL_LIKE_SPECIFICITY_WARNING_VALUES = new Set(["null", "undefined"]);
+
+function normalizeSpecificityWarning(value: string | null | undefined): string | null {
+  const warning = value?.trim();
+  if (!warning) return null;
+  return NULL_LIKE_SPECIFICITY_WARNING_VALUES.has(warning.toLowerCase()) ? null : warning;
+}
+
 function specificityWarningFor(intent: VerifiedIntent): string {
-  const warning = intent.verification?.specificity_warning?.trim();
-  return warning && warning.length > 0 ? warning : DEFAULT_SPECIFICITY_WARNING;
+  return normalizeSpecificityWarning(intent.verification?.specificity_warning) ?? DEFAULT_SPECIFICITY_WARNING;
 }
 
 export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
@@ -388,7 +395,7 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
           semanticEntropy: v.verification?.semantic_entropy ?? null,
           referentialBreadth: v.verification?.referential_breadth ?? null,
           missingSelectionalConstraints: v.verification?.missing_selectional_constraints ?? [],
-          specificityWarning: isBroad ? specificityWarningFor(v) : v.verification?.specificity_warning ?? null,
+          specificityWarning: isBroad ? specificityWarningFor(v) : normalizeSpecificityWarning(v.verification?.specificity_warning),
         };
         return (
           "```intent_proposal\n" +

--- a/packages/protocol/src/intent/tests/update-intent.spec.ts
+++ b/packages/protocol/src/intent/tests/update-intent.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { z } from "zod";
 
 import { createIntentTools } from "../intent.tools.js";
+import { DEFAULT_SPECIFICITY_WARNING } from "../intent.specificity.js";
 
 import type { ToolDeps, ResolvedToolContext } from "../../shared/agent/tool.helpers.js";
 
@@ -132,6 +133,98 @@ describe("create_intent", () => {
     expect(result.error).toContain("broad");
     expect(result.error).toContain("role, outcome, timeframe");
     expect(createCalls).toBe(0);
+  });
+
+  test("uses default broad warning in MCP auto-approve mode when verifier emits a null-like string", async () => {
+    let createCalls = 0;
+    const tools = captureTools({
+      userDb: {},
+      systemDb: {},
+      graphs: {
+        profile: { invoke: async () => ({ profile: null, agentTimings: [] }) },
+        intent: {
+          invoke: async (input: { operationMode?: string }) => {
+            if (input.operationMode === "propose") {
+              return {
+                verifiedIntents: [{
+                  description: "Meet creative people, builders, and makers interested in AI and somatic exploration",
+                  score: 82,
+                  verification: {
+                    classification: "DIRECTIVE",
+                    semantic_entropy: 0.42,
+                    referential_breadth: "broad",
+                    missing_selectional_constraints: ["role", "outcome", "timeframe"],
+                    specificity_warning: " null ",
+                  },
+                }],
+                agentTimings: [],
+                trace: [],
+              };
+            }
+            createCalls++;
+            return { executionResults: [{ success: true }], agentTimings: [] };
+          },
+        },
+      },
+    } as unknown as ToolDeps);
+    const tool = tools.find((t) => t.name === "create_intent")!;
+
+    const result = JSON.parse(await tool.handler({
+      context: makeContext("alice"),
+      query: {
+        description: "Meet creative people, builders, and makers interested in AI and somatic exploration",
+        autoApprove: true,
+      },
+    }));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain(DEFAULT_SPECIFICITY_WARNING);
+    expect(result.error).not.toMatch(/\bnull\b/i);
+    expect(result.error).toContain("role, outcome, timeframe");
+    expect(createCalls).toBe(0);
+  });
+
+  test("normalizes null-like specificity warnings in web proposal cards", async () => {
+    const tools = captureTools({
+      userDb: {},
+      systemDb: {},
+      graphs: {
+        profile: { invoke: async () => ({ profile: null, agentTimings: [] }) },
+        intent: {
+          invoke: async () => ({
+            verifiedIntents: [{
+              description: "Find agent builders for TypeScript protocol tooling",
+              score: 77,
+              verification: {
+                classification: "DIRECTIVE",
+                semantic_entropy: 0.33,
+                referential_breadth: "moderate",
+                missing_selectional_constraints: [],
+                specificity_warning: " undefined ",
+              },
+            }],
+            agentTimings: [],
+            trace: [],
+          }),
+        },
+      },
+    } as unknown as ToolDeps);
+    const tool = tools.find((t) => t.name === "create_intent")!;
+    const context = { ...makeContext("alice"), isMcp: false } as ResolvedToolContext;
+
+    const result = JSON.parse(await tool.handler({
+      context,
+      query: {
+        description: "Find agent builders for TypeScript protocol tooling",
+        autoApprove: false,
+      },
+    }));
+
+    expect(result.success).toBe(true);
+    const proposal = extractFirstIntentProposal(result.data.message);
+    expect(proposal.referentialBreadth).toBe("moderate");
+    expect(proposal.specificityWarning).toBeNull();
+    expect(proposal.semanticEntropy).toBe(0.33);
   });
 
   test("surfaces referential-breadth warnings in web proposal cards", async () => {


### PR DESCRIPTION
## Bug Fixes

- **fix(protocol)**: `normalizeSpecificityWarning()` helper added to `intent.tools.ts` — strips null-like string sentinels (`"null"`, `"undefined"`, case/whitespace variants) from the `specificity_warning` field before it reaches the proposal JSON. Broad proposals without a usable warning fall back to `DEFAULT_SPECIFICITY_WARNING`; non-broad proposals return `null`.
- **fix(frontend)**: Matching `normalizeSpecificityWarning()` guard added to `IntentProposalCard` — historical or malformed payloads that carry null-like strings are normalised at render time so literal `null` / `undefined` text can never appear in the warning banner.

## Tests

- 2 new protocol regression cases in `update-intent.spec.ts` (MCP broad null-like sentinel → default warning; web non-broad `" undefined "` → `specificityWarning: null`).
- 2 new component tests in `IntentProposalCard.test.tsx` (non-broad `" NuLl "` → no banner, countdown button; broad `"undefined"` → default broad warning, `Create anyway` button).
- All 15 targeted tests pass; both protocol and frontend builds clean.