### PR TITLE
fix(protocol): surface detected socials during onboarding profile confirmation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -127,7 +127,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "3.0.0",
+      "version": "3.1.1",
       "dependencies": {
         "@langchain/core": "^1.1.17",
         "@langchain/langgraph": "^1.1.2",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/chat/chat.prompt.ts
+++ b/packages/protocol/src/chat/chat.prompt.ts
@@ -108,7 +108,9 @@ ${ctx.hasName ? `   - Call \`create_user_profile()\` with no arguments to look t
 
 4. **Confirm or edit profile**
    - If user says "yes" / confirms (bio AND all detected socials are correct) → call \`create_user_profile(confirm=true)\` to save their profile, then proceed to step 5
-   - If a detected social is wrong → ask "What's the correct [platform] URL?" → call \`create_user_profile([platform]Url="[corrected url]")\` (no \`confirm\`) — this re-runs the lookup with the corrected URL and shows a new preview — present the new preview and ask again whether everything is correct
+   - If a detected **github**, **linkedin**, or **twitter** is wrong → ask for the correct URL → call \`create_user_profile(githubUrl|linkedinUrl|twitterUrl="[corrected url]")\` (no \`confirm\`) — re-runs the lookup from the corrected source and shows a new preview — present the new preview and ask again
+   - If a detected **telegram** handle is wrong → ask for the correct handle → call \`create_user_profile(websites=["https://t.me/[correct-handle]"])\` (no \`confirm\`) — the t.me URL is detected as telegram automatically
+   - If a detected **website** is wrong → ask for the correct URL → call \`create_user_profile(websites=["[correct-url]"])\` (no \`confirm\`)
    - If user says "no" / wants bio edits → call \`create_user_profile(bioOrDescription="[corrected description]", confirm=true)\` with their corrections — this regenerates and saves the profile from their text
    - If user provides a rewrite → call \`create_user_profile(bioOrDescription="[their rewritten text]", confirm=true)\` to generate and save the updated profile
    - Do NOT use \`update_user_profile()\` during onboarding — the profile doesn't exist yet until confirmed

--- a/packages/protocol/src/chat/chat.prompt.ts
+++ b/packages/protocol/src/chat/chat.prompt.ts
@@ -99,14 +99,17 @@ ${ctx.hasName ? `   - Call \`create_user_profile()\` with no arguments to look t
    - The tool will look up public sources (LinkedIn, GitHub, etc.) using their name/email
 
 3. **Handle lookup results**
-   - **Profile found**: Present summary naturally: "Here's what I found: [bio summary]. Does that sound right?"
+   - **Profile found**: Present the bio summary, then list every detected social handle from \`detectedSocials\`: "Here's what I found: [bio summary]. I also found your GitHub at [url] and LinkedIn at [url] — are these right?"
+     - If \`detectedSocials\` contains handles: list each one and confirm they are correct before proceeding.
+     - If \`detectedSocials\` is empty or absent: ask the user to share links: "I didn't find any public profiles linked to your account. Want to share a LinkedIn, GitHub, or X/Twitter URL?"
    - **Not found**: "I couldn't confidently match your profile. Tell me who you are in a sentence or share a public link."
    - **Multiple matches**: "I found a few people with this name. Which one is you?" (list options)
    - **Sparse signals**: "I found limited public information. I'll start with what you've shared and refine over time."
 
 4. **Confirm or edit profile**
-   - If user says "yes" / confirms → call \`create_user_profile(confirm=true)\` to save their profile, then proceed to step 5
-   - If user says "no" / wants edits → call \`create_user_profile(bioOrDescription="[corrected description]", confirm=true)\` with their corrections — this regenerates and saves the profile from their text
+   - If user says "yes" / confirms (bio AND all detected socials are correct) → call \`create_user_profile(confirm=true)\` to save their profile, then proceed to step 5
+   - If a detected social is wrong → ask "What's the correct [platform] URL?" → call \`create_user_profile([platform]Url="[corrected url]")\` (no \`confirm\`) — this re-runs the lookup with the corrected URL and shows a new preview — present the new preview and ask again whether everything is correct
+   - If user says "no" / wants bio edits → call \`create_user_profile(bioOrDescription="[corrected description]", confirm=true)\` with their corrections — this regenerates and saves the profile from their text
    - If user provides a rewrite → call \`create_user_profile(bioOrDescription="[their rewritten text]", confirm=true)\` to generate and save the updated profile
    - Do NOT use \`update_user_profile()\` during onboarding — the profile doesn't exist yet until confirmed
 

--- a/packages/protocol/src/chat/chat.prompt.ts
+++ b/packages/protocol/src/chat/chat.prompt.ts
@@ -108,7 +108,9 @@ ${ctx.hasName ? `   - Call \`create_user_profile()\` with no arguments to look t
 
 4. **Confirm or edit profile**
    - If user says "yes" / confirms (bio AND all detected socials are correct) → call \`create_user_profile(confirm=true)\` to save their profile, then proceed to step 5
-   - If a detected **github**, **linkedin**, or **twitter** is wrong → ask for the correct URL → call \`create_user_profile(githubUrl|linkedinUrl|twitterUrl="[corrected url]")\` (no \`confirm\`) — re-runs the lookup from the corrected source and shows a new preview — present the new preview and ask again
+   - If a detected **github** is wrong → ask for the correct URL → call \`create_user_profile(githubUrl="[corrected url]")\` (no \`confirm\`) — re-runs the lookup and shows a new preview — present the new preview and ask again
+   - If a detected **linkedin** is wrong → ask for the correct URL → call \`create_user_profile(linkedinUrl="[corrected url]")\` (no \`confirm\`) — re-runs the lookup and shows a new preview — present the new preview and ask again
+   - If a detected **twitter** is wrong → ask for the correct URL → call \`create_user_profile(twitterUrl="[corrected url]")\` (no \`confirm\`) — re-runs the lookup and shows a new preview — present the new preview and ask again
    - If a detected **telegram** handle is wrong → ask for the correct handle → call \`create_user_profile(websites=["https://t.me/[correct-handle]"])\` (no \`confirm\`) — the t.me URL is detected as telegram automatically
    - If a detected **website** is wrong → ask for the correct URL → call \`create_user_profile(websites=["[correct-url]"])\` (no \`confirm\`)
    - If user says "no" / wants bio edits → call \`create_user_profile(bioOrDescription="[corrected description]", confirm=true)\` with their corrections — this regenerates and saves the profile from their text

--- a/packages/protocol/src/chat/chat.prompt.ts
+++ b/packages/protocol/src/chat/chat.prompt.ts
@@ -112,7 +112,7 @@ ${ctx.hasName ? `   - Call \`create_user_profile()\` with no arguments to look t
    - If a detected **linkedin** is wrong → ask for the correct URL → call \`create_user_profile(linkedinUrl="[corrected url]")\` (no \`confirm\`) — re-runs the lookup and shows a new preview — present the new preview and ask again
    - If a detected **twitter** is wrong → ask for the correct URL → call \`create_user_profile(twitterUrl="[corrected url]")\` (no \`confirm\`) — re-runs the lookup and shows a new preview — present the new preview and ask again
    - If a detected **telegram** handle is wrong → ask for the correct handle → call \`create_user_profile(websites=["https://t.me/[correct-handle]"])\` (no \`confirm\`) — the t.me URL is detected as telegram automatically
-   - If a detected **website** is wrong → ask for the correct URL → call \`create_user_profile(websites=["[correct-url]"])\` (no \`confirm\`)
+   - If a detected **website** is wrong → ask for the correct URL → call \`create_user_profile(websites=[...all other detected websites..., "[correct-url]"])\` (no \`confirm\`) — pass ALL detected websites with the wrong one replaced, because \`websites\` overwrites the full custom-website set
    - If user says "no" / wants bio edits → call \`create_user_profile(bioOrDescription="[corrected description]", confirm=true)\` with their corrections — this regenerates and saves the profile from their text
    - If user provides a rewrite → call \`create_user_profile(bioOrDescription="[their rewritten text]", confirm=true)\` to generate and save the updated profile
    - Do NOT use \`update_user_profile()\` during onboarding — the profile doesn't exist yet until confirmed

--- a/packages/protocol/src/profile/profile.tools.ts
+++ b/packages/protocol/src/profile/profile.tools.ts
@@ -873,6 +873,10 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
                   skills: enrichment.attributes.skills,
                   interests: enrichment.attributes.interests,
                 },
+                // Always present when isMeaningfulEnrichment passes — may be {} if the
+                // enrichment found no social handles. LLM should ask the user to provide
+                // links when empty (FR5).
+                detectedSocials: enrichment.socials,
               });
             }
           } catch (err) {

--- a/packages/protocol/src/profile/profile.tools.ts
+++ b/packages/protocol/src/profile/profile.tools.ts
@@ -875,7 +875,7 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
                 },
                 // Always present when isMeaningfulEnrichment passes — may be {} if the
                 // enrichment found no social handles. LLM should ask the user to provide
-                // links when empty (FR5).
+                // links when empty (see buildOnboarding step 3 in chat.prompt.ts).
                 detectedSocials: enrichment.socials,
               });
             }

--- a/packages/protocol/src/profile/tests/profile.public-lookup.spec.ts
+++ b/packages/protocol/src/profile/tests/profile.public-lookup.spec.ts
@@ -138,3 +138,68 @@ describe("preview_user_profile publicLookup block", () => {
     expect(lastGeneratorInput).not.toContain("Enriched bio");
   });
 });
+
+function getCreateUserProfile(deps: ToolDeps): CapturedTool {
+  return captureTools(deps).find((t) => t.name === "create_user_profile")!;
+}
+
+function buildOnboardingDeps(enrichment: EnrichmentResult | null): ToolDeps {
+  return {
+    userDb: {
+      getUser: async () => ({
+        id: "test-user",
+        name: "Test User",
+        email: "test@example.com",
+        socials: [],
+        onboarding: null,
+      }),
+      getProfile: async () => null,
+      updateUser: async () => ({}),
+      getUserSocials: async () => [],
+      setUserSocials: async () => {},
+    },
+    systemDb: {},
+    database: {},
+    graphs: { profile: { invoke: async () => ({}) } },
+    enricher: { enrichUserProfile: async () => enrichment },
+    grantDefaultSystemPermissions: async () => undefined,
+  } as unknown as ToolDeps;
+}
+
+const onboardingContext = {
+  userId: "test-user",
+  userName: "Test User",
+  userEmail: "test@example.com",
+  user: { onboarding: null },
+} as unknown as ResolvedToolContext;
+
+describe("create_user_profile detectedSocials preview", () => {
+  it("includes detectedSocials in preview when enrichment finds social handles", async () => {
+    const enrichment = makeEnrichment({ socials: { github: "github.com/user", linkedin: "linkedin.com/in/user" } });
+    const tool = getCreateUserProfile(buildOnboardingDeps(enrichment));
+    const result = await tool.handler({ context: onboardingContext, query: {} });
+    const parsed = JSON.parse(result);
+    expect(parsed.success).toBe(true);
+    expect(parsed.data.preview).toBe(true);
+    expect(parsed.data.detectedSocials).toEqual({ github: "github.com/user", linkedin: "linkedin.com/in/user" });
+  });
+
+  it("includes empty detectedSocials when enrichment finds no social handles", async () => {
+    const enrichment = makeEnrichment({ socials: {} });
+    const tool = getCreateUserProfile(buildOnboardingDeps(enrichment));
+    const result = await tool.handler({ context: onboardingContext, query: {} });
+    const parsed = JSON.parse(result);
+    expect(parsed.success).toBe(true);
+    expect(parsed.data.preview).toBe(true);
+    expect(parsed.data.detectedSocials).toEqual({});
+  });
+
+  it("returns needsClarification (not a preview) when enrichment is not confident", async () => {
+    const enrichment = makeEnrichment({ confidentMatch: false });
+    const tool = getCreateUserProfile(buildOnboardingDeps(enrichment));
+    const result = await tool.handler({ context: onboardingContext, query: {} });
+    const parsed = JSON.parse(result);
+    expect(parsed.success).toBe(false);
+    expect(parsed.needsClarification).toBe(true);
+  });
+});


### PR DESCRIPTION
## Bug Fixes

- **`create_user_profile` onboarding preview now exposes `detectedSocials`** — enrichment silently picked GitHub/LinkedIn/Twitter handles but never forwarded them to the LLM. The preview response now includes `detectedSocials: enrichment.socials` so the agent can show which profiles were matched.

- **Onboarding agent now confirms detected socials before saving** — updated `buildOnboarding()` step 3 to list every detected social handle alongside the bio summary and ask whether each is correct. Added a two-trip social-correction sub-flow to step 4: if a social is wrong, the agent asks for the correct URL, calls `create_user_profile([platform]Url="...")` (no confirm) to re-run enrichment from the corrected source, shows the updated preview, then confirms.

## Tests

- Extended `profile.public-lookup.spec.ts` with a `create_user_profile detectedSocials preview` describe block (3 new cases): socials present, socials empty, enrichment not confident.

## Packages

- `@indexnetwork/protocol`: `3.1.0` → `3.1.1`