### PR TITLE
feat(digest): suppress already-shown and accepted-counterpart opportunities across days

### DIFF
--- a/backend/src/services/opportunity-delivery.service.ts
+++ b/backend/src/services/opportunity-delivery.service.ts
@@ -12,7 +12,7 @@
  *      committed row for the same (user, opportunity, channel, deliveredAtStatus) tuple.
  */
 
-import { and, eq, isNotNull, isNull, sql } from 'drizzle-orm';
+import { and, eq, inArray, isNotNull, isNull, sql } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
 
 import {
@@ -316,6 +316,53 @@ export class OpportunityDeliveryService {
     }
 
     return 'confirmed';
+  }
+
+  /**
+   * Read committed delivery rows for a set of opportunities delivered to a user
+   * on the OpenClaw channel. Used by the protocol's digest mode (`list_opportunities`
+   * with `includeDigestMarkers`) to suppress opportunities already shown to the user
+   * across days, and to pick the least-recently-shown candidate for cooldown re-shows.
+   *
+   * Multiple committed rows can exist per opportunity (one per `deliveredAtStatus`);
+   * every committed row is returned and the caller decides how to key them.
+   *
+   * @param params.userId - The user the opportunities were delivered to.
+   * @param params.opportunityIds - Candidate opportunity IDs to look up (empty array returns []).
+   * @returns Committed delivery rows: opportunityId, deliveredAtStatus, deliveredAt.
+   */
+  async getDeliveredOpportunities({
+    userId,
+    opportunityIds,
+  }: {
+    userId: string;
+    opportunityIds: string[];
+  }): Promise<Array<{ opportunityId: string; deliveredAtStatus: string; deliveredAt: Date }>> {
+    if (opportunityIds.length === 0) return [];
+
+    const rows = await db
+      .select({
+        opportunityId: opportunityDeliveries.opportunityId,
+        deliveredAtStatus: opportunityDeliveries.deliveredAtStatus,
+        deliveredAt: opportunityDeliveries.deliveredAt,
+      })
+      .from(opportunityDeliveries)
+      .where(
+        and(
+          inArray(opportunityDeliveries.opportunityId, opportunityIds),
+          eq(opportunityDeliveries.userId, userId),
+          eq(opportunityDeliveries.channel, CHANNEL),
+          isNotNull(opportunityDeliveries.deliveredAt),
+        ),
+      );
+
+    return rows
+      .filter((row): row is typeof row & { deliveredAt: Date } => row.deliveredAt != null)
+      .map((row) => ({
+        opportunityId: row.opportunityId,
+        deliveredAtStatus: row.deliveredAtStatus ?? '',
+        deliveredAt: row.deliveredAt,
+      }));
   }
 
   /**

--- a/backend/src/services/tests/opportunity-delivery.spec.ts
+++ b/backend/src/services/tests/opportunity-delivery.spec.ts
@@ -437,3 +437,101 @@ describe('countDeliveriesSince', () => {
     expect(result).toEqual({ ambient: 0, digest: 0 });
   });
 });
+
+describe('getDeliveredOpportunities', () => {
+  const svc = new OpportunityDeliveryService(
+    new StubPresenter() as never,
+    stubPresenterDb as never,
+  );
+
+  beforeEach(async () => {
+    await db.execute(sql`DELETE FROM opportunity_deliveries`);
+    await db.execute(sql`DELETE FROM opportunities`);
+  });
+
+  afterAll(async () => {
+    await db.execute(sql`DELETE FROM opportunity_deliveries`);
+    await db.execute(sql`DELETE FROM opportunities`);
+  });
+
+  it('returns [] for an empty id list without querying', async () => {
+    const userId = await seedUser();
+    const rows = await svc.getDeliveredOpportunities({ userId, opportunityIds: [] });
+    expect(rows).toEqual([]);
+  });
+
+  it('returns committed delivery rows with status and timestamp', async () => {
+    const userId = await seedUser();
+    const agentId = await seedAgent(userId);
+    const opp = await seedOpportunity([userId], 'pending');
+
+    await svc.confirmOpportunityDelivery({ opportunityId: opp, userId, agentId, trigger: 'digest' });
+
+    const rows = await svc.getDeliveredOpportunities({ userId, opportunityIds: [opp] });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].opportunityId).toBe(opp);
+    expect(rows[0].deliveredAtStatus).toBe('pending');
+    expect(rows[0].deliveredAt).toBeInstanceOf(Date);
+  });
+
+  it('only returns rows for the requested ids', async () => {
+    const userId = await seedUser();
+    const agentId = await seedAgent(userId);
+    const oppA = await seedOpportunity([userId], 'pending');
+    const oppB = await seedOpportunity([userId], 'pending');
+
+    await svc.confirmOpportunityDelivery({ opportunityId: oppA, userId, agentId, trigger: 'digest' });
+    await svc.confirmOpportunityDelivery({ opportunityId: oppB, userId, agentId, trigger: 'digest' });
+
+    const rows = await svc.getDeliveredOpportunities({ userId, opportunityIds: [oppA] });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].opportunityId).toBe(oppA);
+  });
+
+  it('does not return rows delivered to a different user', async () => {
+    const userId = await seedUser();
+    const otherId = await seedUser();
+    const agentId = await seedAgent(userId);
+    const opp = await seedOpportunity([userId, otherId], 'pending');
+
+    await svc.confirmOpportunityDelivery({ opportunityId: opp, userId, agentId, trigger: 'digest' });
+
+    const rows = await svc.getDeliveredOpportunities({ userId: otherId, opportunityIds: [opp] });
+    expect(rows).toEqual([]);
+  });
+
+  it('excludes uncommitted reservation rows (delivered_at IS NULL)', async () => {
+    const userId = await seedUser();
+    const agentId = await seedAgent(userId);
+    const opp = await seedOpportunity([userId], 'pending');
+
+    await db.insert(opportunityDeliveries).values({
+      opportunityId: opp,
+      userId,
+      agentId,
+      channel: 'openclaw',
+      trigger: 'pending_pickup',
+      deliveredAtStatus: 'pending',
+      reservationToken: randomUUID(),
+      reservedAt: new Date(),
+    });
+
+    const rows = await svc.getDeliveredOpportunities({ userId, opportunityIds: [opp] });
+    expect(rows).toEqual([]);
+  });
+
+  it('returns one row per deliveredAtStatus for the same opportunity', async () => {
+    const userId = await seedUser();
+    const agentId = await seedAgent(userId);
+    const opp = await seedOpportunity([userId], 'pending');
+
+    // Delivered at pending, then the opportunity advanced and was delivered at accepted.
+    await svc.confirmOpportunityDelivery({ opportunityId: opp, userId, agentId, trigger: 'digest' });
+    await db.update(opportunities).set({ status: 'accepted' }).where(eq(opportunities.id, opp));
+    await svc.confirmOpportunityDelivery({ opportunityId: opp, userId, agentId, trigger: 'accepted' });
+
+    const rows = await svc.getDeliveredOpportunities({ userId, opportunityIds: [opp] });
+    expect(rows).toHaveLength(2);
+    expect(new Set(rows.map((r) => r.deliveredAtStatus))).toEqual(new Set(['pending', 'accepted']));
+  });
+});

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -236,8 +236,11 @@ export {
   validateOpportunityActors,
   classifyOpportunity,
   selectByComposition,
+  selectDigestCandidates,
+  DIGEST_REDELIVERY_COOLDOWN_DAYS,
   FEED_SOFT_TARGETS,
 } from "./opportunity/opportunity.utils.js";
+export type { DigestDeliveredRow } from "./opportunity/opportunity.utils.js";
 export { getPrimaryActionLabel } from "./opportunity/opportunity.labels.js";
 export { computeFeedHealth } from "./opportunity/feed/feed.health.js";
 export type { FeedHealthInput, FeedHealthResult } from "./opportunity/feed/feed.health.js";

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -34,7 +34,7 @@ import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import type { Opportunity, OpportunityStatus } from "../shared/interfaces/database.interface.js";
 import type { DiscoveryRunInput } from "../shared/interfaces/discovery-run.interface.js";
 import type { ConnectLinkKind } from "../shared/interfaces/connect-link.interface.js";
-import { selectByComposition, deduplicateByPerson } from "./opportunity.utils.js";
+import { selectByComposition, deduplicateByPerson, selectDigestCandidates, type DigestDeliveredRow } from "./opportunity.utils.js";
 import { mergePendingQuestions } from "./opportunity.pending-questions.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
@@ -203,6 +203,13 @@ const CHAT_DISPLAY_LIMIT = 6;
  */
 const CHAT_FETCH_LIMIT = 30;
 
