### PR TITLE
fix(protocol): typed, retry-classified errors from confirm_opportunity_delivery

### DIFF
--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -485,6 +485,32 @@ function discoveryScopeKey(ctx: { networkId?: string; indexScope?: string[] }): 
   });
 }
 
+/**
+ * Stable, retry-classified error codes for `confirm_opportunity_delivery`.
+ *
+ * The plain `error()` envelope only carries a human message, which forced
+ * callers (the Hermes digest sweep) to treat every failure — permanent or
+ * transient — as retryable, and made "already delivered but never confirmed"
+ * impossible to distinguish from "opportunity deleted". Each code carries an
+ * explicit `retryable` flag so deterministic callers can retry transient
+ * failures and drop permanent ones instead of re-spamming the ledger.
+ */
+export type ConfirmDeliveryErrorCode =
+  | "unauthenticated"
+  | "ledger_unavailable"
+  | "invalid_opportunity_id"
+  | "opportunity_not_found"
+  | "not_authorized"
+  | "confirm_failed";
+
+function confirmDeliveryError(
+  code: ConfirmDeliveryErrorCode,
+  retryable: boolean,
+  message: string,
+): string {
+  return JSON.stringify({ success: false, error: message, code, retryable });
+}
+
 export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
   const { database, userDb, systemDb, graphs, cache } = deps;
 
