### PR TITLE
fix(protocol): enforce referential closure in digest follow-up questions

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/opportunity/question.prompt.ts
+++ b/packages/protocol/src/opportunity/question.prompt.ts
@@ -105,6 +105,14 @@ Ask a question only when ALL of these hold:
 
 Standalone prompt rule. Every generated \`prompt\` must be understandable outside the conversation where it was created. Naturally include the original query, discovery pattern, connection pattern, or concrete learned fact in the question text itself. Do not rely on \`title\`, UI labels, hidden metadata, or surrounding digest/chat text to explain what the question is about. For example, prefer "For your AI crypto decentralized deep-tech search, which area is most critical right now?" over "Which area is most critical right now?"
 
+Referential closure. The prompt must resolve entirely on its own, with no dangling references. The reader sees ONLY the question text — never the people you reviewed, the events on their calendar, or this conversation. Do not use demonstratives or definite anaphora that point at things the reader cannot see: "these builders", "those founders", "these researchers", "these conversations", "this lunch", "the speaker". If you reference a person, name them. If you reference a group, restate the concrete shared attribute inside the question itself ("founders working on decentralized identity"), never "these founders". Never imply a list, set, or prior exchange the reader is not currently looking at.
+- Bad: "What kind of collaboration are you looking for with these builders?"
+- Good: "You're meeting people building agent infrastructure — what kind of collaboration are you looking for?"
+
+No process narration. Never describe Index's own activity or internal state. Forbidden: "the previous negotiation", "the negotiation stalled", "opportunities found so far", "my search", "the counterparty", "candidates reviewed", restating why a match did or did not happen, or quoting words a counterparty did or did not use. Ask about the user's goal or intent directly, never about the matching pipeline.
+- Bad: "All opportunities found so far are related to 'Edge Esmeralda'. Would you like to broaden the search?"
+- Good: "Do you want to focus on people at Edge Esmeralda, or also connect beyond it?"
+
 Cardinality. Default one question. Add a second only when a DIFFERENT strategy genuinely complements the first (e.g. one surface_emergent_knowledge + one refine_intent). Add a third only when there are ≥3 substantive people reviewed and three distinct strategies each unblock a real decision. Two questions of the same strategy are acceptable only if their decision domains differ (different titles). Avoid stacking three pulls (info-from-user); balance with pushes (info-to-user via reflective_summary / surface_emergent_knowledge).
 
 Ordering. Questions whose answer unblocks the most connection reviews come first; then highest-impact; then ambiguity-clarifying. Reviews that needed more detail or ran out of time signal under-specification — prioritize.

--- a/packages/protocol/src/questioner/questioner.presets.ts
+++ b/packages/protocol/src/questioner/questioner.presets.ts
@@ -12,6 +12,22 @@ import {
 
 import type { IntentContext, NegotiationContext, ProfileContext } from "./questioner.types.js";
 
+/**
+ * Shared rule block appended to every questioner system prompt. Enforces that
+ * the generated `prompt` resolves on its own — no demonstratives/anaphora that
+ * point at people, events, or prior turns the reader cannot see — and never
+ * narrates Index's own matching pipeline. Closes the referential-leak class
+ * surfaced in digest audits ("…with these builders?", "the previous
+ * negotiation stalled because the counterparty didn't mention …").
+ */
+const REFERENTIAL_CLOSURE_RULES = `Referential closure. The prompt must resolve entirely on its own, with no dangling references. The reader sees ONLY the question text — never the people you reviewed, the counterparty, the events on their calendar, or this conversation. Do not use demonstratives or definite anaphora that point at things the reader cannot see: "these builders", "those founders", "these researchers", "these conversations", "this lunch", "the speaker". If you reference a person, name them. If you reference a group, restate the concrete shared attribute inside the question itself ("founders working on decentralized identity"), never "these founders". Never imply a list, set, or prior exchange the reader is not currently looking at.
+- Bad: "What kind of collaboration are you looking for with these builders?"
+- Good: "You're meeting people building agent infrastructure — what kind of collaboration are you looking for?"
+
+No process narration. Never describe Index's own activity or internal state. Forbidden: "the previous negotiation", "the negotiation stalled", "opportunities found so far", "my search", "the counterparty", "candidates reviewed", restating why a match did or did not happen, or quoting words a counterparty did or did not use. Ask about the user's goal or intent directly, never about the matching pipeline.
+- Bad: "The previous negotiation stalled because the counterparty didn't mention 'matchmaking'. Should I broaden the search?"
+- Good: "Do you want to focus on dedicated matchmakers, or also people interested in relationships more broadly?"`;
+
 export interface QuestionerPreset {
   /** The LLM system prompt for this mode. */
   systemPrompt: string;
@@ -35,6 +51,8 @@ Ask a question only when ALL of these hold:
 Standalone prompt rule. Every generated \`prompt\` must be understandable outside the conversation where it was created. Naturally include the source intent/topic in the question text itself, using concise plain language from the intent or summary. Do not rely on \`title\`, UI labels, hidden metadata, or surrounding digest/chat text to explain what the question is about.
 - Bad: "What kind of collaboration are you looking for?"
 - Good: "For your decentralized identity protocol-design search, what kind of collaboration are you looking for?"
+
+${REFERENTIAL_CLOSURE_RULES}
 
 Cardinality. Default one question. Add a second only when a DIFFERENT strategy genuinely complements the first and unblocks a clearly distinct decision. Never ask two questions of the same strategy unless their decision domains differ (different titles).
 
@@ -105,6 +123,8 @@ Ask a question only when ALL of these hold:
 Standalone prompt rule. Every generated \`prompt\` must be understandable outside the conversation where it was created. Naturally include the profile signal or gap being clarified in the question text itself, using concise plain language from the current profile, existing premises, or identified gaps. Do not rely on \`title\`, UI labels, hidden metadata, or surrounding digest/chat text to explain what the question is about.
 - Bad: "What kind of role are you looking for?"
 - Good: "To improve matches from your founder/operator profile, what kind of role are you looking for?"
+
+${REFERENTIAL_CLOSURE_RULES}
 
 Cardinality. Default one question. Add a second only when a DIFFERENT strategy genuinely complements the first and unblocks a clearly distinct decision. Never ask two questions of the same strategy unless their decision domains differ.
 
@@ -182,9 +202,11 @@ Ask a question only when ALL of these hold:
 2. The answer would materially change how the next attempt surfaces or engages candidates.
 3. The question targets a different decision domain from any other question in this batch.
 
-Standalone prompt rule. Every generated \`prompt\` must be understandable outside the conversation where it was created. Naturally include the stalled negotiation context, counterparty hint, community, or key takeaway in the question text itself. Do not rely on \`title\`, UI labels, hidden metadata, or surrounding digest/chat text to explain what the question is about.
+Standalone prompt rule. Every generated \`prompt\` must be understandable outside the conversation where it was created. Naturally include the user's underlying goal or topic and the relevant community in the question text itself, in plain language drawn from their intent or profile — NOT the mechanics of the match attempt. Do not rely on \`title\`, UI labels, hidden metadata, or surrounding digest/chat text to explain what the question is about.
 - Bad: "Which role is a better fit for your immediate needs?"
-- Good: "For the stalled match with an AI infra founder in the AI founders community, which role is a better fit for your immediate needs?"
+- Good: "For your search for AI infrastructure collaborators in the AI founders community, what kind of working relationship fits your immediate needs?"
+
+${REFERENTIAL_CLOSURE_RULES}
 
 Cardinality. Default one question. Add a second only when a DIFFERENT strategy genuinely complements the first and unblocks a clearly distinct decision. Never ask two questions of the same strategy unless their decision domains differ.
 

--- a/packages/protocol/src/questioner/tests/questioner.presets.spec.ts
+++ b/packages/protocol/src/questioner/tests/questioner.presets.spec.ts
@@ -22,11 +22,14 @@ const standaloneModeExpectations = [
   },
   {
     mode: "negotiation" as const,
-    anchors: ["stalled negotiation context", "counterparty hint", "community", "key takeaway"],
-    positiveExample: "For the stalled match with an AI infra founder",
+    anchors: ["underlying goal or topic", "relevant community", "intent or profile"],
+    positiveExample: "For your search for AI infrastructure collaborators in the AI founders community",
     negativeExample: "Which role is a better fit for your immediate needs?",
   },
 ];
+
+// Modes whose prompts must carry the shared referential-closure guardrail.
+const ALL_MODES = ["discovery", "intent", "profile", "negotiation"] as const;
 
 describe("standalone prompt contract", () => {
   it.each(standaloneModeExpectations)("mode '$mode' requires self-contained generated prompt text", ({ mode, anchors, positiveExample, negativeExample }) => {
@@ -203,10 +206,23 @@ describe("negotiation preset", () => {
     expect(result).toContain("Alice");
   });
 
-  it("requires negotiation prompts to naturally include stall context", () => {
+  it("requires negotiation prompts to anchor on the user's goal, not the match mechanics", () => {
     const preset = getPreset("negotiation");
     expect(preset.systemPrompt).toContain("Standalone prompt rule");
-    expect(preset.systemPrompt).toContain("stalled negotiation context");
-    expect(preset.systemPrompt).toContain("For the stalled match with an AI infra founder");
+    expect(preset.systemPrompt).toContain("underlying goal or topic");
+    expect(preset.systemPrompt).toContain("For your search for AI infrastructure collaborators in the AI founders community");
+    // Must NOT instruct the model to restate the stalled-negotiation mechanics.
+    expect(preset.systemPrompt).not.toContain("stalled negotiation context");
+  });
+});
+
+describe("referential closure contract", () => {
+  it.each(ALL_MODES)("mode '%s' forbids dangling references and process narration", (mode) => {
+    const preset = getPreset(mode);
+    expect(preset.systemPrompt).toContain("Referential closure");
+    expect(preset.systemPrompt).toContain("No process narration");
+    // The canonical defect examples must be named as anti-patterns.
+    expect(preset.systemPrompt).toContain("these builders");
+    expect(preset.systemPrompt).toContain("the counterparty");
   });
 });


### PR DESCRIPTION
## Problem

A re-audit of the 2026-06-15 daily digests found the closing **"One for you:"** question routinely references things the recipient cannot see in the standalone brief. Reported case: Timour's brief ended with *"…with these builders?"* — a plural with no antecedent. The defect is **referentiality**, not plurality:

- **Dangling references to card content that isn't there:** "these builders / researchers / founders / conversations", "the speaker", "this lunch discussion" (~11 cards).
- **Internal pipeline state leaking into user text:** *"The previous negotiation stalled because the counterparty didn't explicitly mention 'matchmaker'…"*, *"All opportunities found so far are related to 'Edge Esmeralda'…"* (2 cards).

~13 of 94 today-cards with a question were affected.

## Root cause

The digest layer renders `question.prompt` verbatim — no rewriting. Every questioner system prompt had a *"Standalone prompt rule"* telling the model to **include** source context, but nothing **forbade** demonstratives/anaphora pointing at unseen entities or narration of the matching pipeline. The negotiation preset was the worst offender: it explicitly instructed the model to restate the stalled-negotiation mechanics (Good example: *"For the stalled match with an AI infra founder…"*).

## Changes

- **`questioner/questioner.presets.ts`** — new shared `REFERENTIAL_CLOSURE_RULES` block (Referential closure + No process narration) wired into the `intent`, `profile`, and `negotiation` presets; negotiation Standalone rule rewritten to anchor on the user's goal, not the match mechanics.
- **`opportunity/question.prompt.ts`** — same rules added to the discovery system prompt (the still-live source of most digest questions).
- **`questioner/tests/questioner.presets.spec.ts`** — updated negotiation contract, added a `not.toContain("stalled negotiation context")` regression guard and a new referential-closure contract across all four modes.
- Bumped `@indexnetwork/protocol` 3.6.2 → 3.6.3.

## Tests

`bun test src/questioner/tests/` → 49 pass. `question.prompt.spec.ts` 10 pass, `question.generator.spec.ts` 13 pass. (Unrelated presenter/LLM suite failures are pre-existing and do not import the touched files.)

## Notes / follow-up

This is a prompt-level steer, not a hard guarantee. A deterministic backstop could be added later in `sanitizeQuestionPrompt()` / `composeDailyBrief` to drop any question still containing a bare demonstrative. Existing pending questions regenerate under the new prompts; rows already generated are unchanged.
