### PR TITLE
Release 2026-06-12-2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ bun run maintenance:update:embeddings       # Regenerate embeddings
 bun run maintenance:decompose-profiles      # Backfill: decompose profiles into premises
 bun run maintenance:backfill-premises       # Backfill: enqueue enrichment for users in a network
 bun run maintenance:backfill-context-hyde   # Backfill: generate HyDE docs for user contexts
+bun run maintenance:backfill-profile-questions # Backfill: enqueue profile-gap question generation for existing users
 bun run maintenance:compare-discovery       # Compare profile-HyDE vs context discovery strategies
 
 # Background workers

--- a/backend/package.json
+++ b/backend/package.json
@@ -36,6 +36,7 @@
     "maintenance:backfill-premises": "bun ./src/cli/backfill-premises.ts",
     "maintenance:compare-discovery": "bun ./src/cli/compare-discovery.ts",
     "maintenance:backfill-context-hyde": "bun ./src/cli/backfill-context-hyde.ts",
+    "maintenance:backfill-profile-questions": "bun ./src/cli/backfill-profile-questions.ts",
     "test:opportunity-three-user": "bun ./src/cli/opportunity-three-user-test.ts",
     "test": "NODE_ENV=test bash scripts/test-safe.sh",
     "test:raw": "NODE_ENV=test bun test"

