### PR TITLE
Release 2026-06-15-3

### DIFF
--- a/.pi/skills/learn-skill/scripts/skillctl.ts
+++ b/.pi/skills/learn-skill/scripts/skillctl.ts
@@ -20,14 +20,7 @@
  *                                          candidates (duplicate blocks), shared-dir links
  */
 
-import {
-  existsSync,
-  readdirSync,
-  readFileSync,
-  statSync,
-  mkdirSync,
-  cpSync,
-} from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync, mkdirSync, cpSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve, basename } from "node:path";
 

--- a/.rpiv/artifacts/designs/intent-network-orphaning-fix.md
+++ b/.rpiv/artifacts/designs/intent-network-orphaning-fix.md
@@ -1,0 +1,239 @@
+# Design: Fix silent intent→network orphaning
+
+## Problem (confirmed in prod)
+
+Intents can end up registered to **zero** networks even when the user is an
+eligible member of a network that should accept them. The user sees "intent
+saved" but it never appears in any network, with no feedback.
+
+Production evidence (user `Timour Kosters`, network `Edge City`):
+
+- Owns **11** active intents; only **1** has an `intent_networks` row.
+- The other **10 are in zero networks** — including intents that are clearly
+  on-theme (e.g. *"Meet builders in Healdsburg during Edge Esmeralda"*).
+- He is a member of **Index Early Birds**, a network with **no prompt**, which
+  the assignment policy assigns to **unconditionally at score 1.0**. The orphans
+  are not even there.
+- Systemic: across 203 Edge City members, ~40 intents are orphaned the same way
+  (Timour 1/11, Seren 1/8, Adam Byrne 3/14, Miela 7/10).
+
+## Root causes
+
+Assignment to networks happens **once**, inside the HyDE queue
+(`backend/src/queues/intent.queue.ts` → `handleGenerateHyde`, lines ~196-272),
+at intent-creation time. Three properties of that path each produce permanent,
+silent orphaning:
+
+1. **Creation-time only, no backfill.** Networks are resolved at the instant the
+   intent is created (`getAssignmentNetworkIdsForUser` →
+   `resolveAssignmentNetworkScope`). Joining a network later, or the relevance
+   picture changing later, never re-evaluates existing intents. Intents created
+   before a membership/feature existed stay orphaned forever.
+
+2. **Scope filtering with no fallback.** When the job carries a `networkScopeId`
+   (agent/UI bound to one network), `resolveAssignmentNetworkScope` narrows the
+   candidate set to that single network (+ personal networks). If the intent
+   scores `< 0.7` against that network's prompt, it is assigned to **nothing** —
+   it does not fall back to the user's other memberships (e.g. the no-prompt
+   Index Early Birds), so it disappears entirely.
+
+3. **Swallowed failures.** The whole assignment block is wrapped in
+   `try/catch → logger.warn`, and `intent.service.ts:createFromProposal` returns
+   success even when `assignIntentToNetwork` throws. A lost/failed HyDE job or a
+   transient error produces an orphan with no signal to the user or operator.
+
+The 0.7 relevance threshold is **not** the root cause — orphans include intents
+that would score ~0.9 against the network prompt, and intents eligible for a
+no-prompt network that bypasses scoring entirely.
+
+## Goals
+
+- No active intent should be silently orphaned from networks it qualifies for.
+- Joining a network re-evaluates the joiner's existing intents against it.
+- A safety net reconciles any intent that slips through (job loss, scope drop,
+  pre-feature data).
+- Remediation and the structural fix **share one assignment core** so behavior
+  cannot drift between them.
+- Reconciliation must **not** regenerate HyDE docs or trigger opportunity
+  discovery (avoid notification spam on old intents).
+
+## Design
+
+### 1. Extract an assignment-only core (refactor, no behavior change)
+
+Pull the network-assignment loop out of `handleGenerateHyde` into a private
+method on `IntentQueue`:
+
+```ts
+// backend/src/queues/intent.queue.ts
+/**
+ * Resolve the user's eligible networks (respecting optional scope), score the
+ * intent against each, and upsert intent_networks rows for assigned networks.
+ * Pure assignment: no HyDE regeneration, no opportunity discovery.
+ * Idempotent — assignIntentToNetwork upserts on (intentId, networkId).
+ */
+private async assignIntentToNetworks(
+  intentId: string,
+  userId: string,
+  networkScopeId?: string,
+): Promise<{ assignedNetworkIds: string[]; evaluatedCount: number }> {
+  // ...exactly the existing lines 207-271, returning the assigned ids...
+}
+```
+
+`handleGenerateHyde` then calls `assignIntentToNetworks(intentId, userId,
+networkScopeId)` in place of the inline block. Net behavior unchanged; this just
+makes the core reusable and testable.
+
+**Add an explicit orphan signal** at the end of the core:
+
+```ts
+if (assignedNetworkIds.length === 0) {
+  this.logger.warn('[IntentAssign] Intent assigned to NO networks', {
+    intentId, userId, networkScopeId, evaluatedCount,
+  });
+  // emit metric: intent_network_orphaned_total
+}
+```
+
+This converts silent loss (cause 3) into an observable event.
+
+### 2. New assignment-only job: `reconcile_intent_networks`
+
+Add a job that runs **only** the assignment core — no HyDE, no opportunity
+enqueue:
+
+```ts
+// payload
+export interface IntentReconcileData { intentId: string; userId: string; networkScopeId?: string }
+
+// in processJob switch
+case 'reconcile_intent_networks':
+  await this.handleReconcileNetworks(data as IntentReconcileData);
+  break;
+
+private async handleReconcileNetworks(d: IntentReconcileData) {
+  await this.assignIntentToNetworks(d.intentId, d.userId, d.networkScopeId);
+}
+
+addReconcileJob(d: IntentReconcileData) {
+  // jobId dedupes concurrent reconciles for the same intent+scope
+  return this.addJob('reconcile_intent_networks', d, {
+    jobId: `reconcile-${d.intentId}-${d.networkScopeId ?? 'global'}`,
+  });
+}
+```
+
+This is the shared primitive used by both backfill-on-join and the safety-net
+sweep below.
+
+### 3. Backfill-on-join (membership-event seam)
+
+"Joining a network re-evaluates the member's existing intents against it" is a
+**protocol-level definition of membership**, not application glue. It must fire
+for *every* membership path, not just one backend service method. All paths —
+REST self-join (`joinPublicNetwork`), owner-add (`addMemberForOwner`), and the
+protocol `create_network_membership` graph (`addMemberNode`) — converge on the
+adapter method `ChatDatabaseAdapter.addMemberToNetwork`, which emits
+`NetworkMembershipEvents.onMemberAdded(userId, networkId)` exactly once per
+genuinely-new member. That event is the single canonical seam (it already
+drives profile-HyDE and user-context regen on join).
+
+Wire the reconcile into the existing `onMemberAdded` handler in `main.ts`, and
+encapsulate the per-intent fan-out in the queue so the composition root stays a
+thin wiring line:
+
+```ts
+// IntentQueue
+async addNetworkReconcileForUser(userId: string, networkId: string): Promise<number> {
+  const db = this.deps?.database ?? this.database;
+  const intents = await db.getActiveIntents(userId);
+  await Promise.all(intents.map(i =>
+    this.addReconcileJob({ intentId: i.id, userId, networkScopeId: networkId })
+      .catch(err => this.logger.warn('[IntentReconcile] enqueue failed', { intentId: i.id, networkId, userId, error: err }))
+  ));
+  return intents.length;
+}
+
+// main.ts — NetworkMembershipEvents.onMemberAdded handler
+intentQueue.addNetworkReconcileForUser(userId, networkId).catch((err) => {
+  log.job.from('NetworkMembership').error('Failed to enqueue intent network reconcile', { userId, networkId, error: err });
+});
+```
+
+Do **not** put this in `NetworkService.joinPublicNetwork`/`addMember` — that
+would cover only the REST path and duplicate a definition the protocol/membership
+layer already owns. Scoping to `networkId` keeps it cheap (one network evaluated
+per intent) and avoids re-touching unrelated memberships.
+
+### 4. Safety-net reconciliation sweep (catches everything else)
+
+A maintenance cron that finds active intents with **zero** `intent_networks`
+rows and enqueues a **global** reconcile for each. This is the backstop that
+heals job loss, scope-drop orphans, and pre-feature data without bespoke logic
+per cause.
+
+```ts
+// backend/src/queues/maintenance or a new intent-reconcile cron
+const orphans = await db.getOrphanedActiveIntents({ limit: 500 }); // intents w/ no intent_networks row
+for (const o of orphans) intentQueue.addReconcileJob({ intentId: o.id, userId: o.userId });
+```
+
+New adapter query:
+
+```sql
+select i.id, i.user_id
+from intents i
+left join intent_networks n on n.intent_id = i.id
+where i.archived_at is null and n.intent_id is null
+limit $1;
+```
+
+Idempotent and self-limiting: once an intent gets at least one row it drops out
+of the result set. Safe to run on a schedule.
+
+### 5. (Optional) Stop scoped creation from orphaning at the source
+
+Independent of the safety net, decide the intended semantics of scoped creation:
+
+- **Option A (recommended): scoped creation always assigns the scoped network.**
+  If a human explicitly adds an intent inside a network's context, treat it as a
+  `manual_override` (score 1.0) for that network rather than scoring it out.
+  This matches the existing `createFromProposal(..., networkId)` path, which
+  already force-assigns.
+- **Option B: fallback to global memberships.** If scoped scoring yields zero
+  assignments, re-evaluate against the user's other memberships so the intent at
+  least lands in no-prompt networks.
+
+A is simpler and matches user intent; B preserves relevance filtering. The
+safety-net sweep (4) makes either non-urgent, but A removes the surprise for
+human-initiated, in-network creation.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `backend/src/queues/intent.queue.ts` | Extract `assignIntentToNetworks`; add `reconcile_intent_networks` job + `addReconcileJob`; orphan warning/metric |
+| `backend/src/main.ts` | Enqueue network-scoped reconcile from the `NetworkMembershipEvents.onMemberAdded` handler (covers REST + protocol membership paths uniformly) |
+| `backend/src/adapters/database.adapter.ts` | Add `getOrphanedActiveIntents`; ensure `getActiveIntents` returns `{id,userId}` |
+| `backend/src/queues/*` (cron) | Register orphan-reconcile sweep; wire `startCrons`/`close` in `main.ts` |
+| `backend/src/queues/tests/intent.queue.spec.ts` | Tests: assignment core extraction, reconcile job assigns without HyDE/opportunity, orphan warning fires |
+
+## Testing
+
+- Unit: `assignIntentToNetworks` assigns no-prompt networks at 1.0, scores
+  prompted ones, returns empty + warns when nothing matches.
+- Unit: `reconcile_intent_networks` writes rows but never calls `invokeHyde` or
+  the opportunity enqueue (assert mocks not called).
+- Unit: `addNetworkReconcileForUser` enqueues one network-scoped reconcile per
+  active intent (the join-time fan-out, driven by `onMemberAdded`).
+- Integration: orphan sweep query returns only zero-row active intents and is
+  idempotent across runs.
+
+## Rollout
+
+1. Ship refactor (1) + reconcile job (2) — inert until invoked.
+2. Run the one-off backfill (see `intent-network-backfill.md`) to heal the ~40
+   existing orphans, including Timour's.
+3. Enable backfill-on-join (3) and the safety-net sweep (4).
+4. Decide and ship scoped-creation semantics (5).

--- a/backend/package.json
+++ b/backend/package.json
@@ -38,6 +38,7 @@
     "maintenance:backfill-context-hyde": "bun ./src/cli/backfill-context-hyde.ts",
     "maintenance:backfill-profile-questions": "bun ./src/cli/backfill-profile-questions.ts",
     "maintenance:backfill-intent-questions": "bun ./src/cli/backfill-intent-questions.ts",
+    "maintenance:backfill-intent-networks": "bun ./src/cli/backfill-intent-networks.ts",
     "test:opportunity-three-user": "bun ./src/cli/opportunity-three-user-test.ts",
     "test": "NODE_ENV=test bash scripts/test-safe.sh",
     "test:raw": "NODE_ENV=test bun test"

--- a/backend/package.json
+++ b/backend/package.json
@@ -38,6 +38,7 @@
     "maintenance:backfill-context-hyde": "bun ./src/cli/backfill-context-hyde.ts",
     "maintenance:backfill-profile-questions": "bun ./src/cli/backfill-profile-questions.ts",
     "maintenance:backfill-intent-questions": "bun ./src/cli/backfill-intent-questions.ts",
+    "maintenance:backfill-personal-index-prompts": "bun ./src/cli/backfill-personal-index-prompts.ts",
     "maintenance:backfill-intent-networks": "bun ./src/cli/backfill-intent-networks.ts",
     "test:opportunity-three-user": "bun ./src/cli/opportunity-three-user-test.ts",
     "test": "NODE_ENV=test bash scripts/test-safe.sh",

