### PR TITLE
fix(mcp): create transport per request to prevent cross-user response routing

### DIFF
--- a/backend/src/controllers/mcp.controller.ts
+++ b/backend/src/controllers/mcp.controller.ts
@@ -667,26 +667,24 @@ function getOrCreateMcpServer(): McpServer {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// TRANSPORT (created once, reused across requests)
+// TRANSPORT (created per request to isolate stream mappings)
 // ═══════════════════════════════════════════════════════════════════════════════
 
-let mcpTransportPromise: Promise<WebStandardStreamableHTTPServerTransport> | null = null;
-
-function getOrCreateTransport(): Promise<WebStandardStreamableHTTPServerTransport> {
-  if (mcpTransportPromise) return mcpTransportPromise;
-
-  mcpTransportPromise = (async () => {
-    const server = getOrCreateMcpServer();
-    const transport = new WebStandardStreamableHTTPServerTransport({
-      sessionIdGenerator: undefined,
-    });
-    await server.connect(transport);
-    logger.info('MCP transport connected');
-    return transport;
-  })();
-
-  mcpTransportPromise.catch(() => { mcpTransportPromise = null; });
-  return mcpTransportPromise;
+/**
+ * Creates a fresh transport for each HTTP request and connects it to the
+ * singleton MCP server. This avoids the shared _requestToStreamMapping in
+ * WebStandardStreamableHTTPServerTransport that routes responses by JSON-RPC
+ * message.id — when multiple clients send the same id (e.g. all agentvillage
+ * pods send id:2 for tools/call), a shared transport overwrites the mapping
+ * and routes Response A to Client B, leaking data across users.
+ */
+async function createPerRequestTransport(): Promise<WebStandardStreamableHTTPServerTransport> {
+  const server = getOrCreateMcpServer();
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+  });
+  await server.connect(transport);
+  return transport;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -783,8 +781,9 @@ export async function mcpHandler(
     );
   }
 
+  let transport: WebStandardStreamableHTTPServerTransport | undefined;
   try {
-    const transport = await getOrCreateTransport();
+    transport = await createPerRequestTransport();
     const response = await transport.handleRequest(req);
 
     const newHeaders = new Headers(response.headers);
@@ -852,5 +851,10 @@ export async function mcpHandler(
         headers: { 'Content-Type': 'application/json', ...corsHeaders },
       },
     );
+  } finally {
+    // Close the per-request transport to release accumulated state and prevent memory leaks
+    if (transport) {
+      await transport.close().catch(() => {});
+    }
   }
 }


### PR DESCRIPTION
## Problem

The MCP HTTP handler uses a **singleton** `WebStandardStreamableHTTPServerTransport` for all concurrent requests. The SDK's transport maintains a shared `_requestToStreamMapping` keyed by JSON-RPC `message.id` to route responses back to the correct HTTP connection.

When multiple clients send requests with the **same JSON-RPC message ID** (all agentvillage pods send `id: 2` for `tools/call` during the 02:00 digest batch), concurrent requests overwrite each other's stream mapping. This causes Response A to be routed to Client B's HTTP connection, **leaking one user's opportunity data into another user's daily digest**.

## Evidence

- **36 of 37** opportunity-bearing digest cards on 2026-06-11 contained opportunities belonging to other users
- The wrong identity **varied daily** — consistent with race-condition timing, not static misconfiguration
- Auth resolver and tool handlers run correctly per-request (verified via `apikeys` table + connect link ownership)
- **Reproduced directly**: calling the production MCP with two tenant API keys concurrently returned the wrong user's connect links (`smojeda`'s key returned `jackcmielke`'s data)
- Single (non-concurrent) calls always return correct results

## Fix

Create a fresh `WebStandardStreamableHTTPServerTransport` for each HTTP request so each has its own isolated `_requestToStreamMapping`. The `McpServer` (tool registrations, deps, auth resolver) remains a singleton.

A `finally` block calls `transport.close()` after each request to prevent memory leaks from accumulated per-request state.

## Audit report

Full analysis: `.rpiv/artifacts/research/2026-06-11-daily-digest-opportunity-ownership-audit.md`
