### PR TITLE
Release 2026-06-12-3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ bun run maintenance:decompose-profiles      # Backfill: decompose profiles into 
 bun run maintenance:backfill-premises       # Backfill: enqueue enrichment for users in a network
 bun run maintenance:backfill-context-hyde   # Backfill: generate HyDE docs for user contexts
 bun run maintenance:backfill-profile-questions # Backfill: enqueue profile-gap question generation for existing users
+bun run maintenance:backfill-intent-questions # Backfill: enqueue intent-refinement question generation (most recent active intent per user)
 bun run maintenance:compare-discovery       # Compare profile-HyDE vs context discovery strategies
 
 # Background workers

--- a/backend/package.json
+++ b/backend/package.json
@@ -37,6 +37,7 @@
     "maintenance:compare-discovery": "bun ./src/cli/compare-discovery.ts",
     "maintenance:backfill-context-hyde": "bun ./src/cli/backfill-context-hyde.ts",
     "maintenance:backfill-profile-questions": "bun ./src/cli/backfill-profile-questions.ts",
+    "maintenance:backfill-intent-questions": "bun ./src/cli/backfill-intent-questions.ts",
     "test:opportunity-three-user": "bun ./src/cli/opportunity-three-user-test.ts",
     "test": "NODE_ENV=test bash scripts/test-safe.sh",
     "test:raw": "NODE_ENV=test bun test"

