### PR TITLE
feat(intents): surface network membership on intents (chips + honest toast)

### DIFF
--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -155,6 +155,13 @@ interface IntentListRow {
   archivedAt: Date | null;
   sourceType: string | null;
   sourceId: string | null;
+  /**
+   * Networks this intent is currently registered to. Empty when the intent is
+   * still being evaluated (HyDE assignment not yet run) or genuinely matched
+   * nothing — the frontend distinguishes those two via the intent's age. Lets
+   * the UI surface orphaned intents instead of hiding the assignment outcome.
+   */
+  networks: { id: string; title: string }[];
 }
 // Shapes matching schemas/database.schema userProfiles columns (no lib/protocol import)
 interface ProfileIdentity {
@@ -471,7 +478,43 @@ export class IntentDatabaseAdapter {
       db.select({ count: count() }).from(schema.intents).where(where),
     ]);
 
-    return { rows, total: Number(totalResult[0]?.count ?? 0) };
+    const withNetworks = await this.attachIntentNetworks(rows);
+    return { rows: withNetworks, total: Number(totalResult[0]?.count ?? 0) };
+  }
+
+  /**
+   * Attach each intent's registered networks (excluding soft-deleted networks)
+   * to a page of list rows in a single grouped query. Intents with no
+   * membership get an empty array, which the UI reads as "pending or orphaned".
+   *
+   * @param rows - The paginated intent rows to enrich (mutated copies returned).
+   * @returns The same rows, each with a populated `networks` array.
+   */
+  private async attachIntentNetworks(
+    rows: Omit<IntentListRow, 'networks'>[],
+  ): Promise<IntentListRow[]> {
+    if (rows.length === 0) return [];
+    const intentIds = rows.map(r => r.id);
+    const memberships = await db
+      .select({
+        intentId: schema.intentNetworks.intentId,
+        networkId: schema.networks.id,
+        title: schema.networks.title,
+      })
+      .from(schema.intentNetworks)
+      .innerJoin(schema.networks, eq(schema.intentNetworks.networkId, schema.networks.id))
+      .where(and(
+        inArray(schema.intentNetworks.intentId, intentIds),
+        isNull(schema.networks.deletedAt),
+      ));
+
+    const byIntent = new Map<string, { id: string; title: string }[]>();
+    for (const m of memberships) {
+      const list = byIntent.get(m.intentId) ?? [];
+      list.push({ id: m.networkId, title: m.title });
+      byIntent.set(m.intentId, list);
+    }
+    return rows.map(r => ({ ...r, networks: byIntent.get(r.id) ?? [] }));
   }
 
   async getIntentById(intentId: string, userId: string): Promise<IntentListRow | null> {
@@ -491,7 +534,9 @@ export class IntentDatabaseAdapter {
       .where(and(eq(schema.intents.id, intentId), eq(schema.intents.userId, userId)))
       .limit(1);
 
-    return row[0] ?? null;
+    if (!row[0]) return null;
+    const [withNetworks] = await this.attachIntentNetworks(row);
+    return withNetworks;
   }
 
   /**

--- a/backend/src/controllers/tests/intent.controller.spec.ts
+++ b/backend/src/controllers/tests/intent.controller.spec.ts
@@ -4,7 +4,7 @@ config({ path: '.env.test', override: true });
 
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import { IntentController } from "../intent.controller";
-import { IntentDatabaseAdapter, UserDatabaseAdapter, ProfileDatabaseAdapter } from "../../adapters/database.adapter";
+import { IntentDatabaseAdapter, UserDatabaseAdapter, ProfileDatabaseAdapter, ChatDatabaseAdapter, NetworkGraphDatabaseAdapter } from "../../adapters/database.adapter";
 import type { AuthenticatedUser } from "../../guards/auth.guard";
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -105,6 +105,39 @@ describe("IntentDatabaseAdapter Integration", () => {
     });
 
     expect(updated).toBeNull();
+  });
+
+  test("listIntents attaches an empty networks array for an intent in no networks", async () => {
+    const { rows } = await adapter.listIntents(testUserId, { page: 1, limit: 10, archived: false });
+    const row = rows.find((r) => r.id === testIntentId);
+    expect(row).toBeDefined();
+    expect(row!.networks).toEqual([]);
+  });
+
+  test("listIntents attaches assigned networks and excludes soft-deleted ones", async () => {
+    const chatAdapter = new ChatDatabaseAdapter();
+    const indexAdapter = new NetworkGraphDatabaseAdapter();
+    const live = await chatAdapter.createNetwork({ title: `Intent-Net Live ${Date.now()}` });
+    const removed = await chatAdapter.createNetwork({ title: `Intent-Net Removed ${Date.now()}` });
+    try {
+      await adapter.assignIntentToNetwork(testIntentId, live.id);
+      await adapter.assignIntentToNetwork(testIntentId, removed.id);
+      await chatAdapter.softDeleteNetwork(removed.id);
+
+      const { rows } = await adapter.listIntents(testUserId, { page: 1, limit: 10, archived: false });
+      const row = rows.find((r) => r.id === testIntentId);
+      expect(row).toBeDefined();
+      // Only the live network is attached; the soft-deleted one is excluded.
+      expect(row!.networks).toEqual([{ id: live.id, title: live.title }]);
+
+      // getIntentById carries the same membership data.
+      const single = await adapter.getIntentById(testIntentId, testUserId);
+      expect(single!.networks).toEqual([{ id: live.id, title: live.title }]);
+    } finally {
+      // deleteNetworkAndMembers also clears the intent_networks rows for each network.
+      await indexAdapter.deleteNetworkAndMembers(live.id).catch(() => {});
+      await indexAdapter.deleteNetworkAndMembers(removed.id).catch(() => {});
+    }
   });
 
   test("archiveIntent should set archivedAt timestamp", async () => {

--- a/frontend/src/app/library/page.tsx
+++ b/frontend/src/app/library/page.tsx
@@ -22,6 +22,7 @@ type LibrarySourceIntent = {
   sourceName: string;
   sourceValue: string | null;
   sourceMeta: string | null;
+  networks?: { id: string; title: string }[];
 };
 
 type FileItem = {

--- a/frontend/src/components/ChatContent.tsx
+++ b/frontend/src/components/ChatContent.tsx
@@ -579,15 +579,20 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
       const res = await apiClient.post<{ intentId: string }>("/intents/confirm", { proposalId, description, networkId });
       setIntentProposalStatusMap((prev) => ({ ...prev, [proposalId]: "created" }));
       setProposalIntentMap((prev) => ({ ...prev, [proposalId]: res.intentId }));
+      // Outcome-aware feedback: a network-scoped create lands directly in that
+      // network; an unscoped create is evaluated against all the user's
+      // networks asynchronously, so set expectations rather than implying it's
+      // already broadcasting somewhere specific.
+      const targetNetwork = networkId ? indexes.find((i) => i.id === networkId) : undefined;
       addNotification({
         type: "intent_broadcast",
-        title: "Broadcasting Signal",
+        title: targetNetwork ? `Broadcasting to ${targetNetwork.title}` : "Evaluating networks…",
         message: description,
         duration: 10000,
         onAction: () => archiveProposalIntent(proposalId, res.intentId),
       });
     },
-    [addNotification, archiveProposalIntent],
+    [addNotification, archiveProposalIntent, indexes],
   );
 
   const handleIntentProposalReject = useCallback(

--- a/frontend/src/components/IntentList.tsx
+++ b/frontend/src/components/IntentList.tsx
@@ -1,8 +1,32 @@
 import { useMemo } from 'react';
-import { Calendar, Trash2, ExternalLink, FileText, Link as LinkIcon, Slack, MessageSquare } from 'lucide-react';
+import { Calendar, Trash2, ExternalLink, FileText, Link as LinkIcon, Slack, MessageSquare, Network, AlertTriangle } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import { DebugCopyButton } from './DebugCopyButton';
+
+/**
+ * Grace window after creation during which an intent with zero network
+ * memberships is shown as "Evaluating…" rather than "Not in any network".
+ * Network assignment runs async (HyDE queue) shortly after creation, so a
+ * freshly-created intent legitimately has no memberships for a short while.
+ */
+const NETWORK_EVAL_GRACE_MS = 10 * 60 * 1000;
+
+interface IntentNetwork {
+  id: string;
+  title: string;
+}
+
+/**
+ * Whether an intent is still within the post-creation grace window, during
+ * which zero memberships reads as "evaluating" rather than "orphaned".
+ * A plain (non-component) function so the render-time clock read stays out of
+ * component bodies — mirrors `NegotiationHistory.timeAgo`.
+ */
+function isWithinEvalGrace(createdAt: string): boolean {
+  const ageMs = Date.now() - new Date(createdAt).getTime();
+  return Number.isFinite(ageMs) && ageMs < NETWORK_EVAL_GRACE_MS;
+}
 
 interface BaseIntent {
   id: string;
@@ -14,6 +38,63 @@ interface BaseIntent {
   sourceName?: string;
   sourceValue?: string | null;
   sourceMeta?: string | null;
+  /**
+   * Networks this intent is registered to. `undefined` means the caller did
+   * not supply membership data (membership UI is suppressed); an empty array
+   * means the intent is registered to no networks (pending or orphaned).
+   */
+  networks?: IntentNetwork[];
+}
+
+/**
+ * Renders an intent's network membership as chips, or a pending/orphaned badge
+ * when it belongs to none. Returns null when membership data wasn't provided,
+ * so callers that don't fetch memberships render nothing extra.
+ */
+function NetworkMembership({ networks, createdAt }: { networks?: IntentNetwork[]; createdAt: string }) {
+  if (networks === undefined) return null;
+
+  if (networks.length > 0) {
+    const shown = networks.slice(0, 2);
+    const extra = networks.length - shown.length;
+    return (
+      <div className="flex items-center gap-1.5 flex-wrap">
+        {shown.map((n) => (
+          <span
+            key={n.id}
+            className="flex items-center gap-1 text-xs text-blue-700 font-ibm-plex-mono px-2 py-0.5 rounded-full bg-blue-50 border border-blue-100"
+          >
+            <Network className="w-3 h-3 shrink-0" />
+            <span className="max-w-[140px] truncate">{n.title}</span>
+          </span>
+        ))}
+        {extra > 0 && (
+          <span className="text-xs text-blue-700 font-ibm-plex-mono px-2 py-0.5 rounded-full bg-blue-50 border border-blue-100">
+            +{extra}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  if (isWithinEvalGrace(createdAt)) {
+    return (
+      <span className="flex items-center gap-1.5 text-xs text-gray-500 font-ibm-plex-mono px-2 py-0.5 rounded-full bg-gray-100/50 border border-gray-100">
+        <span className="h-2.5 w-2.5 border border-gray-300 border-t-gray-500 rounded-full animate-spin" />
+        Evaluating…
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className="flex items-center gap-1 text-xs text-amber-700 font-ibm-plex-mono px-2 py-0.5 rounded-full bg-amber-50 border border-amber-200"
+      title="This intent isn't registered to any network yet. It will be re-evaluated when you join a matching network."
+    >
+      <AlertTriangle className="w-3 h-3 shrink-0" />
+      Not in any network
+    </span>
+  );
 }
 
 interface IntentListProps<T extends BaseIntent> {
@@ -128,6 +209,9 @@ export default function IntentList<T extends BaseIntent>({
                       New
                     </span>
                   )}
+
+                  {/* Network membership: chips, or pending/orphaned badge */}
+                  <NetworkMembership networks={intent.networks} createdAt={intent.createdAt} />
                 </div>
               </div>
 

--- a/frontend/src/contexts/NotificationContext.tsx
+++ b/frontend/src/contexts/NotificationContext.tsx
@@ -232,7 +232,7 @@ function IntentBroadcastToast({
               <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-75" />
               <span className="relative inline-flex h-2 w-2 rounded-full bg-green-500" />
             </span>
-            Broadcasting Signal
+            {notification.title || "Broadcasting Signal"}
           </div>
           <p className="text-[13px] text-[#3D3D3D] leading-relaxed mt-0.5 line-clamp-2">
             {notification.message || notification.title}


### PR DESCRIPTION
Makes intent→network assignment **visible** in the UI, so the silent orphaning behind Timour's Edge City report (intents created but registered to zero networks, with no feedback) can no longer go unnoticed. Complements the backend fix in #970 (which stops new orphaning); this surfaces the outcome to users.

## New Features
- **Network chips on intent cards** (`IntentList`, used by the library page). Each intent shows the networks it's registered to as chips (`Edge City`, `+N` overflow). When it belongs to none, the card derives a state from `(membership count, createdAt age)`:
  - **assigned** → network chips
  - **pending** → muted "Evaluating…" within a 10-minute post-creation grace window (assignment runs async via the HyDE queue, so a fresh intent legitimately has no memberships for a moment)
  - **orphaned** → amber "Not in any network" once past the grace window
- **Outcome-aware creation toast.** The "Broadcasting Signal" toast now reflects what actually happens: a network-scoped create shows **"Broadcasting to &lt;network&gt;"**; an unscoped create shows **"Evaluating networks…"** instead of implying it already landed somewhere specific.

## Backend
- `listIntents` / `getIntentById` now attach each intent's registered networks (`{ id, title }`), excluding soft-deleted networks, via a single grouped query (`attachIntentNetworks`). Pure data — no assignment status is computed server-side; the 3-state classification (and its grace window) lives in the frontend as a presentation concern.

## Tests
- `intent.controller.spec`: `listIntents` attaches `[]` for an intent in no networks; attaches assigned networks and **excludes soft-deleted** ones; `getIntentById` carries the same membership data. (13/13 pass.)

## Notes
- Backend typecheck + lint clean. Frontend touched files lint clean; the repo's frontend `tsc` baseline has 63 pre-existing errors unrelated to this change (verified identical with/without these edits).
- The `NetworkOverviewPanel` intent list is intentionally untouched — its endpoint is already network-scoped, so every intent shown there is in-network by definition; chips matter on the cross-network library view.
- No `packages/protocol` or `packages/cli` changes → no published-package version bumps.
