### PR TITLE
feat: non-blocking chat input with steering and queueing

### DIFF
--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -767,6 +767,7 @@ export interface ChatMessage {
   routingDecision: Record<string, unknown> | null;
   subgraphResults: Record<string, unknown> | null;
   tokenCount: number | null;
+  interrupted?: boolean | null;
   createdAt: Date;
 }
 
@@ -793,6 +794,8 @@ export interface ChatMessageMeta {
    * these into message.streamingDrafts on loadSession.
    */
   streamingDrafts?: unknown;
+  /** Set to true when the assistant message was partially generated before a steer interrupt. */
+  interrupted?: boolean;
   [key: string]: unknown;
 }
 
@@ -811,6 +814,7 @@ export interface CreateMessageInput {
   routingDecision?: Record<string, unknown>;
   subgraphResults?: Record<string, unknown>;
   tokenCount?: number;
+  interrupted?: boolean;
 }
 
 /**
@@ -8727,6 +8731,7 @@ export class ConversationDatabaseAdapter {
     if (data.routingDecision) msgMeta.routingDecision = data.routingDecision;
     if (data.subgraphResults) msgMeta.subgraphResults = data.subgraphResults;
     if (data.tokenCount !== undefined) msgMeta.tokenCount = data.tokenCount;
+    if (data.interrupted) msgMeta.interrupted = true;
 
     await db.insert(schema.messages).values({
       id: data.id,
@@ -8775,6 +8780,7 @@ export class ConversationDatabaseAdapter {
         routingDecision: (meta.routingDecision as Record<string, unknown>) ?? null,
         subgraphResults: (meta.subgraphResults as Record<string, unknown>) ?? null,
         tokenCount: typeof meta.tokenCount === 'number' ? meta.tokenCount : null,
+        interrupted: meta.interrupted ?? null,
         createdAt: msg.createdAt,
       };
     });

--- a/backend/src/controllers/chat.controller.ts
+++ b/backend/src/controllers/chat.controller.ts
@@ -12,14 +12,16 @@ import {
 } from "../lib/router/router.decorators";
 import { chatSessionService } from "../services/chat.service";
 import { fileService } from "../services/file.service";
-import { SuggestionGenerator } from '@indexnetwork/protocol';
+import { SuggestionGenerator, ChatInterruptClassifier } from '@indexnetwork/protocol';
 import {
   createDoneEvent,
   createErrorEvent,
   createStatusEvent,
+  createSteerOrQueueEvent,
   formatSSEEvent,
   type DebugMetaDiscoveryQuestions,
 } from "../types/chat-streaming.types";
+import { emitChatInterrupt, onChatInterrupt } from '../lib/chat-interrupt.events';
 
 type RouteParams = Record<string, string>;
 
@@ -45,6 +47,21 @@ function getSuggestionGenerator(): SuggestionGenerator {
     suggestionGeneratorInstance = new SuggestionGenerator();
   }
   return suggestionGeneratorInstance;
+}
+
+const interruptBodySchema = z.object({
+  sessionId: z.string(),
+  message: z.string().min(1),
+  messageId: z.string().uuid(),
+  traceSnapshot: z.array(z.string()).max(20).default([]),
+});
+
+let interruptClassifierInstance: ChatInterruptClassifier | null = null;
+function getInterruptClassifier(): ChatInterruptClassifier {
+  if (!interruptClassifierInstance) {
+    interruptClassifierInstance = new ChatInterruptClassifier();
+  }
+  return interruptClassifierInstance;
 }
 
 @Controller("/chat")
@@ -215,6 +232,12 @@ export class ChatController {
     const factory = chatSessionService.getGraphFactory();
     const useCheckpointer = body.useCheckpointer ?? true;
     const networkIdForStream = effectiveIndexId;
+    const runId = crypto.randomUUID();
+    const streamAbortController = new AbortController();
+    // Forward HTTP client disconnect into the stream abort controller
+    req.signal.addEventListener('abort', () => {
+      if (!streamAbortController.signal.aborted) streamAbortController.abort('client_disconnect');
+    }, { once: true });
 
     // User message is persisted after the stream completes (with the assistant response) so that
     // loadSessionContext during streaming does not include it and the current message is not
@@ -237,7 +260,26 @@ export class ChatController {
     const stream = new ReadableStream({
       start(controller) {
         return requestContext.run({ originUrl }, async () => {
+        let streamInterruptedBySteer = false;
+        let unsubscribeInterrupt: (() => void) | null = null;
         try {
+          // Subscribe to interrupt bus — one listener per stream, cleaned in finally
+          unsubscribeInterrupt = onChatInterrupt(sessionId, ({ decision, messageId }) => {
+            try {
+              controller.enqueue(
+                encoder.encode(
+                  formatSSEEvent(createSteerOrQueueEvent(sessionId, decision, messageId)),
+                ),
+              );
+            } catch {
+              // Stream may have already closed
+            }
+            if (decision === 'steer') {
+              streamInterruptedBySteer = true;
+              streamAbortController.abort('steer');
+            }
+          });
+
           // Send initial status
           controller.enqueue(
             encoder.encode(
@@ -249,6 +291,9 @@ export class ChatController {
 
           // Stream chat graph events with context
           let fullResponse = "";
+          // Accumulates token events as a fallback for steer-interrupted streams where
+          // response_complete may never fire. Cleared on response_reset (agent retry).
+          let partialResponse = "";
           let routingDecision: Record<string, unknown> | undefined;
           let subgraphResults: Record<string, unknown> | undefined;
           let debugMeta: { graph: string; iterations: number; tools: unknown[]; llm?: unknown; orchestratorNegotiations?: unknown; discoveryQuestions?: DebugMetaDiscoveryQuestions } | undefined;
@@ -266,18 +311,26 @@ export class ChatController {
               maxContextMessages: 20,
               networkId: networkIdForStream,
               prefillMessages: body.prefillMessages,
+              runId,
             },
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             checkpointer as any,
-            req.signal,
+            streamAbortController.signal,
           )) {
+            if (streamInterruptedBySteer) break;
             if (event) {
               // response_complete is an internal event carrying the agent's
               // authoritative final text — don't forward it to the SSE client.
               if (event.type === "response_complete") {
                 fullResponse = event.response;
+                partialResponse = ""; // authoritative text is now in fullResponse
               } else {
                 controller.enqueue(encoder.encode(formatSSEEvent(event)));
+                if (event.type === "token") {
+                  partialResponse += (event as { content: string }).content;
+                } else if (event.type === "response_reset") {
+                  partialResponse = ""; // agent retrying — discard accumulated partial
+                }
               }
 
               if (event.type === "routing") {
@@ -305,6 +358,27 @@ export class ChatController {
                 decisionQuestions = (event as { questions: import("@indexnetwork/protocol").Question[] }).questions;
               }
             }
+          }
+
+          // Steer-interrupted: persist partial turn and bail (no done event emitted)
+          if (streamInterruptedBySteer) {
+            try {
+              await chatSessionService.addMessage({ sessionId, role: 'user', content: messageContent });
+              // Use authoritative fullResponse when available; fall back to accumulated
+              // partial tokens when the stream was cut before response_complete fired.
+              const interruptedContent = (fullResponse || partialResponse).trim();
+              if (interruptedContent) {
+                await chatSessionService.addMessage({
+                  sessionId,
+                  role: 'assistant',
+                  content: interruptedContent,
+                  interrupted: true,
+                });
+              }
+            } catch (persistErr) {
+              logger.error('Failed to persist interrupted turn', { sessionId, error: persistErr });
+            }
+            return; // finally block still runs → unsubscribeInterrupt + controller.close()
           }
 
           // Persist prefill messages (e.g. onboarding greeting) only for newly created sessions
@@ -372,8 +446,8 @@ export class ChatController {
             }
           }
 
-          // Skip title/suggestions generation if client disconnected
-          if (!req.signal.aborted) {
+          // Skip title/suggestions generation if client disconnected or stream was aborted
+          if (!req.signal.aborted && !streamAbortController.signal.aborted) {
             // Generate session title and suggestions in parallel
             const [sessionTitle, suggestions] = await Promise.all([
               chatSessionService.generateSessionTitle(sessionId, user.id),
@@ -404,18 +478,23 @@ export class ChatController {
             );
           }
         } catch (error) {
-          controller.enqueue(
-            encoder.encode(
-              formatSSEEvent(
-                createErrorEvent(
-                  sessionId,
-                  error instanceof Error ? error.message : "Unknown error",
-                  "STREAM_ERROR",
+          // AbortError is expected when the stream is intentionally stopped (steer
+          // interrupt, client disconnect, or stopStream). Don't surface as STREAM_ERROR.
+          if (!(error instanceof Error && error.name === 'AbortError')) {
+            controller.enqueue(
+              encoder.encode(
+                formatSSEEvent(
+                  createErrorEvent(
+                    sessionId,
+                    error instanceof Error ? error.message : "Unknown error",
+                    "STREAM_ERROR",
+                  ),
                 ),
               ),
-            ),
-          );
+            );
+          }
         } finally {
+          unsubscribeInterrupt?.();
           controller.close();
         }
         }); // requestContext.run
@@ -714,6 +793,45 @@ export class ChatController {
         { status: 500 },
       );
     }
+  }
+
+  /**
+   * Accept a mid-stream interrupt from the frontend, classify it (steer vs. queue),
+   * and emit the result onto the active SSE stream for this session.
+   *
+   * @param req - Body: { sessionId, message, messageId, traceSnapshot }
+   * @param user - The authenticated user
+   * @returns JSON `{ decision: 'steer' | 'queue', messageId }`
+   */
+  @Post("/interrupt")
+  @UseGuards(RateLimit('write'), AuthGuard)
+  async interrupt(req: Request, user: AuthenticatedUser): Promise<Response> {
+    let body: z.infer<typeof interruptBodySchema>;
+    try {
+      const raw = await req.json();
+      const parsed = interruptBodySchema.safeParse(raw);
+      if (!parsed.success) {
+        return Response.json({ error: "Invalid request body" }, { status: 400 });
+      }
+      body = parsed.data;
+    } catch {
+      return Response.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    const { sessionId, message, messageId, traceSnapshot } = body;
+
+    const session = await chatSessionService.getSession(sessionId, user.id);
+    if (!session) {
+      return Response.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    const agentState = traceSnapshot.slice(-5).join(', ');
+    const classifier = getInterruptClassifier();
+    const decision = await classifier.classify({ message, agentState });
+
+    emitChatInterrupt(sessionId, { decision, messageId });
+
+    return Response.json({ decision, messageId });
   }
 
   @Get("/shared/:token")

--- a/backend/src/lib/chat-interrupt.events.ts
+++ b/backend/src/lib/chat-interrupt.events.ts
@@ -1,0 +1,49 @@
+import { EventEmitter } from 'events';
+
+/**
+ * Payload emitted when a /chat/interrupt request resolves a steer-or-queue decision.
+ */
+export interface ChatInterruptPayload {
+  decision: 'steer' | 'queue';
+  messageId: string;
+}
+
+/**
+ * Singleton event emitter for per-session chat interrupt signals.
+ * A running /chat/stream handler subscribes once per session; the /chat/interrupt
+ * handler emits when the classifier has resolved.
+ *
+ * Multi-instance note: this is in-memory only. A Redis pub/sub upgrade
+ * would swap this module while preserving the emitChatInterrupt/onChatInterrupt API.
+ */
+const chatInterruptEmitter = new EventEmitter();
+chatInterruptEmitter.setMaxListeners(200);
+
+/**
+ * Emit an interrupt decision to any active stream handler for the given session.
+ *
+ * @param sessionId - The chat session that received the interrupt
+ * @param payload - The classifier decision and message ID
+ */
+export function emitChatInterrupt(sessionId: string, payload: ChatInterruptPayload): void {
+  chatInterruptEmitter.emit(`interrupt:${sessionId}`, payload);
+}
+
+/**
+ * Subscribe to interrupt events for a session.
+ * Uses `.on()` so that multiple interrupts during the same stream are all
+ * delivered to the handler (e.g. a first 'queue' decision followed by a
+ * second 'steer' decision). The caller is responsible for unsubscribing
+ * by invoking the returned function — the stream handler calls it in finally.
+ *
+ * @param sessionId - The chat session to subscribe to
+ * @param handler - Called each time an interrupt is resolved for this session
+ * @returns Unsubscribe function
+ */
+export function onChatInterrupt(
+  sessionId: string,
+  handler: (payload: ChatInterruptPayload) => void,
+): () => void {
+  chatInterruptEmitter.on(`interrupt:${sessionId}`, handler);
+  return () => chatInterruptEmitter.off(`interrupt:${sessionId}`, handler);
+}

--- a/backend/src/services/chat.service.ts
+++ b/backend/src/services/chat.service.ts
@@ -160,6 +160,7 @@ export class ChatSessionService {
     routingDecision?: Record<string, unknown>;
     subgraphResults?: Record<string, unknown>;
     tokenCount?: number;
+    interrupted?: boolean;
   }): Promise<string> {
     logger.verbose('Adding message', {
       sessionId: params.sessionId,
@@ -177,6 +178,7 @@ export class ChatSessionService {
       routingDecision: params.routingDecision,
       subgraphResults: params.subgraphResults,
       tokenCount: params.tokenCount,
+      interrupted: params.interrupted,
     });
 
     // Update session timestamp

--- a/backend/src/types/chat-streaming.types.ts
+++ b/backend/src/types/chat-streaming.types.ts
@@ -49,7 +49,8 @@ export type ChatStreamEventType =
   | "chat_summarizer_end"
   | "question_generator_start"
   | "question_generator_end"
-  | "decision_questions";
+  | "decision_questions"
+  | "steer_or_queue";
 
 /**
  * Base interface for all chat stream events.
@@ -554,6 +555,15 @@ export interface DecisionQuestionsEvent extends ChatStreamEventBase {
 }
 
 /**
+ * Steer-or-queue event — injected by /chat/interrupt onto the active SSE stream.
+ */
+export interface SteerOrQueueEvent extends ChatStreamEventBase {
+  type: "steer_or_queue";
+  decision: "steer" | "queue";
+  messageId: string;
+}
+
+/**
  * Union type of all chat stream events.
  */
 export type ChatStreamEvent =
@@ -596,7 +606,8 @@ export type ChatStreamEvent =
   | ChatSummarizerEndEvent
   | QuestionGeneratorStartEvent
   | QuestionGeneratorEndEvent
-  | DecisionQuestionsEvent;
+  | DecisionQuestionsEvent
+  | SteerOrQueueEvent;
 
 /**
  * Formats a chat stream event as an SSE message. If JSON.stringify throws (e.g. circular ref,
@@ -1063,4 +1074,12 @@ export function createDecisionQuestionsEvent(
   payload: { questions: Question[] },
 ): DecisionQuestionsEvent {
   return createStreamEvent<DecisionQuestionsEvent>("decision_questions", sessionId, payload);
+}
+
+export function createSteerOrQueueEvent(
+  sessionId: string,
+  decision: "steer" | "queue",
+  messageId: string,
+): SteerOrQueueEvent {
+  return createStreamEvent<SteerOrQueueEvent>("steer_or_queue", sessionId, { decision, messageId });
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -270,6 +270,32 @@ button {
   animation: cursor-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
 
+/* Steer / queue interrupt animations */
+
+/* Soft throb for the 'classifying…' badge — less aggressive than the default animate-pulse */
+@keyframes classify-throb {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
+}
+.badge-classifying {
+  animation: classify-throb 1.8s ease-in-out infinite;
+}
+
+/* Cancel button fades in after a short delay once 'queued' badge settles */
+@keyframes fade-in-delayed {
+  0%, 30% { opacity: 0; }
+  100% { opacity: 1; }
+}
+.cancel-fade-in {
+  animation: fade-in-delayed 0.4s ease-out forwards;
+}
+
+/* Slide-up fade-out when a queued message is cancelled */
+@keyframes slide-fade-out {
+  from { opacity: 1; transform: translateY(0); }
+  to   { opacity: 0; transform: translateY(-4px); }
+}
+
 @keyframes cursor-pulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.5; }

--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -630,14 +630,13 @@ export default function OnboardingPage() {
             <div key={msg.id}>
               <div className={cn("flex", msg.role === "user" ? "justify-end" : "justify-start")}>
                 {msg.role === "user" ? (
-                  <div className="max-w-[75%] bg-[#FAFAFA] text-gray-900 border border-[#E8E8E8] rounded-4xl px-4 py-1 text-sm leading-relaxed">
-                    <article className="max-w-none">
-                      <div className="chat-markdown max-w-none">
-                        <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                          {mentionsToMarkdownLinks(msg.content)}
-                        </ReactMarkdown>
-                      </div>
-                    </article>
+                  <div className="w-fit max-w-[75%] bg-[#FAFAFA] text-gray-900 border border-[#E8E8E8] rounded-4xl px-4 py-1 text-sm leading-relaxed">
+                    <ReactMarkdown
+                      remarkPlugins={[remarkGfm]}
+                      components={{ p: ({ children }) => <span className="block">{children}</span> }}
+                    >
+                      {mentionsToMarkdownLinks(msg.content)}
+                    </ReactMarkdown>
                   </div>
                 ) : (
                   <div className="w-full text-gray-900">

--- a/frontend/src/components/ChatContent.tsx
+++ b/frontend/src/components/ChatContent.tsx
@@ -374,6 +374,9 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
     setScopeNetworkId,
     sessionNetworkId,
     updateSessionTitle,
+    pendingQueue,
+    cancelQueuedMessage,
+    submitMidStreamMessage,
   } = useAIChat();
   const uploadServiceV2 = useUploadServiceV2();
   const { error: showError, success: showSuccess, addNotification } = useNotifications();
@@ -934,8 +937,6 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
       setIsInputMultiline(true);
     }
   }, [input]);
-  const isBusy = isLoading || isUploadingFiles;
-
   const handleFileSelect = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const files = e.target.files;
@@ -962,7 +963,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!canSend || isBusy) return;
+    if (!canSend || isUploadingFiles) return;  // file upload blocks; stream does not
 
     const message = input.trim();
     setInput("");
