### PR TITLE
fix(auth,digest): prevent cross-user opportunity delivery via wrong INDEX_API_KEY

### DIFF
--- a/.rpiv/artifacts/discover/2026-06-11_00-55-13_agentvillage-digest-wrong-opportunity-delivery.md
+++ b/.rpiv/artifacts/discover/2026-06-11_00-55-13_agentvillage-digest-wrong-opportunity-delivery.md
@@ -1,0 +1,123 @@
+---
+date: 2026-06-11T00:55:13+0300
+author: Yankı Ekin Yüksel
+commit: c5c2c78664
+branch: dev
+repository: index
+topic: "AgentVillage digest wrong-opportunity delivery — root cause and fix"
+tags: [intent, frd, agentvillage, digest, connect-link, opportunity, install]
+status: ready
+last_updated: 2026-06-11T00:55:13+0300
+last_updated_by: Yankı Ekin Yüksel
+---
+
+# FRD: AgentVillage digest wrong-opportunity delivery — root cause and fix
+
+## Summary
+Users received opportunities in their AgentVillage daily digest that belonged to other residents. User C's digest contained a connect link minted for User A, meaning C's Hermes workspace was authenticating as A when the digest was staged. A stop-gap connect-link patch (`resolveConnectLinkForUser`) has shipped, but the root cause — wrong `INDEX_API_KEY` stored in a resident's workspace — remains undetected and potentially present in other residents. This FRD captures the investigation scope and required fix.
+
+## Problem & Intent
+User C received an opportunity between User A and User B in their morning digest. A connect link was embedded in C's digest that — after the connect-link patch landed (Jun 10) — returned 404 for User C, confirming the link was minted for User A's userId, not User C's. This means C's Hermes workspace was calling the Index MCP server with User A's `INDEX_API_KEY`, fetching A's opportunities, minting A's connect links, and staging the result as C's morning brief. The install process never verified that the stored API key corresponds to the expected resident.
+
+In the developer's own words: *"we had to make a patch preventing User C from using that connect link, but we still have to debug and find out why User C received the opportunity to begin with. And we have to fix it."*
+
+## Goals
+- Identify the root cause: confirm that the wrong `INDEX_API_KEY` in User C's workspace is what caused the mis-delivery.
+- Fix the install flow: add an identity-verification step to `installIndex()` so a key that doesn't match the expected resident is rejected at install time, not discovered via a leaked opportunity.
+- Audit existing residents: check every deployed resident workspace for an API key mismatch and re-install affected workspaces with the correct key.
+- Prevent recurrence: the install-time check should run on every fresh install and every reconcile/update pass.
+
+## Non-Goals
+- Replacing or removing the connect-link patch (`resolveConnectLinkForUser`) — it is correct defense-in-depth and stays.
+- Redesigning the digest pipeline beyond the API-key identity check.
+- Fixing the `callerScoped` filter or `visibilityGuard` SQL — those are independently correct and already in place; they do not address mis-configured API keys because the SQL correctly returns opportunities for whoever the key authenticates as.
+- Investigating whether the opportunity was a two-party or three-party connection — that distinction does not change the root cause or the fix.
+
+## Functional Requirements
+1. `installIndex()` SHALL call the Index backend with the provided API key before writing it to disk, and verify the returned authenticated user matches the expected resident identity (Telegram handle or resident ID if available).
+2. If identity verification fails, `installIndex()` SHALL exit with a non-zero code and a human-readable error before modifying `HERMES_HOME/.env` or `config.yaml`.
+3. A reconcile/repair script SHALL be provided (or the existing `reconcile_digest_crons.ts` extended) to check API key identity on already-installed workspaces without re-running the full install.
+4. The `buildDailyBriefContext` function (or `fetchOpportunitiesFromMcp`) SHALL log the authenticated user identity returned by the MCP server on each digest build so future mis-configurations leave a detectable trace in logs.
+5. Installation docs SHALL note that `--index-api-key` must be the key belonging to the resident's own Index account.
+
+## Non-Functional Requirements
+- **Performance**: The identity-check call adds one round-trip to `installIndex()` (< 1 s on typical network). Acceptable for an install-time operation.
+- **Security**: The identity check must not log the raw API key; it may log the first 8 chars of its SHA-256 hash (consistent with the pattern in `backend/src/guards/auth.guard.ts:113`).
+- **UX / Accessibility**: Install-time failures must produce a clear human-readable message naming the mismatch (e.g., "API key authenticates as user@example.com, expected resident telegram handle @handle").
+- **Reliability**: If the identity check endpoint is unreachable (network outage), `installIndex()` should warn and optionally allow a `--skip-key-check` bypass for offline installs, but default to failing fast.
+
+## Constraints & Assumptions
+- Each AgentVillage resident has their own isolated Hermes workspace (`HERMES_HOME`) with their own `INDEX_API_KEY`, `memory/`, and kanban state.
+- The Index backend exposes an authenticated endpoint that returns the current user's identity (userId, email, or Telegram handle) callable with just `x-api-key`. **This needs to be verified by research** — if no such endpoint exists it must be added (or the MCP `read_user_profiles` tool used instead).
+- The AgentVillage landing admin routes (`/api/admin/residents/[tenantId]/…`) are separate from each resident's Hermes digest pipeline and are not implicated in this bug.
+- User C's workspace currently has the wrong key and must be re-installed with the correct one as an immediate operational fix (outside the code change).
+
+## Acceptance Criteria
+- [ ] Running `bun install/install.ts --index-api-key <WRONG_KEY>` exits non-zero with a message identifying the key mismatch before writing any files.
+- [ ] Running `bun install/install.ts --index-api-key <CORRECT_KEY>` completes normally and writes the key.
+- [ ] Running the reconcile/audit script against a workspace with a mismatched key prints a warning identifying that workspace.
+- [ ] After re-installing User C's workspace with the correct key, the next morning digest for User C contains only opportunities where User C is an actor (verified by checking the staged Kanban body before the send pass).
+- [ ] `buildDailyBriefContext` writes a log line containing the authenticated userId returned by the MCP on each digest opportunity fetch (visible in the Hermes run log for the prepare cron).
+
+## Recommended Approach
+Add an identity-verification call inside `installIndex()` in `packages/edge-city/agentvillage/install/install_index.ts` that hits a lightweight authenticated endpoint on the Index backend (e.g., a `GET /api/me` returning `{userId, email}`) before writing the key to disk; extend `reconcile_digest_crons.ts` with a `--check-identity` mode that runs the same check against already-installed workspaces; and add a `userId` log field to `fetchOpportunitiesFromMcp` using the authenticated identity returned in the MCP initialize handshake or a separate `/me` probe.
+
+## Decisions
+
+### Fix scope
+**Question**: The connect-link patch blocks User C from acting on the link, but User C still saw the opportunity in their digest. What does a complete fix look like?
+**Recommended**: Root-cause why User C got it, then fix.
+**Chosen**: Root-cause why User C got it, then fix.
+**Rationale**: The symptom (connect link misuse) is already blocked by the patch; the underlying cause (wrong identity in workspace) must be identified and closed.
+
+### Root cause identification — which layer
+**Question**: What do we know about how the wrong opportunity ended up in User C's digest? Whose userId was the connect link minted for?
+**Recommended**: n/a — evidence question
+**Chosen**: User A's userId (User C had someone else's link). After the patch, User C gets 404 on the link, confirming the link was minted for a different user.
+**Rationale**: evidence: `backend/src/services/connect-link.service.ts:resolveConnectLinkForUser` — filters by `userId`; the 404 confirms the code belongs to User A, not C.
+
+### Deployment isolation model
+**Question**: Does each resident have their own isolated Hermes workspace?
+**Recommended**: Separate workspace per resident (expected architecture).
+**Chosen**: Confirmed — each resident has their own isolated Hermes workspace.
+**Rationale**: Confirmed by developer; consistent with `packages/edge-city/agentvillage/install/install_index.ts:installIndex` which writes one `HERMES_HOME/.env` per install invocation.
+
+### Wrong-delivery mechanism
+**Question**: Pre-resolved from codebase evidence and interview.
+**Recommended**: n/a
+**Chosen**: User C's `HERMES_HOME` contains User A's `INDEX_API_KEY`. `stage-daily-brief.ts` → `buildDailyBriefContext` → `fetchOpportunitiesFromMcp` calls MCP with that key, authenticating as User A. Opportunities returned are User A's. `mintConnectLink(userId=A, ...)` mints User A's links. These appear in User C's staged digest.
+**Rationale**: evidence: `packages/edge-city/agentvillage/skills/index-network/scripts/build-daily-brief-context.ts:fetchOpportunitiesFromMcp` uses `INDEX_API_KEY` from env; `backend/src/services/connect-link.service.ts:mintConnectLink` uses `userId` from `opts.viewerId` which traces to `context.userId` which traces to the authenticated API key.
+
+### Faulty opportunity window
+**Question**: Pre-resolved from codebase evidence — prepare cron runs at 02:00 PST, send at 08:00 PST.
+**Recommended**: n/a — observation
+**Chosen**: The mis-delivered opportunity was staged during the 02:00 prepare pass and sent at 08:00. The bug is in `stage-daily-brief.ts` (the prepare path), not the send pass.
+**Rationale**: evidence: `packages/edge-city/agentvillage/install/install_index.ts:DIGEST_CRON_SPECS` — prepare at `0 2 * * *`, send at `0 8 * * *`. Developer confirmed the window.
+
+### Existing guards are defense-in-depth, not root-cause fixes
+**Question**: Pre-resolved from codebase evidence — callerScoped filter (Jun 7), networkId two-clause fix (May 29), connect-link recipient check (Jun 10).
+**Recommended**: Keep all three; do not remove them.
+**Chosen**: All three safeguards stay. Root cause is upstream of them (wrong key → wrong user → correct opportunities for the wrong person → correct links for the wrong person).
+**Rationale**: evidence: `packages/protocol/src/opportunity/opportunity.tools.ts:1539` (`callerScoped`), `backend/src/adapters/database.adapter.ts:5076` (networkId filter), `backend/src/controllers/connect-link.controller.ts:78` (`resolveConnectLinkForUser`). These guards are correct; they just don't apply when the API key already maps to the wrong user.
+
+## Open Questions
+- Does the Index backend currently expose a lightweight `GET /api/me` (or equivalent) that returns authenticated user identity for an API key? If not, must one be added as part of this fix, or should the identity check use the MCP `initialize` response metadata? **Research should verify** `backend/src/controllers/` and `backend/src/main.ts` for any existing `/me` route.
+- How many residents are currently deployed, and how many have a potential API key mismatch? An audit script should enumerate all `HERMES_HOME` paths and check each before re-installs are scheduled.
+- Was the wrong key a one-off installation error, or is there a systemic flaw in the install process (e.g., an onboarding script that copies the key from a template)?
+
+## Suggested Follow-ups
+- `packages/edge-city/agentvillage/skills/edge-esmeralda/prompts/prepare.md` comment in `stage-daily-brief.ts` header mentions "the cron prompt still fetches Index opportunities through MCP and writes to `memory/digest-opportunities.txt`" — this comment is outdated (the current prompt does not do this); worth cleaning up to avoid confusion: `packages/edge-city/agentvillage/skills/index-network/scripts/stage-daily-brief.ts:1–15`.
+- The `callerScoped` filter logs warnings to Sentry when an opportunity row returns for a user who is not an actor. If these warnings fire in production, they would have flagged the mis-configuration before the digest shipped. Consider hooking Sentry alerts on `list_opportunities: skipping opportunity where caller is not an actor`: `packages/protocol/src/opportunity/opportunity.tools.ts:1539`.
+
+## References
+- Input: free-text description of the AgentVillage daily digest wrong-opportunity bug
+- `packages/edge-city/agentvillage/install/install_index.ts` — install flow, API key storage
+- `packages/edge-city/agentvillage/skills/index-network/scripts/build-daily-brief-context.ts` — `fetchOpportunitiesFromMcp` (MCP identity boundary)
+- `packages/edge-city/agentvillage/skills/index-network/scripts/stage-daily-brief.ts` — prepare-pass entry point
+- `backend/src/services/connect-link.service.ts` — `mintConnectLink` + `resolveConnectLinkForUser` (the patch)
+- `backend/src/controllers/connect-link.controller.ts` — `/c/:code/go` handler
+- `backend/src/adapters/database.adapter.ts:5037` — `getOpportunitiesForUser` + visibilityGuard
+- `packages/protocol/src/opportunity/opportunity.tools.ts:1461` — `list_opportunities` handler
+- git: `d39d08f4a0` — "Require recipients for connect links" (the patch, Jun 10 2026)
+- git: `7162581a44` — "fix(protocol): tighten opportunity caller filtering" (Jun 7 2026)
+- git: `58145358e1` — "fix(backend): scope opportunity reads to opps wholly within the network" (May 29 2026)