@@ -2143,15 +2169,25 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
     }),
     handler: async ({ context, query }) => {
       if (!context.isMcp || !context.agentId) {
-        return error(
+        return confirmDeliveryError(
+          "unauthenticated",
+          false,
           "confirm_opportunity_delivery is only available to authenticated agent MCP contexts.",
         );
       }
       if (!deps.deliveryLedger) {
-        return error("Delivery ledger not available in this context.");
+        return confirmDeliveryError(
+          "ledger_unavailable",
+          false,
+          "Delivery ledger not available in this context.",
+        );
       }
       if (!UUID_REGEX.test(query.opportunityId)) {
-        return error("Invalid opportunity ID format.");
+        return confirmDeliveryError(
+          "invalid_opportunity_id",
+          false,
+          "Invalid opportunity ID format.",
+        );
       }
       try {
         const result = await deps.deliveryLedger.confirmOpportunityDelivery({
@@ -2162,8 +2198,40 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         });
         return success({ status: result });
       } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        // Permanent failures — the caller MUST NOT retry. Retrying a deleted
+        // opportunity or an unauthorized actor never succeeds and only spams
+        // the ledger / MCP transport.
+        if (reason === 'opportunity_not_found') {
+          logger.warn('confirm_opportunity_delivery: opportunity not found', {
+            opportunityId: query.opportunityId,
+          });
+          return confirmDeliveryError(
+            'opportunity_not_found',
+            false,
+            'Opportunity not found — it may have been deleted. Do not retry.',
+          );
+        }
+        if (reason === 'not_authorized') {
+          logger.warn('confirm_opportunity_delivery: caller is not an actor', {
+            opportunityId: query.opportunityId,
+            userId: context.userId,
+          });
+          return confirmDeliveryError(
+            'not_authorized',
+            false,
+            'You are not an actor on this opportunity. Do not retry.',
+          );
+        }
+        // Unknown / transient (e.g. DB connectivity) — safe to retry. The
+        // ledger write is idempotent, so a retry that races a prior success
+        // returns 'already_delivered' rather than a duplicate row.
         logger.error('Failed to confirm opportunity delivery', { err });
-        return error('Failed to confirm opportunity delivery. Please try again.');
+        return confirmDeliveryError(
+          'confirm_failed',
+          true,
+          'Failed to confirm opportunity delivery — transient error, safe to retry.',
+        );
       }
     },
   });

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.confirm-delivery.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.confirm-delivery.spec.ts
@@ -1,0 +1,111 @@
+// Stub API key to prevent module-level createModel() from throwing — only set when absent
+process.env.OPENROUTER_API_KEY ||= 'test-key-unused';
+
+import { mock, describe, expect, it } from 'bun:test';
+import { z } from 'zod';
+
+import { createOpportunityTools } from '../opportunity.tools.js';
+import type { ToolDeps, DefineTool } from '../../shared/agent/tool.helpers.js';
+
+// Minimal passthrough defineTool that mirrors the real registration shape.
+function defineTool<T extends z.ZodType>(opts: {
+  name: string;
+  description: string;
+  querySchema: T;
+  handler: (input: { context: unknown; query: z.infer<T> }) => Promise<string>;
+}) {
+  return opts;
+}
+
+function parseResult(text: string) {
+  return JSON.parse(text) as {
+    success: boolean;
+    data?: { status?: string };
+    error?: string;
+    code?: string;
+    retryable?: boolean;
+  };
+}
+
+const OPP_ID = 'c2505011-2e45-426e-81dd-b9abb9b72023';
+const AGENT_ID = 'a-test-agent';
+const USER_ID = 'u-test-user';
+
+function makeDeps(confirm: ToolDeps['deliveryLedger'] extends infer L
+  ? L extends { confirmOpportunityDelivery: infer F }
+    ? F
+    : never
+  : never): ToolDeps {
+  return {
+    deliveryLedger: { confirmOpportunityDelivery: confirm } as unknown as ToolDeps['deliveryLedger'],
+  } as unknown as ToolDeps;
+}
+
+function getConfirmTool(deps: ToolDeps) {
+  const tools = createOpportunityTools(defineTool as unknown as DefineTool, deps);
+  return tools.find((t: { name: string }) => t.name === 'confirm_opportunity_delivery')!;
+}
+
+const agentContext = {
+  userId: USER_ID,
+  agentId: AGENT_ID,
+  isMcp: true,
+  userName: 'Agent Owner',
+  userNetworks: [],
+};
+
+describe('confirm_opportunity_delivery — retry-classified errors', () => {
+  it('returns success with status on a committed delivery', async () => {
+    const deps = makeDeps(mock(async () => 'confirmed' as const));
+    const res = parseResult(await getConfirmTool(deps).handler({ context: agentContext, query: { opportunityId: OPP_ID, trigger: 'digest' } }));
+    expect(res.success).toBe(true);
+    expect(res.data?.status).toBe('confirmed');
+  });
+
+  it('treats already_delivered as success (idempotent re-confirm)', async () => {
+    const deps = makeDeps(mock(async () => 'already_delivered' as const));
+    const res = parseResult(await getConfirmTool(deps).handler({ context: agentContext, query: { opportunityId: OPP_ID, trigger: 'digest' } }));
+    expect(res.success).toBe(true);
+    expect(res.data?.status).toBe('already_delivered');
+  });
+
+  it('marks opportunity_not_found as a permanent (non-retryable) failure', async () => {
+    const deps = makeDeps(mock(async () => { throw new Error('opportunity_not_found'); }));
+    const res = parseResult(await getConfirmTool(deps).handler({ context: agentContext, query: { opportunityId: OPP_ID, trigger: 'digest' } }));
+    expect(res.success).toBe(false);
+    expect(res.code).toBe('opportunity_not_found');
+    expect(res.retryable).toBe(false);
+  });
+
+  it('marks not_authorized as a permanent (non-retryable) failure', async () => {
+    const deps = makeDeps(mock(async () => { throw new Error('not_authorized'); }));
+    const res = parseResult(await getConfirmTool(deps).handler({ context: agentContext, query: { opportunityId: OPP_ID, trigger: 'digest' } }));
+    expect(res.success).toBe(false);
+    expect(res.code).toBe('not_authorized');
+    expect(res.retryable).toBe(false);
+  });
+
+  it('marks an unknown/transient backend error as retryable', async () => {
+    const deps = makeDeps(mock(async () => { throw new Error('ECONNREFUSED'); }));
+    const res = parseResult(await getConfirmTool(deps).handler({ context: agentContext, query: { opportunityId: OPP_ID, trigger: 'digest' } }));
+    expect(res.success).toBe(false);
+    expect(res.code).toBe('confirm_failed');
+    expect(res.retryable).toBe(true);
+  });
+
+  it('rejects a non-agent MCP context as non-retryable unauthenticated', async () => {
+    const deps = makeDeps(mock(async () => 'confirmed' as const));
+    const res = parseResult(await getConfirmTool(deps).handler({ context: { ...agentContext, agentId: undefined }, query: { opportunityId: OPP_ID, trigger: 'digest' } }));
+    expect(res.success).toBe(false);
+    expect(res.code).toBe('unauthenticated');
+    expect(res.retryable).toBe(false);
+  });
+
+  it('rejects a malformed opportunity id as non-retryable', async () => {
+    const deps = makeDeps(mock(async () => 'confirmed' as const));
+    const res = parseResult(await getConfirmTool(deps).handler({ context: agentContext, query: { opportunityId: 'not-a-uuid', trigger: 'digest' } }));
+    expect(res.success).toBe(false);
+    expect(res.code).toBe('invalid_opportunity_id');
+    expect(res.retryable).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

`confirm_opportunity_delivery` flattened **every** failure into one opaque `"Failed to confirm opportunity delivery. Please try again."`. Callers (the AgentVillage/Hermes daily digest sweep) therefore could not tell a **permanent** failure (deleted opportunity, caller not an actor, bad auth) from a **transient** one, so they either retried doomed calls forever or treated everything as fatal. Combined with the fact that cross-day digest suppression reads the delivery **ledger**, a confirm that silently failed let the same opportunity **resurface in later digests**.

This surfaced as a real bug report from the Hermes digest flows ("Failed to confirm opportunity delivery", plus opportunities re-appearing across days).

## Change

Every error path of the tool now returns a stable machine-readable `code` and an explicit `retryable` flag alongside the human message:

| Condition | `code` | `retryable` |
|---|---|---|
| Non-agent MCP context | `unauthenticated` | false |
| Ledger dep missing | `ledger_unavailable` | false |
| Malformed UUID | `invalid_opportunity_id` | false |
| Opportunity deleted | `opportunity_not_found` | false |
| Caller not an actor | `not_authorized` | false |
| DB / transient | `confirm_failed` | **true** |

`already_delivered` remains a `success` (the write is idempotent). This is purely additive to the error envelope — existing `success:false` parsing is unaffected.

## Companion PR

The consumer side lands in [Edge-City/agentvillage#94](https://github.com/Edge-City/agentvillage/pull/94): the Hermes digest script honors `retryable` and parks transient failures for a cross-run retry, closing the resurfacing gap. That repo is wired in here as the `packages/edge-city/agentvillage` submodule; the pointer bump is intentionally deferred until #94 merges.

## Verification

- New `opportunity.tools.confirm-delivery.spec.ts` — 7 cases (success, idempotent already_delivered, each permanent code non-retryable, transient retryable, unauthenticated, invalid id).
- `bun test` across confirm-delivery + digest-dedup + tools specs → **71 pass**.
- `bun run build` (tsc) clean.