@@ -980,9 +981,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
         setSelectedFiles([]);
       } catch (err) {
         console.error("[AI Chat] Upload failed:", err);
-        showError(
-          err instanceof Error ? err.message : "Failed to upload file(s)",
-        );
+        showError(err instanceof Error ? err.message : "Failed to upload file(s)");
         setIsUploadingFiles(false);
         inputRef.current?.focus();
         return;
@@ -990,11 +989,17 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
       setIsUploadingFiles(false);
     }
 
-    await sendMessage(
-      message || "Attached file(s).",
-      fileIds.length ? fileIds : undefined,
-      attachmentNames.length ? attachmentNames : undefined,
-    );
+    const msgContent = message || "Attached file(s).";
+    const fileArg = fileIds.length ? fileIds : undefined;
+    const nameArg = attachmentNames.length ? attachmentNames : undefined;
+
+    if (isLoading) {
+      // Mid-stream: route via interrupt flow
+      const streamingMsg = messages.find((m) => m.isStreaming);
+      submitMidStreamMessage(msgContent, streamingMsg?.traceEvents ?? [], fileArg, nameArg);
+    } else {
+      await sendMessage(msgContent, fileArg, nameArg);
+    }
     inputRef.current?.focus();
   };
 
@@ -1119,7 +1124,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
               type="button"
               variant="ghost"
               size="icon"