--- a/backend/src/cli/backfill-intent-questions.ts
+++ b/backend/src/cli/backfill-intent-questions.ts
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+/**
+ * Backfill CLI: enqueue intent-refinement question generation for existing users.
+ *
+ * Intent-mode questions are normally generated at intent creation time
+ * (intent.graph.ts), but that trigger fired while QUESTIONER_ENABLED was off
+ * in production, so existing intents never produced questions. This script
+ * enqueues the same intent-mode QuestionerInput for each user's most recent
+ * active intent.
+ *
+ * One job per user (most recent active intent), not per intent: digests
+ * deliver at most one question per day with a re-delivery cooldown, so
+ * enqueueing every intent would only build a stale backlog.
+ *
+ * Idempotent: users with a pending intent-mode question are skipped, so
+ * re-running the script never stacks duplicates.
+ *
+ * Requires a running questioner worker (QUESTIONER_ENABLED=true on the
+ * server) to drain the queue; the CLI only enqueues.
+ *
+ * Usage:
+ *   bun run maintenance:backfill-intent-questions -- [--network <networkId>] [--limit <n>] [--dry-run]
+ */
+import dotenv from 'dotenv';
+import path from 'path';
+
+const envFile = process.env.NODE_ENV === 'development' ? '.env.development' : '.env.production';
+dotenv.config({ path: path.resolve(process.cwd(), envFile) });
+
+import { and, desc, eq, isNull, sql } from 'drizzle-orm';
+
+import db, { closeDb } from '../lib/drizzle/drizzle';
+import { intents, networkMembers, questions, userProfiles, users } from '../schemas/database.schema';
+import { questionerQueue } from '../queues/questioner.queue';
+
+// ---------------------------------------------------------------------------
+// Arg parsing
+// ---------------------------------------------------------------------------
+
+function argValue(args: string[], name: string): string | undefined {
+  const exact = args.indexOf(name);
+  if (exact !== -1 && exact + 1 < args.length) return args[exact + 1];
+  const prefixed = args.find((a) => a.startsWith(`${name}=`));
+  return prefixed?.slice(name.length + 1);
+}
+
+function parseArgs(): { networkId?: string; limit: number; dryRun: boolean } {
+  const args = process.argv.slice(2);
+  const networkId = argValue(args, '--network');
+  const limitRaw = argValue(args, '--limit');
+  const limit = limitRaw ? Number.parseInt(limitRaw, 10) : Number.POSITIVE_INFINITY;
+  if (limitRaw && (!Number.isFinite(limit) || limit <= 0)) {
+    console.error('--limit must be a positive integer');
+    process.exit(1);
+  }
+  return { networkId, limit, dryRun: args.includes('--dry-run') };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const { networkId, limit, dryRun } = parseArgs();
+  console.log(
+    `Backfilling intent questions${networkId ? ` for network ${networkId}` : ' for all users'}` +
+    `${Number.isFinite(limit) ? ` (limit ${limit})` : ''}${dryRun ? ' (dry run)' : ''}`,
+  );
+
+  // Active intents of onboarded, non-ghost users, newest first. Optionally
+  // restricted to members of one network. The newest-first ordering plus the
+  // per-user dedup below selects each user's most recent active intent.
+  const baseConditions = [
+    isNull(intents.archivedAt),
+    eq(users.isGhost, false),
+    sql`${users.onboarding}->>'completedAt' IS NOT NULL`,
+  ];
+
+  const selection = {
+    intentId: intents.id,
+    payload: intents.payload,
+    summary: intents.summary,
+    userId: intents.userId,
+    identity: userProfiles.identity,
+    attributes: userProfiles.attributes,
+  };
+
+  const rows = networkId
+    ? await db
+      .select(selection)
+      .from(intents)
+      .innerJoin(users, eq(intents.userId, users.id))
+      .leftJoin(userProfiles, eq(userProfiles.userId, users.id))
+      .innerJoin(networkMembers, eq(networkMembers.userId, users.id))
+      .where(and(...baseConditions, eq(networkMembers.networkId, networkId)))
+      .orderBy(desc(intents.createdAt))
+    : await db
+      .select(selection)
+      .from(intents)
+      .innerJoin(users, eq(intents.userId, users.id))
+      .leftJoin(userProfiles, eq(userProfiles.userId, users.id))
+      .where(and(...baseConditions))
+      .orderBy(desc(intents.createdAt));
+
+  // Most recent active intent per user.
+  const latestByUser = new Map<string, typeof rows[number]>();
+  for (const row of rows) {
+    if (!latestByUser.has(row.userId)) latestByUser.set(row.userId, row);
+  }
+
+  console.log(`Users with active intents: ${latestByUser.size}`);
+
+  let enqueued = 0;
+  let skippedPending = 0;
+
+  for (const row of latestByUser.values()) {
+    if (enqueued >= limit) break;
+
+    // Idempotency guard: skip users who already have a pending intent question.
+    const [existing] = await db
+      .select({ id: questions.id })
+      .from(questions)
+      .where(and(
+        eq(questions.status, 'pending'),
+        sql`${questions.detection}->>'mode' = 'intent'`,
+        sql`${questions.actors} @> ${JSON.stringify([{ userId: row.userId, role: 'subject' }])}::jsonb`,
+      ))
+      .limit(1);
+    if (existing) {
+      skippedPending += 1;
+      continue;
+    }
+
+    if (dryRun) {
+      console.log(`[dry-run] would enqueue ${row.userId} (intent ${row.intentId}: ${row.payload.slice(0, 60)}…)`);
+      enqueued += 1;
+      continue;
+    }
+
+    // Same payload shape intent.graph.ts emits on intent creation, plus the
+    // stored summary (available for existing intents, absent at create time).
+    await questionerQueue.addGenerateJob({
+      mode: 'intent',
+      userId: row.userId,
+      sourceType: 'intent',
+      sourceId: row.intentId,
+      context: {
+        intentId: row.intentId,
+        payload: row.payload,
+        ...(row.summary ? { summary: row.summary } : {}),
+        userProfile: {
+          name: row.identity?.name,
+          bio: row.identity?.bio,
+          skills: row.attributes?.skills,
+          interests: row.attributes?.interests,
+        },
+      },
+    });
+    enqueued += 1;
+  }
+
+  console.log(`Done. Enqueued: ${enqueued}, skipped (pending question exists): ${skippedPending}`);
+}
+
+main()
+  .catch((err) => {
+    console.error('Backfill failed:', err instanceof Error ? err.message : err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await questionerQueue.queue.close();
+    await closeDb();
+  });


### PR DESCRIPTION
## Release changelog

### Highlights
- **`maintenance:backfill-intent-questions` CLI** — enqueues intent-refinement question generation for each user's most recent active intent (#945). Existing intents (347 across 105 users) never produced questions because the creation-time trigger fired while the questioner was disabled; this backfill gives near-fleet-wide "One for you" digest coverage. Intent-mode answers feed the existing handler (intent description refinement + HyDE regen), directly improving matching.

### Changes
#### New Features
- `feat(backend): add maintenance:backfill-intent-questions CLI` (``)

- `feat(backend): add maintenance:backfill-intent-questions CLI` (`295b2c34ec`)

### Issues and PRs
- #945 — feat(backend): add maintenance:backfill-intent-questions CLI (follow-up to #943). No Linear issues detected.

### Diff summary
```text
 3 files changed, 175 insertions(+)
```

```text
M	CLAUDE.md
M	backend/package.json
A	backend/src/cli/backfill-intent-questions.ts
```

### Verification
- [x] Release branch created from `origin/dev` at `bfad79b5340de81c68365341d7b234dd99910e1d`.
- [x] backend tsc + eslint clean; dev CI green on `bfad79b534`.
- [ ] GitHub checks pass on this PR.
