### PR TITLE
fix(intents): join-time network reconcile + assignment-only foundation

### DIFF
--- a/.rpiv/artifacts/designs/intent-network-orphaning-fix.md
+++ b/.rpiv/artifacts/designs/intent-network-orphaning-fix.md
@@ -127,35 +127,44 @@ addReconcileJob(d: IntentReconcileData) {
 This is the shared primitive used by both backfill-on-join and the safety-net
 sweep below.
 
-### 3. Backfill-on-join
+### 3. Backfill-on-join (membership-event seam)
 
-When a user joins / is added to a non-personal network, enqueue a
-network-scoped reconcile for each of their active intents so existing intents
-get a chance to land in the newly-joined network.
+"Joining a network re-evaluates the member's existing intents against it" is a
+**protocol-level definition of membership**, not application glue. It must fire
+for *every* membership path, not just one backend service method. All paths —
+REST self-join (`joinPublicNetwork`), owner-add (`addMemberForOwner`), and the
+protocol `create_network_membership` graph (`addMemberNode`) — converge on the
+adapter method `ChatDatabaseAdapter.addMemberToNetwork`, which emits
+`NetworkMembershipEvents.onMemberAdded(userId, networkId)` exactly once per
+genuinely-new member. That event is the single canonical seam (it already
+drives profile-HyDE and user-context regen on join).
 
-Hook points (producers only — `NetworkService` already imports queues):
-
-- `network.service.ts:joinPublicNetwork`
-- `network.service.ts:addMember`
+Wire the reconcile into the existing `onMemberAdded` handler in `main.ts`, and
+encapsulate the per-intent fan-out in the queue so the composition root stays a
+thin wiring line:
 
 ```ts
-async joinPublicNetwork(networkId: string, userId: string) {
-  await this.adapter.joinPublicNetwork(networkId, userId);
-  await this.enqueueNetworkBackfill(networkId, userId); // best-effort, catches errors
-  return this.adapter.getNetworkDetail(networkId, userId);
+// IntentQueue
+async addNetworkReconcileForUser(userId: string, networkId: string): Promise<number> {
+  const db = this.deps?.database ?? this.database;
+  const intents = await db.getActiveIntents(userId);
+  await Promise.all(intents.map(i =>
+    this.addReconcileJob({ intentId: i.id, userId, networkScopeId: networkId })
+      .catch(err => this.logger.warn('[IntentReconcile] enqueue failed', { intentId: i.id, networkId, userId, error: err }))
+  ));
+  return intents.length;
 }
 
-private async enqueueNetworkBackfill(networkId: string, userId: string) {
-  const intents = await this.adapter.getActiveIntents(userId); // id + userId
-  await Promise.all(intents.map(i =>
-    intentQueue.addReconcileJob({ intentId: i.id, userId, networkScopeId: networkId })
-      .catch(err => logger.warn('[NetworkBackfill] enqueue failed', { intentId: i.id, networkId, err }))
-  ));
-}
+// main.ts — NetworkMembershipEvents.onMemberAdded handler
+intentQueue.addNetworkReconcileForUser(userId, networkId).catch((err) => {
+  log.job.from('NetworkMembership').error('Failed to enqueue intent network reconcile', { userId, networkId, error: err });
+});
 ```
 
-Scoping to `networkId` keeps it cheap (one network evaluated per intent) and
-avoids re-touching unrelated memberships.
+Do **not** put this in `NetworkService.joinPublicNetwork`/`addMember` — that
+would cover only the REST path and duplicate a definition the protocol/membership
+layer already owns. Scoping to `networkId` keeps it cheap (one network evaluated
+per intent) and avoids re-touching unrelated memberships.
 
 ### 4. Safety-net reconciliation sweep (catches everything else)
 
@@ -205,7 +214,7 @@ human-initiated, in-network creation.
 | File | Change |
 |---|---|
 | `backend/src/queues/intent.queue.ts` | Extract `assignIntentToNetworks`; add `reconcile_intent_networks` job + `addReconcileJob`; orphan warning/metric |
-| `backend/src/services/network.service.ts` | Enqueue network-scoped backfill on `joinPublicNetwork` + `addMember` |
+| `backend/src/main.ts` | Enqueue network-scoped reconcile from the `NetworkMembershipEvents.onMemberAdded` handler (covers REST + protocol membership paths uniformly) |
 | `backend/src/adapters/database.adapter.ts` | Add `getOrphanedActiveIntents`; ensure `getActiveIntents` returns `{id,userId}` |
 | `backend/src/queues/*` (cron) | Register orphan-reconcile sweep; wire `startCrons`/`close` in `main.ts` |
 | `backend/src/queues/tests/intent.queue.spec.ts` | Tests: assignment core extraction, reconcile job assigns without HyDE/opportunity, orphan warning fires |
@@ -216,8 +225,8 @@ human-initiated, in-network creation.
   prompted ones, returns empty + warns when nothing matches.
 - Unit: `reconcile_intent_networks` writes rows but never calls `invokeHyde` or
   the opportunity enqueue (assert mocks not called).
-- Unit: `joinPublicNetwork` enqueues one reconcile per active intent scoped to
-  the joined network.
+- Unit: `addNetworkReconcileForUser` enqueues one network-scoped reconcile per
+  active intent (the join-time fan-out, driven by `onMemberAdded`).
 - Integration: orphan sweep query returns only zero-row active intents and is
   idempotent across runs.
 

--- a/.rpiv/artifacts/designs/intent-network-orphaning-fix.md
+++ b/.rpiv/artifacts/designs/intent-network-orphaning-fix.md
@@ -1,0 +1,230 @@
+# Design: Fix silent intent→network orphaning
+
+## Problem (confirmed in prod)
+
+Intents can end up registered to **zero** networks even when the user is an
+eligible member of a network that should accept them. The user sees "intent
+saved" but it never appears in any network, with no feedback.
+
+Production evidence (user `Timour Kosters`, network `Edge City`):
+
+- Owns **11** active intents; only **1** has an `intent_networks` row.
+- The other **10 are in zero networks** — including intents that are clearly
+  on-theme (e.g. *"Meet builders in Healdsburg during Edge Esmeralda"*).
+- He is a member of **Index Early Birds**, a network with **no prompt**, which
+  the assignment policy assigns to **unconditionally at score 1.0**. The orphans
+  are not even there.
+- Systemic: across 203 Edge City members, ~40 intents are orphaned the same way
+  (Timour 1/11, Seren 1/8, Adam Byrne 3/14, Miela 7/10).
+
+## Root causes
+
+Assignment to networks happens **once**, inside the HyDE queue
+(`backend/src/queues/intent.queue.ts` → `handleGenerateHyde`, lines ~196-272),
+at intent-creation time. Three properties of that path each produce permanent,
+silent orphaning:
+
+1. **Creation-time only, no backfill.** Networks are resolved at the instant the
+   intent is created (`getAssignmentNetworkIdsForUser` →
+   `resolveAssignmentNetworkScope`). Joining a network later, or the relevance
+   picture changing later, never re-evaluates existing intents. Intents created
+   before a membership/feature existed stay orphaned forever.
+
+2. **Scope filtering with no fallback.** When the job carries a `networkScopeId`
+   (agent/UI bound to one network), `resolveAssignmentNetworkScope` narrows the
+   candidate set to that single network (+ personal networks). If the intent
+   scores `< 0.7` against that network's prompt, it is assigned to **nothing** —
+   it does not fall back to the user's other memberships (e.g. the no-prompt
+   Index Early Birds), so it disappears entirely.
+
+3. **Swallowed failures.** The whole assignment block is wrapped in
+   `try/catch → logger.warn`, and `intent.service.ts:createFromProposal` returns
+   success even when `assignIntentToNetwork` throws. A lost/failed HyDE job or a
+   transient error produces an orphan with no signal to the user or operator.
+
+The 0.7 relevance threshold is **not** the root cause — orphans include intents
+that would score ~0.9 against the network prompt, and intents eligible for a
+no-prompt network that bypasses scoring entirely.
+
+## Goals
+
+- No active intent should be silently orphaned from networks it qualifies for.
+- Joining a network re-evaluates the joiner's existing intents against it.
+- A safety net reconciles any intent that slips through (job loss, scope drop,
+  pre-feature data).
+- Remediation and the structural fix **share one assignment core** so behavior
+  cannot drift between them.
+- Reconciliation must **not** regenerate HyDE docs or trigger opportunity
+  discovery (avoid notification spam on old intents).
+
+## Design
+
+### 1. Extract an assignment-only core (refactor, no behavior change)
+
+Pull the network-assignment loop out of `handleGenerateHyde` into a private
+method on `IntentQueue`:
+
+```ts
+// backend/src/queues/intent.queue.ts
+/**
+ * Resolve the user's eligible networks (respecting optional scope), score the
+ * intent against each, and upsert intent_networks rows for assigned networks.
+ * Pure assignment: no HyDE regeneration, no opportunity discovery.
+ * Idempotent — assignIntentToNetwork upserts on (intentId, networkId).
+ */
+private async assignIntentToNetworks(
+  intentId: string,
+  userId: string,
+  networkScopeId?: string,
+): Promise<{ assignedNetworkIds: string[]; evaluatedCount: number }> {
+  // ...exactly the existing lines 207-271, returning the assigned ids...
+}
+```
+
+`handleGenerateHyde` then calls `assignIntentToNetworks(intentId, userId,
+networkScopeId)` in place of the inline block. Net behavior unchanged; this just
+makes the core reusable and testable.
+
+**Add an explicit orphan signal** at the end of the core:
+
+```ts
+if (assignedNetworkIds.length === 0) {
+  this.logger.warn('[IntentAssign] Intent assigned to NO networks', {
+    intentId, userId, networkScopeId, evaluatedCount,
+  });
+  // emit metric: intent_network_orphaned_total
+}
+```
+
+This converts silent loss (cause 3) into an observable event.
+
+### 2. New assignment-only job: `reconcile_intent_networks`
+
+Add a job that runs **only** the assignment core — no HyDE, no opportunity
+enqueue:
+
+```ts
+// payload
+export interface IntentReconcileData { intentId: string; userId: string; networkScopeId?: string }
+
+// in processJob switch
+case 'reconcile_intent_networks':
+  await this.handleReconcileNetworks(data as IntentReconcileData);
+  break;
+
+private async handleReconcileNetworks(d: IntentReconcileData) {
+  await this.assignIntentToNetworks(d.intentId, d.userId, d.networkScopeId);
+}
+
+addReconcileJob(d: IntentReconcileData) {
+  // jobId dedupes concurrent reconciles for the same intent+scope
+  return this.addJob('reconcile_intent_networks', d, {
+    jobId: `reconcile-${d.intentId}-${d.networkScopeId ?? 'global'}`,
+  });
+}
+```
+
+This is the shared primitive used by both backfill-on-join and the safety-net
+sweep below.
+
+### 3. Backfill-on-join
+
+When a user joins / is added to a non-personal network, enqueue a
+network-scoped reconcile for each of their active intents so existing intents
+get a chance to land in the newly-joined network.
+
+Hook points (producers only — `NetworkService` already imports queues):
+
+- `network.service.ts:joinPublicNetwork`
+- `network.service.ts:addMember`
+
+```ts
+async joinPublicNetwork(networkId: string, userId: string) {
+  await this.adapter.joinPublicNetwork(networkId, userId);
+  await this.enqueueNetworkBackfill(networkId, userId); // best-effort, catches errors
+  return this.adapter.getNetworkDetail(networkId, userId);
+}
+
+private async enqueueNetworkBackfill(networkId: string, userId: string) {
+  const intents = await this.adapter.getActiveIntents(userId); // id + userId
+  await Promise.all(intents.map(i =>
+    intentQueue.addReconcileJob({ intentId: i.id, userId, networkScopeId: networkId })
+      .catch(err => logger.warn('[NetworkBackfill] enqueue failed', { intentId: i.id, networkId, err }))
+  ));
+}
+```
+
+Scoping to `networkId` keeps it cheap (one network evaluated per intent) and
+avoids re-touching unrelated memberships.
+
+### 4. Safety-net reconciliation sweep (catches everything else)
+
+A maintenance cron that finds active intents with **zero** `intent_networks`
+rows and enqueues a **global** reconcile for each. This is the backstop that
+heals job loss, scope-drop orphans, and pre-feature data without bespoke logic
+per cause.
+
+```ts
+// backend/src/queues/maintenance or a new intent-reconcile cron
+const orphans = await db.getOrphanedActiveIntents({ limit: 500 }); // intents w/ no intent_networks row
+for (const o of orphans) intentQueue.addReconcileJob({ intentId: o.id, userId: o.userId });
+```
+
+New adapter query:
+
+```sql
+select i.id, i.user_id
+from intents i
+left join intent_networks n on n.intent_id = i.id
+where i.archived_at is null and n.intent_id is null
+limit $1;
+```
+
+Idempotent and self-limiting: once an intent gets at least one row it drops out
+of the result set. Safe to run on a schedule.
+
+### 5. (Optional) Stop scoped creation from orphaning at the source
+
+Independent of the safety net, decide the intended semantics of scoped creation:
+
+- **Option A (recommended): scoped creation always assigns the scoped network.**
+  If a human explicitly adds an intent inside a network's context, treat it as a
+  `manual_override` (score 1.0) for that network rather than scoring it out.
+  This matches the existing `createFromProposal(..., networkId)` path, which
+  already force-assigns.
+- **Option B: fallback to global memberships.** If scoped scoring yields zero
+  assignments, re-evaluate against the user's other memberships so the intent at
+  least lands in no-prompt networks.
+
+A is simpler and matches user intent; B preserves relevance filtering. The
+safety-net sweep (4) makes either non-urgent, but A removes the surprise for
+human-initiated, in-network creation.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `backend/src/queues/intent.queue.ts` | Extract `assignIntentToNetworks`; add `reconcile_intent_networks` job + `addReconcileJob`; orphan warning/metric |
+| `backend/src/services/network.service.ts` | Enqueue network-scoped backfill on `joinPublicNetwork` + `addMember` |
+| `backend/src/adapters/database.adapter.ts` | Add `getOrphanedActiveIntents`; ensure `getActiveIntents` returns `{id,userId}` |
+| `backend/src/queues/*` (cron) | Register orphan-reconcile sweep; wire `startCrons`/`close` in `main.ts` |
+| `backend/src/queues/tests/intent.queue.spec.ts` | Tests: assignment core extraction, reconcile job assigns without HyDE/opportunity, orphan warning fires |
+
+## Testing
+
+- Unit: `assignIntentToNetworks` assigns no-prompt networks at 1.0, scores
+  prompted ones, returns empty + warns when nothing matches.
+- Unit: `reconcile_intent_networks` writes rows but never calls `invokeHyde` or
+  the opportunity enqueue (assert mocks not called).
+- Unit: `joinPublicNetwork` enqueues one reconcile per active intent scoped to
+  the joined network.
+- Integration: orphan sweep query returns only zero-row active intents and is
+  idempotent across runs.
+
+## Rollout
+
+1. Ship refactor (1) + reconcile job (2) — inert until invoked.
+2. Run the one-off backfill (see `intent-network-backfill.md`) to heal the ~40
+   existing orphans, including Timour's.
+3. Enable backfill-on-join (3) and the safety-net sweep (4).
+4. Decide and ship scoped-creation semantics (5).