--- a/backend/src/cli/backfill-profile-questions.ts
+++ b/backend/src/cli/backfill-profile-questions.ts
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+/**
+ * Backfill CLI: enqueue profile-gap question generation for existing users.
+ *
+ * Historical context: question generation was disabled in production until
+ * QUESTIONER_ENABLED was set, so the one-time profile triggers (onboarding)
+ * for existing users fired into a void. This script re-enqueues the same
+ * profile-mode QuestionerInput that profile.graph.ts emits on save, for every
+ * user who has profile gaps and no pending profile question yet.
+ *
+ * Idempotent: users with a pending profile-mode question are skipped, so
+ * re-running the script never stacks duplicates.
+ *
+ * Requires a running questioner worker (QUESTIONER_ENABLED=true on the
+ * server) to drain the queue; the CLI only enqueues.
+ *
+ * Usage:
+ *   bun run maintenance:backfill-profile-questions -- [--network <networkId>] [--limit <n>] [--dry-run]
+ */
+import dotenv from 'dotenv';
+import path from 'path';
+
+const envFile = process.env.NODE_ENV === 'development' ? '.env.development' : '.env.production';
+dotenv.config({ path: path.resolve(process.cwd(), envFile) });
+
+import { and, eq, sql } from 'drizzle-orm';
+
+import db, { closeDb } from '../lib/drizzle/drizzle';
+import { networkMembers, premises, questions, userProfiles, users } from '../schemas/database.schema';
+import { questionerQueue } from '../queues/questioner.queue';
+
+// ---------------------------------------------------------------------------
+// Arg parsing
+// ---------------------------------------------------------------------------
+
+function argValue(args: string[], name: string): string | undefined {
+  const exact = args.indexOf(name);
+  if (exact !== -1 && exact + 1 < args.length) return args[exact + 1];
+  const prefixed = args.find((a) => a.startsWith(`${name}=`));
+  return prefixed?.slice(name.length + 1);
+}
+
+function parseArgs(): { networkId?: string; limit: number; dryRun: boolean } {
+  const args = process.argv.slice(2);
+  const networkId = argValue(args, '--network');
+  const limitRaw = argValue(args, '--limit');
+  const limit = limitRaw ? Number.parseInt(limitRaw, 10) : Number.POSITIVE_INFINITY;
+  if (limitRaw && (!Number.isFinite(limit) || limit <= 0)) {
+    console.error('--limit must be a positive integer');
+    process.exit(1);
+  }
+  return { networkId, limit, dryRun: args.includes('--dry-run') };
+}
+
+// ---------------------------------------------------------------------------
+// Gap computation — mirrors profile.graph.ts save-node logic exactly
+// ---------------------------------------------------------------------------
+
+interface ProfileRow {
+  userId: string;
+  identity: { name?: string; bio?: string; location?: string } | null;
+  narrative: { context?: string } | null;
+  attributes: { interests?: string[]; skills?: string[] } | null;
+}
+
+function computeGaps(profile: ProfileRow): string[] {
+  const gaps: string[] = [];
+  if (!profile.identity?.location) gaps.push('location');
+  if (!profile.attributes?.skills?.length) gaps.push('skills');
+  if (!profile.attributes?.interests?.length) gaps.push('interests');
+  if (!profile.narrative?.context) gaps.push('current work');
+  return gaps;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const { networkId, limit, dryRun } = parseArgs();
+  console.log(
+    `Backfilling profile questions${networkId ? ` for network ${networkId}` : ' for all users'}` +
+    `${Number.isFinite(limit) ? ` (limit ${limit})` : ''}${dryRun ? ' (dry run)' : ''}`,
+  );
+
+  // Candidate users: onboarded, non-ghost, with a stored profile. Optionally
+  // restricted to members of one network.
+  const baseConditions = [
+    eq(users.isGhost, false),
+    sql`${users.onboarding}->>'completedAt' IS NOT NULL`,
+  ];
+
+  const rows = networkId
+    ? await db
+      .select({
+        userId: userProfiles.userId,
+        identity: userProfiles.identity,
+        narrative: userProfiles.narrative,
+        attributes: userProfiles.attributes,
+      })
+      .from(userProfiles)
+      .innerJoin(users, eq(userProfiles.userId, users.id))
+      .innerJoin(networkMembers, eq(networkMembers.userId, users.id))
+      .where(and(...baseConditions, eq(networkMembers.networkId, networkId)))
+    : await db
+      .select({
+        userId: userProfiles.userId,
+        identity: userProfiles.identity,
+        narrative: userProfiles.narrative,
+        attributes: userProfiles.attributes,
+      })
+      .from(userProfiles)
+      .innerJoin(users, eq(userProfiles.userId, users.id))
+      .where(and(...baseConditions));
+
+  console.log(`Candidate users with profiles: ${rows.length}`);
+
+  let enqueued = 0;
+  let skippedNoGaps = 0;
+  let skippedPending = 0;
+
+  for (const row of rows) {
+    if (enqueued >= limit) break;
+
+    const gaps = computeGaps(row);
+    if (gaps.length === 0) {
+      skippedNoGaps += 1;
+      continue;
+    }
+
+    // Idempotency guard: skip users who already have a pending profile question.
+    const [existing] = await db
+      .select({ id: questions.id })
+      .from(questions)
+      .where(and(
+        eq(questions.status, 'pending'),
+        sql`${questions.detection}->>'mode' = 'profile'`,
+        sql`${questions.actors} @> ${JSON.stringify([{ userId: row.userId, role: 'subject' }])}::jsonb`,
+      ))
+      .limit(1);
+    if (existing) {
+      skippedPending += 1;
+      continue;
+    }
+
+    // Active premises let the questioner avoid asking about facts the user
+    // has already stated — same payload profile.graph.ts builds on save.
+    const activePremises = await db
+      .select({ assertion: premises.assertion })
+      .from(premises)
+      .where(and(eq(premises.userId, row.userId), eq(premises.status, 'ACTIVE')));
+    const existingPremises = activePremises.map((p) => p.assertion.text);
+
+    if (dryRun) {
+      console.log(`[dry-run] would enqueue ${row.userId} (gaps: ${gaps.join(', ')})`);
+      enqueued += 1;
+      continue;
+    }
+
+    await questionerQueue.addGenerateJob({
+      mode: 'profile',
+      userId: row.userId,
+      sourceType: 'profile',
+      sourceId: row.userId,
+      context: {
+        userProfile: {
+          name: row.identity?.name,
+          bio: row.identity?.bio,
+          location: row.identity?.location,
+          skills: row.attributes?.skills,
+          interests: row.attributes?.interests,
+        },
+        gaps,
+        existingPremises,
+      },
+    });
+    enqueued += 1;
+  }
+
+  console.log(`Done. Enqueued: ${enqueued}, skipped (no gaps): ${skippedNoGaps}, skipped (pending question exists): ${skippedPending}`);
+}
+
+main()
+  .catch((err) => {
+    console.error('Backfill failed:', err instanceof Error ? err.message : err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await questionerQueue.queue.close();
+    await closeDb();
+  });

--- a/backend/src/queues/enrichment.queue.ts
+++ b/backend/src/queues/enrichment.queue.ts
@@ -10,6 +10,7 @@ import type { PremiseGraphDatabase } from '@indexnetwork/protocol';
 import { enrichUserProfile } from '../lib/parallel/parallel';
 import { EmbedderAdapter } from '../adapters/embedder.adapter';
 import db from '../lib/drizzle/drizzle';
+import { questionerEnqueueIfEnabled } from './questioner.queue';
 import { canRunPublicProfileEnrichment, getProfileEnrichmentPolicy } from '../lib/privacy/profile-enrichment-policy';
 import { networks, userProfiles, users } from '../schemas/database.schema';
 import type { OnboardingState, ProfileEnrichmentPolicy } from '../schemas/database.schema';
@@ -336,7 +337,10 @@ export class EnrichmentQueue {
       premiseDatabase as unknown as PremiseGraphDatabase,
       embedder,
     ).createGraph();
-    const factory = new ProfileGraphFactory(database, scraper, { enrichUserProfile }, undefined, premiseGraph);
+    // Inject the env-gated questioner enqueue so profile regeneration runs
+    // (onboarding, premise cascades) generate profile-gap questions instead
+    // of silently dropping them (the gap that left prod's questions table empty).
+    const factory = new ProfileGraphFactory(database, scraper, { enrichUserProfile }, questionerEnqueueIfEnabled(), premiseGraph);
     const graph = factory.createGraph();
     return graph.invoke({ userId, operationMode });
   }