+/**
+ * How many accepted opportunities to scan when building the digest's
+ * accepted-counterpart suppression set. Wide enough to cover a month-long
+ * popup's accept history without unbounded reads.
+ */
+const ACCEPTED_SUPPRESSION_FETCH_LIMIT = 200;
+
 /** Markdown code fence (three backticks). Avoids embedding ``` in string literals so TS parser stays in sync. */
 const CODE_FENCE = String.fromCharCode(96, 96, 96);
 
@@ -336,6 +343,8 @@ type OpportunityCardLike = Record<string, unknown> & {
   acceptUrl?: string | undefined;
   profileUrl?: string | undefined;
   score?: number | undefined;
+  /** Digest-mode cooldown re-show — the user has seen this card before. */
+  redelivery?: boolean | undefined;
 };
 
 /**
@@ -384,6 +393,7 @@ export function buildOpportunityPresentation(
         if (card.acceptUrl) lines.push(`   acceptUrl: ${card.acceptUrl}`);
         if (card.feedCategory) lines.push(`   feedCategory: ${card.feedCategory}`);
         if (opts.includeDigestMarkers && card.score != null) lines.push(`   confidence: ${Math.round(card.score * 100)}`);
+        if (opts.includeDigestMarkers && card.redelivery) lines.push(`   redelivery: true`);
         // Only surface opportunityId when there's no acceptUrl. Exposing the
         // UUID alongside an actionable link gives the LLM a foothold to
         // hallucinate bare `/api/opportunities/<id>/connect` URLs.
@@ -1569,12 +1579,73 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
       // highest-confidence opportunity per person across discovery runs.
       const deduped = deduplicateByPerson(visible, context.userId);
 
+      const isDigestMode = context.isMcp === true && query.includeDigestMarkers === true;
+
+      // ── Digest-mode cross-day suppression ──
+      // Scheduled briefs must not repeat themselves: drop candidates whose
+      // counterpart the user already connected with (accepted opportunity
+      // exists — a re-discovery run re-minting the same person must not
+      // resurface them), drop candidates already shown per the delivery
+      // ledger, and when nothing fresh remains re-show the least-recently
+      // shown candidate past the cooldown, flagged as a redelivery so the
+      // digest can frame it as a reminder. Chat mode is untouched — a user
+      // asking "show my opportunities" should always see them.
+      // Every fetch here is best-effort: a failed read degrades to no
+      // suppression rather than an empty brief.
+      let digestPool = deduped;
+      let redeliveryIds = new Set<string>();
+      if (isDigestMode && deduped.length > 0) {
+        const acceptedCounterpartIds = new Set<string>();
+        try {
+          const acceptedOpps = await database.getOpportunitiesForUser(context.userId, {
+            ...(effectiveIndexId ? { networkId: effectiveIndexId } : {}),
+            statuses: ["accepted"],
+            limit: ACCEPTED_SUPPRESSION_FETCH_LIMIT,
+          });
+          for (const opp of acceptedOpps) {
+            for (const actor of opp.actors) {
+              if (actor.userId && actor.userId !== context.userId && actor.role !== "introducer") {
+                acceptedCounterpartIds.add(actor.userId);
+              }
+            }
+          }
+        } catch (err) {
+          logger.warn("digest suppression: failed to fetch accepted opportunities, skipping counterpart suppression", { err });
+        }
+
+        let deliveredRows: DigestDeliveredRow[] = [];
+        if (deps.deliveryLedger?.getDeliveredOpportunities) {
+          try {
+            const rows = await deps.deliveryLedger.getDeliveredOpportunities({
+              userId: context.userId,
+              opportunityIds: deduped.map((opp) => opp.id),
+            });
+            // Defensive Date coercion — ledger rows may cross a serialization boundary.
+            deliveredRows = rows.map((row) => ({
+              opportunityId: row.opportunityId,
+              deliveredAtStatus: row.deliveredAtStatus,
+              deliveredAt: row.deliveredAt instanceof Date ? row.deliveredAt : new Date(row.deliveredAt),
+            }));
+          } catch (err) {
+            logger.warn("digest suppression: failed to read delivery ledger, skipping shown-opportunity dedup", { err });
+          }
+        }
+
+        const digestSelection = selectDigestCandidates(deduped, {
+          viewerId: context.userId,
+          acceptedCounterpartIds,
+          deliveredRows,
+        });
+        digestPool = digestSelection.pool;
+        redeliveryIds = digestSelection.redeliveryIds;
+      }
+
       // Compose-balance across feed categories so the digest/ambient prompt
       // can fill both Section A (connection) and Section B (connector-flow).
       // Falls back to the unbalanced view when the helper has nothing to do.
-      const selected = deduped.length > 0
-        ? selectByComposition(deduped, context.userId)
-        : deduped;
+      const selected = digestPool.length > 0
+        ? selectByComposition(digestPool, context.userId)
+        : digestPool;
       const opportunities = selected.slice(0, CHAT_DISPLAY_LIMIT);
 
       if (!opportunities || opportunities.length === 0) {
@@ -1587,6 +1658,18 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
             message:
               "I found opportunities, but couldn't render them. Please try again.",
             ...(listDebugSteps.length ? { debugSteps: listDebugSteps } : {}),
+          });
+        }
+        // Digest mode: distinguish "everything was already shown" from "nothing
+        // exists" so the brief omits the people section instead of prompting
+        // the user to run discovery.
+        if (isDigestMode && deduped.length > 0) {
+          return success({
+            found: false,
+            count: 0,
+            summary: "No new opportunities to show",
+            message:
+              "No new opportunities today — everything actionable has already been shown recently. Omit the people section from the digest.",
           });
         }
         return success({
@@ -1629,7 +1712,6 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         if (user) userMap.set(userId, user);
       });
 
-      const isDigestMode = context.isMcp === true && query.includeDigestMarkers === true;
       const cardDataList: Array<Record<string, unknown> & { opportunityId: string }> = [];
       const seenOpportunityIds = new Set<string>();
 
@@ -1747,6 +1829,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
                       : undefined,
                     status: opp.status,
                     isGhost: isCounterpartGhost,
+                    ...(redeliveryIds.has(opp.id) ? { redelivery: true } : {}),
                     ...(viewerIsIntroducerHere && secondPartyNameForHeadline
                       ? {
                           secondParty: {

--- a/packages/protocol/src/opportunity/opportunity.utils.ts
+++ b/packages/protocol/src/opportunity/opportunity.utils.ts
@@ -348,3 +348,119 @@ export function deduplicateByPerson<T extends {
   }
   return result;
 }
+
+/**
+ * Days a digest-delivered opportunity stays suppressed before it becomes
+ * eligible for a "still open" reminder re-show (when nothing fresh exists).
+ */
+export const DIGEST_REDELIVERY_COOLDOWN_DAYS = 5;
+
+/** Committed delivery row shape consumed by {@link selectDigestCandidates}. */
+export interface DigestDeliveredRow {
+  opportunityId: string;
+  deliveredAtStatus: string;
+  deliveredAt: Date;
+}
+
+/**
+ * Cross-day digest suppression for scheduled-brief candidates.
+ *
+ * Three rules, applied in order:
+ * 1. **Accepted-counterpart suppression** — a direct-connection candidate whose
+ *    counterpart the viewer has already connected with (an `accepted`
+ *    opportunity exists with that person) is dropped permanently. A new
+ *    discovery run re-minting the same person must not resurface them.
+ *    Connector-flow candidates (viewer is the introducer) are exempt: being
+ *    connected with someone doesn't make an intro ask on their behalf stale.
+ * 2. **Delivery-ledger dedup** — candidates with a committed delivery row at
+ *    the same `(opportunityId, status)` key have already been shown. While any
+ *    fresh (never-shown) candidate exists, shown ones are dropped entirely.
+ * 3. **Cooldown re-show** — when *no* fresh candidate survives, already-shown
+ *    candidates whose latest delivery is at least `cooldownDays` old are
+ *    returned instead, least-recently-shown first, flagged via
+ *    `redeliveryIds` so the digest can frame them as reminders.
+ *
+ * Pure function — callers fetch accepted counterparts and ledger rows.
+ *
+ * @param candidates - Deduped, confidence-ordered digest candidates.
+ * @param opts.viewerId - The digest recipient.
+ * @param opts.acceptedCounterpartIds - userIds the viewer already connected with.
+ * @param opts.deliveredRows - Committed ledger rows for the candidate ids.
+ * @param opts.now - Clock override for tests.
+ * @param opts.cooldownDays - Cooldown override (default {@link DIGEST_REDELIVERY_COOLDOWN_DAYS}).
+ * @returns Surviving pool plus the set of candidate ids that are cooldown re-shows.
+ */
+export function selectDigestCandidates<T extends {
+  id: string;
+  status: string;
+  actors: Array<{ userId: string; role: string }>;
+}>(
+  candidates: T[],
+  opts: {
+    viewerId: string;
+    acceptedCounterpartIds: ReadonlySet<string>;
+    deliveredRows: DigestDeliveredRow[];
+    now?: Date;
+    cooldownDays?: number;
+  },
+): { pool: T[]; redeliveryIds: Set<string> } {
+  const { viewerId, acceptedCounterpartIds } = opts;
+
+  // Rule 1: accepted-counterpart suppression (direct connections only).
+  const afterAccepted = candidates.filter((opp) => {
+    const viewerIsIntroducer = opp.actors.some(
+      (a) => a.role === 'introducer' && a.userId === viewerId,
+    );
+    if (viewerIsIntroducer) return true;
+    const counterpart = opp.actors.find(
+      (a) => a.userId !== viewerId && a.role !== 'introducer',
+    );
+    return !counterpart || !acceptedCounterpartIds.has(counterpart.userId);
+  });
+  if (afterAccepted.length < candidates.length) {
+    logger.info(
+      `[selectDigestCandidates] accepted-counterpart suppression dropped ${candidates.length - afterAccepted.length} of ${candidates.length} candidates`,
+    );
+  }
+
+  // Rule 2: delivery-ledger dedup keyed (opportunityId, deliveredAtStatus).
+  // Keep the LATEST committed delivery per key — cooldown measures time since
+  // the user last saw the card, not since they first saw it.
+  const lastDeliveredByKey = new Map<string, Date>();
+  for (const row of opts.deliveredRows) {
+    if (!(row.deliveredAt instanceof Date) || Number.isNaN(row.deliveredAt.getTime())) continue;
+    const key = `${row.opportunityId}:${row.deliveredAtStatus}`;
+    const existing = lastDeliveredByKey.get(key);
+    if (!existing || row.deliveredAt > existing) lastDeliveredByKey.set(key, row.deliveredAt);
+  }
+
+  const fresh = afterAccepted.filter((opp) => !lastDeliveredByKey.has(`${opp.id}:${opp.status}`));
+  if (fresh.length > 0) {
+    if (fresh.length < afterAccepted.length) {
+      logger.info(
+        `[selectDigestCandidates] ledger dedup dropped ${afterAccepted.length - fresh.length} already-shown candidates`,
+      );
+    }
+    return { pool: fresh, redeliveryIds: new Set<string>() };
+  }
+
+  // Rule 3: nothing fresh — re-show the least-recently-shown candidates past cooldown.
+  const cooldownMs = (opts.cooldownDays ?? DIGEST_REDELIVERY_COOLDOWN_DAYS) * 86_400_000;
+  const now = opts.now ?? new Date();
+  const cooled = afterAccepted
+    .map((opp) => ({ opp, at: lastDeliveredByKey.get(`${opp.id}:${opp.status}`) }))
+    .filter((entry): entry is { opp: T; at: Date } =>
+      entry.at instanceof Date && now.getTime() - entry.at.getTime() >= cooldownMs,
+    )
+    .sort((a, b) => a.at.getTime() - b.at.getTime());
+
+  if (cooled.length > 0) {
+    logger.info(
+      `[selectDigestCandidates] no fresh candidates — re-showing ${cooled.length} past-cooldown candidate(s)`,
+    );
+  }
+  return {
+    pool: cooled.map((entry) => entry.opp),
+    redeliveryIds: new Set(cooled.map((entry) => entry.opp.id)),
+  };
+}

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.digest-dedup.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.digest-dedup.spec.ts
@@ -1,0 +1,522 @@
+// Stub API key to prevent module-level createModel() from throwing — only set when absent
+process.env.OPENROUTER_API_KEY ||= 'test-key-unused';
+
+import { mock, describe, expect, it, afterAll } from 'bun:test';
+
+import type { PresenterDatabase } from '../opportunity.presenter.js';
+
+// ─── Module-level mocks: must run before any static import of opportunity.tools ───
+
+let presentHomeCardMock: ReturnType<typeof mock>;
+let gatherPresenterContextMock: ReturnType<typeof mock>;
+
+mock.module('../opportunity.presenter.js', () => {
+  presentHomeCardMock = mock(async () => ({
+    headline: 'Test Headline',
+    personalizedSummary: 'Test personalized summary.',
+    digestSummary: 'A relevant person for your current signals.',
+    suggestedAction: 'Test action',
+    narratorRemark: 'Test narrator remark',
+    mutualIntentsLabel: undefined,
+  }));
+  gatherPresenterContextMock = mock(async (
+    presenterDb: PresenterDatabase,
+    opp: { status: string },
+    _viewerId: string,
+  ) => ({
+    opportunityStatus: opp.status,
+  }));
+
+  return {
+    OpportunityPresenter: class {
+      presentHomeCard(input: unknown) {
+        return presentHomeCardMock(input);
+      }
+    },
+    gatherPresenterContext: (...args: unknown[]) => gatherPresenterContextMock(...args),
+    PresenterDatabase: undefined as unknown as PresenterDatabase, // type-only, not consumed at runtime
+  };
+});
+
+afterAll(() => mock.restore());
+
+// ─── Imports after mocks ──────────────────────────────────────────────────────
+
+const { createOpportunityTools } = await import('../opportunity.tools.js');
+const { selectDigestCandidates, DIGEST_REDELIVERY_COOLDOWN_DAYS } = await import('../opportunity.utils.js');
+const { z } = await import('zod');
+
+import type { ToolDeps, DefineTool } from '../../shared/agent/tool.helpers.js';
+import type {
+  ChatGraphCompositeDatabase,
+  Opportunity,
+  UserRecord,
+  ProfileRow,
+} from '../../shared/interfaces/database.interface.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const testUserId = 'u-test-viewer';
+const DAY_MS = 86_400_000;
+
+function makeOpp(
+  id: string,
+  counterpartUserId: string,
+  status: string = 'pending',
+  confidence: number = 0.85,
+): Opportunity {
+  return {
+    id,
+    status,
+    interpretation: { reasoning: `Reasoning for ${counterpartUserId}`, confidence },
+    actors: [
+      { userId: testUserId, role: 'party' },
+      { userId: counterpartUserId, role: 'party' },
+    ],
+    detection: { source: 'discovery', createdByName: null },
+    context: {},
+    confidence: confidence,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    expiresAt: null,
+  } as unknown as Opportunity;
+}
+
+function defineTool<T extends z.ZodType>(opts: {
+  name: string;
+  description: string;
+  querySchema: T;
+  handler: (input: { context: unknown; query: z.infer<T> }) => Promise<string>;
+}) {
+  return opts;
+}
+
+function parseResult(text: string) {
+  return JSON.parse(text) as { success: boolean; data?: Record<string, unknown>; error?: string };
+}
+
+type OppFilter = { statuses?: string[]; networkId?: string; limit?: number } | undefined;
+
+function makeDeps(opts: {
+  /** Returned for the digest candidate fetch (statuses draft/pending/latent). */
+  candidates: Opportunity[];
+  /** Returned for the accepted-suppression fetch (statuses ['accepted']). */
+  accepted?: Opportunity[];
+  /** Committed ledger rows returned by the delivery ledger read. */
+  deliveredRows?: Array<{ opportunityId: string; deliveredAtStatus: string; deliveredAt: Date }>;
+  /** Force the ledger read to throw. */
+  ledgerThrows?: boolean;
+  /** Force the accepted fetch to throw. */
+  acceptedThrows?: boolean;
+  /** Omit the optional getDeliveredOpportunities method entirely. */
+  ledgerWithoutRead?: boolean;
+  profiles?: Record<string, string>;
+}): { deps: ToolDeps; calls: { acceptedFetches: OppFilter[]; ledgerReads: Array<{ userId: string; opportunityIds: string[] }> } } {
+  const calls = {
+    acceptedFetches: [] as OppFilter[],
+    ledgerReads: [] as Array<{ userId: string; opportunityIds: string[] }>,
+  };
+
+  const getOppsForUser = mock(async (_userId: string, filter: OppFilter) => {
+    if (filter?.statuses?.length === 1 && filter.statuses[0] === 'accepted') {
+      calls.acceptedFetches.push(filter);
+      if (opts.acceptedThrows) throw new Error('accepted fetch boom');
+      return opts.accepted ?? [];
+    }
+    return opts.candidates;
+  });
+  const getUser = mock(async (id: string) => ({ id, name: `Name ${id}` }) as UserRecord | null);
+  const getProfile = mock(async (id: string) => ({
+    identity: { name: opts.profiles?.[id] ?? `Profile ${id}`, bio: '', location: '' },
+    userId: id,
+  }) as unknown as ProfileRow | null);
+
+  const mockDb = {
+    getOpportunitiesForUser: getOppsForUser,
+    getUser,
+    getProfile,
+    getActiveIntents: mock(async () => []),
+    getNetwork: mock(async () => null),
+    getPremisesForUser: mock(async () => []),
+  };
+
+  const deliveryLedger = {
+    confirmOpportunityDelivery: mock(async () => 'confirmed' as const),
+    ...(opts.ledgerWithoutRead
+      ? {}
+      : {
+          getDeliveredOpportunities: mock(async (params: { userId: string; opportunityIds: string[] }) => {
+            calls.ledgerReads.push(params);
+            if (opts.ledgerThrows) throw new Error('ledger boom');
+            return opts.deliveredRows ?? [];
+          }),
+        }),
+  };
+
+  const noopGraph = { invoke: async () => ({}) };
+  const deps = {
+    database: mockDb as unknown as ChatGraphCompositeDatabase,
+    userDb: mockDb as unknown as ToolDeps['userDb'],
+    systemDb: {} as unknown as ToolDeps['systemDb'],
+    scraper: {} as unknown as ToolDeps['scraper'],
+    embedder: { embedText: mock(async () => []), generateEmbedding: mock(async () => []) } as unknown as ToolDeps['embedder'],
+    cache: {} as unknown as ToolDeps['cache'],
+    integration: {} as unknown as ToolDeps['integration'],
+    contactService: {} as unknown as ToolDeps['contactService'],
+    integrationImporter: {} as unknown as ToolDeps['integrationImporter'],
+    enricher: {} as unknown as ToolDeps['enricher'],
+    negotiationDatabase: {} as unknown as ToolDeps['negotiationDatabase'],
+    deliveryLedger: deliveryLedger as unknown as ToolDeps['deliveryLedger'],
+    graphs: {
+      profile: noopGraph,
+      intent: noopGraph,
+      index: noopGraph,
+      networkMembership: noopGraph,
+      intentIndex: noopGraph,
+      opportunity: noopGraph,
+      premise: noopGraph,
+    } as unknown as ToolDeps['graphs'],
+  } as ToolDeps;
+
+  return { deps, calls };
+}
+
+async function runListTool(deps: ToolDeps, query: Record<string, unknown> = { includeDigestMarkers: true }, contextOverrides: Record<string, unknown> = {}) {
+  const tools = createOpportunityTools(defineTool as unknown as DefineTool, deps);
+  const listTool = tools.find((t: { name: string }) => t.name === 'list_opportunities')!;
+  return parseResult(
+    await listTool.handler({
+      context: {
+        userId: testUserId,
+        isMcp: true,
+        networkId: undefined,
+        sessionId: undefined,
+        userName: 'Viewer',
+        userNetworks: [],
+        ...contextOverrides,
+      },
+      query,
+    }),
+  );
+}
+
+// ─── Pure helper: selectDigestCandidates ─────────────────────────────────────
+
+describe('selectDigestCandidates', () => {
+  const now = new Date('2026-06-12T08:00:00Z');
+  const candidate = (id: string, counterpart: string, status = 'pending') => ({
+    id,
+    status,
+    actors: [
+      { userId: testUserId, role: 'party' },
+      { userId: counterpart, role: 'party' },
+    ],
+  });
+
+  it('passes everything through when nothing is accepted or delivered', () => {
+    const cands = [candidate('o1', 'c1'), candidate('o2', 'c2')];
+    const { pool, redeliveryIds } = selectDigestCandidates(cands, {
+      viewerId: testUserId,
+      acceptedCounterpartIds: new Set(),
+      deliveredRows: [],
+      now,
+    });
+    expect(pool.map((o) => o.id)).toEqual(['o1', 'o2']);
+    expect(redeliveryIds.size).toBe(0);
+  });
+
+  it('drops candidates whose counterpart has an accepted opportunity (the Keri case)', () => {
+    const cands = [candidate('o-new-keri', 'u-keri'), candidate('o2', 'c2')];
+    const { pool } = selectDigestCandidates(cands, {
+      viewerId: testUserId,
+      acceptedCounterpartIds: new Set(['u-keri']),
+      deliveredRows: [],
+      now,
+    });
+    expect(pool.map((o) => o.id)).toEqual(['o2']);
+  });
+
+  it('does NOT apply accepted-counterpart suppression when the viewer is the introducer', () => {
+    const introOpp = {
+      id: 'o-intro',
+      status: 'latent',
+      actors: [
+        { userId: testUserId, role: 'introducer' },
+        { userId: 'u-keri', role: 'patient' },
+      ],
+    };
+    const { pool } = selectDigestCandidates([introOpp], {
+      viewerId: testUserId,
+      acceptedCounterpartIds: new Set(['u-keri']),
+      deliveredRows: [],
+      now,
+    });
+    expect(pool.map((o) => o.id)).toEqual(['o-intro']);
+  });
+
+  it('drops already-delivered candidates while fresh ones exist', () => {
+    const cands = [candidate('o-shown', 'c1'), candidate('o-fresh', 'c2')];
+    const { pool, redeliveryIds } = selectDigestCandidates(cands, {
+      viewerId: testUserId,
+      acceptedCounterpartIds: new Set(),
+      deliveredRows: [
+        { opportunityId: 'o-shown', deliveredAtStatus: 'pending', deliveredAt: new Date(now.getTime() - DAY_MS) },
+      ],
+      now,
+    });
+    expect(pool.map((o) => o.id)).toEqual(['o-fresh']);
+    expect(redeliveryIds.size).toBe(0);
+  });
+
+  it('dedups on (id, status): a delivery at a previous status does not suppress the new status', () => {
+    // Delivered while draft, later promoted to pending — pending is fresh.
+    const cands = [candidate('o1', 'c1', 'pending')];
+    const { pool } = selectDigestCandidates(cands, {
+      viewerId: testUserId,
+      acceptedCounterpartIds: new Set(),
+      deliveredRows: [
+        { opportunityId: 'o1', deliveredAtStatus: 'draft', deliveredAt: new Date(now.getTime() - DAY_MS) },
+      ],
+      now,
+    });
+    expect(pool.map((o) => o.id)).toEqual(['o1']);
+  });
+
+  it('returns nothing when everything was shown within the cooldown', () => {
+    const cands = [candidate('o1', 'c1')];
+    const { pool, redeliveryIds } = selectDigestCandidates(cands, {
+      viewerId: testUserId,
+      acceptedCounterpartIds: new Set(),
+      deliveredRows: [
+        { opportunityId: 'o1', deliveredAtStatus: 'pending', deliveredAt: new Date(now.getTime() - 2 * DAY_MS) },
+      ],
+      now,
+    });
+    expect(pool).toEqual([]);
+    expect(redeliveryIds.size).toBe(0);
+  });
+
+  it('re-shows the least-recently-shown candidate past the cooldown, flagged as redelivery', () => {
+    const cands = [candidate('o-recent', 'c1'), candidate('o-stale', 'c2')];
+    const { pool, redeliveryIds } = selectDigestCandidates(cands, {
+      viewerId: testUserId,
+      acceptedCounterpartIds: new Set(),
+      deliveredRows: [
+        { opportunityId: 'o-recent', deliveredAtStatus: 'pending', deliveredAt: new Date(now.getTime() - (DIGEST_REDELIVERY_COOLDOWN_DAYS + 1) * DAY_MS) },
+        { opportunityId: 'o-stale', deliveredAtStatus: 'pending', deliveredAt: new Date(now.getTime() - (DIGEST_REDELIVERY_COOLDOWN_DAYS + 4) * DAY_MS) },
+      ],
+      now,
+    });
+    // Oldest-shown first
+    expect(pool.map((o) => o.id)).toEqual(['o-stale', 'o-recent']);
+    expect(redeliveryIds).toEqual(new Set(['o-stale', 'o-recent']));
+  });
+
+  it('uses the LATEST delivery per key for the cooldown clock', () => {
+    const cands = [candidate('o1', 'c1')];
+    const { pool } = selectDigestCandidates(cands, {
+      viewerId: testUserId,
+      acceptedCounterpartIds: new Set(),
+      deliveredRows: [
+        // Old delivery past cooldown, but a recent one resets the clock.
+        { opportunityId: 'o1', deliveredAtStatus: 'pending', deliveredAt: new Date(now.getTime() - 30 * DAY_MS) },
+        { opportunityId: 'o1', deliveredAtStatus: 'pending', deliveredAt: new Date(now.getTime() - DAY_MS) },
+      ],
+      now,
+    });
+    expect(pool).toEqual([]);
+  });
+
+  it('accepted-counterpart suppression also applies to cooldown re-shows', () => {
+    const cands = [candidate('o-keri', 'u-keri')];
+    const { pool } = selectDigestCandidates(cands, {
+      viewerId: testUserId,
+      acceptedCounterpartIds: new Set(['u-keri']),
+      deliveredRows: [
+        { opportunityId: 'o-keri', deliveredAtStatus: 'pending', deliveredAt: new Date(now.getTime() - 30 * DAY_MS) },
+      ],
+      now,
+    });
+    expect(pool).toEqual([]);
+  });
+
+  it('ignores malformed deliveredAt values', () => {
+    const cands = [candidate('o1', 'c1')];
+    const { pool } = selectDigestCandidates(cands, {
+      viewerId: testUserId,
+      acceptedCounterpartIds: new Set(),
+      deliveredRows: [
+        { opportunityId: 'o1', deliveredAtStatus: 'pending', deliveredAt: new Date('not-a-date') },
+      ],
+      now,
+    });
+    // Malformed row is dropped → candidate counts as fresh.
+    expect(pool.map((o) => o.id)).toEqual(['o1']);
+  });
+});
+
+// ─── Tool integration: list_opportunities digest mode ────────────────────────
+
+describe('list_opportunities digest-mode cross-day suppression', () => {
+  it('suppresses a candidate whose counterpart appears in an accepted opportunity', async () => {
+    const { deps } = makeDeps({
+      candidates: [makeOpp('opp-keri-2', 'u-keri'), makeOpp('opp-other', 'u-other')],
+      accepted: [makeOpp('opp-keri-1', 'u-keri', 'accepted')],
+      profiles: { 'u-keri': 'Keri Shinn', 'u-other': 'Other Person' },
+    });
+
+    const result = await runListTool(deps);
+
+    expect(result.success).toBe(true);
+    const message = String(result.data?.message);
+    expect(message).toContain('opp-other');
+    expect(message).not.toContain('opp-keri-2');
+    expect(message).not.toContain('Keri Shinn');
+  });
+
+  it('suppresses already-delivered opportunities when fresh ones exist', async () => {
+    const { deps, calls } = makeDeps({
+      candidates: [makeOpp('opp-shown', 'c-shown'), makeOpp('opp-fresh', 'c-fresh')],
+      deliveredRows: [
+        { opportunityId: 'opp-shown', deliveredAtStatus: 'pending', deliveredAt: new Date(Date.now() - DAY_MS) },
+      ],
+    });
+
+    const result = await runListTool(deps);
+
+    expect(result.success).toBe(true);
+    expect(calls.ledgerReads).toHaveLength(1);
+    expect(calls.ledgerReads[0]).toEqual({
+      userId: testUserId,
+      opportunityIds: ['opp-shown', 'opp-fresh'],
+    });
+    const message = String(result.data?.message);
+    expect(message).toContain('opp-fresh');
+    expect(message).not.toContain('opp-shown');
+  });
+
+  it('returns the omit-section message when every candidate was shown within cooldown', async () => {
+    const { deps } = makeDeps({
+      candidates: [makeOpp('opp-shown', 'c-shown')],
+      deliveredRows: [
+        { opportunityId: 'opp-shown', deliveredAtStatus: 'pending', deliveredAt: new Date(Date.now() - DAY_MS) },
+      ],
+    });
+
+    const result = await runListTool(deps);
+
+    expect(result.success).toBe(true);
+    expect(result.data?.found).toBe(false);
+    expect(String(result.data?.message)).toContain('Omit the people section');
+    // Must NOT prompt discovery — opportunities exist, they were just shown.
+    expect(String(result.data?.message)).not.toContain('discover_opportunities');
+  });
+
+  it('re-shows a past-cooldown candidate with a redelivery marker when nothing fresh exists', async () => {
+    const staleDate = new Date(Date.now() - (DIGEST_REDELIVERY_COOLDOWN_DAYS + 2) * DAY_MS);
+    const { deps } = makeDeps({
+      candidates: [makeOpp('opp-stale', 'c-stale')],
+      deliveredRows: [
+        { opportunityId: 'opp-stale', deliveredAtStatus: 'pending', deliveredAt: staleDate },
+      ],
+    });
+
+    const result = await runListTool(deps);
+
+    expect(result.success).toBe(true);
+    expect(result.data?.found).toBe(true);
+    const message = String(result.data?.message);
+    expect(message).toContain('digest-opportunity:id=opp-stale');
+    expect(message).toContain('redelivery: true');
+  });
+
+  it('coerces string deliveredAt values across the serialization boundary', async () => {
+    const { deps } = makeDeps({
+      candidates: [makeOpp('opp-shown', 'c-shown'), makeOpp('opp-fresh', 'c-fresh')],
+      deliveredRows: [
+        {
+          opportunityId: 'opp-shown',
+          deliveredAtStatus: 'pending',
+          deliveredAt: new Date(Date.now() - DAY_MS).toISOString() as unknown as Date,
+        },
+      ],
+    });
+
+    const result = await runListTool(deps);
+    const message = String(result.data?.message);
+    expect(message).toContain('opp-fresh');
+    expect(message).not.toContain('opp-shown');
+  });
+
+  it('degrades gracefully when the ledger read throws (no suppression, no failure)', async () => {
+    const { deps } = makeDeps({
+      candidates: [makeOpp('opp-1', 'c-1')],
+      ledgerThrows: true,
+    });
+
+    const result = await runListTool(deps);
+
+    expect(result.success).toBe(true);
+    expect(result.data?.found).toBe(true);
+    expect(String(result.data?.message)).toContain('opp-1');
+  });
+
+  it('degrades gracefully when the accepted fetch throws', async () => {
+    const { deps } = makeDeps({
+      candidates: [makeOpp('opp-1', 'c-1')],
+      acceptedThrows: true,
+    });
+
+    const result = await runListTool(deps);
+
+    expect(result.success).toBe(true);
+    expect(result.data?.found).toBe(true);
+  });
+
+  it('works when the host ledger predates getDeliveredOpportunities', async () => {
+    const { deps } = makeDeps({
+      candidates: [makeOpp('opp-1', 'c-1')],
+      ledgerWithoutRead: true,
+    });
+
+    const result = await runListTool(deps);
+
+    expect(result.success).toBe(true);
+    expect(result.data?.found).toBe(true);
+    expect(String(result.data?.message)).toContain('opp-1');
+  });
+
+  it('applies NO suppression in chat mode (includeDigestMarkers absent)', async () => {
+    const { deps, calls } = makeDeps({
+      candidates: [makeOpp('opp-keri-2', 'u-keri')],
+      accepted: [makeOpp('opp-keri-1', 'u-keri', 'accepted')],
+      deliveredRows: [
+        { opportunityId: 'opp-keri-2', deliveredAtStatus: 'pending', deliveredAt: new Date(Date.now() - DAY_MS) },
+      ],
+      profiles: { 'u-keri': 'Keri Shinn' },
+    });
+
+    const result = await runListTool(deps, {});
+
+    expect(result.success).toBe(true);
+    expect(result.data?.found).toBe(true);
+    expect(String(result.data?.message)).toContain('Keri Shinn');
+    expect(calls.acceptedFetches).toHaveLength(0);
+    expect(calls.ledgerReads).toHaveLength(0);
+  });
+
+  it('applies NO suppression for non-MCP callers even with includeDigestMarkers', async () => {
+    const { deps, calls } = makeDeps({
+      candidates: [makeOpp('opp-1', 'c-1')],
+      deliveredRows: [
+        { opportunityId: 'opp-1', deliveredAtStatus: 'pending', deliveredAt: new Date(Date.now() - DAY_MS) },
+      ],
+    });
+
+    const result = await runListTool(deps, { includeDigestMarkers: true }, { isMcp: false });
+
+    expect(result.success).toBe(true);
+    expect(calls.acceptedFetches).toHaveLength(0);
+    expect(calls.ledgerReads).toHaveLength(0);
+  });
+});

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts
@@ -93,7 +93,14 @@ function parseResult(text: string) {
   return JSON.parse(text) as { success: boolean; data?: Record<string, unknown>; error?: string };
 }
 
