### PR TITLE
fix(protocol): require onboarding before people discovery

### DIFF
--- a/backend/src/controllers/tests/tool.controller.spec.ts
+++ b/backend/src/controllers/tests/tool.controller.spec.ts
@@ -28,13 +28,13 @@ describe("ToolController Integration", () => {
   });
 
   /** Helper to invoke a tool and return parsed JSON. */
-  async function invokeTool(toolName: string, query: Record<string, unknown> = {}) {
+  async function invokeTool(toolName: string, query: Record<string, unknown> = {}, user: AuthenticatedUser = mockUser()) {
     const req = new Request(`http://localhost/api/tools/${toolName}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ query }),
     });
-    const res = await controller.invoke(req, mockUser(), { toolName });
+    const res = await controller.invoke(req, user, { toolName });
     const data = await res.json() as Record<string, unknown>;
     return { status: res.status, data };
   }
@@ -46,6 +46,7 @@ describe("ToolController Integration", () => {
       intro: "Integration test user for ToolController",
     });
     testUserId = userA.id;
+    await userAdapter.update(testUserId, { onboarding: { completedAt: new Date().toISOString() } });
 
     const userB = await userAdapter.create({
       email: testEmailB,
@@ -112,6 +113,19 @@ describe("ToolController Integration", () => {
     expect(status).toBe(200);
     expect(data).toBeDefined();
     console.log("read_intents result:", JSON.stringify(data).slice(0, 200));
+  }, 60_000);
+
+  test("POST /tools blocks non-onboarding tools for incomplete users", async () => {
+    const { status, data } = await invokeTool("list_contacts", {}, {
+      id: testUserBId,
+      email: testEmailB,
+      name: "Test Tool User B",
+    });
+
+    expect(status).toBe(200);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Onboarding required");
+    expect(String(data.message)).toContain("complete_onboarding");
   }, 60_000);
 
   test("POST /tools/unknown_tool should return 404 error", async () => {

--- a/backend/src/services/tool.service.ts
+++ b/backend/src/services/tool.service.ts
@@ -14,7 +14,7 @@ import {
 import { EmbedderAdapter } from '../adapters/embedder.adapter';
 import { ScraperAdapter } from '../adapters/scraper.adapter';
 import { RedisCacheAdapter } from '../adapters/cache.adapter';
-import { IntentGraphFactory, ProfileGraphFactory, OpportunityGraphFactory, HydeGraphFactory, NetworkGraphFactory, NetworkMembershipGraphFactory, IntentNetworkGraphFactory, NegotiationGraphFactory, PremiseGraphFactory, HydeGenerator, LensInferrer, IntentIndexer, resolveChatContext, createToolRegistry, invokeToolRuntime, toolRuntimeErrorToResult } from '@indexnetwork/protocol';
+import { IntentGraphFactory, ProfileGraphFactory, OpportunityGraphFactory, HydeGraphFactory, NetworkGraphFactory, NetworkMembershipGraphFactory, IntentNetworkGraphFactory, NegotiationGraphFactory, PremiseGraphFactory, HydeGenerator, LensInferrer, IntentIndexer, resolveChatContext, createToolRegistry, invokeToolRuntime, toolRuntimeErrorToResult, ONBOARDING_ALLOWED, buildMcpOnboardingMessage } from '@indexnetwork/protocol';
 import type { AgentDispatcher } from '@indexnetwork/protocol';
 import type { HydeGraphDatabase, PremiseGraphDatabase, ToolDeps, ContactServiceAdapter, IntegrationAdapter, PendingQuestionSummary } from '@indexnetwork/protocol';
 import { intentQueue } from '../queues/intent.queue';
@@ -64,6 +64,14 @@ export class ToolService {
 
     // Resolve user context
     const context = await resolveChatContext({ database, userId });
+
+    if (context.isOnboarding && !ONBOARDING_ALLOWED.has(toolName)) {
+      return {
+        success: false,
+        error: 'Onboarding required',
+        message: buildMcpOnboardingMessage(context),
+      };
+    }
 
     // Get or compile graphs (cached across requests — graphs are stateless)
     const graphs = this.getOrCompileGraphs(database);

--- a/packages/protocol/src/chat/chat.prompt.ts
+++ b/packages/protocol/src/chat/chat.prompt.ts
@@ -155,16 +155,13 @@ ${ctx.networkId ? `6. **Community discovery (skipped — already in scoped commu
 
 7. **Capture intent**
    - Ask about their active intent: "Now tell me — what are you open to right now? Building something together, thinking through a problem, exploring partnerships, hiring, or raising?"
-   - When they respond → call \`create_intent(description="...")\` — this returns a proposal card
-   - Include the \`\`\`intent_proposal block verbatim and explain: "I've drafted this as a signal for you. Approving it will let me keep an eye out for relevant people in the background."
-   - IMMEDIATELY proceed to step 8 in the SAME response — do NOT stop and wait for the user to approve the proposal
+   - When they respond → call \`create_intent(description="...", autoApprove=true)\` so the user's first signal is persisted immediately. This is required before onboarding can be completed.
+   - If the tool rejects the signal as too vague, ask one clarifying follow-up and wait. Do NOT complete onboarding until the first signal is saved.
+   - IMMEDIATELY proceed to step 8 in the SAME response after \`create_intent\` succeeds.
 
 8. **Wrap up** (must happen in the same response as step 7)
-   - Call \`discover_opportunities(searchQuery="[user's intent description]")\` to discover initial matches based on their intent
-   - If opportunities found: present them naturally, e.g. "I already found some relevant people based on what you're looking for:" followed by the opportunity cards
-   - If no opportunities found: "No matches yet, but I'll keep looking in the background."
-   - Call \`complete_onboarding()\` — this is REQUIRED and marks onboarding as finished
-   - Close with: "You're all set. I'll keep an eye out for more relevant people — check your home page for new connections."
+   - Call \`complete_onboarding()\` — this is REQUIRED and marks onboarding as finished. It will fail unless the profile is confirmed and the first active signal exists.
+   - Close with: "You're all set. I can now look for relevant people when you ask, and new connections may appear on your home page over time."
    - Offer next actions as a natural question (not buttons): "What do you want to do first? I can help you find relevant people, explore who's in your network, or look into someone specific."
 
 ### CRITICAL: Profile Confirmation Handling

--- a/packages/protocol/src/chat/tests/__snapshots__/chat.prompt.modules.spec.ts.snap
+++ b/packages/protocol/src/chat/tests/__snapshots__/chat.prompt.modules.spec.ts.snap
@@ -91,9 +91,7 @@ Other banned words: leverage, unlock, optimize, scale, disrupt, revolutionary, A
 \`\`\`
 
 ### Scoped Index (preloaded context)
-\`\`\`json
-null
-\`\`\`
+No scoped index — general chat.
 
 ### Preloaded Context Policy
 - The JSON blocks above are already fetched for this turn and are the default source of truth.
@@ -120,7 +118,7 @@ Every tool is a single-purpose CRUD operation — read, create, update, delete. 
 ## Entity Model
 
 - **User** → has one **Profile**, many **Memberships**, many **Intents**
-- **Profile** → identity (bio, skills, interests, location), vector embedding
+- **Profile** → identity (bio, skills, interests, location)
 - **Index** → community with title, prompt (purpose), join policy. Has many **Members**
 - **Membership** → User ↔ Index junction. Tracks permissions
 - **Intent** → what a user is looking for (want/need/signal). Description, summary, embedding
@@ -165,6 +163,11 @@ All tools are simple read/write operations. No hidden logic.
 - No index scope. When creating intents, the system evaluates against all user's indexes in the background.
 - To find shared context with another user, use read_network_memberships to intersect.
 
+
+### CRITICAL: Action Integrity
+- **NEVER claim you performed a write action without calling the corresponding tool.** Statements like "I've updated your profile" or "I've adjusted your premises" without calling the tool are the single most damaging error you can make — the user believes the change happened and acts on that belief. If the user asks for a change: (1) call the tool, (2) check the result, (3) THEN confirm.
+- **Non-preloaded data requires tool calls.** Intents (signals), opportunities, premises, and contacts are NOT preloaded. NEVER describe or reference specific signals without calling \`read_intents\` first. NEVER describe premises without calling \`read_premises\` first. Stating "your signals are X and Y" without a preceding tool call is fabrication.
+- **No implicit confirmation.** If the user asks you to update/change/adjust something and you have not called a write tool in this turn, you have NOT made the update. Do not say you did.
 
 ### URLs
 - Always scrape URLs with scrape_url before using their content (except for create_user_profile which handles URLs directly).
@@ -321,14 +324,10 @@ Other banned words: leverage, unlock, optimize, scale, disrupt, revolutionary, A
 \`\`\`
 
 ### Scoped Index (preloaded context)
-\`\`\`json
-{
-  "id": "idx-community",
-  "title": "AI Builders",
-  "prompt": "AI enthusiasts",
-  "membershipRole": "owner"
-}
-\`\`\`
+## AI Builders
+
+AI enthusiasts
+- **Your Role:** owner
 
 ### Preloaded Context Policy
 - The JSON blocks above are already fetched for this turn and are the default source of truth.
@@ -355,7 +354,7 @@ Every tool is a single-purpose CRUD operation — read, create, update, delete. 
 ## Entity Model
 
 - **User** → has one **Profile**, many **Memberships**, many **Intents**
-- **Profile** → identity (bio, skills, interests, location), vector embedding
+- **Profile** → identity (bio, skills, interests, location)
 - **Index** → community with title, prompt (purpose), join policy. Has many **Members**
 - **Membership** → User ↔ Index junction. Tracks permissions
 - **Intent** → what a user is looking for (want/need/signal). Description, summary, embedding
@@ -403,6 +402,11 @@ All tools are simple read/write operations. No hidden logic.
 - To query other communities, the user must start a new unscoped chat or switch to a different community.
 - When presenting, you may use the index title; avoid being vocal about 'indexes' unless the user asks.
 - You are the **owner** of this index. You can update settings, add members, delete it.
+
+### CRITICAL: Action Integrity
+- **NEVER claim you performed a write action without calling the corresponding tool.** Statements like "I've updated your profile" or "I've adjusted your premises" without calling the tool are the single most damaging error you can make — the user believes the change happened and acts on that belief. If the user asks for a change: (1) call the tool, (2) check the result, (3) THEN confirm.
+- **Non-preloaded data requires tool calls.** Intents (signals), opportunities, premises, and contacts are NOT preloaded. NEVER describe or reference specific signals without calling \`read_intents\` first. NEVER describe premises without calling \`read_premises\` first. Stating "your signals are X and Y" without a preceding tool call is fabrication.
+- **No implicit confirmation.** If the user asks you to update/change/adjust something and you have not called a write tool in this turn, you have NOT made the update. Do not say you did.
 
 ### URLs
 - Always scrape URLs with scrape_url before using their content (except for create_user_profile which handles URLs directly).
@@ -536,14 +540,21 @@ This is the user's first conversation. They just signed up. Guide them through s
    - The tool will look up public sources (LinkedIn, GitHub, etc.) using their name/email
 
 3. **Handle lookup results**
-   - **Profile found**: Present summary naturally: "Here's what I found: [bio summary]. Does that sound right?"
+   - **Profile found**: Present the bio summary, then list every detected social handle from \`detectedSocials\`: "Here's what I found: [bio summary]. I also found your GitHub at [url] and LinkedIn at [url] — are these right?"
+     - If \`detectedSocials\` contains handles: list each one and confirm they are correct before proceeding.
+     - If \`detectedSocials\` is empty or absent: ask the user to share links: "I didn't find any public profiles linked to your account. Want to share a LinkedIn, GitHub, or X/Twitter URL?"
    - **Not found**: "I couldn't confidently match your profile. Tell me who you are in a sentence or share a public link."
    - **Multiple matches**: "I found a few people with this name. Which one is you?" (list options)
    - **Sparse signals**: "I found limited public information. I'll start with what you've shared and refine over time."
 
 4. **Confirm or edit profile**
-   - If user says "yes" / confirms → call \`create_user_profile(confirm=true)\` to save their profile, then proceed to step 5
-   - If user says "no" / wants edits → call \`create_user_profile(bioOrDescription="[corrected description]", confirm=true)\` with their corrections — this regenerates and saves the profile from their text
+   - If user says "yes" / confirms (bio AND all detected socials are correct) → call \`create_user_profile(confirm=true)\` to save their profile, then proceed to step 5
+   - If a detected **github** is wrong → ask for the correct URL → call \`create_user_profile(githubUrl="[corrected url]")\` (no \`confirm\`) — re-runs the lookup and shows a new preview — present the new preview and ask again
+   - If a detected **linkedin** is wrong → ask for the correct URL → call \`create_user_profile(linkedinUrl="[corrected url]")\` (no \`confirm\`) — re-runs the lookup and shows a new preview — present the new preview and ask again
+   - If a detected **twitter** is wrong → ask for the correct URL → call \`create_user_profile(twitterUrl="[corrected url]")\` (no \`confirm\`) — re-runs the lookup and shows a new preview — present the new preview and ask again
+   - If a detected **telegram** handle is wrong → ask for the correct handle → call \`create_user_profile(websites=["https://t.me/[correct-handle]"])\` (no \`confirm\`) — the t.me URL is detected as telegram automatically
+   - If a detected **website** is wrong → ask for the correct URL → call \`create_user_profile(websites=[...all other detected websites..., "[correct-url]"])\` (no \`confirm\`) — pass ALL detected websites with the wrong one replaced, because \`websites\` overwrites the full custom-website set
+   - If user says "no" / wants bio edits → call \`create_user_profile(bioOrDescription="[corrected description]", confirm=true)\` with their corrections — this regenerates and saves the profile from their text
    - If user provides a rewrite → call \`create_user_profile(bioOrDescription="[their rewritten text]", confirm=true)\` to generate and save the updated profile
    - Do NOT use \`update_user_profile()\` during onboarding — the profile doesn't exist yet until confirmed
 
@@ -553,17 +564,26 @@ This is the user's first conversation. They just signed up. Guide them through s
      "Let's start by discovering latent opportunities inside your network.
      Connect your Google account so I can learn from your Gmail and Google Contacts — the people you already know, the conversations you've had, and where alignment may already exist. I never reach out or share anything without your approval.
      [Connect Gmail](authUrl)"
-   - The button is how the user says "yes" — clicking it opens OAuth in a new window. When they complete it the app automatically continues — call \`import_gmail_contacts()\` again to finish the import, then proceed to step 6
-   - If user says "skip", "skip for now", "no", "later", or any variant → proceed directly to step 6
-   - If already connected (tool returns import stats immediately on the first call — user never went through the auth button): **skip to step 6 immediately. Do NOT write any text about Gmail, contacts, or the import. Your next sentence must be the step 6 intro.**
-   - If the user just completed OAuth (you called \`import_gmail_contacts()\` a second time after auth): acknowledge the import with a brief summary, then proceed to step 6
+   - The button is how the user says "yes" — clicking it opens OAuth in a new window. When they complete it the app automatically continues — call \`import_gmail_contacts()\` again to finish the import, then proceed to step 5.5
+   - If user says "skip", "skip for now", "no", "later", or any variant → proceed directly to step 5.5
+   - If already connected (tool returns import stats immediately on the first call — user never went through the auth button): **skip to step 5.5 immediately. Do NOT write any text about Gmail, contacts, or the import. Your next sentence must be the step 5.5 intro.**
+   - If the user just completed OAuth (you called \`import_gmail_contacts()\` a second time after auth): acknowledge the import with a brief summary, then proceed to step 5.5
+
+5.5. **Collect location**
+   - Ask the user where they are based: "Where are you based? A city or region helps me recommend the most relevant communities and people. (e.g. 'Berlin', 'San Francisco', 'Remote' — or skip if you'd prefer not to share)"
+   - When the user provides a location → call \`create_user_profile(location="[their answer]")\` to persist it, then proceed to step 6
+   - If the user says "skip", "not sure", or any variant indicating they don't want to share → proceed directly to step 6 without persisting
 
 6. **Discover communities**
    - Call \`read_networks()\` to get available public networks (returned in \`publicNetworks\` array)
    - **If \`publicNetworks\` is missing/empty or the response carries \`scopeRestriction.isScoped: true\`, skip the panel entirely and proceed directly to step 7. Do NOT write the "communities you might find relevant" intro when there is nothing to offer.**
    - **Do NOT list communities in text.** The UI renders an interactive card panel automatically.
    - First write the intro text: "Here are some communities you might find relevant — pick any you'd like to join, or skip and we'll continue."
-   - Then immediately output this block (do not include any JSON data — just the empty object):
+   - Then immediately output this block. If \`orderedNetworkIds\` was returned by \`read_networks()\`, include those IDs; otherwise use an empty object:
+     \`\`\`networks_panel
+     {"orderedNetworkIds": ["<paste exact UUIDs from orderedNetworkIds array>"]}
+     \`\`\`
+     If \`orderedNetworkIds\` was not returned, write instead:
      \`\`\`networks_panel
      {}
      \`\`\`
@@ -573,16 +593,13 @@ This is the user's first conversation. They just signed up. Guide them through s
 
 7. **Capture intent**
    - Ask about their active intent: "Now tell me — what are you open to right now? Building something together, thinking through a problem, exploring partnerships, hiring, or raising?"
-   - When they respond → call \`create_intent(description="...")\` — this returns a proposal card
-   - Include the \`\`\`intent_proposal block verbatim and explain: "I've drafted this as a signal for you. Approving it will let me keep an eye out for relevant people in the background."
-   - IMMEDIATELY proceed to step 8 in the SAME response — do NOT stop and wait for the user to approve the proposal
+   - When they respond → call \`create_intent(description="...", autoApprove=true)\` so the user's first signal is persisted immediately. This is required before onboarding can be completed.
+   - If the tool rejects the signal as too vague, ask one clarifying follow-up and wait. Do NOT complete onboarding until the first signal is saved.
+   - IMMEDIATELY proceed to step 8 in the SAME response after \`create_intent\` succeeds.
 
 8. **Wrap up** (must happen in the same response as step 7)
-   - Call \`discover_opportunities(searchQuery="[user's intent description]")\` to discover initial matches based on their intent
-   - If opportunities found: present them naturally, e.g. "I already found some relevant people based on what you're looking for:" followed by the opportunity cards
-   - If no opportunities found: "No matches yet, but I'll keep looking in the background."
-   - Call \`complete_onboarding()\` — this is REQUIRED and marks onboarding as finished
-   - Close with: "You're all set. I'll keep an eye out for more relevant people — check your home page for new connections."
+   - Call \`complete_onboarding()\` — this is REQUIRED and marks onboarding as finished. It will fail unless the profile is confirmed and the first active signal exists.
+   - Close with: "You're all set. I can now look for relevant people when you ask, and new connections may appear on your home page over time."
    - Offer next actions as a natural question (not buttons): "What do you want to do first? I can help you find relevant people, explore who's in your network, or look into someone specific."
 
 ### CRITICAL: Profile Confirmation Handling
@@ -650,9 +667,7 @@ When the user says "yes", "looks good", "that's right", "correct", or any affirm
 \`\`\`
 
 ### Scoped Index (preloaded context)
-\`\`\`json
-null
-\`\`\`
+No scoped index — general chat.
 
 ### Preloaded Context Policy
 - The JSON blocks above are already fetched for this turn and are the default source of truth.
@@ -679,7 +694,7 @@ Every tool is a single-purpose CRUD operation — read, create, update, delete. 
 ## Entity Model
 
 - **User** → has one **Profile**, many **Memberships**, many **Intents**
-- **Profile** → identity (bio, skills, interests, location), vector embedding
+- **Profile** → identity (bio, skills, interests, location)
 - **Index** → community with title, prompt (purpose), join policy. Has many **Members**
 - **Membership** → User ↔ Index junction. Tracks permissions
 - **Intent** → what a user is looking for (want/need/signal). Description, summary, embedding
@@ -724,6 +739,11 @@ All tools are simple read/write operations. No hidden logic.
 - No index scope. When creating intents, the system evaluates against all user's indexes in the background.
 - To find shared context with another user, use read_network_memberships to intersect.
 
+
+### CRITICAL: Action Integrity
+- **NEVER claim you performed a write action without calling the corresponding tool.** Statements like "I've updated your profile" or "I've adjusted your premises" without calling the tool are the single most damaging error you can make — the user believes the change happened and acts on that belief. If the user asks for a change: (1) call the tool, (2) check the result, (3) THEN confirm.
+- **Non-preloaded data requires tool calls.** Intents (signals), opportunities, premises, and contacts are NOT preloaded. NEVER describe or reference specific signals without calling \`read_intents\` first. NEVER describe premises without calling \`read_premises\` first. Stating "your signals are X and Y" without a preceding tool call is fabrication.
+- **No implicit confirmation.** If the user asks you to update/change/adjust something and you have not called a write tool in this turn, you have NOT made the update. Do not say you did.
 
 ### URLs
 - Always scrape URLs with scrape_url before using their content (except for create_user_profile which handles URLs directly).
@@ -859,14 +879,21 @@ This is the user's first conversation. They just signed up. Guide them through s
    - The tool will look up public sources (LinkedIn, GitHub, etc.) using their name/email
 
 3. **Handle lookup results**
-   - **Profile found**: Present summary naturally: "Here's what I found: [bio summary]. Does that sound right?"
+   - **Profile found**: Present the bio summary, then list every detected social handle from \`detectedSocials\`: "Here's what I found: [bio summary]. I also found your GitHub at [url] and LinkedIn at [url] — are these right?"
+     - If \`detectedSocials\` contains handles: list each one and confirm they are correct before proceeding.
+     - If \`detectedSocials\` is empty or absent: ask the user to share links: "I didn't find any public profiles linked to your account. Want to share a LinkedIn, GitHub, or X/Twitter URL?"
    - **Not found**: "I couldn't confidently match your profile. Tell me who you are in a sentence or share a public link."
    - **Multiple matches**: "I found a few people with this name. Which one is you?" (list options)
    - **Sparse signals**: "I found limited public information. I'll start with what you've shared and refine over time."
 
 4. **Confirm or edit profile**
-   - If user says "yes" / confirms → call \`create_user_profile(confirm=true)\` to save their profile, then proceed to step 5
-   - If user says "no" / wants edits → call \`create_user_profile(bioOrDescription="[corrected description]", confirm=true)\` with their corrections — this regenerates and saves the profile from their text
+   - If user says "yes" / confirms (bio AND all detected socials are correct) → call \`create_user_profile(confirm=true)\` to save their profile, then proceed to step 5
+   - If a detected **github** is wrong → ask for the correct URL → call \`create_user_profile(githubUrl="[corrected url]")\` (no \`confirm\`) — re-runs the lookup and shows a new preview — present the new preview and ask again
+   - If a detected **linkedin** is wrong → ask for the correct URL → call \`create_user_profile(linkedinUrl="[corrected url]")\` (no \`confirm\`) — re-runs the lookup and shows a new preview — present the new preview and ask again
+   - If a detected **twitter** is wrong → ask for the correct URL → call \`create_user_profile(twitterUrl="[corrected url]")\` (no \`confirm\`) — re-runs the lookup and shows a new preview — present the new preview and ask again
+   - If a detected **telegram** handle is wrong → ask for the correct handle → call \`create_user_profile(websites=["https://t.me/[correct-handle]"])\` (no \`confirm\`) — the t.me URL is detected as telegram automatically
+   - If a detected **website** is wrong → ask for the correct URL → call \`create_user_profile(websites=[...all other detected websites..., "[correct-url]"])\` (no \`confirm\`) — pass ALL detected websites with the wrong one replaced, because \`websites\` overwrites the full custom-website set
+   - If user says "no" / wants bio edits → call \`create_user_profile(bioOrDescription="[corrected description]", confirm=true)\` with their corrections — this regenerates and saves the profile from their text
    - If user provides a rewrite → call \`create_user_profile(bioOrDescription="[their rewritten text]", confirm=true)\` to generate and save the updated profile
    - Do NOT use \`update_user_profile()\` during onboarding — the profile doesn't exist yet until confirmed
 
@@ -876,17 +903,26 @@ This is the user's first conversation. They just signed up. Guide them through s
      "Let's start by discovering latent opportunities inside your network.
      Connect your Google account so I can learn from your Gmail and Google Contacts — the people you already know, the conversations you've had, and where alignment may already exist. I never reach out or share anything without your approval.
      [Connect Gmail](authUrl)"
-   - The button is how the user says "yes" — clicking it opens OAuth in a new window. When they complete it the app automatically continues — call \`import_gmail_contacts()\` again to finish the import, then proceed to step 6
-   - If user says "skip", "skip for now", "no", "later", or any variant → proceed directly to step 6
-   - If already connected (tool returns import stats immediately on the first call — user never went through the auth button): **skip to step 6 immediately. Do NOT write any text about Gmail, contacts, or the import. Your next sentence must be the step 6 intro.**
-   - If the user just completed OAuth (you called \`import_gmail_contacts()\` a second time after auth): acknowledge the import with a brief summary, then proceed to step 6
+   - The button is how the user says "yes" — clicking it opens OAuth in a new window. When they complete it the app automatically continues — call \`import_gmail_contacts()\` again to finish the import, then proceed to step 5.5
+   - If user says "skip", "skip for now", "no", "later", or any variant → proceed directly to step 5.5
+   - If already connected (tool returns import stats immediately on the first call — user never went through the auth button): **skip to step 5.5 immediately. Do NOT write any text about Gmail, contacts, or the import. Your next sentence must be the step 5.5 intro.**
+   - If the user just completed OAuth (you called \`import_gmail_contacts()\` a second time after auth): acknowledge the import with a brief summary, then proceed to step 5.5
+
+5.5. **Collect location**
+   - Ask the user where they are based: "Where are you based? A city or region helps me recommend the most relevant communities and people. (e.g. 'Berlin', 'San Francisco', 'Remote' — or skip if you'd prefer not to share)"
+   - When the user provides a location → call \`create_user_profile(location="[their answer]")\` to persist it, then proceed to step 6
+   - If the user says "skip", "not sure", or any variant indicating they don't want to share → proceed directly to step 6 without persisting
 
 6. **Discover communities**
    - Call \`read_networks()\` to get available public networks (returned in \`publicNetworks\` array)
    - **If \`publicNetworks\` is missing/empty or the response carries \`scopeRestriction.isScoped: true\`, skip the panel entirely and proceed directly to step 7. Do NOT write the "communities you might find relevant" intro when there is nothing to offer.**
    - **Do NOT list communities in text.** The UI renders an interactive card panel automatically.
    - First write the intro text: "Here are some communities you might find relevant — pick any you'd like to join, or skip and we'll continue."
-   - Then immediately output this block (do not include any JSON data — just the empty object):
+   - Then immediately output this block. If \`orderedNetworkIds\` was returned by \`read_networks()\`, include those IDs; otherwise use an empty object:
+     \`\`\`networks_panel
+     {"orderedNetworkIds": ["<paste exact UUIDs from orderedNetworkIds array>"]}
+     \`\`\`
+     If \`orderedNetworkIds\` was not returned, write instead:
      \`\`\`networks_panel
      {}
      \`\`\`
@@ -896,16 +932,13 @@ This is the user's first conversation. They just signed up. Guide them through s
 
 7. **Capture intent**
    - Ask about their active intent: "Now tell me — what are you open to right now? Building something together, thinking through a problem, exploring partnerships, hiring, or raising?"
-   - When they respond → call \`create_intent(description="...")\` — this returns a proposal card
-   - Include the \`\`\`intent_proposal block verbatim and explain: "I've drafted this as a signal for you. Approving it will let me keep an eye out for relevant people in the background."
-   - IMMEDIATELY proceed to step 8 in the SAME response — do NOT stop and wait for the user to approve the proposal
+   - When they respond → call \`create_intent(description="...", autoApprove=true)\` so the user's first signal is persisted immediately. This is required before onboarding can be completed.
+   - If the tool rejects the signal as too vague, ask one clarifying follow-up and wait. Do NOT complete onboarding until the first signal is saved.
+   - IMMEDIATELY proceed to step 8 in the SAME response after \`create_intent\` succeeds.
 
 8. **Wrap up** (must happen in the same response as step 7)
-   - Call \`discover_opportunities(searchQuery="[user's intent description]")\` to discover initial matches based on their intent
-   - If opportunities found: present them naturally, e.g. "I already found some relevant people based on what you're looking for:" followed by the opportunity cards
-   - If no opportunities found: "No matches yet, but I'll keep looking in the background."
-   - Call \`complete_onboarding()\` — this is REQUIRED and marks onboarding as finished
-   - Close with: "You're all set. I'll keep an eye out for more relevant people — check your home page for new connections."
+   - Call \`complete_onboarding()\` — this is REQUIRED and marks onboarding as finished. It will fail unless the profile is confirmed and the first active signal exists.
+   - Close with: "You're all set. I can now look for relevant people when you ask, and new connections may appear on your home page over time."
    - Offer next actions as a natural question (not buttons): "What do you want to do first? I can help you find relevant people, explore who's in your network, or look into someone specific."
 
 ### CRITICAL: Profile Confirmation Handling
@@ -973,9 +1006,7 @@ When the user says "yes", "looks good", "that's right", "correct", or any affirm
 \`\`\`
 
 ### Scoped Index (preloaded context)
-\`\`\`json
-null
-\`\`\`
+No scoped index — general chat.
 
 ### Preloaded Context Policy
 - The JSON blocks above are already fetched for this turn and are the default source of truth.
@@ -1002,7 +1033,7 @@ Every tool is a single-purpose CRUD operation — read, create, update, delete. 
 ## Entity Model
 
 - **User** → has one **Profile**, many **Memberships**, many **Intents**
-- **Profile** → identity (bio, skills, interests, location), vector embedding
+- **Profile** → identity (bio, skills, interests, location)
 - **Index** → community with title, prompt (purpose), join policy. Has many **Members**
 - **Membership** → User ↔ Index junction. Tracks permissions
 - **Intent** → what a user is looking for (want/need/signal). Description, summary, embedding
@@ -1047,6 +1078,11 @@ All tools are simple read/write operations. No hidden logic.
 - No index scope. When creating intents, the system evaluates against all user's indexes in the background.
 - To find shared context with another user, use read_network_memberships to intersect.
 
+
+### CRITICAL: Action Integrity
+- **NEVER claim you performed a write action without calling the corresponding tool.** Statements like "I've updated your profile" or "I've adjusted your premises" without calling the tool are the single most damaging error you can make — the user believes the change happened and acts on that belief. If the user asks for a change: (1) call the tool, (2) check the result, (3) THEN confirm.
+- **Non-preloaded data requires tool calls.** Intents (signals), opportunities, premises, and contacts are NOT preloaded. NEVER describe or reference specific signals without calling \`read_intents\` first. NEVER describe premises without calling \`read_premises\` first. Stating "your signals are X and Y" without a preceding tool call is fabrication.
+- **No implicit confirmation.** If the user asks you to update/change/adjust something and you have not called a write tool in this turn, you have NOT made the update. Do not say you did.
 
 ### URLs
 - Always scrape URLs with scrape_url before using their content (except for create_user_profile which handles URLs directly).
@@ -1215,9 +1251,7 @@ Other banned words: leverage, unlock, optimize, scale, disrupt, revolutionary, A
 \`\`\`
 
 ### Scoped Index (preloaded context)
-\`\`\`json
-null
-\`\`\`
+No scoped index — general chat.
 
 ### Preloaded Context Policy
 - The JSON blocks above are already fetched for this turn and are the default source of truth.
@@ -1244,7 +1278,7 @@ Every tool is a single-purpose CRUD operation — read, create, update, delete. 
 ## Entity Model
 
 - **User** → has one **Profile**, many **Memberships**, many **Intents**
-- **Profile** → identity (bio, skills, interests, location), vector embedding
+- **Profile** → identity (bio, skills, interests, location)
 - **Index** → community with title, prompt (purpose), join policy. Has many **Members**
 - **Membership** → User ↔ Index junction. Tracks permissions
 - **Intent** → what a user is looking for (want/need/signal). Description, summary, embedding
@@ -1460,6 +1494,11 @@ remove_contact(contactId=X)
 - No index scope. When creating intents, the system evaluates against all user's indexes in the background.
 - To find shared context with another user, use read_network_memberships to intersect.
 
+
+### CRITICAL: Action Integrity
+- **NEVER claim you performed a write action without calling the corresponding tool.** Statements like "I've updated your profile" or "I've adjusted your premises" without calling the tool are the single most damaging error you can make — the user believes the change happened and acts on that belief. If the user asks for a change: (1) call the tool, (2) check the result, (3) THEN confirm.
+- **Non-preloaded data requires tool calls.** Intents (signals), opportunities, premises, and contacts are NOT preloaded. NEVER describe or reference specific signals without calling \`read_intents\` first. NEVER describe premises without calling \`read_premises\` first. Stating "your signals are X and Y" without a preceding tool call is fabrication.
+- **No implicit confirmation.** If the user asks you to update/change/adjust something and you have not called a write tool in this turn, you have NOT made the update. Do not say you did.
 
 ### URLs
 - Always scrape URLs with scrape_url before using their content (except for create_user_profile which handles URLs directly).

--- a/packages/protocol/src/chat/tests/chat.prompt.modules.spec.ts
+++ b/packages/protocol/src/chat/tests/chat.prompt.modules.spec.ts
@@ -431,6 +431,7 @@ describe("buildSystemContent snapshot identity", () => {
     expect(output).toContain("## ONBOARDING MODE (ACTIVE)");
     expect(output).toContain("### Onboarding Flow");
     expect(output).toContain("complete_onboarding()");
+    expect(output).not.toContain("Call `discover_opportunities(searchQuery=");
 
     expect(output).toMatchSnapshot();
   });

--- a/packages/protocol/src/mcp/mcp.server.ts
+++ b/packages/protocol/src/mcp/mcp.server.ts
@@ -284,7 +284,6 @@ export const ONBOARDING_ALLOWED: ReadonlySet<string> = new Set([
   'read_networks',
   'create_network_membership',
   'create_intent',
-  'discover_opportunities',
   'read_user_profiles',
 ]);
 
@@ -315,7 +314,7 @@ export function buildMcpOnboardingMessage(ctx: ResolvedToolContext): string {
     `4. Call preview_user_profile(...) using only allowed inputs; do not run public lookup unless consent was granted. If it returns profileRunId, poll get_profile_run(profileRunId=...) until status is succeeded, then use its result as the draft.\n` +
     `5. Present the profile draft and ask "Does that look right?" On approval/correction, call confirm_user_profile(...).\n` +
     `${communityStep}\n` +
-    `6. Ask what the user is looking for and call create_intent(description="...").\n` +
+    `6. Ask what the user is looking for and call create_intent(description="...", autoApprove=true) so the first signal is persisted.\n` +
     `7. Call complete_onboarding() to finish setup. Gmail/contact import and discovery are optional after onboarding, never mandatory.`
   );
 }

--- a/packages/protocol/src/mcp/tests/mcp.server.spec.ts
+++ b/packages/protocol/src/mcp/tests/mcp.server.spec.ts
@@ -271,7 +271,6 @@ describe("ONBOARDING_ALLOWED", () => {
       "read_networks",
       "create_network_membership",
       "create_intent",
-      "discover_opportunities",
       "read_user_profiles",
     ];
     for (const tool of expected) {
@@ -286,7 +285,7 @@ describe("ONBOARDING_ALLOWED", () => {
   });
 
   test("does not contain non-onboarding tools", () => {
-    for (const tool of ["list_contacts", "update_intent", "delete_network"]) {
+    for (const tool of ["list_contacts", "update_intent", "delete_network", "discover_opportunities"]) {
       expect(ONBOARDING_ALLOWED.has(tool)).toBe(false);
     }
   });

--- a/packages/protocol/src/profile/profile.tools.ts
+++ b/packages/protocol/src/profile/profile.tools.ts
@@ -1228,10 +1228,10 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
     name: "complete_onboarding",
     description:
       "Marks the user's onboarding as complete, unlocking full platform access. This is the final step in the new-user setup flow.\n\n" +
-      "**Prerequisites:** The user must have a profile (created via create_user_profile) AND must have explicitly confirmed it " +
-      "(said 'yes', 'looks good', 'that's right', or similar). Do NOT call this until the user confirms.\n\n" +
-      "**What happens:** Sets completedAt timestamp on the user's onboarding record.\n\n" +
-      "**Workflow:** create_user_profile() -> user confirms preview -> create_user_profile(confirm=true) -> user confirms saved profile -> complete_onboarding()\n\n" +
+      "**Prerequisites:** The user must have a confirmed profile AND at least one active intent/signal. The profile must be shown to the user and explicitly approved " +
+      "(said 'yes', 'looks good', 'that's right', or similar). The first signal must be persisted before this tool is called; MCP/onboarding agents should call create_intent(..., autoApprove=true).\n\n" +
+      "**What happens:** Validates that the confirmed profile and first active intent exist, then sets completedAt timestamp on the user's onboarding record.\n\n" +
+      "**Workflow:** create_user_profile() -> user confirms preview -> create_user_profile(confirm=true) -> create_intent(..., autoApprove=true) -> complete_onboarding()\n\n" +
       "**Returns:** Confirmation that onboarding is complete. No parameters needed.",
     querySchema: z.object({}),
     handler: async ({ context }) => {
@@ -1240,6 +1240,17 @@ export function createProfileTools(defineTool: DefineTool, deps: ToolDeps) {
         logger.verbose("Onboarding already completed, skipping", { userId: context.userId });
         return success({ message: "Onboarding already completed." });
       }
+
+      const confirmedProfile = await userDb.getProfile();
+      if (!confirmedProfile) {
+        return error("Onboarding cannot be completed until the user has a confirmed profile. Show the profile draft, get explicit approval, then save it before finishing onboarding.");
+      }
+
+      const activeIntents = await userDb.getActiveIntents();
+      if (activeIntents.length === 0) {
+        return error("Onboarding cannot be completed until the user has at least one active intent. Ask what they are open to right now and create the first signal before finishing onboarding.");
+      }
+
       await userDb.updateUser({
         onboarding: {
           ...currentOnboarding,

--- a/packages/protocol/src/profile/tests/profile.privacy-tools.spec.ts
+++ b/packages/protocol/src/profile/tests/profile.privacy-tools.spec.ts
@@ -54,6 +54,8 @@ describe("onboarding privacy profile tools", () => {
   let tools: CapturedTool[];
   let onboarding: ResolvedToolContext["user"]["onboarding"];
   let currentUser: ResolvedToolContext["user"];
+  let currentProfile: Record<string, unknown> | null;
+  let activeIntents: Array<{ id: string; payload: string; summary: string | null; createdAt: Date }>;
 
   const context = (): ResolvedToolContext => ({
     userId: "u1",
@@ -63,13 +65,17 @@ describe("onboarding privacy profile tools", () => {
   beforeEach(() => {
     generatedInputs = [];
     onboarding = {};
+    currentProfile = null;
+    activeIntents = [];
     currentUser = { id: "u1", name: "Alice", email: "alice@example.com", location: "Healdsburg", intro: null, socials: [], onboarding };
     updateUser = mock(async (data: { onboarding?: typeof onboarding }) => {
       if (data.onboarding) onboarding = data.onboarding;
       currentUser = { ...currentUser, ...data, onboarding };
       return currentUser;
     });
-    saveProfile = mock(async () => {});
+    saveProfile = mock(async (profile: Record<string, unknown>) => {
+      currentProfile = profile;
+    });
     setUserSocials = mock(async () => {});
     enricher = mock(async () => ({
       confidentMatch: true,
@@ -85,7 +91,8 @@ describe("onboarding privacy profile tools", () => {
       userDb: {
         getUser: async () => ({ ...currentUser, onboarding }),
         updateUser,
-        getProfile: async () => null,
+        getProfile: async () => currentProfile,
+        getActiveIntents: async () => activeIntents,
         saveProfile,
         setUserSocials,
         getUserSocials: async () => [],
@@ -322,5 +329,49 @@ describe("onboarding privacy profile tools", () => {
       { type: "graph_start", name: "profile" },
       { type: "graph_end", name: "profile" },
     ]);
+  });
+
+  it("refuses to complete onboarding without a confirmed profile", async () => {
+    const tool = tools.find((t) => t.name === "complete_onboarding")!;
+    activeIntents = [{ id: "intent-1", payload: "Looking for collaborators", summary: null, createdAt: new Date("2026-05-29T00:00:00.000Z") }];
+
+    const result = parseToolResult(await tool.handler({ context: context(), query: {} }));
+
+    expect(result.success).toBe(false);
+    expect(String(result.error)).toContain("confirmed profile");
+    expect(updateUser).not.toHaveBeenCalled();
+  });
+
+  it("refuses to complete onboarding without an active intent", async () => {
+    const tool = tools.find((t) => t.name === "complete_onboarding")!;
+    currentProfile = {
+      userId: "u1",
+      identity: { name: "Alice", bio: "Builder", location: "Healdsburg" },
+      narrative: { context: "Alice builds tools." },
+      attributes: { skills: ["TypeScript"], interests: ["agents"] },
+    };
+
+    const result = parseToolResult(await tool.handler({ context: context(), query: {} }));
+
+    expect(result.success).toBe(false);
+    expect(String(result.error)).toContain("active intent");
+    expect(updateUser).not.toHaveBeenCalled();
+  });
+
+  it("completes onboarding after profile confirmation and first active intent", async () => {
+    const tool = tools.find((t) => t.name === "complete_onboarding")!;
+    currentProfile = {
+      userId: "u1",
+      identity: { name: "Alice", bio: "Builder", location: "Healdsburg" },
+      narrative: { context: "Alice builds tools." },
+      attributes: { skills: ["TypeScript"], interests: ["agents"] },
+    };
+    activeIntents = [{ id: "intent-1", payload: "Looking for collaborators", summary: null, createdAt: new Date("2026-05-29T00:00:00.000Z") }];
+
+    const result = parseToolResult(await tool.handler({ context: context(), query: {} }));
+
+    expect(result.success).toBe(true);
+    expect(onboarding?.completedAt).toBeDefined();
+    expect(updateUser).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- Gate REST tool invocations the same way MCP gates incomplete onboarding
- Require confirmed profile data and at least one active intent before completing onboarding
- Block people discovery until onboarding is complete and update onboarding chat guidance/tests

## Related
- AgentVillage copy/daily-brief follow-up: Edge-City/agentvillage#97

## Tests
- `cd packages/protocol && OPENROUTER_API_KEY=test bun test src/mcp/tests/mcp.server.spec.ts src/profile/tests/profile.privacy-tools.spec.ts src/chat/tests/chat.prompt.modules.spec.ts`
- `cd backend && bun test src/controllers/tests/tool.controller.spec.ts`
