### PR TITLE
fix(onboarding): restore networks panel join flow, remove silent auto-join

### DIFF
--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -11,15 +11,8 @@ import { useNetworksState } from "@/contexts/IndexesContext";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { apiClient } from "@/lib/api";
-import OpportunityCard, {
-  type OpportunityCardData,
-  OpportunitySkeleton,
-} from "@/components/chat/OpportunityCardInChat";
-import IntentProposalCard, {
-  type IntentProposalData,
-  IntentProposalSkeleton,
-} from "@/components/chat/IntentProposalCard";
 import { ToolCallsDisplay } from "@/components/chat/ToolCallsDisplay";
+import AssistantMessageContent from "@/components/chat/AssistantMessageContent";
 import { SuggestionChips } from "@/components/chat/SuggestionChips";
 import { MentionsTextInput } from "@/components/MentionsInput";
 import { cn } from "@/lib/utils";
@@ -46,6 +39,9 @@ const ONBOARDING_STEP_SUGGESTIONS: Record<string, Suggestion[]> = {
   gmail: [
     { label: "Skip for now", type: "direct", followupText: "Skip for now" },
   ],
+  communities: [
+    { label: "Continue", type: "direct", followupText: "I'll skip joining networks for now, let's continue" },
+  ],
   intent: [
     { label: "Building something", type: "prompt", prefill: "Building something " },
     { label: "Exploring partnerships", type: "prompt", prefill: "Exploring partnerships " },
@@ -64,195 +60,6 @@ function buildGreeting(hasName: boolean, userName?: string): string {
   return hasName
     ? `${GREETING_PREAMBLE}\nYou're ${userName}, right? Is that right?`
     : `${GREETING_PREAMBLE} What's your name, and what's your LinkedIn, Twitter/X, or GitHub?`;
-}
-
-// ---------------------------------------------------------------------------
-// Markdown / block parsing (mirrors ChatContent logic)
-// ---------------------------------------------------------------------------
-
-function normalizeBlockquotes(text: string): string {
-  let out = text.replace(/^(>.*?\.\.\.)\s*(\S.+)$/gm, "$1\n\n$2");
-  out = out.replace(/^(>.*)\n(?!>|\n)/gm, "$1\n\n");
-  return out;
-}
-
-type MessageSegment =
-  | { type: "text"; content: string }
-  | { type: "opportunity"; data: OpportunityCardData }
-  | { type: "opportunity_loading" }
-  | { type: "intent_proposal"; data: IntentProposalData }
-  | { type: "intent_proposal_loading" };
-
-function parseAllBlocks(content: string): MessageSegment[] {
-  const segments: MessageSegment[] = [];
-  const regex = /```(opportunity|intent_proposal)\s*\n([\s\S]*?)\n```/g;
-  let lastIndex = 0;
-  let match;
-
-  while ((match = regex.exec(content)) !== null) {
-    if (match.index > lastIndex) {
-      const textBefore = content.slice(lastIndex, match.index);
-      if (textBefore.trim()) segments.push({ type: "text", content: textBefore });
-    }
-    const blockType = match[1];
-
-    {
-      try {
-        const data = JSON.parse(match[2].trim());
-        if (blockType === "opportunity" && data.opportunityId && data.userId) {
-          segments.push({ type: "opportunity", data: data as OpportunityCardData });
-        } else if (blockType === "intent_proposal" && data.proposalId) {
-          segments.push({ type: "intent_proposal", data: data as IntentProposalData });
-        } else {
-          segments.push({ type: "text", content: match[0] });
-        }
-      } catch {
-        segments.push({ type: "text", content: match[0] });
-      }
-    }
-    lastIndex = match.index + match[0].length;
-  }
-
-  const remaining = content.slice(lastIndex);
-  const partialOpp = remaining.match(/```opportunity/);
-  const partialIntent = remaining.match(/```intent_proposal/);
-
-  const candidates = ([partialOpp, partialIntent] as (RegExpMatchArray | null)[]).filter(
-    (c): c is RegExpMatchArray => c !== null,
-  );
-  const partialMatch = candidates.length > 0
-    ? candidates.reduce((earliest, c) => c.index! < earliest.index! ? c : earliest)
-    : null;
-
-  if (partialMatch) {
-    const textBefore = remaining.slice(0, partialMatch.index!);
-    if (textBefore.trim()) segments.push({ type: "text", content: textBefore });
-    if (partialMatch === partialOpp) {
-      segments.push({ type: "opportunity_loading" });
-    } else {
-      segments.push({ type: "intent_proposal_loading" });
-    }
-  } else if (remaining.trim()) {
-    segments.push({ type: "text", content: remaining });
-  }
-
-  if (segments.length === 0 && content.trim()) {
-    segments.push({ type: "text", content });
-  }
-  return segments;
-}
-
-function dedupeSegments(segments: MessageSegment[]): MessageSegment[] {
-  const seenOpps = new Set<string>();
-  const seenProposals = new Set<string>();
-  return segments.filter((seg) => {
-    if (seg.type === "opportunity") {
-      if (seenOpps.has(seg.data.opportunityId)) return false;
-      seenOpps.add(seg.data.opportunityId);
-    }
-    if (seg.type === "intent_proposal") {
-      if (seenProposals.has(seg.data.proposalId)) return false;
-      seenProposals.add(seg.data.proposalId);
-    }
-    return true;
-  });
-}
-
-// ---------------------------------------------------------------------------
-// AssistantMessage (simplified for onboarding — no file upload, no mentions)
-// ---------------------------------------------------------------------------
-
-function AssistantMessageContent({
-  content,
-  isStreaming,
-  onOpportunityPrimaryAction,
-  onOpportunitySecondaryAction,
-  opportunityLoadingMap,
-  currentStatusMap,
-  onIntentProposalApprove,
-  onIntentProposalReject,
-  onIntentProposalUndo,
-  intentProposalStatusMap,
-  OAuthLink,
-}: {
-  content: string;
-  isStreaming: boolean;
-  onOpportunityPrimaryAction?: (id: string, userId: string, role?: string, name?: string) => void;
-  onOpportunitySecondaryAction?: (id: string, userId: string, role?: string, name?: string) => void;
-  opportunityLoadingMap?: Record<string, boolean>;
-  currentStatusMap?: Record<string, string>;
-  onIntentProposalApprove?: (proposalId: string, description: string, networkId?: string) => void;
-  onIntentProposalReject?: (proposalId: string) => void;
-  onIntentProposalUndo?: (proposalId: string) => void;
-  intentProposalStatusMap?: Record<string, "pending" | "created" | "rejected">;
-  OAuthLink?: React.ComponentType<React.ComponentPropsWithoutRef<"a">>;
-}) {
-  const displayed = normalizeBlockquotes(mentionsToMarkdownLinks(content));
-  const showCursor = isStreaming;
-
-  if (!displayed && isStreaming) {
-    return <span className="inline-block w-2 h-4 bg-current animate-pulse" />;
-  }
-
-  const segments = dedupeSegments(parseAllBlocks(displayed));
-
-  return (
-    <div>
-      {segments.map((seg, idx) => {
-        if (seg.type === "text") {
-          const isLast = idx === segments.length - 1;
-          return (
-            <div
-              key={`text-${idx}`}
-              className={cn(
-                "chat-markdown max-w-none",
-                isStreaming && "chat-markdown-streaming",
-                showCursor && isLast && "chat-markdown-typing",
-              )}
-            >
-              <ReactMarkdown
-                remarkPlugins={[remarkGfm]}
-                components={OAuthLink ? { a: OAuthLink } : undefined}
-              >
-                {seg.content}
-              </ReactMarkdown>
-            </div>
-          );
-        }
-        if (seg.type === "opportunity") {
-          return (
-            <div key={seg.data.opportunityId} className="my-3">
-              <OpportunityCard
-                card={seg.data}
-                onPrimaryAction={onOpportunityPrimaryAction}
-                onSecondaryAction={onOpportunitySecondaryAction}
-                isLoading={opportunityLoadingMap?.[seg.data.opportunityId] ?? false}
-                currentStatus={currentStatusMap?.[seg.data.opportunityId]}
-              />
-            </div>
-          );
-        }
-        if (seg.type === "opportunity_loading") {
-          return <div key={`opp-load-${idx}`} className="my-3"><OpportunitySkeleton /></div>;
-        }
-        if (seg.type === "intent_proposal") {
-          return (
-            <div key={seg.data.proposalId} className="my-3">
-              <IntentProposalCard
-                card={seg.data}
-                onApprove={onIntentProposalApprove}
-                onReject={onIntentProposalReject}
-                onUndo={onIntentProposalUndo}
-                currentStatus={intentProposalStatusMap?.[seg.data.proposalId]}
-              />
-            </div>
-          );
-        }
-        // intent_proposal_loading
-        return <div key={`intent-load-${idx}`} className="my-3"><IntentProposalSkeleton /></div>;
-      })}
-    </div>
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -298,6 +105,7 @@ export default function OnboardingPage() {
   const [opportunityStatusMap, setOpportunityStatusMap] = useState<Record<string, string>>({});
   const [intentProposalStatusMap, setIntentProposalStatusMap] = useState<Record<string, "pending" | "created" | "rejected">>({});
   const [proposalIntentMap, setProposalIntentMap] = useState<Record<string, string>>({});
+  const [networkPanelPendingJoinIds, setNetworkPanelPendingJoinIds] = useState<Set<string>>(new Set());
 
   const hasName = !!user?.name?.trim();
   const fullGreeting = buildGreeting(hasName, hasName ? `**${user?.name?.trim()}**` : undefined);
@@ -362,6 +170,16 @@ export default function OnboardingPage() {
     prevLoadingRef.current = isLoading;
   }, [isLoading, refetchUser]);
 
+  // After stream completes with pending network join IDs, clear them and refresh sidebar
+  const prevNetworkJoinLoadingRef = useRef(isLoading);
+  useEffect(() => {
+    if (prevNetworkJoinLoadingRef.current && !isLoading && networkPanelPendingJoinIds.size > 0) {
+      setNetworkPanelPendingJoinIds(new Set());
+      void refreshIndexes();
+    }
+    prevNetworkJoinLoadingRef.current = isLoading;
+  }, [isLoading, networkPanelPendingJoinIds.size, refreshIndexes]);
+
   // Slide transition: sidebar slides in from left, content shifts right
   const [isTransitioning, setIsTransitioning] = useState(false);
   const hasTriggeredRedirect = useRef(false);
@@ -369,6 +187,9 @@ export default function OnboardingPage() {
   useEffect(() => {
     if (!user?.onboarding?.completedAt || hasTriggeredRedirect.current) return;
     hasTriggeredRedirect.current = true;
+
+    // Always refresh so any new memberships appear in the sidebar immediately
+    void refreshIndexes();
 
     // Accept pending invitation deferred from /l/:code (only after onboarding completes)
     const pendingCode = localStorage.getItem('pendingInviteCode');
@@ -485,6 +306,14 @@ export default function OnboardingPage() {
     [sessionId, sendMessage, fullGreeting],
   );
 
+  const handleNetworkJoin = useCallback(
+    (networkId: string, networkTitle: string) => {
+      setNetworkPanelPendingJoinIds((prev) => new Set([...prev, networkId]));
+      sendOnboardingMessage(`I'd like to join ${networkTitle}`);
+    },
+    [sendOnboardingMessage],
+  );
+
   // Infer onboarding step from last assistant message to show step-specific suggestions
   const onboardingStep = useMemo(() => {
     const lastAssistant = [...allMessages].reverse().find((m) => m.role === "assistant");
@@ -494,6 +323,7 @@ export default function OnboardingPage() {
     if (userCount === 0) return hasName ? "identity" : "identity_no_name";
     if (content.includes("does that sound right") || content.includes("here's what i found")) return "profile";
     if (content.includes("connect your google account") || content.includes("connect gmail")) return "gmail";
+    if (content.includes("communities you might find relevant")) return "communities";
     if (content.includes("what are you open to") || content.includes("open to right now")) return "intent";
     return "identity";
   }, [allMessages, chatMessages, hasName]);
@@ -615,6 +445,8 @@ export default function OnboardingPage() {
                           onIntentProposalUndo={handleIntentProposalUndo}
                           intentProposalStatusMap={intentProposalStatusMap}
                           OAuthLink={OAuthLink}
+                          onNetworkJoin={handleNetworkJoin}
+                          networkPanelPendingJoinIds={networkPanelPendingJoinIds}
                         />
                       </article>
                     </div>

--- a/frontend/src/components/ChatContent.tsx
+++ b/frontend/src/components/ChatContent.tsx
@@ -27,16 +27,15 @@ import { validateFiles } from "@/lib/file-validation";
 import InlineDiscoveryCard from "@/components/chat/InlineDiscoveryCard";
 import { DecisionQuestions } from "@/components/DecisionQuestions";
 import InviteMessageModal from "@/components/InviteMessageModal";
-import OpportunityCard, {
-  type OpportunityCardData,
-  OpportunitySkeleton,
-} from "@/components/chat/OpportunityCardInChat";
 import { SuggestionChips } from "@/components/chat/SuggestionChips";
 import { ToolCallsDisplay } from "@/components/chat/ToolCallsDisplay";
 import AssistantMessageContent, {
   parseAllBlocks,
-  type MessageSegment,
 } from "@/components/chat/AssistantMessageContent";
+import OpportunityCard, {
+  type OpportunityCardData,
+  OpportunitySkeleton,
+} from "@/components/chat/OpportunityCardInChat";
 import { DebugCopyButton } from "@/components/DebugCopyButton";
 import { ContentContainer } from "@/components/layout";
 import { cn } from "@/lib/utils";
@@ -68,7 +67,6 @@ interface PendingFile {
 interface ChatContentProps {
   sessionIdParam?: string | null;
 }
-
 export default function ChatContent({ sessionIdParam }: ChatContentProps) {
   const navigate = useNavigate();
   const sessionIdFromUrl = sessionIdParam ?? null;
@@ -240,8 +238,10 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
     setInjectedQuestions((prev) => prev.filter((q) => q.id !== questionId));
   }, [questionsService]);
 
-  // Clear pending join IDs when stream completes (agent processed the join)
+  // Index filter state (needed before stream-end effect so refreshIndexes is in scope)
   const { indexes, refreshIndexes } = useNetworksState();
+
+  // Clear pending join IDs when stream completes and refresh sidebar
   const prevIsLoadingRef = useRef(isLoading);
   useEffect(() => {
     if (prevIsLoadingRef.current && !isLoading && networkPanelPendingJoinIds.size > 0) {

--- a/frontend/src/components/ChatContent.tsx
+++ b/frontend/src/components/ChatContent.tsx
@@ -14,7 +14,6 @@ import {
   Share2,
   Check,
   Users,
-  Loader2,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { MentionsTextInput } from "@/components/MentionsInput";
@@ -32,13 +31,12 @@ import OpportunityCard, {
   type OpportunityCardData,
   OpportunitySkeleton,
 } from "@/components/chat/OpportunityCardInChat";
-import IntentProposalCard, {
-  type IntentProposalData,
-  IntentProposalSkeleton,
-} from "@/components/chat/IntentProposalCard";
-import NetworksPanel from "@/components/chat/NetworksPanel";
 import { SuggestionChips } from "@/components/chat/SuggestionChips";
 import { ToolCallsDisplay } from "@/components/chat/ToolCallsDisplay";
+import AssistantMessageContent, {
+  parseAllBlocks,
+  type MessageSegment,
+} from "@/components/chat/AssistantMessageContent";
 import { DebugCopyButton } from "@/components/DebugCopyButton";
 import { ContentContainer } from "@/components/layout";
 import { cn } from "@/lib/utils";
@@ -69,281 +67,6 @@ interface PendingFile {
 
 interface ChatContentProps {
   sessionIdParam?: string | null;
-}
-
-/**
- * Sub-component for assistant message content.
- */
-/**
- * Ensure blockquote lines are always followed by a blank line so that
- * subsequent non-blockquote text isn't absorbed via markdown "lazy continuation".
- * - "> Retrieving…\nHere is…" → "> Retrieving…\n\nHere is…"
- * - "> Updating...Your profile now" (no newline after "...") → "> Updating...\n\nYour profile now"
- */
-function normalizeBlockquotes(text: string): string {
-  // When a blockquote line ends with "..." and more text follows on the same line (e.g. stream
-  // sent no newline), insert a blank line so the following text renders on a new line.
-  let out = text.replace(/^(>.*?\.\.\.)\s*(\S.+)$/gm, "$1\n\n$2");
-  out = out.replace(/^(>.*)\n(?!>|\n)/gm, "$1\n\n");
-  return out;
-}
-
-/**
- * Parse message content to extract ```opportunity code blocks.
- * Returns an array of segments: either text or opportunity card data.
- */
-type MessageSegment =
-  | { type: "text"; content: string }
-  | { type: "opportunity"; data: OpportunityCardData }
-  | { type: "opportunity_loading" }
-  | { type: "intent_proposal"; data: IntentProposalData }
-  | { type: "intent_proposal_loading" }
-  | { type: "networks_panel" }
-  | { type: "networks_panel_loading" };
-
-function parseAllBlocks(content: string): MessageSegment[] {
-  const segments: MessageSegment[] = [];
-  const regex = /```(opportunity|intent_proposal|networks_panel)\s*\n([\s\S]*?)\n```/g;
-  let lastIndex = 0;
-  let match;
-
-  while ((match = regex.exec(content)) !== null) {
-    if (match.index > lastIndex) {
-      const textBefore = content.slice(lastIndex, match.index);
-      if (textBefore.trim()) {
-        segments.push({ type: "text", content: textBefore });
-      }
-    }
-
-    const blockType = match[1];
-
-    if (blockType === "networks_panel") {
-      segments.push({ type: "networks_panel" });
-    } else {
-      try {
-        const jsonStr = match[2].trim();
-        const data = JSON.parse(jsonStr);
-
-        if (blockType === "opportunity" && data.opportunityId && data.userId) {
-          segments.push({ type: "opportunity", data: data as OpportunityCardData });
-        } else if (
-          blockType === "intent_proposal" &&
-          data.proposalId &&
-          (typeof data.description === "string" || !("description" in data))
-        ) {
-          segments.push({ type: "intent_proposal", data: data as IntentProposalData });
-        } else if (blockType === "intent_proposal") {
-          // Broken block (e.g. model wrote intent_proposal without calling create_intent — no proposalId)
-          segments.push({
-            type: "text",
-            content: "This proposal couldn't be loaded as a card. Ask again to add this as a signal.",
-          });
-        } else {
-          segments.push({ type: "text", content: match[0] });
-        }
-      } catch {
-        segments.push({ type: "text", content: match[0] });
-      }
-    }
-
-    lastIndex = match.index + match[0].length;
-  }
-
-  const remainingContent = content.slice(lastIndex);
-  const partialOpp = remainingContent.match(/```opportunity/);
-  const partialIntent = remainingContent.match(/```intent_proposal/);
-  const partialNetworks = remainingContent.match(/```networks_panel/);
-
-  const candidates = ([partialOpp, partialIntent, partialNetworks] as (RegExpMatchArray | null)[]).filter(
-    (c): c is RegExpMatchArray => c !== null,
-  );
-  const partialMatch = candidates.length > 0
-    ? candidates.reduce((earliest, c) => c.index! < earliest.index! ? c : earliest)
-    : null;
-
-  if (partialMatch) {
-    const partialIndex = partialMatch.index!;
-    const textBefore = remainingContent.slice(0, partialIndex);
-    if (textBefore.trim()) {
-      segments.push({ type: "text", content: textBefore });
-    }
-    if (partialMatch === partialOpp) {
-      segments.push({ type: "opportunity_loading" });
-    } else if (partialMatch === partialIntent) {
-      segments.push({ type: "intent_proposal_loading" });
-    } else {
-      segments.push({ type: "networks_panel_loading" });
-    }
-  } else if (lastIndex < content.length) {
-    const remaining = content.slice(lastIndex);
-    if (remaining.trim()) {
-      segments.push({ type: "text", content: remaining });
-    }
-  }
-
-  if (segments.length === 0 && content.trim()) {
-    segments.push({ type: "text", content });
-  }
-
-  return segments;
-}
-
-function dedupeSegments(segments: MessageSegment[]): MessageSegment[] {
-  const seenOpps = new Set<string>();
-  const seenProposals = new Set<string>();
-  return segments.filter((seg) => {
-    if (seg.type === "opportunity") {
-      if (seenOpps.has(seg.data.opportunityId)) return false;
-      seenOpps.add(seg.data.opportunityId);
-      return true;
-    }
-    if (seg.type === "intent_proposal") {
-      if (seenProposals.has(seg.data.proposalId)) return false;
-      seenProposals.add(seg.data.proposalId);
-      return true;
-    }
-    return true;
-  });
-}
-
-function AssistantMessageContent({
-  content,
-  isStreaming,
-  onOpportunityPrimaryAction,
-  onOpportunitySecondaryAction,
-  opportunityLoadingMap,
-  currentStatusMap,
-  onIntentProposalApprove,
-  onIntentProposalReject,
-  onIntentProposalUndo,
-  intentProposalStatusMap,
-  OAuthLink,
-  onNetworkJoin,
-  networkPanelPendingJoinIds,
-}: {
-  content: string;
-  isStreaming: boolean;
-  onOpportunityPrimaryAction?: (
-    opportunityId: string,
-    userId: string,
-    viewerRole?: string,
-    counterpartName?: string,
-    isGhost?: boolean,
-  ) => void;
-  onOpportunitySecondaryAction?: (
-    opportunityId: string,
-    userId: string,
-    viewerRole?: string,
-    counterpartName?: string,
-    isGhost?: boolean,
-  ) => void;
-  opportunityLoadingMap?: Record<string, boolean>;
-  /** Map of opportunityId -> current status from server */
-  currentStatusMap?: Record<string, string>;
-  onIntentProposalApprove?: (proposalId: string, description: string, networkId?: string) => void;
-  onIntentProposalReject?: (proposalId: string) => void;
-  onIntentProposalUndo?: (proposalId: string) => void;
-  intentProposalStatusMap?: Record<string, "pending" | "created" | "rejected">;
-  OAuthLink?: React.ComponentType<React.ComponentPropsWithoutRef<"a">>;
-  onNetworkJoin?: (networkId: string, networkTitle: string) => void;
-  networkPanelPendingJoinIds?: Set<string>;
-}) {
-  const displayedContent = normalizeBlockquotes(mentionsToMarkdownLinks(content));
-
-  // Show cursor while streaming (before content arrives)
-  const showCursor = isStreaming;
-
-  // No text yet — render a standalone blinking cursor
-  if (!displayedContent && isStreaming) {
-    return <span className="inline-block w-2 h-4 bg-current animate-pulse" />;
-  }
-
-  // Parse opportunity and intent_proposal blocks from the displayed content; dedupe
-  const segments = dedupeSegments(parseAllBlocks(displayedContent));
-
-  return (
-    <div>
-      {segments.map((segment, idx) => {
-        if (segment.type === "text") {
-          const isLast = idx === segments.length - 1;
-          return (
-            <div
-              key={`text-${idx}`}
-              className={cn(
-                "chat-markdown max-w-none",
-                isStreaming && "chat-markdown-streaming",
-                showCursor && isLast && "chat-markdown-typing",
-              )}
-            >
-              <ReactMarkdown
-                remarkPlugins={[remarkGfm]}
-                components={OAuthLink ? { a: OAuthLink } : undefined}
-              >
-                {segment.content}
-              </ReactMarkdown>
-            </div>
-          );
-        } else if (segment.type === "opportunity") {
-          return (
-            <div
-              key={segment.data.opportunityId}
-              className="my-3"
-            >
-              <OpportunityCard
-                card={segment.data}
-                onPrimaryAction={onOpportunityPrimaryAction}
-                onSecondaryAction={onOpportunitySecondaryAction}
-                isLoading={
-                  opportunityLoadingMap?.[segment.data.opportunityId] ?? false
-                }
-                currentStatus={currentStatusMap?.[segment.data.opportunityId]}
-              />
-            </div>
-          );
-        } else if (segment.type === "opportunity_loading") {
-          return (
-            <div key={`loading-${idx}`} className="my-3">
-              <OpportunitySkeleton />
-            </div>
-          );
-        } else if (segment.type === "intent_proposal") {
-          return (
-            <div key={segment.data.proposalId} className="my-3">
-              <IntentProposalCard
-                card={segment.data}
-                onApprove={onIntentProposalApprove}
-                onReject={onIntentProposalReject}
-                onUndo={onIntentProposalUndo}
-                currentStatus={intentProposalStatusMap?.[segment.data.proposalId]}
-              />
-            </div>
-          );
-        } else if (segment.type === "intent_proposal_loading") {
-          return (
-            <div key={`intent-loading-${idx}`} className="my-3">
-              <IntentProposalSkeleton />
-            </div>
-          );
-        } else if (segment.type === "networks_panel") {
-          return (
-            <div key={`networks-panel-${idx}`} className="my-3">
-              <NetworksPanel
-                onJoin={onNetworkJoin ?? (() => {})}
-                pendingJoinIds={networkPanelPendingJoinIds}
-              />
-            </div>
-          );
-        } else {
-          // networks_panel_loading
-          return (
-            <div key={`networks-panel-loading-${idx}`} className="my-3 flex justify-center py-6">
-              <Loader2 className="h-5 w-5 animate-spin text-gray-300" />
-            </div>
-          );
-        }
-      })}
-    </div>
-  );
 }
 
 export default function ChatContent({ sessionIdParam }: ChatContentProps) {
@@ -518,13 +241,15 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
   }, [questionsService]);
 
   // Clear pending join IDs when stream completes (agent processed the join)
+  const { indexes, refreshIndexes } = useNetworksState();
   const prevIsLoadingRef = useRef(isLoading);
   useEffect(() => {
     if (prevIsLoadingRef.current && !isLoading && networkPanelPendingJoinIds.size > 0) {
       setNetworkPanelPendingJoinIds(new Set());
+      void refreshIndexes();
     }
     prevIsLoadingRef.current = isLoading;
-  }, [isLoading, networkPanelPendingJoinIds.size]);
+  }, [isLoading, networkPanelPendingJoinIds.size, refreshIndexes]);
 
   const handleNetworkJoin = useCallback(
     (networkId: string, networkTitle: string) => {
@@ -587,7 +312,6 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
 
   // Index filter
   const { selectedNetworkIds, setSelectedNetworkIds } = useNetworkFilter();
-  const { indexes } = useNetworksState();
   const selectedIndexId =
     selectedNetworkIds.length === 1 ? selectedNetworkIds[0] : null;
 

--- a/frontend/src/components/chat/AssistantMessageContent.tsx
+++ b/frontend/src/components/chat/AssistantMessageContent.tsx
@@ -17,12 +17,8 @@ import { mentionsToMarkdownLinks } from "@/lib/mentions";
 /**
  * Ensure blockquote lines are always followed by a blank line so that
  * subsequent non-blockquote text isn't absorbed via markdown "lazy continuation".
- * - "> Retrieving…\nHere is…" → "> Retrieving…\n\nHere is…"
- * - "> Updating...Your profile now" (no newline after "...") → "> Updating...\n\nYour profile now"
  */
 function normalizeBlockquotes(text: string): string {
-  // When a blockquote line ends with "..." and more text follows on the same line (e.g. stream
-  // sent no newline), insert a blank line so the following text renders on a new line.
   let out = text.replace(/^(>.*?\.\.\.)\s*(\S.+)$/gm, "$1\n\n$2");
   out = out.replace(/^(>.*)\n(?!>|\n)/gm, "$1\n\n");
   return out;
@@ -79,7 +75,6 @@ export function parseAllBlocks(content: string): MessageSegment[] {
         ) {
           segments.push({ type: "intent_proposal", data: data as IntentProposalData });
         } else if (blockType === "intent_proposal") {
-          // Broken block (e.g. model wrote intent_proposal without calling create_intent — no proposalId)
           segments.push({
             type: "text",
             content: "This proposal couldn't be loaded as a card. Ask again to add this as a signal.",
@@ -205,15 +200,12 @@ export default function AssistantMessageContent({
 }: AssistantMessageContentProps) {
   const displayedContent = normalizeBlockquotes(mentionsToMarkdownLinks(content));
 
-  // Show cursor while streaming (before content arrives)
   const showCursor = isStreaming;
 
-  // No text yet — render a standalone blinking cursor
   if (!displayedContent && isStreaming) {
     return <span className="inline-block w-2 h-4 bg-current animate-pulse" />;
   }
 
-  // Parse opportunity and intent_proposal blocks from the displayed content; dedupe
   const segments = dedupeSegments(parseAllBlocks(displayedContent));
 
   return (

--- a/frontend/src/components/chat/AssistantMessageContent.tsx
+++ b/frontend/src/components/chat/AssistantMessageContent.tsx
@@ -1,0 +1,297 @@
+import type { ComponentType, ComponentPropsWithoutRef } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { Loader2 } from "lucide-react";
+import OpportunityCard, {
+  type OpportunityCardData,
+  OpportunitySkeleton,
+} from "@/components/chat/OpportunityCardInChat";
+import IntentProposalCard, {
+  type IntentProposalData,
+  IntentProposalSkeleton,
+} from "@/components/chat/IntentProposalCard";
+import NetworksPanel from "@/components/chat/NetworksPanel";
+import { cn } from "@/lib/utils";
+import { mentionsToMarkdownLinks } from "@/lib/mentions";
+
+/**
+ * Ensure blockquote lines are always followed by a blank line so that
+ * subsequent non-blockquote text isn't absorbed via markdown "lazy continuation".
+ * - "> Retrieving…\nHere is…" → "> Retrieving…\n\nHere is…"
+ * - "> Updating...Your profile now" (no newline after "...") → "> Updating...\n\nYour profile now"
+ */
+function normalizeBlockquotes(text: string): string {
+  // When a blockquote line ends with "..." and more text follows on the same line (e.g. stream
+  // sent no newline), insert a blank line so the following text renders on a new line.
+  let out = text.replace(/^(>.*?\.\.\.)\s*(\S.+)$/gm, "$1\n\n$2");
+  out = out.replace(/^(>.*)\n(?!>|\n)/gm, "$1\n\n");
+  return out;
+}
+
+/**
+ * Segment union for all block types the chat agent can emit.
+ * Exported so consumers (e.g. ChatContent.tsx useMemo hooks) can type
+ * the result of parseAllBlocks without importing via deep paths.
+ */
+export type MessageSegment =
+  | { type: "text"; content: string }
+  | { type: "opportunity"; data: OpportunityCardData }
+  | { type: "opportunity_loading" }
+  | { type: "intent_proposal"; data: IntentProposalData }
+  | { type: "intent_proposal_loading" }
+  | { type: "networks_panel" }
+  | { type: "networks_panel_loading" };
+
+/**
+ * Parse agent message content, extracting fenced blocks as typed segments.
+ * Exported so ChatContent.tsx can call it outside AssistantMessageContent
+ * (for opportunity/proposal ID extraction in useMemo hooks).
+ */
+export function parseAllBlocks(content: string): MessageSegment[] {
+  const segments: MessageSegment[] = [];
+  const regex = /```(opportunity|intent_proposal|networks_panel)\s*\n([\s\S]*?)\n```/g;
+  let lastIndex = 0;
+  let match;
+
+  while ((match = regex.exec(content)) !== null) {
+    if (match.index > lastIndex) {
+      const textBefore = content.slice(lastIndex, match.index);
+      if (textBefore.trim()) {
+        segments.push({ type: "text", content: textBefore });
+      }
+    }
+
+    const blockType = match[1];
+
+    if (blockType === "networks_panel") {
+      segments.push({ type: "networks_panel" });
+    } else {
+      try {
+        const jsonStr = match[2].trim();
+        const data = JSON.parse(jsonStr);
+
+        if (blockType === "opportunity" && data.opportunityId && data.userId) {
+          segments.push({ type: "opportunity", data: data as OpportunityCardData });
+        } else if (
+          blockType === "intent_proposal" &&
+          data.proposalId &&
+          (typeof data.description === "string" || !("description" in data))
+        ) {
+          segments.push({ type: "intent_proposal", data: data as IntentProposalData });
+        } else if (blockType === "intent_proposal") {
+          // Broken block (e.g. model wrote intent_proposal without calling create_intent — no proposalId)
+          segments.push({
+            type: "text",
+            content: "This proposal couldn't be loaded as a card. Ask again to add this as a signal.",
+          });
+        } else {
+          segments.push({ type: "text", content: match[0] });
+        }
+      } catch {
+        segments.push({ type: "text", content: match[0] });
+      }
+    }
+
+    lastIndex = match.index + match[0].length;
+  }
+
+  const remainingContent = content.slice(lastIndex);
+  const partialOpp = remainingContent.match(/```opportunity/);
+  const partialIntent = remainingContent.match(/```intent_proposal/);
+  const partialNetworks = remainingContent.match(/```networks_panel/);
+
+  const candidates = ([partialOpp, partialIntent, partialNetworks] as (RegExpMatchArray | null)[]).filter(
+    (c): c is RegExpMatchArray => c !== null,
+  );
+  const partialMatch =
+    candidates.length > 0
+      ? candidates.reduce((earliest, c) => (c.index! < earliest.index! ? c : earliest))
+      : null;
+
+  if (partialMatch) {
+    const partialIndex = partialMatch.index!;
+    const textBefore = remainingContent.slice(0, partialIndex);
+    if (textBefore.trim()) {
+      segments.push({ type: "text", content: textBefore });
+    }
+    if (partialMatch === partialOpp) {
+      segments.push({ type: "opportunity_loading" });
+    } else if (partialMatch === partialIntent) {
+      segments.push({ type: "intent_proposal_loading" });
+    } else {
+      segments.push({ type: "networks_panel_loading" });
+    }
+  } else if (lastIndex < content.length) {
+    const remaining = content.slice(lastIndex);
+    if (remaining.trim()) {
+      segments.push({ type: "text", content: remaining });
+    }
+  }
+
+  if (segments.length === 0 && content.trim()) {
+    segments.push({ type: "text", content });
+  }
+
+  return segments;
+}
+
+function dedupeSegments(segments: MessageSegment[]): MessageSegment[] {
+  const seenOpps = new Set<string>();
+  const seenProposals = new Set<string>();
+  return segments.filter((seg) => {
+    if (seg.type === "opportunity") {
+      if (seenOpps.has(seg.data.opportunityId)) return false;
+      seenOpps.add(seg.data.opportunityId);
+      return true;
+    }
+    if (seg.type === "intent_proposal") {
+      if (seenProposals.has(seg.data.proposalId)) return false;
+      seenProposals.add(seg.data.proposalId);
+      return true;
+    }
+    return true;
+  });
+}
+
+export interface AssistantMessageContentProps {
+  content: string;
+  isStreaming: boolean;
+  onOpportunityPrimaryAction?: (
+    opportunityId: string,
+    userId: string,
+    viewerRole?: string,
+    counterpartName?: string,
+    isGhost?: boolean,
+  ) => void;
+  onOpportunitySecondaryAction?: (
+    opportunityId: string,
+    userId: string,
+    viewerRole?: string,
+    counterpartName?: string,
+    isGhost?: boolean,
+  ) => void;
+  opportunityLoadingMap?: Record<string, boolean>;
+  /** Map of opportunityId -> current status from server */
+  currentStatusMap?: Record<string, string>;
+  onIntentProposalApprove?: (proposalId: string, description: string, networkId?: string) => void;
+  onIntentProposalReject?: (proposalId: string) => void;
+  onIntentProposalUndo?: (proposalId: string) => void;
+  intentProposalStatusMap?: Record<string, "pending" | "created" | "rejected">;
+  OAuthLink?: ComponentType<ComponentPropsWithoutRef<"a">>;
+  onNetworkJoin?: (networkId: string, networkTitle: string) => void;
+  networkPanelPendingJoinIds?: Set<string>;
+}
+
+/**
+ * Renders assistant message content by parsing fenced blocks and rendering
+ * the appropriate card component for each segment type.
+ *
+ * Shared between ChatContent.tsx (full chat view) and onboarding/page.tsx.
+ */
+export default function AssistantMessageContent({
+  content,
+  isStreaming,
+  onOpportunityPrimaryAction,
+  onOpportunitySecondaryAction,
+  opportunityLoadingMap,
+  currentStatusMap,
+  onIntentProposalApprove,
+  onIntentProposalReject,
+  onIntentProposalUndo,
+  intentProposalStatusMap,
+  OAuthLink,
+  onNetworkJoin,
+  networkPanelPendingJoinIds,
+}: AssistantMessageContentProps) {
+  const displayedContent = normalizeBlockquotes(mentionsToMarkdownLinks(content));
+
+  // Show cursor while streaming (before content arrives)
+  const showCursor = isStreaming;
+
+  // No text yet — render a standalone blinking cursor
+  if (!displayedContent && isStreaming) {
+    return <span className="inline-block w-2 h-4 bg-current animate-pulse" />;
+  }
+
+  // Parse opportunity and intent_proposal blocks from the displayed content; dedupe
+  const segments = dedupeSegments(parseAllBlocks(displayedContent));
+
+  return (
+    <div>
+      {segments.map((segment, idx) => {
+        if (segment.type === "text") {
+          const isLast = idx === segments.length - 1;
+          return (
+            <div
+              key={`text-${idx}`}
+              className={cn(
+                "chat-markdown max-w-none",
+                isStreaming && "chat-markdown-streaming",
+                showCursor && isLast && "chat-markdown-typing",
+              )}
+            >
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                components={OAuthLink ? { a: OAuthLink } : undefined}
+              >
+                {segment.content}
+              </ReactMarkdown>
+            </div>
+          );
+        } else if (segment.type === "opportunity") {
+          return (
+            <div key={segment.data.opportunityId} className="my-3">
+              <OpportunityCard
+                card={segment.data}
+                onPrimaryAction={onOpportunityPrimaryAction}
+                onSecondaryAction={onOpportunitySecondaryAction}
+                isLoading={opportunityLoadingMap?.[segment.data.opportunityId] ?? false}
+                currentStatus={currentStatusMap?.[segment.data.opportunityId]}
+              />
+            </div>
+          );
+        } else if (segment.type === "opportunity_loading") {
+          return (
+            <div key={`loading-${idx}`} className="my-3">
+              <OpportunitySkeleton />
+            </div>
+          );
+        } else if (segment.type === "intent_proposal") {
+          return (
+            <div key={segment.data.proposalId} className="my-3">
+              <IntentProposalCard
+                card={segment.data}
+                onApprove={onIntentProposalApprove}
+                onReject={onIntentProposalReject}
+                onUndo={onIntentProposalUndo}
+                currentStatus={intentProposalStatusMap?.[segment.data.proposalId]}
+              />
+            </div>
+          );
+        } else if (segment.type === "intent_proposal_loading") {
+          return (
+            <div key={`intent-loading-${idx}`} className="my-3">
+              <IntentProposalSkeleton />
+            </div>
+          );
+        } else if (segment.type === "networks_panel") {
+          return (
+            <div key={`networks-panel-${idx}`} className="my-3">
+              <NetworksPanel
+                onJoin={onNetworkJoin ?? (() => {})}
+                pendingJoinIds={networkPanelPendingJoinIds}
+              />
+            </div>
+          );
+        } else {
+          // networks_panel_loading
+          return (
+            <div key={`networks-panel-loading-${idx}`} className="my-3 flex justify-center py-6">
+              <Loader2 className="h-5 w-5 animate-spin text-gray-300" />
+            </div>
+          );
+        }
+      })}
+    </div>
+  );
+}

--- a/packages/protocol/src/profile/profile.tools.ts
+++ b/packages/protocol/src/profile/profile.tools.ts
@@ -35,7 +35,7 @@ const approvedProfileDraftSchema = z.object({
 type ApprovedProfileDraft = z.infer<typeof approvedProfileDraftSchema>;
 
 export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
-  const { userDb, systemDb, database, graphs, enricher, grantDefaultSystemPermissions, reportToolError } = deps;
+  const { userDb, systemDb, graphs, enricher, grantDefaultSystemPermissions, reportToolError } = deps;
 
   function trimToUndefined(value: string | null | undefined): string | undefined {
     const trimmed = value?.trim();
@@ -1230,8 +1230,7 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
       "Marks the user's onboarding as complete, unlocking full platform access. This is the final step in the new-user setup flow.\n\n" +
       "**Prerequisites:** The user must have a profile (created via create_user_profile) AND must have explicitly confirmed it " +
       "(said 'yes', 'looks good', 'that's right', or similar). Do NOT call this until the user confirms.\n\n" +
-      "**What happens:** Sets completedAt timestamp on the user's onboarding record. May also auto-join the user to preconfigured indexes " +
-      "(communities) based on server configuration.\n\n" +
+      "**What happens:** Sets completedAt timestamp on the user's onboarding record.\n\n" +
       "**Workflow:** create_user_profile() -> user confirms preview -> create_user_profile(confirm=true) -> user confirms saved profile -> complete_onboarding()\n\n" +
       "**Returns:** Confirmation that onboarding is complete. No parameters needed.",
     querySchema: z.object({}),
@@ -1259,19 +1258,7 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
         }
       }
 
-      const autoJoinIds = (process.env.AUTO_JOIN_INDEX_IDS ?? '')
-        .split(',')
-        .map(id => id.trim())
-        .filter(Boolean);
-      for (const networkId of autoJoinIds) {
-        try {
-          await database.addMemberToNetwork(networkId, context.userId, 'member');
-        } catch (err) {
-          logger.warn('Auto-join network failed (non-fatal)', { networkId, userId: context.userId, error: err instanceof Error ? err.message : String(err) });
-        }
-      }
-
-      logger.info("Onboarding completed", { userId: context.userId, autoJoinedNetworks: autoJoinIds.length });
+      logger.info("Onboarding completed", { userId: context.userId });
       return success({ message: "Onboarding complete." });
     },
   });


### PR DESCRIPTION
## Summary

Reverses the silent auto-join introduced in `6a2f9a57e1` and restores the interactive networks panel during onboarding so users explicitly choose which networks to join.

## Changes

### Protocol
- **Remove `AUTO_JOIN_INDEX_IDS` auto-join loop** from `complete_onboarding()` in `profile.tools.ts` — joining networks now requires explicit user action via the panel
- Remove `database` from deps destructure (only consumer was the removed loop)
- Update tool description to no longer mention auto-join

### Frontend — shared component extraction
- **Extract `AssistantMessageContent`** into `components/chat/AssistantMessageContent.tsx` — handles all 7 segment types (text, opportunity, opportunity_loading, intent_proposal, intent_proposal_loading, networks_panel, networks_panel_loading)
- Exports `parseAllBlocks` and `MessageSegment` for external callers
- **Wire `ChatContent.tsx`** to use the shared component, removing ~280 lines of local definitions
- Add `refreshIndexes()` to the stream-end effect so the sidebar updates after agent-processed network joins

### Frontend — onboarding restore
- **Wire `onboarding/page.tsx`** to shared `AssistantMessageContent`, removing ~190 lines of local definitions
- Add `communities` step suggestion ("Continue" chip) and step detection
- Add `networkPanelPendingJoinIds` state + `handleNetworkJoin` callback
- Add stream-end effect to clear pending join IDs + `refreshIndexes()`
- Call `refreshIndexes()` **unconditionally** in the `completedAt` watcher (not just inside the `pendingInviteCode` branch)

## Net effect
- `-500` lines removed, `+332` lines added (net `-168`)
- Onboarding shows "Index Early Birds" with an explicit Join button at step 6
- Completing onboarding without clicking Join does NOT silently add the user
- Sidebar updates immediately after joining — no reload needed

## Verification
- `cd packages/protocol && bun run build` ✅
- `cd frontend && bun run build` ✅
- `cd frontend && bunx tsc --noEmit` — no new errors (pre-existing only)
- `cd packages/protocol && bun test src/profile/tests/` — 81 pass, 1 pre-existing fail
- ESLint passes on all changed files

## Plan
`.rpiv/artifacts/plans/2026-06-11_06-34-30_onboarding-networks-panel.md`