-let getOppsForUser = mock(async () => [] as Opportunity[]);
+// Candidate list returned for the digest fetch (draft/pending/latent). The
+// digest path now also fetches statuses=['accepted'] for counterpart
+// suppression — that call must return [] or candidates suppress themselves.
+let candidateOpps: Opportunity[] = [];
+const getOppsForUser = mock(async (_userId: string, filter?: { statuses?: string[] }) => {
+  if (filter?.statuses?.length === 1 && filter.statuses[0] === 'accepted') return [] as Opportunity[];
+  return candidateOpps;
+});
 let getUser = mock(async () => ({ id: testUserId, name: 'Test User' }) as UserRecord | null);
 let getProfile = mock(async () => (null) as ProfileRow | null);
 
@@ -147,7 +154,7 @@ function makeDeps(overrides: Partial<Parameters<typeof createOpportunityTools>[1
 
 describe('list_opportunities digest presenter path', () => {
   it('uses LLM presenter text when includeDigestMarkers=true and isMcp=true', async () => {
-    getOppsForUser = mock(async () => [makeOpp('opp-1', 'c-1')]);
+    candidateOpps = [makeOpp('opp-1', 'c-1')];
     getUser = mock(async () => ({ id: testUserId, name: 'Viewer' }) as UserRecord | null);
     getProfile = mock(async () => ({ identity: { name: 'Alice', bio: '', location: '' }, userId: 'c-1' }) as ProfileRow | null);
 
@@ -177,7 +184,7 @@ describe('list_opportunities digest presenter path', () => {
   });
 
   it('skips digest cards instead of surfacing raw fallback when presenter throws', async () => {
-    getOppsForUser = mock(async () => [makeOpp('opp-2', 'c-2')]);
+    candidateOpps = [makeOpp('opp-2', 'c-2')];
     getUser = mock(async () => ({ id: testUserId, name: 'Viewer' }) as UserRecord | null);
     getProfile = mock(async () => ({ identity: { name: 'Bob', bio: '', location: '' }, userId: 'c-2' }) as ProfileRow | null);
 

--- a/packages/protocol/src/shared/interfaces/delivery-ledger.interface.ts
+++ b/packages/protocol/src/shared/interfaces/delivery-ledger.interface.ts
@@ -3,6 +3,14 @@
  * Implementations live in src/adapters (e.g. database adapter).
  */
 
+/** A committed delivery-ledger row, as read back for digest dedup. */
+export interface DeliveredOpportunityRow {
+  opportunityId: string;
+  /** Opportunity status at the time the delivery was committed. */
+  deliveredAtStatus: string;
+  deliveredAt: Date;
+}
+
 export interface DeliveryLedger {
   /**
    * Write a committed delivery row for an opportunity.
@@ -19,4 +27,17 @@ export interface DeliveryLedger {
     agentId: string | null;
     trigger: 'ambient' | 'digest' | 'accepted';
   }): Promise<'confirmed' | 'already_delivered'>;
+
+  /**
+   * Read committed delivery rows for the given opportunities delivered to the user.
+   * Used by digest mode of `list_opportunities` to suppress opportunities the user
+   * has already been shown across days, and to select cooldown re-show candidates.
+   *
+   * Optional: hosts that predate digest dedup may not implement it; callers must
+   * degrade gracefully (no suppression) when absent.
+   */
+  getDeliveredOpportunities?(params: {
+    userId: string;
+    opportunityIds: string[];
+  }): Promise<DeliveredOpportunityRow[]>;
 }


### PR DESCRIPTION
## Problem

Prod report: a user got the same recommendation **3 mornings in a row**, including for a person he had **already connected with** (accepted opportunity on Jun 6; discovery re-minted the same counterpart as a new draft on Jun 8, verified in prod DB).

Two gaps:

1. `list_opportunities` never consulted the `opportunity_deliveries` ledger — a pending/draft opportunity re-qualified for the digest every morning even after `confirm_opportunity_delivery` recorded it as shown. The AgentVillage-side dedup (`deliveredToday`) only covers the same day.
2. Nothing suppressed by **counterpart** — a re-discovery run minting a new opportunity row for an already-accepted person resurfaced them under a fresh ID.

## Changes

All strictly gated behind digest mode (`isMcp && includeDigestMarkers`) — **plain chat listing behavior is unchanged**, pinned by tests asserting the suppression mocks are never invoked outside digest mode.

- **`DeliveryLedger`** gains optional `getDeliveredOpportunities()`; backend `OpportunityDeliveryService` implements it (committed rows only, keyed user/channel/status).
- **`selectDigestCandidates()`** (pure, exported): ① drop candidates whose counterpart appears in an accepted opportunity (introducer/connector-flow candidates exempt); ② drop candidates already delivered at the same `(id, status)`; ③ when nothing fresh remains, re-show the least-recently-shown candidate past a 5-day cooldown, flagged `redelivery: true` in the digest card text so brief tooling frames it as a reminder.
- Digest-mode empty result now says "omit the people section" instead of prompting discovery when everything was suppressed.
- All suppression reads are best-effort: ledger/accepted-fetch failures degrade to no suppression, never an empty brief. Hosts predating the new ledger method also degrade gracefully.

## Companion PR

Edge-City/agentvillage: deterministic ledger confirm in the send script + "Still open" re-show framing (digest suppression here only has data to work with if confirms actually land — prod showed the LLM-prompt confirm step was being skipped). Submodule pointer bump will follow that merge.

## Tests

- 20 new protocol tests (`opportunity.tools.digest-dedup.spec.ts`): pure-helper matrix + tool integration incl. mode-gating, graceful degradation, serialization-boundary Date coercion
- 6 new backend integration tests for `getDeliveredOpportunities` (real test DB): cross-user isolation, uncommitted reservations excluded, per-status rows
- Regression: digest-presenter / tools / mcp-timeout / tool.factory suites green (146 total), `tsc` clean on protocol + backend
- Note: full-directory `bun test src/opportunity/` has 19 pre-existing failures on clean `dev` (cross-file `mock.module` leakage) — unrelated, reproduced without this change