-              disabled={isBusy}
+              disabled={isUploadingFiles}
               onClick={() => fileInputRef.current?.click()}
               className="shrink-0 h-8 w-8 rounded-full text-gray-500 hover:text-[#4091BB] hover:bg-gray-200 p-0"
               title="Attach files"
@@ -1131,7 +1136,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
               value={input}
               onChange={setInput}
               placeholder={CHAT_INPUT_PLACEHOLDER}
-              disabled={isBusy}
+              disabled={isUploadingFiles}
               autoFocus
               inputRef={inputRef}
               suggestionsAbove
@@ -1340,7 +1345,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
                       type="button"
                       variant="ghost"
                       size="icon"
-                      disabled={isBusy}
+                      disabled={isUploadingFiles}
                       onClick={() => fileInputRef.current?.click()}
                       className="shrink-0 h-8 w-8 rounded-full text-gray-500 hover:text-[#4091BB] hover:bg-gray-200 p-0"
                       title="Attach files"
@@ -1351,7 +1356,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
                       value={input}
                       onChange={setInput}
                       placeholder={CHAT_INPUT_PLACEHOLDER}
-                      disabled={isBusy}
+                      disabled={isUploadingFiles}
                       autoFocus
                       inputRef={inputRef}
                     />
@@ -1515,7 +1520,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
                   type="button"
                   variant="ghost"
                   size="icon"