--- a/backend/src/adapters/contact.database.adapter.ts
+++ b/backend/src/adapters/contact.database.adapter.ts
@@ -20,10 +20,12 @@ async function ensurePersonalNetwork(userId: string): Promise<string> {
 
   const networkId = crypto.randomUUID();
 
+  // Personal indexes are prompt-less by default so the assignment policy treats
+  // them as "no filtration" (score 1.0) — every one of the owner's intents lands
+  // in their own personal index. The owner may later set a prompt to curate it.
   await db.insert(schema.networks).values({
     id: networkId,
     title: 'My Network',
-    prompt: "Personal index containing the owner's imported contacts for network-scoped discovery.",
     isPersonal: true,
   }).onConflictDoNothing();
 

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -48,10 +48,12 @@ export async function ensurePersonalNetwork(userId: string): Promise<string> {
 
   const networkId = crypto.randomUUID();
 
+  // Personal indexes are prompt-less by default so the assignment policy treats
+  // them as "no filtration" (score 1.0) — every one of the owner's intents lands
+  // in their own personal index. The owner may later set a prompt to curate it.
   await db.insert(schema.networks).values({
     id: networkId,
     title: 'My Network',
-    prompt: 'Personal index containing the owner\'s imported contacts for network-scoped discovery.',
     isPersonal: true,
   }).onConflictDoNothing();
 

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -155,6 +155,13 @@ interface IntentListRow {
   archivedAt: Date | null;
   sourceType: string | null;
   sourceId: string | null;
+  /**
+   * Networks this intent is currently registered to. Empty when the intent is
+   * still being evaluated (HyDE assignment not yet run) or genuinely matched
+   * nothing — the frontend distinguishes those two via the intent's age. Lets
+   * the UI surface orphaned intents instead of hiding the assignment outcome.
+   */
+  networks: { id: string; title: string }[];
 }
 // Shapes matching schemas/database.schema userProfiles columns (no lib/protocol import)
 interface ProfileIdentity {
@@ -471,7 +478,43 @@ export class IntentDatabaseAdapter {
       db.select({ count: count() }).from(schema.intents).where(where),
     ]);
 
-    return { rows, total: Number(totalResult[0]?.count ?? 0) };
+    const withNetworks = await this.attachIntentNetworks(rows);
+    return { rows: withNetworks, total: Number(totalResult[0]?.count ?? 0) };
+  }
+
+  /**
+   * Attach each intent's registered networks (excluding soft-deleted networks)
+   * to a page of list rows in a single grouped query. Intents with no
+   * membership get an empty array, which the UI reads as "pending or orphaned".
+   *
+   * @param rows - The paginated intent rows to enrich (mutated copies returned).
+   * @returns The same rows, each with a populated `networks` array.
+   */
+  private async attachIntentNetworks(
+    rows: Omit<IntentListRow, 'networks'>[],
+  ): Promise<IntentListRow[]> {
+    if (rows.length === 0) return [];
+    const intentIds = rows.map(r => r.id);
+    const memberships = await db
+      .select({
+        intentId: schema.intentNetworks.intentId,
+        networkId: schema.networks.id,
+        title: schema.networks.title,
+      })
+      .from(schema.intentNetworks)
+      .innerJoin(schema.networks, eq(schema.intentNetworks.networkId, schema.networks.id))
+      .where(and(
+        inArray(schema.intentNetworks.intentId, intentIds),
+        isNull(schema.networks.deletedAt),
+      ));
+
+    const byIntent = new Map<string, { id: string; title: string }[]>();
+    for (const m of memberships) {
+      const list = byIntent.get(m.intentId) ?? [];
+      list.push({ id: m.networkId, title: m.title });
+      byIntent.set(m.intentId, list);
+    }
+    return rows.map(r => ({ ...r, networks: byIntent.get(r.id) ?? [] }));
   }
 
   async getIntentById(intentId: string, userId: string): Promise<IntentListRow | null> {
@@ -491,7 +534,9 @@ export class IntentDatabaseAdapter {
       .where(and(eq(schema.intents.id, intentId), eq(schema.intents.userId, userId)))
       .limit(1);
 
-    return row[0] ?? null;
+    if (!row[0]) return null;
+    const [withNetworks] = await this.attachIntentNetworks(row);
+    return withNetworks;
   }
 
   /**

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -12,13 +12,7 @@ import { traceAppOperation } from '../lib/sentry-performance';
 import { normalizeEmbedding } from '../lib/embedding/vector';
 import { normalizeTelegramSocialValue } from '../lib/telegram/socials';
 import type { User, NotificationPreferences, OnboardingState, TelegramPrefs } from '../schemas/database.schema';
-import type {
-  Conversation,
-  ConversationParticipant,
-  Message,
-  Task,
-  Artifact,
-} from '../schemas/conversation.schema';
+import type { Conversation, ConversationParticipant, Message, Task, Artifact } from '../schemas/conversation.schema';
 import type { Id } from '../types/common.types';
 import { log } from '../lib/log';
 import { NetworkMembershipEvents } from '../events/network_membership.event';

--- a/backend/src/adapters/embedder.adapter.ts
+++ b/backend/src/adapters/embedder.adapter.ts
@@ -5,11 +5,7 @@
 
 import OpenAI from 'openai';
 import { and, eq, inArray, isNotNull, isNull, ne, sql } from 'drizzle-orm';
-import {
-  OPENROUTER_EMBEDDING_BASE_URL,
-  OPENROUTER_EMBEDDING_DIMENSIONS,
-  OPENROUTER_EMBEDDING_MODEL,
-} from '../lib/embedder/embedder.config';
+import { OPENROUTER_EMBEDDING_BASE_URL, OPENROUTER_EMBEDDING_DIMENSIONS, OPENROUTER_EMBEDDING_MODEL } from '../lib/embedder/embedder.config';
 import db from '../lib/drizzle/drizzle';
 import { traceAppOperation } from '../lib/sentry-performance';
 import * as schema from '../schemas/database.schema';

--- a/backend/src/adapters/tests/adapter-interface-alignment.spec.ts
+++ b/backend/src/adapters/tests/adapter-interface-alignment.spec.ts
@@ -17,73 +17,28 @@ import { describe, it, expect } from 'bun:test';
 // ─────────────────────────────────────────────────────────────────────────────
 // Protocol interface types (the canonical contracts)
 // ─────────────────────────────────────────────────────────────────────────────
-import type {
-  Cache as ProtocolCache,
-  CacheOptions as ProtocolCacheOptions,
-} from '@indexnetwork/protocol';
+import type { Cache as ProtocolCache, CacheOptions as ProtocolCacheOptions } from '@indexnetwork/protocol';
 
-import type {
-  LensEmbedding as ProtocolLensEmbedding,
-  HydeSearchOptions as ProtocolHydeSearchOptions,
-  HydeCandidate as ProtocolHydeCandidate,
-  VectorSearchResult as ProtocolVectorSearchResult,
-  VectorStoreOption as ProtocolVectorStoreOption,
-} from '@indexnetwork/protocol';
+import type { LensEmbedding as ProtocolLensEmbedding, HydeSearchOptions as ProtocolHydeSearchOptions, HydeCandidate as ProtocolHydeCandidate, VectorSearchResult as ProtocolVectorSearchResult, VectorStoreOption as ProtocolVectorStoreOption } from '@indexnetwork/protocol';
 
-import type {
-  IntegrationAdapter as ProtocolIntegrationAdapter,
-  IntegrationSession as ProtocolIntegrationSession,
-  IntegrationSessionOptions as ProtocolIntegrationSessionOptions,
-  ToolActionResponse as ProtocolToolActionResponse,
-  IntegrationConnection as ProtocolIntegrationConnection,
-} from '@indexnetwork/protocol';
+import type { IntegrationAdapter as ProtocolIntegrationAdapter, IntegrationSession as ProtocolIntegrationSession, IntegrationSessionOptions as ProtocolIntegrationSessionOptions, ToolActionResponse as ProtocolToolActionResponse, IntegrationConnection as ProtocolIntegrationConnection } from '@indexnetwork/protocol';
 
-import type {
-  UserDatabase as ProtocolUserDatabase,
-  SystemDatabase as ProtocolSystemDatabase,
-} from '@indexnetwork/protocol';
+import type { UserDatabase as ProtocolUserDatabase, SystemDatabase as ProtocolSystemDatabase } from '@indexnetwork/protocol';
 
-import type {
-  QuestionerDatabase as ProtocolQuestionerDatabase,
-  PersistableQuestion as ProtocolPersistableQuestion,
-  PersistedQuestion as ProtocolPersistedQuestion,
-  QuestionFilters as ProtocolQuestionFilters,
-} from '@indexnetwork/protocol';
+import type { QuestionerDatabase as ProtocolQuestionerDatabase, PersistableQuestion as ProtocolPersistableQuestion, PersistedQuestion as ProtocolPersistedQuestion, QuestionFilters as ProtocolQuestionFilters } from '@indexnetwork/protocol';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Adapter local types (the structurally-aligned copies)
 // ─────────────────────────────────────────────────────────────────────────────
-import type {
-  Cache as AdapterCache,
-  CacheOptions as AdapterCacheOptions,
-} from '../cache.adapter';
+import type { Cache as AdapterCache, CacheOptions as AdapterCacheOptions } from '../cache.adapter';
 
-import type {
-  LensEmbedding as AdapterLensEmbedding,
-  HydeSearchOptions as AdapterHydeSearchOptions,
-  HydeCandidate as AdapterHydeCandidate,
-  VectorSearchResult as AdapterVectorSearchResult,
-  VectorStoreOption as AdapterVectorStoreOption,
-} from '../embedder.adapter';
+import type { LensEmbedding as AdapterLensEmbedding, HydeSearchOptions as AdapterHydeSearchOptions, HydeCandidate as AdapterHydeCandidate, VectorSearchResult as AdapterVectorSearchResult, VectorStoreOption as AdapterVectorStoreOption } from '../embedder.adapter';
 
-import type {
-  IntegrationAdapter as AdapterIntegrationAdapter,
-  IntegrationSession as AdapterIntegrationSession,
-  IntegrationSessionOptions as AdapterIntegrationSessionOptions,
-  ToolActionResponse as AdapterToolActionResponse,
-  IntegrationConnection as AdapterIntegrationConnection,
-} from '../integration.adapter';
+import type { IntegrationAdapter as AdapterIntegrationAdapter, IntegrationSession as AdapterIntegrationSession, IntegrationSessionOptions as AdapterIntegrationSessionOptions, ToolActionResponse as AdapterToolActionResponse, IntegrationConnection as AdapterIntegrationConnection } from '../integration.adapter';
 
-import {
-  createUserDatabase,
-  createSystemDatabase,
-} from '../database.adapter';
+import { createUserDatabase, createSystemDatabase } from '../database.adapter';
 
-import type {
-  AdapterPersistableQuestion,
-  AdapterPersistedQuestion,
-  AdapterQuestionFilters,
-} from '../questioner.adapter';
+import type { AdapterPersistableQuestion, AdapterPersistedQuestion, AdapterQuestionFilters } from '../questioner.adapter';
 import { QuestionerAdapter } from '../questioner.adapter';
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/backend/src/adapters/tests/database.adapter.spec.ts
+++ b/backend/src/adapters/tests/database.adapter.spec.ts
@@ -10,25 +10,8 @@ import { describe, expect, it, beforeAll, afterAll } from 'bun:test';
 import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
 import db from '../../lib/drizzle/drizzle';
-import {
-  users,
-  userProfiles,
-  userSocials,
-  networks,
-  networkMembers,
-  intents,
-  intentNetworks,
-  premises,
-  opportunities,
-} from '../../schemas/database.schema';
-import {
-  IntentDatabaseAdapter,
-  ChatDatabaseAdapter,
-  ProfileDatabaseAdapter,
-  OpportunityDatabaseAdapter,
-  NetworkGraphDatabaseAdapter,
-  HydeDatabaseAdapter,
-} from '../database.adapter';
+import { users, userProfiles, userSocials, networks, networkMembers, intents, intentNetworks, premises, opportunities } from '../../schemas/database.schema';
+import { IntentDatabaseAdapter, ChatDatabaseAdapter, ProfileDatabaseAdapter, OpportunityDatabaseAdapter, NetworkGraphDatabaseAdapter, HydeDatabaseAdapter } from '../database.adapter';
 
 const TEST_PREFIX = 'db_adapter_spec_' + Date.now() + '_';
 

--- a/backend/src/adapters/tests/embedder.adapter.spec.ts
+++ b/backend/src/adapters/tests/embedder.adapter.spec.ts
@@ -11,14 +11,7 @@ import { describe, expect, it, beforeAll, afterAll } from 'bun:test';
 import { eq, inArray } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
 import db from '../../lib/drizzle/drizzle';
-import {
-  users,
-  userProfiles,
-  networks,
-  networkMembers,
-  intents,
-  intentNetworks,
-} from '../../schemas/database.schema';
+import { users, userProfiles, networks, networkMembers, intents, intentNetworks } from '../../schemas/database.schema';
 import { EmbedderAdapter } from '../embedder.adapter';
 
 const TEST_PREFIX = 'embedder_spec_' + Date.now() + '_';

--- a/backend/src/adapters/tests/ghost-dedup.spec.ts
+++ b/backend/src/adapters/tests/ghost-dedup.spec.ts
@@ -6,15 +6,7 @@ import { describe, expect, it, beforeAll, afterAll } from 'bun:test';
 import { eq, and, inArray } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
 import db from '../../lib/drizzle/drizzle';
-import {
-  users,
-  userProfiles,
-  userSocials,
-  networks,
-  networkMembers,
-  intents,
-  opportunities,
-} from '../../schemas/database.schema';
+import { users, userProfiles, userSocials, networks, networkMembers, intents, opportunities } from '../../schemas/database.schema';
 import { ProfileDatabaseAdapter } from '../database.adapter';
 
 const TEST_PREFIX = 'ghost_dedup_spec_' + Date.now() + '_';

--- a/backend/src/adapters/tests/personal-network.adapter.spec.ts
+++ b/backend/src/adapters/tests/personal-network.adapter.spec.ts
@@ -15,20 +15,8 @@ import { describe, expect, it, beforeAll, afterAll } from 'bun:test';
 import { eq, and, inArray } from 'drizzle-orm';
 
 import db from '../../lib/drizzle/drizzle';
-import {
-  users,
-  userProfiles,
-  networks,
-  networkMembers,
-  intents,
-  intentNetworks,
-  personalNetworks,
-} from '../../schemas/database.schema';
-import {
-  ensurePersonalNetwork,
-  getPersonalIndexId,
-  ChatDatabaseAdapter,
-} from '../database.adapter';
+import { users, userProfiles, networks, networkMembers, intents, intentNetworks, personalNetworks } from '../../schemas/database.schema';
+import { ensurePersonalNetwork, getPersonalIndexId, ChatDatabaseAdapter } from '../database.adapter';
 import { NetworkService } from '../../services/network.service';
 
 const TEST_PREFIX = 'personal_idx_' + Date.now() + '_';

--- a/backend/src/adapters/tests/queue.adapter.spec.ts
+++ b/backend/src/adapters/tests/queue.adapter.spec.ts
@@ -8,15 +8,7 @@ config({ path: '.env.test', override: true });
 
 import { describe, expect, it, mock } from 'bun:test';
 import type { Job } from 'bullmq';
-import {
-  createQueueAdapter,
-  wrapQueue,
-  createIntentQueueAdapter,
-  createOpportunityQueueAdapter,
-  createProfileQueueAdapter,
-  createNewsletterQueueAdapter,
-  type NewsletterJobDataUnion,
-} from '../queue.adapter';
+import { createQueueAdapter, wrapQueue, createIntentQueueAdapter, createOpportunityQueueAdapter, createProfileQueueAdapter, createNewsletterQueueAdapter, type NewsletterJobDataUnion } from '../queue.adapter';
 
 describe('QueueAdapter', () => {
   describe('createQueueAdapter', () => {

--- a/backend/src/cli/backfill-intent-networks.ts
+++ b/backend/src/cli/backfill-intent-networks.ts
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/**
+ * Backfill CLI: assignment-only reconciliation of intents → networks.
+ *
+ * Finds active intents that have ZERO intent_networks rows (orphans) and runs
+ * the SAME network-assignment policy the HyDE queue uses
+ * (`buildNetworkAssignmentDecision`), writing intent_networks rows for matches.
+ *
+ * It deliberately does NOT regenerate HyDE documents and does NOT enqueue
+ * opportunity discovery — so it heals registration without spamming users with
+ * new opportunity notifications on old intents.
+ *
+ * Idempotent: assignIntentToNetwork upserts on (intentId, networkId); once an
+ * intent gains at least one row it drops out of the orphan set.
+ *
+ * Usage:
+ *   bun run maintenance:backfill-intent-networks -- [--user <userId>] [--network <networkId>] [--dry-run]
+ *
+ *   --user <id>      Restrict to one user's orphaned intents (e.g. Timour).
+ *   --network <id>   Evaluate ONLY this network (scoped). Default: all the
+ *                    user's assignment-eligible memberships (global scope).
+ *   --dry-run        Score and report what WOULD be assigned; write nothing.
+ *   --limit <n>      Max orphaned intents to process (default 500).
+ */
+import dotenv from 'dotenv';
+import path from 'path';
+
+const envFile = process.env.NODE_ENV === 'development' ? '.env.development' : '.env.production';
+dotenv.config({ path: path.resolve(process.cwd(), envFile) });
+
+import { and, isNull, sql } from 'drizzle-orm';
+
+import db, { closeDb } from '../lib/drizzle/drizzle';
+import * as schema from '../schemas/database.schema';
+import { IntentIndexer, buildNetworkAssignmentDecision, resolveAssignmentNetworkScope } from '@indexnetwork/protocol';
+import { ChatDatabaseAdapter } from '../adapters/database.adapter';
+
+interface Args { userId?: string; networkId?: string; dryRun: boolean; limit: number }
+
+function parseArgs(): Args {
+  const args = process.argv.slice(2);
+  const valueOf = (flag: string): string | undefined => {
+    const a = args.find((x) => x === flag || x.startsWith(`${flag}=`));
+    if (!a) return undefined;
+    const eq = a.indexOf('=');
+    if (eq !== -1) return a.slice(eq + 1);
+    const next = args[args.indexOf(a) + 1];
+    return next && !next.startsWith('--') ? next : undefined;
+  };
+  return {
+    userId: valueOf('--user'),
+    networkId: valueOf('--network'),
+    dryRun: args.includes('--dry-run'),
+    limit: Number(valueOf('--limit') ?? 500),
+  };
+}
+
+/** Active intents with no intent_networks row, optionally scoped to one user. */
+async function findOrphanedIntents(userId: string | undefined, limit: number) {
+  const rows = await db
+    .select({ id: schema.intents.id, userId: schema.intents.userId, payload: schema.intents.payload })
+    .from(schema.intents)
+    .leftJoin(schema.intentNetworks, sql`${schema.intentNetworks.intentId} = ${schema.intents.id}`)
+    .where(
+      and(
+        isNull(schema.intents.archivedAt),
+        isNull(schema.intentNetworks.intentId),
+        userId ? sql`${schema.intents.userId} = ${userId}` : sql`true`,
+      ),
+    )
+    .limit(limit);
+  return rows;
+}
+
+async function main(): Promise<void> {
+  const { userId, networkId, dryRun, limit } = parseArgs();
+  const adapter = new ChatDatabaseAdapter();
+  const indexer = new IntentIndexer();
+
+  console.log(
+    `Backfill intent→networks` +
+    `${userId ? ` user=${userId}` : ' (all users)'}` +
+    `${networkId ? ` network=${networkId} (scoped)` : ' (global memberships)'}` +
+    `${dryRun ? ' — DRY RUN' : ''}`,
+  );
+
+  const orphans = await findOrphanedIntents(userId, limit);
+  console.log(`Found ${orphans.length} orphaned active intent(s)\n`);
+  if (orphans.length === 0) return;
+
+  let assignedRows = 0;
+  let stillOrphan = 0;
+
+  for (const intent of orphans) {
+    const memberships = await adapter.getAssignmentNetworkIdsForUser(intent.userId);
+    const candidateIds = resolveAssignmentNetworkScope({ memberships, networkScopeId: networkId });
+    const preview = intent.payload.length > 50 ? intent.payload.slice(0, 47) + '...' : intent.payload;
+
+    if (candidateIds.length === 0) {
+      stillOrphan++;
+      console.log(`• ${intent.id}  "${preview}"\n    → no eligible networks (scope=${networkId ?? 'global'})`);
+      continue;
+    }
+
+    const assignedTo: string[] = [];
+    for (const nid of candidateIds) {
+      const ctx = await adapter.getNetworkAssignmentContext(nid, intent.userId);
+      if (!ctx) continue;
+      const indexPrompt = ctx.indexPrompt ?? null;
+      const memberPrompt = ctx.memberPrompt ?? null;
+      const hasPrompts = !!indexPrompt?.trim() || !!memberPrompt?.trim();
+
+      let raw: { indexScore: number; memberScore: number } | undefined;
+      if (hasPrompts) {
+        const r = await indexer.invoke(intent.payload, indexPrompt, memberPrompt, null);
+        if (r) raw = { indexScore: r.indexScore, memberScore: r.memberScore };
+      }
+
+      const decision = buildNetworkAssignmentDecision({
+        resourceType: 'intent',
+        mode: 'automatic',
+        scope: networkId ? 'network' : 'global',
+        indexPrompt,
+        memberPrompt,
+        rawScores: raw,
+        evaluator: 'intent-indexer',
+        source: 'backfill-intent-networks',
+        createdAt: new Date().toISOString(),
+      });
+
+      if (!decision.assigned) continue;
+      assignedTo.push(`${nid}@${decision.finalScore.toFixed(2)}`);
+      if (!dryRun) {
+        await adapter.assignIntentToNetwork(intent.id, nid, decision.finalScore, decision.metadata);
+        assignedRows++;
+      } else {
+        assignedRows++;
+      }
+    }
+
+    if (assignedTo.length === 0) {
+      stillOrphan++;
+      console.log(`• ${intent.id}  "${preview}"\n    → matched NO network (would remain orphaned)`);
+    } else {
+      console.log(`• ${intent.id}  "${preview}"\n    → ${dryRun ? 'would assign' : 'assigned'}: ${assignedTo.join(', ')}`);
+    }
+  }
+
+  console.log(
+    `\nDone: ${assignedRows} ${dryRun ? 'would-be ' : ''}row(s) across ${orphans.length} intent(s); ` +
+    `${stillOrphan} intent(s) still unmatched.`,
+  );
+}
+
+main()
+  .then(async () => { await closeDb(); })
+  .catch(async (e: unknown) => {
+    console.error('backfill-intent-networks error:', e instanceof Error ? e.message : `${e}`);
+    await closeDb().catch(() => {});
+    process.exit(1);
+  });

--- a/backend/src/cli/backfill-personal-index-prompts.ts
+++ b/backend/src/cli/backfill-personal-index-prompts.ts
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * Backfill CLI: heal personal indexes after removing the hidden boilerplate prompt.
+ *
+ * Two idempotent steps:
+ *   1. Clear the system boilerplate prompt from personal indexes (only the exact
+ *      boilerplate string — any user-authored prompt is preserved).
+ *   2. Assign every active intent to its owner's personal index (relevancy 1.0)
+ *      when that personal index is now prompt-less and the intent isn't already
+ *      a member. Prompt-less personal index == "no filtration" == holds everything.
+ *
+ * Dry-run by default: pass --apply to write. Defaults to .env.development unless
+ * NODE_ENV=production (mirrors the other maintenance scripts).
+ *
+ * Usage:
+ *   NODE_ENV=development bun run maintenance:backfill-personal-index-prompts          # dry-run
+ *   NODE_ENV=development bun run maintenance:backfill-personal-index-prompts -- --apply
+ */
+import dotenv from 'dotenv';
+import path from 'path';
+
+const envFile = process.env.NODE_ENV === 'production' ? '.env.production' : '.env.development';
+dotenv.config({ path: path.resolve(process.cwd(), envFile) });
+
+import { sql } from 'drizzle-orm';
+
+import db, { closeDb } from '../lib/drizzle/drizzle';
+
+const BOILERPLATE = "Personal index containing the owner's imported contacts for network-scoped discovery.";
+
+async function main() {
+  const apply = process.argv.slice(2).includes('--apply');
+  const mode = apply ? 'APPLY' : 'DRY-RUN';
+  console.log(`\n[backfill-personal-index-prompts] mode=${mode} env=${envFile}\n`);
+
+  // --- Report: current state -------------------------------------------------
+  // postgres-js drizzle: db.execute returns an array-like RowList (no .rows).
+  const boilerplateRows = await db.execute(sql`
+    select count(*)::int as count
+    from networks
+    where is_personal = true and deleted_at is null and prompt = ${BOILERPLATE}
+  `);
+  const boilerplateCount = Number((boilerplateRows[0] as { count: number | string })?.count ?? 0);
+
+  const orphanRows = await db.execute(sql`
+    select count(*)::int as count
+    from intents i
+    join personal_networks pn on pn.user_id = i.user_id
+    join networks n on n.id = pn.network_id and n.deleted_at is null
+    where i.archived_at is null
+      and (n.prompt is null or n.prompt = ${BOILERPLATE})
+      and not exists (
+        select 1 from intent_networks inn
+        where inn.intent_id = i.id and inn.network_id = pn.network_id
+      )
+  `);
+  const orphanCount = Number((orphanRows[0] as { count: number | string })?.count ?? 0);
+
+  console.log(`Personal indexes with boilerplate prompt to clear: ${boilerplateCount}`);
+  console.log(`Active intents missing from their personal index to heal: ${orphanCount}`);
+
+  if (!apply) {
+    console.log('\nDry-run only — re-run with --apply to write changes.\n');
+    return;
+  }
+
+  // --- Step 1: clear the boilerplate prompt ----------------------------------
+  const cleared = await db.execute(sql`
+    update networks set prompt = null, updated_at = now()
+    where is_personal = true and deleted_at is null and prompt = ${BOILERPLATE}
+    returning id
+  `);
+  console.log(`Step 1: cleared boilerplate prompt on ${(cleared as unknown[]).length} personal indexes.`);
+
+  // --- Step 2: assign missing active intents to their personal index ---------
+  // Runs AFTER step 1 so n.prompt is null for indexes we just cleared; any
+  // user-authored prompt remains non-null and is intentionally skipped.
+  const healed = await db.execute(sql`
+    insert into intent_networks (intent_id, network_id, relevancy_score, assignment_metadata)
+    select i.id, pn.network_id, '1', null
+    from intents i
+    join personal_networks pn on pn.user_id = i.user_id
+    join networks n on n.id = pn.network_id and n.deleted_at is null
+    where i.archived_at is null
+      and n.prompt is null
+      and not exists (
+        select 1 from intent_networks inn
+        where inn.intent_id = i.id and inn.network_id = pn.network_id
+      )
+    on conflict (intent_id, network_id) do nothing
+    returning intent_id
+  `);
+  console.log(`Step 2: assigned ${(healed as unknown[]).length} intents to their personal index.\n`);
+}
+
+main()
+  .catch((err) => {
+    console.error('[backfill-personal-index-prompts] failed:', err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await closeDb();
+  });

--- a/backend/src/controllers/agent.controller.ts
+++ b/backend/src/controllers/agent.controller.ts
@@ -6,12 +6,7 @@ import { log } from '../lib/log';
 import { Controller, Delete, Get, Patch, Post, UseGuards } from '../lib/router/router.decorators';
 import { AgentTestMessageService } from '../services/agent-test-message.service';
 import { agentService } from '../services/agent.service';
-import {
-  negotiationPollingService,
-  NotFoundError,
-  ConflictError,
-  UnauthorizedError,
-} from '../services/negotiation-polling.service';
+import { negotiationPollingService, NotFoundError, ConflictError, UnauthorizedError } from '../services/negotiation-polling.service';
 import { opportunityDeliveryService } from '../services/opportunity-delivery.service';
 
 const agentTestMessageService = new AgentTestMessageService();

--- a/backend/src/controllers/chat.controller.ts
+++ b/backend/src/controllers/chat.controller.ts
@@ -4,23 +4,11 @@ import { AuthGuard, type AuthenticatedUser } from "../guards/auth.guard";
 import { RateLimit } from "../guards/limiter.guard";
 import { requestContext } from "../lib/request-context";
 import { log } from "../lib/log";
-import {
-  Controller,
-  Get,
-  Post,
-  UseGuards,
-} from "../lib/router/router.decorators";
+import { Controller, Get, Post, UseGuards } from "../lib/router/router.decorators";
 import { chatSessionService } from "../services/chat.service";
 import { fileService } from "../services/file.service";
 import { SuggestionGenerator, ChatInterruptClassifier } from '@indexnetwork/protocol';
-import {
-  createDoneEvent,
-  createErrorEvent,
-  createStatusEvent,
-  createSteerOrQueueEvent,
-  formatSSEEvent,
-  type DebugMetaDiscoveryQuestions,
-} from "../types/chat-streaming.types";
+import { createDoneEvent, createErrorEvent, createStatusEvent, createSteerOrQueueEvent, formatSSEEvent, type DebugMetaDiscoveryQuestions } from "../types/chat-streaming.types";
 import { emitChatInterrupt, onChatInterrupt } from '../lib/chat-interrupt.events';
 
 type RouteParams = Record<string, string>;

--- a/backend/src/controllers/debug.controller.ts
+++ b/backend/src/controllers/debug.controller.ts
@@ -4,21 +4,8 @@ import db from '../lib/drizzle/drizzle';
 import { log } from '../lib/log';
 import { canUserSeeOpportunity, isActionableForViewer } from '@indexnetwork/protocol';
 import { Controller, Get, Post, UseGuards } from '../lib/router/router.decorators';
-import {
-  intents,
-  hydeDocuments,
-  intentNetworks,
-  networks,
-  networkMembers,
-  opportunities,
-} from '../schemas/database.schema';
-import {
-  conversations,
-  conversationParticipants,
-  conversationMetadata,
-  messages,
-  tasks,
-} from '../schemas/conversation.schema';
+import { intents, hydeDocuments, intentNetworks, networks, networkMembers, opportunities } from '../schemas/database.schema';
+import { conversations, conversationParticipants, conversationMetadata, messages, tasks } from '../schemas/conversation.schema';
 import { debugService } from '../services/debug.service';
 
 import { AuthGuard, type AuthenticatedUser } from '../guards/auth.guard';

--- a/backend/src/controllers/mcp.controller.ts
+++ b/backend/src/controllers/mcp.controller.ts
@@ -4,21 +4,12 @@
  */
 
 import { jwtVerify, createRemoteJWKSet } from 'jose';
-import {
-  McpServer,
-  WebStandardStreamableHTTPServerTransport,
-} from '@modelcontextprotocol/server';
+import { McpServer, WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
 
 import { cacheAdapter, hydeCacheAdapter } from '../adapters/cache.adapter';
 import { agentDatabaseAdapter } from '../adapters/agent.database.adapter';
 import { ComposioIntegrationAdapter } from '../adapters/integration.adapter';
-import {
-  chatDatabaseAdapter,
-  conversationDatabaseAdapter,
-  ChatDatabaseAdapter,
-  createUserDatabase,
-  createSystemDatabase,
-} from '../adapters/database.adapter';
+import { chatDatabaseAdapter, conversationDatabaseAdapter, ChatDatabaseAdapter, createUserDatabase, createSystemDatabase } from '../adapters/database.adapter';
 import { embedderAdapter } from '../adapters/embedder.adapter';
 import { scraperAdapter } from '../adapters/scraper.adapter';
 import { intentQueue } from '../queues/intent.queue';

--- a/backend/src/controllers/tests/chat.controller.decisionQuestions.spec.ts
+++ b/backend/src/controllers/tests/chat.controller.decisionQuestions.spec.ts
@@ -12,10 +12,7 @@
  */
 
 import { describe, it, expect } from "bun:test";
-import {
-  createDoneEvent,
-  formatSSEEvent,
-} from "../../types/chat-streaming.types";
+import { createDoneEvent, formatSSEEvent } from "../../types/chat-streaming.types";
 import type { Question } from "@indexnetwork/protocol";
 
 // ── Minimal event types matching the production shape ─────────────────────────

--- a/backend/src/controllers/tests/intent.controller.spec.ts
+++ b/backend/src/controllers/tests/intent.controller.spec.ts
@@ -4,7 +4,7 @@ config({ path: '.env.test', override: true });
 
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import { IntentController } from "../intent.controller";
-import { IntentDatabaseAdapter, UserDatabaseAdapter, ProfileDatabaseAdapter } from "../../adapters/database.adapter";
+import { IntentDatabaseAdapter, UserDatabaseAdapter, ProfileDatabaseAdapter, ChatDatabaseAdapter, NetworkGraphDatabaseAdapter } from "../../adapters/database.adapter";
 import type { AuthenticatedUser } from "../../guards/auth.guard";
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -105,6 +105,39 @@ describe("IntentDatabaseAdapter Integration", () => {
     });
 
     expect(updated).toBeNull();
+  });
+
+  test("listIntents attaches an empty networks array for an intent in no networks", async () => {
+    const { rows } = await adapter.listIntents(testUserId, { page: 1, limit: 10, archived: false });
+    const row = rows.find((r) => r.id === testIntentId);
+    expect(row).toBeDefined();
+    expect(row!.networks).toEqual([]);
+  });
+
+  test("listIntents attaches assigned networks and excludes soft-deleted ones", async () => {
+    const chatAdapter = new ChatDatabaseAdapter();
+    const indexAdapter = new NetworkGraphDatabaseAdapter();
+    const live = await chatAdapter.createNetwork({ title: `Intent-Net Live ${Date.now()}` });
+    const removed = await chatAdapter.createNetwork({ title: `Intent-Net Removed ${Date.now()}` });
+    try {
+      await adapter.assignIntentToNetwork(testIntentId, live.id);
+      await adapter.assignIntentToNetwork(testIntentId, removed.id);
+      await chatAdapter.softDeleteNetwork(removed.id);
+
+      const { rows } = await adapter.listIntents(testUserId, { page: 1, limit: 10, archived: false });
+      const row = rows.find((r) => r.id === testIntentId);
+      expect(row).toBeDefined();
+      // Only the live network is attached; the soft-deleted one is excluded.
+      expect(row!.networks).toEqual([{ id: live.id, title: live.title }]);
+
+      // getIntentById carries the same membership data.
+      const single = await adapter.getIntentById(testIntentId, testUserId);
+      expect(single!.networks).toEqual([{ id: live.id, title: live.title }]);
+    } finally {
+      // deleteNetworkAndMembers also clears the intent_networks rows for each network.
+      await indexAdapter.deleteNetworkAndMembers(live.id).catch(() => {});
+      await indexAdapter.deleteNetworkAndMembers(removed.id).catch(() => {});
+    }
   });
 
   test("archiveIntent should set archivedAt timestamp", async () => {

--- a/backend/src/controllers/tests/mcp-surface.spec.ts
+++ b/backend/src/controllers/tests/mcp-surface.spec.ts
@@ -1,11 +1,6 @@
 import { describe, expect, spyOn, test } from 'bun:test';
 
-import {
-  findTelegramHandleMismatch,
-  parseClientSurface,
-  resolveMcpApiKeyPrincipal,
-  telegramHandleFromRequest,
-} from '../mcp.controller';
+import { findTelegramHandleMismatch, parseClientSurface, resolveMcpApiKeyPrincipal, telegramHandleFromRequest } from '../mcp.controller';
 
 function requestWithHeaders(headers: Record<string, string>): Request {
   return new Request('https://protocol.index.network/mcp', { headers });

--- a/backend/src/events/handlers/tests/question.answer.handler.test.ts
+++ b/backend/src/events/handlers/tests/question.answer.handler.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect, mock, beforeEach } from "bun:test";
-import {
-  handleQuestionAnswered,
-  type QuestionAnswerHandlerDeps,
-} from "../question.answer.handler";
+import { handleQuestionAnswered, type QuestionAnswerHandlerDeps } from "../question.answer.handler";
 
 function makeDeps(overrides?: Partial<QuestionAnswerHandlerDeps>): QuestionAnswerHandlerDeps {
   return {

--- a/backend/src/gateways/telegram.gateway.ts
+++ b/backend/src/gateways/telegram.gateway.ts
@@ -1,12 +1,7 @@
 import { log } from '../lib/log';
 import { onTelegramNotification, type TelegramNotificationPayload } from '../lib/notification-events';
 import type { TelegramPrefs } from '../schemas/database.schema';
-import {
-  parseResponseSegments,
-  hasStructuredBlocks,
-  formatOpportunityCardHtml,
-  formatOpportunityCardPlainText,
-} from '../lib/telegram/formatter';
+import { parseResponseSegments, hasStructuredBlocks, formatOpportunityCardHtml, formatOpportunityCardPlainText } from '../lib/telegram/formatter';
 import { mergeTelegramHandleIntoSocials } from '../lib/telegram/socials';
 
 const logger = log.lib.from('telegram.gateway');

--- a/backend/src/guards/limiter.guard.ts
+++ b/backend/src/guards/limiter.guard.ts
@@ -2,12 +2,7 @@ import { SYSTEM_AGENT_IDS } from '@indexnetwork/protocol';
 
 import type { Guard } from '../lib/router/router.decorators';
 import { resolveIdentifier, sha256Truncated } from '../lib/limiter/identifier';
-import {
-  getStorage,
-  resolveClassConfig,
-  isLimiterDisabled,
-  type LimiterClass,
-} from '../lib/limiter';
+import { getStorage, resolveClassConfig, isLimiterDisabled, type LimiterClass } from '../lib/limiter';
 import type { HitResult } from '../lib/limiter';
 import { RateLimiterError } from '../lib/limiter/error';
 import { log } from '../lib/log';

--- a/backend/src/lib/email/tests/email-handlers.integration.spec.ts
+++ b/backend/src/lib/email/tests/email-handlers.integration.spec.ts
@@ -2,11 +2,7 @@ import { describe, it, expect, afterAll } from 'bun:test';
 import { config } from 'dotenv';
 config({ path: '.env.test', override: true });
 
-import {
-    sendConnectionRequestEmail,
-    sendConnectionAcceptedEmail,
-
-} from '../notification.sender';
+import { sendConnectionRequestEmail, sendConnectionAcceptedEmail } from '../notification.sender';
 
 // Only run this if explicitly requested or if we have the API key
 const runIntegration = process.env.RESEND_API_KEY && process.env.TESTING_EMAIL_ADDRESS;

--- a/backend/src/lib/embedder/embedder.generator.ts
+++ b/backend/src/lib/embedder/embedder.generator.ts
@@ -5,11 +5,7 @@
 import OpenAI from 'openai';
 
 import { log } from '../log';
-import {
-  OPENROUTER_EMBEDDING_BASE_URL,
-  OPENROUTER_EMBEDDING_DIMENSIONS,
-  OPENROUTER_EMBEDDING_MODEL,
-} from './embedder.config';
+import { OPENROUTER_EMBEDDING_BASE_URL, OPENROUTER_EMBEDDING_DIMENSIONS, OPENROUTER_EMBEDDING_MODEL } from './embedder.config';
 import { EmbeddingGenerator } from './embedder.types';
 
 const logger = log.lib.from('embedder.generator');

--- a/backend/src/lib/privacy/profile-enrichment-policy.spec.ts
+++ b/backend/src/lib/privacy/profile-enrichment-policy.spec.ts
@@ -1,12 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 
-import {
-  canRunPublicProfileEnrichment,
-  hasEdgeosImportConsent,
-  hasPublicProfileLookupConsent,
-  isConsentRequiredPolicy,
-  normalizeProfileEnrichmentPolicy,
-} from './profile-enrichment-policy';
+import { canRunPublicProfileEnrichment, hasEdgeosImportConsent, hasPublicProfileLookupConsent, isConsentRequiredPolicy, normalizeProfileEnrichmentPolicy } from './profile-enrichment-policy';
 import type { OnboardingState } from '../../schemas/database.schema';
 
 const granted: OnboardingState = {

--- a/backend/src/lib/smartest/index.ts
+++ b/backend/src/lib/smartest/index.ts
@@ -5,47 +5,12 @@
 
 import { runScenario } from './smartest.runner';
 import { expectSmartest } from './smartest.expect';
-import type {
-  FixtureDef,
-  GeneratorDef,
-  GeneratorFn,
-  GeneratorParams,
-  GeneratorRegistry,
-  ResolvedFixtures,
-  RunScenarioResult,
-  RunScenarioReport,
-  RunScenarioOptions,
-  SmartestScenario,
-  SmartestSut,
-  SmartestVerification,
-  VerificationResult,
-} from './smartest.types';
+import type { FixtureDef, GeneratorDef, GeneratorFn, GeneratorParams, GeneratorRegistry, ResolvedFixtures, RunScenarioResult, RunScenarioReport, RunScenarioOptions, SmartestScenario, SmartestSut, SmartestVerification, VerificationResult } from './smartest.types';
 
 export { runScenario, expectSmartest };
-export {
-  SMARTEST_GENERATOR_MODEL,
-  SMARTEST_VERIFIER_MODEL,
-} from './smartest.config';
-export {
-  defaultGeneratorRegistry,
-  mergeGeneratorRegistry,
-  textGenerator,
-} from './smartest.generators';
-export type {
-  FixtureDef,
-  GeneratorDef,
-  GeneratorFn,
-  GeneratorParams,
-  GeneratorRegistry,
-  ResolvedFixtures,
-  RunScenarioResult,
-  RunScenarioReport,
-  RunScenarioOptions,
-  SmartestScenario,
-  SmartestSut,
-  SmartestVerification,
-  VerificationResult,
-};
+export { SMARTEST_GENERATOR_MODEL, SMARTEST_VERIFIER_MODEL } from './smartest.config';
+export { defaultGeneratorRegistry, mergeGeneratorRegistry, textGenerator } from './smartest.generators';
+export type { FixtureDef, GeneratorDef, GeneratorFn, GeneratorParams, GeneratorRegistry, ResolvedFixtures, RunScenarioResult, RunScenarioReport, RunScenarioOptions, SmartestScenario, SmartestSut, SmartestVerification, VerificationResult };
 
 /**
  * Helper to define a scenario with type checking (no runtime effect).

--- a/backend/src/lib/smartest/smartest.fixtures.ts
+++ b/backend/src/lib/smartest/smartest.fixtures.ts
@@ -3,14 +3,7 @@
  * All in-memory; no file I/O.
  */
 
-import type {
-  FixtureDef,
-  GeneratorDef,
-  GeneratorParams,
-  GeneratorRegistry,
-  ResolvedFixtures,
-  SmartestScenario,
-} from './smartest.types';
+import type { FixtureDef, GeneratorDef, GeneratorParams, GeneratorRegistry, ResolvedFixtures, SmartestScenario } from './smartest.types';
 
 const FIXTURE_REF_PREFIX = '@fixtures.';
 

--- a/backend/src/lib/smartest/smartest.runner.ts
+++ b/backend/src/lib/smartest/smartest.runner.ts
@@ -4,12 +4,7 @@
  * so tests can use expectSmartest(result) and get a single, bun-test-friendly failure message.
  */
 
-import type {
-  RunScenarioResult,
-  RunScenarioOptions,
-  RunScenarioReport,
-  SmartestScenario,
-} from './smartest.types';
+import type { RunScenarioResult, RunScenarioOptions, RunScenarioReport, SmartestScenario } from './smartest.types';
 import { resolveFixtures, resolveInputRefs } from './smartest.fixtures';
 import { mergeGeneratorRegistry } from './smartest.generators';
 import { getSmartestVerifierModel } from './smartest.config';

--- a/backend/src/lib/smartest/smartest.spec.ts
+++ b/backend/src/lib/smartest/smartest.spec.ts
@@ -7,12 +7,7 @@ config({ path: '.env.test', override: true });
 
 import { describe, expect, it } from 'bun:test';
 import { z } from 'zod';
-import {
-  runScenario,
-  defineScenario,
-  expectSmartest,
-  defaultGeneratorRegistry,
-} from './index';
+import { runScenario, defineScenario, expectSmartest, defaultGeneratorRegistry } from './index';
 import type { SmartestScenario } from './smartest.types';
 import { resolveFixtures, resolveInputRefs, isGeneratorDef } from './smartest.fixtures';
 

--- a/backend/src/lib/smartest/smartest.verifier.ts
+++ b/backend/src/lib/smartest/smartest.verifier.ts
@@ -7,11 +7,7 @@ import { HumanMessage, SystemMessage } from '@langchain/core/messages';
 import { ChatOpenAI } from '@langchain/openai';
 import { getSmartestVerifierModel } from './smartest.config';
 import type { VerificationResult } from './smartest.types';
-import {
-  SMARTEST_VERIFIER_SYSTEM_PROMPT,
-  buildVerifierUserMessage,
-  smartestVerifierOutputSchema,
-} from './smartest.verifier.prompt';
+import { SMARTEST_VERIFIER_SYSTEM_PROMPT, buildVerifierUserMessage, smartestVerifierOutputSchema } from './smartest.verifier.prompt';
 
 /**
  * Truncate output for LLM verification so large conversation/tool payloads don't blow context.

--- a/backend/src/lib/telegram/tests/formatter.spec.ts
+++ b/backend/src/lib/telegram/tests/formatter.spec.ts
@@ -1,11 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import {
-  parseResponseSegments,
-  hasStructuredBlocks,
-  formatOpportunityCardHtml,
-  formatOpportunityCardPlainText,
-  type ResponseSegment,
-} from '../formatter';
+import { parseResponseSegments, hasStructuredBlocks, formatOpportunityCardHtml, formatOpportunityCardPlainText, type ResponseSegment } from '../formatter';
 
 // ── parseResponseSegments ──────────────────────────────────────────────────────
 

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -141,6 +141,13 @@ NetworkMembershipEvents.onMemberAdded = (userId: string, networkId: string) => {
   userContextQueue.addRegenJob({ userId, reason: 'network_membership' }).catch((err) => {
     log.job.from('NetworkMembership').error('Failed to enqueue context regen', { userId, networkId, error: err });
   });
+  // Re-evaluate the member's pre-existing intents against the joined network.
+  // Intents created before joining never get an assignment pass for this network
+  // otherwise, leaving them silently absent from it. Assignment-only (no HyDE
+  // regen / opportunity discovery); scoped to this network.
+  intentQueue.addNetworkReconcileForUser(userId, networkId).catch((err) => {
+    log.job.from('NetworkMembership').error('Failed to enqueue intent network reconcile', { userId, networkId, error: err });
+  });
 };
 
 enrichmentQueue.onEnrichmentComplete = (userId: string) => {

--- a/backend/src/queues/intent.queue.ts
+++ b/backend/src/queues/intent.queue.ts
@@ -4,14 +4,7 @@ import { QueueFactory } from '../lib/bullmq/bullmq';
 import { ChatDatabaseAdapter } from '../adapters/database.adapter';
 import { EmbedderAdapter } from '../adapters/embedder.adapter';
 import { RedisCacheAdapter } from '../adapters/cache.adapter';
-import {
-  HydeGraphFactory,
-  HydeGenerator,
-  LensInferrer,
-  IntentIndexer,
-  buildNetworkAssignmentDecision,
-  resolveAssignmentNetworkScope,
-} from '@indexnetwork/protocol';
+import { HydeGraphFactory, HydeGenerator, LensInferrer, IntentIndexer, buildNetworkAssignmentDecision, resolveAssignmentNetworkScope } from '@indexnetwork/protocol';
 import type { HydeGraphDatabase, IntentGraphQueue, IntentIndexerOutput } from '@indexnetwork/protocol';
 import { fromIntentQueue } from './opportunity/from-intent.queue';
 

--- a/backend/src/queues/intent.queue.ts
+++ b/backend/src/queues/intent.queue.ts
@@ -116,7 +116,7 @@ export class IntentQueue implements IntentGraphQueue {
    * @returns The BullMQ job
    */
   async addJob(
-    name: 'generate_hyde' | 'delete_hyde',
+    name: 'generate_hyde' | 'delete_hyde' | 'reconcile_intent_networks',
     data: IntentJobData | IntentDeleteData,
     options?: { jobId?: string; priority?: number }
   ): Promise<Job<IntentJobPayload>> {
@@ -140,12 +140,60 @@ export class IntentQueue implements IntentGraphQueue {
       case 'generate_hyde':
         await this.handleGenerateHyde(data as IntentJobData);
         break;
+      case 'reconcile_intent_networks':
+        await this.handleReconcileNetworks(data as IntentJobData);
+        break;
       case 'delete_hyde':
         await this.handleDeleteHyde(data as IntentDeleteData);
         break;
       default:
         this.queueLogger.warn(`[IntentProcessor] Unknown job name: ${name}`);
     }
+  }
+
+  /**
+   * Enqueue an assignment-only reconciliation for an intent. Unlike
+   * {@link addGenerateHydeJob} this never regenerates HyDE docs or runs
+   * opportunity discovery — it only (re)evaluates and writes intent_networks
+   * rows. Used by network-join backfill and the orphan-reconcile sweep.
+   *
+   * @param data - intentId, userId, and optional networkScopeId to restrict the
+   *   evaluated network set (defaults to all assignment-eligible memberships).
+   * @returns The BullMQ job.
+   */
+  addReconcileJob(data: IntentJobData): Promise<Job<IntentJobPayload>> {
+    return this.addJob('reconcile_intent_networks', data, {
+      jobId: `reconcile-${data.intentId}-${data.networkScopeId ?? 'global'}`,
+    });
+  }
+
+  /**
+   * Enqueue a network-scoped reconcile for every active intent a user owns.
+   *
+   * This is the join-time half of the protocol rule "membership re-evaluates a
+   * member's existing intents against the network": intents created before the
+   * user joined never get an assignment pass for the new network otherwise.
+   * Driven by the `NetworkMembershipEvents.onMemberAdded` hook so it fires for
+   * every membership path (REST self-join, owner-add, and the protocol
+   * `create_network_membership` graph) — all converge on `addMemberToNetwork`.
+   * Best-effort per intent; assignment-only (no HyDE/opportunity side effects).
+   *
+   * @param userId - The member whose existing intents should be re-evaluated.
+   * @param networkId - The joined network; scopes evaluation to it.
+   * @returns The number of reconcile jobs enqueued.
+   */
+  async addNetworkReconcileForUser(userId: string, networkId: string): Promise<number> {
+    const db = this.deps?.database ?? this.database;
+    const intents = await db.getActiveIntents(userId);
+    await Promise.all(
+      intents.map((i) =>
+        this.addReconcileJob({ intentId: i.id, userId, networkScopeId: networkId }).catch((err) =>
+          this.logger.warn('[IntentReconcile] enqueue failed', { intentId: i.id, networkId, userId, error: err }),
+        ),
+      ),
+    );
+    this.logger.info('[IntentReconcile] Enqueued network reconcile for member', { userId, networkId, intentCount: intents.length });
+    return intents.length;
   }
 
   /**
@@ -197,80 +245,8 @@ export class IntentQueue implements IntentGraphQueue {
     }
     this.logger.info('[IntentHyde] Starting HyDE generation', { intentId, userId });
     this.logger.debug('[IntentHyde] Intent payload preview', { intentId, payload: intent.payload?.slice(0, 80) });
-    let assignedIndexCount = 0;
-    try {
-      const membershipNetworkIds = await db.getAssignmentNetworkIdsForUser(userId);
-      const userIndexIds = resolveAssignmentNetworkScope({ memberships: membershipNetworkIds, networkScopeId });
-      this.logger.info('[IntentHyde] User assignment networks found', { intentId, userId, indexCount: userIndexIds.length, indexIds: userIndexIds });
-
-      // Instantiate once per job run so the same withStructuredOutput binding
-      // is reused across all network evaluations in the Promise.all below.
-      const defaultIndexer = this.deps?.evaluateIntentAssignment ? null : new IntentIndexer();
-      const evaluateIntentAssignment = this.deps?.evaluateIntentAssignment ?? ((opts: {
-        intent: string;
-        indexPrompt: string | null;
-        memberPrompt: string | null;
-        sourceName?: string | null;
-      }) => defaultIndexer!.invoke(opts.intent, opts.indexPrompt, opts.memberPrompt, opts.sourceName ?? null));
-
-      const sourceName = intent.sourceType
-        ? `${intent.sourceType}:${intent.sourceId ?? ''}`
-        : undefined;
-
-      const scoringResults = await Promise.all(
-        userIndexIds.map(async (networkId) => {
-          const ctx = await db.getNetworkAssignmentContext(networkId, userId);
-          if (!ctx) {
-            this.logger.warn('[IntentHyde] Assignment context missing for index, skipping fail-closed', { intentId, userId, networkId });
-            return null;
-          }
-          const indexPrompt = ctx.indexPrompt ?? null;
-          const memberPrompt = ctx.memberPrompt ?? null;
-          const hasPrompts = !!indexPrompt?.trim() || !!memberPrompt?.trim();
-          let result: IntentIndexerOutput | null = null;
-          if (hasPrompts) {
-            try {
-              result = await evaluateIntentAssignment({ intent: intent.payload, indexPrompt, memberPrompt, sourceName });
-            } catch (err) {
-              this.logger.warn('[IntentHyde] IntentIndexer failed for index', { intentId, networkId, error: err });
-            }
-          }
-
-          const decision = buildNetworkAssignmentDecision({
-            resourceType: 'intent',
-            mode: 'automatic',
-            scope: networkScopeId ? 'network' : 'global',
-            indexPrompt,
-            memberPrompt,
-            rawScores: result ? { indexScore: result.indexScore, memberScore: result.memberScore } : undefined,
-            evaluator: 'intent-indexer',
-            source: 'intent-hyde-queue',
-            reason: result?.reasoning,
-            createdAt: new Date().toISOString(),
-          });
-          return { networkId, decision };
-        })
-      );
-
-      for (const scoringResult of scoringResults) {
-        if (!scoringResult) continue;
-        const { networkId, decision } = scoringResult;
-        if (!decision.assigned) continue;
-        try {
-          await db.assignIntentToNetwork(intentId, networkId, decision.finalScore, decision.metadata);
-          assignedIndexCount++;
-        } catch (assignErr) {
-          this.logger.debug('[IntentHyde] Assign intent to index skipped', { intentId, networkId, error: assignErr });
-        }
-      }
-    } catch (err) {
-      this.logger.warn('[IntentHyde] Failed to assign intent to user indexes', {
-        intentId,
-        userId,
-        error: err,
-      });
-    }
-    this.logger.info('[IntentHyde] Index assignment complete', { intentId, assignedIndexCount });
+    const { assignedNetworkIds } = await this.assignIntentToNetworks(intentId, userId, { networkScopeId });
+    this.logger.info('[IntentHyde] Index assignment complete', { intentId, assignedIndexCount: assignedNetworkIds.length });
 
     // Fetch discoverer profile + active intents for HyDE context (best-effort)
     let profileContext: string | undefined;
@@ -346,6 +322,128 @@ export class IntentQueue implements IntentGraphQueue {
     }).catch((err: unknown) =>
       this.logger.error('[IntentHyde] Failed to enqueue opportunity discovery', { intentId, error: err })
     );
+  }
+
+  /**
+   * Resolve the user's eligible networks (respecting optional scope), score the
+   * intent against each, and upsert intent_networks rows for assigned networks.
+   *
+   * Pure assignment: no HyDE regeneration and no opportunity discovery, so it is
+   * safe to call for reconciliation/backfill without spamming users with new
+   * opportunity notifications on existing intents. Idempotent —
+   * {@link ChatDatabaseAdapter.assignIntentToNetwork} upserts on
+   * (intentId, networkId).
+   *
+   * @param intentId - Intent to assign.
+   * @param userId - Owner of the intent.
+   * @param opts - Optional `networkScopeId` to restrict the evaluated set and a
+   *   `source` tag recorded in assignment metadata.
+   * @returns Assigned network IDs and the number of networks evaluated.
+   */
+  private async assignIntentToNetworks(
+    intentId: string,
+    userId: string,
+    opts?: { networkScopeId?: string; source?: string },
+  ): Promise<{ assignedNetworkIds: string[]; evaluatedCount: number }> {
+    const networkScopeId = opts?.networkScopeId;
+    const source = opts?.source ?? 'intent-hyde-queue';
+    const db = this.deps?.database ?? this.database;
+    const intent = await db.getIntentForIndexing(intentId);
+    if (!intent) {
+      this.logger.warn('[IntentAssign] Intent not found, skipping', { intentId });
+      return { assignedNetworkIds: [], evaluatedCount: 0 };
+    }
+
+    const assignedNetworkIds: string[] = [];
+    let evaluatedCount = 0;
+    try {
+      const membershipNetworkIds = await db.getAssignmentNetworkIdsForUser(userId);
+      const userIndexIds = resolveAssignmentNetworkScope({ memberships: membershipNetworkIds, networkScopeId });
+      evaluatedCount = userIndexIds.length;
+      this.logger.info('[IntentAssign] User assignment networks found', { intentId, userId, indexCount: userIndexIds.length, indexIds: userIndexIds });
+
+      // Instantiate once per run so the same withStructuredOutput binding is
+      // reused across all network evaluations in the Promise.all below.
+      const defaultIndexer = this.deps?.evaluateIntentAssignment ? null : new IntentIndexer();
+      const evaluateIntentAssignment = this.deps?.evaluateIntentAssignment ?? ((o: {
+        intent: string;
+        indexPrompt: string | null;
+        memberPrompt: string | null;
+        sourceName?: string | null;
+      }) => defaultIndexer!.invoke(o.intent, o.indexPrompt, o.memberPrompt, o.sourceName ?? null));
+
+      const sourceName = intent.sourceType
+        ? `${intent.sourceType}:${intent.sourceId ?? ''}`
+        : undefined;
+
+      const scoringResults = await Promise.all(
+        userIndexIds.map(async (networkId) => {
+          const ctx = await db.getNetworkAssignmentContext(networkId, userId);
+          if (!ctx) {
+            this.logger.warn('[IntentAssign] Assignment context missing for network, skipping fail-closed', { intentId, userId, networkId });
+            return null;
+          }
+          const indexPrompt = ctx.indexPrompt ?? null;
+          const memberPrompt = ctx.memberPrompt ?? null;
+          const hasPrompts = !!indexPrompt?.trim() || !!memberPrompt?.trim();
+          let result: IntentIndexerOutput | null = null;
+          if (hasPrompts) {
+            try {
+              result = await evaluateIntentAssignment({ intent: intent.payload, indexPrompt, memberPrompt, sourceName });
+            } catch (err) {
+              this.logger.warn('[IntentAssign] IntentIndexer failed for network', { intentId, networkId, error: err });
+            }
+          }
+
+          const decision = buildNetworkAssignmentDecision({
+            resourceType: 'intent',
+            mode: 'automatic',
+            scope: networkScopeId ? 'network' : 'global',
+            indexPrompt,
+            memberPrompt,
+            rawScores: result ? { indexScore: result.indexScore, memberScore: result.memberScore } : undefined,
+            evaluator: 'intent-indexer',
+            source,
+            reason: result?.reasoning,
+            createdAt: new Date().toISOString(),
+          });
+          return { networkId, decision };
+        })
+      );
+
+      for (const scoringResult of scoringResults) {
+        if (!scoringResult) continue;
+        const { networkId, decision } = scoringResult;
+        if (!decision.assigned) continue;
+        try {
+          await db.assignIntentToNetwork(intentId, networkId, decision.finalScore, decision.metadata);
+          assignedNetworkIds.push(networkId);
+        } catch (assignErr) {
+          this.logger.debug('[IntentAssign] Assign intent to network skipped', { intentId, networkId, error: assignErr });
+        }
+      }
+    } catch (err) {
+      this.logger.warn('[IntentAssign] Failed to assign intent to user networks', { intentId, userId, error: err });
+    }
+
+    if (assignedNetworkIds.length === 0) {
+      // Explicit orphan signal: an intent registered to no network is invisible
+      // in every network UI. Surface it so it can be alerted on or swept rather
+      // than silently lost.
+      this.logger.warn('[IntentAssign] Intent assigned to NO networks', { intentId, userId, networkScopeId, evaluatedCount });
+    }
+    return { assignedNetworkIds, evaluatedCount };
+  }
+
+  /**
+   * Handle a `reconcile_intent_networks` job: run assignment only, with no HyDE
+   * regeneration or opportunity discovery. Idempotent and safe to re-run.
+   *
+   * @param data - intentId, userId, and optional networkScopeId.
+   */
+  private async handleReconcileNetworks(data: IntentJobData): Promise<void> {
+    const { intentId, userId, networkScopeId } = data;
+    await this.assignIntentToNetworks(intentId, userId, { networkScopeId, source: 'intent-reconcile-queue' });
   }
 
   private async handleDeleteHyde(data: IntentDeleteData): Promise<void> {

--- a/backend/src/queues/opportunity/discovery-run.queue.ts
+++ b/backend/src/queues/opportunity/discovery-run.queue.ts
@@ -1,27 +1,7 @@
 import { Job } from 'bullmq';
 
-import {
-  HydeGenerator,
-  HydeGraphFactory,
-  LensInferrer,
-  OpportunityGraphFactory,
-  createOpportunityTools,
-  getToolTimeoutPolicy,
-  requestContext,
-  resolveChatContext,
-} from '@indexnetwork/protocol';
-import type {
-  AgentDispatcher,
-  CompiledGraph,
-  DiscoveryRunInput,
-  DiscoveryRunRecord,
-  HydeGraphDatabase,
-  NegotiationGraphLike,
-  OpportunityGraphDatabase,
-  RawToolDefinition,
-  ResolvedToolContext,
-  ToolDeps,
-} from '@indexnetwork/protocol';
+import { HydeGenerator, HydeGraphFactory, LensInferrer, OpportunityGraphFactory, createOpportunityTools, getToolTimeoutPolicy, requestContext, resolveChatContext } from '@indexnetwork/protocol';
+import type { AgentDispatcher, CompiledGraph, DiscoveryRunInput, DiscoveryRunRecord, HydeGraphDatabase, NegotiationGraphLike, OpportunityGraphDatabase, RawToolDefinition, ResolvedToolContext, ToolDeps } from '@indexnetwork/protocol';
 
 import { log } from '../../lib/log';
 import { captureAppException } from '../../lib/sentry';

--- a/backend/src/queues/profile-run.queue.ts
+++ b/backend/src/queues/profile-run.queue.ts
@@ -1,22 +1,7 @@
 import { Job } from 'bullmq';
 
-import {
-  PremiseGraphFactory,
-  ProfileGraphFactory,
-  createProfileTools,
-  getToolTimeoutPolicy,
-  requestContext,
-  resolveChatContext,
-} from '@indexnetwork/protocol';
-import type {
-  CompiledGraph,
-  PremiseGraphDatabase,
-  ProfileRunInput,
-  ProfileRunRecord,
-  RawToolDefinition,
-  ResolvedToolContext,
-  ToolDeps,
-} from '@indexnetwork/protocol';
+import { PremiseGraphFactory, ProfileGraphFactory, createProfileTools, getToolTimeoutPolicy, requestContext, resolveChatContext } from '@indexnetwork/protocol';
+import type { CompiledGraph, PremiseGraphDatabase, ProfileRunInput, ProfileRunRecord, RawToolDefinition, ResolvedToolContext, ToolDeps } from '@indexnetwork/protocol';
 
 import { log } from '../lib/log';
 import { captureAppException } from '../lib/sentry';

--- a/backend/src/queues/tests/from-intent.queue.spec.ts
+++ b/backend/src/queues/tests/from-intent.queue.spec.ts
@@ -26,13 +26,7 @@ afterAll(() => {
   mock.restore();
 });
 
-import {
-  FromIntentQueue,
-  QUEUE_NAME,
-  type FromIntentJobData,
-  type FromIntentDatabase,
-  type FromIntentGraphInvokeOptions,
-} from '../opportunity/from-intent.queue';
+import { FromIntentQueue, QUEUE_NAME, type FromIntentJobData, type FromIntentDatabase, type FromIntentGraphInvokeOptions } from '../opportunity/from-intent.queue';
 
 const asDb = (db: unknown): FromIntentDatabase => db as FromIntentDatabase;
 

--- a/backend/src/queues/tests/from-introducer.queue.spec.ts
+++ b/backend/src/queues/tests/from-introducer.queue.spec.ts
@@ -26,12 +26,7 @@ afterAll(() => {
   mock.restore();
 });
 
-import {
-  FromIntroducerQueue,
-  QUEUE_NAME,
-  type FromIntroducerDatabase,
-  type FromIntroducerGraphInvokeOptions,
-} from '../opportunity/from-introducer.queue';
+import { FromIntroducerQueue, QUEUE_NAME, type FromIntroducerDatabase, type FromIntroducerGraphInvokeOptions } from '../opportunity/from-introducer.queue';
 
 const asDb = (db: unknown): FromIntroducerDatabase => db as FromIntroducerDatabase;
 

--- a/backend/src/queues/tests/from-profile.queue.spec.ts
+++ b/backend/src/queues/tests/from-profile.queue.spec.ts
@@ -25,11 +25,7 @@ afterAll(() => {
   mock.restore();
 });
 
-import {
-  FromProfileQueue,
-  QUEUE_NAME,
-  type FromProfileJobData,
-} from '../opportunity/from-profile.queue';
+import { FromProfileQueue, QUEUE_NAME, type FromProfileJobData } from '../opportunity/from-profile.queue';
 
 describe('FromProfileQueue', () => {
   describe('constructor and static', () => {

--- a/backend/src/queues/tests/integration.queue.spec.ts
+++ b/backend/src/queues/tests/integration.queue.spec.ts
@@ -21,10 +21,7 @@ afterAll(() => {
   mock.restore();
 });
 
-import {
-  IntegrationSyncQueue,
-  QUEUE_NAME,
-} from '../integration.queue';
+import { IntegrationSyncQueue, QUEUE_NAME } from '../integration.queue';
 import type { IntegrationSyncQueueDeps } from '../integration.queue';
 
 /** Helper to build a mock DB adapter with sensible defaults. */

--- a/backend/src/queues/tests/intent.queue.spec.ts
+++ b/backend/src/queues/tests/intent.queue.spec.ts
@@ -24,12 +24,7 @@ afterAll(() => {
   mock.restore();
 });
 
-import {
-  IntentQueue,
-  QUEUE_NAME,
-  type IntentJobPayload,
-  type IntentQueueDatabase,
-} from '../intent.queue';
+import { IntentQueue, QUEUE_NAME, type IntentJobPayload, type IntentQueueDatabase } from '../intent.queue';
 import { DEFAULT_NETWORK_ASSIGNMENT_THRESHOLD } from '@indexnetwork/protocol';
 
 /** Cast a plain object to IntentQueueDatabase for tests and provide assignment-policy defaults. */

--- a/backend/src/queues/tests/intent.queue.spec.ts
+++ b/backend/src/queues/tests/intent.queue.spec.ts
@@ -92,6 +92,47 @@ describe('IntentQueue', () => {
       await queue.addDeleteHydeJob({ intentId: 'i1' });
       expect(mockAdd).toHaveBeenCalledWith('delete_hyde', { intentId: 'i1' }, expect.any(Object));
     });
+
+    it('addReconcileJob delegates to addJob with a global jobId', async () => {
+      const queue = new IntentQueue();
+      await queue.addReconcileJob({ intentId: 'i1', userId: 'u1' });
+      expect(mockAdd).toHaveBeenCalledWith(
+        'reconcile_intent_networks',
+        { intentId: 'i1', userId: 'u1' },
+        expect.objectContaining({ jobId: 'reconcile-i1-global' }),
+      );
+    });
+
+    it('addReconcileJob scopes the jobId to the network when provided', async () => {
+      const queue = new IntentQueue();
+      await queue.addReconcileJob({ intentId: 'i1', userId: 'u1', networkScopeId: 'net-x' });
+      expect(mockAdd).toHaveBeenCalledWith(
+        'reconcile_intent_networks',
+        { intentId: 'i1', userId: 'u1', networkScopeId: 'net-x' },
+        expect.objectContaining({ jobId: 'reconcile-i1-net-x' }),
+      );
+    });
+
+    it('addNetworkReconcileForUser enqueues a network-scoped reconcile per active intent', async () => {
+      const getActiveIntents = mock(async () => [
+        { id: 'i1', payload: 'p1', summary: null, createdAt: new Date() },
+        { id: 'i2', payload: 'p2', summary: null, createdAt: new Date() },
+      ]);
+      const queue = new IntentQueue({ database: asIntentDb({ getActiveIntents } as Partial<IntentQueueDatabase>) });
+      const count = await queue.addNetworkReconcileForUser('u1', 'net-1');
+      expect(count).toBe(2);
+      expect(getActiveIntents).toHaveBeenCalledWith('u1');
+      expect(mockAdd).toHaveBeenCalledWith(
+        'reconcile_intent_networks',
+        { intentId: 'i1', userId: 'u1', networkScopeId: 'net-1' },
+        expect.objectContaining({ jobId: 'reconcile-i1-net-1' }),
+      );
+      expect(mockAdd).toHaveBeenCalledWith(
+        'reconcile_intent_networks',
+        { intentId: 'i2', userId: 'u1', networkScopeId: 'net-1' },
+        expect.objectContaining({ jobId: 'reconcile-i2-net-1' }),
+      );
+    });
   });
 
   describe('processJob', () => {
@@ -348,6 +389,44 @@ describe('IntentQueue', () => {
         expect(assignIntentToNetwork.mock.calls.map((call) => call[1])).toEqual(['net-a']);
         expect(evaluateIntentAssignment).not.toHaveBeenCalled();
       });
+    });
+
+    it('reconcile_intent_networks: assigns networks with no HyDE or opportunity side effects', async () => {
+      const invokeHyde = mock(async () => {});
+      const addOpportunityJob = mock(async () => ({}));
+      const assignIntentToNetwork = mock(async () => {});
+      const db = {
+        getIntentForIndexing: async () => ({ id: 'i1', payload: 'Build AI tools', userId: 'u1', sourceType: null, sourceId: null }),
+        getAssignmentNetworkIdsForUser: async () => ['n1', 'n2'],
+        getNetworkAssignmentContext: async (networkId: string) => ({ networkId, indexPrompt: null, memberPrompt: null }),
+        assignIntentToNetwork,
+        deleteHydeDocumentsForSource: async () => 0,
+      };
+      const queue = new IntentQueue({ database: asIntentDb(db), invokeHyde, addOpportunityJob });
+      await queue.processJob('reconcile_intent_networks', { intentId: 'i1', userId: 'u1' });
+
+      expect(assignIntentToNetwork.mock.calls.map((c) => c[1]).sort()).toEqual(['n1', 'n2']);
+      // Pure assignment: reconcile must never regenerate HyDE or trigger discovery.
+      expect(invokeHyde).not.toHaveBeenCalled();
+      expect(addOpportunityJob).not.toHaveBeenCalled();
+      expect(assignIntentToNetwork.mock.calls[0][3]).toMatchObject({ source: 'intent-reconcile-queue', assigned: true });
+    });
+
+    it('reconcile_intent_networks: networkScopeId restricts evaluation to that network', async () => {
+      const assignIntentToNetwork = mock(async () => {});
+      const getNetworkAssignmentContext = mock(async (networkId: string) => ({ networkId, indexPrompt: null, memberPrompt: null }));
+      const db = {
+        getIntentForIndexing: async () => ({ id: 'i1', payload: 'P', userId: 'u1', sourceType: null, sourceId: null }),
+        getAssignmentNetworkIdsForUser: async () => ['net-a', 'net-b'],
+        getNetworkAssignmentContext,
+        assignIntentToNetwork,
+        deleteHydeDocumentsForSource: async () => 0,
+      };
+      const queue = new IntentQueue({ database: asIntentDb(db) });
+      await queue.processJob('reconcile_intent_networks', { intentId: 'i1', userId: 'u1', networkScopeId: 'net-b' });
+
+      expect(getNetworkAssignmentContext).toHaveBeenCalledTimes(1);
+      expect(assignIntentToNetwork.mock.calls.map((c) => c[1])).toEqual(['net-b']);
     });
 
     it('delete_hyde: calls deleteHydeDocumentsForSource', async () => {

--- a/backend/src/queues/tests/notification.queue.spec.ts
+++ b/backend/src/queues/tests/notification.queue.spec.ts
@@ -66,14 +66,7 @@ afterAll(() => {
   mock.restore();
 });
 
-import {
-  NotificationQueue,
-  QUEUE_NAME,
-  type NotificationJobData,
-  type NotificationPriority,
-  type NotificationQueueDatabase,
-  queueOpportunityNotification,
-} from '../notification.queue';
+import { NotificationQueue, QUEUE_NAME, type NotificationJobData, type NotificationPriority, type NotificationQueueDatabase, queueOpportunityNotification } from '../notification.queue';
 import { onTelegramNotification } from '../../lib/notification-events';
 
 const asNotifDb = (db: { getOpportunity: (id: string) => Promise<unknown> }): NotificationQueueDatabase => ({

--- a/backend/src/queues/tests/profile.queue.spec.ts
+++ b/backend/src/queues/tests/profile.queue.spec.ts
@@ -22,10 +22,7 @@ afterAll(() => {
   mock.restore();
 });
 
-import {
-  ProfileQueue,
-  QUEUE_NAME,
-} from '../profile.queue';
+import { ProfileQueue, QUEUE_NAME } from '../profile.queue';
 
 describe('ProfileQueue', () => {
   describe('addEnsureProfileHydeJob', () => {

--- a/backend/src/queues/tests/run-existing.queue.spec.ts
+++ b/backend/src/queues/tests/run-existing.queue.spec.ts
@@ -21,12 +21,7 @@ afterAll(() => {
   mock.restore();
 });
 
-import {
-  NegotiationRunExistingQueue,
-  QUEUE_NAME,
-  type RunExistingDeps,
-  type RunExistingGraphInvokeOptions,
-} from '../negotiations/run-existing.queue';
+import { NegotiationRunExistingQueue, QUEUE_NAME, type RunExistingDeps, type RunExistingGraphInvokeOptions } from '../negotiations/run-existing.queue';
 
 describe('NegotiationRunExistingQueue', () => {
   describe('constructor and static', () => {

--- a/backend/src/queues/tests/usercontext.queue.spec.ts
+++ b/backend/src/queues/tests/usercontext.queue.spec.ts
@@ -21,13 +21,7 @@ afterAll(() => {
   mock.restore();
 });
 
-import {
-  UserContextQueue,
-  QUEUE_NAME,
-  computePremiseHash,
-  type ContextPremise,
-  type UserContextQueueDeps,
-} from '../usercontext.queue';
+import { UserContextQueue, QUEUE_NAME, computePremiseHash, type ContextPremise, type UserContextQueueDeps } from '../usercontext.queue';
 
 describe('UserContextQueue', () => {
   it('exposes QUEUE_NAME on class', () => {

--- a/backend/src/schemas/conversation.schema.ts
+++ b/backend/src/schemas/conversation.schema.ts
@@ -1,13 +1,4 @@
-import {
-  pgTable,
-  pgEnum,
-  text,
-  timestamp,
-  jsonb,
-  index,
-  primaryKey,
-  uniqueIndex,
-} from 'drizzle-orm/pg-core';
+import { pgTable, pgEnum, text, timestamp, jsonb, index, primaryKey, uniqueIndex } from 'drizzle-orm/pg-core';
 import { relations, sql } from 'drizzle-orm';
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/backend/src/schemas/tests/conversation.schema.spec.ts
+++ b/backend/src/schemas/tests/conversation.schema.spec.ts
@@ -2,10 +2,7 @@ import { config } from 'dotenv';
 config({ path: '.env.test', override: true });
 
 import { describe, it, expect } from 'bun:test';
-import {
-  conversations, conversationParticipants, messages, tasks, artifacts, conversationMetadata,
-  participantTypeEnum, messageRoleEnum, taskStateEnum,
-} from '../conversation.schema';
+import { conversations, conversationParticipants, messages, tasks, artifacts, conversationMetadata, participantTypeEnum, messageRoleEnum, taskStateEnum } from '../conversation.schema';
 
 describe('conversation schema', () => {
   it('exports all tables', () => {

--- a/backend/src/services/agent-dispatcher.service.ts
+++ b/backend/src/services/agent-dispatcher.service.ts
@@ -1,8 +1,4 @@
-import type {
-  AgentDispatcher,
-  AgentDispatchResult,
-  NegotiationTurnPayload,
-} from '@indexnetwork/protocol';
+import type { AgentDispatcher, AgentDispatchResult, NegotiationTurnPayload } from '@indexnetwork/protocol';
 import type { NegotiationTimeoutQueue } from '@indexnetwork/protocol';
 
 import type { AgentWithRelations } from '../adapters/agent.database.adapter';

--- a/backend/src/services/agent.service.ts
+++ b/backend/src/services/agent.service.ts
@@ -1,18 +1,5 @@
-import {
-  agentDatabaseAdapter,
-  type AgentPermissionRow,
-  type AgentRegistryStore,
-  type AgentScope,
-  type AgentRow,
-  type AgentTransportRow,
-  type AgentWithRelations,
-  type PermissionScope,
-  type TransportChannel,
-} from '../adapters/agent.database.adapter';
-import {
-  agentTokenAdapter,
-  type AgentTokenStore,
-} from '../adapters/agent-token.adapter';
+import { agentDatabaseAdapter, type AgentPermissionRow, type AgentRegistryStore, type AgentScope, type AgentRow, type AgentTransportRow, type AgentWithRelations, type PermissionScope, type TransportChannel } from '../adapters/agent.database.adapter';
+import { agentTokenAdapter, type AgentTokenStore } from '../adapters/agent-token.adapter';
 import { userDatabaseAdapter } from '../adapters/database.adapter';
 import { log } from '../lib/log';
 

--- a/backend/src/services/debug.service.ts
+++ b/backend/src/services/debug.service.ts
@@ -1,13 +1,7 @@
 import { eq, and, sql, ne, isNull, isNotNull, count } from 'drizzle-orm';
 
 import db from '../lib/drizzle/drizzle';
-import {
-  intents,
-  intentNetworks,
-  networks,
-  networkMembers,
-  userProfiles,
-} from '../schemas/database.schema';
+import { intents, intentNetworks, networks, networkMembers, userProfiles } from '../schemas/database.schema';
 import { ChatDatabaseAdapter } from '../adapters/database.adapter';
 import { EmbedderAdapter } from '../adapters/embedder.adapter';
 import { RedisCacheAdapter } from '../adapters/cache.adapter';

--- a/backend/src/services/negotiation-summary.service.ts
+++ b/backend/src/services/negotiation-summary.service.ts
@@ -5,11 +5,7 @@
  * OPENROUTER_API_KEY. Tests inject a fake.
  */
 import { NegotiationSummarizer } from "@indexnetwork/protocol";
-import type {
-  DiscoveryNegotiation,
-  DiscoveryNegotiationDigest,
-  NegotiationSummaryReader,
-} from "@indexnetwork/protocol";
+import type { DiscoveryNegotiation, DiscoveryNegotiationDigest, NegotiationSummaryReader } from "@indexnetwork/protocol";
 
 import { log } from "../lib/log";
 

--- a/backend/src/services/network.service.ts
+++ b/backend/src/services/network.service.ts
@@ -125,7 +125,20 @@ export class NetworkService {
    */
   async updateNetwork(networkId: string, userId: string, data: { title?: string; prompt?: string | null; imageUrl?: string | null; joinPolicy?: 'anyone' | 'invite_only'; allowGuestVibeCheck?: boolean; profileEnrichment?: schema.ProfileEnrichmentPolicy; type?: 'community' | 'event'; metadata?: Record<string, unknown>; contextInjection?: { discovery: boolean } }) {
     logger.verbose('[NetworkService] Updating index', { networkId, userId });
-    await this.assertNotPersonal(networkId);
+    if (await this.adapter.isPersonalNetwork(networkId)) {
+      // Personal indexes can't be renamed/deleted/repurposed (see assertNotPersonal),
+      // but the owner may set or clear a discovery prompt to curate what auto-assigns
+      // into My Network. Restrict edits to the prompt field only; ownership is
+      // enforced inside updateIndexSettings.
+      const editableForPersonal = new Set<string>(['prompt']);
+      const rejected = Object.keys(data).filter(
+        (k) => (data as Record<string, unknown>)[k] !== undefined && !editableForPersonal.has(k),
+      );
+      if (rejected.length > 0) {
+        throw new Error(`Access denied: personal indexes only allow editing the prompt (rejected: ${rejected.join(', ')}).`);
+      }
+      return this.adapter.updateIndexSettings(networkId, userId, { prompt: data.prompt });
+    }
     if (data.joinPolicy !== undefined || data.allowGuestVibeCheck !== undefined) {
       await this.assertJoinPolicyNotLockedByExperiment(networkId);
     }

--- a/backend/src/services/opportunity-delivery.service.ts
+++ b/backend/src/services/opportunity-delivery.service.ts
@@ -15,15 +15,7 @@
 import { and, eq, inArray, isNotNull, isNull, sql } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
 
-import {
-  OpportunityPresenter,
-  canUserSeeOpportunity,
-  classifyOpportunity,
-  gatherPresenterContext,
-  getOrCreateDeliveryCardBatch,
-  isActionableForViewer,
-  type PresenterDatabase,
-} from '@indexnetwork/protocol';
+import { OpportunityPresenter, canUserSeeOpportunity, classifyOpportunity, gatherPresenterContext, getOrCreateDeliveryCardBatch, isActionableForViewer, type PresenterDatabase } from '@indexnetwork/protocol';
 
 import type { Cache } from '../adapters/cache.adapter';
 import { RedisCacheAdapter } from '../adapters/cache.adapter';

--- a/backend/src/services/question-generator.service.ts
+++ b/backend/src/services/question-generator.service.ts
@@ -5,11 +5,7 @@
  * so module load never demands `OPENROUTER_API_KEY`. Tests inject a fake.
  */
 import { QuestionGenerator } from "@indexnetwork/protocol";
-import type {
-  DiscoveryQuestionInput,
-  QuestionGenerationResult,
-  QuestionGeneratorReader,
-} from "@indexnetwork/protocol";
+import type { DiscoveryQuestionInput, QuestionGenerationResult, QuestionGeneratorReader } from "@indexnetwork/protocol";
 
 import { log } from "../lib/log";
 

--- a/backend/src/services/question.service.ts
+++ b/backend/src/services/question.service.ts
@@ -1,11 +1,7 @@
 import { log } from '../lib/log';
 
 import { QuestionerAdapter } from '../adapters/questioner.adapter';
-import type {
-  AdapterQuestionAnswer,
-  AdapterQuestionFilters,
-  AdapterPersistedQuestion,
-} from '../adapters/questioner.adapter';
+import type { AdapterQuestionAnswer, AdapterQuestionFilters, AdapterPersistedQuestion } from '../adapters/questioner.adapter';
 import db from '../lib/drizzle/drizzle';
 
 // Re-export adapter types so the controller layer can reference them without

--- a/backend/src/services/tests/contact.service.spec.ts
+++ b/backend/src/services/tests/contact.service.spec.ts
@@ -10,13 +10,7 @@ config({ path: '.env.test', override: true });
 import { describe, expect, it, beforeAll, afterAll } from 'bun:test';
 import { eq, and, inArray, sql } from 'drizzle-orm';
 import db from '../../lib/drizzle/drizzle';
-import {
-  users,
-  userProfiles,
-  networks,
-  networkMembers,
-  personalNetworks,
-} from '../../schemas/database.schema';
+import { users, userProfiles, networks, networkMembers, personalNetworks } from '../../schemas/database.schema';
 import { ContactService } from '../contact.service';
 
 const TEST_PREFIX = 'contact_svc_v2_' + Date.now() + '_';

--- a/backend/src/services/tests/network.service.personal-prompt.spec.ts
+++ b/backend/src/services/tests/network.service.personal-prompt.spec.ts
@@ -1,0 +1,56 @@
+/** Config */
+import { config } from 'dotenv';
+config({ path: '.env.test', override: true });
+
+import { describe, expect, mock, test } from 'bun:test';
+
+import { NetworkService } from '../network.service';
+import type { ChatDatabaseAdapter } from '../../adapters/database.adapter';
+
+const PERSONAL_ID = 'personal-net-1';
+const USER_ID = 'user-1';
+
+/**
+ * Build a NetworkService backed by a minimal mock adapter. `isPersonalNetwork`
+ * reports PERSONAL_ID as personal; `updateIndexSettings` records its call and
+ * echoes the patch. Ownership is enforced inside the real adapter, so the unit
+ * test only exercises the service's field allowlist.
+ */
+function makeService() {
+  const updateIndexSettings = mock(async (id: string, _userId: string, data: Record<string, unknown>) => ({ id, ...data }));
+  const adapter = {
+    isPersonalNetwork: mock(async (id: string) => id === PERSONAL_ID),
+    updateIndexSettings,
+  } as unknown as ChatDatabaseAdapter;
+  return { service: new NetworkService(adapter), updateIndexSettings };
+}
+
+describe('networkService.updateNetwork on a personal index', () => {
+  test('allows a prompt-only edit', async () => {
+    const { service, updateIndexSettings } = makeService();
+    await service.updateNetwork(PERSONAL_ID, USER_ID, { prompt: 'AI founders only' });
+    expect(updateIndexSettings).toHaveBeenCalledWith(PERSONAL_ID, USER_ID, { prompt: 'AI founders only' });
+  });
+
+  test('allows clearing the prompt (null) — restores the prompt-less default', async () => {
+    const { service, updateIndexSettings } = makeService();
+    await service.updateNetwork(PERSONAL_ID, USER_ID, { prompt: null });
+    expect(updateIndexSettings).toHaveBeenCalledWith(PERSONAL_ID, USER_ID, { prompt: null });
+  });
+
+  test('rejects a rename (title) on a personal index', async () => {
+    const { service, updateIndexSettings } = makeService();
+    await expect(
+      service.updateNetwork(PERSONAL_ID, USER_ID, { title: 'Renamed' }),
+    ).rejects.toThrow(/only allow editing the prompt/);
+    expect(updateIndexSettings).not.toHaveBeenCalled();
+  });
+
+  test('rejects non-prompt fields even alongside a valid prompt', async () => {
+    const { service, updateIndexSettings } = makeService();
+    await expect(
+      service.updateNetwork(PERSONAL_ID, USER_ID, { prompt: 'ok', imageUrl: 'x', joinPolicy: 'anyone' }),
+    ).rejects.toThrow(/rejected: imageUrl, joinPolicy/);
+    expect(updateIndexSettings).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/services/tool.service.ts
+++ b/backend/src/services/tool.service.ts
@@ -5,12 +5,7 @@
 
 import { z } from 'zod';
 
-import {
-  chatDatabaseAdapter,
-  createUserDatabase,
-  createSystemDatabase,
-  conversationDatabaseAdapter,
-} from '../adapters/database.adapter';
+import { chatDatabaseAdapter, createUserDatabase, createSystemDatabase, conversationDatabaseAdapter } from '../adapters/database.adapter';
 import { EmbedderAdapter } from '../adapters/embedder.adapter';
 import { ScraperAdapter } from '../adapters/scraper.adapter';
 import { RedisCacheAdapter } from '../adapters/cache.adapter';

--- a/backend/tests/agent.service.spec.ts
+++ b/backend/tests/agent.service.spec.ts
@@ -2,15 +2,7 @@ import '../src/startup.env';
 
 import { beforeEach, describe, expect, it } from 'bun:test';
 
-import {
-  SYSTEM_AGENT_IDS,
-  type AgentPermissionRow,
-  type AgentRegistryStore,
-  type AgentRow,
-  type AgentScope,
-  type AgentTransportRow,
-  type AgentWithRelations,
-} from '../src/adapters/agent.database.adapter';
+import { SYSTEM_AGENT_IDS, type AgentPermissionRow, type AgentRegistryStore, type AgentRow, type AgentScope, type AgentTransportRow, type AgentWithRelations } from '../src/adapters/agent.database.adapter';
 import type { AgentTokenStore } from '../src/adapters/agent-token.adapter';
 import { AgentController } from '../src/controllers/agent.controller';
 import { PERSONAL_AGENT_DEFAULT_ACTIONS, AgentService, type AgentServiceStore } from '../src/services/agent.service';

--- a/backend/tests/auth.jwt-claims.spec.ts
+++ b/backend/tests/auth.jwt-claims.spec.ts
@@ -1,12 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import {
-  generateKeyPair,
-  SignJWT,
-  createLocalJWKSet,
-  exportJWK,
-  jwtVerify,
-  errors as joseErrors,
-} from 'jose';
+import { generateKeyPair, SignJWT, createLocalJWKSet, exportJWK, jwtVerify, errors as joseErrors } from 'jose';
 
 import { BASE_URL, JWT_AUDIENCE } from '../src/lib/betterauth/betterauth';
 

--- a/backend/tests/connect-link.surface.spec.ts
+++ b/backend/tests/connect-link.surface.spec.ts
@@ -6,15 +6,7 @@ import { eq } from 'drizzle-orm';
 import { ConnectLinkController } from '../src/controllers/connect-link.controller';
 import type { AuthenticatedUser } from '../src/guards/auth.guard';
 import db from '../src/lib/drizzle/drizzle';
-import {
-  connectLinks,
-  networkMembers,
-  networks,
-  opportunities,
-  personalNetworks,
-  userSocials,
-  users,
-} from '../src/schemas/database.schema';
+import { connectLinks, networkMembers, networks, opportunities, personalNetworks, userSocials, users } from '../src/schemas/database.schema';
 import { mintConnectLink } from '../src/services/connect-link.service';
 
 const FRONTEND_URL = (process.env.FRONTEND_URL || process.env.APP_URL || 'https://index.network')

--- a/backend/tests/debug.chat.legacy.spec.ts
+++ b/backend/tests/debug.chat.legacy.spec.ts
@@ -8,12 +8,7 @@ import { eq } from 'drizzle-orm';
 import { DebugController } from '../src/controllers/debug.controller';
 import db from '../src/lib/drizzle/drizzle';
 import { opportunities, users } from '../src/schemas/database.schema';
-import {
-  conversationParticipants,
-  conversations,
-  messages,
-  tasks,
-} from '../src/schemas/conversation.schema';
+import { conversationParticipants, conversations, messages, tasks } from '../src/schemas/conversation.schema';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/backend/tests/debug.chat.negotiations.spec.ts
+++ b/backend/tests/debug.chat.negotiations.spec.ts
@@ -8,12 +8,7 @@ import { eq } from 'drizzle-orm';
 import { DebugController } from '../src/controllers/debug.controller';
 import db from '../src/lib/drizzle/drizzle';
 import { opportunities, users } from '../src/schemas/database.schema';
-import {
-  conversationParticipants,
-  conversations,
-  messages,
-  tasks,
-} from '../src/schemas/conversation.schema';
+import { conversationParticipants, conversations, messages, tasks } from '../src/schemas/conversation.schema';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/backend/tests/experiment-signup-lookup.spec.ts
+++ b/backend/tests/experiment-signup-lookup.spec.ts
@@ -6,17 +6,7 @@ import { and, eq } from 'drizzle-orm';
 
 import { experimentService, SignupNotCompleteError } from '../src/services/experiment.service';
 import db from '../src/lib/drizzle/drizzle';
-import {
-  agentPermissions,
-  agents,
-  apikeys,
-  networkMembers,
-  networks,
-  personalNetworks,
-  userProfiles,
-  userSocials,
-  users,
-} from '../src/schemas/database.schema';
+import { agentPermissions, agents, apikeys, networkMembers, networks, personalNetworks, userProfiles, userSocials, users } from '../src/schemas/database.schema';
 import { generateMasterKey } from '../src/lib/experiment/master-key';
 import { NetworkController } from '../src/controllers/network.controller';
 

--- a/backend/tests/experiment-signup.spec.ts
+++ b/backend/tests/experiment-signup.spec.ts
@@ -7,17 +7,7 @@ import { and, eq, isNull } from 'drizzle-orm';
 import { experimentService } from '../src/services/experiment.service';
 import { AuthOrApiKeyGuard } from '../src/guards/auth.guard';
 import db from '../src/lib/drizzle/drizzle';
-import {
-  agentPermissions,
-  agents,
-  apikeys,
-  networkMembers,
-  networks,
-  personalNetworks,
-  userProfiles,
-  userSocials,
-  users,
-} from '../src/schemas/database.schema';
+import { agentPermissions, agents, apikeys, networkMembers, networks, personalNetworks, userProfiles, userSocials, users } from '../src/schemas/database.schema';
 
 const cleanup: Array<() => Promise<void>> = [];
 

--- a/backend/tests/introducer-discovery.spec.ts
+++ b/backend/tests/introducer-discovery.spec.ts
@@ -2,17 +2,7 @@ import { config } from 'dotenv';
 config({ path: '.env.test', override: true });
 
 import { describe, it, expect, mock } from 'bun:test';
-import {
-  selectContactsForDiscovery,
-  shouldRunIntroducerDiscovery,
-  runIntroducerDiscovery,
-  MAX_CONTACTS_PER_CYCLE,
-  MAX_CANDIDATES_PER_CONTACT,
-  INTRODUCER_DISCOVERY_SOURCE,
-  type IntroducerDiscoveryDatabase,
-  type IntroducerDiscoveryQueue,
-  type ContactWithIntents,
-} from '@indexnetwork/protocol';
+import { selectContactsForDiscovery, shouldRunIntroducerDiscovery, runIntroducerDiscovery, MAX_CONTACTS_PER_CYCLE, MAX_CANDIDATES_PER_CONTACT, INTRODUCER_DISCOVERY_SOURCE, type IntroducerDiscoveryDatabase, type IntroducerDiscoveryQueue, type ContactWithIntents } from '@indexnetwork/protocol';
 
 describe('IntroducerDiscovery', () => {
   const userId = 'user-introducer';

--- a/backend/tests/maintenance-introducer-discovery.spec.ts
+++ b/backend/tests/maintenance-introducer-discovery.spec.ts
@@ -2,12 +2,7 @@ import { config } from 'dotenv';
 config({ path: '.env.test', override: true });
 
 import { describe, it, expect, mock } from 'bun:test';
-import {
-  MaintenanceGraphFactory,
-  type MaintenanceGraphDatabase,
-  type MaintenanceGraphCache,
-  type MaintenanceGraphQueue,
-} from '@indexnetwork/protocol';
+import { MaintenanceGraphFactory, type MaintenanceGraphDatabase, type MaintenanceGraphCache, type MaintenanceGraphQueue } from '@indexnetwork/protocol';
 
 describe('MaintenanceGraph — Introducer Discovery', () => {
   const userId = 'test-user';

--- a/backend/tests/network-invitation-resend.spec.ts
+++ b/backend/tests/network-invitation-resend.spec.ts
@@ -12,15 +12,7 @@ import { and, eq } from 'drizzle-orm';
 
 import { networkInvitationService } from '../src/services/network-invitation.service';
 import db from '../src/lib/drizzle/drizzle';
-import {
-  agentPermissions,
-  agents,
-  apikeys,
-  networkMembers,
-  networks,
-  personalNetworks,
-  users,
-} from '../src/schemas/database.schema';
+import { agentPermissions, agents, apikeys, networkMembers, networks, personalNetworks, users } from '../src/schemas/database.schema';
 
 const cleanup: Array<() => Promise<void>> = [];
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "index-monorepo",
@@ -9,6 +8,7 @@
         "eslint": "^9.39.1",
         "eslint-import-resolver-typescript": "^4.4.4",
         "eslint-plugin-boundaries": "^6.0.2",
+        "eslint-plugin-import-newlines": "^1.4.1",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "lint-staged": "^16.4.0",
@@ -127,7 +127,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "3.1.1",
+      "version": "3.6.3",
       "dependencies": {
         "@langchain/core": "^1.1.17",
         "@langchain/langgraph": "^1.1.2",
@@ -1061,6 +1061,8 @@
     "eslint-module-utils": ["eslint-module-utils@2.12.1", "", { "dependencies": { "debug": "^3.2.7" } }, "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw=="],
 
     "eslint-plugin-boundaries": ["eslint-plugin-boundaries@6.0.2", "", { "dependencies": { "@boundaries/elements": "2.0.1", "chalk": "4.1.2", "eslint-import-resolver-node": "0.3.9", "eslint-module-utils": "2.12.1", "handlebars": "4.7.9", "micromatch": "4.0.8" }, "peerDependencies": { "eslint": ">=6.0.0" } }, "sha512-wSHgiYeMEbziP91lH0UQ9oslgF2djG1x+LV9z/qO19ggMKZaCB8pKIGePHAY91eLF4EAgpsxQk8MRSFGRPfPzw=="],
+
+    "eslint-plugin-import-newlines": ["eslint-plugin-import-newlines@1.4.1", "", { "peerDependencies": { "eslint": ">=6.0.0 < 10.0.0" }, "bin": { "import-linter": "lib/index.js" } }, "sha512-C9PQEJ4jS5tKoE9k0yY/5j4l1bxkxmVjrWvAFc1EToCnuQuwZGl1kS1JBlqYNF8svp0pnXLlkSdjByYa3JALcg=="],
 
     "eslint-plugin-react-hooks": ["eslint-plugin-react-hooks@7.1.1", "", { "dependencies": { "@babel/core": "^7.24.4", "@babel/parser": "^7.24.4", "hermes-parser": "^0.25.1", "zod": "^3.25.0 || ^4.0.0", "zod-validation-error": "^3.5.0 || ^4.0.0" }, "peerDependencies": { "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0" } }, "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g=="],
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
 import boundaries from "eslint-plugin-boundaries";
+import importNewlines from "eslint-plugin-import-newlines";
 import reactHooks from "eslint-plugin-react-hooks";
 import reactRefresh from "eslint-plugin-react-refresh";
 
@@ -25,7 +26,12 @@ export default tseslint.config(
   // ── Shared TypeScript rules ─────────────────────────────────────────
   {
     files: ["**/*.ts", "**/*.tsx"],
+    plugins: { "import-newlines": importNewlines },
     rules: {
+      // Keep every import on a single line (auto-fixable).
+      // High thresholds mean an import is only ever broken if it has >100
+      // specifiers or exceeds 100k chars — i.e. effectively never.
+      "import-newlines/enforce": ["error", { items: 100, "max-len": 100000 }],
       "@typescript-eslint/no-explicit-any": "error",
       "@typescript-eslint/no-unused-vars": [
         "warn",

--- a/frontend/src/app/agent/page.tsx
+++ b/frontend/src/app/agent/page.tsx
@@ -1,14 +1,7 @@
 import { useState, useEffect } from "react";
 import { useNavigate, useParams } from "react-router";
 import * as Tabs from "@radix-ui/react-tabs";
-import {
-  Loader2,
-  Sparkles,
-  ArrowUp,
-  Handshake,
-  Clock,
-  TrendingUp,
-} from "lucide-react";
+import { Loader2, Sparkles, ArrowUp, Handshake, Clock, TrendingUp } from "lucide-react";
 import { useAuthContext } from "@/contexts/AuthContext";
 import { useUsers } from "@/contexts/APIContext";
 import UserAvatar from "@/components/UserAvatar";

--- a/frontend/src/app/agents/[id]/page.tsx
+++ b/frontend/src/app/agents/[id]/page.tsx
@@ -3,23 +3,7 @@ import { useNavigate, useParams } from "react-router";
 import * as Tabs from "@radix-ui/react-tabs";
 import * as AlertDialog from "@radix-ui/react-alert-dialog";
 import * as Dialog from "@radix-ui/react-dialog";
-import {
-  Loader2,
-  ArrowLeft,
-  Bot,
-  Handshake,
-  TrendingUp,
-  Clock,
-  KeyRound,
-  Shield,
-  Plus,
-  Trash2,
-  Copy,
-  Check,
-  ChevronDown,
-  ChevronRight,
-  Send,
-} from "lucide-react";
+import { Loader2, ArrowLeft, Bot, Handshake, TrendingUp, Clock, KeyRound, Shield, Plus, Trash2, Copy, Check, ChevronDown, ChevronRight, Send } from "lucide-react";
 import { useAuthContext } from "@/contexts/AuthContext";
 import { useAgents, useUsers } from "@/contexts/APIContext";
 import { useNotifications } from "@/contexts/NotificationContext";

--- a/frontend/src/app/dev/intent-proposal/page.tsx
+++ b/frontend/src/app/dev/intent-proposal/page.tsx
@@ -1,8 +1,6 @@
 import { useState } from "react";
 import { RotateCcw } from "lucide-react";
-import IntentProposalCard, {
-  type IntentProposalData,
-} from "@/components/chat/IntentProposalCard";
+import IntentProposalCard, { type IntentProposalData } from "@/components/chat/IntentProposalCard";
 import { useNotifications } from "@/contexts/NotificationContext";
 
 const MOCK_CARD: IntentProposalData = {

--- a/frontend/src/app/library/page.tsx
+++ b/frontend/src/app/library/page.tsx
@@ -22,6 +22,7 @@ type LibrarySourceIntent = {
   sourceName: string;
   sourceValue: string | null;
   sourceMeta: string | null;
+  networks?: { id: string; title: string }[];
 };
 
 type FileItem = {

--- a/frontend/src/components/ChatContent.tsx
+++ b/frontend/src/components/ChatContent.tsx
@@ -1,20 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useGmailConnect } from "@/hooks/useGmailConnect";
 import { useNavigate } from "react-router";
-import {
-  ArrowUp,
-  Pencil,
-  Paperclip,
-  Square,
-  X,
-  Globe,
-  ChevronDown,
-  Lock,
-  ChevronLeft,
-  Share2,
-  Check,
-  Users,
-} from "lucide-react";
+import { ArrowUp, Pencil, Paperclip, Square, X, Globe, ChevronDown, Lock, ChevronLeft, Share2, Check, Users } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { MentionsTextInput } from "@/components/MentionsInput";
 import { useAIChat } from "@/contexts/AIChatContext";
@@ -29,13 +16,8 @@ import { DecisionQuestions } from "@/components/DecisionQuestions";
 import InviteMessageModal from "@/components/InviteMessageModal";
 import { SuggestionChips } from "@/components/chat/SuggestionChips";
 import { ToolCallsDisplay } from "@/components/chat/ToolCallsDisplay";
-import AssistantMessageContent, {
-  parseAllBlocks,
-} from "@/components/chat/AssistantMessageContent";
-import OpportunityCard, {
-  type OpportunityCardData,
-  OpportunitySkeleton,
-} from "@/components/chat/OpportunityCardInChat";
+import AssistantMessageContent, { parseAllBlocks } from "@/components/chat/AssistantMessageContent";
+import OpportunityCard, { type OpportunityCardData, OpportunitySkeleton } from "@/components/chat/OpportunityCardInChat";
 import { DebugCopyButton } from "@/components/DebugCopyButton";
 import { ContentContainer } from "@/components/layout";
 import { cn } from "@/lib/utils";

--- a/frontend/src/components/ChatContent.tsx
+++ b/frontend/src/components/ChatContent.tsx
@@ -579,15 +579,20 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
       const res = await apiClient.post<{ intentId: string }>("/intents/confirm", { proposalId, description, networkId });
       setIntentProposalStatusMap((prev) => ({ ...prev, [proposalId]: "created" }));
       setProposalIntentMap((prev) => ({ ...prev, [proposalId]: res.intentId }));
+      // Outcome-aware feedback: a network-scoped create lands directly in that
+      // network; an unscoped create is evaluated against all the user's
+      // networks asynchronously, so set expectations rather than implying it's
+      // already broadcasting somewhere specific.
+      const targetNetwork = networkId ? indexes.find((i) => i.id === networkId) : undefined;
       addNotification({
         type: "intent_broadcast",
-        title: "Broadcasting Signal",
+        title: targetNetwork ? `Broadcasting to ${targetNetwork.title}` : "Evaluating networks…",
         message: description,
         duration: 10000,
         onAction: () => archiveProposalIntent(proposalId, res.intentId),
       });
     },
-    [addNotification, archiveProposalIntent],
+    [addNotification, archiveProposalIntent, indexes],
   );
 
   const handleIntentProposalReject = useCallback(

--- a/frontend/src/components/IntentList.tsx
+++ b/frontend/src/components/IntentList.tsx
@@ -1,8 +1,32 @@
 import { useMemo } from 'react';
-import { Calendar, Trash2, ExternalLink, FileText, Link as LinkIcon, Slack, MessageSquare } from 'lucide-react';
+import { Calendar, Trash2, ExternalLink, FileText, Link as LinkIcon, Slack, MessageSquare, Network, AlertTriangle } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import { DebugCopyButton } from './DebugCopyButton';
+
+/**
+ * Grace window after creation during which an intent with zero network
+ * memberships is shown as "Evaluating…" rather than "Not in any network".
+ * Network assignment runs async (HyDE queue) shortly after creation, so a
+ * freshly-created intent legitimately has no memberships for a short while.
+ */
+const NETWORK_EVAL_GRACE_MS = 10 * 60 * 1000;
+
+interface IntentNetwork {
+  id: string;
+  title: string;
+}
+
+/**
+ * Whether an intent is still within the post-creation grace window, during
+ * which zero memberships reads as "evaluating" rather than "orphaned".
+ * A plain (non-component) function so the render-time clock read stays out of
+ * component bodies — mirrors `NegotiationHistory.timeAgo`.
+ */
+function isWithinEvalGrace(createdAt: string): boolean {
+  const ageMs = Date.now() - new Date(createdAt).getTime();
+  return Number.isFinite(ageMs) && ageMs < NETWORK_EVAL_GRACE_MS;
+}
 
 interface BaseIntent {
   id: string;
@@ -14,6 +38,63 @@ interface BaseIntent {
   sourceName?: string;
   sourceValue?: string | null;
   sourceMeta?: string | null;
+  /**
+   * Networks this intent is registered to. `undefined` means the caller did
+   * not supply membership data (membership UI is suppressed); an empty array
+   * means the intent is registered to no networks (pending or orphaned).
+   */
+  networks?: IntentNetwork[];
+}
+
+/**
+ * Renders an intent's network membership as chips, or a pending/orphaned badge
+ * when it belongs to none. Returns null when membership data wasn't provided,
+ * so callers that don't fetch memberships render nothing extra.
+ */
+function NetworkMembership({ networks, createdAt }: { networks?: IntentNetwork[]; createdAt: string }) {
+  if (networks === undefined) return null;
+
+  if (networks.length > 0) {
+    const shown = networks.slice(0, 2);
+    const extra = networks.length - shown.length;
+    return (
+      <div className="flex items-center gap-1.5 flex-wrap">
+        {shown.map((n) => (
+          <span
+            key={n.id}
+            className="flex items-center gap-1 text-xs text-blue-700 font-ibm-plex-mono px-2 py-0.5 rounded-full bg-blue-50 border border-blue-100"
+          >
+            <Network className="w-3 h-3 shrink-0" />
+            <span className="max-w-[140px] truncate">{n.title}</span>
+          </span>
+        ))}
+        {extra > 0 && (
+          <span className="text-xs text-blue-700 font-ibm-plex-mono px-2 py-0.5 rounded-full bg-blue-50 border border-blue-100">
+            +{extra}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  if (isWithinEvalGrace(createdAt)) {
+    return (
+      <span className="flex items-center gap-1.5 text-xs text-gray-500 font-ibm-plex-mono px-2 py-0.5 rounded-full bg-gray-100/50 border border-gray-100">
+        <span className="h-2.5 w-2.5 border border-gray-300 border-t-gray-500 rounded-full animate-spin" />
+        Evaluating…
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className="flex items-center gap-1 text-xs text-amber-700 font-ibm-plex-mono px-2 py-0.5 rounded-full bg-amber-50 border border-amber-200"
+      title="This intent isn't registered to any network yet. It will be re-evaluated when you join a matching network."
+    >
+      <AlertTriangle className="w-3 h-3 shrink-0" />
+      Not in any network
+    </span>
+  );
 }
 
 interface IntentListProps<T extends BaseIntent> {
@@ -128,6 +209,9 @@ export default function IntentList<T extends BaseIntent>({
                       New
                     </span>
                   )}
+
+                  {/* Network membership: chips, or pending/orphaned badge */}
+                  <NetworkMembership networks={intent.networks} createdAt={intent.createdAt} />
                 </div>
               </div>
 

--- a/frontend/src/components/SharedChatView.tsx
+++ b/frontend/src/components/SharedChatView.tsx
@@ -4,10 +4,7 @@ import { ContentContainer } from "@/components/layout";
 import { cn } from "@/lib/utils";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import OpportunityCard, {
-  type OpportunityCardData,
-  OpportunitySkeleton,
-} from "@/components/chat/OpportunityCardInChat";
+import OpportunityCard, { type OpportunityCardData, OpportunitySkeleton } from "@/components/chat/OpportunityCardInChat";
 import { apiUrl } from "@/lib/api";
 
 interface SharedMessage {

--- a/frontend/src/components/chat/AssistantMessageContent.tsx
+++ b/frontend/src/components/chat/AssistantMessageContent.tsx
@@ -2,14 +2,8 @@ import type { ComponentType, ComponentPropsWithoutRef } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { Loader2 } from "lucide-react";
-import OpportunityCard, {
-  type OpportunityCardData,
-  OpportunitySkeleton,
-} from "@/components/chat/OpportunityCardInChat";
-import IntentProposalCard, {
-  type IntentProposalData,
-  IntentProposalSkeleton,
-} from "@/components/chat/IntentProposalCard";
+import OpportunityCard, { type OpportunityCardData, OpportunitySkeleton } from "@/components/chat/OpportunityCardInChat";
+import IntentProposalCard, { type IntentProposalData, IntentProposalSkeleton } from "@/components/chat/IntentProposalCard";
 import NetworksPanel from "@/components/chat/NetworksPanel";
 import { cn } from "@/lib/utils";
 import { mentionsToMarkdownLinks } from "@/lib/mentions";

--- a/frontend/src/components/chat/ToolCallsDisplay.tsx
+++ b/frontend/src/components/chat/ToolCallsDisplay.tsx
@@ -1,20 +1,5 @@
 import { useState, useEffect } from "react";
-import {
-  Loader2,
-  ChevronDown,
-  ChevronRight,
-  Square,
-  Circle,
-  AlertTriangle,
-  Wrench,
-  Workflow,
-  Bot,
-  Sparkles,
-  MessagesSquare,
-  ArrowLeftRight,
-  RotateCw,
-  XCircle,
-} from "lucide-react";
+import { Loader2, ChevronDown, ChevronRight, Square, Circle, AlertTriangle, Wrench, Workflow, Bot, Sparkles, MessagesSquare, ArrowLeftRight, RotateCw, XCircle } from "lucide-react";
 import type { TraceEvent } from "@/contexts/AIChatContext";
 import { cn } from "@/lib/utils";
 

--- a/frontend/src/components/settings/SettingsTab.tsx
+++ b/frontend/src/components/settings/SettingsTab.tsx
@@ -145,11 +145,14 @@ export default function SettingsTab({
       } else if (removeImageRequested) {
         finalImageUrl = null;
       }
-      const updatedIndex = await updateNetwork(networkId, {
-        title: title.trim(),
-        prompt: prompt.trim() || null,
-        imageUrl: finalImageUrl,
-      });
+      // Personal indexes accept only a prompt edit (rename/avatar are blocked
+      // server-side); send prompt alone to avoid a rejected update.
+      const updatedIndex = await updateNetwork(
+        networkId,
+        network.isPersonal
+          ? { prompt: prompt.trim() || null }
+          : { title: title.trim(), prompt: prompt.trim() || null, imageUrl: finalImageUrl },
+      );
       setOriginalTitle(title);
       setOriginalPrompt(prompt);
       setOriginalImageUrl(finalImageUrl);
@@ -255,7 +258,7 @@ export default function SettingsTab({
           <button
             type="button"
             onClick={() => imageInputRef.current?.click()}
-            disabled={isSavingSettings}
+            disabled={isSavingSettings || network.isPersonal}
             className="relative flex-shrink-0 group cursor-pointer disabled:cursor-not-allowed"
           >
             <div className="w-[72px] h-[72px] rounded-full overflow-hidden">
@@ -276,7 +279,7 @@ export default function SettingsTab({
             onChange={handleImageChange}
             className="hidden"
           />
-          {displayImageUrl && (
+          {displayImageUrl && !network.isPersonal && (
             <button
               type="button"
               onClick={handleRemoveImage}
@@ -293,15 +296,16 @@ export default function SettingsTab({
           <label htmlFor="title" className="text-sm font-medium font-ibm-plex-mono text-gray-700 block mb-1.5">
             Title
           </label>
-          <Input id="title" value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Network title" />
+          <Input id="title" value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Network title" disabled={network.isPersonal} />
+          {network.isPersonal && (
+            <p className="text-xs text-gray-400 mt-1.5">Your personal index can&apos;t be renamed.</p>
+          )}
         </div>
-        {!network.isPersonal && (
-          <div>
-            <label className="block text-sm font-medium font-ibm-plex-mono text-gray-700 mb-1.5">Prompt</label>
-            <Textarea value={prompt} onChange={(e) => setPrompt(e.target.value)} placeholder="What people can share in this network..." className="min-h-[100px]" rows={4} />
-            <p className="text-xs text-gray-400 mt-1.5">Guides what kind of intents people can share.</p>
-          </div>
-        )}
+        <div>
+          <label className="block text-sm font-medium font-ibm-plex-mono text-gray-700 mb-1.5">Prompt</label>
+          <Textarea value={prompt} onChange={(e) => setPrompt(e.target.value)} placeholder={network.isPersonal ? 'Optional — describe what should land in My Network. Leave empty to keep every intent.' : 'What people can share in this network...'} className="min-h-[100px]" rows={4} />
+          <p className="text-xs text-gray-400 mt-1.5">{network.isPersonal ? 'Filters which of your intents auto-assign to My Network. Empty keeps everything.' : 'Guides what kind of intents people can share.'}</p>
+        </div>
         <div className="flex justify-end gap-2">
           <Button variant="outline" size="sm" onClick={() => { setTitle(originalTitle); setPrompt(originalPrompt); setImageUrl(originalImageUrl); setImageFile(null); setImagePreview(null); setRemoveImageRequested(false); if (imageInputRef.current) imageInputRef.current.value = ''; }} disabled={isSavingSettings || !hasSettingsChanged}>
             Cancel

--- a/frontend/src/contexts/AIChatContext.tsx
+++ b/frontend/src/contexts/AIChatContext.tsx
@@ -1,10 +1,4 @@
-import React, {
-  createContext,
-  useContext,
-  useState,
-  useCallback,
-  useRef,
-} from "react";
+import React, { createContext, useContext, useState, useCallback, useRef } from "react";
 import { useLocation } from "react-router";
 import { useAIChatSessions } from "@/contexts/AIChatSessionsContext";
 import { apiClient } from "@/lib/api";

--- a/frontend/src/contexts/ConversationContext.tsx
+++ b/frontend/src/contexts/ConversationContext.tsx
@@ -1,11 +1,4 @@
-import React, {
-  createContext,
-  useContext,
-  useState,
-  useCallback,
-  useEffect,
-  useRef,
-} from 'react';
+import React, { createContext, useContext, useState, useCallback, useEffect, useRef } from 'react';
 import { apiClient } from '@/lib/api';
 import { getJwtToken } from '@/lib/auth-client';
 import { useAuthContext } from '@/contexts/AuthContext';

--- a/frontend/src/contexts/NotificationContext.tsx
+++ b/frontend/src/contexts/NotificationContext.tsx
@@ -232,7 +232,7 @@ function IntentBroadcastToast({
               <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-75" />
               <span className="relative inline-flex h-2 w-2 rounded-full bg-green-500" />
             </span>
-            Broadcasting Signal
+            {notification.title || "Broadcasting Signal"}
           </div>
           <p className="text-[13px] text-[#3D3D3D] leading-relaxed mt-0.5 line-clamp-2">
             {notification.message || notification.title}

--- a/frontend/src/services/connections.ts
+++ b/frontend/src/services/connections.ts
@@ -1,7 +1,4 @@
-import {
-  ConnectionEvent,
-  ConnectionsByUserResponse,
-} from '../types';
+import { ConnectionEvent, ConnectionsByUserResponse } from '../types';
 
 // Service functions factory that takes an authenticated API instance
 export const createConnectionsService = (api: ReturnType<typeof import('../lib/api').useAuthenticatedAPI>) => ({

--- a/frontend/src/services/intents.ts
+++ b/frontend/src/services/intents.ts
@@ -1,8 +1,4 @@
-import {
-  Intent,
-  PaginatedResponse,
-  APIResponse,
-} from '../types';
+import { Intent, PaginatedResponse, APIResponse } from '../types';
 
 // Service functions factory that takes an authenticated API instance
 export const createIntentsService = (api: ReturnType<typeof import('../lib/api').useAuthenticatedAPI>) => ({

--- a/frontend/src/services/networks.ts
+++ b/frontend/src/services/networks.ts
@@ -1,12 +1,6 @@
 import { useMemo } from 'react';
 import { useAuthenticatedAPI, apiClient } from '../lib/api';
-import {
-  Network,
-  PaginatedResponse,
-  APIResponse,
-  CreateNetworkRequest,
-  UpdateNetworkRequest
-} from '../types';
+import { Network, PaginatedResponse, APIResponse, CreateNetworkRequest, UpdateNetworkRequest } from '../types';
 
 // Re-export types for convenience
 export type { Network };

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint": "^9.39.1",
     "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-boundaries": "^6.0.2",
+    "eslint-plugin-import-newlines": "^1.4.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "lint-staged": "^16.4.0",

--- a/packages/cli/src/api.client.ts
+++ b/packages/cli/src/api.client.ts
@@ -5,59 +5,10 @@
  * common error patterns (401, network errors).
  */
 
-import type {
-  ChatSession,
-  UserProfile,
-  StreamChatParams,
-  UserData,
-  Intent,
-  ListIntentsOptions,
-  IntentListResult,
-  OpportunityListOptions,
-  Opportunity,
-  OpportunityDetail,
-  Network,
-  NetworkMember,
-  SearchedUser,
-  AddMemberResult,
-  Conversation,
-  ConversationMessage,
-  Negotiation,
-  NegotiationListOptions,
-  ToolResult,
-} from "./types";
+import type { ChatSession, UserProfile, StreamChatParams, UserData, Intent, ListIntentsOptions, IntentListResult, OpportunityListOptions, Opportunity, OpportunityDetail, Network, NetworkMember, SearchedUser, AddMemberResult, Conversation, ConversationMessage, Negotiation, NegotiationListOptions, ToolResult } from "./types";
 
 // Re-export all types for backward compatibility
-export type {
-  ChatSession,
-  UserProfile,
-  StreamChatParams,
-  UserData,
-  Intent,
-  ListIntentsOptions,
-  IntentListResult,
-  OpportunityListOptions,
-  Opportunity,
-  OpportunityActor,
-  OpportunityInterpretation,
-  OpportunityDetection,
-  OpportunityDetail,
-  OpportunityParty,
-  Network,
-  NetworkMember,
-  SearchedUser,
-  AddMemberResult,
-  ConversationParticipant,
-  Conversation,
-  MessagePart,
-  ConversationMessage,
-  Negotiation,
-  NegotiationListOptions,
-  NegotiationSpeaker,
-  NegotiationTurn,
-  NegotiationOutcome,
-  ToolResult,
-} from "./types";
+export type { ChatSession, UserProfile, StreamChatParams, UserData, Intent, ListIntentsOptions, IntentListResult, OpportunityListOptions, Opportunity, OpportunityActor, OpportunityInterpretation, OpportunityDetection, OpportunityDetail, OpportunityParty, Network, NetworkMember, SearchedUser, AddMemberResult, ConversationParticipant, Conversation, MessagePart, ConversationMessage, Negotiation, NegotiationListOptions, NegotiationSpeaker, NegotiationTurn, NegotiationOutcome, ToolResult } from "./types";
 
 export class ApiClient {
   private readonly baseUrl: string;

--- a/packages/cli/src/output/formatters.ts
+++ b/packages/cli/src/output/formatters.ts
@@ -7,24 +7,7 @@
 
 import type { Intent, Opportunity, OpportunityDetail, Conversation, ConversationMessage } from "../types";
 
-import {
-  RESET,
-  BOLD,
-  DIM,
-  RED,
-  GREEN,
-  YELLOW,
-  BLUE,
-  CYAN,
-  WHITE,
-  GRAY,
-  AGENT_TEXT,
-  dim,
-  wordWrap,
-  confidenceBar,
-  padTo,
-  stripAnsi,
-} from "./base";
+import { RESET, BOLD, DIM, RED, GREEN, YELLOW, BLUE, CYAN, WHITE, GRAY, AGENT_TEXT, dim, wordWrap, confidenceBar, padTo, stripAnsi } from "./base";
 
 // ── Profile card ────────────────────────────────────────────────────
 

--- a/packages/cli/src/output/index.ts
+++ b/packages/cli/src/output/index.ts
@@ -5,67 +5,9 @@
  * `import { MarkdownRenderer } from "./output"` unchanged.
  */
 
-export {
-  // ANSI constants
-  RESET,
-  BOLD,
-  DIM,
-  ITALIC,
-  RED,
-  GREEN,
-  YELLOW,
-  BLUE,
-  MAGENTA,
-  CYAN,
-  WHITE,
-  GRAY,
-  ORANGE,
-  AGENT_TEXT,
-  USER_PROMPT,
-
-  // Basic messages
-  error,
-  success,
-  info,
-  warn,
-  dim,
-  heading,
-
-  // Chat UI
-  chatHeader,
-  PROMPT_STR,
-
-  // Streaming
-  raw,
-  status,
-  clearStatus,
-  toolActivity,
-
-  // Tool descriptions
-  humanizeToolName,
-
-  // Helpers
-  wordWrap,
-  confidenceBar,
-  padTo,
-  stripAnsi,
-} from "./base";
+export { RESET, BOLD, DIM, ITALIC, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE, GRAY, ORANGE, AGENT_TEXT, USER_PROMPT, error, success, info, warn, dim, heading, chatHeader, PROMPT_STR, raw, status, clearStatus, toolActivity, humanizeToolName, wordWrap, confidenceBar, padTo, stripAnsi } from "./base";
 
 export { MarkdownRenderer } from "./markdown";
 
 export type { ProfileData } from "./formatters";
-export {
-  profileCard,
-  contactTable,
-  sessionTable,
-  intentTable,
-  intentCard,
-  opportunityTable,
-  opportunityCard,
-  networkTable,
-  networkCard,
-  memberTable,
-  conversationTable,
-  conversationCard,
-  messageList,
-} from "./formatters";
+export { profileCard, contactTable, sessionTable, intentTable, intentCard, opportunityTable, opportunityCard, networkTable, networkCard, memberTable, conversationTable, conversationCard, messageList } from "./formatters";

--- a/packages/cli/src/output/markdown.ts
+++ b/packages/cli/src/output/markdown.ts
@@ -10,19 +10,7 @@
  * (intent_proposal, opportunity).
  */
 
-import {
-  RESET,
-  BOLD,
-  ITALIC,
-  WHITE,
-  CYAN,
-  BLUE,
-  MAGENTA,
-  GRAY,
-  AGENT_TEXT,
-  wordWrap,
-  confidenceBar,
-} from "./base";
+import { RESET, BOLD, ITALIC, WHITE, CYAN, BLUE, MAGENTA, GRAY, AGENT_TEXT, wordWrap, confidenceBar } from "./base";
 
 export class MarkdownRenderer {
   private buffer = "";

--- a/packages/cli/tests/login.command.spec.ts
+++ b/packages/cli/tests/login.command.spec.ts
@@ -10,7 +10,7 @@ import { handleLogin } from "../src/login.command";
 
 function createFakeLoginServer() {
   let handler: ((req: IncomingMessage, res: ServerResponse) => void | Promise<void>) | undefined;
-  let port = 43123;
+  const port = 43123;
 
   return {
     factory(nextHandler: (req: IncomingMessage, res: ServerResponse) => void | Promise<void>) {

--- a/packages/cli/tests/output.base.spec.ts
+++ b/packages/cli/tests/output.base.spec.ts
@@ -1,25 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
 
-import {
-  RESET,
-  BOLD,
-  RED,
-  GREEN,
-  YELLOW,
-  CYAN,
-  GRAY,
-  error,
-  success,
-  info,
-  warn,
-  dim,
-  heading,
-  humanizeToolName,
-  wordWrap,
-  confidenceBar,
-  padTo,
-  stripAnsi,
-} from "../src/output/base";
+import { RESET, BOLD, RED, GREEN, YELLOW, CYAN, GRAY, error, success, info, warn, dim, heading, humanizeToolName, wordWrap, confidenceBar, padTo, stripAnsi } from "../src/output/base";
 
 // ── Basic message helpers ───────────────────────────────────────────
 

--- a/packages/cli/tests/output.formatters.spec.ts
+++ b/packages/cli/tests/output.formatters.spec.ts
@@ -1,19 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
 
-import {
-  profileCard,
-  sessionTable,
-  intentTable,
-  intentCard,
-  opportunityTable,
-  opportunityCard,
-  networkTable,
-  networkCard,
-  memberTable,
-  conversationTable,
-  conversationCard,
-  messageList,
-} from "../src/output/formatters";
+import { profileCard, sessionTable, intentTable, intentCard, opportunityTable, opportunityCard, networkTable, networkCard, memberTable, conversationTable, conversationCard, messageList } from "../src/output/formatters";
 import { stripAnsi } from "../src/output/base";
 import type { Intent, Opportunity, Conversation, ConversationMessage } from "../src/types";
 

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -32,23 +32,39 @@ const tools = await createChatTools({
 
 ### 2. Implement the adapters
 
-The package defines interfaces — your application provides the concrete implementations:
+The package defines interfaces — your application provides the concrete implementations.
+
+**Required** (always needed by `createChatTools`):
 
 | Interface | Responsibility |
 |---|---|
-| `ChatGraphCompositeDatabase` | Core data access (users, intents, indexes, opportunities) |
+| `ChatGraphCompositeDatabase` | Core data access (users, intents, indexes/networks, opportunities) |
+| `UserDatabase` / `SystemDatabase` | Context-bound databases built by `createUserDatabase` / `createSystemDatabase` |
 | `Embedder` | Vector embeddings for semantic search |
 | `Scraper` | Web content extraction |
-| `Cache` / `HydeCache` | Result caching |
+| `Cache` / `HydeCache` | Result caching (HyDE may share the general cache) |
 | `IntegrationAdapter` | OAuth and external tool actions |
-| `ContactServiceAdapter` | Contact management |
 | `IntentGraphQueue` | Background intent processing queue |
+| `ContactServiceAdapter` | Contact management |
 | `ChatSessionReader` | Load conversation history |
 | `ProfileEnricher` | Enrich profiles from external sources |
 | `NegotiationGraphDatabase` | Negotiation state persistence |
+
+**Optional** (enable specific capabilities; omit to run without that feature):
+
+| Interface | Responsibility |
+|---|---|
 | `AgentDatabase` | Agent registry CRUD (agents, transports, permissions) |
-| `AgentDispatcher` | Resolves and invokes agents during negotiation turns |
-| `McpAuthResolver` | Resolves `{ userId, agentId }` from an incoming MCP HTTP request |
+| `AgentDispatcher` | Resolves and invokes personal agents during negotiation turns — required to register the negotiation tools |
+| `McpAuthResolver` | Resolves `{ userId, agentId }` from an incoming MCP HTTP request (MCP server only) |
+| `DeliveryLedger` | Commits OpenClaw opportunity-delivery rows |
+| `DiscoveryRunStore` / `DiscoveryRunQueue` | Persist and execute async MCP discovery runs |
+| `ProfileRunStore` / `ProfileRunQueue` | Persist and execute async MCP profile builds |
+| `MintConnectLink` | Mints short connect links for opportunity accepts |
+| `ChatSummaryReader` | Read-through chat-session digest |
+| `ChatMessageWriter` | Writes user messages into the most-recent chat session (MCP elicitation) |
+| `QuestionGeneratorReader` / `QuestionerDatabase` | Decision-question generation and persistence |
+| `NegotiationSummaryReader` | Negotiation-digest summarization (falls back to deterministic digests) |
 
 All interfaces are exported from the package root — import them with `import type { ... } from "@indexnetwork/protocol"`.
 
@@ -61,36 +77,84 @@ import { createChatTools } from "@indexnetwork/protocol";
 
 const tools = await createChatTools({
   userId: "user-uuid",
-  sessionId: "chat-session-id",
-  indexId: "optional-index-uuid",   // scope tools to a specific index
-  database,
-  embedder,
-  scraper,
-  cache,
-  hydeCache,
-  integration,
-  intentQueue,
-  contactService,
-  chatSession,
-  enricher,
-  negotiationDatabase,
-  integrationImporter,
-  createUserDatabase,
-  createSystemDatabase,
+
+  // ── Required adapters ──
+  database,             // ChatGraphCompositeDatabase
+  embedder,             // Embedder
+  scraper,              // Scraper
+  cache,                // Cache
+  hydeCache,            // HydeCache
+  integration,          // IntegrationAdapter
+  intentQueue,          // IntentGraphQueue
+  contactService,       // ContactServiceAdapter
+  chatSession,          // ChatSessionReader
+  enricher,             // ProfileEnricher
+  negotiationDatabase,  // NegotiationGraphDatabase
+  integrationImporter,  // bulk contact import
+  createUserDatabase,   // (db, userId) => UserDatabase
+  createSystemDatabase, // (db, userId, indexScope, embedder?) => SystemDatabase
+
+  // ── Optional scoping ──
+  networkId: "optional-network-uuid", // scope tools to a specific index/network
+  sessionId: "chat-session-id",       // enables draft opportunities with conversation context
+
+  // ── Optional capabilities (enable when the host supports them) ──
+  agentDatabase,        // AgentDatabase — agent registry
+  agentDispatcher,      // AgentDispatcher — routes negotiation turns to personal agents
+  deliveryLedger,       // DeliveryLedger — OpenClaw delivery commits
+  discoveryRuns,        // DiscoveryRunStore + discoveryRunQueue — async MCP discovery
+  profileRuns,          // ProfileRunStore + profileRunQueue — async MCP profile builds
+  mintConnectLink,      // short connect links for opportunity accepts
+  modelConfig,          // override chat model / reasoning effort (see above)
 });
 
 // tools is an array of LangChain Tool objects ready to bind to an agent
 ```
 
+`createChatTools` accepts a single `ToolContext` object. The required adapters
+above are always needed; the optional capabilities default to a degraded-but-
+functional mode when omitted (e.g. without `agentDispatcher` the negotiation
+tools are not registered, and without `discoveryRuns` MCP discovery runs
+synchronously).
+
 ## Graphs
 
-For direct graph invocation (bypassing the tool layer), factory classes are exported for each workflow:
+For direct graph invocation (bypassing the tool layer), a `*GraphFactory` class is exported for each workflow:
 
 ```typescript
-import { ChatGraphFactory, IntentGraphFactory, OpportunityGraphFactory } from "@indexnetwork/protocol";
+import {
+  ChatGraphFactory,
+  IntentGraphFactory,
+  OpportunityGraphFactory,
+  ProfileGraphFactory,
+  PremiseGraphFactory,
+  NegotiationGraphFactory,
+  HydeGraphFactory,
+  NetworkGraphFactory,
+  NetworkMembershipGraphFactory,
+  IntentNetworkGraphFactory,
+  HomeGraphFactory,
+  MaintenanceGraphFactory,
+} from "@indexnetwork/protocol";
 ```
 
-Each factory exposes a `.createGraph()` method that returns a compiled LangGraph ready for `.invoke()`.
+Each factory takes its typed dependencies in the constructor and exposes a
+`.createGraph()` method that returns a compiled LangGraph ready for `.invoke()`.
+
+| Factory | Workflow |
+|---|---|
+| `ChatGraphFactory` | ReAct chat loop — LLM calls tools, responds to the user |
+| `IntentGraphFactory` | Clarify, infer, verify felicity, reconcile, and persist intents |
+| `OpportunityGraphFactory` | HyDE-based discovery: search, evaluate (valency), rank, persist |
+| `ProfileGraphFactory` | Generate/update user profiles with scraping and embedding |
+| `PremiseGraphFactory` | Decompose and index a user's premises |
+| `NegotiationGraphFactory` | Multi-turn bilateral negotiation flows |
+| `HydeGraphFactory` | Generate hypothetical documents and embed them (cache-aware) |
+| `NetworkGraphFactory` | Manage index/network CRUD |
+| `NetworkMembershipGraphFactory` | Manage index/network member join/leave |
+| `IntentNetworkGraphFactory` | Evaluate and assign/unassign intents to indexes |
+| `HomeGraphFactory` | Categorize and curate home-feed content |
+| `MaintenanceGraphFactory` | Periodic maintenance (feed health, opportunity expiration) |
 
 ## MCP server
 
@@ -165,7 +229,7 @@ git push <remote> dev
 git push <remote> main
 ```
 
-`dev` publishes prerelease versions derived from `package.json` using npm's `rc` tag, for example `0.4.0-rc.123.1`. `main` publishes the base version from `package.json` to `latest`.
+`dev` publishes prerelease versions derived from `package.json` using npm's `rc` tag, for example `3.6.3-rc.123.1`. `main` publishes the base version from `package.json` to `latest` only when that version is not already on npm.
 
 Or publish manually from `packages/protocol/`:
 

--- a/packages/protocol/eval/matching/matching.eval.ts
+++ b/packages/protocol/eval/matching/matching.eval.ts
@@ -30,16 +30,7 @@ import { CASES } from "./matching.cases.js";
 import { runCase } from "./matching.runner.js";
 import { scoreCase, type Judge } from "./matching.scorer.js";
 import { formatCaseList, hasRule, parseTier, selectCases } from "./matching.selection.js";
-import {
-  buildScorecard,
-  computeRollingBaseline,
-  diffBaseline,
-  formatConsole,
-  readBaseline,
-  writeBaseline,
-  writeHtmlReport,
-  writeRunReport,
-} from "./matching.reporter.js";
+import { buildScorecard, computeRollingBaseline, diffBaseline, formatConsole, readBaseline, writeBaseline, writeHtmlReport, writeRunReport } from "./matching.reporter.js";
 import type { CaseResult } from "./matching.types.js";
 
 const DEFAULT_ALPHA = 0.05;

--- a/packages/protocol/eval/matching/matching.reporter.ts
+++ b/packages/protocol/eval/matching/matching.reporter.ts
@@ -1,15 +1,6 @@
 import { readdir } from "node:fs/promises";
 
-import type {
-  CaseResult,
-  RuleResult,
-  Scorecard,
-  Rule,
-  MatchingCase,
-  CandidateExpectation,
-  CandidateOutcome,
-  AssertionKind,
-} from "./matching.types.js";
+import type { CaseResult, RuleResult, Scorecard, Rule, MatchingCase, CandidateExpectation, CandidateOutcome, AssertionKind } from "./matching.types.js";
 
 // ── Statistical helpers ─────────────────────────────────────────────────────
 

--- a/packages/protocol/eval/matching/matching.runner.ts
+++ b/packages/protocol/eval/matching/matching.runner.ts
@@ -1,13 +1,6 @@
-import type {
-  EvaluatorInput,
-  EvaluatedOpportunityWithActors,
-} from "../../src/opportunity/opportunity.evaluator.js";
+import type { EvaluatorInput, EvaluatedOpportunityWithActors } from "../../src/opportunity/opportunity.evaluator.js";
 
-import {
-  MATCHING_EVAL_MAX_ATTEMPTS,
-  MATCHING_EVAL_RETRY_DELAY_MS,
-  MATCHING_MIN_SCORE,
-} from "./matching.constants.js";
+import { MATCHING_EVAL_MAX_ATTEMPTS, MATCHING_EVAL_RETRY_DELAY_MS, MATCHING_MIN_SCORE } from "./matching.constants.js";
 import type { MatchingCase } from "./matching.types.js";
 
 /** Minimal evaluator surface the runner needs (real OpportunityEvaluator satisfies this). */

--- a/packages/protocol/eval/matching/matching.scorer.ts
+++ b/packages/protocol/eval/matching/matching.scorer.ts
@@ -1,14 +1,7 @@
 import type { EvaluatedOpportunityWithActors } from "../../src/opportunity/opportunity.evaluator.js";
 
 import { MATCHING_MIN_SCORE } from "./matching.constants.js";
-import type {
-  MatchingCase,
-  CandidateExpectation,
-  AssertionResult,
-  CandidateOutcome,
-  RunResult,
-  CaseResult,
-} from "./matching.types.js";
+import type { MatchingCase, CandidateExpectation, AssertionResult, CandidateOutcome, RunResult, CaseResult } from "./matching.types.js";
 
 /** Grades a natural-language criterion. Returns true on pass. Injected for testability. */
 export type Judge = (output: unknown, criteria: string) => Promise<boolean>;

--- a/packages/protocol/eval/matching/tests/matching.reporter.spec.ts
+++ b/packages/protocol/eval/matching/tests/matching.reporter.spec.ts
@@ -2,20 +2,7 @@ import { describe, it, expect } from "bun:test";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { mkdir, rm, unlink } from "node:fs/promises";
-import {
-  binomialCI,
-  binomialPValue,
-  binomialSignificance,
-  predictivePValue,
-  buildScorecard,
-  computeRollingBaseline,
-  diffBaseline,
-  formatConsole,
-  renderHtml,
-  writeBaseline,
-  writeRunReport,
-  readBaseline,
-} from "../matching.reporter.js";
+import { binomialCI, binomialPValue, binomialSignificance, predictivePValue, buildScorecard, computeRollingBaseline, diffBaseline, formatConsole, renderHtml, writeBaseline, writeRunReport, readBaseline } from "../matching.reporter.js";
 import type { CaseResult, MatchingCase, Scorecard } from "../matching.types.js";
 
 const caseResult = (caseId: string, rule: CaseResult["rule"], passRate: number): CaseResult => ({

--- a/packages/protocol/src/README.md
+++ b/packages/protocol/src/README.md
@@ -6,23 +6,31 @@ This is the protocol layer: LangGraph workflows, AI agents, chat tools, and supp
 
 ```
 packages/protocol/src/
-  chat/             Chat graph, agent, prompt, streaming, suggestions, title generation
+  agent/            Agent-registry tools (register/list/update/delete, grant/revoke permission)
+  chat/             Chat graph, agent, prompt modules, streaming, suggestions, title, summarizer, interrupt classifier
   contact/          Contact invites and contact tools
+  context/          User Context generator (premise → network-scoped context paragraphs)
   integration/      Integration sync tools
-  intent/           Intent graph, inferrer, verifier, reconciler, clarifier, indexer
+  intent/           Intent graph, inferrer, verifier, reconciler, clarifier, specificity, indexer
   maintenance/      Maintenance graph (feed health, opportunity expiration)
-  mcp/              MCP server
-  negotiation/      Negotiation graph, proposer, responder, insights generator
-  network/          Network (index) graph, membership graph, intent-index (indexer) graph, tools
-  opportunity/      Opportunity graph, evaluator, presenter, enricher, discover, utils
+  mcp/              MCP server + elicitation builder/dispatcher
+  negotiation/      Negotiation graph, agent (IndexNegotiator), insight + summarizer, tools
+  network/          Network (index) graph, membership graph, intent-index (indexer) graph, recommender, tools
+  opportunity/      Opportunity graph, evaluator, presenter, enricher, discover, evidence, introducer, delivery card, utils
     feed/           Home feed graph, feed categorizer, feed health
-  profile/          Profile graph, generator, hyde generator, enricher, tools
+  premise/          Premise graph, decomposer, analyzer, indexer, tools
+  profile/          Profile graph, generator, enricher, tools
+  questioner/       Questioner agent (mode-driven decision-question generation), presets, tools
   shared/
-    agent/          Model config, response streamer, tool factory/helpers/registry
+    agent/          Model config/signal, response streamer, tool factory/helpers/registry/runtime
+    assignment/     Network-assignment policy (threshold scoring, scope resolution)
     hyde/           HyDE graph, generator, strategies, lens inferrer
-    interfaces/     Adapter contracts (database, embedder, cache, queue, scraper, etc.)
-    observability/  Logger, request context, performance, log utilities
+    interfaces/     Adapter contracts (database, embedder, cache, queue, scraper, agent, runs, etc.)
+    network/        Network metadata renderer
+    observability/  Logger, request context, performance, trace, debug-meta sanitizer
+    schemas/        Shared Zod schemas (question, profile, negotiation, network-assignment, etc.)
     ui/             Lucide icon catalog
+    utils/          Telegram-handle and social-label helpers
   docs/             Design papers (linguistic and semantic governance theory)
 ```
 
@@ -32,7 +40,8 @@ packages/protocol/src/
 |-------|------|---------|
 | Chat | `chat/chat.graph.ts` | ReAct agent loop — LLM calls tools, responds to user |
 | Intent | `intent/intent.graph.ts` | Clarify, infer, verify felicity conditions, reconcile, and persist intents |
-| Profile | `profile/profile.graph.ts` | Generate/update user profiles with scraping and embedding |
+| Profile | `profile/profile.graph.ts` | Generate/update user profiles with scraping and embedding (decomposes into premises) |
+| Premise | `premise/premise.graph.ts` | Decompose self-descriptive input into atomic premises, classify/score felicity, index + assign to networks |
 | Opportunity | `opportunity/opportunity.graph.ts` | HyDE-based discovery: search, evaluate (valency), rank, persist |
 | HyDE | `shared/hyde/hyde.graph.ts` | Generate hypothetical documents (Mirror, Reciprocal, Neighborhood) and embed them (cache-aware) |
 | Network | `network/network.graph.ts` | Manage index CRUD |
@@ -51,14 +60,21 @@ packages/protocol/src/
 | Chat Prompt Modules | `chat/chat.prompt.modules.ts` | Chat graph — composable prompt modules |
 | Title Generator | `chat/chat.title.generator.ts` | Chat service — generates conversation titles |
 | Chat Suggester | `chat/chat.suggester.ts` | Chat — generates proactive reply suggestions |
+| Chat Summarizer | `chat/chat.summarizer.ts` | Chat — produces a read-through digest of a chat session |
+| Chat Interrupt Classifier | `chat/chat.interrupt.classifier.ts` | Chat — classifies whether a new message interrupts an in-flight turn |
 | Intent Clarifier | `intent/intent.clarifier.ts` | Intent tools — checks specificity (entropy threshold) before persisting |
 | Intent Inferrer | `intent/intent.inferrer.ts` | Intent graph — extracts structured intents from free text |
 | Intent Reconciler | `intent/intent.reconciler.ts` | Intent graph — determines create/update/expire action (Donnellan's distinction) |
 | Intent Verifier | `intent/intent.verifier.ts` | Intent graph — classifies speech act type; scores felicity conditions and semantic entropy |
 | Intent Indexer | `intent/intent.indexer.ts` | Intent Index graph — scores intent-index fit as relevancy score |
 | Profile Generator | `profile/profile.generator.ts` | Profile graph — generates structured identity from raw data |
-| Profile HyDE Generator | `profile/profile.hyde.generator.ts` | Profile graph — generates HyDE documents for profiles |
 | Profile Enricher | `profile/profile.enricher.ts` | Profile enrichment — display name and metadata enrichment |
+| Premise Decomposer | `premise/premise.decomposer.ts` | Premise graph — decomposes free text into atomic, first-person self-descriptive premises |
+| Premise Analyzer | `premise/premise.analyzer.ts` | Premise graph — classifies the premise speech act (declarative/assertive) and scores felicity |
+| Premise Indexer | `premise/premise.indexer.ts` | Premise graph — embeds premises and scores network fit for assignment |
+| User Context Generator | `context/context.generator.ts` | Enrichment / UserContextQueue — synthesizes network-scoped context paragraphs from a user's premises |
+| Questioner Agent | `questioner/questioner.agent.ts` | Questioner queue — mode-driven structured decision-question generation (profile/intent/negotiation/discovery) |
+| Network Recommender | `network/network.recommender.ts` | Network flows — recommends networks for a user/intent |
 | HyDE Generator | `shared/hyde/hyde.generator.ts` | HyDE graph — generates hypothetical match documents per strategy |
 | HyDE Strategies | `shared/hyde/hyde.strategies.ts` | HyDE graph — LLM-selected strategy registry |
 | Lens Inferrer | `shared/hyde/lens.inferrer.ts` | HyDE graph — infers target corpus (profiles vs. intents) per strategy |
@@ -66,22 +82,32 @@ packages/protocol/src/
 | Opportunity Presenter | `opportunity/opportunity.presenter.ts` | Home graph, opportunity tools — generates role-appropriate descriptions (Grice's Maxim of Relation) |
 | Feed Categorizer | `opportunity/feed/feed.categorizer.ts` | Feed graph — classifies and curates feed items |
 | Opportunity Introducer | `opportunity/opportunity.introducer.ts` | Introducer-driven contact-pair discovery |
+| Opportunity Question Generator | `opportunity/question.generator.ts` | Discovery — generates clarifying questions that sharpen a discovery query |
 | Contact Inviter | `contact/contact.inviter.ts` | Invite flow — generates personalized invite messages |
-| Negotiation Proposer | `negotiation/negotiation.proposer.ts` | Negotiation graph — drafts negotiation proposals |
-| Negotiation Responder | `negotiation/negotiation.responder.ts` | Negotiation graph — evaluates and responds to proposals |
+| Index Negotiator | `negotiation/negotiation.agent.ts` | Negotiation graph — system AI that drafts/evaluates a turn when no personal agent responds |
 | Negotiation Insights Generator | `negotiation/insight.generator.ts` | Negotiation graph — synthesizes negotiation session insights |
+| Negotiation Summarizer | `negotiation/negotiation.summarizer.ts` | Negotiation — builds the discovery negotiation digest (deterministic fallback when LLM unavailable) |
 
 ## Tools (Chat)
 
+Tools are registered in `shared/agent/tool.registry.ts` and assembled per session by `shared/agent/tool.factory.ts`.
+
 | File | Tools |
 |------|-------|
-| `profile/profile.tools.ts` | `read_user_profiles`, `create_user_profile`, `update_user_profile`, `complete_onboarding` |
-| `intent/intent.tools.ts` | `read_intents`, `create_intent`, `update_intent`, `delete_intent`, `create_intent_index`, `read_intent_indexes`, `delete_intent_index` |
-| `network/network.tools.ts` | `read_networks`, `read_network_memberships`, `create_network`, `update_network`, `delete_network`, `create_network_membership`, `delete_network_membership` |
-| `opportunity/opportunity.tools.ts` | `discover_opportunities`, `list_opportunities`, `update_opportunity` |
-| `contact/contact.tools.ts` | `import_contacts`, `list_contacts`, `add_contact`, `remove_contact` |
+| `profile/profile.tools.ts` | `read_user_profiles`, `preview_user_profile`, `confirm_user_profile`, `create_user_profile`, `update_user_profile`, `record_onboarding_privacy_consent`, `complete_onboarding`, `get_profile_run`, `cancel_profile_run` |
+| `premise/premise.tools.ts` | `create_premise`, `read_premises`, `update_premise`, `retract_premise` |
+| `intent/intent.tools.ts` | `read_intents`, `create_intent`, `update_intent`, `delete_intent`, `search_intents`, `create_intent_index`, `read_intent_indexes`, `delete_intent_index` |
+| `network/network.tools.ts` | `read_networks`, `create_network`, `update_network`, `delete_network`, `read_network_memberships`, `create_network_membership`, `delete_network_membership` |
+| `opportunity/opportunity.tools.ts` | `discover_opportunities`, `get_discovery_run`, `cancel_discovery_run`, `list_opportunities`, `update_opportunity`, `confirm_opportunity_delivery`¹ |
+| `contact/contact.tools.ts` | `import_contacts`, `list_contacts`, `add_contact`, `remove_contact`, `search_contacts` |
 | `integration/integration.tools.ts` | `import_gmail_contacts` |
+| `agent/agent.tools.ts` | `register_agent`, `list_agents`, `update_agent`, `delete_agent`, `grant_agent_permission`, `revoke_agent_permission` |
+| `negotiation/negotiation.tools.ts`² | `list_negotiations`, `get_negotiation`, `respond_to_negotiation` |
+| `questioner/questioner.tools.ts` | `read_pending_questions` |
 | `shared/agent/utility.tools.ts` | `scrape_url`, `read_docs` |
+
+¹ `confirm_opportunity_delivery` is an OpenClaw delivery-ledger write — it is filtered out of regular chat sessions and only reachable over MCP.
+² Negotiation tools are only registered when an `agentDispatcher` is provided.
 
 ## Core Concepts
 
@@ -90,7 +116,9 @@ The system models human collaboration through a linguistic and information-theor
 | Concept | Description |
 |---------|-------------|
 | **User** | Identity (session auth). Has one profile and many intents. Member of indexes. |
-| **Profile** | User's identity, narrative, skills, interests. Provides the **constitutive context** — what the user *is* and therefore has the *authority* to do. Has vector embedding and HyDE embeddings for semantic matching. |
+| **Profile** | User's identity, narrative, skills, interests. Provides the **constitutive context** — what the user *is* and therefore has the *authority* to do. Has vector embedding and HyDE embeddings for semantic matching. Decomposed into premises during enrichment. |
+| **Premise** | A **declarative or assertive speech act** about the self — an atomic, first-person proposition a user asserts about who they are ("I am a climate-tech founder", "I hold a PhD in computational biology"). Premises are *conditions of possibility*: facts that ground discovery, as opposed to intents, which are desires/requests. They are decomposed from profile/free-text input, classified and felicity-scored by the Premise Analyzer, embedded, and assigned to networks. The premise graph (`premise/premise.graph.ts`) owns their create/update/query lifecycle, and premise changes cascade into profile and user-context regeneration. |
+| **User Context** | A network-scoped synthetic paragraph synthesized from a user's premises by the `UserContextGenerator`, stored with its embedding. The opportunity graph uses contexts for **context-to-intent discovery** — it loads a user's contexts and searches for matching intents, running alongside profile-HyDE discovery as a complementary strategy. Regenerated whenever the user's premises change. |
 | **Intent** | A **commissive** or **directive speech act** — what the user is seeking or offering. Modelled as a Specific Indefinite: a future state uniquely satisfiable by a matching candidate. Each intent carries a **semantic entropy** score (constraint density), a **referential anchor** (Donnellan referential/attributive mode), and **felicity condition** scores (preparatory/authority and sincerity). |
 | **Index** | A community scoped to a purpose. Has members with roles, an optional prompt for LLM-based evaluation, and a join policy. Discovery is index-scoped — opportunities only arise between intents that share an index. |
 | **Opportunity** | A **semantic intersection**: the point where a candidate's constitutive facts (profile/intent) satisfy the propositional content of a source intent. Scored by the Opportunity Evaluator using **valency** (argument-role fit) and **constraint satisfaction**. Presented with dual descriptions per **Grice's Maxim of Relation** — one framed for the source, one for the candidate. |
@@ -301,6 +329,15 @@ Handled by the **Intent Graph**:
 4. **Reconciliation**: `IntentReconciler` applies Donnellan's distinction — referential intents (user has a specific target in mind) update an existing record; attributive intents (any member of a class) create a new one if sufficiently different.
 5. **Persistence**: Executor writes the intent with `semanticEntropy`, `referentialAnchor`, `speechActType`, and `felicityScores` fields.
 
+### Premise & Context Lifecycle
+
+Handled by the **Premise Graph**, **Profile Graph**, and **User Context Generator**:
+1. **Decomposition**: `PremiseDecomposer` splits profile data or free text into atomic, first-person, non-redundant premises.
+2. **Analysis**: `PremiseAnalyzer` classifies each premise's speech act (declarative vs. assertive) and scores its felicity conditions — premises are the *constitutive* facts that establish what a user has the authority to do.
+3. **Indexing & assignment**: `PremiseIndexer` embeds each premise and scores network fit; the shared network-assignment policy (`shared/assignment/network-assignment.policy.ts`) decides which networks the premise is assigned to.
+4. **Context synthesis**: premise changes cascade into the `UserContextGenerator`, which regenerates the user's network-scoped context paragraph (plus embedding and HyDE docs). Cold-start mode synthesizes from all premises; incremental mode applies a single add/update/retract/expire to the existing context.
+5. **Discovery feed**: stored context embeddings power **context-to-intent discovery** in the opportunity graph, complementing profile-HyDE matching.
+
 ### HyDE Pipeline
 
 Handled by the **HyDE Graph** and **Profile Graph**:
@@ -314,7 +351,7 @@ Handled by the **HyDE Graph** and **Profile Graph**:
 Handled by the **Opportunity Graph**:
 1. **Prep**: Load user's indexed intents and HyDE documents.
 2. **Scope**: Determine target indexes (single or all).
-3. **Discovery**: Vector similarity search using HyDE embeddings within index scope. Both source and candidate require HyDE documents.
+3. **Discovery**: Vector similarity search within index scope. Two complementary strategies run and merge: **profile-HyDE** matching (both source and candidate require HyDE documents) and **context-to-intent** matching (a user's network-scoped context embeddings are searched against candidate intents).
 4. **Evaluation**: `OpportunityEvaluator` scores each candidate pair via **valency** (does the candidate fill the argument slot of the source's goal verb?) and **constraint satisfaction** (does the candidate's constitutive context match all extracted constraints?). Assigns role: Agent, Patient, or Peer.
 5. **Presentation**: `OpportunityPresenter` generates two descriptions per Grice's Maxim of Relation — one from the source's frame, one from the candidate's frame.
 6. **Persist**: Opportunities created as `latent` with actor roles. Role determines tier-0 visibility (see Opportunity Lifecycle above).
@@ -338,18 +375,35 @@ The **Chat Graph** is a ReAct loop: one `agent_loop` node where the LLM decides 
 |------|---------|
 | `shared/observability/protocol.logger.ts` | Protocol-layer logging with call-scoped tracing |
 | `shared/agent/model.config.ts` | Centralized model and OpenRouter configuration |
+| `shared/agent/model-signal.ts` | Abort-signal-aware model invocation helper |
+| `shared/agent/tool.runtime.ts` | Per-tool timeout/output-budget runtime and stable error envelopes |
 | `shared/agent/response.streamer.ts` | SSE streaming for chat responses |
+| `shared/assignment/network-assignment.policy.ts` | Threshold-based network-assignment scoring and scope resolution |
+| `shared/network/metadata.renderer.ts` | Renders network metadata into prompt context |
 | `chat/chat.utils.ts` | Token counting and context window management |
 | `opportunity/opportunity.discover.ts` | Ad-hoc discovery from chat queries |
 | `opportunity/opportunity.presentation.ts` | Pure card text generation for opportunity display |
 | `opportunity/opportunity.enricher.ts` | Enrich opportunity records with profile data |
 | `opportunity/opportunity.utils.ts` | HyDE strategy selection and actor role derivation |
 | `opportunity/opportunity.introducer.ts` | Introducer-driven contact-pair discovery |
+| `opportunity/opportunity.evidence.ts` | Builds and merges per-candidate opportunity evidence |
+| `opportunity/delivery-card.cache.ts` | Cached delivery-card batch builder for opportunity delivery |
 | `opportunity/feed/feed.health.ts` | Feed health metrics computation |
 | `opportunity/opportunity.labels.ts` | Opportunity status and role label constants |
 
 ## Data Model
 
-Full schema: `protocol/src/schemas/database.schema.ts`
+This package is adapter-free and owns **no** schema — it accesses data only through the
+interfaces in `shared/interfaces/`. The canonical Drizzle schema lives in the backend at
+`backend/src/schemas/database.schema.ts`.
 
-Core tables: `users`, `user_profiles`, `intents`, `indexes`, `index_members`, `intent_indexes`, `opportunities`, `hyde_documents`, `chat_sessions`, `chat_messages`.
+Core tables the protocol interfaces read/write:
+
+- **Identity & profile**: `users`, `user_profiles`, `user_socials`, `premises`, `premise_networks`, `user_contexts`
+- **Intents & networks**: `intents`, `networks`, `network_members`, `intent_networks`, `personal_networks`
+- **Opportunities & discovery**: `opportunities`, `hyde_documents`, `opportunity_discovery_runs`, `profile_tool_runs`, `questions`
+- **Agents**: `agents`, `agent_transports`, `agent_permissions`, `apikey`
+
+> Terminology note: "index" and "network" refer to the same concept. The product
+> surface says *index*; the current schema and most tool names use **network**
+> (`networks`, `network_members`, `intent_networks`).

--- a/packages/protocol/src/agent/tests/fakes.ts
+++ b/packages/protocol/src/agent/tests/fakes.ts
@@ -4,16 +4,7 @@
  * implemented — unused methods throw if called so tests fail loudly.
  */
 
-import type {
-  AgentDatabase,
-  AgentPermissionRecord,
-  AgentRecord,
-  AgentTransportRecord,
-  AgentWithRelations,
-  CreateAgentInput,
-  CreateTransportInput,
-  GrantPermissionInput,
-} from '../../shared/interfaces/agent.interface.js';
+import type { AgentDatabase, AgentPermissionRecord, AgentRecord, AgentTransportRecord, AgentWithRelations, CreateAgentInput, CreateTransportInput, GrantPermissionInput } from '../../shared/interfaces/agent.interface.js';
 
 export interface SeedAgentInput {
   id: string;

--- a/packages/protocol/src/chat/chat.agent.ts
+++ b/packages/protocol/src/chat/chat.agent.ts
@@ -1,22 +1,9 @@
 import type { ChatOpenAI } from "@langchain/openai";
-import {
-  AIMessage,
-  BaseMessage,
-  SystemMessage,
-  ToolMessage,
-  AIMessageChunk,
-} from "@langchain/core/messages";
-import {
-  createChatTools,
-  type ToolContext,
-  type ResolvedToolContext,
-} from "../shared/agent/tool.factory.js";
+import { AIMessage, BaseMessage, SystemMessage, ToolMessage, AIMessageChunk } from "@langchain/core/messages";
+import { createChatTools, type ToolContext, type ResolvedToolContext } from "../shared/agent/tool.factory.js";
 import { resolveChatContext } from "../shared/agent/tool.helpers.js";
 import { ITERATION_NUDGE, buildSystemContent } from "./chat.prompt.js";
-import {
-  extractRecentToolCalls,
-  type IterationContext,
-} from "./chat.prompt.modules.js";
+import { extractRecentToolCalls, type IterationContext } from "./chat.prompt.modules.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { createModel, type ModelConfig } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";

--- a/packages/protocol/src/chat/chat.streamer.ts
+++ b/packages/protocol/src/chat/chat.streamer.ts
@@ -1,37 +1,8 @@
 import { AIMessage, BaseMessage, HumanMessage } from "@langchain/core/messages";
 import { BaseCheckpointSaver } from "@langchain/langgraph";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
-import type {
-  ChatStreamEvent,
-  DebugMetaDiscoveryQuestions,
-  DebugMetaToolCall,
-  DebugMetaLlm,
-  DebugMetaOrchestratorNegotiations,
-} from "./chat-streaming.types.js";
-import {
-  createAgentEndEvent,
-  createAgentStartEvent,
-  createDebugMetaEvent,
-  createDecisionQuestionsEvent,
-  createErrorEvent,
-  createGraphEndEvent,
-  createPhaseStartEvent,
-  createPhaseEndEvent,
-  createGraphStartEvent,
-  createIterationStartEvent,
-  createLlmStartEvent,
-  createLlmEndEvent,
-  createResponseCompleteEvent,
-  createResponseResetEvent,
-  createHallucinationDetectedEvent,
-  createStatusEvent,
-  createTokenEvent,
-  createToolActivityEvent,
-  createChatSummarizerStartEvent,
-  createChatSummarizerEndEvent,
-  createQuestionGeneratorStartEvent,
-  createQuestionGeneratorEndEvent,
-} from "./chat-streaming.types.js";
+import type { ChatStreamEvent, DebugMetaDiscoveryQuestions, DebugMetaToolCall, DebugMetaLlm, DebugMetaOrchestratorNegotiations } from "./chat-streaming.types.js";
+import { createAgentEndEvent, createAgentStartEvent, createDebugMetaEvent, createDecisionQuestionsEvent, createErrorEvent, createGraphEndEvent, createPhaseStartEvent, createPhaseEndEvent, createGraphStartEvent, createIterationStartEvent, createLlmStartEvent, createLlmEndEvent, createResponseCompleteEvent, createResponseResetEvent, createHallucinationDetectedEvent, createStatusEvent, createTokenEvent, createToolActivityEvent, createChatSummarizerStartEvent, createChatSummarizerEndEvent, createQuestionGeneratorStartEvent, createQuestionGeneratorEndEvent } from "./chat-streaming.types.js";
 import type { AgentStreamEvent } from "./chat.agent.js";
 
 const logger = protocolLogger("ChatStreamer");

--- a/packages/protocol/src/chat/chat.summarizer.ts
+++ b/packages/protocol/src/chat/chat.summarizer.ts
@@ -10,10 +10,7 @@
 import type { ChatOpenAI } from "@langchain/openai";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 
-import {
-  ChatContextDigestSchema,
-  type ChatContextDigest,
-} from "../shared/schemas/chat-context.schema.js";
+import { ChatContextDigestSchema, type ChatContextDigest } from "../shared/schemas/chat-context.schema.js";
 import { createModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";

--- a/packages/protocol/src/chat/tests/chat-streaming.types.discoveryQuestions.spec.ts
+++ b/packages/protocol/src/chat/tests/chat-streaming.types.discoveryQuestions.spec.ts
@@ -1,14 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import {
-  createChatSummarizerStartEvent,
-  createChatSummarizerEndEvent,
-  createQuestionGeneratorStartEvent,
-  createQuestionGeneratorEndEvent,
-  createDecisionQuestionsEvent,
-  createDebugMetaEvent,
-  type DebugMetaDiscoveryQuestions,
-  type DebugMetaLlm,
-} from "../chat-streaming.types.js";
+import { createChatSummarizerStartEvent, createChatSummarizerEndEvent, createQuestionGeneratorStartEvent, createQuestionGeneratorEndEvent, createDecisionQuestionsEvent, createDebugMetaEvent, type DebugMetaDiscoveryQuestions, type DebugMetaLlm } from "../chat-streaming.types.js";
 import type { Question, QuestionStrategy } from "../../shared/schemas/question.schema.js";
 
 const question: Question = {

--- a/packages/protocol/src/chat/tests/chat.agent.spec.ts
+++ b/packages/protocol/src/chat/tests/chat.agent.spec.ts
@@ -82,10 +82,7 @@ mock.module("../../shared/agent/tool.factory", () => ({
   createChatTools: async () => createMockTools(),
 }));
 
-import {
-  AIMessageChunk,
-  HumanMessage,
-} from "@langchain/core/messages";
+import { AIMessageChunk, HumanMessage } from "@langchain/core/messages";
 import { ChatAgent, type AgentStreamEvent } from "../chat.agent.js";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────

--- a/packages/protocol/src/chat/tests/chat.graph.mocks.ts
+++ b/packages/protocol/src/chat/tests/chat.graph.mocks.ts
@@ -4,17 +4,7 @@
  * with controllable profile, intents, index membership, and opportunities.
  */
 
-import type {
-  ChatGraphCompositeDatabase,
-  CreateIntentData,
-  ActiveIntent,
-  IndexedIntentDetails,
-  NetworkMembership,
-  OwnedIndex,
-  UserRecord,
-  Opportunity,
-  OpportunityStatus,
-} from "../../shared/interfaces/database.interface.js";
+import type { ChatGraphCompositeDatabase, CreateIntentData, ActiveIntent, IndexedIntentDetails, NetworkMembership, OwnedIndex, UserRecord, Opportunity, OpportunityStatus } from "../../shared/interfaces/database.interface.js";
 import type { ChatSessionReader } from "../../shared/interfaces/chat-session.interface.js";
 import type { ProtocolDeps } from "../../shared/agent/tool.helpers.js";
 
@@ -295,7 +285,7 @@ export function createMockProtocolDeps(overrides?: Partial<ProtocolDeps>): Proto
   return {
     cache: { get: async () => null, set: async () => {}, delete: async () => false, exists: async () => false, mget: async () => [], deleteByPattern: async () => 0 },
     hydeCache: { get: async () => null, set: async () => {}, delete: async () => false, exists: async () => false },
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+     
     integration: { createSession: async () => ({ toolkits: async () => ({ items: [] }), authorize: async () => ({ redirectUrl: "" }) }), executeToolAction: async () => ({ successful: true }), listConnections: async () => [], getAuthUrl: async () => ({ redirectUrl: "" }), disconnect: async () => ({ success: true }) } as unknown as ProtocolDeps["integration"],
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     intentQueue: { addGenerateHydeJob: async () => ({}), addDeleteHydeJob: async () => ({}) } as any,

--- a/packages/protocol/src/chat/tests/chat.prompt.modules.spec.ts
+++ b/packages/protocol/src/chat/tests/chat.prompt.modules.spec.ts
@@ -8,12 +8,7 @@ import { AIMessage, HumanMessage, ToolMessage } from "@langchain/core/messages";
 import type { ResolvedToolContext } from "../../shared/agent/tool.factory.js";
 
 import { buildSystemContent } from "../chat.prompt.js";
-import {
-  extractRecentToolCalls,
-  resolveModules,
-  PROMPT_MODULES,
-  type IterationContext,
-} from "../chat.prompt.modules.js";
+import { extractRecentToolCalls, resolveModules, PROMPT_MODULES, type IterationContext } from "../chat.prompt.modules.js";
 
 describe("extractRecentToolCalls", () => {
   test("returns empty array when no tool calls in messages", () => {

--- a/packages/protocol/src/chat/tests/chat.prompt.spec.ts
+++ b/packages/protocol/src/chat/tests/chat.prompt.spec.ts
@@ -18,11 +18,7 @@ import type { BaseMessage } from "@langchain/core/messages";
 
 import type { ResolvedToolContext } from "../../shared/agent/tool.factory.js";
 import { buildSystemContent } from "../chat.prompt.js";
-import {
-  extractRecentToolCalls,
-  resolveModules,
-  type IterationContext,
-} from "../chat.prompt.modules.js";
+import { extractRecentToolCalls, resolveModules, type IterationContext } from "../chat.prompt.modules.js";
 
 // ─── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -417,12 +413,7 @@ import { assertLLM } from "../../shared/agent/tests/llm-assert.js";
 import { ChatGraphFactory } from "../chat.graph.js";
 import type { Embedder } from "../../shared/interfaces/embedder.interface.js";
 import type { Scraper } from "../../shared/interfaces/scraper.interface.js";
-import {
-  createChatGraphMockDb,
-  mockProfile,
-  mockActiveIntent,
-  createMockProtocolDeps,
-} from "./chat.graph.mocks.js";
+import { createChatGraphMockDb, mockProfile, mockActiveIntent, createMockProtocolDeps } from "./chat.graph.mocks.js";
 import type { ChatSessionReader } from "../../shared/interfaces/chat-session.interface.js";
 import type { NetworkMembership } from "../../shared/interfaces/database.interface.js";
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -4,23 +4,11 @@ export { createChatTools } from "./shared/agent/tool.factory.js";
 export { getModelName } from "./shared/agent/model.config.js";
 export type { ChatTools } from "./shared/agent/tool.factory.js";
 export type { ModelConfig, ModelSettings } from "./shared/agent/model.config.js";
-export type {
-  ToolContext,
-  ResolvedToolContext,
-  ToolDeps,
-  ProtocolDeps,
-  RawToolDefinition,
-  CompiledGraph,
-} from "./shared/agent/tool.helpers.js";
+export type { ToolContext, ResolvedToolContext, ToolDeps, ProtocolDeps, RawToolDefinition, CompiledGraph } from "./shared/agent/tool.helpers.js";
 export { ChatContextAccessError, resolveChatContext } from "./shared/agent/tool.helpers.js";
 export { requestContext } from "./shared/observability/request-context.js";
 export { setTimingWrapper } from "./shared/observability/performance.js";
-export {
-  ToolRuntimeError,
-  getToolTimeoutPolicy,
-  invokeToolRuntime,
-  toolRuntimeErrorToResult,
-} from "./shared/agent/tool.runtime.js";
+export { ToolRuntimeError, getToolTimeoutPolicy, invokeToolRuntime, toolRuntimeErrorToResult } from "./shared/agent/tool.runtime.js";
 export type { ToolRuntimeErrorCode, ToolTimeoutClass, ToolTimeoutPolicy } from "./shared/agent/tool.runtime.js";
 
 // ─── Interfaces (implement these to wire up your infrastructure) ───────────────
@@ -31,12 +19,7 @@ export type * from "./shared/interfaces/chat-session.interface.js";
 export type { ChatSummaryReader } from "./shared/interfaces/chat-summary.interface.js";
 export type { ChatMessageWriter } from "./shared/interfaces/chat-message-writer.interface.js";
 export type { QuestionGeneratorReader } from "./shared/interfaces/question-generator.interface.js";
-export type {
-  QuestionerDatabase,
-  PersistableQuestion,
-  PersistedQuestion,
-  QuestionFilters,
-} from "./shared/interfaces/questioner.interface.js";
+export type { QuestionerDatabase, PersistableQuestion, PersistedQuestion, QuestionFilters } from "./shared/interfaces/questioner.interface.js";
 export type { NegotiationSummaryReader } from "./shared/interfaces/negotiation-summary.interface.js";
 export type { DiscoveryNegotiationDigest } from "./shared/schemas/negotiation-digest.schema.js";
 export { NegotiationSummarizer, buildFallbackDigest } from "./negotiation/negotiation.summarizer.js";
@@ -54,105 +37,22 @@ export type * from "./shared/interfaces/discovery-run.interface.js";
 export type * from "./shared/interfaces/profile-run.interface.js";
 export type * from "./shared/interfaces/negotiation-events.interface.js";
 export type { AgentDispatcher, AgentDispatchResult, NegotiationTurnPayload } from "./shared/interfaces/agent-dispatcher.interface.js";
-export type {
-  AgentRecord,
-  AgentTransportRecord,
-  AgentPermissionRecord,
-  AgentWithRelations,
-  CreateAgentInput,
-  CreateTransportInput,
-  GrantPermissionInput,
-  AgentDatabase,
-} from './shared/interfaces/agent.interface.js';
+export type { AgentRecord, AgentTransportRecord, AgentPermissionRecord, AgentWithRelations, CreateAgentInput, CreateTransportInput, GrantPermissionInput, AgentDatabase } from './shared/interfaces/agent.interface.js';
 export { SYSTEM_AGENT_IDS } from './shared/interfaces/agent.interface.js';
 
 // ─── Shared schemas ───────────────────────────────────────────────────────────
 
-export {
-  ChatContextDigestSchema,
-  type ChatContextDigest,
-} from "./shared/schemas/chat-context.schema.js";
-export {
-  QuestionOptionSchema,
-  QuestionSchema,
-  QuestionStrategySchema,
-  QuestionWithStrategySchema,
-  QuestionGeneratorResponseSchema,
-  QuestionModeSchema,
-  QuestionDetectionSchema,
-  QuestionActorSchema,
-  QuestionAnswerSchema,
-  type Question,
-  type QuestionOption,
-  type QuestionStrategy,
-  type QuestionWithStrategy,
-  type QuestionGeneratorResponse,
-  type QuestionGenerationResult,
-  type QuestionMode,
-  type QuestionDetection,
-  type QuestionActor,
-  type QuestionAnswer,
-} from "./shared/schemas/question.schema.js";
+export { ChatContextDigestSchema, type ChatContextDigest } from "./shared/schemas/chat-context.schema.js";
+export { QuestionOptionSchema, QuestionSchema, QuestionStrategySchema, QuestionWithStrategySchema, QuestionGeneratorResponseSchema, QuestionModeSchema, QuestionDetectionSchema, QuestionActorSchema, QuestionAnswerSchema, type Question, type QuestionOption, type QuestionStrategy, type QuestionWithStrategy, type QuestionGeneratorResponse, type QuestionGenerationResult, type QuestionMode, type QuestionDetection, type QuestionActor, type QuestionAnswer } from "./shared/schemas/question.schema.js";
 export type { PendingQuestionSummary } from "./shared/schemas/pending-question.schema.js";
 export type { McpAuthInput } from "./shared/schemas/mcp-auth.schema.js";
-export {
-  ProfileIdentitySchema,
-  ProfileNarrativeSchema,
-  ProfileAttributesSchema,
-  ProfileDocumentSchema,
-  type ProfileDocument,
-} from "./shared/schemas/profile.schema.js";
-export type {
-  DiscoverySourceProfile,
-  DiscoverySummary,
-  DiscoveryNegotiation,
-  DiscoveryTurn,
-  DiscoveryOutcome,
-  DiscoveryQuestionInput,
-  NegotiationRole,
-} from "./shared/schemas/discovery-question.schema.js";
-export {
-  NetworkAssignmentResourceTypeSchema,
-  NetworkAssignmentModeSchema,
-  NetworkAssignmentScopeSchema,
-  NetworkAssignmentPromptPresenceSchema,
-  NetworkAssignmentPolicySchema,
-  NetworkAssignmentRawScoresSchema,
-  NetworkAssignmentMetadataSchema,
-  OpportunityEvidenceKindSchema,
-  OpportunityEvidenceSchema,
-} from "./shared/schemas/network-assignment.schema.js";
-export type {
-  NetworkAssignmentResourceType,
-  NetworkAssignmentMode,
-  NetworkAssignmentScope,
-  NetworkAssignmentPromptPresence,
-  NetworkAssignmentPolicy,
-  NetworkAssignmentRawScores,
-  NetworkAssignmentMetadata,
-  OpportunityEvidenceKind,
-  OpportunityEvidence,
-} from "./shared/schemas/network-assignment.schema.js";
-export {
-  DEFAULT_NETWORK_ASSIGNMENT_THRESHOLD,
-  classifyPromptPresence,
-  resolveAssignmentNetworkScope,
-  buildNetworkAssignmentDecision,
-  combineAssignmentScores,
-} from "./shared/assignment/network-assignment.policy.js";
-export type {
-  PromptPresenceInput,
-  ResolveAssignmentNetworkScopeArgs,
-  BuildNetworkAssignmentDecisionArgs,
-  NetworkAssignmentDecision,
-} from "./shared/assignment/network-assignment.policy.js";
-export {
-  buildCandidateEvidence,
-  withCandidateEvidence,
-  mergeOpportunityEvidence,
-  withMatchedStrategies,
-  renderOpportunityEvidenceForPrompt,
-} from "./opportunity/opportunity.evidence.js";
+export { ProfileIdentitySchema, ProfileNarrativeSchema, ProfileAttributesSchema, ProfileDocumentSchema, type ProfileDocument } from "./shared/schemas/profile.schema.js";
+export type { DiscoverySourceProfile, DiscoverySummary, DiscoveryNegotiation, DiscoveryTurn, DiscoveryOutcome, DiscoveryQuestionInput, NegotiationRole } from "./shared/schemas/discovery-question.schema.js";
+export { NetworkAssignmentResourceTypeSchema, NetworkAssignmentModeSchema, NetworkAssignmentScopeSchema, NetworkAssignmentPromptPresenceSchema, NetworkAssignmentPolicySchema, NetworkAssignmentRawScoresSchema, NetworkAssignmentMetadataSchema, OpportunityEvidenceKindSchema, OpportunityEvidenceSchema } from "./shared/schemas/network-assignment.schema.js";
+export type { NetworkAssignmentResourceType, NetworkAssignmentMode, NetworkAssignmentScope, NetworkAssignmentPromptPresence, NetworkAssignmentPolicy, NetworkAssignmentRawScores, NetworkAssignmentMetadata, OpportunityEvidenceKind, OpportunityEvidence } from "./shared/schemas/network-assignment.schema.js";
+export { DEFAULT_NETWORK_ASSIGNMENT_THRESHOLD, classifyPromptPresence, resolveAssignmentNetworkScope, buildNetworkAssignmentDecision, combineAssignmentScores } from "./shared/assignment/network-assignment.policy.js";
+export type { PromptPresenceInput, ResolveAssignmentNetworkScopeArgs, BuildNetworkAssignmentDecisionArgs, NetworkAssignmentDecision } from "./shared/assignment/network-assignment.policy.js";
+export { buildCandidateEvidence, withCandidateEvidence, mergeOpportunityEvidence, withMatchedStrategies, renderOpportunityEvidenceForPrompt } from "./opportunity/opportunity.evidence.js";
 export type { EvidenceCandidateInput } from "./opportunity/opportunity.evidence.js";
 
 // ─── Graph factories ──────────────────────────────────────────────────────────
@@ -165,11 +65,7 @@ export { NetworkMembershipGraphFactory } from "./network/membership/membership.g
 export { IntentGraphFactory } from "./intent/intent.graph.js";
 export { IntentNetworkGraphFactory } from "./network/indexer/indexer.graph.js";
 export { MaintenanceGraphFactory } from "./maintenance/maintenance.graph.js";
-export type {
-  MaintenanceGraphDatabase,
-  MaintenanceGraphCache,
-  MaintenanceGraphQueue,
-} from "./maintenance/maintenance.graph.js";
+export type { MaintenanceGraphDatabase, MaintenanceGraphCache, MaintenanceGraphQueue } from "./maintenance/maintenance.graph.js";
 export { NegotiationGraphFactory, createDefaultNegotiationGraph, negotiateCandidates } from "./negotiation/negotiation.graph.js";
 export { OpportunityGraphFactory } from "./opportunity/opportunity.graph.js";
 export { ProfileGraphFactory } from "./profile/profile.graph.js";
@@ -204,23 +100,11 @@ export { IndexNegotiator } from "./negotiation/negotiation.agent.js";
 export type { NegotiationAgentInput } from "./negotiation/negotiation.agent.js";
 export { QuestionerAgent } from "./questioner/questioner.agent.js";
 export type { QuestionerAgentConfig } from "./questioner/questioner.agent.js";
-export type {
-  QuestionerInput,
-  QuestionerContext,
-  QuestionerEnqueuePayload,
-  QuestionerEnqueueFn,
-  DiscoveryContext,
-  IntentContext,
-  ProfileContext,
-  NegotiationContext,
-} from "./questioner/questioner.types.js";
+export type { QuestionerInput, QuestionerContext, QuestionerEnqueuePayload, QuestionerEnqueueFn, DiscoveryContext, IntentContext, ProfileContext, NegotiationContext } from "./questioner/questioner.types.js";
 export { getPreset } from "./questioner/questioner.presets.js";
 export type { QuestionerPreset } from "./questioner/questioner.presets.js";
 export { OpportunityEvaluator } from "./opportunity/opportunity.evaluator.js";
-export type {
-  EvaluatorInput,
-  OpportunityEvaluatorOptionsConstructor,
-} from "./opportunity/opportunity.evaluator.js";
+export type { EvaluatorInput, OpportunityEvaluatorOptionsConstructor } from "./opportunity/opportunity.evaluator.js";
 export { OpportunityPresenter, gatherPresenterContext } from "./opportunity/opportunity.presenter.js";
 export { createOpportunityTools } from "./opportunity/opportunity.tools.js";
 export { createProfileTools } from "./profile/profile.tools.js";
@@ -230,43 +114,18 @@ export { QuestionGenerator } from "./opportunity/question.generator.js";
 // ─── Support utilities ────────────────────────────────────────────────────────
 
 export { renderNetworkContext } from './shared/network/metadata.renderer.js';
-export {
-  canUserSeeOpportunity,
-  isActionableForViewer,
-  validateOpportunityActors,
-  classifyOpportunity,
-  selectByComposition,
-  selectDigestCandidates,
-  DIGEST_REDELIVERY_COOLDOWN_DAYS,
-  FEED_SOFT_TARGETS,
-} from "./opportunity/opportunity.utils.js";
+export { canUserSeeOpportunity, isActionableForViewer, validateOpportunityActors, classifyOpportunity, selectByComposition, selectDigestCandidates, DIGEST_REDELIVERY_COOLDOWN_DAYS, FEED_SOFT_TARGETS } from "./opportunity/opportunity.utils.js";
 export type { DigestDeliveredRow } from "./opportunity/opportunity.utils.js";
 export { getPrimaryActionLabel } from "./opportunity/opportunity.labels.js";
 export { computeFeedHealth } from "./opportunity/feed/feed.health.js";
 export type { FeedHealthInput, FeedHealthResult } from "./opportunity/feed/feed.health.js";
-export {
-  selectContactsForDiscovery,
-  shouldRunIntroducerDiscovery,
-  runIntroducerDiscovery,
-  MAX_CONTACTS_PER_CYCLE,
-  MAX_CANDIDATES_PER_CONTACT,
-  INTRODUCER_DISCOVERY_SOURCE,
-} from "./opportunity/opportunity.introducer.js";
-export type {
-  IntroducerDiscoveryDatabase,
-  IntroducerDiscoveryQueue,
-  ContactWithIntents,
-} from "./opportunity/opportunity.introducer.js";
+export { selectContactsForDiscovery, shouldRunIntroducerDiscovery, runIntroducerDiscovery, MAX_CONTACTS_PER_CYCLE, MAX_CANDIDATES_PER_CONTACT, INTRODUCER_DISCOVERY_SOURCE } from "./opportunity/opportunity.introducer.js";
+export type { IntroducerDiscoveryDatabase, IntroducerDiscoveryQueue, ContactWithIntents } from "./opportunity/opportunity.introducer.js";
 export { persistOpportunities } from "./opportunity/opportunity.persist.js";
 export { presentOpportunity } from "./opportunity/opportunity.presentation.js";
 export type { UserInfo } from "./opportunity/opportunity.presentation.js";
 export { stripUuids, stripIntroducerMentions } from "./opportunity/opportunity.presentation.js";
-export {
-  getOrCreateDeliveryCardBatch,
-  DELIVERY_CARD_CACHE_TTL,
-  type CachedDeliveryCard,
-  type OpportunityWithContext,
-} from "./opportunity/delivery-card.cache.js";
+export { getOrCreateDeliveryCardBatch, DELIVERY_CARD_CACHE_TTL, type CachedDeliveryCard, type OpportunityWithContext } from "./opportunity/delivery-card.cache.js";
 
 // ─── Tools ────────────────────────────────────────────────────────────────────
 
@@ -285,12 +144,7 @@ export type { ElicitResultLike, ElicitInputFn, DispatchElicitationsParams } from
 
 // ─── States (for advanced graph consumers) ────────────────────────────────────
 
-export type {
-  UserNegotiationContext,
-  NegotiationTurn,
-  NegotiationOutcome,
-  SeedAssessment,
-} from "./shared/schemas/negotiation-state.schema.js";
+export type { UserNegotiationContext, NegotiationTurn, NegotiationOutcome, SeedAssessment } from "./shared/schemas/negotiation-state.schema.js";
 export type { NegotiationGraphLike } from "./negotiation/negotiation.state.js";
 
 // ─── Streamers ────────────────────────────────────────────────────────────────

--- a/packages/protocol/src/intent/intent.graph.ts
+++ b/packages/protocol/src/intent/intent.graph.ts
@@ -498,7 +498,7 @@ export class IntentGraphFactory {
     /** Strip URLs and "More details at [url]" from intent payloads before persisting. */
     const sanitizePayload = (payload: string): string => {
       if (!payload || typeof payload !== "string") return payload;
-      let out = payload
+      const out = payload
         .replace(/\s*More details at\s*:?\s*https?:\/\/[^\s"'<>)\]]+/gi, "")
         .replace(/\s*See\s+https?:\/\/[^\s"'<>)\]]+\s+for\s+more[^.]*\.?/gi, "")
         .replace(/https?:\/\/[^\s"'<>)\]]+/g, "")

--- a/packages/protocol/src/intent/tests/intent.graph.scoped.spec.ts
+++ b/packages/protocol/src/intent/tests/intent.graph.scoped.spec.ts
@@ -8,12 +8,7 @@
 import { describe, expect, test } from 'bun:test';
 
 import { IntentGraphFactory } from '../intent.graph.js';
-import type {
-  IntentGraphDatabase,
-  ActiveIntent,
-  CreatedIntent,
-  ArchiveResult,
-} from '../../shared/interfaces/database.interface.js';
+import type { IntentGraphDatabase, ActiveIntent, CreatedIntent, ArchiveResult } from '../../shared/interfaces/database.interface.js';
 
 const PERSONAL = 'personal-idx';
 const EDGE_CITY = 'edge-city-idx';

--- a/packages/protocol/src/maintenance/maintenance.graph.ts
+++ b/packages/protocol/src/maintenance/maintenance.graph.ts
@@ -11,12 +11,7 @@ import { StateGraph, START, END } from '@langchain/langgraph';
 import { MaintenanceGraphState } from './maintenance.state.js';
 import { computeFeedHealth } from '../opportunity/feed/feed.health.js';
 import { canUserSeeOpportunity, classifyOpportunity, isActionableForViewer, FEED_SOFT_TARGETS } from '../opportunity/opportunity.utils.js';
-import {
-  shouldRunIntroducerDiscovery,
-  runIntroducerDiscovery,
-  type IntroducerDiscoveryDatabase,
-  type IntroducerDiscoveryQueue,
-} from '../opportunity/opportunity.introducer.js';
+import { shouldRunIntroducerDiscovery, runIntroducerDiscovery, type IntroducerDiscoveryDatabase, type IntroducerDiscoveryQueue } from '../opportunity/opportunity.introducer.js';
 import { protocolLogger } from '../shared/observability/protocol.logger.js';
 
 const logger = protocolLogger('MaintenanceGraph');

--- a/packages/protocol/src/mcp/tests/mcp.server.elicitation.spec.ts
+++ b/packages/protocol/src/mcp/tests/mcp.server.elicitation.spec.ts
@@ -5,10 +5,7 @@ import { config } from "dotenv";
 config({ path: ".env.test", override: true });
 
 import { describe, it, expect } from "bun:test";
-import {
-  extractDecisionQuestions,
-  renderQuestionsEnvelope,
-} from "../mcp.server.js";
+import { extractDecisionQuestions, renderQuestionsEnvelope } from "../mcp.server.js";
 import type { Question } from "../../shared/schemas/question.schema.js";
 
 const sampleQ: Question = {

--- a/packages/protocol/src/negotiation/negotiation.agent.ts
+++ b/packages/protocol/src/negotiation/negotiation.agent.ts
@@ -1,12 +1,6 @@
 import { createModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
-import {
-  SystemNegotiationTurnSchema,
-  FinalNegotiationTurnSchema,
-  type NegotiationTurn,
-  type UserNegotiationContext,
-  type SeedAssessment,
-} from "./negotiation.state.js";
+import { SystemNegotiationTurnSchema, FinalNegotiationTurnSchema, type NegotiationTurn, type UserNegotiationContext, type SeedAssessment } from "./negotiation.state.js";
 import type { NegotiationUserAnswer } from "../shared/interfaces/database.interface.js";
 
 const SYSTEM_PROMPT = `You are the Index Negotiator, an AI agent acting on behalf of {userName}. You represent their interests in a bilateral negotiation about a potential connection on a discovery network.

--- a/packages/protocol/src/negotiation/negotiation.summarizer.ts
+++ b/packages/protocol/src/negotiation/negotiation.summarizer.ts
@@ -15,10 +15,7 @@ import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { createModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
-import {
-  DiscoveryNegotiationDigestSchema,
-  type DiscoveryNegotiationDigest,
-} from "../shared/schemas/negotiation-digest.schema.js";
+import { DiscoveryNegotiationDigestSchema, type DiscoveryNegotiationDigest } from "../shared/schemas/negotiation-digest.schema.js";
 import type { DiscoveryNegotiation } from "../opportunity/question.prompt.js";
 
 const logger = protocolLogger("NegotiationSummarizer");

--- a/packages/protocol/src/negotiation/tests/negotiation.on-resolved.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.on-resolved.spec.ts
@@ -7,15 +7,8 @@
  */
 
 import { describe, it, expect } from 'bun:test';
-import {
-  negotiateCandidates,
-  type NegotiationCandidate,
-  type OnNegotiationResolved,
-} from '../negotiation.graph.js';
-import type {
-  NegotiationGraphLike,
-  UserNegotiationContext,
-} from '../negotiation.state.js';
+import { negotiateCandidates, type NegotiationCandidate, type OnNegotiationResolved } from '../negotiation.graph.js';
+import type { NegotiationGraphLike, UserNegotiationContext } from '../negotiation.state.js';
 import type { NegotiationOutcome } from '../../shared/interfaces/database.interface.js';
 
 function makeCandidate(userId: string, opportunityId: string): NegotiationCandidate {

--- a/packages/protocol/src/network/indexer/indexer.graph.ts
+++ b/packages/protocol/src/network/indexer/indexer.graph.ts
@@ -1,9 +1,7 @@
 import { StateGraph, START, END } from "@langchain/langgraph";
 
 import { IntentIndexer } from "../../intent/intent.indexer.js";
-import {
-  buildNetworkAssignmentDecision,
-} from "../../shared/assignment/network-assignment.policy.js";
+import { buildNetworkAssignmentDecision } from "../../shared/assignment/network-assignment.policy.js";
 import type { IntentNetworkGraphDatabase } from "../../shared/interfaces/database.interface.js";
 import { protocolLogger } from "../../shared/observability/protocol.logger.js";
 import { timed } from "../../shared/observability/performance.js";
@@ -11,12 +9,7 @@ import { requestContext } from "../../shared/observability/request-context.js";
 import type { DebugMetaAgent } from "../../chat/chat-streaming.types.js";
 import { renderNetworkContext } from "../../shared/network/metadata.renderer.js";
 
-import {
-  IntentNetworkGraphState,
-  type IntentForIndexing,
-  type IndexMemberContext,
-  type AssignmentResult,
-} from "./indexer.state.js";
+import { IntentNetworkGraphState, type IntentForIndexing, type IndexMemberContext, type AssignmentResult } from "./indexer.state.js";
 
 const logger = protocolLogger("IntentNetworkGraphFactory");
 

--- a/packages/protocol/src/opportunity/delivery-card.cache.spec.ts
+++ b/packages/protocol/src/opportunity/delivery-card.cache.spec.ts
@@ -74,7 +74,7 @@ describe('getOrCreateDeliveryCardBatch', () => {
     };
 
     let presentCalledCount = 0;
-    let setCalls: any[] = [];
+    const setCalls: any[] = [];
 
     const mockCache: Cache = {
       get: mock(() => Promise.resolve(null)),
@@ -167,7 +167,7 @@ describe('getOrCreateDeliveryCardBatch', () => {
       narratorRemark: 'Cached remark',
     };
     let presentCalledCount = 0;
-    let setCalls: any[] = [];
+    const setCalls: any[] = [];
 
     const mockCache: Cache = {
       get: mock(() => Promise.resolve(null)),

--- a/packages/protocol/src/opportunity/discovery-question.helper.ts
+++ b/packages/protocol/src/opportunity/discovery-question.helper.ts
@@ -6,11 +6,7 @@
 import type { ChatContextDigest } from "../shared/schemas/chat-context.schema.js";
 import type { DiscoveryNegotiationDigest } from "../shared/schemas/negotiation-digest.schema.js";
 import type { SourceProfileData } from "./opportunity.state.js";
-import type {
-  DiscoveryQuestionInput,
-  DiscoverySourceProfile,
-  DiscoverySummary,
-} from "./question.prompt.js";
+import type { DiscoveryQuestionInput, DiscoverySourceProfile, DiscoverySummary } from "./question.prompt.js";
 
 export interface BuildDiscoveryQuestionInputArgs {
   query: string;

--- a/packages/protocol/src/opportunity/feed/feed.graph.ts
+++ b/packages/protocol/src/opportunity/feed/feed.graph.ts
@@ -15,13 +15,7 @@ import { StateGraph, START, END } from '@langchain/langgraph';
 
 import type { HomeGraphDatabase, OpportunityStatus } from '../../shared/interfaces/database.interface.js';
 import type { OpportunityCache } from '../../shared/interfaces/cache.interface.js';
-import {
-  HomeGraphState,
-  type HomeCardItem,
-  type HomeSection,
-  type HomeSectionProposal,
-  type HomeSectionItem,
-} from './feed.state.js';
+import { HomeGraphState, type HomeCardItem, type HomeSection, type HomeSectionProposal, type HomeSectionItem } from './feed.state.js';
 import { OpportunityPresenter, gatherPresenterContext, type PresenterDatabase } from '../opportunity.presenter.js';
 import { loadNegotiationContext } from '../negotiation-context.loader.js';
 import { HomeCategorizerAgent } from './feed.categorizer.js';

--- a/packages/protocol/src/opportunity/negotiation-summary.builder.ts
+++ b/packages/protocol/src/opportunity/negotiation-summary.builder.ts
@@ -3,17 +3,8 @@
  * `DiscoveryNegotiation` / `DiscoverySummary` shapes consumed by the question
  * generator. No DB access, no LLM — safe to import from anywhere.
  */
-import type {
-  NegotiationTurn,
-  NegotiationOutcome,
-} from "../negotiation/negotiation.state.js";
-import type {
-  DiscoveryNegotiation,
-  DiscoveryOutcome,
-  DiscoverySummary,
-  DiscoveryTurn,
-  NegotiationRole,
-} from "./question.prompt.js";
+import type { NegotiationTurn, NegotiationOutcome } from "../negotiation/negotiation.state.js";
+import type { DiscoveryNegotiation, DiscoveryOutcome, DiscoverySummary, DiscoveryTurn, NegotiationRole } from "./question.prompt.js";
 
 /**
  * The input shape collected by the opportunity graph's negotiate node for

--- a/packages/protocol/src/opportunity/opportunity.discover.ts
+++ b/packages/protocol/src/opportunity/opportunity.discover.ts
@@ -14,14 +14,7 @@ import type { Cache } from "../shared/interfaces/cache.interface.js";
 import type { OpportunityGraphOptions, CandidateMatch, SourceProfileData } from "./opportunity.state.js";
 import type { DiscoveryNegotiation, DiscoverySummary } from "./question.prompt.js";
 import type { QuestionerEnqueueFn } from "../questioner/questioner.types.js";
-import {
-  OpportunityPresenter,
-  gatherPresenterContext,
-  type OpportunityPresentationResult,
-  type HomeCardPresentationResult,
-  type HomeCardLLMResult,
-  type HomeCardPresenterInput,
-} from "./opportunity.presenter.js";
+import { OpportunityPresenter, gatherPresenterContext, type OpportunityPresentationResult, type HomeCardPresentationResult, type HomeCardLLMResult, type HomeCardPresenterInput } from "./opportunity.presenter.js";
 import { MINIMAL_MAIN_TEXT_MAX_CHARS, getPrimaryActionLabel, SECONDARY_ACTION_LABEL } from "./opportunity.labels.js";
 import { viewerCentricCardSummary, narratorRemarkFromReasoning } from "./opportunity.presentation.js";
 import { protocolLogger, withCallLogging } from "../shared/observability/protocol.logger.js";

--- a/packages/protocol/src/opportunity/opportunity.enricher.ts
+++ b/packages/protocol/src/opportunity/opportunity.enricher.ts
@@ -4,14 +4,7 @@
  * optionally merge into a single enriched opportunity and expire the old one(s).
  */
 
-import type {
-  CreateOpportunityData,
-  Opportunity,
-  OpportunityActor,
-  OpportunityInterpretation,
-  OpportunitySignal,
-  OpportunityStatus,
-} from '../shared/interfaces/database.interface.js';
+import type { CreateOpportunityData, Opportunity, OpportunityActor, OpportunityInterpretation, OpportunitySignal, OpportunityStatus } from '../shared/interfaces/database.interface.js';
 import { getAbortSignalConfig } from '../shared/agent/model-signal.js';
 import type { Embedder } from '../shared/interfaces/embedder.interface.js';
 import type { Id } from '../shared/interfaces/database.interface.js';

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -15,24 +15,9 @@
 import { StateGraph, START, END, Annotation } from '@langchain/langgraph';
 import type { Id } from '../shared/interfaces/database.interface.js';
 import type { DebugMetaAgent } from '../chat/chat-streaming.types.js';
-import {
-  OpportunityGraphState,
-  type IndexedIntent,
-  type SourceProfileData,
-  type TargetNetwork,
-  type CandidateMatch,
-  type EvaluatedCandidate,
-  type EvaluatedOpportunity,
-  type EvaluatedOpportunityActor,
-} from './opportunity.state.js';
+import { OpportunityGraphState, type IndexedIntent, type SourceProfileData, type TargetNetwork, type CandidateMatch, type EvaluatedCandidate, type EvaluatedOpportunity, type EvaluatedOpportunityActor } from './opportunity.state.js';
 import { resolveInitialStatus } from './opportunity.state.js';
-import {
-  OpportunityEvaluator,
-  type CandidateProfile,
-  type EvaluatedOpportunityWithActors,
-  type EvaluatorEntity,
-  type EvaluatorInput,
-} from './opportunity.evaluator.js';
+import { OpportunityEvaluator, type CandidateProfile, type EvaluatedOpportunityWithActors, type EvaluatorEntity, type EvaluatorInput } from './opportunity.evaluator.js';
 import type { OpportunityGraphDatabase } from '../shared/interfaces/database.interface.js';
 import { IntentIndexer } from '../intent/intent.indexer.js';
 import { getModelName } from '../shared/agent/model.config.js';
@@ -59,21 +44,12 @@ export type OpportunityEvaluatorLike = {
   }>>;
 };
 import type { Embedder, LensEmbedding } from '../shared/interfaces/embedder.interface.js';
-import type {
-  CreateOpportunityData,
-  Opportunity,
-  OpportunityActor,
-  ActiveIntent,
-} from '../shared/interfaces/database.interface.js';
+import type { CreateOpportunityData, Opportunity, OpportunityActor, ActiveIntent } from '../shared/interfaces/database.interface.js';
 import { persistOpportunities } from './opportunity.persist.js';
 import { INTRODUCER_DISCOVERY_SOURCE } from './opportunity.introducer.js';
 import { negotiateCandidates, type NegotiationCandidate, type OnNegotiationResolved } from "../negotiation/negotiation.graph.js";
 import { AMBIENT_PARK_WINDOW_MS } from "../negotiation/negotiation.tools.js";
-import {
-  buildDiscoverySummary,
-  toDiscoveryNegotiation,
-  type NegotiationResolution,
-} from "./negotiation-summary.builder.js";
+import { buildDiscoverySummary, toDiscoveryNegotiation, type NegotiationResolution } from "./negotiation-summary.builder.js";
 import type { NegotiationGraphLike } from "../negotiation/negotiation.state.js";
 import type { AgentDispatcher } from "../shared/interfaces/agent-dispatcher.interface.js";
 import { protocolLogger, withCallLogging } from '../shared/observability/protocol.logger.js';
@@ -81,11 +57,7 @@ import { timed } from '../shared/observability/performance.js';
 import { renderNetworkContext } from '../shared/network/metadata.renderer.js';
 import { requestContext } from "../shared/observability/request-context.js";
 import type { OpportunityEvidence } from '../shared/schemas/network-assignment.schema.js';
-import {
-  mergeOpportunityEvidence,
-  withCandidateEvidence,
-  withMatchedStrategies,
-} from './opportunity.evidence.js';
+import { mergeOpportunityEvidence, withCandidateEvidence, withMatchedStrategies } from './opportunity.evidence.js';
 
 const logger = protocolLogger('OpportunityGraph');
 
@@ -436,7 +408,7 @@ export class OpportunityGraphFactory {
           });
 
           // ── Populate index relevancy scores for dedup tie-breaking ──
-          let indexRelevancyScores: Record<string, number> = {};
+          const indexRelevancyScores: Record<string, number> = {};
 
           if (state.triggerIntentId) {
             // Background path: look up persisted scores from intent_indexes

--- a/packages/protocol/src/opportunity/opportunity.persist.ts
+++ b/packages/protocol/src/opportunity/opportunity.persist.ts
@@ -3,11 +3,7 @@
  * Used by the opportunity graph persist node and by the manual opportunity service for consistency.
  */
 
-import type {
-  CreateOpportunityData,
-  Opportunity,
-  OpportunityStatus,
-} from '../shared/interfaces/database.interface.js';
+import type { CreateOpportunityData, Opportunity, OpportunityStatus } from '../shared/interfaces/database.interface.js';
 import type { Embedder } from '../shared/interfaces/embedder.interface.js';
 import type { EnricherDatabase } from './opportunity.enricher.js';
 import { enrichOrCreate } from './opportunity.enricher.js';

--- a/packages/protocol/src/opportunity/question.generator.ts
+++ b/packages/protocol/src/opportunity/question.generator.ts
@@ -16,22 +16,12 @@
 import type { ChatOpenAI } from "@langchain/openai";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 
-import {
-  QuestionGeneratorResponseSchema,
-  type Question,
-  type QuestionGenerationResult,
-  type QuestionStrategy,
-  type QuestionWithStrategy,
-} from "../shared/schemas/question.schema.js";
+import { QuestionGeneratorResponseSchema, type Question, type QuestionGenerationResult, type QuestionStrategy, type QuestionWithStrategy } from "../shared/schemas/question.schema.js";
 import { createModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { Timed } from "../shared/observability/performance.js";
-import {
-  SYSTEM_PROMPT,
-  buildQuestionPrompt,
-  type DiscoveryQuestionInput,
-} from "./question.prompt.js";
+import { SYSTEM_PROMPT, buildQuestionPrompt, type DiscoveryQuestionInput } from "./question.prompt.js";
 
 const logger = protocolLogger("QuestionGenerator");
 

--- a/packages/protocol/src/opportunity/tests/feed.graph.status-filter.spec.ts
+++ b/packages/protocol/src/opportunity/tests/feed.graph.status-filter.spec.ts
@@ -5,16 +5,8 @@ import { config } from 'dotenv';
 config({ path: '.env.test', override: true });
 
 import { describe, test, expect } from 'bun:test';
-import {
-  HomeGraphFactory,
-  DEFAULT_HOME_STATUSES,
-  ALL_OPPORTUNITY_STATUSES,
-} from '../feed/feed.graph.js';
-import type {
-  HomeGraphDatabase,
-  Opportunity,
-  OpportunityStatus,
-} from '../../shared/interfaces/database.interface.js';
+import { HomeGraphFactory, DEFAULT_HOME_STATUSES, ALL_OPPORTUNITY_STATUSES } from '../feed/feed.graph.js';
+import type { HomeGraphDatabase, Opportunity, OpportunityStatus } from '../../shared/interfaces/database.interface.js';
 import type { OpportunityCache } from '../../shared/interfaces/cache.interface.js';
 
 function createMockCache(): OpportunityCache {

--- a/packages/protocol/src/opportunity/tests/introducer-gating-lifecycle.spec.ts
+++ b/packages/protocol/src/opportunity/tests/introducer-gating-lifecycle.spec.ts
@@ -4,11 +4,7 @@ config({ path: '.env.test', override: true });
 import { describe, test, expect } from 'bun:test';
 import { OpportunityGraphFactory } from '../opportunity.graph.js';
 import type { Id } from '../../types/common.types.js';
-import type {
-  OpportunityGraphDatabase,
-  OpportunityActor,
-  Opportunity,
-} from '../../shared/interfaces/database.interface.js';
+import type { OpportunityGraphDatabase, OpportunityActor, Opportunity } from '../../shared/interfaces/database.interface.js';
 import type { Embedder } from '../../shared/interfaces/embedder.interface.js';
 import type { OpportunityEvaluatorLike } from '../opportunity.graph.js';
 

--- a/packages/protocol/src/opportunity/tests/negotiation-context.loader.spec.ts
+++ b/packages/protocol/src/opportunity/tests/negotiation-context.loader.spec.ts
@@ -3,10 +3,7 @@ config({ path: ".env.test", override: true });
 
 import { describe, expect, it } from "bun:test";
 
-import {
-  loadNegotiationContext,
-  type NegotiationContextDatabase,
-} from "../negotiation-context.loader.js";
+import { loadNegotiationContext, type NegotiationContextDatabase } from "../negotiation-context.loader.js";
 import type { NegotiationOutcome } from "../../negotiation/negotiation.state.js";
 
 const OPPORTUNITY_ID = "opp-123";

--- a/packages/protocol/src/opportunity/tests/negotiation-summary.builder.spec.ts
+++ b/packages/protocol/src/opportunity/tests/negotiation-summary.builder.spec.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import {
-  toDiscoveryNegotiation,
-  buildDiscoverySummary,
-  type NegotiationResolution,
-} from "../negotiation-summary.builder.js";
+import { toDiscoveryNegotiation, buildDiscoverySummary, type NegotiationResolution } from "../negotiation-summary.builder.js";
 
 const baseResolution: NegotiationResolution = {
   candidateUserId: "cand-1",

--- a/packages/protocol/src/opportunity/tests/opportunity.evidence.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.evidence.spec.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 
-import {
-  buildCandidateEvidence,
-  mergeOpportunityEvidence,
-  renderOpportunityEvidenceForPrompt,
-  withMatchedStrategies,
-} from '../opportunity.evidence.js';
+import { buildCandidateEvidence, mergeOpportunityEvidence, renderOpportunityEvidenceForPrompt, withMatchedStrategies } from '../opportunity.evidence.js';
 
 describe('opportunity.evidence', () => {
   it('builds premise-similarity evidence', () => {

--- a/packages/protocol/src/opportunity/tests/opportunity.graph.dedup.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.graph.dedup.spec.ts
@@ -17,10 +17,7 @@ import { describe, test, expect } from 'bun:test';
 import { OpportunityGraphFactory } from '../opportunity.graph.js';
 import type { OpportunityEvaluatorLike } from '../opportunity.graph.js';
 import type { Id } from '../../types/common.types.js';
-import type {
-  OpportunityGraphDatabase,
-  Opportunity,
-} from '../../shared/interfaces/database.interface.js';
+import type { OpportunityGraphDatabase, Opportunity } from '../../shared/interfaces/database.interface.js';
 import type { Embedder } from '../../shared/interfaces/embedder.interface.js';
 
 // ---------------------------------------------------------------------------

--- a/packages/protocol/src/opportunity/tests/opportunity.graph.negotiate-timeout.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.graph.negotiate-timeout.spec.ts
@@ -8,10 +8,7 @@ process.env.OPENROUTER_API_KEY ??= 'test';
 import { describe, test, expect } from 'bun:test';
 import { OpportunityGraphFactory } from '../opportunity.graph.js';
 import type { Id } from '../../types/common.types.js';
-import type {
-  OpportunityGraphDatabase,
-  OpportunityActor,
-} from '../../shared/interfaces/database.interface.js';
+import type { OpportunityGraphDatabase, OpportunityActor } from '../../shared/interfaces/database.interface.js';
 import type { Embedder } from '../../shared/interfaces/embedder.interface.js';
 import type { EvaluatedOpportunityWithActors } from '../opportunity.evaluator.js';
 

--- a/packages/protocol/src/opportunity/tests/opportunity.graph.self-accept-guard.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.graph.self-accept-guard.spec.ts
@@ -5,10 +5,7 @@ process.env.OPENROUTER_API_KEY ??= 'test';
 import { describe, test, expect } from 'bun:test';
 import { OpportunityGraphFactory } from '../opportunity.graph.js';
 import type { Id } from '../../types/common.types.js';
-import type {
-  OpportunityGraphDatabase,
-  Opportunity,
-} from '../../shared/interfaces/database.interface.js';
+import type { OpportunityGraphDatabase, Opportunity } from '../../shared/interfaces/database.interface.js';
 import type { Embedder } from '../../shared/interfaces/embedder.interface.js';
 import type { OpportunityEvaluatorLike } from '../opportunity.graph.js';
 

--- a/packages/protocol/src/opportunity/tests/opportunity.graph.send-actedAt.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.graph.send-actedAt.spec.ts
@@ -5,10 +5,7 @@ process.env.OPENROUTER_API_KEY ??= 'test';
 import { describe, test, expect } from 'bun:test';
 import { OpportunityGraphFactory } from '../opportunity.graph.js';
 import type { Id } from '../../shared/interfaces/database.interface.js';
-import type {
-  OpportunityGraphDatabase,
-  Opportunity,
-} from '../../shared/interfaces/database.interface.js';
+import type { OpportunityGraphDatabase, Opportunity } from '../../shared/interfaces/database.interface.js';
 import type { Embedder } from '../../shared/interfaces/embedder.interface.js';
 import type { OpportunityEvaluatorLike } from '../opportunity.graph.js';
 

--- a/packages/protocol/src/opportunity/tests/opportunity.graph.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.graph.spec.ts
@@ -10,11 +10,7 @@ config({ path: '.env.test', override: true });
 import { afterAll, beforeAll, describe, test, it, expect, mock, spyOn } from 'bun:test';
 import { OpportunityGraphFactory, type OpportunityEvaluatorLike, buildDiscovererContext } from '../opportunity.graph.js';
 import type { Id } from '../../types/common.types.js';
-import type {
-  OpportunityGraphDatabase,
-  OpportunityActor,
-  Opportunity,
-} from '../../shared/interfaces/database.interface.js';
+import type { OpportunityGraphDatabase, OpportunityActor, Opportunity } from '../../shared/interfaces/database.interface.js';
 import type { Embedder } from '../../shared/interfaces/embedder.interface.js';
 import type { SourceProfileData } from '../opportunity.state.js';
 import { OpportunityEvaluator, type EvaluatorInput, type EvaluatorEntity } from '../opportunity.evaluator.js';

--- a/packages/protocol/src/opportunity/tests/opportunity.graph.update.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.graph.update.spec.ts
@@ -4,10 +4,7 @@ config({ path: '.env.test', override: true });
 import { describe, test, expect } from 'bun:test';
 import { OpportunityGraphFactory } from '../opportunity.graph.js';
 import type { Id } from '../../types/common.types.js';
-import type {
-  OpportunityGraphDatabase,
-  Opportunity,
-} from '../../shared/interfaces/database.interface.js';
+import type { OpportunityGraphDatabase, Opportunity } from '../../shared/interfaces/database.interface.js';
 import type { Embedder } from '../../shared/interfaces/embedder.interface.js';
 import type { OpportunityEvaluatorLike } from '../opportunity.graph.js';
 

--- a/packages/protocol/src/opportunity/tests/opportunity.labels.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.labels.spec.ts
@@ -3,13 +3,7 @@ import { config } from "dotenv";
 config({ path: '.env.test', override: true });
 
 import { describe, it, expect } from "bun:test";
-import {
-  MINIMAL_MAIN_TEXT_MAX_CHARS,
-  PRIMARY_ACTION_LABEL_INTRODUCER,
-  PRIMARY_ACTION_LABEL_DEFAULT,
-  SECONDARY_ACTION_LABEL,
-  getPrimaryActionLabel,
-} from "../opportunity.labels.js";
+import { MINIMAL_MAIN_TEXT_MAX_CHARS, PRIMARY_ACTION_LABEL_INTRODUCER, PRIMARY_ACTION_LABEL_DEFAULT, SECONDARY_ACTION_LABEL, getPrimaryActionLabel } from "../opportunity.labels.js";
 
 describe('opportunity.constants', () => {
   it('MINIMAL_MAIN_TEXT_MAX_CHARS is a positive number', () => {

--- a/packages/protocol/src/opportunity/tests/opportunity.presenter.negotiation.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.presenter.negotiation.spec.ts
@@ -4,10 +4,7 @@ config({ path: ".env.test", override: true });
 import { describe, expect, it, mock } from "bun:test";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 
-import {
-  OpportunityPresenter,
-  type HomeCardPresenterInput,
-} from "../opportunity.presenter.js";
+import { OpportunityPresenter, type HomeCardPresenterInput } from "../opportunity.presenter.js";
 import type { NegotiationContext } from "../negotiation-context.loader.js";
 
 type PresenterWithInvokeOverride = {

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.coalesce.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.coalesce.spec.ts
@@ -6,10 +6,7 @@ import { describe, test, expect } from 'bun:test';
 
 import { createOpportunityTools } from '../opportunity.tools.js';
 import type { ToolDeps, ResolvedToolContext } from '../../shared/agent/tool.helpers.js';
-import type {
-  CreateDiscoveryRunInput,
-  DiscoveryRunRecord,
-} from '../../shared/interfaces/discovery-run.interface.js';
+import type { CreateDiscoveryRunInput, DiscoveryRunRecord } from '../../shared/interfaces/discovery-run.interface.js';
 
 function parseToolResult(raw: string) {
   return JSON.parse(raw) as {

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.digest-dedup.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.digest-dedup.spec.ts
@@ -10,7 +10,7 @@ import type { PresenterDatabase } from '../opportunity.presenter.js';
 
 // ─── Presenter test doubles injected via ToolDeps (no cross-file module mocks) ───
 
-let presentHomeCardMock = mock(async () => ({
+const presentHomeCardMock = mock(async () => ({
   headline: 'Test Headline',
   personalizedSummary: 'Test personalized summary.',
   digestSummary: 'A relevant person for your current signals.',
@@ -19,7 +19,7 @@ let presentHomeCardMock = mock(async () => ({
   mutualIntentsLabel: undefined,
   greeting: '',
 }));
-let gatherPresenterContextMock = mock(async (
+const gatherPresenterContextMock = mock(async (
   _presenterDb: PresenterDatabase,
   opp: { status: string },
   _viewerId: string,
@@ -28,12 +28,7 @@ let gatherPresenterContextMock = mock(async (
 }));
 
 import type { ToolDeps, DefineTool } from '../../shared/agent/tool.helpers.js';
-import type {
-  ChatGraphCompositeDatabase,
-  Opportunity,
-  UserRecord,
-  ProfileRow,
-} from '../../shared/interfaces/database.interface.js';
+import type { ChatGraphCompositeDatabase, Opportunity, UserRecord, ProfileRow } from '../../shared/interfaces/database.interface.js';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts
@@ -18,7 +18,7 @@ let presentHomeCardMock = mock(async () => ({
   mutualIntentsLabel: undefined,
   greeting: '',
 }));
-let gatherPresenterContextMock = mock(async (
+const gatherPresenterContextMock = mock(async (
   _presenterDb: PresenterDatabase,
   opp: { status: string },
   _viewerId: string,
@@ -27,12 +27,7 @@ let gatherPresenterContextMock = mock(async (
 }));
 
 import type { ToolDeps, DefineTool } from '../../shared/agent/tool.helpers.js';
-import type {
-  ChatGraphCompositeDatabase,
-  Opportunity,
-  UserRecord,
-  ProfileRow,
-} from '../../shared/interfaces/database.interface.js';
+import type { ChatGraphCompositeDatabase, Opportunity, UserRecord, ProfileRow } from '../../shared/interfaces/database.interface.js';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/packages/protocol/src/opportunity/tests/opportunity.utils.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.utils.spec.ts
@@ -3,12 +3,7 @@ import { config } from "dotenv";
 config({ path: '.env.test', override: true });
 
 import { describe, test, expect, it } from 'bun:test';
-import {
-  deriveRolesFromCorpus,
-  canUserSeeOpportunity,
-  isActionableForViewer,
-  validateOpportunityActors,
-} from '../opportunity.utils.js';
+import { deriveRolesFromCorpus, canUserSeeOpportunity, isActionableForViewer, validateOpportunityActors } from '../opportunity.utils.js';
 
 describe('opportunity.utils', () => {
   describe('deriveRolesFromCorpus', () => {
@@ -419,10 +414,7 @@ describe('opportunity.utils', () => {
 
 // ─── Introducer-related utility tests ────────────────────────────────────────
 
-import {
-  selectByComposition,
-  classifyOpportunity,
-} from '../opportunity.utils.js';
+import { selectByComposition, classifyOpportunity } from '../opportunity.utils.js';
 
 type TestOpp = {
   id: string;

--- a/packages/protocol/src/opportunity/tests/question.prompt.spec.ts
+++ b/packages/protocol/src/opportunity/tests/question.prompt.spec.ts
@@ -1,10 +1,6 @@
 import { describe, it, expect } from "bun:test";
 
-import {
-  SYSTEM_PROMPT,
-  buildQuestionPrompt,
-  type DiscoveryQuestionInput,
-} from "../question.prompt.js";
+import { SYSTEM_PROMPT, buildQuestionPrompt, type DiscoveryQuestionInput } from "../question.prompt.js";
 import type { DiscoveryNegotiationDigest } from "../../shared/schemas/negotiation-digest.schema.js";
 import type { ChatContextDigest } from "../../shared/schemas/chat-context.schema.js";
 

--- a/packages/protocol/src/premise/premise.graph.ts
+++ b/packages/protocol/src/premise/premise.graph.ts
@@ -4,10 +4,7 @@ import { PremiseGraphState } from "./premise.state.js";
 import { PremiseAnalyzer } from "./premise.analyzer.js";
 import { PremiseIndexer } from "./premise.indexer.js";
 
-import {
-  buildNetworkAssignmentDecision,
-  resolveAssignmentNetworkScope,
-} from "../shared/assignment/network-assignment.policy.js";
+import { buildNetworkAssignmentDecision, resolveAssignmentNetworkScope } from "../shared/assignment/network-assignment.policy.js";
 import { getAbortSignalConfig } from "../shared/agent/model-signal.js";
 import type { PremiseGraphDatabase, PremiseAnalysis } from "../shared/interfaces/database.interface.js";
 import type { Embedder } from "../shared/interfaces/embedder.interface.js";

--- a/packages/protocol/src/premise/tests/premise.graph.spec.ts
+++ b/packages/protocol/src/premise/tests/premise.graph.spec.ts
@@ -4,10 +4,7 @@ config({ path: ".env.test", override: true });
 
 import { describe, it, expect } from "bun:test";
 import { PremiseGraphFactory } from "../premise.graph.js";
-import type {
-  PremiseGraphDatabase,
-  PremiseRecord,
-} from "../../shared/interfaces/database.interface.js";
+import type { PremiseGraphDatabase, PremiseRecord } from "../../shared/interfaces/database.interface.js";
 import type { Embedder } from "../../shared/interfaces/embedder.interface.js";
 
 function createMockDatabase(): PremiseGraphDatabase {

--- a/packages/protocol/src/profile/profile.graph.ts
+++ b/packages/protocol/src/profile/profile.graph.ts
@@ -151,7 +151,7 @@ export class ProfileGraphFactory {
 
           // If we need to scrape, check if we have sufficient user information
           let needsUserInfo = false;
-          let missingUserInfo: string[] = [];
+          const missingUserInfo: string[] = [];
 
           if (willNeedScraping) {
             logger.verbose("Will need scraping - checking user information...");

--- a/packages/protocol/src/questioner/questioner.agent.ts
+++ b/packages/protocol/src/questioner/questioner.agent.ts
@@ -10,13 +10,7 @@
 import type { ChatOpenAI } from "@langchain/openai";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 
-import {
-  QuestionGeneratorResponseSchema,
-  type Question,
-  type QuestionGenerationResult,
-  type QuestionStrategy,
-  type QuestionWithStrategy,
-} from "../shared/schemas/question.schema.js";
+import { QuestionGeneratorResponseSchema, type Question, type QuestionGenerationResult, type QuestionStrategy, type QuestionWithStrategy } from "../shared/schemas/question.schema.js";
 import { createModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";

--- a/packages/protocol/src/questioner/questioner.presets.ts
+++ b/packages/protocol/src/questioner/questioner.presets.ts
@@ -5,10 +5,7 @@
  * until their implementation slices land.
  */
 import type { QuestionMode } from "../shared/schemas/question.schema.js";
-import {
-  SYSTEM_PROMPT as DISCOVERY_SYSTEM_PROMPT,
-  buildQuestionPrompt as buildDiscoveryPrompt,
-} from "../opportunity/question.prompt.js";
+import { SYSTEM_PROMPT as DISCOVERY_SYSTEM_PROMPT, buildQuestionPrompt as buildDiscoveryPrompt } from "../opportunity/question.prompt.js";
 
 import type { IntentContext, NegotiationContext, ProfileContext } from "./questioner.types.js";
 

--- a/packages/protocol/src/shared/agent/response.streamer.ts
+++ b/packages/protocol/src/shared/agent/response.streamer.ts
@@ -1,8 +1,5 @@
 import type { ChatStreamEvent } from "../../chat/chat-streaming.types.js";
-import {
-  createTokenEvent,
-  createErrorEvent,
-} from "../../chat/chat-streaming.types.js";
+import { createTokenEvent, createErrorEvent } from "../../chat/chat-streaming.types.js";
 import { protocolLogger } from "../observability/protocol.logger.js";
 
 const logger = protocolLogger("ResponseStreamer");

--- a/packages/protocol/src/shared/agent/tests/tool.helpers.spec.ts
+++ b/packages/protocol/src/shared/agent/tests/tool.helpers.spec.ts
@@ -4,11 +4,7 @@ config({ path: ".env.test", override: true });
 
 import { describe, expect, test } from "bun:test";
 import type { ChatGraphCompositeDatabase } from "../../interfaces/database.interface.js";
-import {
-  ChatContextAccessError,
-  redactSensitiveFields,
-  resolveChatContext,
-} from "../tool.helpers.js";
+import { ChatContextAccessError, redactSensitiveFields, resolveChatContext } from "../tool.helpers.js";
 
 const userId = "00000000-0000-4000-8000-000000000111";
 const networkId = "00000000-0000-4000-8000-000000000222";

--- a/packages/protocol/src/shared/agent/tests/tool.runtime.spec.ts
+++ b/packages/protocol/src/shared/agent/tests/tool.runtime.spec.ts
@@ -3,12 +3,7 @@ import { describe, expect, test } from "bun:test";
 import { invokeWithAbortSignal } from "../model-signal.js";
 import { requestContext } from "../../observability/request-context.js";
 import type { ResolvedToolContext } from "../tool.helpers.js";
-import {
-  ToolRuntimeError,
-  getToolTimeoutPolicy,
-  invokeToolRuntime,
-  toolRuntimeErrorToResult,
-} from "../tool.runtime.js";
+import { ToolRuntimeError, getToolTimeoutPolicy, invokeToolRuntime, toolRuntimeErrorToResult } from "../tool.runtime.js";
 
 const context = {
   userId: "user-1",

--- a/packages/protocol/src/shared/agent/tool.factory.ts
+++ b/packages/protocol/src/shared/agent/tool.factory.ts
@@ -17,12 +17,7 @@ import { protocolLogger } from "../observability/protocol.logger.js";
 
 import type { QuestionerEnqueueFn } from "../../questioner/questioner.types.js";
 
-import {
-  type ToolContext,
-  type ResolvedToolContext,
-  type ToolDeps,
-  resolveChatContext,
-} from "./tool.helpers.js";
+import { type ToolContext, type ResolvedToolContext, type ToolDeps, resolveChatContext } from "./tool.helpers.js";
 import { error, redactSensitiveFields } from "./tool.helpers.js";
 import { invokeToolRuntime, toolRuntimeErrorToResult } from "./tool.runtime.js";
 import { createProfileTools } from "../../profile/profile.tools.js";

--- a/packages/protocol/src/shared/agent/tool.helpers.ts
+++ b/packages/protocol/src/shared/agent/tool.helpers.ts
@@ -1,14 +1,7 @@
 import { z } from "zod";
 import type { ModelConfig } from "./model.config.js";
 import type { ProfileDocument } from "../schemas/profile.schema.js";
-import type {
-  ChatGraphCompositeDatabase,
-  NetworkMembership,
-  UserRecord,
-  UserDatabase,
-  SystemDatabase,
-  NegotiationGraphDatabase,
-} from "../interfaces/database.interface.js";
+import type { ChatGraphCompositeDatabase, NetworkMembership, UserRecord, UserDatabase, SystemDatabase, NegotiationGraphDatabase } from "../interfaces/database.interface.js";
 import type { Scraper } from "../interfaces/scraper.interface.js";
 import type { Cache, HydeCache } from "../interfaces/cache.interface.js";
 import type { CompiledOpportunityGraph } from "../../opportunity/opportunity.discover.js";

--- a/packages/protocol/src/shared/assignment/network-assignment.policy.ts
+++ b/packages/protocol/src/shared/assignment/network-assignment.policy.ts
@@ -1,11 +1,4 @@
-import type {
-  NetworkAssignmentMetadata,
-  NetworkAssignmentMode,
-  NetworkAssignmentPromptPresence,
-  NetworkAssignmentRawScores,
-  NetworkAssignmentResourceType,
-  NetworkAssignmentScope,
-} from "../schemas/network-assignment.schema.js";
+import type { NetworkAssignmentMetadata, NetworkAssignmentMode, NetworkAssignmentPromptPresence, NetworkAssignmentRawScores, NetworkAssignmentResourceType, NetworkAssignmentScope } from "../schemas/network-assignment.schema.js";
 
 /** Centralized default for unified premise/intent network assignment. */
 export const DEFAULT_NETWORK_ASSIGNMENT_THRESHOLD = 0.7;

--- a/packages/protocol/src/shared/assignment/tests/network-assignment.policy.spec.ts
+++ b/packages/protocol/src/shared/assignment/tests/network-assignment.policy.spec.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import {
-  buildNetworkAssignmentDecision,
-  classifyPromptPresence,
-  DEFAULT_NETWORK_ASSIGNMENT_THRESHOLD,
-  resolveAssignmentNetworkScope,
-} from "../network-assignment.policy.js";
+import { buildNetworkAssignmentDecision, classifyPromptPresence, DEFAULT_NETWORK_ASSIGNMENT_THRESHOLD, resolveAssignmentNetworkScope } from "../network-assignment.policy.js";
 
 
 describe("network-assignment.policy", () => {

--- a/packages/protocol/src/shared/interfaces/questioner.interface.ts
+++ b/packages/protocol/src/shared/interfaces/questioner.interface.ts
@@ -3,14 +3,7 @@
  * the QuestionerAgent. Implementations live in the backend and are injected
  * into ProtocolDeps.
  */
-import type {
-  Question,
-  QuestionMode,
-  QuestionStrategy,
-  QuestionDetection,
-  QuestionActor,
-  QuestionAnswer,
-} from "../schemas/question.schema.js";
+import type { Question, QuestionMode, QuestionStrategy, QuestionDetection, QuestionActor, QuestionAnswer } from "../schemas/question.schema.js";
 
 /** Shape accepted by `persist()` — everything needed to insert a question row. */
 export interface PersistableQuestion {

--- a/packages/protocol/src/shared/interfaces/tests/question-generator.interface.spec.ts
+++ b/packages/protocol/src/shared/interfaces/tests/question-generator.interface.spec.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import type {
-  QuestionGenerationResult,
-  Question,
-  QuestionStrategy,
-} from "../../schemas/question.schema.js";
+import type { QuestionGenerationResult, Question, QuestionStrategy } from "../../schemas/question.schema.js";
 import type { DiscoveryQuestionInput } from "../../../opportunity/question.prompt.js";
 import type { QuestionGeneratorReader } from "../question-generator.interface.js";
 

--- a/packages/protocol/src/shared/interfaces/tests/questioner.interface.spec.ts
+++ b/packages/protocol/src/shared/interfaces/tests/questioner.interface.spec.ts
@@ -3,11 +3,7 @@
  * is importable and that a mock implementation satisfies the contract.
  */
 import { describe, it, expect } from "bun:test";
-import type {
-  QuestionerDatabase,
-  PersistableQuestion,
-  PersistedQuestion,
-} from "../questioner.interface.js";
+import type { QuestionerDatabase, PersistableQuestion, PersistedQuestion } from "../questioner.interface.js";
 import type { QuestionAnswer } from "../../schemas/question.schema.js";
 
 describe("QuestionerDatabase interface", () => {

--- a/packages/protocol/src/shared/observability/tests/debug-meta.sanitizer.spec.ts
+++ b/packages/protocol/src/shared/observability/tests/debug-meta.sanitizer.spec.ts
@@ -2,10 +2,7 @@ import { config } from "dotenv";
 config({ path: ".env.test", override: true });
 
 import { describe, it, expect } from "bun:test";
-import {
-  sanitizeForDebugMeta,
-  SANITIZATION_ERROR_PLACEHOLDER,
-} from "../debug-meta.sanitizer.js";
+import { sanitizeForDebugMeta, SANITIZATION_ERROR_PLACEHOLDER } from "../debug-meta.sanitizer.js";
 
 describe("sanitizeForDebugMeta", () => {
   it("replaces embedding array with placeholder", () => {

--- a/packages/protocol/src/shared/schemas/tests/question.schema.spec.ts
+++ b/packages/protocol/src/shared/schemas/tests/question.schema.spec.ts
@@ -1,16 +1,6 @@
 import { describe, it, expect } from "bun:test";
 
-import {
-  QuestionOptionSchema,
-  QuestionSchema,
-  QuestionStrategySchema,
-  QuestionWithStrategySchema,
-  QuestionGeneratorResponseSchema,
-  QuestionModeSchema,
-  QuestionDetectionSchema,
-  QuestionActorSchema,
-  QuestionAnswerSchema,
-} from "../question.schema.js";
+import { QuestionOptionSchema, QuestionSchema, QuestionStrategySchema, QuestionWithStrategySchema, QuestionGeneratorResponseSchema, QuestionModeSchema, QuestionDetectionSchema, QuestionActorSchema, QuestionAnswerSchema } from "../question.schema.js";
 
 const okOption = { label: "Stay focused", description: "Higher risk but cleaner narrative" };
 

--- a/packages/protocol/src/shared/ui/tests/lucide.icon-catalog.spec.ts
+++ b/packages/protocol/src/shared/ui/tests/lucide.icon-catalog.spec.ts
@@ -3,13 +3,7 @@ import { config } from "dotenv";
 config({ path: '.env.test', override: true });
 
 import { describe, it, expect } from "bun:test";
-import {
-  DEFAULT_HOME_SECTION_ICON,
-  HOME_SECTION_ICON_NAMES,
-  normalizeIconName,
-  resolveHomeSectionIcon,
-  getIconNamesForPrompt,
-} from "../lucide.icon-catalog.js";
+import { DEFAULT_HOME_SECTION_ICON, HOME_SECTION_ICON_NAMES, normalizeIconName, resolveHomeSectionIcon, getIconNamesForPrompt } from "../lucide.icon-catalog.js";
 
 describe('lucide.icon-catalog', () => {
   describe('normalizeIconName', () => {


### PR DESCRIPTION
## Release changelog

Release `2026-06-15-3` — third release of the day. Carries 7 commits from `dev` that landed after the previous release (`release/2026-06-15`, merged via #968).

### Highlights
- **Intent → network orphaning fix**: intents no longer end up silently registered to zero networks. Adds an assignment-only reconcile foundation, join-time backfill at the membership-event seam, surfaces network membership in the UI, and makes personal indexes hold all intents by default.
- **Docs sync**: protocol `README.md` and `src/README.md` brought in line with the current public API and internal architecture.
- **Lint/style**: enforce single-line imports via `eslint-plugin-import-newlines` (repo-wide auto-collapse).
- **Submodule bump**: agentvillage updated to lowercase Telegram handles.

### Changes

**New Features (`feat`)**
- Surface network membership on intents — chips + honest toast (`64fc5170c1`, #971)

**Bug Fixes (`fix`)**
- Join-time network reconcile + assignment-only foundation (`3df8a49a9e`, #970)
- Personal index holds all intents by default; let owners set a prompt (`88ed1b5f39`, #972)

**Documentation (`docs`)**
- Sync protocol `README` with current public API (`35832e21b1`)
- Sync protocol `src/README` with current internal architecture (`c14be2f353`)

**Style (`style`)**
- Enforce single-line imports via `eslint-plugin-import-newlines` (`717241d24f`)

**Chores (`chore`)**
- Bump agentvillage submodule — lowercase Telegram handles (`4061de2ae5`, Edge-City/agentvillage#103)

### Issues and PRs
- #970 — fix(intents): join-time network reconcile + assignment-only foundation (MERGED to dev)
- #971 — feat(intents): surface network membership on intents (MERGED to dev)
- #972 — fix(networks): personal index holds all intents by default (MERGED to dev)
- Linear IND-356 — Intent→network orphan safety-net: reconcile sweep + observability (follow-up structural work; this release ships the foundation, not the full safety-net)
- Edge-City/agentvillage#103 — cross-repo submodule reference (agentvillage)

### Diff summary
```text
 166 files changed, 1434 insertions(+), 1666 deletions(-)
```

### Changed files (selected)
```text
A  .rpiv/artifacts/designs/intent-network-orphaning-fix.md
A  backend/src/cli/backfill-intent-networks.ts
A  backend/src/cli/backfill-personal-index-prompts.ts
A  backend/src/services/tests/network.service.personal-prompt.spec.ts
M  backend/src/queues/intent.queue.ts
M  backend/src/adapters/database.adapter.ts
M  backend/src/adapters/contact.database.adapter.ts
M  backend/src/services/network.service.ts
M  backend/src/main.ts
M  backend/src/controllers/tests/intent.controller.spec.ts
M  frontend/src/components/IntentList.tsx
M  frontend/src/components/settings/SettingsTab.tsx
M  frontend/src/services/intents.ts
M  packages/protocol/README.md
M  packages/protocol/src/README.md
M  packages/protocol/src/index.ts
M  eslint.config.mjs
M  packages/edge-city/agentvillage  (submodule)
... (166 files total; ~140 are single-line-import style auto-fixes)
```

### Verification
- [x] Release branch `release/2026-06-15-3` created from `origin/dev` at `88ed1b5f39`.
- [ ] GitHub checks pass on this PR.
- [ ] Release PR reviewed and approved.
