### PR TITLE
fix(opportunity): word-boundary truncation for presenter fallback cards + fallback telemetry

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol",
-  "version": "0.27.5",
+  "version": "0.27.6",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/backend/src/instrument.ts
+++ b/backend/src/instrument.ts
@@ -51,6 +51,10 @@ Sentry.init({
 
   integrations: (defaultIntegrations) => [
     ...defaultIntegrations.filter((integration) => !['LangChain', 'LangGraph', 'PostgresJs'].includes(integration.name)),
+    // Forward console.warn/error into Sentry Logs (not issues) so structured
+    // protocol signals — e.g. presenter_fallback — become queryable in the
+    // logs dataset without creating issue noise. Requires enableLogs below.
+    Sentry.consoleLoggingIntegration({ levels: ['warn', 'error'] }),
     Sentry.langChainIntegration({
       recordInputs: false,
       recordOutputs: false,

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "3.6.3",
+  "version": "3.6.4",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/opportunity/opportunity.presentation.ts
+++ b/packages/protocol/src/opportunity/opportunity.presentation.ts
@@ -127,6 +127,36 @@ export function stripUuids(text: string): string {
 }
 
 /**
+ * Truncate user-facing text to at most `maxChars` without cutting mid-word.
+ *
+ * Prefers a sentence boundary, then a word boundary, and only falls back to a
+ * hard slice if no boundary exists within the limit. An ellipsis is appended
+ * when the text is actually shortened. Used by presenter fallbacks so a degraded
+ * card never shows a sentence chopped mid-word (e.g. "His focus on 'indiv").
+ */
+export function truncateAtBoundary(text: string, maxChars: number): string {
+  const trimmed = text.trim();
+  if (trimmed.length <= maxChars) return trimmed;
+
+  const slice = trimmed.slice(0, maxChars);
+
+  // Prefer ending on the last completed sentence within the limit.
+  const lastSentence = Math.max(
+    slice.lastIndexOf(". "),
+    slice.lastIndexOf("! "),
+    slice.lastIndexOf("? "),
+  );
+  if (lastSentence >= maxChars * 0.5) {
+    return slice.slice(0, lastSentence + 1).trim();
+  }
+
+  // Otherwise back off to the last whole word and add an ellipsis.
+  const lastSpace = slice.lastIndexOf(" ");
+  const body = lastSpace > 0 ? slice.slice(0, lastSpace) : slice;
+  return body.replace(/[\s,;:.!?'"-]+$/, "").trim() + "\u2026";
+}
+
+/**
  * Strips introducer mentions from opportunity summary text.
  * Removes patterns like:
  * - "[Introducer] introduced you to [Counterpart]"

--- a/packages/protocol/src/opportunity/opportunity.presenter.ts
+++ b/packages/protocol/src/opportunity/opportunity.presenter.ts
@@ -19,7 +19,7 @@ import { viewerCentricCardSummary } from "./opportunity.presentation.js";
 import type { Opportunity } from "../shared/interfaces/database.interface.js";
 import type { ChatGraphCompositeDatabase } from "../shared/interfaces/database.interface.js";
 import type { NegotiationContext } from "./negotiation-context.loader.js";
-import { stripUuids, stripIntroducerMentions } from "./opportunity.presentation.js";
+import { stripUuids, stripIntroducerMentions, truncateAtBoundary } from "./opportunity.presentation.js";
 
 /**
  * Minimal database interface required by gatherPresenterContext.
@@ -354,13 +354,16 @@ Produce headline, personalizedSummary (2-3 sentences in "you" language), suggest
       logger.warn(
         "[OpportunityPresenter.present] LLM failed, returning fallback",
         {
+          event: "presenter_fallback",
+          presenter: "opportunity",
+          reason: timeoutReason ? "timeout" : "parse_error",
           message,
           timeoutReason,
         },
       );
       return {
         headline: "A promising connection",
-        personalizedSummary: stripUuids(input.matchReasoning.slice(0, 300)),
+        personalizedSummary: truncateAtBoundary(stripUuids(input.matchReasoning), 300),
         suggestedAction: "Take a look and decide whether to reach out.",
         greeting: "",
       };
@@ -451,11 +454,14 @@ Produce headline, personalizedSummary, digestSummary, suggestedAction, narratorR
       logger.warn(
         "[OpportunityPresenter.presentHomeCard] LLM failed, returning fallback",
         {
+          event: "presenter_fallback",
+          presenter: "home_card",
+          reason: timeoutReason ? "timeout" : "parse_error",
           message,
           timeoutReason,
         },
       );
-      let fallbackSummary = stripUuids(input.matchReasoning.slice(0, 300));
+      let fallbackSummary = truncateAtBoundary(stripUuids(input.matchReasoning), 300);
       if (input.isIntroduction && input.introducerName) {
         fallbackSummary = stripIntroducerMentions(fallbackSummary, input.introducerName);
       }

--- a/packages/protocol/src/opportunity/tests/opportunity.presentation.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.presentation.spec.ts
@@ -3,7 +3,7 @@ import { config } from "dotenv";
 config({ path: '.env.test', override: true });
 
 import { describe, test, expect } from 'bun:test';
-import { presentOpportunity } from '../opportunity.presentation.js';
+import { presentOpportunity, truncateAtBoundary } from '../opportunity.presentation.js';
 import type { Opportunity } from '../../shared/interfaces/database.interface.js';
 
 describe('presentOpportunity', () => {
@@ -81,5 +81,37 @@ describe('presentOpportunity', () => {
     if (result.description.length >= 100) {
       expect(result.description.slice(-3)).toBe('...');
     }
+  });
+});
+
+describe('truncateAtBoundary', () => {
+  test('returns text unchanged when within the limit', () => {
+    const text = 'Short and sweet.';
+    expect(truncateAtBoundary(text, 300)).toBe(text);
+  });
+
+  test('never cuts mid-word', () => {
+    const text =
+      "Eric is a computational neuroscientist with a background in engineering and explicitly develops systems for humans to better understand and interact with AI. His focus on individual cognition makes this a strong match.";
+    const out = truncateAtBoundary(text, 120);
+    expect(out.length).toBeLessThanOrEqual(120);
+    // The last token must be a complete word from the source, not a fragment.
+    const lastWord = out.replace(/[\u2026.!?]+$/, '').trim().split(/\s+/).pop() ?? '';
+    expect(text).toContain(lastWord);
+  });
+
+  test('prefers a sentence boundary when one is available', () => {
+    const text =
+      'You both work on developer tooling. They are hiring a founding engineer right now and could use your distributed-systems background.';
+    const out = truncateAtBoundary(text, 60);
+    expect(out).toBe('You both work on developer tooling.');
+  });
+
+  test('falls back to a word boundary with an ellipsis', () => {
+    const text =
+      'Acomplicatedrunonphrasewithoutanyearlysentencebreak that keeps going well past the limit and onward';
+    const out = truncateAtBoundary(text, 40);
+    expect(out.length).toBeLessThanOrEqual(41); // body + ellipsis char
+    expect(out.endsWith('\u2026')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

A discovery card on the home view showed its body text cut off mid-word (e.g. *"His focus on 'indiv"*). That card is the presenter's **degraded fallback**, served when the home-card LLM call fails (20s timeout or structured-output parse error). The frontend (`OpportunityCardInChat.tsx`) renders the full `mainText` with no clamp — the cut-off came from the **data**: the fallback hard-sliced `input.matchReasoning.slice(0, 300)`, chopping the sentence mid-word with no boundary handling or ellipsis.

## Bug Fixes
- Add `truncateAtBoundary(text, maxChars)` in `opportunity.presentation.ts` — prefers a sentence boundary, then a whole-word boundary with an ellipsis (`…`), and only hard-slices when no boundary exists within the limit.
- Apply it to **both** presenter fallbacks: `present()` and `presentHomeCard()` (runs `stripUuids` first, then truncates).

## Observability
This fix is cosmetic — it makes a degraded card look clean but doesn't stop it from being degraded. To measure/triage the real cause:
- Tag both fallback `warn` logs with structured fields: `event=presenter_fallback`, `presenter=opportunity|home_card`, `reason=timeout|parse_error`.
- Forward `console.warn`/`error` into **Sentry Logs** via `consoleLoggingIntegration` (`enableLogs` was already on). Previously these warns never reached Sentry, so fallback frequency was invisible. Now queryable in the logs dataset, e.g. `message:*returning fallback*` broken down by `reason`.

> Note: `consoleLoggingIntegration({ levels: ['warn','error'] })` forwards *all* backend warn/error console output to Sentry Logs (not issues). Intentional and reversible; flagged here for visibility.

## Tests
- 4 unit tests for `truncateAtBoundary` (unchanged-within-limit, never-mid-word, sentence-boundary preference, word-boundary ellipsis fallback). All 21 presenter/presentation tests pass; `tsc --noEmit` clean for protocol and backend.

## Versions
- `@indexnetwork/protocol` 3.6.3 → 3.6.4
- `backend` 0.27.5 → 0.27.6

## Follow-up
Once deployed and Sentry Logs has data, query `event:presenter_fallback` to see how often the presenter LLM is failing and whether it is dominated by timeouts (consider raising `LLM_TIMEOUT_MS`, currently 20s) or parse errors (tighten the structured-output schema/prompt).
