### PR TITLE
fix(networks): personal index holds all intents by default; let owners set a prompt

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -38,6 +38,7 @@
     "maintenance:backfill-context-hyde": "bun ./src/cli/backfill-context-hyde.ts",
     "maintenance:backfill-profile-questions": "bun ./src/cli/backfill-profile-questions.ts",
     "maintenance:backfill-intent-questions": "bun ./src/cli/backfill-intent-questions.ts",
+    "maintenance:backfill-personal-index-prompts": "bun ./src/cli/backfill-personal-index-prompts.ts",
     "test:opportunity-three-user": "bun ./src/cli/opportunity-three-user-test.ts",
     "test": "NODE_ENV=test bash scripts/test-safe.sh",
     "test:raw": "NODE_ENV=test bun test"

--- a/backend/src/adapters/contact.database.adapter.ts
+++ b/backend/src/adapters/contact.database.adapter.ts
@@ -20,10 +20,12 @@ async function ensurePersonalNetwork(userId: string): Promise<string> {
 
   const networkId = crypto.randomUUID();
 
+  // Personal indexes are prompt-less by default so the assignment policy treats
+  // them as "no filtration" (score 1.0) — every one of the owner's intents lands
+  // in their own personal index. The owner may later set a prompt to curate it.
   await db.insert(schema.networks).values({
     id: networkId,
     title: 'My Network',
-    prompt: "Personal index containing the owner's imported contacts for network-scoped discovery.",
     isPersonal: true,
   }).onConflictDoNothing();
 

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -48,10 +48,12 @@ export async function ensurePersonalNetwork(userId: string): Promise<string> {
 
   const networkId = crypto.randomUUID();
 
+  // Personal indexes are prompt-less by default so the assignment policy treats
+  // them as "no filtration" (score 1.0) — every one of the owner's intents lands
+  // in their own personal index. The owner may later set a prompt to curate it.
   await db.insert(schema.networks).values({
     id: networkId,
     title: 'My Network',
-    prompt: 'Personal index containing the owner\'s imported contacts for network-scoped discovery.',
     isPersonal: true,
   }).onConflictDoNothing();
 

--- a/backend/src/cli/backfill-personal-index-prompts.ts
+++ b/backend/src/cli/backfill-personal-index-prompts.ts
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * Backfill CLI: heal personal indexes after removing the hidden boilerplate prompt.
+ *
+ * Two idempotent steps:
+ *   1. Clear the system boilerplate prompt from personal indexes (only the exact
+ *      boilerplate string — any user-authored prompt is preserved).
+ *   2. Assign every active intent to its owner's personal index (relevancy 1.0)
+ *      when that personal index is now prompt-less and the intent isn't already
+ *      a member. Prompt-less personal index == "no filtration" == holds everything.
+ *
+ * Dry-run by default: pass --apply to write. Defaults to .env.development unless
+ * NODE_ENV=production (mirrors the other maintenance scripts).
+ *
+ * Usage:
+ *   NODE_ENV=development bun run maintenance:backfill-personal-index-prompts          # dry-run
+ *   NODE_ENV=development bun run maintenance:backfill-personal-index-prompts -- --apply
+ */
+import dotenv from 'dotenv';
+import path from 'path';
+
+const envFile = process.env.NODE_ENV === 'production' ? '.env.production' : '.env.development';
+dotenv.config({ path: path.resolve(process.cwd(), envFile) });
+
+import { sql } from 'drizzle-orm';
+
+import db, { closeDb } from '../lib/drizzle/drizzle';
+
+const BOILERPLATE = "Personal index containing the owner's imported contacts for network-scoped discovery.";
+
+async function main() {
+  const apply = process.argv.slice(2).includes('--apply');
+  const mode = apply ? 'APPLY' : 'DRY-RUN';
+  console.log(`\n[backfill-personal-index-prompts] mode=${mode} env=${envFile}\n`);
+
+  // --- Report: current state -------------------------------------------------
+  // postgres-js drizzle: db.execute returns an array-like RowList (no .rows).
+  const boilerplateRows = await db.execute(sql`
+    select count(*)::int as count
+    from networks
+    where is_personal = true and deleted_at is null and prompt = ${BOILERPLATE}
+  `);
+  const boilerplateCount = Number((boilerplateRows[0] as { count: number | string })?.count ?? 0);
+
+  const orphanRows = await db.execute(sql`
+    select count(*)::int as count
+    from intents i
+    join personal_networks pn on pn.user_id = i.user_id
+    join networks n on n.id = pn.network_id and n.deleted_at is null
+    where i.archived_at is null
+      and (n.prompt is null or n.prompt = ${BOILERPLATE})
+      and not exists (
+        select 1 from intent_networks inn
+        where inn.intent_id = i.id and inn.network_id = pn.network_id
+      )
+  `);
+  const orphanCount = Number((orphanRows[0] as { count: number | string })?.count ?? 0);
+
+  console.log(`Personal indexes with boilerplate prompt to clear: ${boilerplateCount}`);
+  console.log(`Active intents missing from their personal index to heal: ${orphanCount}`);
+
+  if (!apply) {
+    console.log('\nDry-run only — re-run with --apply to write changes.\n');
+    return;
+  }
+
+  // --- Step 1: clear the boilerplate prompt ----------------------------------
+  const cleared = await db.execute(sql`
+    update networks set prompt = null, updated_at = now()
+    where is_personal = true and deleted_at is null and prompt = ${BOILERPLATE}
+    returning id
+  `);
+  console.log(`Step 1: cleared boilerplate prompt on ${(cleared as unknown[]).length} personal indexes.`);
+
+  // --- Step 2: assign missing active intents to their personal index ---------
+  // Runs AFTER step 1 so n.prompt is null for indexes we just cleared; any
+  // user-authored prompt remains non-null and is intentionally skipped.
+  const healed = await db.execute(sql`
+    insert into intent_networks (intent_id, network_id, relevancy_score, assignment_metadata)
+    select i.id, pn.network_id, '1', null
+    from intents i
+    join personal_networks pn on pn.user_id = i.user_id
+    join networks n on n.id = pn.network_id and n.deleted_at is null
+    where i.archived_at is null
+      and n.prompt is null
+      and not exists (
+        select 1 from intent_networks inn
+        where inn.intent_id = i.id and inn.network_id = pn.network_id
+      )
+    on conflict (intent_id, network_id) do nothing
+    returning intent_id
+  `);
+  console.log(`Step 2: assigned ${(healed as unknown[]).length} intents to their personal index.\n`);
+}
+
+main()
+  .catch((err) => {
+    console.error('[backfill-personal-index-prompts] failed:', err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await closeDb();
+  });

--- a/backend/src/services/network.service.ts
+++ b/backend/src/services/network.service.ts
@@ -125,7 +125,20 @@ export class NetworkService {
    */
   async updateNetwork(networkId: string, userId: string, data: { title?: string; prompt?: string | null; imageUrl?: string | null; joinPolicy?: 'anyone' | 'invite_only'; allowGuestVibeCheck?: boolean; profileEnrichment?: schema.ProfileEnrichmentPolicy; type?: 'community' | 'event'; metadata?: Record<string, unknown>; contextInjection?: { discovery: boolean } }) {
     logger.verbose('[NetworkService] Updating index', { networkId, userId });
-    await this.assertNotPersonal(networkId);
+    if (await this.adapter.isPersonalNetwork(networkId)) {
+      // Personal indexes can't be renamed/deleted/repurposed (see assertNotPersonal),
+      // but the owner may set or clear a discovery prompt to curate what auto-assigns
+      // into My Network. Restrict edits to the prompt field only; ownership is
+      // enforced inside updateIndexSettings.
+      const editableForPersonal = new Set<string>(['prompt']);
+      const rejected = Object.keys(data).filter(
+        (k) => (data as Record<string, unknown>)[k] !== undefined && !editableForPersonal.has(k),
+      );
+      if (rejected.length > 0) {
+        throw new Error(`Access denied: personal indexes only allow editing the prompt (rejected: ${rejected.join(', ')}).`);
+      }
+      return this.adapter.updateIndexSettings(networkId, userId, { prompt: data.prompt });
+    }
     if (data.joinPolicy !== undefined || data.allowGuestVibeCheck !== undefined) {
       await this.assertJoinPolicyNotLockedByExperiment(networkId);
     }

--- a/backend/src/services/tests/network.service.personal-prompt.spec.ts
+++ b/backend/src/services/tests/network.service.personal-prompt.spec.ts
@@ -1,0 +1,56 @@
+/** Config */
+import { config } from 'dotenv';
+config({ path: '.env.test', override: true });
+
+import { describe, expect, mock, test } from 'bun:test';
+
+import { NetworkService } from '../network.service';
+import type { ChatDatabaseAdapter } from '../../adapters/database.adapter';
+
+const PERSONAL_ID = 'personal-net-1';
+const USER_ID = 'user-1';
+
+/**
+ * Build a NetworkService backed by a minimal mock adapter. `isPersonalNetwork`
+ * reports PERSONAL_ID as personal; `updateIndexSettings` records its call and
+ * echoes the patch. Ownership is enforced inside the real adapter, so the unit
+ * test only exercises the service's field allowlist.
+ */
+function makeService() {
+  const updateIndexSettings = mock(async (id: string, _userId: string, data: Record<string, unknown>) => ({ id, ...data }));
+  const adapter = {
+    isPersonalNetwork: mock(async (id: string) => id === PERSONAL_ID),
+    updateIndexSettings,
+  } as unknown as ChatDatabaseAdapter;
+  return { service: new NetworkService(adapter), updateIndexSettings };
+}
+
+describe('networkService.updateNetwork on a personal index', () => {
+  test('allows a prompt-only edit', async () => {
+    const { service, updateIndexSettings } = makeService();
+    await service.updateNetwork(PERSONAL_ID, USER_ID, { prompt: 'AI founders only' });
+    expect(updateIndexSettings).toHaveBeenCalledWith(PERSONAL_ID, USER_ID, { prompt: 'AI founders only' });
+  });
+
+  test('allows clearing the prompt (null) — restores the prompt-less default', async () => {
+    const { service, updateIndexSettings } = makeService();
+    await service.updateNetwork(PERSONAL_ID, USER_ID, { prompt: null });
+    expect(updateIndexSettings).toHaveBeenCalledWith(PERSONAL_ID, USER_ID, { prompt: null });
+  });
+
+  test('rejects a rename (title) on a personal index', async () => {
+    const { service, updateIndexSettings } = makeService();
+    await expect(
+      service.updateNetwork(PERSONAL_ID, USER_ID, { title: 'Renamed' }),
+    ).rejects.toThrow(/only allow editing the prompt/);
+    expect(updateIndexSettings).not.toHaveBeenCalled();
+  });
+
+  test('rejects non-prompt fields even alongside a valid prompt', async () => {
+    const { service, updateIndexSettings } = makeService();
+    await expect(
+      service.updateNetwork(PERSONAL_ID, USER_ID, { prompt: 'ok', imageUrl: 'x', joinPolicy: 'anyone' }),
+    ).rejects.toThrow(/rejected: imageUrl, joinPolicy/);
+    expect(updateIndexSettings).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/settings/SettingsTab.tsx
+++ b/frontend/src/components/settings/SettingsTab.tsx
@@ -145,11 +145,14 @@ export default function SettingsTab({
       } else if (removeImageRequested) {
         finalImageUrl = null;
       }
-      const updatedIndex = await updateNetwork(networkId, {
-        title: title.trim(),
-        prompt: prompt.trim() || null,
-        imageUrl: finalImageUrl,
-      });
+      // Personal indexes accept only a prompt edit (rename/avatar are blocked
+      // server-side); send prompt alone to avoid a rejected update.
+      const updatedIndex = await updateNetwork(
+        networkId,
+        network.isPersonal
+          ? { prompt: prompt.trim() || null }
+          : { title: title.trim(), prompt: prompt.trim() || null, imageUrl: finalImageUrl },
+      );
       setOriginalTitle(title);
       setOriginalPrompt(prompt);
       setOriginalImageUrl(finalImageUrl);
@@ -255,7 +258,7 @@ export default function SettingsTab({
           <button
             type="button"
             onClick={() => imageInputRef.current?.click()}
-            disabled={isSavingSettings}
+            disabled={isSavingSettings || network.isPersonal}
             className="relative flex-shrink-0 group cursor-pointer disabled:cursor-not-allowed"
           >
             <div className="w-[72px] h-[72px] rounded-full overflow-hidden">
@@ -276,7 +279,7 @@ export default function SettingsTab({
             onChange={handleImageChange}
             className="hidden"
           />
-          {displayImageUrl && (
+          {displayImageUrl && !network.isPersonal && (
             <button
               type="button"
               onClick={handleRemoveImage}
@@ -293,15 +296,16 @@ export default function SettingsTab({
           <label htmlFor="title" className="text-sm font-medium font-ibm-plex-mono text-gray-700 block mb-1.5">
             Title
           </label>
-          <Input id="title" value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Network title" />
+          <Input id="title" value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Network title" disabled={network.isPersonal} />
+          {network.isPersonal && (
+            <p className="text-xs text-gray-400 mt-1.5">Your personal index can&apos;t be renamed.</p>
+          )}
         </div>
-        {!network.isPersonal && (
-          <div>
-            <label className="block text-sm font-medium font-ibm-plex-mono text-gray-700 mb-1.5">Prompt</label>
-            <Textarea value={prompt} onChange={(e) => setPrompt(e.target.value)} placeholder="What people can share in this network..." className="min-h-[100px]" rows={4} />
-            <p className="text-xs text-gray-400 mt-1.5">Guides what kind of intents people can share.</p>
-          </div>
-        )}
+        <div>
+          <label className="block text-sm font-medium font-ibm-plex-mono text-gray-700 mb-1.5">Prompt</label>
+          <Textarea value={prompt} onChange={(e) => setPrompt(e.target.value)} placeholder={network.isPersonal ? 'Optional — describe what should land in My Network. Leave empty to keep every intent.' : 'What people can share in this network...'} className="min-h-[100px]" rows={4} />
+          <p className="text-xs text-gray-400 mt-1.5">{network.isPersonal ? 'Filters which of your intents auto-assign to My Network. Empty keeps everything.' : 'Guides what kind of intents people can share.'}</p>
+        </div>
         <div className="flex justify-end gap-2">
           <Button variant="outline" size="sm" onClick={() => { setTitle(originalTitle); setPrompt(originalPrompt); setImageUrl(originalImageUrl); setImageFile(null); setImagePreview(null); setRemoveImageRequested(false); if (imageInputRef.current) imageInputRef.current.value = ''; }} disabled={isSavingSettings || !hasSettingsChanged}>
             Cancel


### PR DESCRIPTION
Fixes a silent bug where a user's own intents don't all land in their personal index ("My Network") — surfaced by the network-membership chips in #971.

## Root cause
Personal indexes were created with a **hidden, system-authored boilerplate prompt** (*"Personal index containing the owner's imported contacts for network-scoped discovery."*). A *prompted* network is **scored**, not auto-assigned — so that hidden prompt silently filtered the owner's own intents out of their own personal index. The Settings UI **hid the prompt field** for personal indexes (`!isPersonal` gate), so it was invisible and uneditable. On dev, **12 active intents** were missing from their owners' personal indexes.

## Behavior after this change
- **Default (no prompt):** every intent you create lands in My Network (prompt-less ⇒ policy scores 1.0 ⇒ holds everything). Restores the invariant.
- **Optional:** you can now author a prompt on your personal index to curate what auto-assigns.

## Backend
- Stop hard-coding the boilerplate prompt at both creation sites (`database.adapter` `ensurePersonalNetwork`, `contact.database.adapter`).
- Relax `updateNetwork`'s blanket `assertNotPersonal` to a **field allowlist**: personal indexes accept a `prompt` edit only — rename/avatar/join-policy stay blocked; ownership is enforced by `updateIndexSettings`.

## Frontend
- Un-hide the Prompt editor in `SettingsTab` for personal indexes (reachable via `/mynetwork` → Settings), with copy explaining it curates what lands in My Network.
- Title is read-only and the avatar editor disabled for personal indexes (rename/avatar are server-blocked); the save payload sends **prompt only** for personal so the server doesn't reject it.

## Backfill
`maintenance:backfill-personal-index-prompts` (dry-run by default, `--apply` to write):
1. Clears the boilerplate prompt from existing personal indexes — **preserving any user-authored prompt**.
2. Assigns every active intent to its owner's now prompt-less personal index (relevancy 1.0), idempotent (`ON CONFLICT DO NOTHING`).

**Applied on the dev branch: 36 prompts cleared, 12 intents healed** (verified: the test account's intents are now all in My Network). **Production run pending explicit approval** (dry-run first).

## Tests
- `network.service.personal-prompt.spec`: prompt-only edit allowed, prompt-clear allowed, rename rejected, non-prompt fields rejected. Existing network-service + controller specs still green (31/31).

## Notes
- No `packages/protocol` / `packages/cli` changes → no published-package version bumps.
- Pairs with #971 (membership chips) — the chips made this bug visible; this restores the invariant they surface.