--- a/.rpiv/artifacts/plans/2026-06-11_01-52-31_agentvillage-digest-api-key-mismatch-fix.md
+++ b/.rpiv/artifacts/plans/2026-06-11_01-52-31_agentvillage-digest-api-key-mismatch-fix.md
@@ -541,8 +541,8 @@ describe('AuthController.me() — API key support (Phase 1 guard swap)', () => {
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Test file exists: `ls backend/tests/auth-me-apikey.spec.ts` exits 0
-- [ ] Tests pass: `cd backend && bun test tests/auth-me-apikey.spec.ts`
+- [x] Test file exists: `ls backend/tests/auth-me-apikey.spec.ts` exits 0
+- [x] Tests pass: `cd backend && bun test tests/auth-me-apikey.spec.ts`
 
 #### Manual Verification:
 - [ ] Covers success path: API key resolves + `me()` returns `{ user: { id, email, socials[] } }`

--- a/.rpiv/artifacts/plans/2026-06-11_01-52-31_agentvillage-digest-api-key-mismatch-fix.md
+++ b/.rpiv/artifacts/plans/2026-06-11_01-52-31_agentvillage-digest-api-key-mismatch-fix.md
@@ -301,13 +301,13 @@ export async function installIndex(): Promise<void> {
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] `normalizeTelegramHandle` exported: `grep -c 'export function normalizeTelegramHandle' packages/edge-city/agentvillage/install/install_index.ts` returns 1
-- [ ] `installIndex` is async: `grep -c 'export async function installIndex' packages/edge-city/agentvillage/install/install_index.ts` returns 1
-- [ ] `normalizeTelegramHandle('@alice')` → `'alice'`
-- [ ] `normalizeTelegramHandle('https://t.me/Alice/')` → `'alice'`
-- [ ] `normalizeTelegramHandle('t.me/alice')` → `'alice'`
-- [ ] `normalizeTelegramHandle('')` → `''` (empty string passthrough)
-- [ ] `normalizeTelegramHandle('ALICE')` → `'alice'` (case-insensitive)
+- [x] `normalizeTelegramHandle` exported: `grep -c 'export function normalizeTelegramHandle' packages/edge-city/agentvillage/install/install_index.ts` returns 1
+- [x] `installIndex` is async: `grep -c 'export async function installIndex' packages/edge-city/agentvillage/install/install_index.ts` returns 1
+- [x] `normalizeTelegramHandle('@alice')` → `'alice'`
+- [x] `normalizeTelegramHandle('https://t.me/Alice/')` → `'alice'`
+- [x] `normalizeTelegramHandle('t.me/alice')` → `'alice'`
+- [x] `normalizeTelegramHandle('')` → `''` (empty string passthrough)
+- [x] `normalizeTelegramHandle('ALICE')` → `'alice'` (case-insensitive)
 
 #### Manual Verification:
 - [ ] `verifyIndexIdentity` is NOT exported (internal helper)
@@ -381,10 +381,10 @@ Make `install.ts main()` async to `await installIndex()`. Add a best-effort `/ap
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] `install.ts` has async main: `grep -c 'async function main' packages/edge-city/agentvillage/install/install.ts` returns 1
-- [ ] `install.ts` awaits installIndex: `grep -c 'await installIndex' packages/edge-city/agentvillage/install/install.ts` returns 1
-- [ ] `install.ts` error-catches main: `grep -c 'main().catch' packages/edge-city/agentvillage/install/install.ts` returns 1
-- [ ] digest identity log present: `grep -c "console.log.*authenticatedAs" packages/edge-city/agentvillage/skills/index-network/scripts/build-daily-brief-context.ts` returns 1
+- [x] `install.ts` has async main: `grep -c 'async function main' packages/edge-city/agentvillage/install/install.ts` returns 1
+- [x] `install.ts` awaits installIndex: `grep -c 'await installIndex' packages/edge-city/agentvillage/install/install.ts` returns 1
+- [x] `install.ts` error-catches main: `grep -c 'main().catch' packages/edge-city/agentvillage/install/install.ts` returns 1
+- [x] digest identity log present: `grep -c "console.log.*authenticatedAs" packages/edge-city/agentvillage/skills/index-network/scripts/build-daily-brief-context.ts` returns 1
 
 #### Manual Verification:
 - [ ] `installEdgeos()` and `installGeo()` still called without await (they are synchronous)

--- a/.rpiv/artifacts/plans/2026-06-11_01-52-31_agentvillage-digest-api-key-mismatch-fix.md
+++ b/.rpiv/artifacts/plans/2026-06-11_01-52-31_agentvillage-digest-api-key-mismatch-fix.md
@@ -151,9 +151,9 @@ async me(_req: Request, user: AuthenticatedUser) {
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] ESLint passes: `cd backend && bun run lint`
-- [ ] `AuthOrApiKeyGuard` exported from guard file: `grep -c 'export const AuthOrApiKeyGuard' backend/src/guards/auth.guard.ts` returns 1
-- [ ] `AuthGuard` still imported (used by updateProfile + deleteAccount): `grep -c 'AuthGuard' backend/src/controllers/auth.controller.ts` returns >= 3
+- [x] ESLint passes: `cd backend && bun run lint`
+- [x] `AuthOrApiKeyGuard` exported from guard file: `grep -c 'export const AuthOrApiKeyGuard' backend/src/guards/auth.guard.ts` returns 1
+- [x] `AuthGuard` still imported (used by updateProfile + deleteAccount): `grep -c 'AuthGuard' backend/src/controllers/auth.controller.ts` returns >= 3
 
 #### Manual Verification:
 - [ ] Only `me()` guard changed; `updateProfile` and `deleteAccount` still use `AuthGuard`

--- a/.rpiv/artifacts/plans/2026-06-11_01-52-31_agentvillage-digest-api-key-mismatch-fix.md
+++ b/.rpiv/artifacts/plans/2026-06-11_01-52-31_agentvillage-digest-api-key-mismatch-fix.md
@@ -1,0 +1,632 @@
+---
+date: 2026-06-11T01:52:31+0300
+author: Yankı Ekin Yüksel
+commit: 9291ec3595
+branch: dev
+repository: index
+topic: "AgentVillage digest API key mismatch root-cause fix"
+tags: [fix, agentvillage, digest, install, auth-guard, api-key, identity, install_index]
+status: ready
+parent: .rpiv/artifacts/research/2026-06-11_01-25-06_agentvillage-digest-api-key-mismatch.md
+phase_count: 4
+phases:
+  - { n: 1, title: Backend guard swap }
+  - { n: 2, title: Install identity check }
+  - { n: 3, title: Async wiring and digest runtime logging }
+  - { n: 4, title: Backend test for /me with API key }
+unresolved_phase_count: 0
+last_updated: 2026-06-11T01:52:31+0300
+last_updated_by: Yankı Ekin Yüksel
+---
+
+# AgentVillage Digest API Key Mismatch Root-Cause Fix Implementation Plan
+
+## Overview
+
+User C received User A's opportunities in their daily digest because User C's `HERMES_HOME` had User A's `INDEX_API_KEY`. The MCP session authenticated as User A, fetched User A's opportunities, minted User A's connect links, and staged them into User C's digest. Fix: (1) swap `GET /api/auth/me` from `AuthGuard` to `AuthOrApiKeyGuard` so the endpoint accepts API keys, (2) call it during `installIndex()` before any disk write and fail on telegram-handle mismatch, (3) log the authenticated identity before every digest MCP session so misconfigurations are visible in logs.
+
+## Requirements
+
+- A `GET /api/auth/me` must accept `x-api-key` header and return the authenticated user's identity (including `socials[]` for telegram handle extraction)
+- `installIndex()` must verify the API key resolves to the expected resident before writing `INDEX_API_KEY` to disk
+  - Present + mismatched telegram handle → exit 1 with clear error
+  - Profile has no telegram handle but `--telegram-handle` was provided → warn + continue
+  - Network error calling `/api/auth/me` → warn + continue
+- `buildDailyBriefContext` must log `authenticatedAs: { id, name, email }` before calling `fetchOpportunitiesFromMcp` — never block on failure
+- All existing behavior for JWT-authenticated calls to `GET /api/auth/me` must be unchanged
+
+## Current State Analysis
+
+### Key Discoveries
+
+- `auth.controller.ts:63` — `GET /me` under `@UseGuards(RateLimit('read'), AuthGuard)` — JWT only; an API-key-only request throws `'Access token required'`
+- `auth.guard.ts:93` — `AuthOrApiKeyGuard` already implements SHA-256 key hash → `apikeys` table lookup → `resolveApiKeyUserId` → user fetch; backward compatible with JWT (tries Bearer first)
+- `auth.controller.ts:71` — `userService.findWithGraph(user.id)` — `findWithGraph` returns `{ id, name, email, intro, avatar, location, socials[], onboarding? }` (confirmed at `database.adapter.ts:4427`)
+- `auth.controller.ts:78-83` — response is `const { profile: _profile, notificationPreferences, ...userFields } = fullUser; return { user: { ...userFields, notificationPreferences } }` — **`socials` is already in the response envelope** — no response shape change needed
+- `install_index.ts` — `installIndex()` is synchronous: `readApiKey()` → `readTelegramHandle()` → `upsertEnvVar()` (first disk write) → `writeMcpServerEntry()` → `reconcileDigestCronJobs()`; identity check inserts between `readTelegramHandle()` and `upsertEnvVar()`
+- `install_index.ts:21-23` — `PROTOCOL_MCP_URL` is a module-level constant; backend base URL = `PROTOCOL_MCP_URL.replace(/\/mcp$/, '')`
+- `install.ts:183` — `function main(): void`; `install.ts:199` — `installIndex()` called synchronously; `install.ts:214` — `main()` top-level call
+- `build-daily-brief-context.ts:704-706` — reads `INDEX_API_KEY` + `INDEX_MCP_URL` from env; backend base URL = `mcpUrl.replace(/\/mcp$/, '')`
+- No existing `normalizeTelegramHandle` in install scripts (`args.ts`, `env.ts`); normalization logic in SQL at `database.adapter.ts:4483` — strips `@`, URL prefix, lowercases
+
+### Constraints
+
+- `AuthGuard` → `AuthOrApiKeyGuard` swap is safe: `AuthOrApiKeyGuard` tries JWT Bearer first, so all existing JWT callers (frontend, `/api/auth` flow) are unaffected
+- `install.ts main()` must go async to `await installIndex()` — it's currently `function main(): void` + `main()` at the top level
+- `fetchOpportunitiesFromMcp` must NOT be blocked by the identity log call; always catch and continue
+
+## Desired End State
+
+```ts
+// Backend: GET /api/auth/me now accepts x-api-key
+// curl -H 'x-api-key: index_abc123' https://protocol.index.network/api/auth/me
+// → { user: { id, name, email, socials: [{ label: 'telegram', value: 'https://t.me/alice' }], ... } }
+
+// Install: identity verified before any disk write
+// bun install/install.ts --index-api-key index_abc123 --telegram-handle alice
+// → index network: target=production (https://protocol.index.network/mcp)
+// → verifying Index Network identity...
+// → authenticated as Alice Smith (alice@example.com) — telegram: @alice ✓
+// → wrote INDEX_API_KEY to .env
+// ...
+
+// Install: mismatch exits non-zero
+// bun install/install.ts --index-api-key index_abc123 --telegram-handle bob
+// → verifying Index Network identity...
+// error: API key authenticates as @alice, expected @bob — wrong key for this resident
+// (exit 1)
+
+// Digest: identity logged every run
+// [build-daily-brief-context] authenticatedAs: { id: 'user-abc', name: 'Alice Smith', email: 'alice@...' }
+```
+
+## What We're NOT Doing
+
+- Adding a new REST endpoint (guard swap is enough; `/api/auth/me` already has the right shape)
+- Changing the `/me` response body (socials already returned)
+- Adding `--check-identity` mode to `reconcile_digest_crons.ts` (not in FRD scope; deferred)
+- Building a fleet audit script (research Open Question #1; deferred)
+- Failing the digest on identity log error (always warn + continue)
+- Adding new DB methods (existing `findWithGraph` returns socials)
+- Schema migrations (no model changes)
+
+## Decisions
+
+### Decision 1: Guard swap vs. new endpoint
+
+**Ambiguity:** Does `GET /api/auth/me` need a new route for API-key access or can the existing handler be extended?
+
+**Explored:**
+- Option A: New `GET /api/identify` under `AuthOrApiKeyGuard` on `auth.controller.ts` — adds a route, keeps `/me` JWT-only
+- Option B: Swap `GET /me` guard from `AuthGuard` to `AuthOrApiKeyGuard` — one-line change, backward compatible
+
+**Decision:** Option B — swap guard. `AuthOrApiKeyGuard` (`auth.guard.ts:93`) tries JWT Bearer first; existing frontend JWT callers are unaffected. No new route, no new response envelope needed. Modeled after agent.controller.ts and network.controller.ts which use `AuthOrApiKeyGuard` on GET endpoints.
+
+### Decision 2: Response shape change
+
+**Ambiguity:** Does `/me` need to return `telegramHandle: string | null` explicitly?
+
+**Explored:**
+- Option A: Add `telegramHandle` as a top-level field by extracting it in `auth.controller.ts:me()`
+- Option B: Return `socials[]` as-is (already in the response body) — client filters
+
+**Decision:** Option B — `socials[]` already in `userFields` spread (`auth.controller.ts:78`). Install script filters for `label === 'telegram'` and normalizes inline. Cleaner: the endpoint stays general-purpose; callers extract what they need.
+
+### Decision 3: Network error behavior at install time
+
+**Decision:** Warn + continue. Log: `"  warning: identity check unavailable — proceeding without verification"`. Allows offline installs and container startup-order cases. Only a present + mismatched handle causes exit 1.
+
+### Decision 4: normalizeTelegramHandle implementation
+
+**Decision:** Inline helper in `install_index.ts`, modeled after `database.adapter.ts:4483` SQL normalization — strip leading `@`, strip `https://t.me/` or `http://t.me/` or `t.me/`, lowercase everything.
+
+### Decision 5: Digest identity log failure behavior
+
+**Decision:** Always catch and continue — the digest run must never be blocked by an identity log call that fails due to network issues.
+
+## Phase 1: Backend guard swap
+
+### Overview
+Swap `auth.controller.ts:63` from `@UseGuards(RateLimit('read'), AuthGuard)` to `@UseGuards(RateLimit('read'), AuthOrApiKeyGuard)`. This is the foundation: without this, the install script cannot call `/api/auth/me` with an API key. Depends on nothing. All subsequent phases depend on this.
+
+### Changes Required:
+
+#### 1. backend/src/controllers/auth.controller.ts
+
+**File**: `backend/src/controllers/auth.controller.ts`
+**Changes**: MODIFY — import `AuthOrApiKeyGuard`, swap guard on `me()`
+
+```ts
+// Replace the AuthGuard import line:
+import { AuthGuard, AuthOrApiKeyGuard } from '../guards/auth.guard';
+
+// Replace the me() UseGuards decorator:
+@Get('/me')
+@UseGuards(RateLimit('read'), AuthOrApiKeyGuard)
+async me(_req: Request, user: AuthenticatedUser) {
+  // body unchanged
+}
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] ESLint passes: `cd backend && bun run lint`
+- [ ] `AuthOrApiKeyGuard` exported from guard file: `grep -c 'export const AuthOrApiKeyGuard' backend/src/guards/auth.guard.ts` returns 1
+- [ ] `AuthGuard` still imported (used by updateProfile + deleteAccount): `grep -c 'AuthGuard' backend/src/controllers/auth.controller.ts` returns >= 3
+
+#### Manual Verification:
+- [ ] Only `me()` guard changed; `updateProfile` and `deleteAccount` still use `AuthGuard`
+- [ ] Import line has both guards side-by-side (not a replacement)
+- [ ] Frontend JWT callers to GET /me unaffected — `AuthOrApiKeyGuard` tries Bearer first
+
+## Phase 2: Install identity check
+
+### Overview
+Add `normalizeTelegramHandle()` and `verifyIndexIdentity()` helpers to `install_index.ts`, then make `installIndex()` async and insert the identity check between `readTelegramHandle()` and the first `upsertEnvVar()` call. Depends on Phase 1 (the backend endpoint must accept API keys before the install script can call it).
+
+### Changes Required:
+
+#### 1. packages/edge-city/agentvillage/install/install_index.ts
+
+**File**: `packages/edge-city/agentvillage/install/install_index.ts`
+**Changes**: MODIFY — add normalizeTelegramHandle, verifyIndexIdentity; make installIndex() async
+
+```ts
+// Add after the existing `buildIndexMcpHeaders` export and before `writeMcpServerEntry`:
+
+/**
+ * Normalize a Telegram handle to a bare lowercase handle.
+ * Strips leading @, URL prefix (t.me/, https://t.me/, telegram.me/), and
+ * everything after the first /, ?, or # — matching the SQL normalization
+ * in database.adapter.ts:4483.
+ */
+export function normalizeTelegramHandle(value: string): string {
+  let v = value.trim().toLowerCase();
+  v = v.replace(/^(https?:\/\/)?(t\.me|telegram\.me)\//, '');
+  v = v.replace(/^@/, '');
+  v = v.replace(/[/?#].*$/, '');
+  return v;
+}
+
+/**
+ * Verify that the given API key resolves to the expected resident on Index Network.
+ * Calls GET /api/auth/me with the key and compares the profile telegram handle against
+ * the expected handle (if provided).
+ *
+ * Exit codes:
+ *   - HTTP 401/403: key is invalid/expired → exit 1
+ *   - telegram handle mismatch: wrong key for this resident → exit 1
+ *   - network error / missing profile handle: warn + continue
+ */
+async function verifyIndexIdentity(apiKey: string, telegramHandle: string): Promise<void> {
+  const baseUrl = PROTOCOL_MCP_URL.replace(/\/mcp$/, '');
+  console.log('  verifying Index Network identity...');
+
+  type MeUser = {
+    id: string;
+    name: string;
+    email: string | null;
+    socials?: Array<{ label: string; value: string }>;
+  };
+
+  let identity: MeUser | null = null;
+
+  try {
+    const resp = await fetch(`${baseUrl}/api/auth/me`, {
+      headers: { 'x-api-key': apiKey },
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (resp.status === 401 || resp.status === 403) {
+      console.error(
+        `error: API key rejected by Index Network (HTTP ${resp.status}) — invalid or expired key`,
+      );
+      process.exit(1);
+    }
+
+    if (!resp.ok) {
+      console.warn(
+        `  warning: identity check unavailable (HTTP ${resp.status}) — proceeding without verification`,
+      );
+      return;
+    }
+
+    const json = (await resp.json()) as { user?: MeUser };
+    identity = json.user ?? null;
+  } catch (err) {
+    const reason = err instanceof Error && err.name === 'TimeoutError'
+      ? 'timeout after 10 s'
+      : 'network error';
+    console.warn(
+      `  warning: identity check unavailable (${reason}) — proceeding without verification`,
+    );
+    return;
+  }
+
+  if (!identity) {
+    console.warn(
+      '  warning: identity check returned empty user — proceeding without verification',
+    );
+    return;
+  }
+
+  const displayName = `${identity.name}${identity.email ? ` (${identity.email})` : ''}`;
+
+  if (!telegramHandle) {
+    console.log(`  authenticated as ${displayName}`);
+    return;
+  }
+
+  const telegramSocial = identity.socials?.find((s) => s.label === 'telegram');
+
+  if (!telegramSocial) {
+    console.warn(
+      `  warning: authenticated as ${displayName} — no telegram handle on profile, cannot verify @${telegramHandle}`,
+    );
+    return;
+  }
+
+  const profileHandle = normalizeTelegramHandle(telegramSocial.value);
+  const expectedHandle = normalizeTelegramHandle(telegramHandle);
+
+  if (profileHandle !== expectedHandle) {
+    console.error(
+      `error: API key authenticates as @${profileHandle}, expected @${expectedHandle} — wrong key for this resident`,
+    );
+    process.exit(1);
+  }
+
+  console.log(`  authenticated as ${displayName} — telegram: @${profileHandle} ✓`);
+}
+
+// Replace the existing installIndex() function:
+export async function installIndex(): Promise<void> {
+  const apiKey = readApiKey();
+  const telegramHandle = readTelegramHandle();
+  console.log(
+    `→ index network: target=${IS_DEV ? 'dev' : 'production'} (${PROTOCOL_MCP_URL})`,
+  );
+  await verifyIndexIdentity(apiKey, telegramHandle);
+  upsertEnvVar('INDEX_API_KEY', apiKey);
+  if (telegramHandle) upsertEnvVar('INDEX_TELEGRAM_HANDLE', telegramHandle);
+  writeMcpServerEntry(apiKey, telegramHandle);
+
+  if (!process.argv.includes('--skip-crons')) {
+    reconcileDigestCronJobs(hermesExecEnv());
+  }
+}
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] `normalizeTelegramHandle` exported: `grep -c 'export function normalizeTelegramHandle' packages/edge-city/agentvillage/install/install_index.ts` returns 1
+- [ ] `installIndex` is async: `grep -c 'export async function installIndex' packages/edge-city/agentvillage/install/install_index.ts` returns 1
+- [ ] `normalizeTelegramHandle('@alice')` → `'alice'`
+- [ ] `normalizeTelegramHandle('https://t.me/Alice/')` → `'alice'`
+- [ ] `normalizeTelegramHandle('t.me/alice')` → `'alice'`
+- [ ] `normalizeTelegramHandle('')` → `''` (empty string passthrough)
+- [ ] `normalizeTelegramHandle('ALICE')` → `'alice'` (case-insensitive)
+
+#### Manual Verification:
+- [ ] `verifyIndexIdentity` is NOT exported (internal helper)
+- [ ] Identity check is called after `readTelegramHandle()` and before `upsertEnvVar("INDEX_API_KEY", ...)`
+- [ ] On HTTP 401/403 → `process.exit(1)` with clear error
+- [ ] On network error / non-ok response → warn + continue (no exit)
+- [ ] On telegram mismatch → `process.exit(1)` with clear error
+- [ ] On missing telegram social but handle provided → warn + continue
+- [ ] On no `--telegram-handle` flag → just log identity, no comparison
+
+## Phase 3: Async wiring and digest runtime logging
+
+### Overview
+Make `install.ts main()` async to `await installIndex()`. Add a best-effort `/api/auth/me` call at the start of `buildDailyBriefContext` that logs the authenticated identity before any MCP call. Depends on Phase 2 (`installIndex()` is now async). Can run in parallel with Phase 4.
+
+### Changes Required:
+
+#### 1. packages/edge-city/agentvillage/install/install.ts:183-214
+
+**File**: `packages/edge-city/agentvillage/install/install.ts`
+**Changes**: MODIFY — `function main(): void` → `async function main()`, `installIndex()` → `await installIndex()`, `main()` → `main().catch(console.error)`
+
+```ts
+// Change 1: line 183
+- function main(): void {
++ async function main(): Promise<void> {
+
+// Change 2: line 199
+-   installIndex();
++   await installIndex();
+
+// Change 3: line 214
+- main();
++ main().catch((err) => { console.error(err); process.exit(1); });
+```
+
+#### 2. packages/edge-city/agentvillage/skills/index-network/scripts/build-daily-brief-context.ts:704
+
+**File**: `packages/edge-city/agentvillage/skills/index-network/scripts/build-daily-brief-context.ts`
+**Changes**: MODIFY — add best-effort identity log inside `if (apiKey)` block before the existing `fetchOpportunitiesFromMcp` try
+
+```ts
+  if (apiKey) {
+    // Best-effort identity log before each MCP session. Never blocks digest.
+    try {
+      const baseUrl = mcpUrl.replace(/\/mcp$/, '');
+      const meResp = await fetch(`${baseUrl}/api/auth/me`, { headers: { 'x-api-key': apiKey } });
+      if (meResp.ok) {
+        const meJson = (await meResp.json()) as {
+          user?: { id: string; name: string; email: string | null };
+        };
+        if (meJson.user) {
+          console.log('[build-daily-brief-context] authenticatedAs:', {
+            id: meJson.user.id,
+            name: meJson.user.name,
+            email: meJson.user.email,
+          });
+        }
+      }
+    } catch {
+      // best-effort; never propagate
+    }
+    try {
+      const deliveredIds = await readDeliveredIds(options.stateFile ?? "memory/heartbeat-state.json", date);
+      const fetched = await fetchOpportunitiesFromMcp({ apiKey, mcpUrl });
+      // ... rest of existing try block unchanged
+    }
+  }
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] `install.ts` has async main: `grep -c 'async function main' packages/edge-city/agentvillage/install/install.ts` returns 1
+- [ ] `install.ts` awaits installIndex: `grep -c 'await installIndex' packages/edge-city/agentvillage/install/install.ts` returns 1
+- [ ] `install.ts` error-catches main: `grep -c 'main().catch' packages/edge-city/agentvillage/install/install.ts` returns 1
+- [ ] digest identity log present: `grep -c "console.log.*authenticatedAs" packages/edge-city/agentvillage/skills/index-network/scripts/build-daily-brief-context.ts` returns 1
+
+#### Manual Verification:
+- [ ] `installEdgeos()` and `installGeo()` still called without await (they are synchronous)
+- [ ] Identity log `try/catch` never propagates — outer opportunities try/catch is unaffected
+- [ ] Identity log is inside the existing `if (apiKey)` block, before `readDeliveredIds` / `fetchOpportunitiesFromMcp`
+- [ ] Log format: `console.log('[build-daily-brief-context] authenticatedAs:', { id, name, email })`
+
+## Phase 4: Backend test for /me with API key
+
+### Overview
+Add a targeted test that calls `GET /me` with an API key and verifies the response includes the user identity and socials. Depends on Phase 1. Can run in parallel with Phase 3.
+
+### Changes Required:
+
+#### 1. backend/tests/auth-me-apikey.spec.ts
+
+**File**: `backend/tests/auth-me-apikey.spec.ts`
+**Changes**: NEW — test GET /me with x-api-key: success (returns user + socials), cross-resolution prevention, invalid key throws, missing auth throws
+
+```ts
+import '../src/startup.env';
+
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import { eq } from 'drizzle-orm';
+
+import { experimentService } from '../src/services/experiment.service';
+import { AuthController } from '../src/controllers/auth.controller';
+import { AuthOrApiKeyGuard } from '../src/guards/auth.guard';
+import db from '../src/lib/drizzle/drizzle';
+import {
+  agentPermissions,
+  agents,
+  apikeys,
+  networkMembers,
+  networks,
+  personalNetworks,
+  userProfiles,
+  userSocials,
+  users,
+} from '../src/schemas/database.schema';
+
+const cleanup: Array<() => Promise<void>> = [];
+
+afterAll(async () => {
+  for (const f of [...cleanup].reverse()) await f();
+});
+
+async function setupExperimentNetwork() {
+  const [network] = await db
+    .insert(networks)
+    .values({
+      title: `Auth Me API Key Test ${randomUUID().slice(0, 6)}`,
+      isExperiment: true,
+      isPersonal: false,
+      experimentMasterKeyHash: 'test-hash-not-verified-at-service-layer',
+    })
+    .returning({ id: networks.id });
+
+  cleanup.push(async () => {
+    await db.delete(networkMembers).where(eq(networkMembers.networkId, network.id));
+    await db.delete(networks).where(eq(networks.id, network.id));
+  });
+
+  return { networkId: network.id };
+}
+
+async function cleanupUser(userId: string) {
+  await db.delete(apikeys).where(eq(apikeys.userId, userId));
+  await db.delete(agentPermissions).where(eq(agentPermissions.userId, userId));
+  await db.delete(agents).where(eq(agents.ownerId, userId));
+  await db.delete(networkMembers).where(eq(networkMembers.userId, userId));
+  await db.delete(userSocials).where(eq(userSocials.userId, userId));
+  await db.delete(userProfiles).where(eq(userProfiles.userId, userId));
+  const pn = await db
+    .select({ networkId: personalNetworks.networkId })
+    .from(personalNetworks)
+    .where(eq(personalNetworks.userId, userId));
+  await db.delete(personalNetworks).where(eq(personalNetworks.userId, userId));
+  for (const { networkId: pnId } of pn) {
+    await db.delete(networks).where(eq(networks.id, pnId));
+  }
+  await db.delete(users).where(eq(users.id, userId));
+}
+
+describe('AuthController.me() — API key support (Phase 1 guard swap)', () => {
+  let controller: AuthController;
+  let testUserId: string;
+  let testApiKey: string;
+
+  beforeAll(async () => {
+    const { networkId } = await setupExperimentNetwork();
+    const email = `auth-me-apikey-${randomUUID()}@test.example.com`;
+    const result = await experimentService.signup(networkId, { email });
+    testUserId = result.user.id;
+    testApiKey = result.apiKey;
+    cleanup.push(() => cleanupUser(testUserId));
+    controller = new AuthController();
+  });
+
+  it('returns user identity and socials when called with a valid API key', async () => {
+    const user = await AuthOrApiKeyGuard(
+      new Request('http://localhost/api/auth/me', { headers: { 'x-api-key': testApiKey } }),
+    );
+
+    const response = await controller.me(
+      new Request('http://localhost/api/auth/me'),
+      user,
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json() as {
+      user: { id: string; email: string | null; name: string; socials: unknown[] };
+    };
+    expect(json.user.id).toBe(testUserId);
+    expect(json.user.email).toBeTruthy();
+    expect(Array.isArray(json.user.socials)).toBe(true);
+  }, 10000);
+
+  it('two different API keys resolve to two different users — no cross-resolution', async () => {
+    const { networkId: netId2 } = await setupExperimentNetwork();
+    const email2 = `auth-me-apikey-other-${randomUUID()}@test.example.com`;
+    const result2 = await experimentService.signup(netId2, { email: email2 });
+    cleanup.push(() => cleanupUser(result2.user.id));
+
+    const user1 = await AuthOrApiKeyGuard(
+      new Request('http://localhost/api/auth/me', { headers: { 'x-api-key': testApiKey } }),
+    );
+    const user2 = await AuthOrApiKeyGuard(
+      new Request('http://localhost/api/auth/me', { headers: { 'x-api-key': result2.apiKey } }),
+    );
+
+    expect(user1.id).toBe(testUserId);
+    expect(user2.id).toBe(result2.user.id);
+    expect(user1.id).not.toBe(user2.id);
+  }, 10000);
+
+  it('throws when an invalid API key is supplied', async () => {
+    await expect(
+      AuthOrApiKeyGuard(
+        new Request('http://localhost/api/auth/me', { headers: { 'x-api-key': 'invalid-key-xyz' } }),
+      ),
+    ).rejects.toThrow();
+  });
+
+  it('throws when no authentication is provided', async () => {
+    await expect(
+      AuthOrApiKeyGuard(new Request('http://localhost/api/auth/me')),
+    ).rejects.toThrow();
+  });
+});
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Test file exists: `ls backend/tests/auth-me-apikey.spec.ts` exits 0
+- [ ] Tests pass: `cd backend && bun test tests/auth-me-apikey.spec.ts`
+
+#### Manual Verification:
+- [ ] Covers success path: API key resolves + `me()` returns `{ user: { id, email, socials[] } }`
+- [ ] Covers cross-resolution prevention (regression test for the bug): two API keys → two distinct user IDs
+- [ ] Covers invalid key → guard throws (HTTP 401 in production via main.ts error mapping)
+- [ ] Covers missing auth → guard throws
+- [ ] Cleanup mirrors `experiment-signup.spec.ts` pattern (cleanup stack, reversed execution)
+
+## Ordering Constraints
+
+- Phase 1 (guard swap) must complete before Phase 2 (install script) and Phase 4 (test) — the backend endpoint must accept API keys before any calling code can function
+- Phase 2 (install identity check) must complete before Phase 3 (async wiring in install.ts) — `install.ts` awaits `installIndex()`, which must be async first
+- Phase 3 and Phase 4 can run in parallel after Phases 1 and 2 complete
+
+## Verification Notes
+
+- **Precedent (d39d08f4a0):** Test both rejection (wrong user) and success (correct user) paths — not just happy path
+- **Precedent (420c5602381):** Any new path that reads `x-api-key` must go through `AuthOrApiKeyGuard`/`resolveApiKeyUserId` — confirmed: guard swap routes through it
+- **Guard regression:** Verify JWT-authenticated frontend calls to `GET /me` still work after the swap — `AuthOrApiKeyGuard` tries Bearer JWT first; JWT callers are unaffected
+- **normalizeTelegramHandle coverage:** Test empty string, `@alice`, `t.me/alice`, `https://t.me/alice/`, `ALICE` (case-insensitive) all normalize to `alice`
+- **Install edge cases:** Test network error → warn + continue; mismatch → exit 1; missing profile handle → warn + continue; no `--telegram-handle` flag → skip comparison
+- **Digest non-blocking:** Verify identity log failure does not propagate to `buildDailyBriefContext` return value or throw
+
+## Performance Considerations
+
+- One extra HTTP call at install time — acceptable (install is a one-time manual operation)
+- One extra HTTP call per digest prepare run (~once/day at 02:00) — acceptable latency overhead; always caught so no failure propagation
+
+## Migration Notes
+
+Not applicable — no schema changes, no data migration required.
+
+## Pattern References
+
+- `auth.guard.ts:93-160` — `AuthOrApiKeyGuard` full implementation (hash → lookup → resolve → user)
+- `backend/tests/experiment-signup.spec.ts:66-90` — pattern for testing API key creation + use in e2e tests
+- `database.adapter.ts:4483` — SQL normalization regex for telegram handle (reference for `normalizeTelegramHandle` TS port)
+- `packages/edge-city/agentvillage/install/args.ts:readFlag()` — flag parser pattern used in `readApiKey` / `readTelegramHandle`
+
+## Developer Context
+
+**Q (research: Endpoint approach): Where should API-key-capable identity endpoint live?**
+A: Swap `GET /me` from `AuthGuard` to `AuthOrApiKeyGuard`. One guard change, no new route, backward-compatible.
+
+**Q (research: Check strictness): What should the install check compare?**
+A: Also verify telegram handle from socials — fetch `user_socials` where `label='telegram'`, normalize, compare against `--telegram-handle`. Mismatch → fail; missing handle → warn and continue.
+
+**Q (research: No handle case): What if user has no telegram handle in their Index profile?**
+A: Warn but continue.
+
+**Q (Step 4: Network failure): What if /api/auth/me call fails (network error, timeout, 5xx)?**
+A: Warn + continue. Log: "identity check unavailable — proceeding without verification." Only present + mismatched handle causes exit 1.
+
+**Q (Step 5: Decomposition): 4 slices approved.**
+A: Phase 1 guard swap → Phase 2 install check → Phase 3 async wiring + digest logging (parallel with 4) → Phase 4 backend test (parallel with 3).
+
+**Step 6.3 Phase 4 by-design violations:**
+1. Test calls `AuthOrApiKeyGuard` + `controller.me()` directly (not via RouteRegistry). By-design: no full-server test pattern exists in codebase; direct guard + method is the established convention (`backend/tests/experiment-signup.spec.ts:146`).
+2. Invalid/missing key tests assert `.rejects.toThrow()` not HTTP 401. By-design: `AuthOrApiKeyGuard` throws an Error; the 401 status is produced by `main.ts` error mapping, which is not exercised in direct-call tests.
+
+## Plan Review (Step 8)
+
+_Independent post-finalization review by artifact-code-reviewer and artifact-coverage-reviewer subagents. Findings triaged at Step 9._
+
+| source | plan-loc | codebase-loc | severity | dimension | finding | recommendation | resolution |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| code | Phase 1 §1 (auth.controller.ts) | backend/src/main.ts:510 | blocker | actionability | Route is `/api/auth/me` not `/api/me` — `@Controller('/auth')` + GLOBAL_PREFIX `/api` | Update all URL references in the plan and code fences from `/api/me` to `/api/auth/me` | applied: all URL references updated to `/api/auth/me` across all phases and prose |
+| code | Phase 2 §1 (install_index.ts) | backend/src/main.ts:510 | blocker | actionability | `fetch(`${baseUrl}/api/auth/me`)` targets a non-existent route at HEAD | Change to `${baseUrl}/api/auth/me` in Phase 2 code fence | applied: Phase 2 code fence URL updated |
+| code | Phase 3 §2 (build-daily-brief-context.ts) | backend/src/main.ts:510 | blocker | actionability | Digest identity log also calls non-existent `${baseUrl}/api/me` | Change to `${baseUrl}/api/auth/me` in Phase 3 code fence | applied: Phase 3 code fence URL updated |
+| coverage | ## Verification Notes §4 | <n/a> | blocker | verification-coverage | `normalizeTelegramHandle` edge cases: empty string and `ALICE` not covered in Phase 2 SC | Add bullets: `normalizeTelegramHandle('')` → `''` and `normalizeTelegramHandle('ALICE')` → `'alice'` | applied: two SC bullets added to Phase 2 Automated Verification |
+| code | Phase 2 §1 (install_index.ts) | <n/a> | concern | code-quality | `verifyIndexIdentity()` has no timeout — stalled fetch can hang install | Add `AbortSignal.timeout(10000)` and treat aborts like network-error warning path | applied: `signal: AbortSignal.timeout(10_000)` added; catch distinguishes TimeoutError from network error |
+| code | Phase 3 §1 (install.ts) | packages/edge-city/agentvillage/install/install.ts:214 | concern | code-quality | `main().catch(console.error)` doesn't set exit code 1 on unhandled rejection | Replace with `.catch(err => { console.error(err); process.exit(1); })` | applied: Phase 3 code fence updated to `main().catch((err) => { console.error(err); process.exit(1); })` |
+| code | Phase 4 §1 (auth-me-apikey.spec.ts) | <n/a> | concern | actionability | Test calls guard + controller directly; guard swap not exercised end-to-end | Add route-level assertion exercising `/api/auth/me` | deferred: direct guard+controller is the established test pattern; full-server test deferred to follow-up |
+
+## Plan History
+
+- Phase 1: Backend guard swap — approved as generated
+- Phase 2: Install identity check — approved as generated
+- Phase 3: Async wiring and digest runtime logging — approved as generated (slice-verifier: 2 iterations, log format fix)
+- Phase 4: Backend test for /me with API key — approved as generated (slice-verifier: 2 by-design violations ratified by developer)
+
+## References
+
+- Research: `.rpiv/artifacts/research/2026-06-11_01-25-06_agentvillage-digest-api-key-mismatch.md`
+- FRD: `.rpiv/artifacts/discover/2026-06-11_00-55-13_agentvillage-digest-wrong-opportunity-delivery.md`
+- Precedent: `d39d08f4a0` — "Require recipients for connect links" (2026-06-10)
+- Precedent: `420c5602381` — "share API-key principal resolution, fail closed" (2026-06-08)

--- a/.rpiv/artifacts/research/2026-06-11_01-25-06_agentvillage-digest-api-key-mismatch.md
+++ b/.rpiv/artifacts/research/2026-06-11_01-25-06_agentvillage-digest-api-key-mismatch.md
@@ -1,0 +1,219 @@
+---
+date: 2026-06-11T01:25:06+0300
+author: Yankı Ekin Yüksel
+commit: c5c2c78664
+branch: dev
+repository: index
+topic: "AgentVillage digest wrong-opportunity delivery — API key mismatch root cause and fix"
+tags: [research, codebase, agentvillage, digest, install, connect-link, auth-guard, api-key, identity]
+status: ready
+last_updated: 2026-06-11T01:25:06+0300
+last_updated_by: Yankı Ekin Yüksel
+---
+
+# Research: AgentVillage digest wrong-opportunity delivery — API key mismatch root cause and fix
+
+## Research Question
+
+Ground the FRD `.rpiv/artifacts/discover/2026-06-11_00-55-13_agentvillage-digest-wrong-opportunity-delivery.md` in codebase reality. Specifically:
+- Does a `GET /api/me`-style endpoint that accepts `x-api-key` already exist?
+- Where exactly is the insertion point for an identity check in `installIndex()`?
+- What does the full install orchestration look like and what's the blast radius of making `installIndex()` async?
+- How is the telegram handle stored (normalize/compare pattern)?
+- What does `fetchOpportunitiesFromMcp` currently expose for user identity at runtime?
+
+## Summary
+
+No REST endpoint currently accepts `x-api-key` and returns user identity. The existing `GET /api/me` (`auth.controller.ts:63`) uses `AuthGuard` (JWT only). The fix is a one-line guard swap to `AuthOrApiKeyGuard` — all the plumbing already exists. The `/me` response needs one extension: also fetch the resident's telegram social from `user_socials` (label='telegram') and return a normalized handle. `installIndex()` is synchronous and must go async; `install.ts` calls it synchronously and must `await` it. `fetchOpportunitiesFromMcp` has no identity surface today — the MCP `initialize` response contains only server name/version, not the authenticated userId.
+
+## Detailed Findings
+
+### 1. No API-key-capable identity endpoint exists
+
+`auth.controller.ts:63` — `GET /me` under `@UseGuards(RateLimit('read'), AuthGuard)`. `AuthGuard` verifies a JWT via JWKS (`auth.guard.ts:25`). It does not inspect `x-api-key`. An API-key-only request to `GET /me` throws `'Access token required'`.
+
+`agent.controller.ts:180` — `GET /agents/me` under `AuthOrApiKeyGuard`, but immediately checks `resolveApiKeyAgentId(req)` (`auth.guard.ts:48`) and returns HTTP 400 if no `agentId` metadata is present on the key. Index API keys written by `installIndex()` are not agent-bound, so this endpoint is also unavailable.
+
+**Resolution:** change `auth.controller.ts:63` guard from `AuthGuard` to `AuthOrApiKeyGuard`. No new route. The existing `me()` handler already calls `userService.findWithGraph(user.id)` which returns the full user + socials; the telegram handle is a subset of that.
+
+### 2. AuthOrApiKeyGuard — full resolution flow
+
+`auth.guard.ts:93-160`:
+1. Hash the raw `x-api-key` with SHA-256, base64url-encode
+2. Look up `apikeys` table by hash — check `enabled` and `expiresAt`
+3. Call `resolveApiKeyUserId(row)` (`lib/apikey/principal.ts:44`): prefer `userId`, then `referenceId`; reject (fail closed) if both set and disagree
+4. Load `{ id, email, name }` from `users` table
+5. Return `AuthenticatedUser { id, email, name }`
+
+The install script needs to call `GET /me` with `x-api-key: <key>` and receive `{ user: { id, email, name, telegramHandle? } }`.
+
+### 3. installIndex() — insertion point and async conversion
+
+`install_index.ts:293-305` (the full `installIndex()` body):
+
+```
+readApiKey()                            line ~32-38  — no I/O
+readTelegramHandle()                    line ~46-50  — no I/O
+upsertEnvVar("INDEX_API_KEY", apiKey)   line ~298    — first write to HERMES_HOME/.env
+writeMcpServerEntry(apiKey, handle)     line ~300    — writes config.yaml
+reconcileDigestCronJobs(env)            line ~303    — runs hermes CLI subprocesses
+```
+
+Identity check inserts **between `readTelegramHandle()` and `upsertEnvVar()`** — before any disk mutation. `installIndex()` must become `async installIndex()` because the check is a fetch call.
+
+`install.ts` imports and calls `installIndex()` at its main flow. It must switch to `await installIndex()`. The top-level `install.ts` script uses a sync `main()` pattern; it would become `async function main()` + `main().catch(...)`.
+
+### 4. reconcile_digest_crons.ts — minimal shim, no flags
+
+`reconcile_digest_crons.ts` is 12 lines: reads `hermesExecEnv()` and calls `reconcileDigestCronJobs()`. No argument parsing, no checks. Extending it with `--check-identity` requires adding `readApiKey()` + `readTelegramHandle()` from `args.ts`/`env.ts`, calling the identity endpoint, printing the result, and exiting 0 (audit mode, no disk changes).
+
+### 5. hermesExecEnv() — environment augmentation
+
+`hermes_cli.ts:14-22`: returns `{ ...process.env, PATH: [hermesBin dir, /opt/hermes/.venv/bin, ~/.npm/bin, ~/.local/bin, process.env.PATH].join(':') }`. Pure env passthrough — no identity semantics. Relevant only as the env passed to cron subprocesses.
+
+### 6. Telegram handle storage pattern
+
+`database.schema.ts:108-120` — `user_socials` table: `{ id, userId, label, value }`.
+- `label = 'telegram'` (auto-detected by `detectSocialLabel` at `database.adapter.ts:31`)
+- `value` may be bare handle, `@handle`, `t.me/handle`, `https://t.me/handle`
+- Normalized in SQL via regex: strip leading `@` or URL prefix, drop everything after first `/`, `?`, or `#` (`database.adapter.ts:4483`)
+
+For the `/me` response: `getUserSocials(userId)` (`database.adapter.ts:4462`) returns all socials. Filter for `label === 'telegram'`, normalize value client-side (strip `@`, strip `t.me/` prefix) → return as `telegramHandle`.
+
+The install script normalizes `readTelegramHandle()` the same way and compares. Install logic:
+- Both present and differ → exit 1, print mismatch
+- Expected handle present but `/me` returns none → warn, continue
+- Either not present → just log identity, continue
+
+### 7. MCP initialize response — no user identity
+
+`mcp.server.ts:454-456`: the `McpServer` is constructed with `{ name: 'index-network', version: '1.0.0' }`. The `initialize` response carries only server name, version, capabilities, and instructions.
+
+`fetchOpportunitiesFromMcp` (`build-daily-brief-context.ts:655-690`): receives `initResp`, checks `initResp.error`, then discards `initResp.result`. No user identity available here.
+
+For runtime logging: the install-time REST endpoint (`GET /api/me`) can be reused by `buildDailyBriefContext` to log the authenticated userId before fetching opportunities. The base URL is already derivable from `INDEX_MCP_URL` (replace `/mcp` suffix with empty string).
+
+### 8. read_user_profiles (no args) — not the right probe path
+
+`profile.tools.ts:293-350`: `read_user_profiles` with no args returns the caller's profile (name, bio, skills, interests). It uses `context.userId` scoped by the MCP auth resolver. The response is a text-format tool output — not structured JSON. Extracting userId from the text output is fragile. The REST `/api/me` endpoint is cleaner for a programmatic check.
+
+## Code References
+
+- `backend/src/controllers/auth.controller.ts:63` — `GET /me` handler; guard swap target
+- `backend/src/guards/auth.guard.ts:25` — `AuthGuard` (JWT only)
+- `backend/src/guards/auth.guard.ts:93` — `AuthOrApiKeyGuard` hash→lookup→resolve→user flow
+- `backend/src/guards/auth.guard.ts:113` — keyHashPrefix logging pattern (sha256 prefix, never raw key)
+- `backend/src/lib/apikey/principal.ts:44` — `resolveApiKeyUserId` — prefer userId, fail closed
+- `packages/edge-city/agentvillage/install/install_index.ts:32` — `readApiKey()`
+- `packages/edge-city/agentvillage/install/install_index.ts:46` — `readTelegramHandle()`
+- `packages/edge-city/agentvillage/install/install_index.ts:293` — `installIndex()` body start
+- `packages/edge-city/agentvillage/install/install_index.ts:298` — `upsertEnvVar()` — first disk write; insertion point for identity check
+- `packages/edge-city/agentvillage/install/install.ts:1-60` — orchestrator; calls `installIndex()` synchronously
+- `packages/edge-city/agentvillage/install/reconcile_digest_crons.ts:1-12` — minimal shim
+- `packages/edge-city/agentvillage/install/hermes_cli.ts:14` — `hermesExecEnv()`
+- `packages/edge-city/agentvillage/skills/index-network/scripts/build-daily-brief-context.ts:655` — `fetchOpportunitiesFromMcp` — init + list_opportunities; no identity surface today
+- `packages/edge-city/agentvillage/skills/index-network/scripts/build-daily-brief-context.ts:704` — `buildDailyBriefContext` INDEX_API_KEY read; logging insertion point
+- `packages/protocol/src/mcp/mcp.server.ts:454` — MCP server initialized with `{ name: 'index-network', version: '1.0.0' }` only
+- `backend/src/adapters/database.adapter.ts:31` — `detectSocialLabel` — telegram label detection
+- `backend/src/adapters/database.adapter.ts:4462` — `getUserSocials(userId)` — all socials for user
+- `backend/src/adapters/database.adapter.ts:4483` — `findTelegramHandleOwners` — SQL normalization regex (strip @, URL prefix)
+- `backend/src/schemas/database.schema.ts:108` — `user_socials` table definition
+- `backend/src/controllers/agent.controller.ts:180` — `GET /agents/me`; requires agentId binding, not usable
+
+## Integration Points
+
+### Inbound References (to `installIndex()`)
+- `packages/edge-city/agentvillage/install/install.ts:~45` — only caller; invokes synchronously
+
+### Outbound Dependencies (from the new identity check)
+- `GET /api/me` on `PROTOCOL_MCP_URL.replace('/mcp', '')` — new REST dependency from install script; backend must deploy it before install script can call it
+- `hermesHome()` (`install_index.ts:20`) + `readApiKey()` + `readTelegramHandle()` — all available before the check runs
+
+### Infrastructure Wiring
+- `AuthOrApiKeyGuard` is already registered as a guard; no route registry changes needed for a guard swap
+- `userService.findWithGraph()` (`auth.controller.ts:me()`) returns full user + socials array; filtering for label='telegram' is a client-side operation on the existing response data (no new DB method needed)
+- `reconcile_digest_crons.ts` has no argument parsing infrastructure; `readFlag` from `install/args.ts` is available for `--check-identity` addition
+
+## Architecture Insights
+
+**Guard swap is safe.** `AuthOrApiKeyGuard` is a strict superset of `AuthGuard` for JWT; it tries Bearer first, then falls back to API key. Existing frontend calls (which send JWT) are unaffected. The only behavioral change for `/me` is that API-key callers now get a response instead of a 401.
+
+**installIndex() must go async.** The function is exported and called by `install.ts`. Making it async requires `install.ts` to `await` it. The script uses top-level async idiom elsewhere (e.g., the file is `#!/usr/bin/env bun`), so `async function main()` + `main().catch(console.error)` is the right pattern.
+
+**No new DB method needed for socials.** `userService.findWithGraph(user.id)` at `auth.controller.ts:71` already fetches socials via `findWithGraph` in the database adapter. The response already carries `socials: Array<{ label, value }>`. The `/me` handler just needs to extract the telegram social from the existing graph response and add it to the returned JSON.
+
+**Reconcile script audit mode is additive.** `reconcile_digest_crons.ts` imports `reconcileDigestCronJobs` from `install_index.ts`; an audit mode can be added without touching the reconcile function itself — just read the API key, call `/api/me`, print result, exit. No flags need to propagate into `reconcileDigestCronJobs`.
+
+**Digest runtime logging.** `buildDailyBriefContext` at line 704 reads `INDEX_API_KEY` from env and `INDEX_MCP_URL`. The backend base URL is `INDEX_MCP_URL.replace(/\/mcp$/, '')`. One `fetch(baseUrl + '/api/me', { headers: { 'x-api-key': apiKey } })` before the MCP call will log `authenticatedAs: { id, name, email }` for every digest run, creating a permanent trail for diagnosing future misconfigurations.
+
+## Precedents & Lessons
+
+3 relevant past changes analyzed.
+
+### Precedent: Recipient-bound connect links
+**Commit(s):** `d39d08f4a0` — "Require recipients for connect links (#927)" (2026-06-10)
+**Blast radius:** 8 files — `.rpiv/artifacts/` (5 docs), `connect-link.controller.ts`, `connect-link.service.ts`, `connect-link.e2e.spec.ts`
+
+**Follow-up fixes:** None found.
+
+**Takeaway:** Patch was reactive (added after leak was observed). Tests covered both the rejection (wrong user) and success (correct user) paths in `connect-link.e2e.spec.ts`. Same pattern needed here: install-time check test for mismatch + success + missing handle cases.
+
+### Precedent: Share API-key principal resolution, fail closed
+**Commit(s):** `420c5602381` — "refactor(auth): share API-key principal resolution, fail closed on divergent columns" (2026-06-08)
+**Blast radius:** extracted `resolveApiKeyUserId` to `lib/apikey/principal.ts`; routed both MCP (`mcp.controller.ts`) and REST (`auth.guard.ts`) through it
+
+**Follow-up fixes:** None found.
+
+**Lessons from docs:** This commit explicitly fixed a case where the same API key resolved to different users on different codepaths (MCP preferred `userId`, REST preferred `referenceId`). **This is structurally the same class of bug** — a key resolving to the wrong user. The fix was to centralize resolution and fail closed.
+
+**Takeaway:** Divergent codepaths for the same key always produce subtle identity bugs. Any new path that reads `x-api-key` must go through `AuthOrApiKeyGuard`/`resolveApiKeyUserId`, never hand-roll key-to-user resolution.
+
+### Precedent: Tighten opportunity caller filtering
+**Commit(s):** `7162581a44` — "fix(protocol): tighten opportunity caller filtering" (2026-06-07)
+**Blast radius:** 3 files in protocol only (`opportunity.tools.ts`, `opportunity.utils.ts`, 1 test)
+
+**Takeaway:** Scattered inline caller checks were consolidated into a single centralized `callerScoped` filter. Pattern to follow: one place to fail, not N scattered conditions.
+
+### Composite Lessons
+- Guards added retrospectively after incidents (`d39d08f4a0`, `7162581a44`) consistently miss edge cases (empty/null values). Add explicit tests for empty handle, mismatch, and invalid key at install time — not just the happy path.
+- Centralization is the remedy for divergent-codepath identity bugs (`420c5602381`). The new `/api/me` guard swap and the `resolveApiKeyUserId` helper already enforce this for REST; the install script just needs to consume the same endpoint.
+- When a check fails because a value is missing vs. wrong, these are different errors. Empty telegram handle → warn and continue; present but wrong → fail. This distinction prevents the fix from becoming a blocker for new residents with incomplete profiles.
+
+## Historical Context (from `.rpiv/artifacts/`)
+
+- `.rpiv/artifacts/discover/2026-06-11_00-55-13_agentvillage-digest-wrong-opportunity-delivery.md` — FRD that drove this research; captures the incident, decisions, and open questions this document resolves
+
+## Developer Context
+
+**Q (discover: Fix scope): Root-cause why User C got it, then fix.**
+A: Root cause it, close the path. Connect-link patch stays as defense-in-depth.
+
+**Q (discover: Root cause identification — which layer): Whose userId was on the connect link?**
+A: User A's — User C's 404 after the patch confirmed the code resolves to `userId=A`, meaning C's workspace authenticated as A via a wrong API key.
+
+**Q (discover: Deployment isolation model): Per-resident Hermes workspace?**
+A: Confirmed — separate `HERMES_HOME` per resident.
+
+**Q (discover: Wrong-delivery mechanism): How?**
+A: User C's `HERMES_HOME` had User A's `INDEX_API_KEY`. `fetchOpportunitiesFromMcp` → MCP authenticated as A → `mintConnectLink(userId=A, ...)` → A's link in C's digest.
+
+**Q (discover: Faulty window): When?**
+A: Staged at 02:00 prepare cron, sent at 08:00. Bug is in prepare path.
+
+**Q (discover: Existing guards): Sufficient?**
+A: All three guards stay; root cause is upstream (wrong key → wrong user → correctly scoped data for the wrong person).
+
+**Q (`auth.controller.ts:63`): Where should the API-key-capable identity endpoint live?**
+A: Swap `GET /me` from `AuthGuard` to `AuthOrApiKeyGuard`. One guard change, no new route, backward-compatible.
+
+**Q (`install_index.ts:298`): What should the install check compare?**
+A: Also verify telegram handle from socials — fetch `user_socials` where `label='telegram'`, normalize, compare against `--telegram-handle`. Mismatch → fail; missing handle → warn and continue.
+
+**Q (empty handle edge case): What if user has no telegram handle in their Index profile?**
+A: Warn but continue. Log: "authenticates as {name} ({email}) — no telegram handle on profile, cannot verify @{handle}." Only hard-fail on a present but mismatched handle.
+
+## Open Questions
+
+- How many residents are currently deployed, and which have a potential API key mismatch? An audit script should enumerate all `HERMES_HOME` paths (from Railway env or a fleet config) and call `GET /api/me` with each resident's stored `INDEX_API_KEY` before scheduling re-installs.
+- Was the wrong key a one-off installation error, or is there a systemic flaw in the install process (e.g., an onboarding script that copies the key from a template or a previous resident's env file)?
+- Does `userService.findWithGraph()` eagerly load socials in the current `me()` handler path, or is it a separate query? Verify at `auth.controller.ts:71` + `database.adapter.ts:4427` that socials are included in the existing `findWithGraph` call before relying on them in the response.

--- a/.rpiv/artifacts/validation/2026-06-11_06-20-42_agentvillage-digest-api-key-mismatch-root-cause-fix.md
+++ b/.rpiv/artifacts/validation/2026-06-11_06-20-42_agentvillage-digest-api-key-mismatch-root-cause-fix.md
@@ -1,0 +1,120 @@
+---
+date: 2026-06-11T06:20:42+0300
+author: Yankı Ekin Yüksel
+commit: 0ee89a4dcd
+branch: fix/agentvillage-digest-api-key-mismatch
+repository: index
+topic: "Validation of AgentVillage digest API key mismatch root-cause fix"
+status: ready
+verdict: pass
+parent: ".rpiv/artifacts/plans/2026-06-11_01-52-31_agentvillage-digest-api-key-mismatch-fix.md"
+tags: [validation, fix, agentvillage, digest, install, auth-guard, api-key, identity, install_index]
+last_updated: 2026-06-11T06:20:42+0300
+---
+
+## Validation Report: AgentVillage Digest API Key Mismatch Root-Cause Fix
+
+### Implementation Status
+
+- ✓ Phase 1: Backend guard swap — Fully implemented
+- ✓ Phase 2: Install identity check — Fully implemented
+- ✓ Phase 3: Async wiring and digest runtime logging — Fully implemented
+- ✓ Phase 4: Backend test for /me with API key — Fully implemented
+
+### Automated Verification Results
+
+- ✓ ESLint passes (`cd backend && bun run lint`): 0 errors, 58 pre-existing warnings — none from changed files
+- ✓ `AuthOrApiKeyGuard` exported (`grep -c 'export const AuthOrApiKeyGuard' backend/src/guards/auth.guard.ts`): returns 1
+- ✓ `AuthGuard` still imported (`grep -c 'AuthGuard' backend/src/controllers/auth.controller.ts`): returns 3 (import line + `updateProfile` + `deleteAccount`)
+- ✓ `normalizeTelegramHandle` exported (`grep -c 'export function normalizeTelegramHandle' ...install_index.ts`): returns 1
+- ✓ `installIndex` is async (`grep -c 'export async function installIndex' ...install_index.ts`): returns 1
+- ✓ `normalizeTelegramHandle('@alice')` → `'alice'`: PASS
+- ✓ `normalizeTelegramHandle('https://t.me/Alice/')` → `'alice'`: PASS
+- ✓ `normalizeTelegramHandle('t.me/alice')` → `'alice'`: PASS
+- ✓ `normalizeTelegramHandle('')` → `''`: PASS
+- ✓ `normalizeTelegramHandle('ALICE')` → `'alice'`: PASS
+- ✓ `async function main` in `install.ts`: returns 1
+- ✓ `await installIndex` in `install.ts`: returns 1
+- ✓ `main().catch` in `install.ts`: returns 1
+- ✓ `console.log.*authenticatedAs` in `build-daily-brief-context.ts`: returns 1
+- ✓ Test file exists (`ls backend/tests/auth-me-apikey.spec.ts`): exits 0
+- ✓ Tests pass (`cd backend && bun test tests/auth-me-apikey.spec.ts`): 4 pass, 0 fail (ran twice; consistent)
+- ✓ No regressions detected
+
+### Code Review Findings
+
+#### Matches Plan:
+
+- `auth.controller.ts:5` — Both guards imported side-by-side: `import { AuthGuard, AuthOrApiKeyGuard } from '../guards/auth.guard'`
+- `auth.controller.ts:64` — Only `me()` uses `AuthOrApiKeyGuard`; ordering correct: `@UseGuards(RateLimit('read'), AuthOrApiKeyGuard)`
+- `auth.controller.ts:96,128` — `updateProfile` and `deleteAccount` unchanged: `@UseGuards(RateLimit('write'), AuthGuard)`
+- `install_index.ts:66` — `normalizeTelegramHandle` exported, correct normalization order: lowercase → strip URL prefix → strip `@` → strip path suffix
+- `install_index.ts:84` — `verifyIndexIdentity` declared without `export` (private/internal)
+- `install_index.ts:100` — `AbortSignal.timeout(10_000)` present on the identity fetch
+- `install_index.ts:103–107` — HTTP 401/403 → `console.error` clear message + `process.exit(1)`
+- `install_index.ts:110–114` — Non-ok non-401/403 → `console.warn` + `return` (no exit)
+- `install_index.ts:120–127` — Network/timeout error → `console.warn` distinguishing TimeoutError vs. network error + `return`
+- `install_index.ts:138–140` — Empty `telegramHandle` → log identity only, return without comparison
+- `install_index.ts:143–149` — Missing telegram social → `console.warn` + `return` (no exit)
+- `install_index.ts:155–159` — Handle mismatch → `console.error` clear message + `process.exit(1)`
+- `install_index.ts:398–404` — Call order: `readApiKey()` → `readTelegramHandle()` → `await verifyIndexIdentity()` → first `upsertEnvVar()` — identity check is before any disk mutation
+- `install.ts:183` — `async function main(): Promise<void>` (was `function main(): void`)
+- `install.ts:199` — `await installIndex()` — awaited
+- `install.ts:200–201` — `installEdgeos()` and `installGeo()` still called synchronously (no await)
+- `install.ts:214` — `main().catch((err) => { console.error(err); process.exit(1); })` — correct exit-code-1 form (not bare `console.error`)
+- `build-daily-brief-context.ts:707–726` — Identity log try/catch is inside `if (apiKey)` block, before `readDeliveredIds` (line 728) and `fetchOpportunitiesFromMcp` (line 729); catch block is empty of executable statements (comment only)
+- `build-daily-brief-context.ts:717–720` — Log format matches: `console.log('[build-daily-brief-context] authenticatedAs:', { id, name, email })`
+- `auth-me-apikey.spec.ts:23,26` — Cleanup stack pattern identical to `experiment-signup.spec.ts`: `[...cleanup].reverse()`
+- `auth-me-apikey.spec.ts:82–97` — Success path: `AuthOrApiKeyGuard` + `controller.me()` → `response.status === 200`, `json.user.id`, `email`, `socials[]`
+- `auth-me-apikey.spec.ts:99–115` — Cross-resolution: two distinct keys → `user1.id !== user2.id`
+- `auth-me-apikey.spec.ts:118–123,126–129` — Invalid key throws; missing auth throws
+
+#### Deviations from Plan:
+
+None. Implementation is a faithful realization of the plan.
+
+#### Pattern Conformance:
+
+- ✓ Guard swap follows the established mixed-controller pattern present in `network.controller.ts`, `intent.controller.ts`, `agent.controller.ts`, and `opportunity.controller.ts` — `RateLimit` first, auth guard second
+- ✓ `AuthOrApiKeyGuard` on read-only GET endpoint (`/me`), `AuthGuard` on mutating endpoints — consistent with `agent.controller.ts:/me` (closest existing analog)
+- ✓ Import style (`AuthGuard` + `AuthOrApiKeyGuard` as values, `AuthenticatedUser` as a separate `import type`) matches `opportunity.controller.ts` pattern exactly
+- ✓ Test cleanup stack, helper signatures (`setupExperimentNetwork`, `cleanupUser`), and `AuthOrApiKeyGuard(new Request(...))` call style are identical to `experiment-signup.spec.ts`
+- Acceptable variation: `auth-me-apikey.spec.ts` uses `beforeAll` for shared state; `experiment-signup.spec.ts` creates fixtures per-test. Both are valid given the test structures differ.
+
+#### Potential Issues:
+
+- `install_index.ts:143` — `s.label === "telegram"` is case-sensitive. In practice, Index Network stores social labels as lowercase (`database.adapter.ts` write paths), so the risk is negligible. No change required.
+- `build-daily-brief-context.ts:711` — Identity log fetch has no timeout (unlike `verifyIndexIdentity`'s `AbortSignal.timeout(10_000)`). A stalled call could delay the 02:00 digest cron. The plan marks this as best-effort with a "never propagate" catch, so a stall would eventually be released by the OS, but could delay digest startup. Non-blocking concern; no action required before merge.
+
+### Manual Testing Required:
+
+1. Phase 1 — Guard scope isolation:
+   - [ ] Only `me()` guard changed; `updateProfile` and `deleteAccount` still use `AuthGuard`
+   - [ ] Import line has both guards side-by-side (not a replacement import)
+   - [ ] Frontend JWT callers to `GET /api/auth/me` unaffected — `AuthOrApiKeyGuard` tries Bearer JWT first
+
+2. Phase 2 — Install identity verification:
+   - [ ] On HTTP 401/403: error message printed, `process.exit(1)` called — verified by reading code at `install_index.ts:103–107`
+   - [ ] On network error / non-ok response: warns and continues — verified by reading code at `install_index.ts:110–127`
+   - [ ] On telegram mismatch: error message printed, `process.exit(1)` called — verified by reading code at `install_index.ts:155–159`
+   - [ ] On missing telegram social but handle provided: warns and continues — verified by reading code at `install_index.ts:143–149`
+   - [ ] On no `--telegram-handle` flag: just logs identity, no comparison — verified by reading code at `install_index.ts:138–140`
+
+3. Phase 3 — Async wiring and digest logging:
+   - [ ] `installEdgeos()` and `installGeo()` still called without await — confirmed at `install.ts:200–201`
+   - [ ] Identity log `try/catch` never propagates — `catch {}` block has no executable statements at `build-daily-brief-context.ts:724–726`
+   - [ ] Identity log is inside the existing `if (apiKey)` block, before `readDeliveredIds` / `fetchOpportunitiesFromMcp` — confirmed at lines 707, 728, 729
+
+4. Phase 4 — Tests:
+   - [ ] Covers success path: API key resolves + `me()` returns `{ user: { id, email, socials[] } }` — confirmed by test at `auth-me-apikey.spec.ts:80–98`
+   - [ ] Covers cross-resolution prevention — confirmed at `auth-me-apikey.spec.ts:99–115`
+   - [ ] Covers invalid key → guard throws — confirmed at `auth-me-apikey.spec.ts:118–123`
+   - [ ] Covers missing auth → guard throws — confirmed at `auth-me-apikey.spec.ts:126–129`
+   - [ ] Cleanup mirrors `experiment-signup.spec.ts` — confirmed identical stack/reversal pattern
+
+### Recommendations:
+
+- Ready to merge — implementation is complete and all automated criteria pass.
+- Before opening a PR, bump the `packages/edge-city/agentvillage` version in `package.json` per CLAUDE.md's "Finishing a Branch" checklist (the submodule has new commits on `fix/install-index-identity-check`).
+- Push `fix/install-index-identity-check` to `Edge-City/agentvillage` and open a PR there before promoting the monorepo's submodule pointer to `dev` — per the CLAUDE.md agentvillage submodule workflow.
+- The identity log fetch timeout (`build-daily-brief-context.ts:711`) can be added in a follow-up if cron delay is observed in practice.

--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { RateLimit } from '../guards/limiter.guard';
 import { Controller, Get, Patch, Delete, UseGuards } from '../lib/router/router.decorators';
-import { AuthGuard } from '../guards/auth.guard';
+import { AuthGuard, AuthOrApiKeyGuard } from '../guards/auth.guard';
 import type { AuthenticatedUser } from '../guards/auth.guard';
 import { userService } from '../services/user.service';
 import { profileService } from '../services/profile.service';
@@ -61,7 +61,7 @@ export class AuthController {
    * Response shape: { user: User } for frontend APIResponse compatibility.
    */
   @Get('/me')
-  @UseGuards(RateLimit('read'), AuthGuard)
+  @UseGuards(RateLimit('read'), AuthOrApiKeyGuard)
   async me(_req: Request, user: AuthenticatedUser) {
     logger.verbose('Auth me requested', { userId: user.id });
     const fullUser = await userService.findWithGraph(user.id);

--- a/backend/tests/auth-me-apikey.spec.ts
+++ b/backend/tests/auth-me-apikey.spec.ts
@@ -1,0 +1,131 @@
+import '../src/startup.env';
+
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import { eq } from 'drizzle-orm';
+
+import { experimentService } from '../src/services/experiment.service';
+import { AuthController } from '../src/controllers/auth.controller';
+import { AuthOrApiKeyGuard } from '../src/guards/auth.guard';
+import db from '../src/lib/drizzle/drizzle';
+import {
+  agentPermissions,
+  agents,
+  apikeys,
+  networkMembers,
+  networks,
+  personalNetworks,
+  userProfiles,
+  userSocials,
+  users,
+} from '../src/schemas/database.schema';
+
+const cleanup: Array<() => Promise<void>> = [];
+
+afterAll(async () => {
+  for (const f of [...cleanup].reverse()) await f();
+});
+
+async function setupExperimentNetwork() {
+  const [network] = await db
+    .insert(networks)
+    .values({
+      title: `Auth Me API Key Test ${randomUUID().slice(0, 6)}`,
+      isExperiment: true,
+      isPersonal: false,
+      experimentMasterKeyHash: 'test-hash-not-verified-at-service-layer',
+    })
+    .returning({ id: networks.id });
+
+  cleanup.push(async () => {
+    await db.delete(networkMembers).where(eq(networkMembers.networkId, network.id));
+    await db.delete(networks).where(eq(networks.id, network.id));
+  });
+
+  return { networkId: network.id };
+}
+
+async function cleanupUser(userId: string) {
+  await db.delete(apikeys).where(eq(apikeys.userId, userId));
+  await db.delete(agentPermissions).where(eq(agentPermissions.userId, userId));
+  await db.delete(agents).where(eq(agents.ownerId, userId));
+  await db.delete(networkMembers).where(eq(networkMembers.userId, userId));
+  await db.delete(userSocials).where(eq(userSocials.userId, userId));
+  await db.delete(userProfiles).where(eq(userProfiles.userId, userId));
+  const pn = await db
+    .select({ networkId: personalNetworks.networkId })
+    .from(personalNetworks)
+    .where(eq(personalNetworks.userId, userId));
+  await db.delete(personalNetworks).where(eq(personalNetworks.userId, userId));
+  for (const { networkId: pnId } of pn) {
+    await db.delete(networks).where(eq(networks.id, pnId));
+  }
+  await db.delete(users).where(eq(users.id, userId));
+}
+
+describe('AuthController.me() — API key support (Phase 1 guard swap)', () => {
+  let controller: AuthController;
+  let testUserId: string;
+  let testApiKey: string;
+
+  beforeAll(async () => {
+    const { networkId } = await setupExperimentNetwork();
+    const email = `auth-me-apikey-${randomUUID()}@test.example.com`;
+    const result = await experimentService.signup(networkId, { email });
+    testUserId = result.user.id;
+    testApiKey = result.apiKey;
+    cleanup.push(() => cleanupUser(testUserId));
+    controller = new AuthController();
+  });
+
+  it('returns user identity and socials when called with a valid API key', async () => {
+    const user = await AuthOrApiKeyGuard(
+      new Request('http://localhost/api/auth/me', { headers: { 'x-api-key': testApiKey } }),
+    );
+
+    const response = await controller.me(
+      new Request('http://localhost/api/auth/me'),
+      user,
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json() as {
+      user: { id: string; email: string | null; name: string; socials: unknown[] };
+    };
+    expect(json.user.id).toBe(testUserId);
+    expect(json.user.email).toBeTruthy();
+    expect(Array.isArray(json.user.socials)).toBe(true);
+  }, 10000);
+
+  it('two different API keys resolve to two different users — no cross-resolution', async () => {
+    const { networkId: netId2 } = await setupExperimentNetwork();
+    const email2 = `auth-me-apikey-other-${randomUUID()}@test.example.com`;
+    const result2 = await experimentService.signup(netId2, { email: email2 });
+    cleanup.push(() => cleanupUser(result2.user.id));
+
+    const user1 = await AuthOrApiKeyGuard(
+      new Request('http://localhost/api/auth/me', { headers: { 'x-api-key': testApiKey } }),
+    );
+    const user2 = await AuthOrApiKeyGuard(
+      new Request('http://localhost/api/auth/me', { headers: { 'x-api-key': result2.apiKey } }),
+    );
+
+    expect(user1.id).toBe(testUserId);
+    expect(user2.id).toBe(result2.user.id);
+    expect(user1.id).not.toBe(user2.id);
+  }, 10000);
+
+  it('throws when an invalid API key is supplied', async () => {
+    await expect(
+      AuthOrApiKeyGuard(
+        new Request('http://localhost/api/auth/me', { headers: { 'x-api-key': 'invalid-key-xyz' } }),
+      ),
+    ).rejects.toThrow();
+  });
+
+  it('throws when no authentication is provided', async () => {
+    await expect(
+      AuthOrApiKeyGuard(new Request('http://localhost/api/auth/me')),
+    ).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

End-to-end fix for the AgentVillage daily digest bug where User C received User A's opportunities because User C's `HERMES_HOME` had User A's `INDEX_API_KEY` stored.

## Root Cause

`stage-daily-brief.ts` reads `INDEX_API_KEY` from `$HERMES_HOME/.env`, authenticates an MCP session as whoever that key belongs to, fetches _their_ opportunities, mints _their_ connect links, and stages everything into the current machine's Kanban board — regardless of who is supposed to own that board.

## Changes

### Backend (this repo)
**`backend/src/controllers/auth.controller.ts`** — swap `GET /api/auth/me` guard

- `AuthGuard` → `AuthOrApiKeyGuard` on `me()` only
- `updateProfile` and `deleteAccount` keep `AuthGuard`
- `AuthOrApiKeyGuard` tries JWT Bearer first → backward-compatible with all existing frontend callers
- Exposes `socials[]` (already returned by `findWithGraph`) to API-key callers for telegram handle extraction

**`backend/tests/auth-me-apikey.spec.ts`** — new targeted test (4 tests, 4 pass)
- Valid API key → correct user + socials returned
- Two API keys → two distinct user IDs (cross-resolution regression test)
- Invalid key → guard throws
- Missing auth → guard throws

### AgentVillage submodule (Edge-City/agentvillage#85)
- `install/install_index.ts`: add `normalizeTelegramHandle()`, `verifyIndexIdentity()`, make `installIndex()` async — identity check before first disk write
- `install/install.ts`: async `main()`, `await installIndex()`, `main().catch` with `exit 1`
- `skills/index-network/scripts/build-daily-brief-context.ts`: best-effort identity log before each MCP session

## Defense in Depth

| Layer | Protection |
|---|---|
| Install time | `verifyIndexIdentity()` fails fast on mismatched key before writing to disk |
| Digest runtime | `authenticatedAs` log makes key identity visible in cron logs |
| Backend | `GET /api/auth/me` now accepts API keys — install scripts and digest can verify identity without a separate endpoint |

## Testing

```bash
cd backend && bun test tests/auth-me-apikey.spec.ts
# 4 pass, 0 fail
```

## Related

- AgentVillage PR: https://github.com/Edge-City/agentvillage/pull/85
- FRD: `.rpiv/artifacts/discover/2026-06-11_00-55-13_agentvillage-digest-wrong-opportunity-delivery.md`
- Research: `.rpiv/artifacts/research/2026-06-11_01-25-06_agentvillage-digest-api-key-mismatch.md`
- Validation: `.rpiv/artifacts/validation/2026-06-11_06-20-42_agentvillage-digest-api-key-mismatch-root-cause-fix.md`