### PR TITLE
feat: premise source tracking & cascade retraction

### DIFF
--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -4220,6 +4220,30 @@ export class ChatDatabaseAdapter {
     return rows.map((r) => ({ id: r.id, userId: r.userId }));
   }
 
+  /**
+   * Find premises for a user with a specific provenance source.
+   * Used for bulk-retraction of premises derived from a given source type
+   * (e.g. 'integration' when social URLs are updated).
+   *
+   * @param userId - Owner of the premises
+   * @param source - Provenance source value to filter by (e.g. 'integration', 'explicit')
+   * @returns Minimal rows: id for each matching non-deleted premise
+   */
+  async getPremisesBySource(userId: string, source: string): Promise<Array<{ id: string }>> {
+    const rows = await db
+      .select({ id: schema.premises.id })
+      .from(schema.premises)
+      .where(
+        and(
+          eq(schema.premises.userId, userId),
+          isNull(schema.premises.deletedAt),
+          sql`(${schema.premises.provenance}->>'source') = ${source}`,
+        )
+      );
+    return rows.map(r => ({ id: r.id }));
+  }
+
+
   // ─────────────────────────────────────────────────────────────────────────────
   // User Context Methods — CRUD for per-user-per-network context summaries
   // ─────────────────────────────────────────────────────────────────────────────

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -4227,7 +4227,7 @@ export class ChatDatabaseAdapter {
    *
    * @param userId - Owner of the premises
    * @param source - Provenance source value to filter by (e.g. 'integration', 'explicit')
-   * @returns Minimal rows: id for each matching non-deleted premise
+   * @returns Minimal rows: id for each matching ACTIVE (non-deleted, non-retracted) premise
    */
   async getPremisesBySource(userId: string, source: string): Promise<Array<{ id: string }>> {
     const rows = await db
@@ -4236,6 +4236,7 @@ export class ChatDatabaseAdapter {
       .where(
         and(
           eq(schema.premises.userId, userId),
+          eq(schema.premises.status, 'ACTIVE'),
           isNull(schema.premises.deletedAt),
           sql`(${schema.premises.provenance}->>'source') = ${source}`,
         )

--- a/backend/src/adapters/tests/database.adapter.spec.ts
+++ b/backend/src/adapters/tests/database.adapter.spec.ts
@@ -393,6 +393,38 @@ describe('ChatDatabaseAdapter', () => {
     await db.delete(premises).where(eq(premises.id, premise.id));
   });
 
+  it('should return premises matching a specific provenance source', async () => {
+    const integrationPremise = await adapter.createPremise({
+      userId: fixture.userBId,
+      assertion: { text: TEST_PREFIX + 'integration-source-test', tier: 'assertive' as const },
+      provenance: { source: 'integration', sourceId: 'social-id-1', confidence: 1, timestamp: new Date().toISOString() },
+      validity: { volatile: false },
+    });
+    const explicitPremise = await adapter.createPremise({
+      userId: fixture.userBId,
+      assertion: { text: TEST_PREFIX + 'explicit-source-test', tier: 'assertive' as const },
+      provenance: { source: 'explicit', confidence: 1, timestamp: new Date().toISOString() },
+      validity: { volatile: false },
+    });
+
+    try {
+      const integrationResults = await adapter.getPremisesBySource(fixture.userBId, 'integration');
+      const explicitResults = await adapter.getPremisesBySource(fixture.userBId, 'explicit');
+
+      expect(integrationResults.some(p => p.id === integrationPremise.id)).toBe(true);
+      expect(integrationResults.some(p => p.id === explicitPremise.id)).toBe(false);
+      expect(explicitResults.some(p => p.id === explicitPremise.id)).toBe(true);
+      expect(explicitResults.some(p => p.id === integrationPremise.id)).toBe(false);
+    } finally {
+      await db.delete(premises).where(inArray(premises.id, [integrationPremise.id, explicitPremise.id]));
+    }
+  });
+
+  it('should return empty array for user with no premises of that source', async () => {
+    const results = await adapter.getPremisesBySource(uuidv4(), 'integration');
+    expect(results).toEqual([]);
+  });
+
   it('should get owned indexes for owner', async () => {
     const owned = await adapter.getOwnedIndexes(fixture.userAId);
     expect(owned.length).toBeGreaterThanOrEqual(1);

--- a/backend/src/controllers/mcp.controller.ts
+++ b/backend/src/controllers/mcp.controller.ts
@@ -45,6 +45,7 @@ import { AgentDispatcherImpl } from '../services/agent-dispatcher.service';
 import { contactService } from '../services/contact.service';
 import { IntegrationService } from '../services/integration.service';
 import { opportunityDeliveryService } from '../services/opportunity-delivery.service';
+import { userService } from '../services/user.service';
 import { negotiationTimeoutQueue } from '../queues/negotiations/timeout.queue';
 import { signConnectToken } from '../services/connect-token.service';
 import type { ConnectLinkKind } from '../services/connect-link.service';
@@ -382,7 +383,7 @@ async function finalizeMcpIdentity(telegramHandle: string | undefined, identity:
     const merged = mergeTelegramHandleIntoSocials(existingSocials, telegramHandle);
     if (!merged) return identity;
 
-    await chatDatabaseAdapter.setUserSocials(identity.userId, merged);
+    await userService.setSocials(identity.userId, merged);
   } catch (err) {
     logger.warn('Failed to persist Telegram MCP handle', {
       userId: identity.userId,

--- a/backend/src/services/tests/user.service.setSocials.spec.ts
+++ b/backend/src/services/tests/user.service.setSocials.spec.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
+import { UserService, type UserServiceDeps } from '../user.service';
+
+describe('UserService.setSocials cascade', () => {
+  let deps: Required<UserServiceDeps>;
+  let mockDb: { setSocials: ReturnType<typeof mock>; [key: string]: unknown };
+
+  beforeEach(() => {
+    mockDb = {
+      setSocials: mock(async () => {}),
+    } as any;
+
+    deps = {
+      getPremisesBySource: mock(async () => []),
+      retractPremise: mock(async () => {}),
+      emitPremiseRetracted: mock(() => {}),
+      enqueueEnrichment: mock(async () => {}),
+    };
+  });
+
+  it('persists socials via the db adapter', async () => {
+    const svc = new UserService(mockDb as any, deps);
+    const socials = [{ label: 'github', value: 'https://github.com/test' }];
+    await svc.setSocials('user-1', socials);
+    expect(mockDb.setSocials).toHaveBeenCalledWith('user-1', socials);
+  });
+
+  it('retracts all integration premises returned by getPremisesBySource', async () => {
+    (deps.getPremisesBySource as ReturnType<typeof mock>).mockResolvedValue([
+      { id: 'premise-1' },
+      { id: 'premise-2' },
+    ]);
+    const svc = new UserService(mockDb as any, deps);
+    await svc.setSocials('user-1', []);
+
+    expect(deps.getPremisesBySource).toHaveBeenCalledWith('user-1', 'integration');
+    expect(deps.retractPremise).toHaveBeenCalledTimes(2);
+    expect(deps.retractPremise).toHaveBeenCalledWith('premise-1');
+    expect(deps.retractPremise).toHaveBeenCalledWith('premise-2');
+  });
+
+  it('emits PremiseRetracted event for each retracted premise', async () => {
+    (deps.getPremisesBySource as ReturnType<typeof mock>).mockResolvedValue([{ id: 'premise-1' }]);
+    const svc = new UserService(mockDb as any, deps);
+    await svc.setSocials('user-1', []);
+
+    expect(deps.emitPremiseRetracted).toHaveBeenCalledWith('premise-1', 'user-1');
+  });
+
+  it('enqueues enrichment even when there are no integration premises', async () => {
+    const svc = new UserService(mockDb as any, deps);
+    await svc.setSocials('user-1', []);
+
+    expect(deps.retractPremise).not.toHaveBeenCalled();
+    expect(deps.emitPremiseRetracted).not.toHaveBeenCalled();
+    expect(deps.enqueueEnrichment).toHaveBeenCalledWith('user-1');
+  });
+
+  it('does not propagate enqueueEnrichment errors to caller', async () => {
+    (deps.enqueueEnrichment as ReturnType<typeof mock>).mockRejectedValue(new Error('queue unavailable'));
+    const svc = new UserService(mockDb as any, deps);
+    await expect(svc.setSocials('user-1', [])).resolves.toBeUndefined();
+  });
+
+  it('retraction order: persist → query → retract loop → enqueue', async () => {
+    const callOrder: string[] = [];
+    (mockDb as any).setSocials = mock(async () => { callOrder.push('persist'); });
+    deps.getPremisesBySource = mock(async () => { callOrder.push('query'); return [{ id: 'p1' }]; });
+    deps.retractPremise = mock(async () => { callOrder.push('retract'); });
+    deps.emitPremiseRetracted = mock(() => { callOrder.push('emit'); });
+    deps.enqueueEnrichment = mock(async () => { callOrder.push('enqueue'); });
+
+    const svc = new UserService(mockDb as any, deps);
+    await svc.setSocials('user-1', []);
+    // enqueue is fire-and-forget — give it a microtask tick to settle
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(callOrder).toEqual(['persist', 'query', 'retract', 'emit', 'enqueue']);
+  });
+});

--- a/backend/src/services/user.service.ts
+++ b/backend/src/services/user.service.ts
@@ -1,9 +1,27 @@
 import { log } from '../lib/log';
-import { userDatabaseAdapter } from '../adapters/database.adapter';
+import { userDatabaseAdapter, chatDatabaseAdapter } from '../adapters/database.adapter';
 import type { User } from '../schemas/database.schema';
 import { validateKey } from '../lib/keys';
+import { PremiseEvents } from '../events/premise.event';
+import { enrichmentQueue } from '../queues/enrichment.queue';
 
 const logger = log.service.from("UserService");
+
+/**
+ * Injectable dependencies for `UserService.setSocials` cascade behavior.
+ * All fields are optional; the class uses production singletons as defaults.
+ * Inject mocks in tests.
+ */
+export interface UserServiceDeps {
+  /** Query premise IDs by provenance source for a user. */
+  getPremisesBySource?: (userId: string, source: string) => Promise<Array<{ id: string }>>;
+  /** Retract a single premise (set status RETRACTED + retractedAt). */
+  retractPremise?: (premiseId: string) => Promise<void>;
+  /** Emit the onRetracted lifecycle event for a premise. */
+  emitPremiseRetracted?: (premiseId: string, userId: string) => void;
+  /** Enqueue an enrichment job to rebuild premises from updated socials. */
+  enqueueEnrichment?: (userId: string) => Promise<void>;
+}
 
 /**
  * UserService
@@ -16,7 +34,10 @@ const logger = log.service.from("UserService");
  * - Graph resolution: `findWithGraph` joins User + Profile + Settings.
  */
 export class UserService {
-  constructor(private db = userDatabaseAdapter) {}
+  constructor(
+    private db = userDatabaseAdapter,
+    private readonly deps?: UserServiceDeps,
+  ) {}
     async findById(userId: string) {
         logger.verbose('[UserService] Finding user by ID', { userId });
         return this.db.findById(userId);
@@ -53,9 +74,55 @@ export class UserService {
         return this.db.getSocials(userId);
     }
 
-    async setSocials(userId: string, socials: { label: string; value: string }[]) {
+    async setSocials(userId: string, socials: { label: string; value: string }[]): Promise<void> {
         logger.verbose('[UserService] Setting socials', { userId, count: socials.length });
-        return this.db.setSocials(userId, socials);
+        await this.db.setSocials(userId, socials);
+        await this.retractIntegrationPremises(userId);
+    }
+
+    /**
+     * Retract all `source='integration'` premises for a user after their social URLs
+     * change, then fire-and-forget a re-enrichment job to rebuild from the new social set.
+     *
+     * Retraction loop is synchronous — errors propagate to the caller.
+     * Re-enrichment failure is logged and swallowed (best-effort).
+     */
+    private async retractIntegrationPremises(userId: string): Promise<void> {
+        const getPremisesBySource =
+            this.deps?.getPremisesBySource ??
+            ((uid: string, src: string) => chatDatabaseAdapter.getPremisesBySource(uid, src));
+
+        const retractPremise =
+            this.deps?.retractPremise ??
+            (async (id: string) => { await chatDatabaseAdapter.updatePremise(id, { status: 'RETRACTED', retractedAt: new Date() }); });
+
+        const emitPremiseRetracted =
+            this.deps?.emitPremiseRetracted ??
+            ((id: string, uid: string) => PremiseEvents.onRetracted(id, uid));
+
+        const enqueueEnrichment =
+            this.deps?.enqueueEnrichment ??
+            (async (uid: string) => { await enrichmentQueue.addEnrichUserJob({ userId: uid, reason: 'socials_updated' }); });
+
+        const toRetract = await getPremisesBySource(userId, 'integration');
+
+        logger.verbose('[UserService] Retracting integration premises before re-enrich', {
+            userId,
+            count: toRetract.length,
+        });
+
+        for (const { id } of toRetract) {
+            await retractPremise(id);
+            emitPremiseRetracted(id, userId);
+        }
+
+        // Re-enrichment is fire-and-forget — failure is logged but does not propagate to caller.
+        enqueueEnrichment(userId).catch(err =>
+            logger.error('[UserService] Failed to enqueue re-enrichment after social update', {
+                userId,
+                error: err,
+            }),
+        );
     }
 
     async softDelete(userId: string) {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/profile/profile.graph.ts
+++ b/packages/protocol/src/profile/profile.graph.ts
@@ -1,7 +1,7 @@
 import { StateGraph, START, END } from "@langchain/langgraph";
 import { ProfileGraphState } from "./profile.state.js";
 import { ProfileGenerator, ProfileDocument } from "./profile.generator.js";
-import { ProfileGraphDatabase, PremiseRecord } from "../shared/interfaces/database.interface.js";
+import { ProfileGraphDatabase, PremiseRecord, PremiseProvenance } from "../shared/interfaces/database.interface.js";
 import { Scraper } from "../shared/interfaces/scraper.interface.js";
 import type { ProfileEnricher } from "../shared/interfaces/enrichment.interface.js";
 import { shouldEnrichGhostDisplayNameFromParallel, isEnrichedNameMeaningful } from "./profile.enricher.js";
@@ -24,6 +24,8 @@ export interface CompiledPremiseGraph {
     assertionText: string;
     tier: 'assertive' | 'contextual';
     operationMode: 'create';
+    provenanceSource?: PremiseProvenance['source'];
+    provenanceSourceId?: string;
   }): Promise<{
     premise?: { id: string } | undefined;
     error?: string | undefined;
@@ -319,6 +321,7 @@ export class ProfileGraphFactory {
           return {
             objective,
             input: scrapedData,
+            activeSocialIds: socials.map(s => s.id),
             operationsPerformed: { scraped: true }
           };
         } catch (error) {
@@ -492,6 +495,7 @@ export class ProfileGraphFactory {
                 needsUserInfo: false,
                 needsProfileGeneration: true,
                 forceUpdate: true,
+                activeSocialIds: socials.map(s => s.id),
                 operationsPerformed: { scraped: true },
               };
             }
@@ -779,6 +783,9 @@ export class ProfileGraphFactory {
                 assertionText: p.text,
                 tier: p.tier,
                 operationMode: 'create',
+                ...(state.activeSocialIds?.length
+                  ? { provenanceSource: 'integration' as const, provenanceSourceId: state.activeSocialIds[0] }
+                  : {}),
               });
 
               if (premiseResult.premise) {

--- a/packages/protocol/src/profile/profile.state.ts
+++ b/packages/protocol/src/profile/profile.state.ts
@@ -63,6 +63,17 @@ export const ProfileGraphState = Annotation.Root({
   }),
 
   /**
+   * IDs of the user_socials records active during the current scrape/generate run.
+   * Populated by scrapeNode and autoGenerateNode after getUserSocials is called.
+   * Empty by default; read by decomposePremisesNode to set provenanceSource:
+   * 'integration' + provenanceSourceId when premises derive from social enrichment.
+   */
+  activeSocialIds: Annotation<string[]>({
+    reducer: (_, next) => next ?? [],
+    default: () => [],
+  }),
+
+  /**
    * The generated or loaded profile document.
    */
   profile: Annotation<ProfileDocument | undefined>({

--- a/packages/protocol/src/profile/tests/profile.graph.spec.ts
+++ b/packages/protocol/src/profile/tests/profile.graph.spec.ts
@@ -324,6 +324,37 @@ describe('ProfileGraph', () => {
       expect(mockScraper.scrape).not.toHaveBeenCalled();
     });
   });
+
+  describe('Provenance tracking via activeSocialIds', () => {
+    it('should populate activeSocialIds in output state when getUserSocials returns records on scrape path', async () => {
+      (mockDatabase.getProfile as any).mockResolvedValue(null);
+      (mockDatabase.getUserSocials as any).mockResolvedValue([
+        { id: 'social-id-1', userId: 'test-user-id', label: 'github', value: 'https://github.com/test' },
+        { id: 'social-id-2', userId: 'test-user-id', label: 'linkedin', value: 'https://linkedin.com/in/test' },
+      ]);
+
+      const graph = factory.createGraph();
+      const result = await graph.invoke({
+        userId: 'test-user-id',
+        operationMode: 'write',
+      });
+
+      expect(result.activeSocialIds).toEqual(['social-id-1', 'social-id-2']);
+    });
+
+    it('should leave activeSocialIds as empty array when user has no socials', async () => {
+      (mockDatabase.getProfile as any).mockResolvedValue(null);
+      (mockDatabase.getUserSocials as any).mockResolvedValue([]);
+
+      const graph = factory.createGraph();
+      const result = await graph.invoke({
+        userId: 'test-user-id',
+        operationMode: 'write',
+      });
+
+      expect(result.activeSocialIds).toEqual([]);
+    });
+  });
 });
 
 // ─── Generate mode tests ─────────────────────────────────────────────────────


### PR DESCRIPTION
## New Features

- **Integration-path premise provenance**: premises created via the social-URL enrichment flow are now tagged with `source: 'integration'` and `sourceId: <user_social.id>`. Previously all premises fell through to `source: 'explicit'` regardless of origin.

- **Cascade retraction on `setSocials`**: `UserService.setSocials` now retracts all `source='integration'` premises for the user after persisting the new social set, emits `PremiseEvents.onRetracted` per premise (which triggers the existing cascade: opportunity stalling + profile regen), and fire-and-forget enqueues re-enrichment with `reason: 'socials_updated'`.

- **`ChatDatabaseAdapter.getPremisesBySource`**: new method querying `(provenance->>'source') = $source` via Drizzle JSONB extraction, modeled after `getExpiredPremises`.

- **MCP Telegram handle merge**: `mcp.controller.ts` Telegram handle merge path now routes through `userService.setSocials` instead of calling `chatDatabaseAdapter.setUserSocials` directly, so the cascade fires on MCP-triggered handle registration.

## Refactors

- `UserServiceDeps` optional constructor interface (mirrors `PremiseQueueDeps` pattern) — singleton defaults apply in production, inject mocks in tests. No `main.ts` changes needed.

- `ProfileGraphState` extended with `activeSocialIds: string[]` annotation; `scrapeNode` and `autoGenerateNode` populate it; `decomposePremisesNode` reads it to set provenance.

## Tests

- 2 profile graph tests: `activeSocialIds` populated from social records; empty array when no socials
- 2 adapter integration tests: cross-source isolation (`integration` vs `explicit`); empty result for unknown user
- 6 service unit tests: persist call, retract loop, event emit, idempotent enqueue, error suppression, call order

## Notes

- `telegram.gateway.ts` `productionDeps().setUserSocials` still routes directly to `userDatabaseAdapter.setSocials` (bot path) — flagged for a follow-up; only the MCP tool path is fixed in this PR.
- No schema changes — `PremiseProvenance.sourceId` already existed.
- Existing premises carry `source: 'explicit'` pre-feature; no backfill.