-                  disabled={isBusy}
+                  disabled={isUploadingFiles}
                   onClick={() => fileInputRef.current?.click()}
                   className="shrink-0 h-8 w-8 rounded-full text-gray-500 hover:text-[#4091BB] hover:bg-gray-200 p-0"
                   title="Attach files"
@@ -1526,7 +1531,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
                   value={input}
                   onChange={setInput}
                   placeholder={CHAT_INPUT_PLACEHOLDER}
-                  disabled={isBusy}
+                  disabled={isUploadingFiles}
                   autoFocus
                   inputRef={inputRef}
                 />
@@ -1687,18 +1692,42 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
                   )}
                 >
                   {msg.role === "user" ? (
-                    <div className="max-w-[75%] bg-[#FAFAFA] text-gray-900 border border-[#E8E8E8] rounded-4xl px-4 py-1 text-sm leading-relaxed">
-                      <article className="max-w-none">
-                        <div className="chat-markdown max-w-none">
-                          <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                            {mentionsToMarkdownLinks(msg.content)}
-                          </ReactMarkdown>
-                        </div>
-                      </article>
+                    <div className="flex flex-col items-end gap-1 max-w-[75%]">
+                      {(msg.isPending || msg.isQueued) && (
+                        <span className={cn(
+                          "inline-flex items-center gap-1 text-[10px] px-2.5 py-0.5 rounded-full font-medium font-ibm-plex-mono tracking-wide transition-colors duration-150",
+                          msg.isPending
+                            ? "bg-amber-50 text-amber-600 border border-amber-200 badge-classifying"
+                            : "bg-blue-50 text-blue-500 border border-blue-200",
+                        )}>
+                          {msg.isPending ? "classifying…" : "queued"}
+                          {msg.isQueued && (
+                            <button
+                              type="button"
+                              onClick={() => cancelQueuedMessage(msg.id)}
+                              className="ml-0.5 text-blue-400 hover:text-blue-700 focus:outline-none cancel-fade-in"
+                              aria-label="Cancel queued message"
+                            >
+                              <X className="w-2.5 h-2.5" />
+                            </button>
+                          )}
+                        </span>
+                      )}
+                      <div className={cn(
+                        "w-fit max-w-full bg-[#FAFAFA] text-gray-900 border border-[#E8E8E8] rounded-4xl px-4 py-1 text-sm leading-relaxed transition-opacity duration-150",
+                        (msg.isPending || msg.isQueued) && "opacity-60",
+                      )}>
+                        <ReactMarkdown
+                          remarkPlugins={[remarkGfm]}
+                          components={{ p: ({ children }) => <span className="block">{children}</span> }}
+                        >
+                          {mentionsToMarkdownLinks(msg.content)}
+                        </ReactMarkdown>
+                      </div>
                     </div>
                   ) : (
                     <div className="w-full text-gray-900">
-                      <span className="text-[10px] uppercase tracking-wider text-black font-bold mb-1 block">
+                      <span className="text-[10px] uppercase tracking-[0.12em] text-gray-400 font-ibm-plex-mono mb-1.5 block">
                         Index
                       </span>
                       {msg.traceEvents && msg.traceEvents.length > 0 && (
@@ -1758,6 +1787,9 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
                           />
                         </article>
                       </div>
+                      {msg.wasInterrupted && (
+                        <p className="text-[10px] text-gray-300 mt-1 font-ibm-plex-mono tracking-wide">{"\u2014 interrupted"}</p>
+                      )}
                     </div>
                   )}
                 </div>
@@ -1876,7 +1908,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
           <ContentContainer>
             <SuggestionChips
               suggestions={suggestions}
-              disabled={isBusy}
+              disabled={isUploadingFiles}
               onSuggestionClick={handleSuggestionClick}
             />
             {renderInputForm()}

--- a/frontend/src/contexts/AIChatContext.tsx
+++ b/frontend/src/contexts/AIChatContext.tsx
@@ -106,6 +106,14 @@ export interface TraceEvent {
   agreedRoles?: { ownUser?: string; otherUser?: string };
 }
 
+export interface QueuedMessage {
+  id: string;
+  message: string;
+  fileIds?: string[];
+  attachmentNames?: string[];
+  status: 'pending' | 'queued';
+}
+
 interface ChatMessage {
   id: string;
   role: "user" | "assistant";
@@ -129,6 +137,9 @@ interface ChatMessage {
   decisionQuestions?: Question[];
   /** True once the user has submitted answers; disables/mutes the renderer. */
   decisionQuestionsSubmitted?: boolean;
+  isPending?: boolean;
+  isQueued?: boolean;
+  wasInterrupted?: boolean;
 }
 
 interface AIChatContextType {
@@ -159,6 +170,9 @@ interface AIChatContextType {
   clearChat: (options?: { abortStream?: boolean }) => void;
   loadSession: (sessionId: string) => Promise<void>;
   updateSessionTitle: (sessionId: string, title: string) => Promise<boolean>;
+  pendingQueue: QueuedMessage[];
+  cancelQueuedMessage: (id: string) => void;
+  submitMidStreamMessage: (message: string, traceEvents: TraceEvent[], fileIds?: string[], attachmentNames?: string[]) => void;
 }
 
 const AIChatContext = createContext<AIChatContextType | null>(null);
@@ -264,8 +278,71 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
   const [isLoading, setIsLoading] = useState(false);
   const { refetchSessions } = useAIChatSessions();
   const abortControllerRef = useRef<AbortController | null>(null);
+  const pendingQueueRef = useRef<QueuedMessage[]>([]);
+  const steerPendingRef = useRef<Array<{ message: string; fileIds?: string[]; attachmentNames?: string[] }>>([]);
+  /** Per-message timeout IDs so cancelling or resolving one pending message doesn't affect others. */
+  const interruptTimeoutsRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  const [pendingQueue, setPendingQueue] = useState<QueuedMessage[]>([]);
   /** When true, sendMessage will only refetch sessions on X-Session-Id and not set sessionId (used when user navigated away during stream). */
   const skipSessionUpdateForRequestRef = useRef(false);
+
+  const cancelQueuedMessage = useCallback((id: string) => {
+    const t = interruptTimeoutsRef.current.get(id);
+    if (t !== undefined) { clearTimeout(t); interruptTimeoutsRef.current.delete(id); }
+    pendingQueueRef.current = pendingQueueRef.current.filter((q) => q.id !== id);
+    setPendingQueue([...pendingQueueRef.current]);
+    setMessages((prev) => prev.filter((msg) => msg.id !== id));
+  }, []);
+
+  const submitMidStreamMessage = useCallback(
+    (message: string, traceEvents: TraceEvent[], fileIds?: string[], attachmentNames?: string[]) => {
+      if (!sessionId) return;
+      const pendingMsgId = crypto.randomUUID();
+      const displayContent = message.trim() || (fileIds?.length ? 'Attached file(s).' : '');
+      if (!displayContent) return;
+
+      setMessages((prev) => [...prev, {
+        id: pendingMsgId, role: 'user' as const, content: displayContent,
+        timestamp: new Date(), isPending: true,
+        ...(attachmentNames?.length ? { attachmentNames } : {}),
+      }]);
+      const entry: QueuedMessage = { id: pendingMsgId, message, fileIds, attachmentNames, status: 'pending' };
+      pendingQueueRef.current = [...pendingQueueRef.current, entry];
+      setPendingQueue([...pendingQueueRef.current]);
+
+      const agentStateNames = traceEvents
+        .filter((e) => ['tool_start', 'graph_start', 'agent_start', 'phase_start'].includes(e.type))
+        .slice(-5)
+        .map((e) => `${e.type}: ${(e as { name?: string }).name ?? 'unknown'}`);
+
+      // 5-second fallback → steer (in case SSE steer_or_queue event never arrives)
+      const timeoutId = setTimeout(() => {
+        interruptTimeoutsRef.current.delete(pendingMsgId); // clean up map entry when timeout fires
+        steerPendingRef.current = [...steerPendingRef.current, { message, fileIds, attachmentNames }];
+        pendingQueueRef.current = pendingQueueRef.current.filter((q) => q.id !== pendingMsgId);
+        setPendingQueue([...pendingQueueRef.current]);
+        setMessages((prev) => prev.map((msg) => msg.id === pendingMsgId ? { ...msg, isPending: false } : msg));
+        if (abortControllerRef.current) abortControllerRef.current.abort('steer');
+      }, 5_000);
+      interruptTimeoutsRef.current.set(pendingMsgId, timeoutId);
+
+      apiClient
+        .post('/chat/interrupt', { sessionId, message, messageId: pendingMsgId, traceSnapshot: agentStateNames })
+        .catch(() => {
+          clearTimeout(timeoutId);
+          interruptTimeoutsRef.current.delete(pendingMsgId);
+          // Guard: message may have been cancelled before the POST failed.
+          // If it's no longer tracked, don't steer or abort.
+          if (!pendingQueueRef.current.some((q) => q.id === pendingMsgId)) return;
+          steerPendingRef.current = [...steerPendingRef.current, { message, fileIds, attachmentNames }];
+          pendingQueueRef.current = pendingQueueRef.current.filter((q) => q.id !== pendingMsgId);
+          setPendingQueue([...pendingQueueRef.current]);
+          setMessages((prev) => prev.map((msg) => msg.id === pendingMsgId ? { ...msg, isPending: false } : msg));
+          if (abortControllerRef.current) abortControllerRef.current.abort('steer');
+        });
+    },
+    [sessionId],
+  );
 
   const sendMessage = useCallback(
     async (message: string, fileIds?: string[], attachmentNames?: string[], options?: { hidden?: boolean; prefillMessages?: Array<{ role: "assistant" | "user"; content: string }> }) => {
@@ -805,6 +882,37 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
                     );
                     break;
                   }
+                  case "steer_or_queue": {
+                    const t = interruptTimeoutsRef.current.get((event as { messageId: string }).messageId ?? '');
+                    if (t !== undefined) { clearTimeout(t); interruptTimeoutsRef.current.delete((event as { messageId: string }).messageId); }
+                    const { decision, messageId: pendingId } = event as { decision: 'steer' | 'queue'; messageId: string };
+                    if (decision === 'steer') {
+                      const steerEntry = pendingQueueRef.current.find((q) => q.id === pendingId);
+                      // Only act if the message is still tracked — it may have been cancelled
+                      // or drained already, in which case we must not abort the current stream.
+                      if (steerEntry) {
+                        steerPendingRef.current = [...steerPendingRef.current, { message: steerEntry.message, fileIds: steerEntry.fileIds, attachmentNames: steerEntry.attachmentNames }];
+                        pendingQueueRef.current = pendingQueueRef.current.filter((q) => q.id !== pendingId);
+                        setPendingQueue([...pendingQueueRef.current]);
+                        setMessages((prev) => prev.map((msg) => msg.id === pendingId ? { ...msg, isPending: false, isQueued: false } : msg));
+                        if (abortControllerRef.current) abortControllerRef.current.abort('steer');
+                      }
+                    } else {
+                      // Only act if the message is still tracked — the 5s fallback may have
+                      // already fired and moved it to steerPendingRef before this SSE arrived.
+                      const queueEntry = pendingQueueRef.current.find((q) => q.id === pendingId);
+                      if (queueEntry) {
+                        pendingQueueRef.current = pendingQueueRef.current.map((q) =>
+                          q.id === pendingId ? { ...q, status: 'queued' as const } : q,
+                        );
+                        setPendingQueue([...pendingQueueRef.current]);
+                        setMessages((prev) => prev.map((msg) =>
+                          msg.id === pendingId ? { ...msg, isPending: false, isQueued: true } : msg,
+                        ));
+                      }
+                    }
+                    break;
+                  }
                   case "decision_questions": {
                     const incoming = (event.questions ?? []) as Question[];
                     setMessages((prev) =>
@@ -905,7 +1013,8 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
         }
       } catch (error) {
         if (error instanceof Error && error.name === "AbortError") {
-          console.log("Chat stream aborted");
+          const isSteerAbort = abortControllerRef.current?.signal.reason === 'steer';
+          console.log(isSteerAbort ? "Chat stream interrupted by steer" : "Chat stream aborted");
           const stoppedAt = Date.now();
           setMessages((prev) =>
             prev.map((msg) =>
@@ -913,8 +1022,9 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
                 ? {
                     ...msg,
                     isStreaming: false,
-                    wasStoppedByUser: true,
-                    stoppedAt,
+                    ...(isSteerAbort
+                      ? { wasInterrupted: true }
+                      : { wasStoppedByUser: true, stoppedAt }),
                   }
                 : msg,
             ),
@@ -936,6 +1046,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
       } finally {
         skipSessionUpdateForRequestRef.current = false;
         setIsLoading(false);
+        // Queue drain is handled by the useEffect below (watches isLoading transition to false).
         // Ensure isStreaming is always cleared when the stream ends
         setMessages((prev) =>
           prev.map((msg) =>
@@ -955,8 +1066,46 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
     }
   }, []);
 
+  // Drain the pending queue whenever loading ends.
+  // Steer messages take priority; queued messages drain FIFO.
+  // Uses useEffect (not inline in sendMessage) to avoid React Compiler circular-reference issues.
+  React.useEffect(() => {
+    if (isLoading) return;
+    if (steerPendingRef.current.length > 0) {
+      const [steerMsg, ...rest] = steerPendingRef.current;
+      steerPendingRef.current = rest;
+      // Use hidden:true so sendMessage does not add a duplicate user message —
+      // the placeholder added by submitMidStreamMessage already represents this turn.
+      void sendMessage(steerMsg.message, steerMsg.fileIds, steerMsg.attachmentNames, { hidden: true });
+    } else if (pendingQueueRef.current.length > 0) {
+      const [nextMsg, ...rest] = pendingQueueRef.current;
+      pendingQueueRef.current = rest;
+      setPendingQueue(rest);
+      // Cancel any live fallback timer for this message (may still be running if
+      // the stream ended before the SSE decision arrived).
+      const t = interruptTimeoutsRef.current.get(nextMsg.id);
+      if (t !== undefined) { clearTimeout(t); interruptTimeoutsRef.current.delete(nextMsg.id); }
+      // Reset both isPending and isQueued so the placeholder no longer shows "classifying…".
+      setMessages((prev) =>
+        prev.map((msg) => msg.id === nextMsg.id ? { ...msg, isPending: false, isQueued: false } : msg),
+      );
+      // Use hidden:true — the placeholder is the canonical user bubble.
+      void sendMessage(nextMsg.message, nextMsg.fileIds, nextMsg.attachmentNames, { hidden: true });
+    }
+  // sendMessage is stable when sessionId/scopeNetworkId/refetchSessions don't change;
+  // including it would loop. Drain only fires on isLoading transitions.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoading]);
+
   const clearChat = useCallback((options?: { abortStream?: boolean }) => {
     const abortStream = options?.abortStream !== false;
+    // Cancel all pending interrupt timers and reset queue refs so the drain
+    // effect does not fire stale queued messages into the freshly-cleared chat.
+    interruptTimeoutsRef.current.forEach((t) => clearTimeout(t));
+    interruptTimeoutsRef.current.clear();
+    pendingQueueRef.current = [];
+    steerPendingRef.current = [];
+    setPendingQueue([]);
     if (!abortStream) {
       skipSessionUpdateForRequestRef.current = true;
       setIsLoading(false); // Stop showing loading on home while stream continues in background
@@ -972,6 +1121,13 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const loadSession = useCallback(async (id: string) => {
+    // Reset steer/queue state so messages queued against the previous session
+    // don't drain into this one via the useEffect.
+    interruptTimeoutsRef.current.forEach((t) => clearTimeout(t));
+    interruptTimeoutsRef.current.clear();
+    pendingQueueRef.current = [];
+    steerPendingRef.current = [];
+    setPendingQueue([]);
     try {
       const data = await apiClient.post<{
         session: {
@@ -988,6 +1144,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
           streamingDrafts?: StreamingDraft[] | null;
           decisionQuestions?: Question[] | null;
           decisionQuestionsSubmitted?: boolean | null;
+          interrupted?: boolean | null;
           debugMeta?: {
             tools?: Array<{
               name: string;
@@ -1023,6 +1180,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
           ...(m.decisionQuestionsSubmitted
             ? { decisionQuestionsSubmitted: true }
             : {}),
+          ...(m.interrupted ? { wasInterrupted: true } : {}),
         })),
       );
     } catch (err) {
@@ -1069,6 +1227,9 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
         clearChat,
         loadSession,
         updateSessionTitle,
+        pendingQueue,
+        cancelQueuedMessage,
+        submitMidStreamMessage,
       }}
     >
       {children}

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/chat/chat-streaming.types.ts
+++ b/packages/protocol/src/chat/chat-streaming.types.ts
@@ -49,7 +49,9 @@ export type ChatStreamEventType =
   | "chat_summarizer_end"
   | "question_generator_start"
   | "question_generator_end"
-  | "decision_questions";
+  | "decision_questions"
+  // Steer-or-queue interrupt event
+  | "steer_or_queue";
 
 /**
  * Base interface for all chat stream events.
@@ -558,6 +560,19 @@ export interface DecisionQuestionsEvent extends ChatStreamEventBase {
 }
 
 /**
+ * Steer-or-queue event — injected into the active SSE stream by the /chat/interrupt
+ * endpoint after the classifier runs. The frontend holds the mid-stream message as
+ * "pending" until this event arrives, then acts on the decision.
+ */
+export interface SteerOrQueueEvent extends ChatStreamEventBase {
+  type: "steer_or_queue";
+  /** Classifier decision: interrupt and restart, or buffer until current run completes. */
+  decision: "steer" | "queue";
+  /** Echoed from the interrupt request so the frontend can update the correct pending message. */
+  messageId: string;
+}
+
+/**
  * Union type of all chat stream events.
  */
 export type ChatStreamEvent =
@@ -600,7 +615,8 @@ export type ChatStreamEvent =
   | ChatSummarizerEndEvent
   | QuestionGeneratorStartEvent
   | QuestionGeneratorEndEvent
-  | DecisionQuestionsEvent;
+  | DecisionQuestionsEvent
+  | SteerOrQueueEvent;
 
 /**
  * Formats a chat stream event as an SSE message. If JSON.stringify throws (e.g. circular ref,
@@ -1075,4 +1091,18 @@ export function createDecisionQuestionsEvent(
   payload: { questions: Question[] },
 ): DecisionQuestionsEvent {
   return createStreamEvent<DecisionQuestionsEvent>("decision_questions", sessionId, payload);
+}
+
+/**
+ * Creates a steer-or-queue event injected into the active stream by the interrupt endpoint.
+ */
+export function createSteerOrQueueEvent(
+  sessionId: string,
+  decision: "steer" | "queue",
+  messageId: string,
+): SteerOrQueueEvent {
+  return createStreamEvent<SteerOrQueueEvent>("steer_or_queue", sessionId, {
+    decision,
+    messageId,
+  });
 }

--- a/packages/protocol/src/chat/chat.graph.ts
+++ b/packages/protocol/src/chat/chat.graph.ts
@@ -153,6 +153,8 @@ export class ChatGraphFactory {
       maxContextMessages?: number;
       networkId?: string;
       prefillMessages?: Array<{ role: "assistant" | "user"; content: string }>;
+      /** Per-run identifier used to form a composite LangGraph thread_id (sessionId:runId). */
+      runId?: string;
     },
     checkpointer?: BaseCheckpointSaver,
     signal?: AbortSignal,

--- a/packages/protocol/src/chat/chat.interrupt.classifier.ts
+++ b/packages/protocol/src/chat/chat.interrupt.classifier.ts
@@ -1,0 +1,74 @@
+import type { ChatOpenAI } from "@langchain/openai";
+import { HumanMessage, SystemMessage } from "@langchain/core/messages";
+
+import { log } from "../shared/observability/log.js";
+import { Timed } from "../shared/observability/performance.js";
+import { createModel } from "../shared/agent/model.config.js";
+import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
+
+const logger = log.lib.from("ChatInterruptClassifier");
+
+const SYSTEM_PROMPT = `You decide whether a new user message sent during an active AI process should STEER or QUEUE.
+
+Rules:
+- Reply with ONLY one word: steer or queue (lowercase).
+- STEER: the message redirects, corrects, stops, contradicts, or changes what the AI is doing. Keywords: "wait", "stop", "actually", "ignore that", "instead", "no", "cancel".
+- QUEUE: the message adds context, asks a follow-up, or complements what the AI is doing. Keywords: "also", "and", "when done", "additionally", "plus".
+- When ambiguous, default to steer.`;
+
+export interface ClassifyInterruptInput {
+  /** The new user message sent while the agent is running. */
+  message: string;
+  /**
+   * Current agent activity summary derived from the last few SSE trace event names
+   * (e.g. "tool_start: discover_opportunities, graph_start: opportunity").
+   */
+  agentState: string;
+}
+
+/**
+ * Binary classifier that decides whether a mid-stream user message should steer
+ * (interrupt the current run) or queue (buffer until the run completes).
+ * Uses a low-temperature, minimal-token model for sub-1 s latency.
+ */
+export class ChatInterruptClassifier {
+  private model: ChatOpenAI;
+
+  constructor() {
+    this.model = createModel("interruptClassifier");
+  }
+
+  /**
+   * Classify a mid-stream interrupt as steer or queue.
+   *
+   * @param input - The new message and current agent state context
+   * @returns "steer" to interrupt the current run; "queue" to buffer
+   */
+  @Timed()
+  async classify(input: ClassifyInterruptInput): Promise<"steer" | "queue"> {
+    const { message, agentState } = input;
+
+    try {
+      const response = await invokeWithAbortSignal(this.model, [
+        new SystemMessage(SYSTEM_PROMPT),
+        new HumanMessage(
+          `Current agent activity: ${agentState || "idle"}\n\nNew user message: "${message.slice(0, 500)}"\n\nDecision:`,
+        ),
+      ]);
+
+      const text =
+        typeof response.content === "string"
+          ? response.content.trim().toLowerCase()
+          : String(response.content ?? "").trim().toLowerCase();
+
+      if (text.startsWith("queue")) return "queue";
+      // Default to steer on any ambiguity or unexpected output
+      return "steer";
+    } catch (error) {
+      logger.warn("[ChatInterruptClassifier.classify] Classification failed, defaulting to steer", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return "steer";
+    }
+  }
+}

--- a/packages/protocol/src/chat/chat.streamer.ts
+++ b/packages/protocol/src/chat/chat.streamer.ts
@@ -76,6 +76,10 @@ export class ChatStreamer {
       maxContextMessages?: number;
       networkId?: string;
       prefillMessages?: Array<{ role: "assistant" | "user"; content: string }>;
+      /** Per-run identifier used to form a composite LangGraph thread_id (sessionId:runId).
+       * When provided, prevents stale checkpoint state from a prior run being resumed.
+       * Defaults to sessionId alone when absent (backward compatible). */
+      runId?: string;
     },
     checkpointer?: BaseCheckpointSaver,
     signal?: AbortSignal,
@@ -87,6 +91,7 @@ export class ChatStreamer {
       maxContextMessages = 20,
       networkId,
       prefillMessages,
+      runId,
     } = input;
     logger.verbose("Starting context-aware streaming", {
       userId,
@@ -118,12 +123,16 @@ export class ChatStreamer {
         totalCount: allMessages.length,
       });
 
+      // Form composite thread_id when a runId is provided
+      const threadId = runId ? `${sessionId}:${runId}` : sessionId;
+
       // Stream with context using the optional checkpointer
       yield* this.streamChatEvents(
         { userId, messages: allMessages, networkId },
         sessionId,
         checkpointer,
         signal,
+        threadId,
       );
     } catch (error) {
       logger.error("Stream error", {
@@ -157,6 +166,7 @@ export class ChatStreamer {
     sessionId: string,
     checkpointer?: BaseCheckpointSaver,
     signal?: AbortSignal,
+    threadId?: string,
   ): AsyncGenerator<ChatStreamEvent> {
     const graph = this.createStreamingGraph(checkpointer);
 
@@ -177,7 +187,7 @@ export class ChatStreamer {
       // Custom events come from config.writer() inside agentLoopNode.
       const eventStream = await graph.stream(initialState, {
         streamMode: ["custom", "updates"] as const,
-        configurable: { thread_id: sessionId, signal },
+        configurable: { thread_id: threadId ?? sessionId, signal },
         signal,
       });
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -180,6 +180,8 @@ export { PremiseGraphFactory } from "./premise/premise.graph.js";
 export { UserContextGenerator } from "./context/context.generator.js";
 export type { UserContextInput, IncrementalContextInput, UserContextResult } from "./context/context.generator.js";
 export { ChatTitleGenerator } from "./chat/chat.title.generator.js";
+export { ChatInterruptClassifier } from "./chat/chat.interrupt.classifier.js";
+export type { ClassifyInterruptInput } from "./chat/chat.interrupt.classifier.js";
 export { ChatSummarizer } from "./chat/chat.summarizer.js";
 export type { ChatSummarizerInput, ChatSummarizerMessage } from "./chat/chat.summarizer.js";
 export { HydeGenerator } from "./shared/hyde/hyde.generator.js";

--- a/packages/protocol/src/shared/agent/model.config.ts
+++ b/packages/protocol/src/shared/agent/model.config.ts
@@ -54,6 +54,7 @@ function getModelConfig(config?: ModelConfig) {
     premiseIndexer:       { model: "google/gemini-2.5-flash" },
     userContextGenerator: { model: "google/gemini-2.5-flash", temperature: 0.3, maxTokens: 512 },
     networkRecommender:   { model: "google/gemini-2.5-flash", temperature: 0.2, maxTokens: 512 },
+    interruptClassifier:  { model: "google/gemini-2.5-flash", temperature: 0.0, maxTokens: 16 },
     chat: {
       model: config?.chatModel ?? process.env.CHAT_MODEL ?? "google/gemini-3-pro-preview",
       maxTokens: 8192,


### PR DESCRIPTION
## Summary

Removes the `disabled={isBusy}` input block from the chat UI and replaces it with a classifier-driven interrupt/queue system. Users can now type and submit mid-stream; a small LLM classifier decides whether to steer (interrupt + restart) or queue (buffer + auto-drain).

## New Features

- **Non-blocking input** — textarea and file attachment controls stay enabled while a response is streaming; only file uploads block submission
- **Steer flow** — mid-stream submit POSTs to `POST /chat/interrupt`; classifier returns `steer` → running stream self-terminates, partial assistant response persists with `interrupted: true` metadata, new stream starts automatically
- **Queue flow** — classifier returns `queue` → message shows a "queued" badge and appears in a dismissable queue panel above the input; auto-drains FIFO after the current stream completes
- **5-second fallback** — if no SSE `steer_or_queue` event arrives, steer is assumed
- **Interrupted message indicator** — reloaded sessions show "— interrupted" label on partial assistant messages

## Implementation

### Protocol (`packages/protocol`)
- `ChatInterruptClassifier` — binary steer/queue LLM classifier (Gemini 2.5 Flash, temp 0.0, maxTokens 16) following `ChatTitleGenerator` pattern
- `steer_or_queue` added to `ChatStreamEventType` union with `SteerOrQueueEvent` interface and `createSteerOrQueueEvent()` factory
- `streamChatEventsWithContext` accepts optional `runId`; derives composite `thread_id: sessionId:runId` for all runs to prevent stale LangGraph checkpoint reuse

### Backend
- `backend/src/lib/chat-interrupt.events.ts` — singleton EventEmitter interrupt bus (`emitChatInterrupt` / `onChatInterrupt`) following `notification-events.ts` pattern; per-session `interrupt:<sessionId>` events; `setMaxListeners(200)`
- `POST /chat/interrupt` endpoint — validates session ownership, runs classifier, emits interrupt event; `RateLimit('write') + AuthGuard`
- Stream handler — per-stream `runId` (UUID) + secondary `streamAbortController` (separate from `req.signal`); subscribes interrupt bus via `.once()`, injects `steer_or_queue` SSE event, aborts on steer; steer path persists partial turn before exiting; `unsubscribeInterrupt()` in `finally`
- `interrupted?: boolean` stored in existing `metadata: jsonb` column (no migration)

### Frontend
- `AIChatContext` — `QueuedMessage` type; `pendingQueueRef` / `steerPendingRef` / `interruptTimeoutRef` refs; `submitMidStreamMessage` callback; `steer_or_queue` SSE case; `useEffect([isLoading])` queue drain (steer-priority-first, then FIFO)
- `ChatContent` — 7 `disabled={isBusy}` → `disabled={isUploadingFiles}`; `handleSubmit` routes mid-stream to interrupt flow; queue panel; pending/queued badges on user messages; interrupted label on assistant messages

## What's Not Included
- `/s/[token]` shared view and `/u/[id]/chat` paths (non-blocking input is primary chat only)
- User-controlled steer-vs-queue override — classifier decides
- Redis interrupt bus (in-memory EventEmitter; Redis upgrade path noted in comments)