### PR TITLE
fix(backend): case-fold Telegram social handles

### DIFF
--- a/backend/src/lib/telegram/socials.ts
+++ b/backend/src/lib/telegram/socials.ts
@@ -5,10 +5,12 @@ export interface SocialRow {
 
 /**
  * Normalize a Telegram social value into the canonical DB representation.
- * Stored Telegram handles are bare handles only: no leading @, no t.me URL.
+ * Stored Telegram handles are bare, lowercase handles only: no leading @, no
+ * t.me URL. Telegram usernames are case-insensitive (@Seref and @seref resolve
+ * to the same account), so case is folded to keep comparisons drift-free.
  *
  * @param raw - Raw Telegram handle or URL.
- * @returns Bare Telegram handle, or null when the value is not routable.
+ * @returns Bare lowercase Telegram handle, or null when the value is not routable.
  */
 export function normalizeTelegramSocialValue(raw: string | null | undefined): string | null {
   if (!raw) return null;
@@ -19,7 +21,7 @@ export function normalizeTelegramSocialValue(raw: string | null | undefined): st
     .replace(/^@/, '')
     .split(/[/?#]/)[0];
 
-  return /^[A-Za-z0-9_]{5,32}$/.test(stripped) ? stripped : null;
+  return /^[A-Za-z0-9_]{5,32}$/.test(stripped) ? stripped.toLowerCase() : null;
 }
 
 /**

--- a/backend/src/lib/telegram/tests/socials.spec.ts
+++ b/backend/src/lib/telegram/tests/socials.spec.ts
@@ -8,6 +8,13 @@ describe('normalizeTelegramSocialValue', () => {
     expect(normalizeTelegramSocialValue('https://t.me/alice_tg?start=1')).toBe('alice_tg');
     expect(normalizeTelegramSocialValue('Alice Example')).toBeNull();
   });
+
+  test('folds case so @Seref and seref are the same canonical handle', () => {
+    // Telegram usernames are case-insensitive; a case-only difference is not drift.
+    expect(normalizeTelegramSocialValue('@Seref')).toBe('seref');
+    expect(normalizeTelegramSocialValue('seref')).toBe('seref');
+    expect(normalizeTelegramSocialValue('https://t.me/Alice_TG')).toBe('alice_tg');
+  });
 });
 
 describe('mergeTelegramHandleIntoSocials', () => {


### PR DESCRIPTION
## Bug Fixes
- **Case-fold Telegram social handles on write.** `normalizeTelegramSocialValue` now lowercases the validated handle, so stored Telegram socials are canonical bare + lowercase (e.g. `@Seref` → `seref`).

### Why
A Seref tenant's `Edge — heartbeat` cron failed with:
> `RuntimeError: I found conflicting Telegram handles … EdgeOS has seref while the runtime system is using @Seref`

Telegram usernames are case-insensitive, so `seref` and `@Seref` are the same account — but the **write path** stored mixed case, while the read/ownership paths (`findTelegramHandleOwners` SQL `lower(...)`, `findTelegramHandleMismatch`) already folded case. That asymmetry let a case-only difference register as drift and trip the heartbeat `telegram-handle-reconciliation` false positive. This aligns the write path with the read path.

### Scope
This is the backend half. The AgentVillage submodule (`Edge-City/agentvillage`) carries the matching fix to `normalizeTelegramHandle`, the persisted `INDEX_TELEGRAM_HANDLE`, and the `heartbeat.md`/`tools.md`/`bootstrap.md` normalize rules — landing via a separate PR against `Edge-City/agentvillage:main`, then a submodule pointer bump.

## Tests
- `backend/src/lib/telegram/tests/socials.spec.ts` — added a case-folding case; 6/6 pass.
