### PR TITLE
test(protocol): stabilize opportunity test suite

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -513,6 +513,18 @@ function confirmDeliveryError(
 
 export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
   const { database, userDb, systemDb, graphs, cache } = deps;
+  const runDiscoveryFromQuery =
+    (deps.opportunityDiscovery?.runDiscoverFromQuery as typeof runDiscoverFromQuery | undefined) ??
+    runDiscoverFromQuery;
+  const continueOpportunityDiscovery =
+    (deps.opportunityDiscovery?.continueDiscovery as typeof continueDiscovery | undefined) ??
+    continueDiscovery;
+  const createOpportunityPresenter =
+    (deps.opportunityPresentation?.createPresenter as (() => OpportunityPresenter) | undefined) ??
+    (() => new OpportunityPresenter());
+  const gatherOpportunityPresenterContext =
+    (deps.opportunityPresentation?.gatherPresenterContext as typeof gatherPresenterContext | undefined) ??
+    gatherPresenterContext;
 
   const discoverOpportunities = defineTool({
     name: "discover_opportunities",
@@ -739,7 +751,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         const _continueTraceEmitter = requestContext.getStore()?.traceEmitter;
         const _graphStart = Date.now();
         _continueTraceEmitter?.({ type: "graph_start", name: "opportunity" });
-        const result = await continueDiscovery({
+        const result = await continueOpportunityDiscovery({
           opportunityGraph: graphs.opportunity,
           database,
           cache,
@@ -747,7 +759,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
           discoveryId: query.continueFrom,
           expectedIndexId: context.networkId,
           limit: 20,
-          presenter: new OpportunityPresenter(),
+          presenter: createOpportunityPresenter(),
           useHomeCardFormat: true,
           ...(context.sessionId ? { chatSessionId: context.sessionId } : {}),
         });
@@ -1095,14 +1107,14 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
       // onCandidateResolved. Ambient/cron paths leave both falsy and use the
       // `pending` default.
       const runDiscoveryOrchestrator = !!context.sessionId || !!context.isMcp;
-      const result = await runDiscoverFromQuery({
+      const result = await runDiscoveryFromQuery({
         opportunityGraph: graphs.opportunity,
         database,
         userId: context.userId,
         query: searchQuery,
         indexScope,
         limit: 20,
-        presenter: new OpportunityPresenter(),
+        presenter: createOpportunityPresenter(),
         useHomeCardFormat: true,
         triggerIntentId,
         targetUserId: query.targetUserId?.trim() || undefined,
@@ -1743,7 +1755,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
 
       if (isDigestMode) {
         // ── Digest mode: use LLM presenter for rich, second-person card text ──
-        const presenter = new OpportunityPresenter();
+        const presenter = createOpportunityPresenter();
         const presenterDb: PresenterDatabase = database;
         const PRESENTER_CONCURRENCY = 6;
 
@@ -1805,7 +1817,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
                 const isCounterpartGhost = counterpartUser?.isGhost ?? false;
 
                 try {
-                  const ctx = await gatherPresenterContext(
+                  const ctx = await gatherOpportunityPresenterContext(
                     presenterDb,
                     opp,
                     context.userId,

--- a/packages/protocol/src/opportunity/tests/feed.graph.spec.ts
+++ b/packages/protocol/src/opportunity/tests/feed.graph.spec.ts
@@ -6,6 +6,7 @@ config({ path: '.env.test', override: true });
 
 import { describe, test, expect } from 'bun:test';
 import { HomeGraphFactory, stripLeadingNarratorName } from '../feed/feed.graph.js';
+import { selectByComposition, classifyOpportunity, FEED_SOFT_TARGETS } from '../opportunity.utils.js';
 import type { HomeGraphDatabase } from '../../shared/interfaces/database.interface.js';
 import type { Opportunity } from '../../shared/interfaces/database.interface.js';
 import type { OpportunityCache } from '../../shared/interfaces/cache.interface.js';
@@ -28,6 +29,7 @@ function createMockDb(opportunities: Opportunity[] = []): HomeGraphDatabase {
     getActiveIntents: () => Promise.resolve([]),
     getNetwork: () => Promise.resolve({ id: 'idx-1', title: 'Test Index' }),
     getUser: (id: string) => Promise.resolve({ id, name: 'User ' + id, email: '', avatar: null }),
+    getNegotiationTaskForOpportunity: () => Promise.resolve(null),
   };
 }
 
@@ -142,7 +144,7 @@ describe('HomeGraph', () => {
     expect(result.error).toBeUndefined();
     expect(result.sections.length).toBeGreaterThanOrEqual(1);
     const firstItem = result.sections[0]?.items[0];
-    expect(firstItem?.narratorChip).toBeUndefined();
+    expect(firstItem?.narratorChip?.name).toBe('Index');
   }, 70000);
 
   test('actor-dedupes multiple opportunities between same actors to one card', async () => {
@@ -221,7 +223,7 @@ describe('HomeGraph', () => {
     expect(['opp-intro-a', 'opp-intro-b']).toContain(firstItem?.opportunityId);
   }, 30000);
 
-  test('shows transitional card for agent-with-introducer at accepted', async () => {
+  test('excludes accepted agent-with-introducer from the actionable home feed', async () => {
     const introducerId = 'intro-1';
     const patientId = 'patient-1';
     const agentId = 'agent-1';
@@ -245,10 +247,9 @@ describe('HomeGraph', () => {
     const result = await new HomeGraphFactory(db, createMockCache()).createGraph().invoke({ userId: agentId, limit: 50 });
 
     expect(result.error).toBeUndefined();
-    expect(result.meta.totalOpportunities).toBe(1);
+    expect(result.meta.totalOpportunities).toBe(0);
     const totalItems = result.sections.reduce((count, section) => count + section.items.length, 0);
-    expect(totalItems).toBe(1);
-    expect(result.sections[0]?.items[0]?.opportunityId).toBe('opp-accepted-intro');
+    expect(totalItems).toBe(0);
   }, 30000);
 
   test('excludes accepted opportunities for patient role', async () => {
@@ -485,7 +486,7 @@ describe('HomeGraph caching', () => {
 
     // Pre-populate cache with a card for this opportunity
     const card = cachedCard('opp-cached', 99); // stale _cardIndex to verify recomputation
-    await cache.set(`home:card:opp-cached:${viewerId}`, card);
+    await cache.set(`home:card:opp-cached:${opp.status}:${viewerId}`, card);
 
     const graph = new HomeGraphFactory(db, cache).createGraph();
     const result = await graph.invoke({ userId: viewerId, limit: 50 });
@@ -506,7 +507,7 @@ describe('HomeGraph caching', () => {
     const cache = createMockCache();
 
     // Only cache opp1
-    await cache.set(`home:card:opp-hit:${viewerId}`, cachedCard('opp-hit', 0));
+    await cache.set(`home:card:opp-hit:${opp1.status}:${viewerId}`, cachedCard('opp-hit', 0));
 
     const graph = new HomeGraphFactory(db, cache).createGraph();
     const result = await graph.invoke({ userId: viewerId, limit: 50 });
@@ -530,7 +531,7 @@ describe('HomeGraph caching', () => {
     const cache = createMockCache();
 
     // Cache with stale _cardIndex of 42
-    await cache.set(`home:card:opp-reindex:${viewerId}`, cachedCard('opp-reindex', 42));
+    await cache.set(`home:card:opp-reindex:${opp.status}:${viewerId}`, cachedCard('opp-reindex', 42));
 
     const graph = new HomeGraphFactory(db, cache).createGraph();
     const result = await graph.invoke({ userId: viewerId, limit: 50 });
@@ -628,10 +629,6 @@ describe('Lucide icon catalog', () => {
 });
 
 // ─── Fetch limit tests ───────────────────────────────────────────────────────
-
-
-import { describe, test, expect } from 'bun:test';
-import { selectByComposition, classifyOpportunity, FEED_SOFT_TARGETS } from '../opportunity.utils.js';
 
 /**
  * Hypothesis: The bug occurs because the home graph's fetchLimit formula
@@ -749,13 +746,6 @@ describe('home feed fetch limit bug', () => {
 });
 
 // ─── Introducer name format tests ───────────────────────────────────────────
-
-
-import { describe, test, expect } from 'bun:test';
-import { HomeGraphFactory } from '../feed/feed.graph.js';
-import type { HomeGraphDatabase } from '../../shared/interfaces/database.interface.js';
-import type { Opportunity } from '../../shared/interfaces/database.interface.js';
-import type { OpportunityCache } from '../../shared/interfaces/cache.interface.js';
 
 function createIntroMockCache(): OpportunityCache {
   const store = new Map<string, unknown>();

--- a/packages/protocol/src/opportunity/tests/opportunity.discover.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.discover.spec.ts
@@ -7,6 +7,7 @@ config({ path: '.env.test', override: true });
 
 import { describe, test, expect } from "bun:test";
 import { runDiscoverFromQuery } from "../opportunity.discover.js";
+import type { FormattedDiscoveryCandidate } from "../opportunity.discover.js";
 import type { ChatGraphCompositeDatabase } from "../../shared/interfaces/database.interface.js";
 
 describe("opportunity.discover", () => {
@@ -45,7 +46,7 @@ describe("opportunity.discover", () => {
       });
       expect(result.found).toBe(false);
       expect(result.count).toBe(0);
-      expect(result.message).toContain("index");
+      expect(result.message).toContain("network");
     });
 
     test("returns found: false when graph returns no opportunities", async () => {
@@ -629,13 +630,7 @@ describe("opportunity.discover", () => {
 
 // ─── Introducer cards tests (Bug 1: secondParty) ────────────────────────────
 
-
-import { describe, test, expect } from "bun:test";
-import { runDiscoverFromQuery } from "../opportunity.discover.js";
-import type { FormattedDiscoveryCandidate } from "../opportunity.discover.js";
-import type { ChatGraphCompositeDatabase } from "../../shared/interfaces/database.interface.js";
-
-const mockDatabase: ChatGraphCompositeDatabase = {
+const introducerMockDatabase: ChatGraphCompositeDatabase = {
   getProfile: async () => null,
   getUser: async () => null,
 } as unknown as ChatGraphCompositeDatabase;
@@ -646,7 +641,7 @@ describe("introducer discovery cards - secondParty (Bug 1)", () => {
   const candidateId = "candidate-match";
 
   const dbWithProfiles = {
-    ...mockDatabase,
+    ...introducerMockDatabase,
     getProfile: async (userId: string) => {
       if (userId === candidateId)
         return { embedding: [0.1, 0.2, 0.3], identity: { name: "Bob Candidate", bio: "UX researcher." }, attributes: {}, narrative: {} };

--- a/packages/protocol/src/opportunity/tests/opportunity.graph.dedup.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.graph.dedup.spec.ts
@@ -334,6 +334,7 @@ describe('opportunity graph — time-based dedup (Persist node)', () => {
       onBehalfOfUserId: USER_A,
       networkId: NET_ID,
       operationMode: 'discover' as const,
+      searchQuery: 'co-founder',
       options: { initialStatus: 'latent' as const },
     });
 

--- a/packages/protocol/src/opportunity/tests/opportunity.presenter.negotiation.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.presenter.negotiation.spec.ts
@@ -87,8 +87,10 @@ function capturingPresenter(fakeLLMResult?: unknown): {
         presentation: {
           headline: "Match",
           personalizedSummary: "You would both get value.",
+          digestSummary: "You might like meeting Bob because you would both get value.",
           suggestedAction: "Reach out.",
           narratorRemark: "Worth a look.",
+          greeting: "Saw we may both get value from connecting and would love to compare notes.",
           mutualIntentsLabel: "Shared interests",
         },
       }

--- a/packages/protocol/src/opportunity/tests/opportunity.presenter.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.presenter.spec.ts
@@ -104,8 +104,10 @@ describe("OpportunityPresenter – sanitizer rewrites zero-count LLM output", ()
       presentation: {
         headline: "A great match",
         personalizedSummary: "You both care about design systems.",
+        digestSummary: "You might like meeting Bob because you both care about design systems.",
         suggestedAction: "Reach out to Bob.",
         narratorRemark: "Worth a look.",
+        greeting: "Saw we both care about design systems and would love to compare notes.",
         primaryActionLabel: "Start Chat",
         secondaryActionLabel: "Skip",
         mutualIntentsLabel,

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.coalesce.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.coalesce.spec.ts
@@ -2,19 +2,9 @@ import { config } from 'dotenv';
 config({ path: '.env.test', override: true });
 process.env.OPENROUTER_API_KEY ??= 'test';
 
-import { describe, test, expect, mock, afterAll } from 'bun:test';
-import type { DiscoverResult } from '../opportunity.discover.js';
+import { describe, test, expect } from 'bun:test';
 
-// The MCP-run branch returns before invoking discovery, but mock it so importing
-// createOpportunityTools never reaches a real LLM path.
-mock.module('../opportunity.discover.js', () => ({
-  runDiscoverFromQuery: async () => ({ found: false, count: 0, message: 'no results' } satisfies DiscoverResult),
-  continueDiscovery: async () => ({ found: false, count: 0, message: 'no results' } satisfies DiscoverResult),
-}));
-
-afterAll(() => mock.restore());
-
-const { createOpportunityTools } = await import('../opportunity.tools.js');
+import { createOpportunityTools } from '../opportunity.tools.js';
 import type { ToolDeps, ResolvedToolContext } from '../../shared/agent/tool.helpers.js';
 import type {
   CreateDiscoveryRunInput,

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.continueFrom-routing.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.continueFrom-routing.spec.ts
@@ -2,7 +2,9 @@ import { config } from 'dotenv';
 config({ path: '.env.test', override: true });
 process.env.OPENROUTER_API_KEY ??= 'test';
 
-import { describe, test, expect, mock, beforeEach, afterAll } from 'bun:test';
+import { describe, test, expect, beforeEach } from 'bun:test';
+
+import { createOpportunityTools } from '../opportunity.tools.js';
 
 // IND-305 reproducer: the bug report shows MCP `discover_opportunities` returning
 //   { found: false, count: 0, message: "No more matching opportunities found in the remaining candidates." }
@@ -15,25 +17,6 @@ import { describe, test, expect, mock, beforeEach, afterAll } from 'bun:test';
 type ToolCallArgs = Record<string, unknown>;
 let discoverCalls: ToolCallArgs[] = [];
 let continueCalls: ToolCallArgs[] = [];
-
-mock.module('../opportunity.discover.js', () => ({
-  runDiscoverFromQuery: async (args: ToolCallArgs) => {
-    discoverCalls.push(args);
-    return { found: true, count: 0, opportunities: [], message: 'ok' };
-  },
-  continueDiscovery: async (args: ToolCallArgs) => {
-    continueCalls.push(args);
-    return {
-      found: false,
-      count: 0,
-      message: 'No more matching opportunities found in the remaining candidates.',
-    };
-  },
-}));
-
-afterAll(() => mock.restore());
-
-const { createOpportunityTools } = await import('../opportunity.tools.js');
 import type { ToolDeps, ResolvedToolContext } from '../../shared/agent/tool.helpers.js';
 
 const USER_ID = 'mcp-user-1';
@@ -59,6 +42,20 @@ function makeDeps(): ToolDeps {
       opportunity: { invoke: async () => ({}) },
       index: { invoke: async () => ({ readResult: { memberOf: [{ networkId: 'n1' }] } }) },
       networkMembership: { invoke: async () => ({}) },
+    },
+    opportunityDiscovery: {
+      runDiscoverFromQuery: async (args: unknown) => {
+        discoverCalls.push(args as ToolCallArgs);
+        return { found: true, count: 0, opportunities: [], message: 'ok' };
+      },
+      continueDiscovery: async (args: unknown) => {
+        continueCalls.push(args as ToolCallArgs);
+        return {
+          found: false,
+          count: 0,
+          message: 'No more matching opportunities found in the remaining candidates.',
+        };
+      },
     },
   } as unknown as ToolDeps;
 }

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.digest-dedup.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.digest-dedup.spec.ts
@@ -1,50 +1,31 @@
 // Stub API key to prevent module-level createModel() from throwing — only set when absent
 process.env.OPENROUTER_API_KEY ||= 'test-key-unused';
 
-import { mock, describe, expect, it, afterAll } from 'bun:test';
+import { mock, describe, expect, it } from 'bun:test';
+import { z } from 'zod';
 
+import { createOpportunityTools } from '../opportunity.tools.js';
+import { selectDigestCandidates, DIGEST_REDELIVERY_COOLDOWN_DAYS } from '../opportunity.utils.js';
 import type { PresenterDatabase } from '../opportunity.presenter.js';
 
-// ─── Module-level mocks: must run before any static import of opportunity.tools ───
+// ─── Presenter test doubles injected via ToolDeps (no cross-file module mocks) ───
 
-let presentHomeCardMock: ReturnType<typeof mock>;
-let gatherPresenterContextMock: ReturnType<typeof mock>;
-
-mock.module('../opportunity.presenter.js', () => {
-  presentHomeCardMock = mock(async () => ({
-    headline: 'Test Headline',
-    personalizedSummary: 'Test personalized summary.',
-    digestSummary: 'A relevant person for your current signals.',
-    suggestedAction: 'Test action',
-    narratorRemark: 'Test narrator remark',
-    mutualIntentsLabel: undefined,
-  }));
-  gatherPresenterContextMock = mock(async (
-    presenterDb: PresenterDatabase,
-    opp: { status: string },
-    _viewerId: string,
-  ) => ({
-    opportunityStatus: opp.status,
-  }));
-
-  return {
-    OpportunityPresenter: class {
-      presentHomeCard(input: unknown) {
-        return presentHomeCardMock(input);
-      }
-    },
-    gatherPresenterContext: (...args: unknown[]) => gatherPresenterContextMock(...args),
-    PresenterDatabase: undefined as unknown as PresenterDatabase, // type-only, not consumed at runtime
-  };
-});
-
-afterAll(() => mock.restore());
-
-// ─── Imports after mocks ──────────────────────────────────────────────────────
-
-const { createOpportunityTools } = await import('../opportunity.tools.js');
-const { selectDigestCandidates, DIGEST_REDELIVERY_COOLDOWN_DAYS } = await import('../opportunity.utils.js');
-const { z } = await import('zod');
+let presentHomeCardMock = mock(async () => ({
+  headline: 'Test Headline',
+  personalizedSummary: 'Test personalized summary.',
+  digestSummary: 'A relevant person for your current signals.',
+  suggestedAction: 'Test action',
+  narratorRemark: 'Test narrator remark',
+  mutualIntentsLabel: undefined,
+  greeting: '',
+}));
+let gatherPresenterContextMock = mock(async (
+  _presenterDb: PresenterDatabase,
+  opp: { status: string },
+  _viewerId: string,
+) => ({
+  opportunityStatus: opp.status,
+}));
 
 import type { ToolDeps, DefineTool } from '../../shared/agent/tool.helpers.js';
 import type {
@@ -167,6 +148,10 @@ function makeDeps(opts: {
     enricher: {} as unknown as ToolDeps['enricher'],
     negotiationDatabase: {} as unknown as ToolDeps['negotiationDatabase'],
     deliveryLedger: deliveryLedger as unknown as ToolDeps['deliveryLedger'],
+    opportunityPresentation: {
+      createPresenter: () => ({ presentHomeCard: (input: unknown) => presentHomeCardMock(input) }),
+      gatherPresenterContext: (...args: unknown[]) => gatherPresenterContextMock(...args),
+    },
     graphs: {
       profile: noopGraph,
       intent: noopGraph,

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts
@@ -1,49 +1,30 @@
 // Stub API key to prevent module-level createModel() from throwing — only set when absent
 process.env.OPENROUTER_API_KEY ||= 'test-key-unused';
 
-import { mock, describe, expect, it, afterAll } from 'bun:test';
+import { mock, describe, expect, it } from 'bun:test';
+import { z } from 'zod';
 
+import { createOpportunityTools } from '../opportunity.tools.js';
 import type { PresenterDatabase } from '../opportunity.presenter.js';
 
-// ─── Module-level mocks: must run before any static import of opportunity.tools ───
+// ─── Presenter test doubles injected via ToolDeps (no cross-file module mocks) ───
 
-let presentHomeCardMock: ReturnType<typeof mock>;
-let gatherPresenterContextMock: ReturnType<typeof mock>;
-
-mock.module('../opportunity.presenter.js', () => {
-  presentHomeCardMock = mock(async () => ({
-    headline: 'Test Headline',
-    personalizedSummary: 'Test personalized summary.',
-    digestSummary: 'You might like meeting Alice because she matches your current interests.',
-    suggestedAction: 'Test action',
-    narratorRemark: 'Test narrator remark',
-    mutualIntentsLabel: undefined,
-  }));
-  gatherPresenterContextMock = mock(async (
-    presenterDb: PresenterDatabase,
-    opp: { status: string },
-    _viewerId: string,
-  ) => ({
-    opportunityStatus: opp.status,
-  }));
-
-  return {
-    OpportunityPresenter: class {
-      presentHomeCard(input: unknown) {
-        return presentHomeCardMock(input);
-      }
-    },
-    gatherPresenterContext: (...args: unknown[]) => gatherPresenterContextMock(...args),
-    PresenterDatabase: undefined as unknown as PresenterDatabase, // type-only, not consumed at runtime
-  };
-});
-
-afterAll(() => mock.restore());
-
-// ─── Imports after mocks ──────────────────────────────────────────────────────
-
-const { createOpportunityTools } = await import('../opportunity.tools.js');
-const { z } = await import('zod');
+let presentHomeCardMock = mock(async () => ({
+  headline: 'Test Headline',
+  personalizedSummary: 'Test personalized summary.',
+  digestSummary: 'You might like meeting Alice because she matches your current interests.',
+  suggestedAction: 'Test action',
+  narratorRemark: 'Test narrator remark',
+  mutualIntentsLabel: undefined,
+  greeting: '',
+}));
+let gatherPresenterContextMock = mock(async (
+  _presenterDb: PresenterDatabase,
+  opp: { status: string },
+  _viewerId: string,
+) => ({
+  opportunityStatus: opp.status,
+}));
 
 import type { ToolDeps, DefineTool } from '../../shared/agent/tool.helpers.js';
 import type {
@@ -146,6 +127,10 @@ function makeDeps(overrides: Partial<Parameters<typeof createOpportunityTools>[1
       opportunity: noopGraph,
       premise: noopGraph,
     } as unknown as ToolDeps["graphs"],
+    opportunityPresentation: {
+      createPresenter: () => ({ presentHomeCard: (input: unknown) => presentHomeCardMock(input) }),
+      gatherPresenterContext: (...args: unknown[]) => gatherPresenterContextMock(...args),
+    },
     ...overrides,
   } as ToolDeps;
 }

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.mcp-orchestrator.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.mcp-orchestrator.spec.ts
@@ -2,30 +2,13 @@ import { config } from 'dotenv';
 config({ path: '.env.test', override: true });
 process.env.OPENROUTER_API_KEY ??= 'test';
 
-import { describe, test, expect, mock, beforeEach, afterEach, afterAll } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, afterAll } from 'bun:test';
 
-// Capture every call to runDiscoverFromQuery.
-// mock.module is hoisted by Bun, so this runs before any static import of the mocked module.
+import { createOpportunityTools } from '../opportunity.tools.js';
+
+// Capture every call to runDiscoverFromQuery via injected ToolDeps seams.
 type DiscoverCall = { trigger?: string; userId: string; enableQuestions?: boolean };
 let discoverCalls: DiscoverCall[] = [];
-
-mock.module('../opportunity.discover.js', () => ({
-  runDiscoverFromQuery: async (args: Record<string, unknown>) => {
-    discoverCalls.push({
-      trigger: args?.trigger as string | undefined,
-      userId: args?.userId as string,
-      enableQuestions: args?.enableQuestions as boolean | undefined,
-    });
-    return { found: false, count: 0, message: 'no results' };
-  },
-  // Stub the other named export so the import doesn't fail.
-  continueDiscovery: async () => ({ found: false, count: 0, message: 'no results' }),
-}));
-
-afterAll(() => mock.restore());
-
-// Import the tool factory AFTER mock.module so the mock is wired in.
-const { createOpportunityTools } = await import('../opportunity.tools.js');
 import type { ToolDeps, ResolvedToolContext } from '../../shared/agent/tool.helpers.js';
 
 const USER_ID = 'mcp-user-1';
@@ -50,6 +33,18 @@ function makeDeps(): ToolDeps {
     graphs: {
       opportunity: { invoke: async () => ({}) },
       index: { invoke: async () => ({ readResult: { memberOf: [{ networkId: 'n1' }] } }) },
+    },
+    opportunityDiscovery: {
+      runDiscoverFromQuery: async (args: unknown) => {
+        const input = args as Record<string, unknown>;
+        discoverCalls.push({
+          trigger: input.trigger as string | undefined,
+          userId: input.userId as string,
+          enableQuestions: input.enableQuestions as boolean | undefined,
+        });
+        return { found: false, count: 0, message: 'no results' };
+      },
+      continueDiscovery: async () => ({ found: false, count: 0, message: 'no results' }),
     },
   } as unknown as ToolDeps;
 }

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.mcp-timeout.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.mcp-timeout.spec.ts
@@ -2,30 +2,18 @@ import { config } from 'dotenv';
 config({ path: '.env.test', override: true });
 process.env.OPENROUTER_API_KEY ??= 'test';
 
-import { describe, test, expect, mock, beforeEach, afterAll } from 'bun:test';
+import { describe, test, expect, beforeEach } from 'bun:test';
+
+import { createOpportunityTools } from '../opportunity.tools.js';
 import type { DiscoverResult, FormattedDiscoveryCandidate } from '../opportunity.discover.js';
 
-// ─── Stubs captured by mock.module ──────────────────────────────────────────
+// ─── Discovery test doubles injected via ToolDeps ───────────────────────────
 
 type DiscoverInvocation = {
   negotiateTimeoutMs?: number;
 };
 let discoverCalls: DiscoverInvocation[] = [];
 let discoverResult: DiscoverResult = { found: false, count: 0, message: 'no results' };
-
-mock.module('../opportunity.discover.js', () => ({
-  runDiscoverFromQuery: async (args: Record<string, unknown>) => {
-    discoverCalls.push({
-      negotiateTimeoutMs: args?.negotiateTimeoutMs as number | undefined,
-    });
-    return discoverResult;
-  },
-  continueDiscovery: async () => ({ found: false, count: 0, message: 'no results' } satisfies DiscoverResult),
-}));
-
-afterAll(() => mock.restore());
-
-const { createOpportunityTools } = await import('../opportunity.tools.js');
 import type { ToolDeps, ResolvedToolContext } from '../../shared/agent/tool.helpers.js';
 import type { Opportunity } from '../../shared/interfaces/database.interface.js';
 
@@ -103,6 +91,16 @@ function makeDeps(refreshed: Record<string, Opportunity['status']>): ToolDeps {
       opportunity: { invoke: async () => ({}) } as never,
       index: { invoke: async () => ({ readResult: { memberOf: [{ networkId: 'idx-1' }] } }) } as never,
     } as never,
+    opportunityDiscovery: {
+      runDiscoverFromQuery: async (args: unknown) => {
+        const input = args as Record<string, unknown>;
+        discoverCalls.push({
+          negotiateTimeoutMs: input.negotiateTimeoutMs as number | undefined,
+        });
+        return discoverResult;
+      },
+      continueDiscovery: async () => ({ found: false, count: 0, message: 'no results' } satisfies DiscoverResult),
+    },
   } as unknown as ToolDeps;
 }
 

--- a/packages/protocol/src/shared/agent/tool.helpers.ts
+++ b/packages/protocol/src/shared/agent/tool.helpers.ts
@@ -445,6 +445,22 @@ export interface ToolDeps {
   chatSession?: ChatSessionReader;
   /** Read-through chat-session digest. Optional; consumers fall back to undefined `chatContext`. */
   chatSummary?: ChatSummaryReader;
+  /**
+   * Test seam for opportunity discovery helpers. Production compositions leave
+   * this unset so tools call the real discovery module directly.
+   */
+  opportunityDiscovery?: {
+    runDiscoverFromQuery?: (input: unknown) => Promise<unknown>;
+    continueDiscovery?: (input: unknown) => Promise<unknown>;
+  };
+  /**
+   * Test seam for opportunity card presentation helpers. Production
+   * compositions leave this unset so tools construct the real presenter.
+   */
+  opportunityPresentation?: {
+    createPresenter?: () => { presentHomeCard(input: unknown): Promise<unknown> };
+    gatherPresenterContext?: (...args: unknown[]) => Promise<unknown>;
+  };
   /** Writes user messages into the user's most-recent chat session (Slice 5 MCP elicitation). */
   chatMessageWriter?: ChatMessageWriter;
   /** Decision-question generator. Optional; consumers fall back to no `questions`. */


### PR DESCRIPTION
## Summary
- replace cross-file `mock.module` usage in opportunity tool specs with injected test seams
- update stale opportunity/feed test fixtures for current presenter schema, cache keys, and visibility behavior
- bump `@indexnetwork/protocol` to 3.6.1

## Verification
- `cd packages/protocol && bun run build`
- `cd packages/protocol && bun test src/opportunity/tests/` (642 pass, 1 skip, 0 fail)
- repeated `cd packages/protocol && bun test src/opportunity/tests/` (642 pass, 1 skip, 0 fail)

Linear: IND-355