--- a/backend/src/queues/opportunity/discovery-run.queue.ts
+++ b/backend/src/queues/opportunity/discovery-run.queue.ts
@@ -35,6 +35,7 @@ import { mintConnectLink as mintConnectLinkSvc, buildConnectShortUrl } from '../
 import { resolveProtocolBaseUrl } from '../../lib/protocol-url';
 import type { ConnectLinkKind } from '../../services/connect-link.service';
 import { negotiationRunExistingQueue } from '../negotiations/run-existing.queue';
+import { questionerEnqueueIfEnabled } from '../questioner.queue';
 
 export const QUEUE_NAME = 'opportunity-discovery-run';
 
@@ -226,6 +227,12 @@ export class DiscoveryRunQueue {
       },
     ).createGraph();
 
+    // Env-gated questioner enqueue: queued/async discovery runs generate
+    // discovery-mode questions exactly like synchronous MCP discover calls
+    // (the tool computes enableQuestions from ENABLE_DISCOVERY_QUESTIONS +
+    // context.isMcp, which is true here).
+    const questionerEnqueue = questionerEnqueueIfEnabled();
+
     const rawTools = new Map<string, RawToolDefinition>();
     createOpportunityTools(((opts: {
       name: string;
@@ -255,6 +262,7 @@ export class DiscoveryRunQueue {
       mintConnectLink,
       frontendUrl: process.env.FRONTEND_URL ?? process.env.APP_URL ?? 'https://index.network',
       apiBaseUrl,
+      ...(questionerEnqueue && { questionerEnqueue }),
       graphs: {
         profile: { invoke: async () => ({}) } as CompiledGraph,
         intent: { invoke: async () => ({}) } as CompiledGraph,

--- a/backend/src/queues/profile-run.queue.ts
+++ b/backend/src/queues/profile-run.queue.ts
@@ -27,6 +27,7 @@ import { cacheAdapter } from '../adapters/cache.adapter';
 import { scraperAdapter } from '../adapters/scraper.adapter';
 import { enricherAdapter } from '../adapters/enricher.adapter';
 import { profileRunAdapter } from '../adapters/profile-run.adapter';
+import { questionerEnqueueIfEnabled } from './questioner.queue';
 
 export const QUEUE_NAME = 'profile-tool-run';
 
@@ -180,7 +181,9 @@ export class ProfileRunQueue {
       chatDatabaseAdapter,
       scraperAdapter,
       enricherAdapter,
-      undefined,
+      // Env-gated questioner enqueue: async profile runs generate
+      // profile-gap questions just like the MCP composition root.
+      questionerEnqueueIfEnabled(),
       premiseGraph,
     ).createGraph();
 

--- a/backend/src/queues/questioner.queue.ts
+++ b/backend/src/queues/questioner.queue.ts
@@ -1,7 +1,7 @@
 import { Job } from 'bullmq';
 
 import { QuestionerAgent } from '@indexnetwork/protocol';
-import type { QuestionerInput, PersistableQuestion, QuestionGenerationResult } from '@indexnetwork/protocol';
+import type { QuestionerInput, QuestionerEnqueueFn, PersistableQuestion, QuestionGenerationResult } from '@indexnetwork/protocol';
 
 import { log } from '../lib/log';
 import { QueueFactory } from '../lib/bullmq/bullmq';
@@ -184,3 +184,20 @@ export class QuestionerQueue {
 
 /** Singleton questioner queue instance. Use for adding jobs and starting the worker. */
 export const questionerQueue = new QuestionerQueue();
+
+/**
+ * Returns the questioner enqueue callback when question generation is enabled
+ * (`QUESTIONER_ENABLED=true`), or `undefined` otherwise.
+ *
+ * Use at graph/tool composition sites (MCP composition root, background
+ * queues) so every path injects the same env-gated enqueue instead of
+ * silently dropping question generation. Reads the env at call time, so
+ * composition sites that build graphs per job pick up flag changes without
+ * a process restart ordering hazard.
+ */
+export function questionerEnqueueIfEnabled(): QuestionerEnqueueFn | undefined {
+  if (process.env.QUESTIONER_ENABLED !== 'true') return undefined;
+  return async (input) => {
+    await questionerQueue.addGenerateJob(input);
+  };
+}

--- a/backend/src/queues/tests/questioner-enqueue-if-enabled.spec.ts
+++ b/backend/src/queues/tests/questioner-enqueue-if-enabled.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * Unit tests for questionerEnqueueIfEnabled — the env-gated enqueue used by
+ * graph/tool composition sites (MCP root, enrichment, profile-run,
+ * discovery-run queues). Gating only; the returned closure delegates to the
+ * singleton queue and is exercised by integration paths.
+ */
+process.env.DATABASE_URL = process.env.DATABASE_URL ?? 'postgresql://unused:unused@localhost:5432/unused';
+
+import { afterEach, describe, expect, it } from 'bun:test';
+
+import { questionerEnqueueIfEnabled } from '../questioner.queue';
+
+const originalFlag = process.env.QUESTIONER_ENABLED;
+
+afterEach(() => {
+  if (originalFlag === undefined) {
+    delete process.env.QUESTIONER_ENABLED;
+  } else {
+    process.env.QUESTIONER_ENABLED = originalFlag;
+  }
+});
+
+describe('questionerEnqueueIfEnabled', () => {
+  it('returns undefined when QUESTIONER_ENABLED is unset', () => {
+    delete process.env.QUESTIONER_ENABLED;
+    expect(questionerEnqueueIfEnabled()).toBeUndefined();
+  });
+
+  it('returns undefined when QUESTIONER_ENABLED is not "true"', () => {
+    process.env.QUESTIONER_ENABLED = 'false';
+    expect(questionerEnqueueIfEnabled()).toBeUndefined();
+    process.env.QUESTIONER_ENABLED = '1';
+    expect(questionerEnqueueIfEnabled()).toBeUndefined();
+  });
+
+  it('returns an enqueue function when QUESTIONER_ENABLED is "true"', () => {
+    process.env.QUESTIONER_ENABLED = 'true';
+    const fn = questionerEnqueueIfEnabled();
+    expect(typeof fn).toBe('function');
+  });
+
+  it('re-reads the flag on every call (no caching)', () => {
+    process.env.QUESTIONER_ENABLED = 'true';
+    expect(questionerEnqueueIfEnabled()).toBeDefined();
+    process.env.QUESTIONER_ENABLED = 'false';
+    expect(questionerEnqueueIfEnabled()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Release changelog

### Highlights
- **Questioner pipeline actually generates questions** — background queues (enrichment, profile-run, discovery-run) now inject the env-gated `questionerEnqueue`, closing the gap that left the production `questions` table empty: onboarding/profile regeneration and queued MCP discovery runs silently dropped question generation (#943).
- **`maintenance:backfill-profile-questions` CLI** — idempotent one-shot backfill that enqueues profile-gap question generation for existing users whose onboarding fired while the questioner was disabled. Unblocks "One for you" daily-digest questions (shipped in #937/#941) for the existing AgentVillage fleet.

### Changes
#### Bug Fixes
- `fix(backend): inject questioner enqueue into enrichment, profile-run, and discovery-run queues` (`46dbd42f10`)
#### New Features
- `feat(backend): add maintenance:backfill-profile-questions CLI` (`8411132d69`)

### Issues and PRs
- #943 — fix(backend): wire questioner enqueue into background queues + profile-question backfill CLI
- Follow-up to #937 / #941 (daily brief question injection). No Linear issues detected.

### Diff summary
```text
 8 files changed, 276 insertions(+), 3 deletions(-)
```

```text
M	CLAUDE.md
M	backend/package.json
A	backend/src/cli/backfill-profile-questions.ts
M	backend/src/queues/enrichment.queue.ts
M	backend/src/queues/opportunity/discovery-run.queue.ts
M	backend/src/queues/profile-run.queue.ts
M	backend/src/queues/questioner.queue.ts
A	backend/src/queues/tests/questioner-enqueue-if-enabled.spec.ts
```

### Verification
- [x] Release branch created from `origin/dev` at `a00fedc491541318826566485f20b915cf6a92e9`.
- [x] backend tsc + eslint clean; 4 new unit tests + 13 existing questioner tests pass.
- [x] Dev CI green on merge commit `a00fedc491`.
- [ ] GitHub checks pass on this PR.
