### PR TITLE
fix(protocol): contextualize generated questions

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/opportunity/question.prompt.ts
+++ b/packages/protocol/src/opportunity/question.prompt.ts
@@ -103,6 +103,8 @@ Ask a question only when ALL of these hold:
 2. The answer would materially change which candidates surface next.
 3. The same fact is NOT already in chatContext.statedFacts, NOT already asked in chatContext.openQuestions, and NOT already shared in chatContext.surfacedFindings.
 
+Standalone prompt rule. Every generated \`prompt\` must be understandable outside the conversation where it was created. Naturally include the original query, discovery pattern, negotiation pattern, or concrete learned fact in the question text itself. Do not rely on \`title\`, UI labels, hidden metadata, or surrounding digest/chat text to explain what the question is about. For example, prefer "For your AI crypto decentralized deep-tech search, which area is most critical right now?" over "Which area is most critical right now?"
+
 Cardinality. Default one question. Add a second only when a DIFFERENT strategy genuinely complements the first (e.g. one surface_emergent_knowledge + one refine_intent). Add a third only when there are ≥3 substantive candidates and three distinct strategies each unblock a real decision. Two questions of the same strategy are acceptable only if their decision domains differ (different titles). Avoid stacking three pulls (info-from-user); balance with pushes (info-to-user via reflective_summary / surface_emergent_knowledge).
 
 Ordering. Questions whose answer unblocks the most failed negotiations come first; then highest-impact; then ambiguity-clarifying. Negotiations whose outcome.reason is "turn_cap" or "timeout" signal under-specification — prioritize.

--- a/packages/protocol/src/opportunity/tests/question.prompt.spec.ts
+++ b/packages/protocol/src/opportunity/tests/question.prompt.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "bun:test";
 
 import {
+  SYSTEM_PROMPT,
   buildQuestionPrompt,
   type DiscoveryQuestionInput,
 } from "../question.prompt.js";
@@ -37,6 +38,19 @@ function makeInput(overrides: Partial<DiscoveryQuestionInput> = {}): DiscoveryQu
 }
 
 describe("buildQuestionPrompt", () => {
+  it("requires generated prompts to stand alone with discovery context", () => {
+    expect(SYSTEM_PROMPT).toContain("Standalone prompt rule");
+    expect(SYSTEM_PROMPT).toContain("Every generated `prompt` must be understandable outside the conversation where it was created");
+    expect(SYSTEM_PROMPT).toContain("question text itself");
+    expect(SYSTEM_PROMPT).toContain("original query");
+    expect(SYSTEM_PROMPT).toContain("discovery pattern");
+    expect(SYSTEM_PROMPT).toContain("negotiation pattern");
+    expect(SYSTEM_PROMPT).toContain("concrete learned fact");
+    expect(SYSTEM_PROMPT).toContain("Do not rely on `title`, UI labels, hidden metadata, or surrounding digest/chat text");
+    expect(SYSTEM_PROMPT).toContain("For your AI crypto decentralized deep-tech search");
+    expect(SYSTEM_PROMPT).toContain("Which area is most critical right now?");
+  });
+
   it("includes the query verbatim", () => {
     const out = buildQuestionPrompt(makeInput({ query: "find me a Rust mentor" }));
     expect(out).toContain("find me a Rust mentor");

--- a/packages/protocol/src/questioner/questioner.presets.ts
+++ b/packages/protocol/src/questioner/questioner.presets.ts
@@ -32,6 +32,10 @@ Ask a question only when ALL of these hold:
 2. The answer would materially change which candidates surface.
 3. The question targets a different decision domain from any other question in this batch.
 
+Standalone prompt rule. Every generated \`prompt\` must be understandable outside the conversation where it was created. Naturally include the source intent/topic in the question text itself, using concise plain language from the intent or summary. Do not rely on \`title\`, UI labels, hidden metadata, or surrounding digest/chat text to explain what the question is about.
+- Bad: "What kind of collaboration are you looking for?"
+- Good: "For your decentralized identity protocol-design search, what kind of collaboration are you looking for?"
+
 Cardinality. Default one question. Add a second only when a DIFFERENT strategy genuinely complements the first and unblocks a clearly distinct decision. Never ask two questions of the same strategy unless their decision domains differ (different titles).
 
 Option construction. Each option must represent a meaningfully different outcome. Suffix the safest or most common path with " (Recommended)" and list it first. The description states the CONSEQUENCE of choosing the option, not its definition. 2–4 options. Never add an "Other" option — clients provide a free-text fallback automatically.
@@ -97,6 +101,10 @@ Ask a question only when ALL of these hold:
 2. The answer is not already covered by an existing premise listed below the profile.
 3. The answer would meaningfully change which opportunities surface for this user.
 4. The question targets a different profile domain from any other question in this batch.
+
+Standalone prompt rule. Every generated \`prompt\` must be understandable outside the conversation where it was created. Naturally include the profile signal or gap being clarified in the question text itself, using concise plain language from the current profile, existing premises, or identified gaps. Do not rely on \`title\`, UI labels, hidden metadata, or surrounding digest/chat text to explain what the question is about.
+- Bad: "What kind of role are you looking for?"
+- Good: "To improve matches from your founder/operator profile, what kind of role are you looking for?"
 
 Cardinality. Default one question. Add a second only when a DIFFERENT strategy genuinely complements the first and unblocks a clearly distinct decision. Never ask two questions of the same strategy unless their decision domains differ.
 
@@ -173,6 +181,10 @@ Ask a question only when ALL of these hold:
 1. The answer is not already visible in the negotiation context or user profile shown.
 2. The answer would materially change how the next attempt surfaces or engages candidates.
 3. The question targets a different decision domain from any other question in this batch.
+
+Standalone prompt rule. Every generated \`prompt\` must be understandable outside the conversation where it was created. Naturally include the stalled negotiation context, counterparty hint, community, or key takeaway in the question text itself. Do not rely on \`title\`, UI labels, hidden metadata, or surrounding digest/chat text to explain what the question is about.
+- Bad: "Which role is a better fit for your immediate needs?"
+- Good: "For the stalled match with an AI infra founder in the AI founders community, which role is a better fit for your immediate needs?"
 
 Cardinality. Default one question. Add a second only when a DIFFERENT strategy genuinely complements the first and unblocks a clearly distinct decision. Never ask two questions of the same strategy unless their decision domains differ.
 

--- a/packages/protocol/src/questioner/tests/questioner.agent.spec.ts
+++ b/packages/protocol/src/questioner/tests/questioner.agent.spec.ts
@@ -51,6 +51,59 @@ function makeAgent(
   return agent;
 }
 
+function messageContent(message: unknown): string {
+  const content = (message as { content?: unknown }).content;
+  return typeof content === "string" ? content : JSON.stringify(content);
+}
+
+function modeInput(mode: QuestionerInput["mode"]): QuestionerInput {
+  const discoveryContext: DiscoveryContext = {
+    query: "find decentralized identity protocol designers",
+    sourceProfile: { name: "Dana" },
+    negotiationDigests: [],
+    summary: {
+      totalCandidates: 3,
+      opportunitiesFound: 1,
+      noOpportunityCount: 2,
+      timeoutCount: 1,
+      roleDistribution: {},
+    },
+    now: "2026-05-24T12:00:00.000Z",
+  };
+  const intentContext: IntentContext = {
+    intentId: "i-1",
+    payload: "Connect with people building decentralized identity protocols",
+    summary: "Decentralized identity protocol design collaborations",
+    userProfile: { name: "Dana" },
+  };
+  const profileContext: ProfileContext = {
+    userProfile: { name: "Dana", bio: "Builder of agent tools" },
+    gaps: ["availability"],
+    existingPremises: ["I build agent tools for event communities"],
+  };
+  const negotiationContext: NegotiationContext = {
+    negotiationId: "n-1",
+    counterpartyHint: "AI infra founder, Berlin",
+    indexContext: "AI founders community",
+    outcomeReason: "turn_cap",
+    keyTake: "Both interested but scope unclear",
+    userProfile: { name: "Dana" },
+  };
+  const contexts = {
+    discovery: discoveryContext,
+    intent: intentContext,
+    profile: profileContext,
+    negotiation: negotiationContext,
+  } satisfies Record<QuestionerInput["mode"], DiscoveryContext | IntentContext | ProfileContext | NegotiationContext>;
+  return {
+    mode,
+    userId: "user-1",
+    sourceType: "test",
+    sourceId: "test-1",
+    context: contexts[mode],
+  };
+}
+
 describe("QuestionerAgent", () => {
   it("returns null when the LLM throws", async () => {
     const agent = makeAgent(async () => { throw new Error("model down"); });
@@ -137,6 +190,32 @@ describe("QuestionerAgent", () => {
     });
     const result = await agent.invoke(makeDiscoveryInput(), { signal: controller.signal });
     expect(result).toBeNull();
+  });
+
+  it.each([
+    { mode: "discovery" as const, contextNeedles: ["find decentralized identity protocol designers", "3 candidates evaluated"] },
+    { mode: "intent" as const, contextNeedles: ["Connect with people building decentralized identity protocols", "Decentralized identity protocol design collaborations"] },
+    { mode: "profile" as const, contextNeedles: ["availability", "I build agent tools for event communities"] },
+    { mode: "negotiation" as const, contextNeedles: ["AI infra founder, Berlin", "Both interested but scope unclear"] },
+  ])("mode '$mode' sends standalone-context instructions alongside source evidence", async ({ mode, contextNeedles }) => {
+    let capturedMessages: unknown[] | undefined;
+    const agent = makeAgent(async (input) => {
+      capturedMessages = input as unknown[];
+      return { questions: [makeQuestion({ title: "Test" })] };
+    });
+
+    const result = await agent.invoke(modeInput(mode));
+
+    expect(result).not.toBeNull();
+    expect(capturedMessages).toHaveLength(2);
+    const systemPrompt = messageContent(capturedMessages![0]);
+    const humanPrompt = messageContent(capturedMessages![1]);
+    expect(systemPrompt).toContain("Standalone prompt rule");
+    expect(systemPrompt).toContain("Every generated `prompt` must be understandable outside the conversation where it was created");
+    expect(systemPrompt).toContain("question text itself");
+    for (const needle of contextNeedles) {
+      expect(humanPrompt).toContain(needle);
+    }
   });
 
   it.each(["discovery", "intent", "profile", "negotiation"] as const)("mode '%s' invokes the LLM and returns questions", async (mode) => {

--- a/packages/protocol/src/questioner/tests/questioner.presets.spec.ts
+++ b/packages/protocol/src/questioner/tests/questioner.presets.spec.ts
@@ -1,6 +1,49 @@
 import { describe, it, expect } from "bun:test";
 import { getPreset } from "../questioner.presets.js";
 
+const standaloneModeExpectations = [
+  {
+    mode: "discovery" as const,
+    anchors: ["original query", "discovery pattern", "negotiation pattern", "concrete learned fact"],
+    positiveExample: "For your AI crypto decentralized deep-tech search",
+    negativeExample: "Which area is most critical right now?",
+  },
+  {
+    mode: "intent" as const,
+    anchors: ["source intent/topic", "intent or summary"],
+    positiveExample: "For your decentralized identity protocol-design search",
+    negativeExample: "What kind of collaboration are you looking for?",
+  },
+  {
+    mode: "profile" as const,
+    anchors: ["profile signal or gap", "current profile", "existing premises", "identified gaps"],
+    positiveExample: "To improve matches from your founder/operator profile",
+    negativeExample: "What kind of role are you looking for?",
+  },
+  {
+    mode: "negotiation" as const,
+    anchors: ["stalled negotiation context", "counterparty hint", "community", "key takeaway"],
+    positiveExample: "For the stalled match with an AI infra founder",
+    negativeExample: "Which role is a better fit for your immediate needs?",
+  },
+];
+
+describe("standalone prompt contract", () => {
+  it.each(standaloneModeExpectations)("mode '$mode' requires self-contained generated prompt text", ({ mode, anchors, positiveExample, negativeExample }) => {
+    const preset = getPreset(mode);
+
+    expect(preset.systemPrompt).toContain("Standalone prompt rule");
+    expect(preset.systemPrompt).toContain("Every generated `prompt` must be understandable outside the conversation where it was created");
+    expect(preset.systemPrompt).toContain("question text itself");
+    expect(preset.systemPrompt).toContain("Do not rely on `title`, UI labels, hidden metadata, or surrounding digest/chat text");
+    expect(preset.systemPrompt).toContain(positiveExample);
+    expect(preset.systemPrompt).toContain(negativeExample);
+    for (const anchor of anchors) {
+      expect(preset.systemPrompt).toContain(anchor);
+    }
+  });
+});
+
 describe("getPreset", () => {
   it("returns the discovery preset with systemPrompt and buildPrompt", () => {
     const preset = getPreset("discovery");
@@ -30,6 +73,12 @@ describe("getPreset", () => {
     expect(result).toContain("Alice");
   });
 
+  it("requires discovery prompts to include source context", () => {
+    const preset = getPreset("discovery");
+    expect(preset.systemPrompt).toContain("Standalone prompt rule");
+    expect(preset.systemPrompt).toContain("original query");
+    expect(preset.systemPrompt).toContain("discovery pattern");
+  });
 });
 
 describe("intent preset", () => {
@@ -51,6 +100,14 @@ describe("intent preset", () => {
     expect(typeof result).toBe("string");
     expect(result).toContain("cofounder");
     expect(result).toContain("Alice");
+  });
+
+  it("requires intent prompts to naturally include intent context", () => {
+    const preset = getPreset("intent");
+    expect(preset.systemPrompt).toContain("Standalone prompt rule");
+    expect(preset.systemPrompt).toContain("source intent/topic");
+    expect(preset.systemPrompt).toContain("What kind of collaboration are you looking for?");
+    expect(preset.systemPrompt).toContain("decentralized identity protocol-design search");
   });
 });
 
@@ -112,6 +169,13 @@ describe("profile preset", () => {
     const preset = getPreset("profile");
     expect(preset.systemPrompt).toContain("premises");
   });
+
+  it("requires profile prompts to naturally include profile context", () => {
+    const preset = getPreset("profile");
+    expect(preset.systemPrompt).toContain("Standalone prompt rule");
+    expect(preset.systemPrompt).toContain("profile signal or gap");
+    expect(preset.systemPrompt).toContain("To improve matches from your founder/operator profile");
+  });
 });
 
 describe("negotiation preset", () => {
@@ -137,5 +201,12 @@ describe("negotiation preset", () => {
     expect(result).toContain("turn_cap");
     expect(result).toContain("AI infra founder");
     expect(result).toContain("Alice");
+  });
+
+  it("requires negotiation prompts to naturally include stall context", () => {
+    const preset = getPreset("negotiation");
+    expect(preset.systemPrompt).toContain("Standalone prompt rule");
+    expect(preset.systemPrompt).toContain("stalled negotiation context");
+    expect(preset.systemPrompt).toContain("For the stalled match with an AI infra founder");
   });
 });


### PR DESCRIPTION
## Summary
- require generated question prompts to include their originating context naturally across intent, profile, negotiation, and discovery modes
- preserve discovery prompt behavior while making standalone context explicit
- add exhaustive tests for standalone prompt contracts and agent message wiring
- bump @indexnetwork/protocol to 3.6.2

## Tests
- `cd packages/protocol && bun test src/questioner/tests/questioner.presets.spec.ts src/questioner/tests/questioner.agent.spec.ts src/opportunity/tests/question.prompt.spec.ts`
- `cd packages/protocol && bun run build`