### PR TITLE
hotfix(backend): refresh connect-link preferredSurface on idempotent re-mint

### DIFF
--- a/backend/src/services/connect-link.service.ts
+++ b/backend/src/services/connect-link.service.ts
@@ -65,7 +65,10 @@ export interface MintArgs {
 /**
  * Idempotent mint: if a non-expired link exists for (opportunityId, userId, kind),
  * return it. Otherwise insert a fresh row. Greeting is snapshotted at first mint
- * and preserved across re-mints until expiry.
+ * and preserved across re-mints until expiry. `preferredSurface`, by contrast,
+ * is refreshed on reuse when the caller supplies one: the surface should
+ * reflect where the link was most recently delivered, and this also self-heals
+ * rows that were mis-stamped by a caller that omitted its surface.
  *
  * @param args - Recipient/opportunity/kind tuple plus optional greeting snapshot.
  * @returns The short code and stored greeting (null if none was supplied at mint).
@@ -97,6 +100,15 @@ export async function mintConnectLink({
     .limit(1);
 
   if (existing && existing.expiresAt > now) {
+    // Reuse the fresh row, but let the latest delivery surface win so the
+    // click-time redirect matches where the link was actually sent. Only
+    // update when the caller declares a surface — omission keeps the stamp.
+    if (preferredSurface && existing.preferredSurface !== preferredSurface) {
+      await db
+        .update(connectLinks)
+        .set({ preferredSurface })
+        .where(eq(connectLinks.code, existing.code));
+    }
     return { code: existing.code, greeting: existing.greeting };
   }
 

--- a/backend/src/services/tests/connect-link.service.spec.ts
+++ b/backend/src/services/tests/connect-link.service.spec.ts
@@ -86,6 +86,23 @@ describe('connect-link service', () => {
     expect(a.code).toBe(b.code);
   });
 
+  test('reuse refreshes preferredSurface when the new mint declares one, and omission preserves it', async () => {
+    // First mint without a surface (e.g. a caller that forgot the header → web/null stamp).
+    const a = await mintConnectLink({ userId: USER_ID, opportunityId: OPP_ID, kind: 'connect', preferredSurface: 'web' });
+
+    // Re-mint from a telegram surface — same row reused, surface refreshed.
+    const b = await mintConnectLink({ userId: USER_ID, opportunityId: OPP_ID, kind: 'connect', preferredSurface: 'telegram' });
+    expect(b.code).toBe(a.code);
+    let [row] = await db.select().from(connectLinks).where(eq(connectLinks.code, a.code));
+    expect(row.preferredSurface).toBe('telegram');
+
+    // Re-mint with no surface declared — stamp must be preserved, not nulled.
+    const c = await mintConnectLink({ userId: USER_ID, opportunityId: OPP_ID, kind: 'connect' });
+    expect(c.code).toBe(a.code);
+    [row] = await db.select().from(connectLinks).where(eq(connectLinks.code, a.code));
+    expect(row.preferredSurface).toBe('telegram');
+  });
+
   test('different kinds produce different codes for same recipient', async () => {
     const c1 = await mintConnectLink({ userId: USER_ID, opportunityId: OPP_ID, kind: 'connect' });
     const c2 = await mintConnectLink({ userId: USER_ID, opportunityId: OPP_ID, kind: 'outreach' });


### PR DESCRIPTION
Hotfix to `main` (supersedes #947, rebased onto `origin/main`).

## Problem

Connect links delivered in the AgentVillage Telegram daily digest landed on the index.network web-chat fallback (`/u/<id>/chat?msg=…`) instead of deep-linking to Telegram (`t.me/<handle>?text=…`), even when the counterpart has a verified Telegram handle.

## Root cause (two halves)

1. The digest staging script calls the MCP server directly and didn't send `x-index-surface: telegram`; the server coerces the missing header to `web`, so digest-minted links were stamped `preferredSurface=web`. Fixed in the canonical repo: Edge-City/agentvillage#87.
2. **This PR**: `mintConnectLink` reused a fresh existing row verbatim, so a mis-stamped surface stuck for the full 30-day TTL even when a later telegram-surface mint re-delivered the same link.

Prod data confirms the window: for affected users, every link minted via the Hermes chat path is `telegram`; everything minted by the digest script since it shipped is `web` (e.g. `connect_links.code = 'sM2bGKCHMZ'`, counterpart handle present in `user_socials`).

## Fix

On idempotent reuse, update `preferredSurface` when the caller declares one — latest delivery surface wins, and rows mis-stamped during the regression window self-heal on the next digest re-mint. Omitting the surface preserves the existing stamp; greeting snapshot semantics unchanged.

## Tests

- `backend/src/services/tests/connect-link.service.spec.ts`: new test covering surface refresh on reuse and stamp preservation when omitted — 13/13 pass (re-run after rebase onto main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)