--- a/backend/package.json
+++ b/backend/package.json
@@ -38,6 +38,7 @@
     "maintenance:backfill-context-hyde": "bun ./src/cli/backfill-context-hyde.ts",
     "maintenance:backfill-profile-questions": "bun ./src/cli/backfill-profile-questions.ts",
     "maintenance:backfill-intent-questions": "bun ./src/cli/backfill-intent-questions.ts",
+    "maintenance:backfill-intent-networks": "bun ./src/cli/backfill-intent-networks.ts",
     "test:opportunity-three-user": "bun ./src/cli/opportunity-three-user-test.ts",
     "test": "NODE_ENV=test bash scripts/test-safe.sh",
     "test:raw": "NODE_ENV=test bun test"

--- a/backend/src/cli/backfill-intent-networks.ts
+++ b/backend/src/cli/backfill-intent-networks.ts
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/**
+ * Backfill CLI: assignment-only reconciliation of intents → networks.
+ *
+ * Finds active intents that have ZERO intent_networks rows (orphans) and runs
+ * the SAME network-assignment policy the HyDE queue uses
+ * (`buildNetworkAssignmentDecision`), writing intent_networks rows for matches.
+ *
+ * It deliberately does NOT regenerate HyDE documents and does NOT enqueue
+ * opportunity discovery — so it heals registration without spamming users with
+ * new opportunity notifications on old intents.
+ *
+ * Idempotent: assignIntentToNetwork upserts on (intentId, networkId); once an
+ * intent gains at least one row it drops out of the orphan set.
+ *
+ * Usage:
+ *   bun run maintenance:backfill-intent-networks -- [--user <userId>] [--network <networkId>] [--dry-run]
+ *
+ *   --user <id>      Restrict to one user's orphaned intents (e.g. Timour).
+ *   --network <id>   Evaluate ONLY this network (scoped). Default: all the
+ *                    user's assignment-eligible memberships (global scope).
+ *   --dry-run        Score and report what WOULD be assigned; write nothing.
+ *   --limit <n>      Max orphaned intents to process (default 500).
+ */
+import dotenv from 'dotenv';
+import path from 'path';
+
+const envFile = process.env.NODE_ENV === 'development' ? '.env.development' : '.env.production';
+dotenv.config({ path: path.resolve(process.cwd(), envFile) });
+
+import { and, isNull, sql } from 'drizzle-orm';
+
+import db, { closeDb } from '../lib/drizzle/drizzle';
+import * as schema from '../schemas/database.schema';
+import { IntentIndexer, buildNetworkAssignmentDecision, resolveAssignmentNetworkScope } from '@indexnetwork/protocol';
+import { ChatDatabaseAdapter } from '../adapters/database.adapter';
+
+interface Args { userId?: string; networkId?: string; dryRun: boolean; limit: number }
+
+function parseArgs(): Args {
+  const args = process.argv.slice(2);
+  const valueOf = (flag: string): string | undefined => {
+    const a = args.find((x) => x === flag || x.startsWith(`${flag}=`));
+    if (!a) return undefined;
+    const eq = a.indexOf('=');
+    if (eq !== -1) return a.slice(eq + 1);
+    const next = args[args.indexOf(a) + 1];
+    return next && !next.startsWith('--') ? next : undefined;
+  };
+  return {
+    userId: valueOf('--user'),
+    networkId: valueOf('--network'),
+    dryRun: args.includes('--dry-run'),
+    limit: Number(valueOf('--limit') ?? 500),
+  };
+}
+
+/** Active intents with no intent_networks row, optionally scoped to one user. */
+async function findOrphanedIntents(userId: string | undefined, limit: number) {
+  const rows = await db
+    .select({ id: schema.intents.id, userId: schema.intents.userId, payload: schema.intents.payload })
+    .from(schema.intents)
+    .leftJoin(schema.intentNetworks, sql`${schema.intentNetworks.intentId} = ${schema.intents.id}`)
+    .where(
+      and(
+        isNull(schema.intents.archivedAt),
+        isNull(schema.intentNetworks.intentId),
+        userId ? sql`${schema.intents.userId} = ${userId}` : sql`true`,
+      ),
+    )
+    .limit(limit);
+  return rows;
+}
+
+async function main(): Promise<void> {
+  const { userId, networkId, dryRun, limit } = parseArgs();
+  const adapter = new ChatDatabaseAdapter();
+  const indexer = new IntentIndexer();
+
+  console.log(
+    `Backfill intent→networks` +
+    `${userId ? ` user=${userId}` : ' (all users)'}` +
+    `${networkId ? ` network=${networkId} (scoped)` : ' (global memberships)'}` +
+    `${dryRun ? ' — DRY RUN' : ''}`,
+  );
+
+  const orphans = await findOrphanedIntents(userId, limit);
+  console.log(`Found ${orphans.length} orphaned active intent(s)\n`);
+  if (orphans.length === 0) return;
+
+  let assignedRows = 0;
+  let stillOrphan = 0;
+
+  for (const intent of orphans) {
+    const memberships = await adapter.getAssignmentNetworkIdsForUser(intent.userId);
+    const candidateIds = resolveAssignmentNetworkScope({ memberships, networkScopeId: networkId });
+    const preview = intent.payload.length > 50 ? intent.payload.slice(0, 47) + '...' : intent.payload;
+
+    if (candidateIds.length === 0) {
+      stillOrphan++;
+      console.log(`• ${intent.id}  "${preview}"\n    → no eligible networks (scope=${networkId ?? 'global'})`);
+      continue;
+    }
+
+    const assignedTo: string[] = [];
+    for (const nid of candidateIds) {
+      const ctx = await adapter.getNetworkAssignmentContext(nid, intent.userId);
+      if (!ctx) continue;
+      const indexPrompt = ctx.indexPrompt ?? null;
+      const memberPrompt = ctx.memberPrompt ?? null;
+      const hasPrompts = !!indexPrompt?.trim() || !!memberPrompt?.trim();
+
+      let raw: { indexScore: number; memberScore: number } | undefined;
+      if (hasPrompts) {
+        const r = await indexer.invoke(intent.payload, indexPrompt, memberPrompt, null);
+        if (r) raw = { indexScore: r.indexScore, memberScore: r.memberScore };
+      }
+
+      const decision = buildNetworkAssignmentDecision({
+        resourceType: 'intent',
+        mode: 'automatic',
+        scope: networkId ? 'network' : 'global',
+        indexPrompt,
+        memberPrompt,
+        rawScores: raw,
+        evaluator: 'intent-indexer',
+        source: 'backfill-intent-networks',
+        createdAt: new Date().toISOString(),
+      });
+
+      if (!decision.assigned) continue;
+      assignedTo.push(`${nid}@${decision.finalScore.toFixed(2)}`);
+      if (!dryRun) {
+        await adapter.assignIntentToNetwork(intent.id, nid, decision.finalScore, decision.metadata);
+        assignedRows++;
+      } else {
+        assignedRows++;
+      }
+    }
+
+    if (assignedTo.length === 0) {
+      stillOrphan++;
+      console.log(`• ${intent.id}  "${preview}"\n    → matched NO network (would remain orphaned)`);
+    } else {
+      console.log(`• ${intent.id}  "${preview}"\n    → ${dryRun ? 'would assign' : 'assigned'}: ${assignedTo.join(', ')}`);
+    }
+  }
+
+  console.log(
+    `\nDone: ${assignedRows} ${dryRun ? 'would-be ' : ''}row(s) across ${orphans.length} intent(s); ` +
+    `${stillOrphan} intent(s) still unmatched.`,
+  );
+}
+
+main()
+  .then(async () => { await closeDb(); })
+  .catch(async (e: unknown) => {
+    console.error('backfill-intent-networks error:', e instanceof Error ? e.message : `${e}`);
+    await closeDb().catch(() => {});
+    process.exit(1);
+  });

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -141,6 +141,13 @@ NetworkMembershipEvents.onMemberAdded = (userId: string, networkId: string) => {
   userContextQueue.addRegenJob({ userId, reason: 'network_membership' }).catch((err) => {
     log.job.from('NetworkMembership').error('Failed to enqueue context regen', { userId, networkId, error: err });
   });
+  // Re-evaluate the member's pre-existing intents against the joined network.
+  // Intents created before joining never get an assignment pass for this network
+  // otherwise, leaving them silently absent from it. Assignment-only (no HyDE
+  // regen / opportunity discovery); scoped to this network.
+  intentQueue.addNetworkReconcileForUser(userId, networkId).catch((err) => {
+    log.job.from('NetworkMembership').error('Failed to enqueue intent network reconcile', { userId, networkId, error: err });
+  });
 };
 
 enrichmentQueue.onEnrichmentComplete = (userId: string) => {

--- a/backend/src/queues/intent.queue.ts
+++ b/backend/src/queues/intent.queue.ts
@@ -175,6 +175,35 @@ export class IntentQueue implements IntentGraphQueue {
   }
 
   /**
+   * Enqueue a network-scoped reconcile for every active intent a user owns.
+   *
+   * This is the join-time half of the protocol rule "membership re-evaluates a
+   * member's existing intents against the network": intents created before the
+   * user joined never get an assignment pass for the new network otherwise.
+   * Driven by the `NetworkMembershipEvents.onMemberAdded` hook so it fires for
+   * every membership path (REST self-join, owner-add, and the protocol
+   * `create_network_membership` graph) — all converge on `addMemberToNetwork`.
+   * Best-effort per intent; assignment-only (no HyDE/opportunity side effects).
+   *
+   * @param userId - The member whose existing intents should be re-evaluated.
+   * @param networkId - The joined network; scopes evaluation to it.
+   * @returns The number of reconcile jobs enqueued.
+   */
+  async addNetworkReconcileForUser(userId: string, networkId: string): Promise<number> {
+    const db = this.deps?.database ?? this.database;
+    const intents = await db.getActiveIntents(userId);
+    await Promise.all(
+      intents.map((i) =>
+        this.addReconcileJob({ intentId: i.id, userId, networkScopeId: networkId }).catch((err) =>
+          this.logger.warn('[IntentReconcile] enqueue failed', { intentId: i.id, networkId, userId, error: err }),
+        ),
+      ),
+    );
+    this.logger.info('[IntentReconcile] Enqueued network reconcile for member', { userId, networkId, intentCount: intents.length });
+    return intents.length;
+  }
+
+  /**
    * Run HyDE generation for an intent synchronously (e.g. during db-seed).
    * When skipOpportunity is true, does not enqueue opportunity discovery — use for seed to avoid matching test users.
    * @param data - intentId and userId

--- a/backend/src/queues/intent.queue.ts
+++ b/backend/src/queues/intent.queue.ts
@@ -123,7 +123,7 @@ export class IntentQueue implements IntentGraphQueue {
    * @returns The BullMQ job
    */
   async addJob(
-    name: 'generate_hyde' | 'delete_hyde',
+    name: 'generate_hyde' | 'delete_hyde' | 'reconcile_intent_networks',
     data: IntentJobData | IntentDeleteData,
     options?: { jobId?: string; priority?: number }
   ): Promise<Job<IntentJobPayload>> {
@@ -147,12 +147,31 @@ export class IntentQueue implements IntentGraphQueue {
       case 'generate_hyde':
         await this.handleGenerateHyde(data as IntentJobData);
         break;
+      case 'reconcile_intent_networks':
+        await this.handleReconcileNetworks(data as IntentJobData);
+        break;
       case 'delete_hyde':
         await this.handleDeleteHyde(data as IntentDeleteData);
         break;
       default:
         this.queueLogger.warn(`[IntentProcessor] Unknown job name: ${name}`);
     }
+  }
+
+  /**
+   * Enqueue an assignment-only reconciliation for an intent. Unlike
+   * {@link addGenerateHydeJob} this never regenerates HyDE docs or runs
+   * opportunity discovery — it only (re)evaluates and writes intent_networks
+   * rows. Used by network-join backfill and the orphan-reconcile sweep.
+   *
+   * @param data - intentId, userId, and optional networkScopeId to restrict the
+   *   evaluated network set (defaults to all assignment-eligible memberships).
+   * @returns The BullMQ job.
+   */
+  addReconcileJob(data: IntentJobData): Promise<Job<IntentJobPayload>> {
+    return this.addJob('reconcile_intent_networks', data, {
+      jobId: `reconcile-${data.intentId}-${data.networkScopeId ?? 'global'}`,
+    });
   }
 
   /**
@@ -204,80 +223,8 @@ export class IntentQueue implements IntentGraphQueue {
     }
     this.logger.info('[IntentHyde] Starting HyDE generation', { intentId, userId });
     this.logger.debug('[IntentHyde] Intent payload preview', { intentId, payload: intent.payload?.slice(0, 80) });
-    let assignedIndexCount = 0;
-    try {
-      const membershipNetworkIds = await db.getAssignmentNetworkIdsForUser(userId);
-      const userIndexIds = resolveAssignmentNetworkScope({ memberships: membershipNetworkIds, networkScopeId });
-      this.logger.info('[IntentHyde] User assignment networks found', { intentId, userId, indexCount: userIndexIds.length, indexIds: userIndexIds });
-
-      // Instantiate once per job run so the same withStructuredOutput binding
-      // is reused across all network evaluations in the Promise.all below.
-      const defaultIndexer = this.deps?.evaluateIntentAssignment ? null : new IntentIndexer();
-      const evaluateIntentAssignment = this.deps?.evaluateIntentAssignment ?? ((opts: {
-        intent: string;
-        indexPrompt: string | null;
-        memberPrompt: string | null;
-        sourceName?: string | null;
-      }) => defaultIndexer!.invoke(opts.intent, opts.indexPrompt, opts.memberPrompt, opts.sourceName ?? null));
-
-      const sourceName = intent.sourceType
-        ? `${intent.sourceType}:${intent.sourceId ?? ''}`
-        : undefined;
-
-      const scoringResults = await Promise.all(
-        userIndexIds.map(async (networkId) => {
-          const ctx = await db.getNetworkAssignmentContext(networkId, userId);
-          if (!ctx) {
-            this.logger.warn('[IntentHyde] Assignment context missing for index, skipping fail-closed', { intentId, userId, networkId });
-            return null;
-          }
-          const indexPrompt = ctx.indexPrompt ?? null;
-          const memberPrompt = ctx.memberPrompt ?? null;
-          const hasPrompts = !!indexPrompt?.trim() || !!memberPrompt?.trim();
-          let result: IntentIndexerOutput | null = null;
-          if (hasPrompts) {
-            try {
-              result = await evaluateIntentAssignment({ intent: intent.payload, indexPrompt, memberPrompt, sourceName });
-            } catch (err) {
-              this.logger.warn('[IntentHyde] IntentIndexer failed for index', { intentId, networkId, error: err });
-            }
-          }
-
-          const decision = buildNetworkAssignmentDecision({
-            resourceType: 'intent',
-            mode: 'automatic',
-            scope: networkScopeId ? 'network' : 'global',
-            indexPrompt,
-            memberPrompt,
-            rawScores: result ? { indexScore: result.indexScore, memberScore: result.memberScore } : undefined,
-            evaluator: 'intent-indexer',
-            source: 'intent-hyde-queue',
-            reason: result?.reasoning,
-            createdAt: new Date().toISOString(),
-          });
-          return { networkId, decision };
-        })
-      );
-
-      for (const scoringResult of scoringResults) {
-        if (!scoringResult) continue;
-        const { networkId, decision } = scoringResult;
-        if (!decision.assigned) continue;
-        try {
-          await db.assignIntentToNetwork(intentId, networkId, decision.finalScore, decision.metadata);
-          assignedIndexCount++;
-        } catch (assignErr) {
-          this.logger.debug('[IntentHyde] Assign intent to index skipped', { intentId, networkId, error: assignErr });
-        }
-      }
-    } catch (err) {
-      this.logger.warn('[IntentHyde] Failed to assign intent to user indexes', {
-        intentId,
-        userId,
-        error: err,
-      });
-    }
-    this.logger.info('[IntentHyde] Index assignment complete', { intentId, assignedIndexCount });
+    const { assignedNetworkIds } = await this.assignIntentToNetworks(intentId, userId, { networkScopeId });
+    this.logger.info('[IntentHyde] Index assignment complete', { intentId, assignedIndexCount: assignedNetworkIds.length });
 
     // Fetch discoverer profile + active intents for HyDE context (best-effort)
     let profileContext: string | undefined;
@@ -353,6 +300,128 @@ export class IntentQueue implements IntentGraphQueue {
     }).catch((err: unknown) =>
       this.logger.error('[IntentHyde] Failed to enqueue opportunity discovery', { intentId, error: err })
     );
+  }
+
+  /**
+   * Resolve the user's eligible networks (respecting optional scope), score the
+   * intent against each, and upsert intent_networks rows for assigned networks.
+   *
+   * Pure assignment: no HyDE regeneration and no opportunity discovery, so it is
+   * safe to call for reconciliation/backfill without spamming users with new
+   * opportunity notifications on existing intents. Idempotent —
+   * {@link ChatDatabaseAdapter.assignIntentToNetwork} upserts on
+   * (intentId, networkId).
+   *
+   * @param intentId - Intent to assign.
+   * @param userId - Owner of the intent.
+   * @param opts - Optional `networkScopeId` to restrict the evaluated set and a
+   *   `source` tag recorded in assignment metadata.
+   * @returns Assigned network IDs and the number of networks evaluated.
+   */
+  private async assignIntentToNetworks(
+    intentId: string,
+    userId: string,
+    opts?: { networkScopeId?: string; source?: string },
+  ): Promise<{ assignedNetworkIds: string[]; evaluatedCount: number }> {
+    const networkScopeId = opts?.networkScopeId;
+    const source = opts?.source ?? 'intent-hyde-queue';
+    const db = this.deps?.database ?? this.database;
+    const intent = await db.getIntentForIndexing(intentId);
+    if (!intent) {
+      this.logger.warn('[IntentAssign] Intent not found, skipping', { intentId });
+      return { assignedNetworkIds: [], evaluatedCount: 0 };
+    }
+
+    const assignedNetworkIds: string[] = [];
+    let evaluatedCount = 0;
+    try {
+      const membershipNetworkIds = await db.getAssignmentNetworkIdsForUser(userId);
+      const userIndexIds = resolveAssignmentNetworkScope({ memberships: membershipNetworkIds, networkScopeId });
+      evaluatedCount = userIndexIds.length;
+      this.logger.info('[IntentAssign] User assignment networks found', { intentId, userId, indexCount: userIndexIds.length, indexIds: userIndexIds });
+
+      // Instantiate once per run so the same withStructuredOutput binding is
+      // reused across all network evaluations in the Promise.all below.
+      const defaultIndexer = this.deps?.evaluateIntentAssignment ? null : new IntentIndexer();
+      const evaluateIntentAssignment = this.deps?.evaluateIntentAssignment ?? ((o: {
+        intent: string;
+        indexPrompt: string | null;
+        memberPrompt: string | null;
+        sourceName?: string | null;
+      }) => defaultIndexer!.invoke(o.intent, o.indexPrompt, o.memberPrompt, o.sourceName ?? null));
+
+      const sourceName = intent.sourceType
+        ? `${intent.sourceType}:${intent.sourceId ?? ''}`
+        : undefined;
+
+      const scoringResults = await Promise.all(
+        userIndexIds.map(async (networkId) => {
+          const ctx = await db.getNetworkAssignmentContext(networkId, userId);
+          if (!ctx) {
+            this.logger.warn('[IntentAssign] Assignment context missing for network, skipping fail-closed', { intentId, userId, networkId });
+            return null;
+          }
+          const indexPrompt = ctx.indexPrompt ?? null;
+          const memberPrompt = ctx.memberPrompt ?? null;
+          const hasPrompts = !!indexPrompt?.trim() || !!memberPrompt?.trim();
+          let result: IntentIndexerOutput | null = null;
+          if (hasPrompts) {
+            try {
+              result = await evaluateIntentAssignment({ intent: intent.payload, indexPrompt, memberPrompt, sourceName });
+            } catch (err) {
+              this.logger.warn('[IntentAssign] IntentIndexer failed for network', { intentId, networkId, error: err });
+            }
+          }
+
+          const decision = buildNetworkAssignmentDecision({
+            resourceType: 'intent',
+            mode: 'automatic',
+            scope: networkScopeId ? 'network' : 'global',
+            indexPrompt,
+            memberPrompt,
+            rawScores: result ? { indexScore: result.indexScore, memberScore: result.memberScore } : undefined,
+            evaluator: 'intent-indexer',
+            source,
+            reason: result?.reasoning,
+            createdAt: new Date().toISOString(),
+          });
+          return { networkId, decision };
+        })
+      );
+
+      for (const scoringResult of scoringResults) {
+        if (!scoringResult) continue;
+        const { networkId, decision } = scoringResult;
+        if (!decision.assigned) continue;
+        try {
+          await db.assignIntentToNetwork(intentId, networkId, decision.finalScore, decision.metadata);
+          assignedNetworkIds.push(networkId);
+        } catch (assignErr) {
+          this.logger.debug('[IntentAssign] Assign intent to network skipped', { intentId, networkId, error: assignErr });
+        }
+      }
+    } catch (err) {
+      this.logger.warn('[IntentAssign] Failed to assign intent to user networks', { intentId, userId, error: err });
+    }
+
+    if (assignedNetworkIds.length === 0) {
+      // Explicit orphan signal: an intent registered to no network is invisible
+      // in every network UI. Surface it so it can be alerted on or swept rather
+      // than silently lost.
+      this.logger.warn('[IntentAssign] Intent assigned to NO networks', { intentId, userId, networkScopeId, evaluatedCount });
+    }
+    return { assignedNetworkIds, evaluatedCount };
+  }
+
+  /**
+   * Handle a `reconcile_intent_networks` job: run assignment only, with no HyDE
+   * regeneration or opportunity discovery. Idempotent and safe to re-run.
+   *
+   * @param data - intentId, userId, and optional networkScopeId.
+   */
+  private async handleReconcileNetworks(data: IntentJobData): Promise<void> {
+    const { intentId, userId, networkScopeId } = data;
+    await this.assignIntentToNetworks(intentId, userId, { networkScopeId, source: 'intent-reconcile-queue' });
   }
 
   private async handleDeleteHyde(data: IntentDeleteData): Promise<void> {

--- a/backend/src/queues/tests/intent.queue.spec.ts
+++ b/backend/src/queues/tests/intent.queue.spec.ts
@@ -97,6 +97,26 @@ describe('IntentQueue', () => {
       await queue.addDeleteHydeJob({ intentId: 'i1' });
       expect(mockAdd).toHaveBeenCalledWith('delete_hyde', { intentId: 'i1' }, expect.any(Object));
     });
+
+    it('addReconcileJob delegates to addJob with a global jobId', async () => {
+      const queue = new IntentQueue();
+      await queue.addReconcileJob({ intentId: 'i1', userId: 'u1' });
+      expect(mockAdd).toHaveBeenCalledWith(
+        'reconcile_intent_networks',
+        { intentId: 'i1', userId: 'u1' },
+        expect.objectContaining({ jobId: 'reconcile-i1-global' }),
+      );
+    });
+
+    it('addReconcileJob scopes the jobId to the network when provided', async () => {
+      const queue = new IntentQueue();
+      await queue.addReconcileJob({ intentId: 'i1', userId: 'u1', networkScopeId: 'net-x' });
+      expect(mockAdd).toHaveBeenCalledWith(
+        'reconcile_intent_networks',
+        { intentId: 'i1', userId: 'u1', networkScopeId: 'net-x' },
+        expect.objectContaining({ jobId: 'reconcile-i1-net-x' }),
+      );
+    });
   });
 
   describe('processJob', () => {
@@ -353,6 +373,44 @@ describe('IntentQueue', () => {
         expect(assignIntentToNetwork.mock.calls.map((call) => call[1])).toEqual(['net-a']);
         expect(evaluateIntentAssignment).not.toHaveBeenCalled();
       });
+    });
+
+    it('reconcile_intent_networks: assigns networks with no HyDE or opportunity side effects', async () => {
+      const invokeHyde = mock(async () => {});
+      const addOpportunityJob = mock(async () => ({}));
+      const assignIntentToNetwork = mock(async () => {});
+      const db = {
+        getIntentForIndexing: async () => ({ id: 'i1', payload: 'Build AI tools', userId: 'u1', sourceType: null, sourceId: null }),
+        getAssignmentNetworkIdsForUser: async () => ['n1', 'n2'],
+        getNetworkAssignmentContext: async (networkId: string) => ({ networkId, indexPrompt: null, memberPrompt: null }),
+        assignIntentToNetwork,
+        deleteHydeDocumentsForSource: async () => 0,
+      };
+      const queue = new IntentQueue({ database: asIntentDb(db), invokeHyde, addOpportunityJob });
+      await queue.processJob('reconcile_intent_networks', { intentId: 'i1', userId: 'u1' });
+
+      expect(assignIntentToNetwork.mock.calls.map((c) => c[1]).sort()).toEqual(['n1', 'n2']);
+      // Pure assignment: reconcile must never regenerate HyDE or trigger discovery.
+      expect(invokeHyde).not.toHaveBeenCalled();
+      expect(addOpportunityJob).not.toHaveBeenCalled();
+      expect(assignIntentToNetwork.mock.calls[0][3]).toMatchObject({ source: 'intent-reconcile-queue', assigned: true });
+    });
+
+    it('reconcile_intent_networks: networkScopeId restricts evaluation to that network', async () => {
+      const assignIntentToNetwork = mock(async () => {});
+      const getNetworkAssignmentContext = mock(async (networkId: string) => ({ networkId, indexPrompt: null, memberPrompt: null }));
+      const db = {
+        getIntentForIndexing: async () => ({ id: 'i1', payload: 'P', userId: 'u1', sourceType: null, sourceId: null }),
+        getAssignmentNetworkIdsForUser: async () => ['net-a', 'net-b'],
+        getNetworkAssignmentContext,
+        assignIntentToNetwork,
+        deleteHydeDocumentsForSource: async () => 0,
+      };
+      const queue = new IntentQueue({ database: asIntentDb(db) });
+      await queue.processJob('reconcile_intent_networks', { intentId: 'i1', userId: 'u1', networkScopeId: 'net-b' });
+
+      expect(getNetworkAssignmentContext).toHaveBeenCalledTimes(1);
+      expect(assignIntentToNetwork.mock.calls.map((c) => c[1])).toEqual(['net-b']);
     });
 
     it('delete_hyde: calls deleteHydeDocumentsForSource', async () => {

--- a/backend/src/queues/tests/intent.queue.spec.ts
+++ b/backend/src/queues/tests/intent.queue.spec.ts
@@ -117,6 +117,27 @@ describe('IntentQueue', () => {
         expect.objectContaining({ jobId: 'reconcile-i1-net-x' }),
       );
     });
+
+    it('addNetworkReconcileForUser enqueues a network-scoped reconcile per active intent', async () => {
+      const getActiveIntents = mock(async () => [
+        { id: 'i1', payload: 'p1', summary: null, createdAt: new Date() },
+        { id: 'i2', payload: 'p2', summary: null, createdAt: new Date() },
+      ]);
+      const queue = new IntentQueue({ database: asIntentDb({ getActiveIntents } as Partial<IntentQueueDatabase>) });
+      const count = await queue.addNetworkReconcileForUser('u1', 'net-1');
+      expect(count).toBe(2);
+      expect(getActiveIntents).toHaveBeenCalledWith('u1');
+      expect(mockAdd).toHaveBeenCalledWith(
+        'reconcile_intent_networks',
+        { intentId: 'i1', userId: 'u1', networkScopeId: 'net-1' },
+        expect.objectContaining({ jobId: 'reconcile-i1-net-1' }),
+      );
+      expect(mockAdd).toHaveBeenCalledWith(
+        'reconcile_intent_networks',
+        { intentId: 'i2', userId: 'u1', networkScopeId: 'net-1' },
+        expect.objectContaining({ jobId: 'reconcile-i2-net-1' }),
+      );
+    });
   });
 
   describe('processJob', () => {

--- a/backend/src/services/network.service.ts
+++ b/backend/src/services/network.service.ts
@@ -7,7 +7,6 @@ import { generateMasterKey } from '../lib/experiment/master-key';
 import { executeSendEmail } from '../lib/email/transport.helper';
 import { networkMasterKeyRotatedTemplate } from '../lib/email/templates/network-master-key-rotated.template';
 import { validateKey } from '../lib/keys';
-import { intentQueue } from '../queues/intent.queue';
 import * as schema from '../schemas/database.schema';
 import { ContextInjectionSchema, ProfileEnrichmentPolicySchema, validateNetworkMetadata } from '../schemas/network.validation';
 
@@ -184,34 +183,7 @@ export class NetworkService {
   async addMember(networkId: string, userId: string, requestingUserId: string, role: 'owner' | 'member' = 'member') {
     logger.verbose('[NetworkService] Adding member', { networkId, userId, role });
     await this.assertNotPersonal(networkId);
-    const result = await this.adapter.addMemberForOwner(networkId, userId, requestingUserId, role);
-    await this.enqueueNetworkBackfill(networkId, userId);
-    return result;
-  }
-
-  /**
-   * Re-evaluate a user's existing active intents against a network they just
-   * joined, so intents created before joining get a chance to register in the
-   * new network. Best-effort and assignment-only (no HyDE/opportunity side
-   * effects); never throws into the join flow.
-   *
-   * @param networkId - The network the user just joined / was added to.
-   * @param userId - The joining user whose intents should be re-evaluated.
-   */
-  private async enqueueNetworkBackfill(networkId: string, userId: string): Promise<void> {
-    try {
-      const intents = await this.adapter.getActiveIntents(userId);
-      await Promise.all(
-        intents.map((i) =>
-          intentQueue
-            .addReconcileJob({ intentId: i.id, userId, networkScopeId: networkId })
-            .catch((err) => logger.warn('[NetworkBackfill] enqueue failed', { intentId: i.id, networkId, userId, error: err })),
-        ),
-      );
-      logger.info('[NetworkBackfill] Enqueued reconcile for joined network', { networkId, userId, intentCount: intents.length });
-    } catch (err) {
-      logger.warn('[NetworkBackfill] Failed to enqueue network backfill', { networkId, userId, error: err });
-    }
+    return this.adapter.addMemberForOwner(networkId, userId, requestingUserId, role);
   }
 
   /**
@@ -338,7 +310,6 @@ export class NetworkService {
   async joinPublicNetwork(networkId: string, userId: string) {
     logger.verbose('[NetworkService] Joining public index', { networkId, userId });
     await this.adapter.joinPublicNetwork(networkId, userId);
-    await this.enqueueNetworkBackfill(networkId, userId);
     return this.adapter.getNetworkDetail(networkId, userId);
   }
 

--- a/backend/src/services/network.service.ts
+++ b/backend/src/services/network.service.ts
@@ -7,6 +7,7 @@ import { generateMasterKey } from '../lib/experiment/master-key';
 import { executeSendEmail } from '../lib/email/transport.helper';
 import { networkMasterKeyRotatedTemplate } from '../lib/email/templates/network-master-key-rotated.template';
 import { validateKey } from '../lib/keys';
+import { intentQueue } from '../queues/intent.queue';
 import * as schema from '../schemas/database.schema';
 import { ContextInjectionSchema, ProfileEnrichmentPolicySchema, validateNetworkMetadata } from '../schemas/network.validation';
 
@@ -183,7 +184,34 @@ export class NetworkService {
   async addMember(networkId: string, userId: string, requestingUserId: string, role: 'owner' | 'member' = 'member') {
     logger.verbose('[NetworkService] Adding member', { networkId, userId, role });
     await this.assertNotPersonal(networkId);
-    return this.adapter.addMemberForOwner(networkId, userId, requestingUserId, role);
+    const result = await this.adapter.addMemberForOwner(networkId, userId, requestingUserId, role);
+    await this.enqueueNetworkBackfill(networkId, userId);
+    return result;
+  }
+
+  /**
+   * Re-evaluate a user's existing active intents against a network they just
+   * joined, so intents created before joining get a chance to register in the
+   * new network. Best-effort and assignment-only (no HyDE/opportunity side
+   * effects); never throws into the join flow.
+   *
+   * @param networkId - The network the user just joined / was added to.
+   * @param userId - The joining user whose intents should be re-evaluated.
+   */
+  private async enqueueNetworkBackfill(networkId: string, userId: string): Promise<void> {
+    try {
+      const intents = await this.adapter.getActiveIntents(userId);
+      await Promise.all(
+        intents.map((i) =>
+          intentQueue
+            .addReconcileJob({ intentId: i.id, userId, networkScopeId: networkId })
+            .catch((err) => logger.warn('[NetworkBackfill] enqueue failed', { intentId: i.id, networkId, userId, error: err })),
+        ),
+      );
+      logger.info('[NetworkBackfill] Enqueued reconcile for joined network', { networkId, userId, intentCount: intents.length });
+    } catch (err) {
+      logger.warn('[NetworkBackfill] Failed to enqueue network backfill', { networkId, userId, error: err });
+    }
   }
 
   /**
@@ -310,6 +338,7 @@ export class NetworkService {
   async joinPublicNetwork(networkId: string, userId: string) {
     logger.verbose('[NetworkService] Joining public index', { networkId, userId });
     await this.adapter.joinPublicNetwork(networkId, userId);
+    await this.enqueueNetworkBackfill(networkId, userId);
     return this.adapter.getNetworkDetail(networkId, userId);
   }
 


### PR DESCRIPTION
Fixes the silent intent→network orphaning surfaced by Timour's Edge City report (11 intents, only 1 registered to the network). Production data was already healed via a one-off backfill; this PR lands the structural foundation + join-time reconcile so it stops recurring.

Closes part of the structural fix tracked in **IND-356** (safety-net sweep + observability + scoped-creation semantics remain there).

## Background
Intents only get `intent_networks` rows at creation time (HyDE queue). Three properties each caused permanent, silent orphaning:
1. **Creation-time only, no backfill** — joining a network later never re-evaluated existing intents.
2. **Scope filtering with no fallback** — a `networkScopeId`-scoped job scoring below threshold assigned the intent to *nothing*, not even no-prompt memberships.
3. **Swallowed failures** — `try/catch → warn` + success returned regardless, so orphaning was invisible.

## New Features
- **Join-time reconcile** wired at the canonical membership seam: `NetworkMembershipEvents.onMemberAdded` (`main.ts`). All membership paths — REST self-join, owner-add, and the protocol `create_network_membership` graph — converge on `addMemberToNetwork`, which emits the event once per new member, so existing intents are re-evaluated against a network on join **regardless of entry path**.
- **`reconcile_intent_networks` job** + `IntentQueue.addReconcileJob()` + fan-out `IntentQueue.addNetworkReconcileForUser()` — assignment-only, jobId-deduped per `intent+scope`.
- **`maintenance:backfill-intent-networks`** one-off remediation script (reuses the production assignment policy; no HyDE/opportunity side effects). Already healed 30 orphaned intents across 12 users.

## Refactors
- Extracted `IntentQueue.assignIntentToNetworks()` from `handleGenerateHyde` — pure, idempotent assignment core (no HyDE regen, no opportunity discovery). `generate_hyde` behavior unchanged.
- Added an explicit `[IntentAssign] Intent assigned to NO networks` warning so orphaning is observable.

## Tests
- `reconcile_intent_networks` assigns networks with **no** HyDE/opportunity side effects; respects `networkScopeId`.
- `addReconcileJob` jobId scoping; `addNetworkReconcileForUser` fans out one scoped reconcile per active intent.
- Existing assignment tests still pass (behavior preserved): `intent.queue.spec.ts` 27/27; network service + controller specs green; lint clean.

## Documentation
- `.rpiv/artifacts/designs/intent-network-orphaning-fix.md` — full design (parts 4–5 deferred to IND-356).
