### PR TITLE
feat(protocol): multi-harness eval suite + plain-language reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ packages/protocol/CLAUDE.md
 packages/protocol/eval/matching/runs/
 packages/protocol/eval/premise/runs/
 packages/protocol/eval/profile/runs/
+packages/protocol/eval/opportunity/runs/

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ packages/protocol/CLAUDE.md
 # ===================
 *.report.md
 packages/protocol/eval/matching/runs/
+packages/protocol/eval/premise/runs/
+packages/protocol/eval/profile/runs/

--- a/packages/protocol/eval/README.md
+++ b/packages/protocol/eval/README.md
@@ -12,13 +12,17 @@ equivalent env) — harnesses call real models.
 
 | Harness    | Script                  | Agent(s) under test                                              |
 | :--------- | :---------------------- | :-------------------------------------------------------------- |
-| `matching` | `bun run eval:matching` | `OpportunityEvaluator.invokeEntityBundle`                        |
-| `premise`  | `bun run eval:premise`  | `PremiseDecomposer.invoke`, `PremiseAnalyzer.invoke`            |
-| `profile`  | `bun run eval:profile`  | `ProfileGenerator.invoke` (incl. the PII-redaction guarantee)   |
+| `matching`    | `bun run eval:matching`    | `OpportunityEvaluator.invokeEntityBundle` (which people get surfaced + scored) |
+| `premise`     | `bun run eval:premise`     | `PremiseDecomposer.invoke`, `PremiseAnalyzer.invoke`                           |
+| `profile`     | `bun run eval:profile`     | `ProfileGenerator.invoke` (incl. the PII-redaction guarantee)                 |
+| `opportunity` | `bun run eval:opportunity` | `OpportunityPresenter.present` (the user-facing card: headline/summary/greeting) |
 
 Each harness has its own README with full flag docs:
 [`matching`](./matching/README.md) · [`premise`](./premise/README.md) ·
-[`profile`](./profile/README.md).
+[`profile`](./profile/README.md) · [`opportunity`](./opportunity/README.md).
+
+`matching` scores *which* people get surfaced; `opportunity` judges the *card a person
+actually reads* once a match exists — complementary surfaces of the same feature.
 
 Common flags (all harnesses): `--runs N`, `--rule R`, `--case ID`, `--tier N`,
 `--list-cases`, `--no-judge`, `--update-baseline`, `--report [path]`, `--html [path]`,
@@ -47,7 +51,8 @@ eval/
 │   └── tests/              # unit tests for the shared lib
 ├── matching/               # matching corpus, scorer, bespoke HTML renderer
 ├── premise/                # premise corpus, scorer, reporter (shared HTML shell)
-└── profile/                # profile corpus, scorer, PII detectors, reporter
+├── profile/                # profile corpus, scorer, PII detectors, reporter
+└── opportunity/            # opportunity-card corpus, scorer, leakage detectors, reporter
 ```
 
 The shared scorecard types are **structural**: they describe only the aggregate fields the

--- a/packages/protocol/eval/README.md
+++ b/packages/protocol/eval/README.md
@@ -1,7 +1,8 @@
 # Protocol Eval Harnesses
 
-Standalone eval harnesses for the protocol's LLM agents. Each harness exercises one agent
-against a curated golden corpus and gives you a scorecard plus regression detection.
+Standalone eval harnesses for the protocol's LLM agents. Each harness exercises one (or a
+small group of related) agent(s) against a curated golden corpus and gives you a scorecard
+plus regression detection.
 
 They run **outside** `bun test` — run them via package scripts, e.g.
 `bun run eval:matching`. Expects `OPENROUTER_API_KEY` in your `.env.test` (or the
@@ -9,123 +10,142 @@ equivalent env) — harnesses call real models.
 
 ## Harnesses
 
-| Harness    | Script             | Agent under test                    |
-| :--------- | :------------------ | :----------------------------------- |
-| `matching` | `bun run eval:matching` | `OpportunityEvaluator.invokeEntityBundle` |
+| Harness    | Script                  | Agent(s) under test                                              |
+| :--------- | :---------------------- | :-------------------------------------------------------------- |
+| `matching` | `bun run eval:matching` | `OpportunityEvaluator.invokeEntityBundle`                        |
+| `premise`  | `bun run eval:premise`  | `PremiseDecomposer.invoke`, `PremiseAnalyzer.invoke`            |
+| `profile`  | `bun run eval:profile`  | `ProfileGenerator.invoke` (incl. the PII-redaction guarantee)   |
 
-### Matching eval
+Each harness has its own README with full flag docs:
+[`matching`](./matching/README.md) · [`premise`](./premise/README.md) ·
+[`profile`](./profile/README.md).
 
-Measures whether the evaluator correctly surfaces / rejects / scores candidates.
-Full docs at [`eval/matching/README.md`](./matching/README.md).
+Common flags (all harnesses): `--runs N`, `--rule R`, `--case ID`, `--tier N`,
+`--list-cases`, `--no-judge`, `--update-baseline`, `--report [path]`, `--html [path]`,
+`--rolling-baseline [days]`, `--alpha P`, `--no-save`. The `premise` harness additionally
+takes `--component decompose|analyze`.
 
-Quick reference:
+## Architecture: shared lib + thin harnesses
 
-```bash
-bun run eval:matching                         # All cases × 3 runs, judge on, diff baseline
-bun run eval:matching -- --runs 5              # More runs, less noise
-bun run eval:matching -- --rule is_a_identity   # One rule only
-bun run eval:matching -- --no-judge             # Skip LLM reasoning checks (free)
-bun run eval:matching -- --update-baseline      # Overwrite the committed baseline
-bun run eval:matching -- --report               # Write full run report (incl. evaluator reasoning)
-bun run eval:matching -- --report out.json      # …to a specific path
-bun run eval:matching -- --html                 # Write standalone HTML scorecard
-bun run eval:matching -- --rolling-baseline     # Compare against recent run reports (7d)
-bun run eval:matching -- --alpha 0.01           # Stricter regression gate
+The harness-agnostic machinery lives in [`eval/shared/`](./shared) and is reused by every
+harness, so a new harness only authors its corpus, scorer, and CLI — never the statistics,
+baseline math, or reporting again.
+
 ```
+eval/
+├── shared/                 # generic, harness-agnostic library
+│   ├── stats.ts            # Wilson CI, binomial + beta-binomial p-values
+│   ├── types.ts            # CaseResultLike / ScorecardLike / RuleResult / Regression
+│   ├── scorecard.ts        # buildScorecard (generic over the case type)
+│   ├── baseline.ts         # read/write/diff baselines, writeRunReport
+│   ├── rolling.ts          # computeRollingBaseline from recent run reports
+│   ├── console.ts          # formatConsole (parameterized title)
+│   ├── runner.ts           # repeatRuns: repeat-with-retry execution loop
+│   ├── html.ts             # renderScorecardShell: standalone HTML document shell
+│   ├── cli.ts              # arg / has / flagValue argv helpers
+│   ├── index.ts            # barrel export — import everything from "../shared/index.js"
+│   └── tests/              # unit tests for the shared lib
+├── matching/               # matching corpus, scorer, bespoke HTML renderer
+├── premise/                # premise corpus, scorer, reporter (shared HTML shell)
+└── profile/                # profile corpus, scorer, PII detectors, reporter
+```
+
+The shared scorecard types are **structural**: they describe only the aggregate fields the
+shared functions read (`caseId`, `rule`, `runs`, `passes`, `passRate`, `flaky`). Each
+harness defines its own richer `CaseResult` (with per-run assertions + agent-output detail)
+that extends `CaseResultLike`, and specializes `Scorecard = ScorecardLike<CaseResult>`. The
+shared layer never reads harness-specific run internals, so harness types stay fully owned
+by the harness while reusing all aggregation, baseline, rolling, console, and HTML code.
 
 ## Anatomy of a harness
 
-Each harness lives in its own subdirectory (`eval/<name>/`) and follows this layout:
+Each harness lives in `eval/<name>/` and follows this layout:
 
 ```
 eval/<name>/
-├── <name>.types.ts       # Shared types used by the corpus, scorer, and reporter
+├── <name>.types.ts       # Harness types; specialize the shared scorecard types
 ├── <name>.cases.ts       # The golden corpus (Tier 1 surgical → Tier N realistic)
-├── <name>.scorer.ts      # Per-run scoring logic + aggregation into a CaseResult
-├── <name>.runner.ts       # Wraps the agent under test, repeats N runs
-├── <name>.reporter.ts    # Scorecard builder, baseline diff, CLI formatting
-├── <name>.eval.ts        # CLI entry point (drives runner → scorer → reporter → exit code)
-├── <name>.personas.ts    # Shared persona pool (optional — Tier-2+ cases benefit from this)
-├── <name>.historical.ts  # Historical-collaboration cases (optional)
+├── <name>.runner.ts      # Wraps the agent(s); calls shared repeatRuns N times
+├── <name>.scorer.ts      # Per-run assertions → CaseResult (deterministic + judged)
+├── <name>.selection.ts   # --rule / --case / --tier (and harness-specific) filters
+├── <name>.reporter.ts    # HTML scorecard via the shared shell (matching uses a bespoke one)
+├── <name>.constants.ts   # Retry budget, etc.
+├── <name>.eval.ts        # CLI entry point (runner → scorer → shared baseline/report → exit)
 ├── baselines/
-│   └── <name>.baseline.json  # Committed baseline scorecard (stripped of per-candidate reasoning)
-├── runs/
-│   └── *.json                 # gitignored — full run reports incl. evaluator reasoning
-├── tsconfig.json               # Extends ../../tsconfig.json, includes eval + src
-└── tests/
-    └── *.spec.ts               # Unit tests for scorer, runner, reporter, cases
+│   └── <name>.baseline.json  # Committed baseline (per-run detail stripped)
+├── runs/                      # gitignored — full run reports incl. agent output/reasoning
+├── tsconfig.json              # Extends ../../tsconfig.json, includes eval + src
+└── tests/                     # Unit tests (no live agents)
 ```
 
 ## Adding a new harness
 
-1. **Create the directory** following the layout above. Copy `matching/tsconfig.json`
-   and adjust its paths.
+1. **Create the directory** and copy `premise/tsconfig.json` (paths are generic).
 
-2. **Define your types** in `<name>.types.ts`. At minimum you'll need a case type and
-   a scorecard aggregate type.
+2. **Define your types** in `<name>.types.ts`: import `CaseResultLike`, `RuleResult`,
+   `ScorecardLike` from `../shared/index.js`; declare your `Rule` union and a `CaseResult
+   extends CaseResultLike`; alias `Scorecard = ScorecardLike<CaseResult>`. Add a per-run
+   `detail` type for agent output you want in run reports.
 
-3. **Build a corpus** in `<name>.cases.ts`. Start with a few Tier-1 surgical cases
-   (single expectation, binary pass/fail), then add Tier-2 realistic scenarios. If you
-   need shared synthetic personas, put them in `<name>.personas.ts`.
+3. **Build a corpus** in `<name>.cases.ts`. Start with a few Tier-1 surgical cases (single
+   expectation, deterministic pass/fail), then add realistic ones.
 
-4. **Wire the agent** via a minimal `RunnerLike` interface in `<name>.runner.ts`.
-   The runner calls the agent N times and collects its outputs.
+4. **Wire the agent(s)** in `<name>.runner.ts` via a minimal `*Like` interface, and call
+   `repeatRuns(invoke, runs, { label })` from the shared lib.
 
-5. **Score each run** in `<name>.scorer.ts`. The scorer compares agent output to
-   expectations (match/surfacing threshold, band, role, LLM-checked reasoning) and returns per-run
-   assertions. Aggregate multiple runs into a `CaseResult` with pass-rate.
+5. **Score each run** in `<name>.scorer.ts`. Prefer deterministic checks; route fuzzy
+   expectations through an injected `Judge` (the CLI passes `assertLLM`, or a pass-through
+   under `--no-judge`). Aggregate with your own `scoreCase`.
 
-6. **Report results** in `<name>.reporter.ts`. Build a scorecard, diff against the
-   committed or rolling baseline with the posterior-predictive regression test, and format
-   console/HTML output. Prefer domain/rule/tier/component breakdowns for interpretable failures.
+6. **Report** in `<name>.reporter.ts` using `renderScorecardShell` from the shared lib —
+   supply a title, an intro, summary sections (e.g. `renderRuleTable(sc)`), and your
+   case-card HTML.
 
-7. **Write the CLI entry point** in `<name>.eval.ts`. Parse --runs, --rule, --no-judge,
-   --update-baseline, --report, --html, and optional rolling-baseline flags from
-   process.argv. Drive the flow: cases → runner → scorer → baseline → console + optional
-   report.
+7. **Write the CLI** in `<name>.eval.ts`, importing `buildScorecard`, `diffBaseline`,
+   `readBaseline`, `writeBaseline`, `writeRunReport`, `computeRollingBaseline`,
+   `formatConsole`, and `arg`/`has`/`flagValue` from `../shared/index.js`. Pass a
+   `leanCase` to `writeBaseline` that strips your per-run `detail`.
 
-8. **Add a package.json script** in the protocol root:
+8. **Add a package.json script**:
    ```json
-   "eval:<name>": "bun run eval/<name>/<name>.eval.ts"
+   "eval:<name>": "bun --env-file=.env.test ./eval/<name>/<name>.eval.ts"
    ```
+   and gitignore `packages/protocol/eval/<name>/runs/`.
 
-9. **Write tests** in `eval/<name>/tests/`. Cover at minimum: case corpus invariants,
-   scorer correctness, and reporter/baseline round-trips.
+9. **Write tests** in `eval/<name>/tests/`: corpus invariants, scorer correctness,
+   selection. These do NOT invoke live agents.
 
 10. **Commit the baseline** after a stable run:
     ```bash
     bun run eval:<name> -- --runs 7 --update-baseline
     git add eval/<name>/baselines/
     ```
-    The committed baseline omits per-candidate `reasoning` to keep diffs lean.
 
 ## Testing the evals themselves
 
-Each harness has unit tests in its `tests/` subdirectory. Run with:
-
 ```bash
-bun test eval/<name>/tests/
+bun test eval/shared/tests/      # the shared lib
+bun test eval/matching/tests/    # a harness
+bun test eval/premise/tests/ eval/profile/tests/
 ```
 
-These are standard `bun test` specs — they do NOT invoke live agents; they validate that
-types, scoring logic, runner wiring, reporter math, and baseline handling are correct.
+These are standard `bun test` specs — they do NOT invoke live agents; they validate types,
+scoring logic, runner wiring, reporter math, and baseline handling.
 
 ## Baseline contract
 
-- **Committed baseline** (`baselines/<name>.baseline.json`): the scorecard with
-  `reasoning` fields stripped. Kept lean so diffs are meaningful. Updated with
-  `--update-baseline` after intentional eval changes.
+- **Committed baseline** (`baselines/<name>.baseline.json`): the scorecard with per-run
+  `detail` stripped (via the harness's `leanCase`). Kept lean so diffs are meaningful.
+  Updated with `--update-baseline` after intentional eval changes.
 
-- **Run report** (`runs/<timestamp>.json`): the full scorecard with evaluator reasoning
-  verbatim, written by full-corpus runs and on demand with `--report`. gitignored — for
-  human review and rolling-baseline computation, not diffing.
+- **Run report** (`runs/<timestamp>.json`): the full scorecard with agent output/reasoning
+  verbatim, written by full-corpus runs and on demand with `--report`. gitignored.
 
 - **Rolling baseline** (`--rolling-baseline [days]`): a synthetic baseline computed from
-  recent JSON reports in `runs/`. Useful for drift detection relative to current model
-  behavior. Default window is 7 days.
+  recent JSON reports in `runs/`. Default window is 7 days.
 
 - **Regression detection**: run → scorecard → `diffBaseline()` → exit code 1 if any case
-  or rule is significantly below the baseline by one-sided beta-binomial posterior
-  predictive test (default α=0.05). The baseline is treated as finite evidence, not a
-  perfect point estimate, so e.g. 6/7 after a 7/7 baseline is not automatically a hard
-  regression. New cases never count as regressions.
+  or rule is significantly below the baseline by a one-sided beta-binomial
+  posterior-predictive test (default α=0.05). The baseline is treated as finite evidence,
+  not a perfect point estimate, so e.g. 6/7 after a 7/7 baseline is not automatically a
+  hard regression. New cases never count as regressions.

--- a/packages/protocol/eval/matching/matching.reporter.ts
+++ b/packages/protocol/eval/matching/matching.reporter.ts
@@ -1,5 +1,5 @@
-import { binomialCI, buildScorecard, computeRollingBaseline, diffBaseline, formatConsole as sharedFormatConsole, readBaseline as sharedReadBaseline, writeBaseline as sharedWriteBaseline, writeRunReport, binomialPValue, binomialSignificance, predictivePValue, type Regression } from "../shared/index.js";
-import type { CaseResult, Scorecard, MatchingCase, CandidateExpectation, CandidateOutcome, AssertionKind } from "./matching.types.js";
+import { binomialCI, buildScorecard, computeRollingBaseline, diffBaseline, formatConsole as sharedFormatConsole, readBaseline as sharedReadBaseline, writeBaseline as sharedWriteBaseline, writeRunReport, binomialPValue, binomialSignificance, predictivePValue, renderHumanReport, HUMAN_CSS, type HumanReport, type Regression } from "../shared/index.js";
+import type { CaseResult, Scorecard, MatchingCase, CandidateExpectation, CandidateOutcome, AssertionKind, Rule } from "./matching.types.js";
 
 // ── Shared machinery re-exported for matching consumers and tests ────────────
 // The statistics, scorecard aggregation, baseline diff, rolling baseline, and
@@ -304,8 +304,67 @@ function componentRows(sc: Scorecard): string {
  * @param cases - The corpus the run was scored against; joined by id for expectations, names, tier.
  * @returns A complete HTML document string.
  */
+// ─── Plain-language copy for the non-technical report ───────────────────────
+
+/** Ordered themes for "What we tested", each mapped to one matching rule. */
+const HUMAN_GROUPS: { ruleIds: Rule[]; label: string; blurb: string }[] = [
+  { ruleIds: ["is_a_identity"], label: "Telling similar people apart", blurb: "Not confusing an investor with the engineer they funded, or a scout with the athlete they scout." },
+  { ruleIds: ["query_primary"], label: "Matching on what was actually asked", blurb: "Letting the request drive the match, not unrelated background detail." },
+  { ruleIds: ["complementary_role"], label: "Matching people who fit together", blurb: "Pairing people whose needs and offerings complement each other." },
+  { ruleIds: ["same_side"], label: "Not matching people who want the same thing", blurb: "Two people both hiring, or both raising, aren't a match for each other." },
+  { ruleIds: ["valency_role"], label: "Getting who-helps-whom right", blurb: "Assigning the seeker and the provider roles correctly." },
+  { ruleIds: ["location"], label: "Respecting where people are", blurb: "Honoring a location requirement without over-penalizing unknown cities." },
+  { ruleIds: ["score_calibration"], label: "Scoring matches sensibly", blurb: "Strong matches score high, weak ones score low." },
+  { ruleIds: ["already_known"], label: "Skipping people who already know each other", blurb: "Not re-introducing people who are already connected." },
+  { ruleIds: ["event_network"], label: "Using shared events as a signal", blurb: "Recognizing when attending the same event makes two people more relevant." },
+  { ruleIds: ["historical"], label: "Rediscovering real collaborations", blurb: "Surfacing pairs who actually went on to work together, over plausible lookalikes." },
+];
+
+/** Plain-language name for each failing check, used in "what happened" notes. */
+const HUMAN_CHECK_COPY: Record<AssertionKind, string> = {
+  match: "surfaced the wrong person, or hid the right one",
+  band: "scored the match too high or too low",
+  role: "got who-helps-whom backwards",
+  reasoning: "its explanation didn't hold up",
+};
+
+/** Distinct plain-language reasons a case failed, across its runs. */
+function humanFailNote(c: CaseResult): string | undefined {
+  const kinds = new Set<AssertionKind>();
+  for (const rr of c.runResults) for (const a of rr.assertions) if (!a.passed) kinds.add(a.kind);
+  if (kinds.size === 0) return undefined;
+  return [...kinds].map((k) => HUMAN_CHECK_COPY[k]).join("; ") + ".";
+}
+
+/** Build the plain-language report from the scorecard + corpus descriptions. */
+function buildHumanReport(sc: Scorecard, cases: MatchingCase[]): HumanReport {
+  const byId = new Map(cases.map((c) => [c.id, c]));
+  const resultById = new Map(sc.cases.map((c) => [c.caseId, c]));
+  const groups = HUMAN_GROUPS.map((g) => ({
+    label: g.label,
+    blurb: g.blurb,
+    ruleIds: g.ruleIds as string[],
+    cases: sc.cases
+      .filter((c) => g.ruleIds.includes(c.rule))
+      .map((c) => {
+        const result = resultById.get(c.caseId);
+        return {
+          caseId: c.caseId,
+          scenario: byId.get(c.caseId)?.description ?? c.caseId,
+          failNote: result ? humanFailNote(result) : undefined,
+        };
+      }),
+  })).filter((g) => g.cases.length > 0);
+  return {
+    subject: "the matchmaker",
+    oneLiner: "It looks at one person and decides which other people are worth introducing them to — and why.",
+    groups,
+  };
+}
+
 export function renderHtml(sc: Scorecard, regressions: Regression[], cases: MatchingCase[]): string {
   const meta = indexCases(cases);
+  const human = renderHumanReport(sc, regressions, buildHumanReport(sc, cases));
 
   // Per-tier and per-domain aggregates, derived from the corpus join.
   const tierAgg = new Map<number, { count: number; sum: number; passes: number; runs: number }>();
@@ -383,6 +442,7 @@ export function renderHtml(sc: Scorecard, regressions: Regression[], cases: Matc
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Matching eval — ${pctText(sc.aggregatePassRate)} (${esc(sc.model)})</title>
 <style>
+  ${HUMAN_CSS}
   :root{--good:#16a34a;--ok:#d97706;--bad:#dc2626;--bg:#0f172a;--card:#1e293b;--line:#334155;--fg:#e2e8f0;--muted:#94a3b8}
   *{box-sizing:border-box}
   body{margin:0;font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:var(--bg);color:var(--fg)}
@@ -434,6 +494,8 @@ export function renderHtml(sc: Scorecard, regressions: Regression[], cases: Matc
   .ci{font-size:11px;color:var(--muted)}
 </style></head>
 <body><div class="wrap">
+  ${human}
+  <details class="tech"><summary>Technical details (for engineers)</summary>
   <div class="banner">
     <div><div class="score ${agg}">${pctText(sc.aggregatePassRate)}</div><div class="meta">aggregate pass-rate</div><div class="ci">${htmlRateCI(sc.aggregatePassRate, totalPasses, totalObs)}</div></div>
     <div class="meta">
@@ -467,6 +529,7 @@ export function renderHtml(sc: Scorecard, regressions: Regression[], cases: Matc
   </section>
   ${caseSections}
   <p class="meta">Chip color is an at-a-glance indicator (surfaced-ness + band); failed-check details and each case's pass-rate are authoritative. Hover over pass-rates for 95% Wilson confidence intervals.</p>
+  </details>
 </div></body></html>`;
 }
 

--- a/packages/protocol/eval/matching/matching.reporter.ts
+++ b/packages/protocol/eval/matching/matching.reporter.ts
@@ -1,388 +1,47 @@
-import { readdir } from "node:fs/promises";
+import { binomialCI, buildScorecard, computeRollingBaseline, diffBaseline, formatConsole as sharedFormatConsole, readBaseline as sharedReadBaseline, writeBaseline as sharedWriteBaseline, writeRunReport, binomialPValue, binomialSignificance, predictivePValue, type Regression } from "../shared/index.js";
+import type { CaseResult, Scorecard, MatchingCase, CandidateExpectation, CandidateOutcome, AssertionKind } from "./matching.types.js";
 
-import type { CaseResult, RuleResult, Scorecard, Rule, MatchingCase, CandidateExpectation, CandidateOutcome, AssertionKind } from "./matching.types.js";
+// ── Shared machinery re-exported for matching consumers and tests ────────────
+// The statistics, scorecard aggregation, baseline diff, rolling baseline, and
+// run-report writer all live in `eval/shared`. Matching keeps only its bespoke
+// HTML renderer and a candidate-stripping baseline writer below.
+export {
+  binomialCI,
+  binomialPValue,
+  binomialSignificance,
+  predictivePValue,
+  buildScorecard,
+  computeRollingBaseline,
+  diffBaseline,
+  writeRunReport,
+  type Regression,
+};
 
-// ── Statistical helpers ─────────────────────────────────────────────────────
-
-/** Wilson score interval without continuity correction. Returns [lo, hi]. */
-export function binomialCI(passes: number, total: number, z = 1.96): [number, number] {
-  if (total === 0) return [0, 1];
-  const p = passes / total;
-  const denom = 1 + z * z / total;
-  const centre = (p + z * z / (2 * total)) / denom;
-  const margin = (z * Math.sqrt((p * (1 - p) + z * z / (4 * total)) / total)) / denom;
-  return [Math.max(0, centre - margin), Math.min(1, centre + margin)];
+/** Read a committed matching baseline, typed as a matching {@link Scorecard}. */
+export function readBaseline(path: string): Promise<Scorecard | null> {
+  return sharedReadBaseline<Scorecard>(path);
 }
 
-/** ln(n!) computed exactly enough for the small-n exact binomial CDF path. */
-function lnFactorial(n: number): number {
-  let out = 0;
-  for (let i = 2; i <= n; i++) out += Math.log(i);
-  return out;
-}
-
-/** Natural log of binomial coefficient C(n, k). */
-function lnChoose(n: number, k: number): number {
-  return lnFactorial(n) - lnFactorial(k) - lnFactorial(n - k);
-}
-
-function lnBetaInt(a: number, b: number): number {
-  return lnFactorial(a - 1) + lnFactorial(b - 1) - lnFactorial(a + b - 1);
-}
-
-/**
- * One-sided binomial point-null p-value.
- * H₀: true pass-rate = nullRate; Ha: true pass-rate < nullRate (regression).
- */
-export function binomialPValue(observedPasses: number, total: number, nullRate: number): number {
-  if (total === 0) return 1;
-  if (nullRate <= 0) return 1;
-  if (nullRate >= 1) return observedPasses < total ? 0 : 1;
-  let cumulative = 0;
-  for (let k = 0; k <= observedPasses; k++) {
-    const logP = lnChoose(total, k) + k * Math.log(nullRate) + (total - k) * Math.log1p(-nullRate);
-    cumulative += Math.exp(logP);
-  }
-  return Math.min(1, Math.max(0, cumulative));
-}
-
-/**
- * One-sided beta-binomial posterior-predictive p-value.
- *
- * This treats the committed baseline as observed evidence rather than a perfect
- * point estimate. With a uniform Beta(1,1) prior, baseline x/n gives posterior
- * Beta(x+1, n-x+1), and we ask how likely the current pass count or lower is
- * under that posterior predictive distribution. This prevents 7/7 baselines
- * from making a single future miss mathematically impossible.
- */
-export function predictivePValue(
-  observedPasses: number,
-  observedRuns: number,
-  baselinePasses: number,
-  baselineRuns: number,
-): number {
-  if (observedRuns === 0 || baselineRuns === 0) return 1;
-  const a = baselinePasses + 1;
-  const b = baselineRuns - baselinePasses + 1;
-  const base = lnBetaInt(a, b);
-  let cumulative = 0;
-  for (let k = 0; k <= observedPasses; k++) {
-    const logP = lnChoose(observedRuns, k) + lnBetaInt(k + a, observedRuns - k + b) - base;
-    cumulative += Math.exp(logP);
-  }
-  return Math.min(1, Math.max(0, cumulative));
-}
-
-/** True when the posterior-predictive p-value is at or below alpha. */
-export function binomialSignificance(observedPasses: number, total: number, nullRate: number, alpha = 0.05): boolean {
-  return binomialPValue(observedPasses, total, nullRate) <= alpha;
-}
-
-/** Analytical error function (Abramowitz & Stegun 7.1.26). */
-function erf(x: number): number {
-  const sign = x < 0 ? -1 : 1;
-  x = Math.abs(x);
-  const p = 0.3275911;
-  const a1 = 0.254829592;
-  const a2 = -0.284496736;
-  const a3 = 1.421413741;
-  const a4 = -1.453152027;
-  const a5 = 1.061405429;
-  const t = 1 / (1 + p * x);
-  const y = 1 - ((((a5 * t + a4) * t + a3) * t + a2) * t + a1) * t * Math.exp(-x * x);
-  return sign * y;
-}
-
-/** Rate string with 95% confidence — only call this when n ≤ 1 cases (D2NPFN). */
-function rateWithCI(passes: number, total: number): string {
-  const [lo, hi] = binomialCI(passes, total);
-  return `${Math.round((passes / total) * 100)}% (CI₉₅ ${Math.round(lo * 100)}%–${Math.round(hi * 100)}%)`;
-}
-
-const mean = (xs: number[]): number => (xs.length === 0 ? 0 : xs.reduce((a, b) => a + b, 0) / xs.length);
-
-/** Computes the arithmetic mean of case rates within a list of CaseResult entries. */
-export function meanRate(list: CaseResult[]): number {
-  if (list.length === 0) return 0;
-  return list.reduce((s, c) => s + c.passRate, 0) / list.length;
-}
-
-/**
- * Aggregates raw case results into a scorecard with per-rule and aggregate pass-rates.
- *
- * @param results - The individual case results to aggregate.
- * @param meta - Run metadata: the model name and number of runs per case.
- * @returns A scorecard with per-rule breakdowns, aggregate pass-rate, and generation timestamp.
- */
-export function buildScorecard(
-  results: CaseResult[],
-  meta: { model: string; runs: number },
-): Scorecard {
-  const byRule = new Map<Rule, CaseResult[]>();
-  for (const r of results) {
-    const list = byRule.get(r.rule) ?? [];
-    list.push(r);
-    byRule.set(r.rule, list);
-  }
-  const rules: RuleResult[] = [...byRule.entries()].map(([rule, list]) => ({
-    rule,
-    caseCount: list.length,
-    passRate: mean(list.map((c) => c.passRate)),
-  }));
-  return {
-    generatedAt: new Date().toISOString(),
-    model: meta.model,
-    runs: meta.runs,
-    aggregatePassRate: mean(results.map((c) => c.passRate)),
-    rules,
-    cases: results,
-  };
-}
-
-export interface Regression {
-  id: string;
-  kind: "case" | "rule";
-  before: number;
-  after: number;
-  /** One-sided posterior-predictive p-value for observing the current pass count or lower under the baseline evidence. */
-  pValue: number;
-}
-
-/**
- * Compares a current scorecard against a baseline and returns any regressions.
- *
- * A regression is a case or rule where the current pass count is significantly
- * lower than expected from the baseline evidence (one-sided beta-binomial
- * posterior-predictive test at significance level alpha). New cases (absent from
- * baseline) are never regressions.
- *
- * @param current - The scorecard produced by the current run.
- * @param baseline - The previously saved baseline scorecard, or `null` if none exists.
- * @param alpha - Significance level for the one-sided binomial test.
- * @returns An object containing the list of detected regressions.
- */
-export function diffBaseline(
-  current: Scorecard,
-  baseline: Scorecard | null,
-  alpha = 0.05,
-): { regressions: Regression[]; skippedCaseIds: string[] } {
-  if (!baseline) return { regressions: [], skippedCaseIds: [] };
-  const regressions: Regression[] = [];
-  const skippedCaseIds: string[] = [];
-
-  const baseCases = new Map(baseline.cases.map((c) => [c.caseId, c]));
-  for (const c of current.cases) {
-    const base = baseCases.get(c.caseId);
-    if (base === undefined) {
-      skippedCaseIds.push(c.caseId);
-      continue;
-    }
-    const pValue = predictivePValue(c.passes, c.runs, base.passes, base.runs);
-    if (pValue <= alpha) {
-      regressions.push({ id: c.caseId, kind: "case", before: base.passRate, after: c.passRate, pValue });
-    }
-  }
-
-  const baseByRule = new Map<Rule, { passes: number; runs: number }>();
-  for (const c of baseline.cases) {
-    const acc = baseByRule.get(c.rule) ?? { passes: 0, runs: 0 };
-    acc.passes += c.passes;
-    acc.runs += c.runs;
-    baseByRule.set(c.rule, acc);
-  }
-  const comparableByRule = new Map<Rule, { passes: number; runs: number }>();
-  for (const c of current.cases) {
-    if (!baseCases.has(c.caseId)) continue;
-    const acc = comparableByRule.get(c.rule) ?? { passes: 0, runs: 0 };
-    acc.passes += c.passes;
-    acc.runs += c.runs;
-    comparableByRule.set(c.rule, acc);
-  }
-  for (const [rule, acc] of comparableByRule.entries()) {
-    const base = baseByRule.get(rule);
-    if (base === undefined || acc.runs === 0 || base.runs === 0) continue;
-    const before = base.passes / base.runs;
-    const after = acc.passes / acc.runs;
-    const pValue = predictivePValue(acc.passes, acc.runs, base.passes, base.runs);
-    if (pValue <= alpha) {
-      regressions.push({ id: rule, kind: "rule", before, after, pValue });
-    }
-  }
-
-  return { regressions, skippedCaseIds };
-}
-
-const pct = (n: number): string => `${Math.round(n * 100)}%`;
-const fmtPValue = (p: number): string => (p < 0.001 ? "p<0.001" : `p=${p.toFixed(3)}`);
-
-/** Format a pass-rate with 95% confidence for console display. */
-function fmtRate(passes: number, total: number): string {
-  return rateWithCI(passes, total);
-}
-
-/** Human-readable scorecard for the console. */
+/** Console scorecard with the matching-specific title. */
 export function formatConsole(sc: Scorecard, regressions: Regression[], skippedCaseIds: string[] = []): string {
-  const lines: string[] = [];
-  lines.push(`\n=== Matching Quality Scorecard ===`);
-  lines.push(`model=${sc.model}  runs=${sc.runs}  cases=${sc.cases.length}`);
-  // Use per-run observations for the CI while preserving case-level pass-rates for aggregate display.
-  lines.push(`aggregate pass-rate: ${fmtRate(sc.cases.reduce((s, c) => s + c.passes, 0), sc.cases.length * sc.runs)}\n`);
-  lines.push(`Per rule:`);
-  for (const r of [...sc.rules].sort((a, b) => a.passRate - b.passRate)) {
-    const n = r.caseCount * sc.runs;
-    const passes = Math.round(r.passRate * n);
-    lines.push(`  ${r.rule.padEnd(20)} ${fmtRate(passes, n)}  (${r.caseCount} case(s))`);
-  }
-  const flaky = sc.cases.filter((c) => c.flaky);
-  if (flaky.length > 0) {
-    lines.push(`\nFlaky (passed some runs, failed others):`);
-    for (const c of flaky) lines.push(`  ${c.caseId}  ${c.passes}/${c.runs}`);
-  }
-  if (regressions.length > 0) {
-    lines.push(`\n⚠ Regressions vs baseline:`);
-    for (const r of regressions) {
-      lines.push(`  [${r.kind}] ${r.id}: ${pct(r.before)} → ${pct(r.after)} (${fmtPValue(r.pValue)})`);
-    }
-  }
-  if (skippedCaseIds.length > 0) {
-    lines.push(`\nℹ ${skippedCaseIds.length} case(s) absent from baseline; not regression-checked:`);
-    for (const id of skippedCaseIds.slice(0, 10)) lines.push(`  ${id}`);
-    if (skippedCaseIds.length > 10) lines.push(`  …and ${skippedCaseIds.length - 10} more`);
-  }
-  return lines.join("\n");
+  return sharedFormatConsole(sc, regressions, skippedCaseIds, { title: "Matching Quality Scorecard" });
 }
 
 /**
- * Reads a baseline scorecard from a JSON file on disk.
+ * Writes the committed baseline, stripping each run's per-candidate `reasoning`.
+ * The baseline is a diff target, so verbose model reasoning would make every
+ * `--update-baseline` a noisy diff; the full reasoning lives in the run report.
  *
- * @param path - Absolute or relative path to the baseline JSON file.
- * @returns The parsed scorecard, or `null` if the file does not exist.
- */
-export async function readBaseline(path: string): Promise<Scorecard | null> {
-  const file = Bun.file(path);
-  if (!(await file.exists())) return null;
-  return (await file.json()) as Scorecard;
-}
-
-/**
- * Writes a scorecard to disk as a formatted JSON baseline file.
- *
- * Per-candidate `reasoning` is stripped from each run before writing: the baseline
- * is a diff target, and verbose model reasoning would make every `--update-baseline`
- * a noisy diff. The full reasoning lives in the run report instead ({@link writeRunReport}).
- *
- * @param path - Absolute or relative path to write to (created or overwritten).
- * @param sc - The scorecard to persist.
+ * @param path - Absolute or relative path to write to.
+ * @param sc - The scorecard to persist (candidate detail stripped before writing).
  */
 export async function writeBaseline(path: string, sc: Scorecard): Promise<void> {
-  const lean: Scorecard = {
-    ...sc,
-    cases: sc.cases.map((c) => ({
+  await sharedWriteBaseline(path, sc, {
+    leanCase: (c) => ({
       ...c,
       runResults: c.runResults.map(({ candidates: _candidates, ...rest }) => rest),
-    })),
-  };
-  await Bun.write(path, JSON.stringify(lean, null, 2) + "\n");
-}
-
-/**
- * Writes a full run report to disk: the scorecard *including* each run's
- * per-candidate `reasoning`. This is the explanatory artifact a reviewer or the
- * matching-eval report skill reads to see the evaluator's own justification for
- * every score. Written on demand via the `--report` flag; never committed.
- *
- * @param path - Absolute or relative path to write to. Parent dirs are created.
- * @param sc - The scorecard to persist, with candidate reasoning intact.
- */
-export async function writeRunReport(path: string, sc: Scorecard): Promise<void> {
-  await Bun.write(path, JSON.stringify(sc, null, 2) + "\n");
-}
-
-// ─── Rolling baseline ─────────────────────────────────────────────────────
-
-interface RollingCaseAcc {
-  caseId: string;
-  rule: Rule;
-  passes: number;
-  runs: number;
-}
-
-/** Reads all JSON scorecards in a run directory, ignoring malformed files. */
-async function readRunScorecards(runsDir: string): Promise<Scorecard[]> {
-  let entries: string[];
-  try {
-    entries = await readdir(runsDir);
-  } catch {
-    return [];
-  }
-
-  const out: Scorecard[] = [];
-  for (const entry of entries) {
-    if (!entry.endsWith(".json")) continue;
-    try {
-      const file = Bun.file(`${runsDir}/${entry}`);
-      const sc = (await file.json()) as Scorecard;
-      if (sc.generatedAt && Array.isArray(sc.cases)) out.push(sc);
-    } catch {
-      // Run reports are diagnostic artifacts; one malformed file should not
-      // disable baseline computation for every other run.
-    }
-  }
-  return out;
-}
-
-/**
- * Computes a rolling baseline from recent run reports in `runsDir`.
- *
- * The resulting scorecard is synthetic: each case's baseline pass-rate is the
- * pass-weighted average across all recent scorecards containing that case. This
- * means filtered reports can still contribute to the subset of cases they ran,
- * while absent cases simply fall back to no comparison.
- *
- * @param runsDir - Directory containing JSON scorecards written by `writeRunReport`.
- * @param days - Lookback window in days.
- * @param now - Clock injection for tests.
- * @returns A synthetic scorecard, or `null` when no reports fall in the window.
- */
-export async function computeRollingBaseline(
-  runsDir: string,
-  days: number,
-  now = new Date(),
-): Promise<Scorecard | null> {
-  const cutoff = now.getTime() - days * 24 * 60 * 60 * 1000;
-  const scorecards = (await readRunScorecards(runsDir)).filter((sc) => {
-    const t = Date.parse(sc.generatedAt);
-    return Number.isFinite(t) && t >= cutoff && t < now.getTime();
+    }),
   });
-  if (scorecards.length === 0) return null;
-
-  const byCase = new Map<string, RollingCaseAcc>();
-  for (const sc of scorecards) {
-    for (const c of sc.cases) {
-      const acc = byCase.get(c.caseId) ?? { caseId: c.caseId, rule: c.rule, passes: 0, runs: 0 };
-      acc.passes += c.passes;
-      acc.runs += c.runs;
-      byCase.set(c.caseId, acc);
-    }
-  }
-
-  const cases: CaseResult[] = [...byCase.values()].map((acc) => {
-    const passRate = acc.runs === 0 ? 0 : acc.passes / acc.runs;
-    return {
-      caseId: acc.caseId,
-      rule: acc.rule,
-      runs: acc.runs,
-      passes: acc.passes,
-      passRate,
-      flaky: passRate > 0 && passRate < 1,
-      runResults: [],
-    };
-  });
-
-  return {
-    ...buildScorecard(cases, { model: `rolling:${days}d:${scorecards.length}run${scorecards.length === 1 ? "" : "s"}`, runs: 1 }),
-    generatedAt: now.toISOString(),
-  };
 }
 
 // ─── HTML report ──────────────────────────────────────────────────────────
@@ -393,6 +52,9 @@ export async function computeRollingBaseline(
 // corpus. `renderHtml` joins the two by case id so every candidate shows
 // expected-vs-actual side by side, with the evaluator's own reasoning behind a
 // collapsible block. No external assets, no JS: openable straight from disk.
+
+const pctText = (n: number): string => `${Math.round(n * 100)}%`;
+const fmtPValue = (p: number): string => (p < 0.001 ? "p<0.001" : `p=${p.toFixed(3)}`);
 
 /** Pass-rate → quality class used for color-coding (≥90% good, ≥70% ok, else bad). */
 function rateClass(rate: number): "good" | "ok" | "bad" {
@@ -407,8 +69,6 @@ function esc(s: string): string {
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;");
 }
-
-const pctText = (n: number): string => `${Math.round(n * 100)}%`;
 
 /** Pass-rate cell text with 95% CI tooltip for HTML tables. */
 function htmlRateCI(rate: number, passes: number, total: number): string {

--- a/packages/protocol/eval/matching/matching.runner.ts
+++ b/packages/protocol/eval/matching/matching.runner.ts
@@ -1,5 +1,6 @@
 import type { EvaluatorInput, EvaluatedOpportunityWithActors } from "../../src/opportunity/opportunity.evaluator.js";
 
+import { repeatRuns } from "../shared/index.js";
 import { MATCHING_EVAL_MAX_ATTEMPTS, MATCHING_EVAL_RETRY_DELAY_MS, MATCHING_MIN_SCORE } from "./matching.constants.js";
 import type { MatchingCase } from "./matching.types.js";
 
@@ -16,41 +17,17 @@ export interface RunCaseOptions {
   retryDelayMs?: number;
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function describeError(err: unknown): string {
-  if (err instanceof Error) return err.message;
-  return String(err);
-}
-
-async function invokeWithRetry(
-  evaluator: EvaluatorLike,
-  input: EvaluatorInput,
-  options: Required<RunCaseOptions>,
-): Promise<EvaluatedOpportunityWithActors[]> {
-  let lastError: unknown;
-  for (let attempt = 1; attempt <= options.maxAttempts; attempt++) {
-    try {
-      return await evaluator.invokeEntityBundle(input, { minScore: MATCHING_MIN_SCORE, returnAll: true });
-    } catch (err) {
-      lastError = err;
-      if (attempt >= options.maxAttempts) break;
-      const delay = options.retryDelayMs * 2 ** (attempt - 1);
-      console.warn(
-        `[matching eval] evaluator call failed (attempt ${attempt}/${options.maxAttempts}); retrying in ${delay}ms: ${describeError(err)}`,
-      );
-      await sleep(delay);
-    }
-  }
-  throw lastError;
-}
-
 /**
  * Run a case `runs` times. Uses MATCHING_MIN_SCORE + returnAll so reject bands
  * and sub-threshold diagnostic scores are visible to the scorer rather than filtered out.
- * Retries transient live-model/API failures so long full-corpus runs are less brittle.
+ * Transient live-model/API failures are retried (shared {@link repeatRuns}) so long
+ * full-corpus runs are less brittle.
+ *
+ * @param evaluator - The opportunity evaluator under test.
+ * @param c - The case whose `input` is evaluated each run.
+ * @param runs - Number of repetitions.
+ * @param options - Retry tuning (defaults from matching constants).
+ * @returns One opportunity list per run.
  */
 export async function runCase(
   evaluator: EvaluatorLike,
@@ -58,13 +35,13 @@ export async function runCase(
   runs: number,
   options: RunCaseOptions = {},
 ): Promise<EvaluatedOpportunityWithActors[][]> {
-  const retryOptions: Required<RunCaseOptions> = {
-    maxAttempts: options.maxAttempts ?? MATCHING_EVAL_MAX_ATTEMPTS,
-    retryDelayMs: options.retryDelayMs ?? MATCHING_EVAL_RETRY_DELAY_MS,
-  };
-  const outputs: EvaluatedOpportunityWithActors[][] = [];
-  for (let i = 0; i < runs; i++) {
-    outputs.push(await invokeWithRetry(evaluator, c.input, retryOptions));
-  }
-  return outputs;
+  return repeatRuns(
+    () => evaluator.invokeEntityBundle(c.input, { minScore: MATCHING_MIN_SCORE, returnAll: true }),
+    runs,
+    {
+      maxAttempts: options.maxAttempts ?? MATCHING_EVAL_MAX_ATTEMPTS,
+      retryDelayMs: options.retryDelayMs ?? MATCHING_EVAL_RETRY_DELAY_MS,
+      label: "matching eval",
+    },
+  );
 }

--- a/packages/protocol/eval/matching/matching.types.ts
+++ b/packages/protocol/eval/matching/matching.types.ts
@@ -1,4 +1,5 @@
 import type { EvaluatorInput } from "../../src/opportunity/opportunity.evaluator.js";
+import type { CaseResultLike, RuleResult as SharedRuleResult, ScorecardLike } from "../shared/index.js";
 
 /** Each rule maps to a distinct evaluator behaviour the corpus exercises. */
 export type Rule =
@@ -86,28 +87,18 @@ export interface RunResult {
   candidates?: CandidateOutcome[];
 }
 
-export interface CaseResult {
-  caseId: string;
+/**
+ * Matching case result: the shared aggregate shape narrowed to matching's `Rule`
+ * union and carrying matching's per-run {@link RunResult} detail (candidate
+ * outcomes + reasoning).
+ */
+export interface CaseResult extends CaseResultLike {
   rule: Rule;
-  runs: number;
-  passes: number;
-  passRate: number;
-  /** True when the case passed some runs and failed others. */
-  flaky: boolean;
   runResults: RunResult[];
 }
 
-export interface RuleResult {
-  rule: Rule;
-  caseCount: number;
-  passRate: number;
-}
+/** Per-rule rollup. Aliased from the shared type (rule stored as a string label). */
+export type RuleResult = SharedRuleResult;
 
-export interface Scorecard {
-  generatedAt: string;
-  model: string;
-  runs: number;
-  aggregatePassRate: number;
-  rules: RuleResult[];
-  cases: CaseResult[];
-}
+/** Matching scorecard: the shared scorecard specialized to matching {@link CaseResult}s. */
+export type Scorecard = ScorecardLike<CaseResult>;

--- a/packages/protocol/eval/opportunity/README.md
+++ b/packages/protocol/eval/opportunity/README.md
@@ -1,0 +1,67 @@
+# Opportunity-Card Quality Eval Harness
+
+Measures whether `OpportunityPresenter.present` writes good **user-facing cards** — the
+headline, the "why this matters to you" summary, a suggested next step, and a ready-to-send
+intro greeting. This is distinct from the `matching` eval, which scores *which* people get
+surfaced; this one judges the *card a person actually reads*. Standalone and opt-in — NOT
+part of `bun test`.
+
+## Run
+
+```bash
+# from packages/protocol
+bun run eval:opportunity                          # all cases, 3 runs, judge on, diff baseline
+bun run eval:opportunity -- --runs 5              # more runs = less noise
+bun run eval:opportunity -- --rule no_leakage      # one rule
+bun run eval:opportunity -- --case greeting/        # one case or id prefix
+bun run eval:opportunity -- --tier 1               # one tier
+bun run eval:opportunity -- --list-cases           # print selected cases and exit
+bun run eval:opportunity -- --no-judge             # skip LLM grounding/framing/tone checks (free)
+bun run eval:opportunity -- --update-baseline      # overwrite the committed baseline
+bun run eval:opportunity -- --report [path]        # write a full run report incl. generated cards
+bun run eval:opportunity -- --html [path]          # write a standalone HTML scorecard
+bun run eval:opportunity -- --rolling-baseline [d] # compare against trailing run average (default 7d)
+bun run eval:opportunity -- --alpha 0.01           # stricter regression significance threshold
+bun run eval:opportunity -- --no-save              # do not auto-save full-corpus run JSON
+```
+
+Requires `OPENROUTER_API_KEY` (loaded via `.env.test`). Exits non-zero on a regression
+versus `baselines/opportunity.baseline.json`. Shared machinery lives in [`eval/shared`](../shared).
+
+## Checks
+
+Deterministic (on by default for every card): **`voice`** (the summary speaks to the
+viewer in second person), **`uuid`** / **`label`** (no raw ids or internal jargon like "the
+source user" / `intentId` in any field), **`greeting_format`** + **`greeting_length`** (the
+intro is plain prose, no markdown, no "Hey Name," prefix, ≤500 chars), and **`non_empty`**.
+
+Judged (skipped with `--no-judge`): **`grounding`** (the card reflects the real context and
+doesn't invent facts), **`framing`** (introducer cards frame the viewer as the matchmaker;
+introduction cards acknowledge the human introducer), and **`tone`** (warm and personal, not
+a clinical third-party analysis).
+
+The presenter takes pre-assembled string context (`PresenterInput`) — no database is needed,
+so cases are authored directly in `opportunity.cases.ts`.
+
+## Adding a case
+
+Append an `OpportunityCase` to `CASES`. Set `rule`, `tier` (1 surgical, 2 realistic), the
+`input` (viewer/other-party context, match reasoning, role, optional introduction), and
+`expect`. The deterministic guarantees are on by default; add judged `mustReference` /
+`framingCriteria` / `toneCriteria` for grounding, framing, and tone. To stress leakage, embed
+a UUID or an internal label in the `input` and rely on the default `no_leakage` assertion.
+Re-run with `--update-baseline` after an intentional change.
+
+## Layout
+
+- `opportunity.cases.ts` — the golden corpus.
+- `opportunity.leakage.ts` — deterministic UUID / label / markdown / salutation detectors.
+- `opportunity.types.ts` — harness types (specializes the shared scorecard types).
+- `opportunity.runner.ts` — invokes the presenter N times (shared retry loop).
+- `opportunity.scorer.ts` — per-run assertions → `CaseResult`.
+- `opportunity.reporter.ts` — HTML scorecard via the shared shell (plain-language report on top).
+- `opportunity.selection.ts` — `--rule` / `--case` / `--tier` filtering.
+- `opportunity.eval.ts` — CLI.
+- `baselines/opportunity.baseline.json` — committed baseline (per-run detail stripped).
+- `runs/*.json` — gitignored full run reports (rolling-baseline fuel).
+- `tests/` — unit tests (no live agents).

--- a/packages/protocol/eval/opportunity/baselines/opportunity.baseline.json
+++ b/packages/protocol/eval/opportunity/baselines/opportunity.baseline.json
@@ -1,0 +1,855 @@
+{
+  "generatedAt": "2026-06-16T17:14:34.977Z",
+  "model": "google/gemini-2.5-flash",
+  "runs": 3,
+  "aggregatePassRate": 0.7916666666666666,
+  "rules": [
+    {
+      "rule": "viewer_voice",
+      "caseCount": 2,
+      "passRate": 1
+    },
+    {
+      "rule": "no_leakage",
+      "caseCount": 1,
+      "passRate": 1
+    },
+    {
+      "rule": "greeting",
+      "caseCount": 1,
+      "passRate": 0
+    },
+    {
+      "rule": "grounding",
+      "caseCount": 1,
+      "passRate": 1
+    },
+    {
+      "rule": "introducer_role",
+      "caseCount": 2,
+      "passRate": 0.8333333333333333
+    },
+    {
+      "rule": "tone",
+      "caseCount": 1,
+      "passRate": 0.6666666666666666
+    }
+  ],
+  "cases": [
+    {
+      "caseId": "viewer_voice/founder-investor",
+      "rule": "viewer_voice",
+      "runs": 3,
+      "passes": 3,
+      "passRate": 1,
+      "flaky": false,
+      "runResults": [
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "non_empty",
+              "passed": true,
+              "detail": "headline, summary, and suggested action must be non-empty"
+            },
+            {
+              "kind": "voice",
+              "passed": true,
+              "detail": "summary speaks to the viewer"
+            },
+            {
+              "kind": "uuid",
+              "passed": true,
+              "detail": "no UUIDs in user-facing copy"
+            },
+            {
+              "kind": "label",
+              "passed": true,
+              "detail": "no internal labels in user-facing copy"
+            },
+            {
+              "kind": "grounding",
+              "passed": true,
+              "detail": "judge: grounded in context"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "non_empty",
+              "passed": true,
+              "detail": "headline, summary, and suggested action must be non-empty"
+            },
+            {
+              "kind": "voice",
+              "passed": true,
+              "detail": "summary speaks to the viewer"
+            },
+            {
+              "kind": "uuid",
+              "passed": true,
+              "detail": "no UUIDs in user-facing copy"
+            },
+            {
+              "kind": "label",
+              "passed": true,
+              "detail": "no internal labels in user-facing copy"
+            },
+            {
+              "kind": "grounding",
+              "passed": true,
+              "detail": "judge: grounded in context"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "non_empty",
+              "passed": true,
+              "detail": "headline, summary, and suggested action must be non-empty"
+            },
+            {
+              "kind": "voice",
+              "passed": true,
+              "detail": "summary speaks to the viewer"
+            },
+            {
+              "kind": "uuid",
+              "passed": true,
+              "detail": "no UUIDs in user-facing copy"
+            },
+            {
+              "kind": "label",
+              "passed": true,
+              "detail": "no internal labels in user-facing copy"
+            },
+            {
+              "kind": "grounding",
+              "passed": true,
+              "detail": "judge: grounded in context"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "caseId": "no_leakage/identifiers-in-context",
+      "rule": "no_leakage",
+      "runs": 3,
+      "passes": 3,
+      "passRate": 1,
+      "flaky": false,
+      "runResults": [
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "non_empty",
+              "passed": true,
+              "detail": "headline, summary, and suggested action must be non-empty"
+            },
+            {
+              "kind": "voice",
+              "passed": true,
+              "detail": "summary speaks to the viewer"
+            },
+            {
+              "kind": "uuid",
+              "passed": true,
+              "detail": "no UUIDs in user-facing copy"
+            },
+            {
+              "kind": "label",
+              "passed": true,
+              "detail": "no internal labels in user-facing copy"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "non_empty",
+              "passed": true,
+              "detail": "headline, summary, and suggested action must be non-empty"
+            },
+            {
+              "kind": "voice",
+              "passed": true,
+              "detail": "summary speaks to the viewer"
+            },
+            {
+              "kind": "uuid",
+              "passed": true,
+              "detail": "no UUIDs in user-facing copy"
+            },
+            {
+              "kind": "label",
+              "passed": true,
+              "detail": "no internal labels in user-facing copy"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "non_empty",
+              "passed": true,
+              "detail": "headline, summary, and suggested action must be non-empty"
+            },
+            {
+              "kind": "voice",
+              "passed": true,
+              "detail": "summary speaks to the viewer"
+            },
+            {
+              "kind": "uuid",
+              "passed": true,
+              "detail": "no UUIDs in user-facing copy"
+            },
+            {
+              "kind": "label",
+              "passed": true,
+              "detail": "no internal labels in user-facing copy"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "caseId": "greeting/plain-prose",
+      "rule": "greeting",
+      "runs": 3,
+      "passes": 0,
+      "passRate": 0,
+      "flaky": false,
+      "runResults": [
+        {
+          "passed": false,
+          "assertions": [
+            {
+              "kind": "non_empty",
+              "passed": true,
+              "detail": "headline, summary, and suggested action must be non-empty"
+            },
+            {
+              "kind": "voice",
+              "passed": true,
+              "detail": "summary speaks to the viewer"
+            },
+            {
+              "kind": "uuid",
+              "passed": true,
+              "detail": "no UUIDs in user-facing copy"
+            },
+            {
+              "kind": "label",
+              "passed": true,
+              "detail": "no internal labels in user-facing copy"
+            },
+            {
+              "kind": "greeting_format",
+              "passed": false,
+              "detail": "greeting has markdown or a 'Hey Name,' prefix"
+            },
+            {
+              "kind": "greeting_length",
+              "passed": true,
+              "detail": "greeting is 209 chars (max 500)"
+            }
+          ]
+        },
+        {
+          "passed": false,
+          "assertions": [
+            {
+              "kind": "non_empty",
+              "passed": true,
+              "detail": "headline, summary, and suggested action must be non-empty"
+            },
+            {
+              "kind": "voice",
+              "passed": true,
+              "detail": "summary speaks to the viewer"
+            },
+            {
+              "kind": "uuid",
+              "passed": true,
+              "detail": "no UUIDs in user-facing copy"
+            },
+            {
+              "kind": "label",
+              "passed": true,
+              "detail": "no internal labels in user-facing copy"
+            },
+            {
+              "kind": "greeting_format",
+              "passed": false,
+              "detail": "greeting has markdown or a 'Hey Name,' prefix"
+            },
+            {
+              "kind": "greeting_length",
+              "passed": true,
+              "detail": "greeting is 223 chars (max 500)"
+            }
+          ]
+        },
+        {
+          "passed": false,
+          "assertions": [
+            {
+              "kind": "non_empty",
+              "passed": true,
+              "detail": "headline, summary, and suggested action must be non-empty"
+            },
+            {
+              "kind": "voice",
+              "passed": true,
+              "detail": "summary speaks to the viewer"
+            },
+            {
+              "kind": "uuid",
+              "passed": true,
+              "detail": "no UUIDs in user-facing copy"
+            },
+            {
+              "kind": "label",
+              "passed": true,
+              "detail": "no internal labels in user-facing copy"
+            },
+            {
+              "kind": "greeting_format",
+              "passed": false,
+              "detail": "greeting has markdown or a 'Hey Name,' prefix"
+            },
+            {
+              "kind": "greeting_length",
+              "passed": true,
+              "detail": "greeting is 223 chars (max 500)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "caseId": "grounding/specific-intents",
+      "rule": "grounding",
+      "runs": 3,
+      "passes": 3,
+      "passRate": 1,
+      "flaky": false,
+      "runResults": [
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "non_empty",
+              "passed": true,
+              "detail": "headline, summary, and suggested action must be non-empty"
+            },
+            {
+              "kind": "voice",
+              "passed": true,
+              "detail": "summary speaks to the viewer"
+            },
+            {
+              "kind": "uuid",
+              "passed": true,
+              "detail": "no UUIDs in user-facing copy"
+            },
+            {
+              "kind": "label",
+              "passed": true,
+              "detail": "no internal labels in user-facing copy"
+            },
+            {
+              "kind": "grounding",
+              "passed": true,
+              "detail": "judge: grounded in context"
+            },
+            {
+              "kind": "tone",
+              "passed": true,
+              "detail": "judge: tone good"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "non_empty",
+              "passed": true,
+              "detail": "headline, summary, and suggested action must be non-empty"
+            },
+            {
+              "kind": "voice",
+              "passed": true,
+              "detail": "summary speaks to the viewer"
+            },
+            {
+              "kind": "uuid",
+              "passed": true,
+              "detail": "no UUIDs in user-facing copy"
+            },
+            {
+              "kind": "label",
+              "passed": true,
+              "detail": "no internal labels in user-facing copy"
+            },
+            {
+              "kind": "grounding",
+              "passed": true,
+              "detail": "judge: grounded in context"
+            },
+            {
+              "kind": "tone",
+              "passed": true,
+              "detail": "judge: tone good"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "non_empty",
+              "passed": true,
+              "detail": "headline, summary, and suggested action must be non-empty"
+            },
+            {
+              "kind": "voice",
+              "passed": true,
+              "detail": "summary speaks to the viewer"
+            },
+            {
+              "kind": "uuid",
+              "passed": true,
+              "detail": "no UUIDs in user-facing copy"
+            },
+            {
+              "kind": "label",
+              "passed": true,
+              "detail": "no internal labels in user-facing copy"
+            },
+            {
+              "kind": "grounding",
+              "passed": true,
+              "detail": "judge: grounded in context"
+            },
+            {
+              "kind": "tone",
+              "passed": true,
+              "detail": "judge: tone good"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "caseId": "introducer_role/connecting-two-others",
+      "rule": "introducer_role",
+      "runs": 3,
+      "passes": 2,
+      "passRate": 0.6666666666666666,
+      "flaky": true,
+      "runResults": [
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "non_empty",
+              "passed": true,
+              "detail": "headline, summary, and suggested action must be non-empty"
+            },
+            {
+              "kind": "voice",
+              "passed": true,
+              "detail": "summary speaks to the viewer"
+            },
+            {
+              "kind": "uuid",
+              "passed": true,
+              "detail": "no UUIDs in user-facing copy"
+            },
+            {
+              "kind": "label",
+              "passed": true,
+              "detail": "no internal labels in user-facing copy"
+            },
+            {
+              "kind": "framing",
+              "passed": true,
+              "detail": "judge: framing correct"
+            }
+          ]
+        },
+        {
+          "passed": false,
+          "assertions": [
+            {
+              "kind": "non_empty",
+              "passed": true,
+              "detail": "headline, summary, and suggested action must be non-empty"
+            },
+            {
+              "kind": "voice",
+              "passed": true,
+              "detail": "summary speaks to the viewer"
+            },
+            {
+              "kind": "uuid",
+              "passed": true,
+              "detail": "no UUIDs in user-facing copy"
+            },
+            {
+              "kind": "label",
+              "passed": true,
+              "detail": "no internal labels in user-facing copy"
+            },
+            {
+              "kind": "framing",
+              "passed": false,
+              "detail": "judge: framing wrong"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "non_empty",
+              "passed": true,
+              "detail": "headline, summary, and suggested action must be non-empty"
+            },
+            {
+              "kind": "voice",
+              "passed": true,
+              "detail": "summary speaks to the viewer"
+            },
+            {
+              "kind": "uuid",
+              "passed": true,
+              "detail": "no UUIDs in user-facing copy"
+            },
+            {
+              "kind": "label",
+              "passed": true,
+              "detail": "no internal labels in user-facing copy"
+            },
+            {
+              "kind": "framing",
+              "passed": true,
+              "detail": "judge: framing correct"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "caseId": "introducer_role/explicit-introduction",
+      "rule": "introducer_role",
+      "runs": 3,
+      "passes": 3,
+      "passRate": 1,
+      "flaky": false,
+      "runResults": [
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "non_empty",
+              "passed": true,
+              "detail": "headline, summary, and suggested action must be non-empty"
+            },
+            {
+              "kind": "voice",
+              "passed": true,
+              "detail": "summary speaks to the viewer"
+            },
+            {
+              "kind": "uuid",
+              "passed": true,
+              "detail": "no UUIDs in user-facing copy"
+            },
+            {
+              "kind": "label",
+              "passed": true,
+              "detail": "no internal labels in user-facing copy"
+            },
+            {
+              "kind": "framing",
+              "passed": true,
+              "detail": "judge: framing correct"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "non_empty",
+              "passed": true,
+              "detail": "headline, summary, and suggested action must be non-empty"
+            },
+            {
+              "kind": "voice",
+              "passed": true,
+              "detail": "summary speaks to the viewer"
+            },
+            {
+              "kind": "uuid",
+              "passed": true,
+              "detail": "no UUIDs in user-facing copy"
+            },
+            {
+              "kind": "label",
+              "passed": true,
+              "detail": "no internal labels in user-facing copy"
+            },
+            {
+              "kind": "framing",
+              "passed": true,
+              "detail": "judge: framing correct"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "non_empty",
+              "passed": true,
+              "detail": "headline, summary, and suggested action must be non-empty"
+            },
+            {
+              "kind": "voice",
+              "passed": true,
+              "detail": "summary speaks to the viewer"
+            },
+            {
+              "kind": "uuid",
+              "passed": true,
+              "detail": "no UUIDs in user-facing copy"
+            },
+            {
+              "kind": "label",
+              "passed": true,
+              "detail": "no internal labels in user-facing copy"
+            },
+            {
+              "kind": "framing",
+              "passed": true,
+              "detail": "judge: framing correct"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "caseId": "tone/compelling-not-analytical",
+      "rule": "tone",
+      "runs": 3,
+      "passes": 2,
+      "passRate": 0.6666666666666666,
+      "flaky": true,
+      "runResults": [
+        {
+          "passed": false,
+          "assertions": [
+            {
+              "kind": "non_empty",
+              "passed": true,
+              "detail": "headline, summary, and suggested action must be non-empty"
+            },
+            {
+              "kind": "voice",
+              "passed": true,
+              "detail": "summary speaks to the viewer"
+            },
+            {
+              "kind": "uuid",
+              "passed": true,
+              "detail": "no UUIDs in user-facing copy"
+            },
+            {
+              "kind": "label",
+              "passed": true,
+              "detail": "no internal labels in user-facing copy"
+            },
+            {
+              "kind": "tone",
+              "passed": false,
+              "detail": "judge: tone off"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "non_empty",
+              "passed": true,
+              "detail": "headline, summary, and suggested action must be non-empty"
+            },
+            {
+              "kind": "voice",
+              "passed": true,
+              "detail": "summary speaks to the viewer"
+            },
+            {
+              "kind": "uuid",
+              "passed": true,
+              "detail": "no UUIDs in user-facing copy"
+            },
+            {
+              "kind": "label",
+              "passed": true,
+              "detail": "no internal labels in user-facing copy"
+            },
+            {
+              "kind": "tone",
+              "passed": true,
+              "detail": "judge: tone good"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "non_empty",
+              "passed": true,
+              "detail": "headline, summary, and suggested action must be non-empty"
+            },
+            {
+              "kind": "voice",
+              "passed": true,
+              "detail": "summary speaks to the viewer"
+            },
+            {
+              "kind": "uuid",
+              "passed": true,
+              "detail": "no UUIDs in user-facing copy"
+            },
+            {
+              "kind": "label",
+              "passed": true,
+              "detail": "no internal labels in user-facing copy"
+            },
+            {
+              "kind": "tone",
+              "passed": true,
+              "detail": "judge: tone good"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "caseId": "viewer_voice/patient-role",
+      "rule": "viewer_voice",
+      "runs": 3,
+      "passes": 3,
+      "passRate": 1,
+      "flaky": false,
+      "runResults": [
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "non_empty",
+              "passed": true,
+              "detail": "headline, summary, and suggested action must be non-empty"
+            },
+            {
+              "kind": "voice",
+              "passed": true,
+              "detail": "summary speaks to the viewer"
+            },
+            {
+              "kind": "uuid",
+              "passed": true,
+              "detail": "no UUIDs in user-facing copy"
+            },
+            {
+              "kind": "label",
+              "passed": true,
+              "detail": "no internal labels in user-facing copy"
+            },
+            {
+              "kind": "grounding",
+              "passed": true,
+              "detail": "judge: grounded in context"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "non_empty",
+              "passed": true,
+              "detail": "headline, summary, and suggested action must be non-empty"
+            },
+            {
+              "kind": "voice",
+              "passed": true,
+              "detail": "summary speaks to the viewer"
+            },
+            {
+              "kind": "uuid",
+              "passed": true,
+              "detail": "no UUIDs in user-facing copy"
+            },
+            {
+              "kind": "label",
+              "passed": true,
+              "detail": "no internal labels in user-facing copy"
+            },
+            {
+              "kind": "grounding",
+              "passed": true,
+              "detail": "judge: grounded in context"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "non_empty",
+              "passed": true,
+              "detail": "headline, summary, and suggested action must be non-empty"
+            },
+            {
+              "kind": "voice",
+              "passed": true,
+              "detail": "summary speaks to the viewer"
+            },
+            {
+              "kind": "uuid",
+              "passed": true,
+              "detail": "no UUIDs in user-facing copy"
+            },
+            {
+              "kind": "label",
+              "passed": true,
+              "detail": "no internal labels in user-facing copy"
+            },
+            {
+              "kind": "grounding",
+              "passed": true,
+              "detail": "judge: grounded in context"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/protocol/eval/opportunity/opportunity.cases.ts
+++ b/packages/protocol/eval/opportunity/opportunity.cases.ts
@@ -1,0 +1,198 @@
+import type { OpportunityCase } from "./opportunity.types.js";
+
+/**
+ * Opportunity-card eval golden corpus (starter set).
+ *
+ * Exercises `OpportunityPresenter.present`: the user-facing card (headline,
+ * personalized summary, suggested action, intro greeting). Every case asserts the
+ * always-on guarantees by default \u2014 second-person voice, no UUID/label leakage,
+ * and a clean greeting \u2014 plus judged grounding / framing / tone where relevant.
+ *
+ * `viewerRole` drives framing: a `party`/`patient` viewer is one side of the
+ * match; an `introducer` is connecting two OTHER people. Grow by appending cases.
+ */
+export const CASES: OpportunityCase[] = [
+  {
+    id: "viewer_voice/founder-investor",
+    rule: "viewer_voice",
+    tier: 1,
+    description: "Party viewer (founder) shown an aligned investor \u2014 card speaks to the viewer.",
+    human: {
+      scenario: "a founder raising a seed round, shown an investor who backs climate hardware at exactly their stage.",
+      expectation: "write the card directly to the founder (\u201cyou\u201d), explaining why this investor is worth meeting.",
+    },
+    input: {
+      viewerContext: "Ava is a climate-hardware founder raising a $2M seed round for a direct-air-capture startup. She wants investors who understand deep tech and hardware timelines.",
+      otherPartyContext: "Ben is an early-stage investor who writes first checks into climate hardware and deep tech, typically at seed.",
+      matchReasoning: "Both are anchored on climate hardware; the founder is raising seed and the investor writes seed checks in exactly this space.",
+      category: "funding",
+      confidence: 0.86,
+      signalsSummary: "Shared focus on climate hardware; complementary fundraising stage.",
+      indexName: "Climate Builders",
+      viewerRole: "party",
+    },
+    expect: {
+      mustReference: "the viewer is a climate-hardware founder raising a seed round, and the other person is a seed-stage climate-hardware investor",
+    },
+  },
+  {
+    id: "no_leakage/identifiers-in-context",
+    rule: "no_leakage",
+    tier: 2,
+    description: "Raw UUID + internal label in the context must never reach the card.",
+    human: {
+      scenario: "match context that accidentally includes a raw database id and an internal label (\u201cthe source user\u201d).",
+      expectation: "write a clean card with no database ids or internal jargon \u2014 just plain, human copy.",
+    },
+    input: {
+      viewerContext: "A product designer focused on design systems and accessibility.",
+      otherPartyContext: "A frontend engineer who needs design-system help.",
+      matchReasoning: "The source user (userId 5f0a2c14-6b3e-4f9a-8c21-9d7e1b2a4c6f) overlaps with the candidate on design systems.",
+      category: "collaboration",
+      confidence: 0.78,
+      signalsSummary: "intentId a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d: shared design-system focus.",
+      indexName: "Design Guild",
+      viewerRole: "party",
+    },
+    expect: {},
+  },
+  {
+    id: "greeting/plain-prose",
+    rule: "greeting",
+    tier: 1,
+    description: "Greeting is plain first-person prose \u2014 no markdown, no 'Hey Name,' prefix.",
+    human: {
+      scenario: "a complementary match between a designer and an engineer, where the card also drafts an intro message.",
+      expectation: "draft a short, natural opener the viewer could send \u2014 plain text, no formatting, no \u201cHey Sam,\u201d header.",
+    },
+    input: {
+      viewerContext: "Sam is a brand designer who loves working with early-stage founders on visual identity.",
+      otherPartyContext: "Priya is a solo technical founder who just launched and needs help with brand and identity.",
+      matchReasoning: "Sam offers exactly the brand/identity help Priya is looking for.",
+      category: "collaboration",
+      confidence: 0.82,
+      signalsSummary: "Complementary: designer offering, founder needing brand work.",
+      indexName: "Founders & Makers",
+      viewerRole: "party",
+    },
+    expect: { greetingClean: true },
+  },
+  {
+    id: "grounding/specific-intents",
+    rule: "grounding",
+    tier: 2,
+    description: "Summary must reflect the viewer's specific intents without inventing facts.",
+    human: {
+      scenario: "a researcher whose stated goals are very specific (finding a co-author on a protein-folding paper).",
+      expectation: "explain the match using their actual goal, not vague or made-up reasons.",
+    },
+    input: {
+      viewerContext: "Dr. Lin is a computational biologist looking for a co-author with wet-lab experience to validate a protein-folding model before submitting to a journal.",
+      otherPartyContext: "Marco runs a wet lab and has validated structural-biology models for several published papers.",
+      matchReasoning: "The viewer needs wet-lab validation for a protein-folding model; the other party runs a wet lab with exactly that track record.",
+      category: "research",
+      confidence: 0.84,
+      signalsSummary: "Complementary: needs wet-lab validation / offers wet-lab validation.",
+      indexName: "Bio Researchers",
+      viewerRole: "patient",
+    },
+    expect: {
+      mustReference: "the viewer needs wet-lab validation for a protein-folding model and the other person runs a wet lab that does exactly that",
+      toneCriteria: "The copy should be specific and compelling, not generic filler like 'a promising connection'.",
+    },
+  },
+  {
+    id: "introducer_role/connecting-two-others",
+    rule: "introducer_role",
+    tier: 2,
+    description: "Introducer viewer: frame as connecting two OTHER people, not the viewer's own needs.",
+    human: {
+      scenario: "a community host who is connecting two other members \u2014 they are the matchmaker, not a party to the match.",
+      expectation: "frame the card as \u201cyou're connecting X and Y because\u2026\u201d and never reference the host's own goals.",
+    },
+    input: {
+      viewerContext: "Jordan hosts the community and frequently introduces members. Jordan is not part of this match.",
+      otherPartyContext: "Connecting two members: Lea (a grant-writer for climate nonprofits) and Tom (a climate nonprofit founder seeking grant help).",
+      matchReasoning: "Lea writes climate grants; Tom needs grant help for his nonprofit. Jordan saw the fit and wants to connect them.",
+      category: "introduction",
+      confidence: 0.8,
+      signalsSummary: "Grant-writer and grant-seeker in the climate-nonprofit space.",
+      indexName: "Climate Builders",
+      viewerRole: "introducer",
+    },
+    expect: {
+      framingCriteria: "The card must frame the viewer as connecting Lea and Tom (the matchmaker), explaining why those two should meet \u2014 NOT describing the viewer's own intents or needs.",
+    },
+  },
+  {
+    id: "introducer_role/explicit-introduction",
+    rule: "introducer_role",
+    tier: 2,
+    description: "Introduction-originated card must acknowledge the human introducer.",
+    human: {
+      scenario: "a connection that a real person (Maya) deliberately set up, rather than an automatic match.",
+      expectation: "acknowledge that Maya made the introduction and treat it as a personal recommendation.",
+    },
+    input: {
+      viewerContext: "You are a product manager exploring a move into developer tools.",
+      otherPartyContext: "Noah leads developer experience at a fast-growing dev-tools company.",
+      matchReasoning: "Maya knows both and thinks the viewer's PM background fits Noah's team and interests.",
+      category: "introduction",
+      confidence: 0.75,
+      signalsSummary: "Personal introduction; overlapping interest in developer tools.",
+      indexName: "Dev Tools Circle",
+      viewerRole: "party",
+      isIntroduction: true,
+      introducerName: "Maya",
+    },
+    expect: {
+      framingCriteria: "The card must acknowledge that Maya personally made this introduction (e.g. 'Maya thinks you should meet Noah'), treating it as a recommendation rather than an automatic system match.",
+    },
+  },
+  {
+    id: "tone/compelling-not-analytical",
+    rule: "tone",
+    tier: 1,
+    description: "Copy is warm and compelling, not a dry third-party analysis.",
+    human: {
+      scenario: "a strong mutual match between two people building in the same niche.",
+      expectation: "make the card feel personal and inviting, not like a clinical report about two strangers.",
+    },
+    input: {
+      viewerContext: "Rae builds open-source developer tooling and cares a lot about contributor experience.",
+      otherPartyContext: "Kai maintains a popular OSS framework and writes about sustainable maintainership.",
+      matchReasoning: "Both care deeply about open-source contributor and maintainer experience.",
+      category: "peer",
+      confidence: 0.83,
+      signalsSummary: "Shared focus on OSS contributor / maintainer experience.",
+      indexName: "Open Source Collective",
+      viewerRole: "party",
+    },
+    expect: {
+      toneCriteria: "The copy must read as warm, personal, and compelling (addressed to the viewer), not as a detached third-party analysis of two users.",
+    },
+  },
+  {
+    id: "viewer_voice/patient-role",
+    rule: "viewer_voice",
+    tier: 1,
+    description: "Patient viewer is addressed directly about why the match helps them.",
+    human: {
+      scenario: "someone who has been looking for a specific kind of mentor, now shown a strong match.",
+      expectation: "speak to them directly about why this person can help with what they asked for.",
+    },
+    input: {
+      viewerContext: "Tariq is a junior data scientist looking for a mentor experienced in deploying ML models to production.",
+      otherPartyContext: "Sofia is a staff ML engineer who has shipped many production ML systems and enjoys mentoring.",
+      matchReasoning: "Tariq wants production-ML mentorship; Sofia is an experienced production-ML engineer who mentors.",
+      category: "mentorship",
+      confidence: 0.85,
+      signalsSummary: "Mentee seeking production-ML mentorship / mentor offering it.",
+      indexName: "ML Practitioners",
+      viewerRole: "patient",
+    },
+    expect: {
+      mustReference: "the viewer wants a mentor for deploying ML to production and the other person is an experienced production-ML engineer who mentors",
+    },
+  },
+];

--- a/packages/protocol/eval/opportunity/opportunity.constants.ts
+++ b/packages/protocol/eval/opportunity/opportunity.constants.ts
@@ -1,0 +1,6 @@
+/** Retry budget for transient live-model failures during an opportunity eval run. */
+export const OPPORTUNITY_EVAL_MAX_ATTEMPTS = 3;
+/** Base backoff between opportunity eval retries (doubles each attempt). */
+export const OPPORTUNITY_EVAL_RETRY_DELAY_MS = 1000;
+/** Hard cap on the greeting length (mirrors the presenter's schema `.max(500)`). */
+export const GREETING_MAX_LEN = 500;

--- a/packages/protocol/eval/opportunity/opportunity.eval.ts
+++ b/packages/protocol/eval/opportunity/opportunity.eval.ts
@@ -1,0 +1,198 @@
+#!/usr/bin/env bun
+/**
+ * Opportunity-card quality eval harness.
+ *
+ * Usage (from packages/protocol):
+ *   bun run eval:opportunity                          # all cases, 3 runs, judge on, diff baseline
+ *   bun run eval:opportunity -- --runs 5              # more runs = less noise
+ *   bun run eval:opportunity -- --rule no_leakage      # one rule
+ *   bun run eval:opportunity -- --case greeting/        # one case or id prefix
+ *   bun run eval:opportunity -- --tier 1               # one tier
+ *   bun run eval:opportunity -- --list-cases           # print selected cases and exit
+ *   bun run eval:opportunity -- --no-judge             # skip LLM grounding/framing/tone checks
+ *   bun run eval:opportunity -- --update-baseline      # overwrite the committed baseline
+ *   bun run eval:opportunity -- --report [path]        # write a full run report (incl. generated cards)
+ *   bun run eval:opportunity -- --html [path]          # write a standalone HTML scorecard
+ *   bun run eval:opportunity -- --rolling-baseline [d] # compare against recent runs (default 7d)
+ *   bun run eval:opportunity -- --alpha 0.01           # stricter regression significance threshold
+ *   bun run eval:opportunity -- --no-save              # do not auto-save full-corpus run JSON
+ *
+ * Requires OPENROUTER_API_KEY (loaded via --env-file=.env.test in the package script).
+ * Exits non-zero when a regression vs the committed baseline is detected.
+ */
+import path from "path";
+
+import { OpportunityPresenter } from "../../src/opportunity/opportunity.presenter.js";
+import { getModelName } from "../../src/shared/agent/model.config.js";
+import { assertLLM } from "../../src/shared/agent/tests/llm-assert.js";
+import { arg, buildScorecard, computeRollingBaseline, diffBaseline, flagValue, formatConsole, has, readBaseline, writeBaseline, writeRunReport } from "../shared/index.js";
+import { CASES } from "./opportunity.cases.js";
+import { runCase } from "./opportunity.runner.js";
+import { scoreCase, type Judge } from "./opportunity.scorer.js";
+import { writeHtmlReport } from "./opportunity.reporter.js";
+import { formatCaseList, hasRule, parseTier, selectCases } from "./opportunity.selection.js";
+import type { CaseResult, Scorecard } from "./opportunity.types.js";
+
+const DEFAULT_ALPHA = 0.05;
+const BASELINE_PATH = path.resolve(import.meta.dir, "baselines/opportunity.baseline.json");
+const RUNS_DIR = path.resolve(import.meta.dir, "runs");
+
+function usage(): string {
+  return `Opportunity-card quality eval harness
+
+Usage (from packages/protocol):
+  bun run eval:opportunity [-- options]
+
+Selection:
+  --rule <rule>             Run one rule (viewer_voice|no_leakage|greeting|grounding|introducer_role|tone)
+  --case <id-or-prefix>     Run one case or id prefix
+  --tier <1|2>              Run one tier
+  --list-cases              Print selected cases and exit
+
+Execution:
+  --runs <n>                Runs per case (default: 3)
+  --no-judge                Skip LLM grounding/framing/tone checks
+  --alpha <p>               Regression significance threshold (default: ${DEFAULT_ALPHA})
+  --no-save                 Do not auto-save full-corpus run JSON for rolling-baseline fuel
+
+Baselines/reports:
+  --update-baseline         Overwrite committed baseline (full corpus only)
+  --rolling-baseline [days] Compare against recent run reports (default: 7)
+  --report [path]           Write JSON scorecard
+  --html [path]             Write standalone HTML scorecard
+
+Other:
+  --help, -h                Show this help
+`;
+}
+
+async function main(): Promise<void> {
+  if (has("--help") || has("-h")) {
+    console.log(usage());
+    process.exit(0);
+  }
+
+  const runs = Number(arg("--runs") ?? 3);
+  if (!Number.isInteger(runs) || runs < 1) {
+    console.error(`--runs must be a positive integer (got "${arg("--runs")}")`);
+    process.exit(2);
+  }
+  const ruleFilter = arg("--rule");
+  if (ruleFilter && !hasRule(CASES, ruleFilter)) {
+    console.error(`No cases match --rule ${ruleFilter}`);
+    process.exit(2);
+  }
+  const caseFilter = arg("--case");
+  let tierFilter: 1 | 2 | undefined;
+  try {
+    tierFilter = parseTier(arg("--tier"));
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(2);
+  }
+  const listCases = has("--list-cases");
+  const updateBaseline = has("--update-baseline");
+  const noJudge = has("--no-judge");
+  const report = has("--report");
+  const html = has("--html");
+  const noSave = has("--no-save");
+  const alpha = Number(arg("--alpha") ?? DEFAULT_ALPHA);
+  if (!Number.isFinite(alpha) || alpha <= 0 || alpha >= 1) {
+    console.error(`--alpha must be a number between 0 and 1 (got "${arg("--alpha")}")`);
+    process.exit(2);
+  }
+  const rollingBaseline = has("--rolling-baseline");
+  const rollingBaselineDays = rollingBaseline ? Number(flagValue("--rolling-baseline") ?? 7) : null;
+  if (rollingBaselineDays !== null && (!Number.isFinite(rollingBaselineDays) || rollingBaselineDays <= 0)) {
+    console.error(`--rolling-baseline must be a positive number of days (got "${flagValue("--rolling-baseline")}")`);
+    process.exit(2);
+  }
+
+  const judge: Judge = noJudge
+    ? async () => true
+    : async (output, criteria) => {
+        try {
+          await assertLLM(output, criteria);
+          return true;
+        } catch {
+          return false;
+        }
+      };
+
+  const selected = selectCases(CASES, { rule: ruleFilter, caseId: caseFilter, tier: tierFilter });
+  const fullCorpus = !ruleFilter && !caseFilter && tierFilter === undefined;
+  if (listCases) {
+    console.log(formatCaseList(selected));
+    process.exit(0);
+  }
+  if (selected.length === 0) {
+    console.error(`No cases match selected filters`);
+    process.exit(2);
+  }
+  if (updateBaseline && !fullCorpus) {
+    console.error(`--update-baseline requires a full-corpus run (remove --rule/--case/--tier filters)`);
+    process.exit(2);
+  }
+
+  const presenter = new OpportunityPresenter();
+  const model = getModelName("opportunityPresenter");
+  console.log(`Running ${selected.length} case(s) × ${runs} run(s) against ${model}${noJudge ? " (judge off)" : ""}…`);
+
+  const results: CaseResult[] = [];
+  for (const c of selected) {
+    process.stdout.write(`  ${c.id} … `);
+    const details = await runCase(presenter, c, runs);
+    const result = await scoreCase(c, details, judge);
+    results.push(result);
+    console.log(`${result.passes}/${result.runs}${result.flaky ? " (flaky)" : ""}`);
+  }
+
+  const scorecard = buildScorecard(results, { model, runs }) as Scorecard;
+  const baseline =
+    rollingBaselineDays !== null
+      ? await computeRollingBaseline(RUNS_DIR, rollingBaselineDays)
+      : await readBaseline<Scorecard>(BASELINE_PATH);
+  const { regressions, skippedCaseIds } = diffBaseline(scorecard, baseline, alpha);
+
+  if (rollingBaselineDays !== null) {
+    console.log(
+      baseline
+        ? `\nComparing against rolling ${rollingBaselineDays}-day baseline (${baseline.model}, α=${alpha}).`
+        : `\nNo rolling ${rollingBaselineDays}-day baseline found; skipping regression comparison.`,
+    );
+  }
+
+  console.log(formatConsole(scorecard, regressions, skippedCaseIds, { title: "Opportunity Card Quality Scorecard" }));
+
+  if (updateBaseline) {
+    await writeBaseline(BASELINE_PATH, scorecard, {
+      leanCase: (c) => ({ ...c, runResults: c.runResults.map(({ detail: _detail, ...rest }) => rest) }),
+    });
+    console.log(`\nBaseline updated at ${BASELINE_PATH}`);
+  }
+
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const autoRunPath = path.resolve(RUNS_DIR, `${stamp}.json`);
+  if (fullCorpus && !noSave) {
+    await writeRunReport(autoRunPath, scorecard);
+  }
+
+  if (report) {
+    const reportPath = flagValue("--report") ?? autoRunPath;
+    if (reportPath !== autoRunPath) await writeRunReport(reportPath, scorecard);
+    console.log(`\nRun report written to ${reportPath}`);
+  }
+
+  if (html) {
+    const htmlPath = flagValue("--html") ?? path.resolve(RUNS_DIR, `${stamp}.html`);
+    await writeHtmlReport(htmlPath, scorecard, regressions, CASES);
+    console.log(`\nHTML report written to ${htmlPath}`);
+  }
+
+  process.exit(regressions.length > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(2);
+});

--- a/packages/protocol/eval/opportunity/opportunity.leakage.ts
+++ b/packages/protocol/eval/opportunity/opportunity.leakage.ts
@@ -1,0 +1,40 @@
+/**
+ * Deterministic leakage / formatting detectors for opportunity cards.
+ *
+ * The presenter promises user-facing copy with no raw identifiers, no internal
+ * role labels, and a plain-prose greeting. These back the deterministic
+ * `no_leakage` and `greeting` assertions.
+ */
+
+const UUID_RE = /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i;
+
+/** Internal labels / field names that must never reach user-facing copy. */
+const LABEL_RE = /\b(the source user|the candidate|source user|candidate user|userId|intentId|networkId)\b/i;
+
+/** True when any UUID appears in the text. */
+export function hasUuid(text: string): boolean {
+  return UUID_RE.test(text);
+}
+
+/** True when an internal role label / field name leaks into the text. */
+export function hasInternalLabel(text: string): boolean {
+  return LABEL_RE.test(text);
+}
+
+/**
+ * True when the greeting carries markdown. Greetings must be plain prose:
+ * no emphasis, headers, links, code, or bullet markers.
+ */
+export function hasMarkdown(text: string): boolean {
+  return (
+    /\*\*|__|`|^#{1,6}\s|\]\(|\[[^\]]*\]\(|^\s*[-*]\s+/m.test(text)
+  );
+}
+
+/**
+ * True when the greeting opens with a salutation prefix like "Hey Sarah," or
+ * "Hi there," — the presenter requires the greeting body only, no prefix.
+ */
+export function hasGreetingPrefix(text: string): boolean {
+  return /^\s*(hey|hi|hello|dear|greetings)\b[^.!?\n]{0,40},/i.test(text);
+}

--- a/packages/protocol/eval/opportunity/opportunity.reporter.ts
+++ b/packages/protocol/eval/opportunity/opportunity.reporter.ts
@@ -1,0 +1,147 @@
+import { htmlEscape, rateClass, htmlRateCI, renderRuleTable, renderScorecardShell, type HumanReport, type Regression } from "../shared/index.js";
+import type { AssertionKind, CaseResult, OpportunityCase, Rule, Scorecard, OpportunityRunDetail } from "./opportunity.types.js";
+
+// ─── Plain-language copy for the non-technical report ────────────────────────
+
+/** Ordered themes for "What we tested", each mapped to one rule. */
+const GROUPS: { ruleIds: Rule[]; label: string; blurb: string }[] = [
+  { ruleIds: ["viewer_voice"], label: "Speaking to the reader directly", blurb: "Writing the card to \u201cyou\u201d \u2014 the person it's for \u2014 not as a detached report." },
+  { ruleIds: ["no_leakage"], label: "No database leaks or jargon", blurb: "Never showing raw ids or internal labels in a card a person reads." },
+  { ruleIds: ["greeting"], label: "A clean intro message", blurb: "Drafting a natural opener with no formatting and no \u201cHey Name,\u201d header." },
+  { ruleIds: ["grounding"], label: "Sticking to the facts", blurb: "Explaining the match using the real context, not invented details." },
+  { ruleIds: ["introducer_role"], label: "Getting the framing right", blurb: "When someone is connecting two others \u2014 or made a personal intro \u2014 the card reflects that." },
+  { ruleIds: ["tone"], label: "Warm, not clinical", blurb: "Reading like a personal recommendation, not a dry analysis of two strangers." },
+];
+
+/** Plain-language name for each failing check, used in "what happened" notes. */
+const CHECK_COPY: Record<AssertionKind, string> = {
+  non_empty: "left part of the card blank",
+  voice: "didn't speak to the reader directly",
+  uuid: "leaked a raw database id into the card",
+  label: "used internal jargon in the card",
+  greeting_format: "the intro message had formatting or a \u201cHey Name,\u201d header",
+  greeting_length: "the intro message was too long",
+  grounding: "described the match inaccurately",
+  framing: "framed the connection from the wrong point of view",
+  tone: "the copy read as cold or clinical",
+};
+
+/** Distinct plain-language reasons a case failed, across its runs. */
+function failNote(c: CaseResult): string | undefined {
+  const kinds = new Set<AssertionKind>();
+  for (const rr of c.runResults) for (const a of rr.assertions) if (!a.passed) kinds.add(a.kind);
+  if (kinds.size === 0) return undefined;
+  return [...kinds].map((k) => CHECK_COPY[k]).join("; ") + ".";
+}
+
+/** Build the plain-language report from the scorecard + corpus narratives. */
+function buildHumanReport(sc: Scorecard, cases: OpportunityCase[]): HumanReport {
+  const byId = new Map(cases.map((c) => [c.id, c]));
+  const resultById = new Map(sc.cases.map((c) => [c.caseId, c]));
+  const groups = GROUPS.map((g) => ({
+    label: g.label,
+    blurb: g.blurb,
+    ruleIds: g.ruleIds as string[],
+    cases: sc.cases
+      .filter((c) => g.ruleIds.includes(c.rule))
+      .map((c) => {
+        const meta = byId.get(c.caseId);
+        const result = resultById.get(c.caseId);
+        return {
+          caseId: c.caseId,
+          scenario: meta?.human?.scenario ?? meta?.description ?? c.caseId,
+          expectation: meta?.human?.expectation ?? "produce a good card.",
+          failNote: result ? failNote(result) : undefined,
+        };
+      }),
+  })).filter((g) => g.cases.length > 0);
+  return {
+    subject: "the card writer",
+    oneLiner: "It writes the connection cards people actually read \u2014 the headline, the why-this-matters, and a ready-to-send intro \u2014 and must keep them clean, accurate, and personal.",
+    groups,
+  };
+}
+
+// ─── Technical case cards ────────────────────────────────────────────────────
+
+/** Render one run's generated card behind a collapsible block. */
+function detailHtml(d: OpportunityRunDetail, i: number): string {
+  const leaks = d.leaks.length > 0 ? ` <span class="bad">leaks: ${htmlEscape(d.leaks.join(", "))}</span>` : "";
+  return `<div class="reason">
+    <span class="muted">run ${i + 1}</span>${leaks}
+    <p><strong>${htmlEscape(d.headline)}</strong></p>
+    <p>${htmlEscape(d.personalizedSummary)}</p>
+    <p class="muted">action: ${htmlEscape(d.suggestedAction)}</p>
+    <p class="muted">greeting: ${htmlEscape(d.greeting || "\u2014")}</p>
+  </div>`;
+}
+
+/** Render failed assertions for a case. */
+function failedChecks(c: CaseResult): string {
+  const failed = c.runResults.flatMap((rr, i) =>
+    rr.assertions
+      .filter((a) => !a.passed)
+      .map((a) => `<li><span class="muted">run ${i + 1}</span> <span class="component">${htmlEscape(a.kind)}</span>: ${htmlEscape(a.detail)}</li>`),
+  );
+  if (failed.length === 0) return "";
+  return `<details class="failures" open><summary>failed checks (${failed.length})</summary><ul>${failed.join("")}</ul></details>`;
+}
+
+/** Render one case card. */
+function caseCard(c: CaseResult, meta: OpportunityCase | undefined): string {
+  const tier = meta ? `<span class="badge">tier ${meta.tier}</span>` : "";
+  const role = meta ? `<span class="badge">${htmlEscape(meta.input.viewerRole)}</span>` : "";
+  const flaky = c.flaky ? `<span class="badge flaky">flaky</span>` : "";
+  const desc = meta?.description ? `<p class="desc">${htmlEscape(meta.description)}</p>` : "";
+  const details = c.runResults.map((rr, i) => (rr.detail ? detailHtml(rr.detail, i) : "")).join("");
+  return `
+  <article class="case ${rateClass(c.passRate)}">
+    <header>
+      <code class="cid">${htmlEscape(c.caseId)}</code>
+      <span class="verdict ${rateClass(c.passRate)}" title="${c.passes}/${c.runs} runs">${htmlRateCI(c.passRate, c.passes, c.runs)}</span>
+      ${role}${tier}${flaky}
+    </header>
+    ${desc}
+    ${failedChecks(c)}
+    <details><summary>generated card (${c.runResults.length} run${c.runResults.length === 1 ? "" : "s"})</summary>${details}</details>
+  </article>`;
+}
+
+const INTRO = `<h2>What this report is measuring</h2>
+<p>This is a repeatability test for the opportunity-card writer \u2014 the part that turns a match into the card a person reads: a headline, a \u201cwhy this matters to you\u201d summary, a suggested next step, and a ready-to-send intro message. Each case runs N times; a run passes only when every check passes. Leaking a raw id, slipping into internal jargon, or drifting from the facts fails the run.</p>`;
+
+/**
+ * Render a standalone HTML scorecard for an opportunity-card run via the shared shell.
+ *
+ * @param sc - The scorecard (run-report grade, with per-run detail intact).
+ * @param regressions - Regressions vs the baseline.
+ * @param cases - The corpus, joined by id for description, role, and narratives.
+ */
+export function renderHtml(sc: Scorecard, regressions: Regression[], cases: OpportunityCase[]): string {
+  const byId = new Map(cases.map((c) => [c.id, c]));
+  const caseCards = [...sc.rules]
+    .sort((x, y) => x.passRate - y.passRate)
+    .map((r) => {
+      const cards = sc.cases.filter((c) => c.rule === r.rule).map((c) => caseCard(c, byId.get(c.caseId))).join("");
+      return `<section class="rule"><h2>${htmlEscape(r.rule)}</h2>${cards}</section>`;
+    })
+    .join("");
+
+  return renderScorecardShell(sc, regressions, {
+    title: "Opportunity eval",
+    intro: INTRO,
+    sections: [{ heading: "By rule", html: renderRuleTable(sc) }],
+    caseCardsHtml: caseCards,
+    human: buildHumanReport(sc, cases),
+  });
+}
+
+/** Write a standalone HTML scorecard to disk. */
+export async function writeHtmlReport(
+  path: string,
+  sc: Scorecard,
+  regressions: Regression[],
+  cases: OpportunityCase[],
+): Promise<void> {
+  await Bun.write(path, renderHtml(sc, regressions, cases));
+}

--- a/packages/protocol/eval/opportunity/opportunity.runner.ts
+++ b/packages/protocol/eval/opportunity/opportunity.runner.ts
@@ -1,0 +1,88 @@
+import { repeatRuns } from "../shared/index.js";
+import { OPPORTUNITY_EVAL_MAX_ATTEMPTS, OPPORTUNITY_EVAL_RETRY_DELAY_MS } from "./opportunity.constants.js";
+import { hasInternalLabel, hasUuid } from "./opportunity.leakage.js";
+import type { OpportunityCase, OpportunityRunDetail } from "./opportunity.types.js";
+
+/** Minimal presenter surface the runner needs (real OpportunityPresenter satisfies this). */
+export interface PresenterLike {
+  present(input: {
+    viewerContext: string;
+    otherPartyContext: string;
+    matchReasoning: string;
+    category: string;
+    confidence: number;
+    signalsSummary: string;
+    indexName: string;
+    viewerRole: string;
+    isIntroduction?: boolean;
+    introducerName?: string;
+  }): Promise<{ headline: string; personalizedSummary: string; suggestedAction: string; greeting: string }>;
+}
+
+export interface RunCaseOptions {
+  maxAttempts?: number;
+  retryDelayMs?: number;
+}
+
+/**
+ * The presenter swallows LLM timeouts/failures and returns a fixed fallback card
+ * (headline "A promising connection", the raw matchReasoning as summary, empty
+ * greeting). That degraded path is a resilience concern, not card quality — detect
+ * it so the runner retries and the eval measures the real model output.
+ */
+function isFallbackCard(p: { headline: string; suggestedAction: string; greeting: string }): boolean {
+  return (
+    p.headline === "A promising connection" &&
+    p.suggestedAction === "Take a look and decide whether to reach out." &&
+    p.greeting === ""
+  );
+}
+
+/** Invoke the presenter once and normalize its card output (collecting leakage findings). */
+async function invokeOnce(presenter: PresenterLike, c: OpportunityCase): Promise<OpportunityRunDetail> {
+  const p = await presenter.present(c.input);
+  if (isFallbackCard(p)) {
+    // Throwing lets the shared retry loop re-run past a transient timeout fallback.
+    throw new Error("opportunity presenter returned its timeout fallback card");
+  }
+  const fields: [string, string][] = [
+    ["headline", p.headline],
+    ["summary", p.personalizedSummary],
+    ["suggestedAction", p.suggestedAction],
+    ["greeting", p.greeting],
+  ];
+  const leaks: string[] = [];
+  for (const [name, value] of fields) {
+    if (hasUuid(value)) leaks.push(`UUID in ${name}`);
+    if (hasInternalLabel(value)) leaks.push(`internal label in ${name}`);
+  }
+  return {
+    headline: p.headline,
+    personalizedSummary: p.personalizedSummary,
+    suggestedAction: p.suggestedAction,
+    greeting: p.greeting,
+    leaks,
+  };
+}
+
+/**
+ * Run an opportunity card case `runs` times, retrying transient live-model failures.
+ *
+ * @param presenter - The opportunity presenter under test.
+ * @param c - The case to run.
+ * @param runs - Number of repetitions.
+ * @param options - Retry tuning (defaults from opportunity constants).
+ * @returns One normalized card detail per run.
+ */
+export async function runCase(
+  presenter: PresenterLike,
+  c: OpportunityCase,
+  runs: number,
+  options: RunCaseOptions = {},
+): Promise<OpportunityRunDetail[]> {
+  return repeatRuns(() => invokeOnce(presenter, c), runs, {
+    maxAttempts: options.maxAttempts ?? OPPORTUNITY_EVAL_MAX_ATTEMPTS,
+    retryDelayMs: options.retryDelayMs ?? OPPORTUNITY_EVAL_RETRY_DELAY_MS,
+    label: "opportunity eval",
+  });
+}

--- a/packages/protocol/eval/opportunity/opportunity.runner.ts
+++ b/packages/protocol/eval/opportunity/opportunity.runner.ts
@@ -25,17 +25,16 @@ export interface RunCaseOptions {
 }
 
 /**
- * The presenter swallows LLM timeouts/failures and returns a fixed fallback card
- * (headline "A promising connection", the raw matchReasoning as summary, empty
- * greeting). That degraded path is a resilience concern, not card quality — detect
- * it so the runner retries and the eval measures the real model output.
+ * The presenter swallows LLM timeouts/failures and returns a fixed fallback card:
+ * headline "A promising connection", the raw matchReasoning as the summary, and an
+ * empty greeting (both the party and introducer fallback branches share this — only
+ * the suggestedAction copy differs between them). That degraded path is a resilience
+ * concern, not card quality, so detect it and let the runner retry past it so the
+ * eval measures real model output. A genuine card always populates the greeting and
+ * never reuses the fixed fallback headline, so this signature does not false-positive.
  */
-function isFallbackCard(p: { headline: string; suggestedAction: string; greeting: string }): boolean {
-  return (
-    p.headline === "A promising connection" &&
-    p.suggestedAction === "Take a look and decide whether to reach out." &&
-    p.greeting === ""
-  );
+function isFallbackCard(p: { headline: string; greeting: string }): boolean {
+  return p.headline === "A promising connection" && p.greeting === "";
 }
 
 /** Invoke the presenter once and normalize its card output (collecting leakage findings). */

--- a/packages/protocol/eval/opportunity/opportunity.scorer.ts
+++ b/packages/protocol/eval/opportunity/opportunity.scorer.ts
@@ -1,0 +1,96 @@
+import { GREETING_MAX_LEN } from "./opportunity.constants.js";
+import { hasGreetingPrefix, hasInternalLabel, hasMarkdown, hasUuid } from "./opportunity.leakage.js";
+import type { AssertionResult, CaseResult, OpportunityCase, OpportunityRunDetail, RunResult } from "./opportunity.types.js";
+
+/** Grades a natural-language criterion. Returns true on pass. Injected for testability. */
+export type Judge = (output: unknown, criteria: string) => Promise<boolean>;
+
+const SECOND_PERSON_RE = /\byou(r|rs|rself)?\b/i;
+
+/**
+ * Score a single run of an opportunity card case. A run passes iff every assertion passes.
+ *
+ * @param c - The case being evaluated.
+ * @param d - The normalized presenter output for this run.
+ * @param judge - Injected LLM judge for grounding/framing/tone checks.
+ */
+export async function scoreRun(c: OpportunityCase, d: OpportunityRunDetail, judge: Judge): Promise<RunResult> {
+  const out: AssertionResult[] = [];
+  const { expect: e } = c;
+  const fields = [d.headline, d.personalizedSummary, d.suggestedAction, d.greeting];
+
+  // The card must actually say something.
+  out.push({
+    kind: "non_empty",
+    passed: d.headline.trim() !== "" && d.personalizedSummary.trim() !== "" && d.suggestedAction.trim() !== "",
+    detail: "headline, summary, and suggested action must be non-empty",
+  });
+
+  // Addresses the viewer directly (on by default).
+  if (e.secondPerson !== false) {
+    out.push({
+      kind: "voice",
+      passed: SECOND_PERSON_RE.test(d.personalizedSummary),
+      detail: SECOND_PERSON_RE.test(d.personalizedSummary) ? "summary speaks to the viewer" : "summary never says 'you'/'your'",
+    });
+  }
+
+  // No raw identifiers or internal labels in any field (on by default).
+  if (e.noLeakage !== false) {
+    const uuidField = fields.find((f) => hasUuid(f));
+    out.push({ kind: "uuid", passed: uuidField === undefined, detail: uuidField === undefined ? "no UUIDs in user-facing copy" : "a UUID leaked into the card" });
+    const labelField = fields.find((f) => hasInternalLabel(f));
+    out.push({ kind: "label", passed: labelField === undefined, detail: labelField === undefined ? "no internal labels in user-facing copy" : "an internal label leaked into the card" });
+  }
+
+  // Greeting must be plain prose within length (opt-in via greetingClean; skipped when empty).
+  if (e.greetingClean === true && d.greeting.trim() !== "") {
+    const cleanFormat = !hasMarkdown(d.greeting) && !hasGreetingPrefix(d.greeting);
+    out.push({ kind: "greeting_format", passed: cleanFormat, detail: cleanFormat ? "greeting is plain prose with no salutation prefix" : "greeting has markdown or a 'Hey Name,' prefix" });
+    out.push({ kind: "greeting_length", passed: d.greeting.length <= GREETING_MAX_LEN, detail: `greeting is ${d.greeting.length} chars (max ${GREETING_MAX_LEN})` });
+  }
+
+  // ── Judged ────────────────────────────────────────────────────────────
+  if (e.mustReference) {
+    const passed = await judge(
+      { headline: d.headline, summary: d.personalizedSummary, suggestedAction: d.suggestedAction },
+      `The card must accurately reflect this context and not contradict or invent facts beyond it: ${e.mustReference}.`,
+    );
+    out.push({ kind: "grounding", passed, detail: passed ? "judge: grounded in context" : "judge: hallucinated or off-context" });
+  }
+  if (e.framingCriteria) {
+    const passed = await judge(
+      { headline: d.headline, summary: d.personalizedSummary, suggestedAction: d.suggestedAction, greeting: d.greeting },
+      e.framingCriteria,
+    );
+    out.push({ kind: "framing", passed, detail: passed ? "judge: framing correct" : "judge: framing wrong" });
+  }
+  if (e.toneCriteria) {
+    const passed = await judge({ headline: d.headline, summary: d.personalizedSummary, suggestedAction: d.suggestedAction }, e.toneCriteria);
+    out.push({ kind: "tone", passed, detail: passed ? "judge: tone good" : "judge: tone off" });
+  }
+
+  return { passed: out.every((a) => a.passed), assertions: out, detail: d };
+}
+
+/**
+ * Aggregate N runs of a case into a CaseResult with pass-rate and flakiness.
+ *
+ * @param c - The case being evaluated.
+ * @param details - One normalized card detail per run.
+ * @param judge - Injected LLM judge.
+ */
+export async function scoreCase(c: OpportunityCase, details: OpportunityRunDetail[], judge: Judge): Promise<CaseResult> {
+  const runResults = await Promise.all(details.map((d) => scoreRun(c, d, judge)));
+  const passes = runResults.filter((r) => r.passed).length;
+  const total = runResults.length;
+  return {
+    caseId: c.id,
+    rule: c.rule,
+    runs: total,
+    passes,
+    passRate: total === 0 ? 0 : passes / total,
+    flaky: passes > 0 && passes < total,
+    runResults,
+  };
+}

--- a/packages/protocol/eval/opportunity/opportunity.selection.ts
+++ b/packages/protocol/eval/opportunity/opportunity.selection.ts
@@ -1,0 +1,61 @@
+import type { OpportunityCase, Rule } from "./opportunity.types.js";
+
+export interface CaseFilters {
+  rule?: string;
+  caseId?: string;
+  tier?: number;
+}
+
+/** Parse and validate a tier CLI argument. */
+export function parseTier(value: string | undefined): 1 | 2 | undefined {
+  if (value === undefined) return undefined;
+  const n = Number(value);
+  if (n === 1 || n === 2) return n;
+  throw new Error(`--tier must be one of 1, 2 (got "${value}")`);
+}
+
+/** Select opportunity eval cases by optional rule, id/prefix, and tier filters. */
+export function selectCases(cases: OpportunityCase[], filters: CaseFilters): OpportunityCase[] {
+  return cases.filter((c) => {
+    if (filters.rule && c.rule !== filters.rule) return false;
+    if (filters.tier !== undefined && c.tier !== filters.tier) return false;
+    if (filters.caseId) {
+      const q = filters.caseId;
+      if (c.id !== q && !c.id.startsWith(q)) return false;
+    }
+    return true;
+  });
+}
+
+function countBy<T extends string | number>(values: T[]): Map<T, number> {
+  const out = new Map<T, number>();
+  for (const v of values) out.set(v, (out.get(v) ?? 0) + 1);
+  return out;
+}
+
+/** Format corpus counts by tier and rule. */
+export function formatCaseSummary(cases: OpportunityCase[]): string {
+  const byTier = [...countBy(cases.map((c) => c.tier)).entries()]
+    .sort((a, b) => Number(a[0]) - Number(b[0]))
+    .map(([tier, count]) => `t${tier}:${count}`)
+    .join("  ");
+  const byRule = [...countBy(cases.map((c) => c.rule)).entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([rule, count]) => `${rule}:${count}`)
+    .join("  ");
+  return `total:${cases.length}${byTier ? `\nby tier: ${byTier}` : ""}${byRule ? `\nby rule: ${byRule}` : ""}`;
+}
+
+/** Format a case inventory for --list-cases. */
+export function formatCaseList(cases: OpportunityCase[]): string {
+  const lines = ["Opportunity eval cases:", formatCaseSummary(cases), ""];
+  for (const c of [...cases].sort((a, b) => a.rule.localeCompare(b.rule) || a.id.localeCompare(b.id))) {
+    lines.push(`  [t${c.tier}] ${c.rule.padEnd(16)} ${c.id}`);
+  }
+  return lines.join("\n");
+}
+
+/** True when a string is a known rule value in the corpus. */
+export function hasRule(cases: OpportunityCase[], rule: string): rule is Rule {
+  return cases.some((c) => c.rule === rule);
+}

--- a/packages/protocol/eval/opportunity/opportunity.types.ts
+++ b/packages/protocol/eval/opportunity/opportunity.types.ts
@@ -1,0 +1,95 @@
+import type { CaseResultLike, RuleResult as SharedRuleResult, ScorecardLike } from "../shared/index.js";
+
+/** Each rule maps to a distinct presenter behaviour the corpus exercises. */
+export type Rule = "viewer_voice" | "no_leakage" | "greeting" | "grounding" | "introducer_role" | "tone";
+
+/** Viewer's role in the opportunity (drives framing rules). */
+export type ViewerRole = "party" | "patient" | "introducer";
+
+/** The pre-assembled context handed to `OpportunityPresenter.present`. */
+export interface PresenterInputCase {
+  viewerContext: string;
+  otherPartyContext: string;
+  matchReasoning: string;
+  category: string;
+  confidence: number;
+  signalsSummary: string;
+  indexName: string;
+  viewerRole: ViewerRole;
+  isIntroduction?: boolean;
+  introducerName?: string;
+}
+
+export interface OpportunityExpectation {
+  // ── Deterministic (default on for every card) ───────────────────────────
+  /** personalizedSummary must address the viewer in second person. Default true. */
+  secondPerson?: boolean;
+  /** No UUIDs or internal labels in any field. Default true. */
+  noLeakage?: boolean;
+  /**
+   * Assert the greeting is plain prose within length, with no salutation prefix.
+   * Opt-in (default off) so a minor greeting nit doesn't fail a card whose primary
+   * concern is voice/grounding/framing; set on greeting-focused cases.
+   */
+  greetingClean?: boolean;
+  // ── Judged (LLM) ────────────────────────────────────────────────────────
+  /** Grounding: the summary must reference this (real context fact), not hallucinate. */
+  mustReference?: string;
+  /** Role framing requirement for introduction / introducer cases. */
+  framingCriteria?: string;
+  /** Tone rubric (compelling, personal, not analytical). */
+  toneCriteria?: string;
+}
+
+export interface OpportunityCase {
+  id: string;
+  rule: Rule;
+  tier: 1 | 2;
+  /** Technical one-liner (for the engineer view). */
+  description: string;
+  /** Plain-language narrative for the non-technical report. */
+  human?: { scenario: string; expectation: string };
+  input: PresenterInputCase;
+  expect: OpportunityExpectation;
+}
+
+export type AssertionKind =
+  | "non_empty"
+  | "voice"
+  | "uuid"
+  | "label"
+  | "greeting_format"
+  | "greeting_length"
+  | "grounding"
+  | "framing"
+  | "tone";
+
+export interface AssertionResult {
+  kind: AssertionKind;
+  passed: boolean;
+  detail: string;
+}
+
+/** Normalized presenter output for one run (stripped from baselines, kept in run reports). */
+export interface OpportunityRunDetail {
+  headline: string;
+  personalizedSummary: string;
+  suggestedAction: string;
+  greeting: string;
+  /** Leakage findings for the report (empty when clean). */
+  leaks: string[];
+}
+
+export interface RunResult {
+  passed: boolean;
+  assertions: AssertionResult[];
+  detail?: OpportunityRunDetail;
+}
+
+export interface CaseResult extends CaseResultLike {
+  rule: Rule;
+  runResults: RunResult[];
+}
+
+export type RuleResult = SharedRuleResult;
+export type Scorecard = ScorecardLike<CaseResult>;

--- a/packages/protocol/eval/opportunity/tests/opportunity.cases.spec.ts
+++ b/packages/protocol/eval/opportunity/tests/opportunity.cases.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "bun:test";
+
+import { CASES } from "../opportunity.cases.js";
+import { formatCaseList, formatCaseSummary, hasRule, parseTier, selectCases } from "../opportunity.selection.js";
+
+describe("corpus invariants", () => {
+  it("has unique case ids", () => {
+    const ids = CASES.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("every case has an id prefix, a viewer role, and non-empty context", () => {
+    for (const c of CASES) {
+      expect(c.id).toContain("/");
+      expect(["party", "patient", "introducer"]).toContain(c.input.viewerRole);
+      expect(c.input.viewerContext.length).toBeGreaterThan(0);
+      expect(c.input.otherPartyContext.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("covers the leakage, voice, greeting, and framing rules", () => {
+    for (const rule of ["viewer_voice", "no_leakage", "greeting", "introducer_role"]) {
+      expect(CASES.some((c) => c.rule === rule)).toBe(true);
+    }
+  });
+});
+
+describe("parseTier", () => {
+  it("accepts supported tiers and rejects others", () => {
+    expect(parseTier("1")).toBe(1);
+    expect(parseTier(undefined)).toBeUndefined();
+    expect(() => parseTier("3")).toThrow();
+  });
+});
+
+describe("selectCases", () => {
+  it("filters by rule, tier, and id prefix", () => {
+    expect(selectCases(CASES, { rule: "no_leakage" }).every((c) => c.rule === "no_leakage")).toBe(true);
+    expect(selectCases(CASES, { tier: 1 }).every((c) => c.tier === 1)).toBe(true);
+    expect(selectCases(CASES, { caseId: "viewer_voice/" }).every((c) => c.id.startsWith("viewer_voice/"))).toBe(true);
+  });
+});
+
+describe("formatting + hasRule", () => {
+  it("summary and list render counts and ids", () => {
+    expect(formatCaseSummary(CASES)).toContain(`total:${CASES.length}`);
+    expect(formatCaseList(CASES)).toContain(CASES[0].id);
+  });
+
+  it("hasRule detects known and unknown rules", () => {
+    expect(hasRule(CASES, "no_leakage")).toBe(true);
+    expect(hasRule(CASES, "nope")).toBe(false);
+  });
+});

--- a/packages/protocol/eval/opportunity/tests/opportunity.leakage.spec.ts
+++ b/packages/protocol/eval/opportunity/tests/opportunity.leakage.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "bun:test";
+
+import { hasUuid, hasInternalLabel, hasMarkdown, hasGreetingPrefix } from "../opportunity.leakage.js";
+
+describe("hasUuid", () => {
+  it("detects a UUID", () => {
+    expect(hasUuid("see 5f0a2c14-6b3e-4f9a-8c21-9d7e1b2a4c6f for details")).toBe(true);
+  });
+  it("ignores ordinary text and numbers", () => {
+    expect(hasUuid("You raised $2M in 2024 with 3 mutual intents.")).toBe(false);
+  });
+});
+
+describe("hasInternalLabel", () => {
+  it("flags internal labels and field names", () => {
+    expect(hasInternalLabel("The source user overlaps with the candidate")).toBe(true);
+    expect(hasInternalLabel("matched on intentId")).toBe(true);
+  });
+  it("passes clean copy", () => {
+    expect(hasInternalLabel("Ava is raising a seed round and Ben invests at seed.")).toBe(false);
+  });
+});
+
+describe("hasMarkdown", () => {
+  it("flags emphasis, links, code, and bullets", () => {
+    expect(hasMarkdown("**bold** opener")).toBe(true);
+    expect(hasMarkdown("see [this](http://x)")).toBe(true);
+    expect(hasMarkdown("- a bullet")).toBe(true);
+    expect(hasMarkdown("`code`")).toBe(true);
+  });
+  it("passes plain prose", () => {
+    expect(hasMarkdown("Saw we're both working on climate hardware — would love to compare notes.")).toBe(false);
+  });
+});
+
+describe("hasGreetingPrefix", () => {
+  it("flags salutation prefixes", () => {
+    expect(hasGreetingPrefix("Hey Sarah, saw your post")).toBe(true);
+    expect(hasGreetingPrefix("Hi there, quick note")).toBe(true);
+  });
+  it("passes a body-only greeting", () => {
+    expect(hasGreetingPrefix("Saw we're both into ZK proofs — keen to chat.")).toBe(false);
+  });
+});

--- a/packages/protocol/eval/opportunity/tests/opportunity.scorer.spec.ts
+++ b/packages/protocol/eval/opportunity/tests/opportunity.scorer.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "bun:test";
+
+import { scoreRun, scoreCase, type Judge } from "../opportunity.scorer.js";
+import type { OpportunityCase, OpportunityRunDetail } from "../opportunity.types.js";
+
+const yes: Judge = async () => true;
+const no: Judge = async () => false;
+
+const mkCase = (expect: OpportunityCase["expect"], rule: OpportunityCase["rule"] = "viewer_voice"): OpportunityCase => ({
+  id: "o/case",
+  rule,
+  tier: 1,
+  description: "synthetic",
+  input: {
+    viewerContext: "v",
+    otherPartyContext: "o",
+    matchReasoning: "m",
+    category: "peer",
+    confidence: 0.8,
+    signalsSummary: "s",
+    indexName: "i",
+    viewerRole: "party",
+  },
+  expect,
+});
+
+const detail = (over: Partial<OpportunityRunDetail> = {}): OpportunityRunDetail => ({
+  headline: "A great connection",
+  personalizedSummary: "You should meet them because your goals align.",
+  suggestedAction: "Send a quick note.",
+  greeting: "Saw we're both building climate tooling — would love to compare notes.",
+  leaks: [],
+  ...over,
+});
+
+describe("scoreRun — deterministic", () => {
+  it("passes voice, leakage, and non-empty by default; greeting checks are opt-in", async () => {
+    const rr = await scoreRun(mkCase({}), detail(), yes);
+    expect(rr.passed).toBe(true);
+    expect(rr.assertions.find((a) => a.kind === "voice")!.passed).toBe(true);
+    expect(rr.assertions.find((a) => a.kind === "uuid")!.passed).toBe(true);
+    expect(rr.assertions.some((a) => a.kind === "greeting_format")).toBe(false); // off unless greetingClean
+    const withGreeting = await scoreRun(mkCase({ greetingClean: true }), detail(), yes);
+    expect(withGreeting.assertions.find((a) => a.kind === "greeting_format")!.passed).toBe(true);
+  });
+
+  it("fails when the summary never addresses the viewer", async () => {
+    const rr = await scoreRun(mkCase({}), detail({ personalizedSummary: "The two people share a focus on climate." }), yes);
+    expect(rr.assertions.find((a) => a.kind === "voice")!.passed).toBe(false);
+    expect(rr.passed).toBe(false);
+  });
+
+  it("fails on a leaked UUID in any field", async () => {
+    const d = detail({ headline: "Meet 5f0a2c14-6b3e-4f9a-8c21-9d7e1b2a4c6f" });
+    const rr = await scoreRun(mkCase({}), d, yes);
+    expect(rr.assertions.find((a) => a.kind === "uuid")!.passed).toBe(false);
+  });
+
+  it("fails an opt-in greeting with a salutation prefix or markdown", async () => {
+    const prefix = await scoreRun(mkCase({ greetingClean: true }), detail({ greeting: "Hey Sam, great to connect!" }), yes);
+    expect(prefix.assertions.find((a) => a.kind === "greeting_format")!.passed).toBe(false);
+    const md = await scoreRun(mkCase({ greetingClean: true }), detail({ greeting: "**Loved** your work." }), yes);
+    expect(md.assertions.find((a) => a.kind === "greeting_format")!.passed).toBe(false);
+  });
+
+  it("skips greeting checks when opt-in but the greeting is empty", async () => {
+    const rr = await scoreRun(mkCase({ greetingClean: true }), detail({ greeting: "" }), yes);
+    expect(rr.assertions.some((a) => a.kind === "greeting_format")).toBe(false);
+    expect(rr.passed).toBe(true);
+  });
+
+  it("can opt out of leakage and voice checks", async () => {
+    const rr = await scoreRun(mkCase({ noLeakage: false, secondPerson: false }), detail({ personalizedSummary: "no second person", headline: "intentId leak" }), yes);
+    expect(rr.assertions.some((a) => a.kind === "uuid" || a.kind === "label" || a.kind === "voice")).toBe(false);
+  });
+});
+
+describe("scoreRun — judged", () => {
+  it("routes grounding, framing, and tone through the judge", async () => {
+    const c = mkCase({ mustReference: "x", framingCriteria: "y", toneCriteria: "z" }, "introducer_role");
+    expect((await scoreRun(c, detail(), yes)).passed).toBe(true);
+    const failed = await scoreRun(c, detail(), no);
+    expect(failed.passed).toBe(false);
+    expect(failed.assertions.find((a) => a.kind === "grounding")!.passed).toBe(false);
+    expect(failed.assertions.find((a) => a.kind === "framing")!.passed).toBe(false);
+    expect(failed.assertions.find((a) => a.kind === "tone")!.passed).toBe(false);
+  });
+});
+
+describe("scoreCase", () => {
+  it("aggregates runs into pass-rate and flags flakiness", async () => {
+    const c = mkCase({});
+    const result = await scoreCase(c, [detail(), detail({ personalizedSummary: "no viewer voice here" })], yes);
+    expect(result.runs).toBe(2);
+    expect(result.passes).toBe(1);
+    expect(result.flaky).toBe(true);
+  });
+});

--- a/packages/protocol/eval/opportunity/tsconfig.json
+++ b/packages/protocol/eval/opportunity/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "composite": false,
+    "rootDir": "../../",
+    "types": ["node", "bun-types"]
+  },
+  "include": ["**/*.ts", "../../src/**/*.ts"],
+  "exclude": ["node_modules", "../../src/**/*.spec.ts", "../../src/**/*.test.ts"]
+}

--- a/packages/protocol/eval/premise/README.md
+++ b/packages/protocol/eval/premise/README.md
@@ -1,0 +1,70 @@
+# Premise Quality Eval Harness
+
+Measures whether the premise agents make the right judgments against a curated golden
+set. Standalone and opt-in — NOT part of `bun test`. Two agents are under test:
+
+- **Decompose** (`PremiseDecomposer.invoke`): free text → atomic, first-person premises
+  with `assertive` / `contextual` tiering and no leaked intents.
+- **Analyze** (`PremiseAnalyzer.invoke`): a premise → speech-act class
+  (`DECLARATIVE` / `ASSERTIVE`) + felicity scores (authority, sincerity, clarity) and
+  semantic entropy.
+
+## Run
+
+```bash
+# from packages/protocol
+bun run eval:premise                          # all cases, 3 runs, judge on, diff baseline
+bun run eval:premise -- --runs 5              # more runs = less noise
+bun run eval:premise -- --component analyze    # only the analyzer (or: decompose)
+bun run eval:premise -- --rule speech_act      # one rule
+bun run eval:premise -- --case atomicity/      # one case or id prefix
+bun run eval:premise -- --tier 1               # one tier
+bun run eval:premise -- --list-cases           # print selected cases and exit
+bun run eval:premise -- --no-judge             # skip LLM coverage/exclusion/reasoning checks (free)
+bun run eval:premise -- --update-baseline      # overwrite the committed baseline
+bun run eval:premise -- --report [path]        # write a full run report incl. agent output
+bun run eval:premise -- --html [path]          # write a standalone HTML scorecard
+bun run eval:premise -- --rolling-baseline [d] # compare against trailing run average (default 7d)
+bun run eval:premise -- --alpha 0.01           # stricter regression significance threshold
+bun run eval:premise -- --no-save              # do not auto-save full-corpus run JSON
+```
+
+Requires `OPENROUTER_API_KEY` (loaded via `.env.test`). Exits non-zero on a regression
+versus `baselines/premise.baseline.json` (one-sided beta-binomial posterior-predictive
+test, default α=0.05). Shared machinery (scorecard math, baseline diff, rolling baseline,
+console/HTML reporting, runner) lives in [`eval/shared`](../shared); this harness owns only
+its corpus, scorer, types, and CLI.
+
+## Checks
+
+**Decompose** — deterministic: premise `count` band, `empty` for no-fact inputs, `tier`
+counts (assertive/contextual), `first_person` structural check. Judged (skipped with
+`--no-judge`): `coverage` (all expected facts represented) and `exclusion` (no leaked
+intents/desires).
+
+**Analyze** — deterministic: `speech_act` class, and `authority` / `sincerity` / `clarity`
+/ `entropy` score bands. Judged: optional `reasoning` rubric.
+
+Score bands are intentionally generous — they assert direction (high vs low), not exact
+model values.
+
+## Adding a case
+
+Append a `PremiseCase` to `CASES` in `premise.cases.ts`. Set `component`
+(`decompose` | `analyze`), `rule`, `tier` (1 surgical, 2 realistic), `input`, and the
+component-specific `expect`. Prefer deterministic expectations; reach for judged
+`mustCover` / `mustNotContain` / `reasoningCriteria` only when a code check can't express
+the expectation. Re-run with `--update-baseline` after an intentional change.
+
+## Layout
+
+- `premise.cases.ts` — the golden corpus.
+- `premise.types.ts` — harness types (specializes the shared scorecard types).
+- `premise.runner.ts` — invokes the agents N times (shared retry loop).
+- `premise.scorer.ts` — per-run assertions → `CaseResult`.
+- `premise.reporter.ts` — HTML scorecard via the shared shell.
+- `premise.selection.ts` — `--rule` / `--component` / `--case` / `--tier` filtering.
+- `premise.eval.ts` — CLI.
+- `baselines/premise.baseline.json` — committed baseline (per-run detail stripped).
+- `runs/*.json` — gitignored full run reports (rolling-baseline fuel).
+- `tests/` — unit tests (no live agents).

--- a/packages/protocol/eval/premise/baselines/premise.baseline.json
+++ b/packages/protocol/eval/premise/baselines/premise.baseline.json
@@ -1,0 +1,640 @@
+{
+  "generatedAt": "2026-06-16T15:27:23.785Z",
+  "model": "google/gemini-2.5-flash / google/gemini-2.5-flash",
+  "runs": 3,
+  "aggregatePassRate": 1,
+  "rules": [
+    {
+      "rule": "atomicity",
+      "caseCount": 2,
+      "passRate": 1
+    },
+    {
+      "rule": "tier_classification",
+      "caseCount": 1,
+      "passRate": 1
+    },
+    {
+      "rule": "intent_exclusion",
+      "caseCount": 1,
+      "passRate": 1
+    },
+    {
+      "rule": "empty_input",
+      "caseCount": 1,
+      "passRate": 1
+    },
+    {
+      "rule": "speech_act",
+      "caseCount": 2,
+      "passRate": 1
+    },
+    {
+      "rule": "felicity_calibration",
+      "caseCount": 2,
+      "passRate": 1
+    },
+    {
+      "rule": "entropy",
+      "caseCount": 1,
+      "passRate": 1
+    }
+  ],
+  "cases": [
+    {
+      "caseId": "atomicity/compound-split",
+      "rule": "atomicity",
+      "runs": 3,
+      "passes": 3,
+      "passRate": 1,
+      "flaky": false,
+      "runResults": [
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "count",
+              "passed": true,
+              "detail": "expected 4–7 premises, got 5"
+            },
+            {
+              "kind": "first_person",
+              "passed": true,
+              "detail": "all premises first-person"
+            },
+            {
+              "kind": "coverage",
+              "passed": true,
+              "detail": "judge: all facts covered"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "count",
+              "passed": true,
+              "detail": "expected 4–7 premises, got 5"
+            },
+            {
+              "kind": "first_person",
+              "passed": true,
+              "detail": "all premises first-person"
+            },
+            {
+              "kind": "coverage",
+              "passed": true,
+              "detail": "judge: all facts covered"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "count",
+              "passed": true,
+              "detail": "expected 4–7 premises, got 5"
+            },
+            {
+              "kind": "first_person",
+              "passed": true,
+              "detail": "all premises first-person"
+            },
+            {
+              "kind": "coverage",
+              "passed": true,
+              "detail": "judge: all facts covered"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "caseId": "atomicity/third-person-to-first",
+      "rule": "atomicity",
+      "runs": 3,
+      "passes": 3,
+      "passRate": 1,
+      "flaky": false,
+      "runResults": [
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "count",
+              "passed": true,
+              "detail": "expected 3–6 premises, got 4"
+            },
+            {
+              "kind": "first_person",
+              "passed": true,
+              "detail": "all premises first-person"
+            },
+            {
+              "kind": "coverage",
+              "passed": true,
+              "detail": "judge: all facts covered"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "count",
+              "passed": true,
+              "detail": "expected 3–6 premises, got 4"
+            },
+            {
+              "kind": "first_person",
+              "passed": true,
+              "detail": "all premises first-person"
+            },
+            {
+              "kind": "coverage",
+              "passed": true,
+              "detail": "judge: all facts covered"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "count",
+              "passed": true,
+              "detail": "expected 3–6 premises, got 4"
+            },
+            {
+              "kind": "first_person",
+              "passed": true,
+              "detail": "all premises first-person"
+            },
+            {
+              "kind": "coverage",
+              "passed": true,
+              "detail": "judge: all facts covered"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "caseId": "tier_classification/founder-raising",
+      "rule": "tier_classification",
+      "runs": 3,
+      "passes": 3,
+      "passRate": 1,
+      "flaky": false,
+      "runResults": [
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "count",
+              "passed": true,
+              "detail": "expected 3–∞ premises, got 4"
+            },
+            {
+              "kind": "tier",
+              "passed": true,
+              "detail": "expected ≥2 assertive, got 3"
+            },
+            {
+              "kind": "tier",
+              "passed": true,
+              "detail": "expected ≥1 contextual, got 1"
+            },
+            {
+              "kind": "first_person",
+              "passed": true,
+              "detail": "all premises first-person"
+            },
+            {
+              "kind": "coverage",
+              "passed": true,
+              "detail": "judge: all facts covered"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "count",
+              "passed": true,
+              "detail": "expected 3–∞ premises, got 4"
+            },
+            {
+              "kind": "tier",
+              "passed": true,
+              "detail": "expected ≥2 assertive, got 3"
+            },
+            {
+              "kind": "tier",
+              "passed": true,
+              "detail": "expected ≥1 contextual, got 1"
+            },
+            {
+              "kind": "first_person",
+              "passed": true,
+              "detail": "all premises first-person"
+            },
+            {
+              "kind": "coverage",
+              "passed": true,
+              "detail": "judge: all facts covered"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "count",
+              "passed": true,
+              "detail": "expected 3–∞ premises, got 4"
+            },
+            {
+              "kind": "tier",
+              "passed": true,
+              "detail": "expected ≥2 assertive, got 3"
+            },
+            {
+              "kind": "tier",
+              "passed": true,
+              "detail": "expected ≥1 contextual, got 1"
+            },
+            {
+              "kind": "first_person",
+              "passed": true,
+              "detail": "all premises first-person"
+            },
+            {
+              "kind": "coverage",
+              "passed": true,
+              "detail": "judge: all facts covered"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "caseId": "intent_exclusion/skip-desires",
+      "rule": "intent_exclusion",
+      "runs": 3,
+      "passes": 3,
+      "passRate": 1,
+      "flaky": false,
+      "runResults": [
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "count",
+              "passed": true,
+              "detail": "expected 2–4 premises, got 2"
+            },
+            {
+              "kind": "first_person",
+              "passed": true,
+              "detail": "all premises first-person"
+            },
+            {
+              "kind": "coverage",
+              "passed": true,
+              "detail": "judge: all facts covered"
+            },
+            {
+              "kind": "exclusion",
+              "passed": true,
+              "detail": "judge: excluded content absent"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "count",
+              "passed": true,
+              "detail": "expected 2–4 premises, got 2"
+            },
+            {
+              "kind": "first_person",
+              "passed": true,
+              "detail": "all premises first-person"
+            },
+            {
+              "kind": "coverage",
+              "passed": true,
+              "detail": "judge: all facts covered"
+            },
+            {
+              "kind": "exclusion",
+              "passed": true,
+              "detail": "judge: excluded content absent"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "count",
+              "passed": true,
+              "detail": "expected 2–4 premises, got 2"
+            },
+            {
+              "kind": "first_person",
+              "passed": true,
+              "detail": "all premises first-person"
+            },
+            {
+              "kind": "coverage",
+              "passed": true,
+              "detail": "judge: all facts covered"
+            },
+            {
+              "kind": "exclusion",
+              "passed": true,
+              "detail": "judge: excluded content absent"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "caseId": "empty_input/greeting",
+      "rule": "empty_input",
+      "runs": 3,
+      "passes": 3,
+      "passRate": 1,
+      "flaky": false,
+      "runResults": [
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "empty",
+              "passed": true,
+              "detail": "expected no premises, got 0"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "empty",
+              "passed": true,
+              "detail": "expected no premises, got 0"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "empty",
+              "passed": true,
+              "detail": "expected no premises, got 0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "caseId": "speech_act/declarative-identity",
+      "rule": "speech_act",
+      "runs": 3,
+      "passes": 3,
+      "passRate": 1,
+      "flaky": false,
+      "runResults": [
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "speech_act",
+              "passed": true,
+              "detail": "expected DECLARATIVE, got DECLARATIVE"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "speech_act",
+              "passed": true,
+              "detail": "expected DECLARATIVE, got DECLARATIVE"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "speech_act",
+              "passed": true,
+              "detail": "expected DECLARATIVE, got DECLARATIVE"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "caseId": "speech_act/assertive-capability",
+      "rule": "speech_act",
+      "runs": 3,
+      "passes": 3,
+      "passRate": 1,
+      "flaky": false,
+      "runResults": [
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "speech_act",
+              "passed": true,
+              "detail": "expected ASSERTIVE, got ASSERTIVE"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "speech_act",
+              "passed": true,
+              "detail": "expected ASSERTIVE, got ASSERTIVE"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "speech_act",
+              "passed": true,
+              "detail": "expected ASSERTIVE, got ASSERTIVE"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "caseId": "felicity_calibration/specific-high-clarity",
+      "rule": "felicity_calibration",
+      "runs": 3,
+      "passes": 3,
+      "passRate": 1,
+      "flaky": false,
+      "runResults": [
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "clarity",
+              "passed": true,
+              "detail": "expected clarity in [65,100], got 100"
+            },
+            {
+              "kind": "entropy",
+              "passed": true,
+              "detail": "expected entropy in [0,0.45], got 0.05"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "clarity",
+              "passed": true,
+              "detail": "expected clarity in [65,100], got 100"
+            },
+            {
+              "kind": "entropy",
+              "passed": true,
+              "detail": "expected entropy in [0,0.45], got 0"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "clarity",
+              "passed": true,
+              "detail": "expected clarity in [65,100], got 100"
+            },
+            {
+              "kind": "entropy",
+              "passed": true,
+              "detail": "expected entropy in [0,0.45], got 0.05"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "caseId": "felicity_calibration/grandiose-low-authority",
+      "rule": "felicity_calibration",
+      "runs": 3,
+      "passes": 3,
+      "passRate": 1,
+      "flaky": false,
+      "runResults": [
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "authority",
+              "passed": true,
+              "detail": "expected authority in [0,45], got 0"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "authority",
+              "passed": true,
+              "detail": "expected authority in [0,45], got 0"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "authority",
+              "passed": true,
+              "detail": "expected authority in [0,45], got 0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "caseId": "entropy/vague-high-entropy",
+      "rule": "entropy",
+      "runs": 3,
+      "passes": 3,
+      "passRate": 1,
+      "flaky": false,
+      "runResults": [
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "clarity",
+              "passed": true,
+              "detail": "expected clarity in [0,45], got 20"
+            },
+            {
+              "kind": "entropy",
+              "passed": true,
+              "detail": "expected entropy in [0.6,1], got 1"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "clarity",
+              "passed": true,
+              "detail": "expected clarity in [0,45], got 5"
+            },
+            {
+              "kind": "entropy",
+              "passed": true,
+              "detail": "expected entropy in [0.6,1], got 0.99"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "clarity",
+              "passed": true,
+              "detail": "expected clarity in [0,45], got 20"
+            },
+            {
+              "kind": "entropy",
+              "passed": true,
+              "detail": "expected entropy in [0.6,1], got 1"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/protocol/eval/premise/premise.cases.ts
+++ b/packages/protocol/eval/premise/premise.cases.ts
@@ -19,6 +19,10 @@ export const CASES: PremiseCase[] = [
     tier: 2,
     component: "decompose",
     description: "Compound, multi-fact sentence splits into atomic first-person premises.",
+    human: {
+      scenario: "a run-on sentence packing several facts together: a software engineer at Google who knows Python and Rust and lives in San Francisco.",
+      expectation: "break it into separate, single-fact statements — one each for the role, each skill, and the location.",
+    },
     input: "I'm a software engineer at Google and I know Python and Rust, based in San Francisco.",
     expect: {
       minPremises: 4,
@@ -32,6 +36,10 @@ export const CASES: PremiseCase[] = [
     tier: 2,
     component: "decompose",
     description: "Third-person bio is converted to first-person atomic premises.",
+    human: {
+      scenario: "a bio written about someone else (\u201cJane Smith is a senior data scientist at Netflix\u2026\u201d).",
+      expectation: "rewrite the facts in the person's own voice and split them out: role, employer, location, experience.",
+    },
     input: "Jane Smith is a senior data scientist at Netflix in Los Angeles. She has 8 years of experience in recommender systems.",
     expect: {
       minPremises: 3,
@@ -45,6 +53,10 @@ export const CASES: PremiseCase[] = [
     tier: 1,
     component: "decompose",
     description: "Stable identity facts are assertive; current fundraising status is contextual.",
+    human: {
+      scenario: "a founder who lists permanent facts (their role, their PhD, their city) alongside a temporary one (currently raising a Series A).",
+      expectation: "keep the lasting facts as stable identity, and mark the fundraising as a current, time-bound status.",
+    },
     input: "I'm a climate tech founder based in Berlin. I hold a PhD in renewable energy systems and I'm currently raising a Series A.",
     expect: {
       minPremises: 3,
@@ -59,6 +71,10 @@ export const CASES: PremiseCase[] = [
     tier: 1,
     component: "decompose",
     description: "Self-descriptive facts are kept; desires/requests (intents) are dropped.",
+    human: {
+      scenario: "someone who states who they are (a product designer in New York) but also what they want (a cofounder, and to learn ML).",
+      expectation: "keep the facts about who they are, and drop the wishes — those are goals, not facts.",
+    },
     input: "I'm a product designer in New York. I'm looking for a technical cofounder and I want to learn machine learning.",
     expect: {
       minPremises: 2,
@@ -73,6 +89,10 @@ export const CASES: PremiseCase[] = [
     tier: 1,
     component: "decompose",
     description: "Input with no self-descriptive facts yields an empty premise array.",
+    human: {
+      scenario: "a message with no real facts in it — just \u201cYes, please create my profile now.\u201d",
+      expectation: "recognize there's nothing to save and not invent any facts.",
+    },
     input: "Yes, please create my profile now.",
     expect: { expectEmpty: true },
   },
@@ -84,6 +104,10 @@ export const CASES: PremiseCase[] = [
     tier: 1,
     component: "analyze",
     description: "An identity/role/status premise classifies as DECLARATIVE.",
+    human: {
+      scenario: "the statement \u201cI am a climate-tech founder.\u201d",
+      expectation: "recognize this as an identity claim (who someone is), not just a description of what they've done.",
+    },
     input: "I am a climate-tech founder",
     expect: { speechActType: "DECLARATIVE" },
   },
@@ -93,6 +117,10 @@ export const CASES: PremiseCase[] = [
     tier: 1,
     component: "analyze",
     description: "A capability/experience premise classifies as ASSERTIVE.",
+    human: {
+      scenario: "the statement \u201cI have 10 years of experience in distributed systems.\u201d",
+      expectation: "recognize this as a description of experience, not an identity claim.",
+    },
     input: "I have 10 years of experience in distributed systems",
     expect: { speechActType: "ASSERTIVE" },
   },
@@ -102,6 +130,10 @@ export const CASES: PremiseCase[] = [
     tier: 1,
     component: "analyze",
     description: "A highly specific premise scores high clarity and low semantic entropy.",
+    human: {
+      scenario: "a very specific claim: \u201cI build distributed database systems in Rust at a Series B startup in Berlin.\u201d",
+      expectation: "rate it as highly specific and easy to match (high clarity, low vagueness).",
+    },
     input: "I build distributed database systems in Rust at a Series B startup in Berlin",
     expect: { clarityBand: [65, 100], entropyBand: [0, 0.45] },
   },
@@ -111,6 +143,10 @@ export const CASES: PremiseCase[] = [
     tier: 1,
     component: "analyze",
     description: "A grandiose, unverifiable claim scores low authority.",
+    human: {
+      scenario: "a grandiose, unverifiable boast: \u201cI am the world's leading expert in absolutely everything.\u201d",
+      expectation: "rate its credibility low — the speaker has no real standing to claim it.",
+    },
     input: "I am the world's leading expert in absolutely everything",
     expect: { authorityBand: [0, 45] },
   },
@@ -120,6 +156,10 @@ export const CASES: PremiseCase[] = [
     tier: 1,
     component: "analyze",
     description: "An uninformative premise scores low clarity and high semantic entropy.",
+    human: {
+      scenario: "an empty, vague statement: \u201cI'm a person who does things.\u201d",
+      expectation: "rate it as too vague to be useful (low clarity, high vagueness).",
+    },
     input: "I'm a person who does things",
     expect: { clarityBand: [0, 45], entropyBand: [0.6, 1] },
   },

--- a/packages/protocol/eval/premise/premise.cases.ts
+++ b/packages/protocol/eval/premise/premise.cases.ts
@@ -1,0 +1,126 @@
+import type { PremiseCase } from "./premise.types.js";
+
+/**
+ * Premise eval golden corpus (starter set).
+ *
+ * Tier 1 cases are surgical: one clear behaviour, mostly deterministic checks.
+ * Tier 2 cases are more realistic, multi-fact inputs. Decomposer cases exercise
+ * `PremiseDecomposer.invoke`; analyzer cases exercise `PremiseAnalyzer.invoke`.
+ *
+ * Grow the corpus by appending cases here. Re-run with `--update-baseline` after
+ * an intentional change. Score bands are intentionally generous — they assert
+ * direction (high vs low), not exact LLM values.
+ */
+export const CASES: PremiseCase[] = [
+  // ─── Decomposer ──────────────────────────────────────────────────────────
+  {
+    id: "atomicity/compound-split",
+    rule: "atomicity",
+    tier: 2,
+    component: "decompose",
+    description: "Compound, multi-fact sentence splits into atomic first-person premises.",
+    input: "I'm a software engineer at Google and I know Python and Rust, based in San Francisco.",
+    expect: {
+      minPremises: 4,
+      maxPremises: 7,
+      mustCover: ["works at Google / is a software engineer", "knows Python", "knows Rust", "based in San Francisco"],
+    },
+  },
+  {
+    id: "atomicity/third-person-to-first",
+    rule: "atomicity",
+    tier: 2,
+    component: "decompose",
+    description: "Third-person bio is converted to first-person atomic premises.",
+    input: "Jane Smith is a senior data scientist at Netflix in Los Angeles. She has 8 years of experience in recommender systems.",
+    expect: {
+      minPremises: 3,
+      maxPremises: 6,
+      mustCover: ["senior data scientist", "works at Netflix", "based in Los Angeles", "experience in recommender systems"],
+    },
+  },
+  {
+    id: "tier_classification/founder-raising",
+    rule: "tier_classification",
+    tier: 1,
+    component: "decompose",
+    description: "Stable identity facts are assertive; current fundraising status is contextual.",
+    input: "I'm a climate tech founder based in Berlin. I hold a PhD in renewable energy systems and I'm currently raising a Series A.",
+    expect: {
+      minPremises: 3,
+      minAssertive: 2,
+      minContextual: 1,
+      mustCover: ["climate tech founder", "based in Berlin", "PhD in renewable energy", "raising Series A"],
+    },
+  },
+  {
+    id: "intent_exclusion/skip-desires",
+    rule: "intent_exclusion",
+    tier: 1,
+    component: "decompose",
+    description: "Self-descriptive facts are kept; desires/requests (intents) are dropped.",
+    input: "I'm a product designer in New York. I'm looking for a technical cofounder and I want to learn machine learning.",
+    expect: {
+      minPremises: 2,
+      maxPremises: 4,
+      mustCover: ["product designer", "based in New York"],
+      mustNotContain: "a desire, request, or intent such as looking for a cofounder or wanting to learn machine learning",
+    },
+  },
+  {
+    id: "empty_input/greeting",
+    rule: "empty_input",
+    tier: 1,
+    component: "decompose",
+    description: "Input with no self-descriptive facts yields an empty premise array.",
+    input: "Yes, please create my profile now.",
+    expect: { expectEmpty: true },
+  },
+
+  // ─── Analyzer ────────────────────────────────────────────────────────────
+  {
+    id: "speech_act/declarative-identity",
+    rule: "speech_act",
+    tier: 1,
+    component: "analyze",
+    description: "An identity/role/status premise classifies as DECLARATIVE.",
+    input: "I am a climate-tech founder",
+    expect: { speechActType: "DECLARATIVE" },
+  },
+  {
+    id: "speech_act/assertive-capability",
+    rule: "speech_act",
+    tier: 1,
+    component: "analyze",
+    description: "A capability/experience premise classifies as ASSERTIVE.",
+    input: "I have 10 years of experience in distributed systems",
+    expect: { speechActType: "ASSERTIVE" },
+  },
+  {
+    id: "felicity_calibration/specific-high-clarity",
+    rule: "felicity_calibration",
+    tier: 1,
+    component: "analyze",
+    description: "A highly specific premise scores high clarity and low semantic entropy.",
+    input: "I build distributed database systems in Rust at a Series B startup in Berlin",
+    expect: { clarityBand: [65, 100], entropyBand: [0, 0.45] },
+  },
+  {
+    id: "felicity_calibration/grandiose-low-authority",
+    rule: "felicity_calibration",
+    tier: 1,
+    component: "analyze",
+    description: "A grandiose, unverifiable claim scores low authority.",
+    input: "I am the world's leading expert in absolutely everything",
+    expect: { authorityBand: [0, 45] },
+  },
+  {
+    id: "entropy/vague-high-entropy",
+    rule: "entropy",
+    tier: 1,
+    component: "analyze",
+    description: "An uninformative premise scores low clarity and high semantic entropy.",
+    input: "I'm a person who does things",
+    expect: { clarityBand: [0, 45], entropyBand: [0.6, 1] },
+  },
+];

--- a/packages/protocol/eval/premise/premise.constants.ts
+++ b/packages/protocol/eval/premise/premise.constants.ts
@@ -1,0 +1,4 @@
+/** Retry budget for transient live-model failures during a premise eval run. */
+export const PREMISE_EVAL_MAX_ATTEMPTS = 3;
+/** Base backoff between premise eval retries (doubles each attempt). */
+export const PREMISE_EVAL_RETRY_DELAY_MS = 1000;

--- a/packages/protocol/eval/premise/premise.eval.ts
+++ b/packages/protocol/eval/premise/premise.eval.ts
@@ -1,0 +1,203 @@
+#!/usr/bin/env bun
+/**
+ * Premise quality eval harness.
+ *
+ * Usage (from packages/protocol):
+ *   bun run eval:premise                          # all cases, 3 runs, judge on, diff baseline
+ *   bun run eval:premise -- --runs 5              # more runs = less noise
+ *   bun run eval:premise -- --rule speech_act     # one rule
+ *   bun run eval:premise -- --component analyze    # one agent (decompose | analyze)
+ *   bun run eval:premise -- --case atomicity/      # one case or id prefix
+ *   bun run eval:premise -- --tier 1               # one tier
+ *   bun run eval:premise -- --list-cases           # print selected cases and exit
+ *   bun run eval:premise -- --no-judge             # skip LLM coverage/exclusion/reasoning checks
+ *   bun run eval:premise -- --update-baseline      # overwrite the committed baseline
+ *   bun run eval:premise -- --report [path]        # write a full run report (incl. agent output)
+ *   bun run eval:premise -- --html [path]          # write a standalone HTML scorecard
+ *   bun run eval:premise -- --rolling-baseline [d] # compare against recent runs (default 7d)
+ *   bun run eval:premise -- --alpha 0.01           # stricter regression significance threshold
+ *   bun run eval:premise -- --no-save              # do not auto-save full-corpus run JSON
+ *
+ * Requires OPENROUTER_API_KEY (loaded via --env-file=.env.test in the package script).
+ * Exits non-zero when a regression vs the committed baseline is detected.
+ */
+import path from "path";
+
+import { PremiseAnalyzer } from "../../src/premise/premise.analyzer.js";
+import { PremiseDecomposer } from "../../src/premise/premise.decomposer.js";
+import { getModelName } from "../../src/shared/agent/model.config.js";
+import { assertLLM } from "../../src/shared/agent/tests/llm-assert.js";
+import { arg, buildScorecard, computeRollingBaseline, diffBaseline, flagValue, formatConsole, has, readBaseline, writeBaseline, writeRunReport } from "../shared/index.js";
+import { CASES } from "./premise.cases.js";
+import { runCase } from "./premise.runner.js";
+import { scoreCase, type Judge } from "./premise.scorer.js";
+import { writeHtmlReport } from "./premise.reporter.js";
+import { formatCaseList, hasRule, parseComponent, parseTier, selectCases } from "./premise.selection.js";
+import type { CaseResult, Scorecard } from "./premise.types.js";
+
+const DEFAULT_ALPHA = 0.05;
+const BASELINE_PATH = path.resolve(import.meta.dir, "baselines/premise.baseline.json");
+const RUNS_DIR = path.resolve(import.meta.dir, "runs");
+
+function usage(): string {
+  return `Premise quality eval harness
+
+Usage (from packages/protocol):
+  bun run eval:premise [-- options]
+
+Selection:
+  --rule <rule>             Run one rule
+  --component <c>           Run one agent: decompose | analyze
+  --case <id-or-prefix>     Run one case or id prefix
+  --tier <1|2>              Run one tier
+  --list-cases              Print selected cases and exit
+
+Execution:
+  --runs <n>                Runs per case (default: 3)
+  --no-judge                Skip LLM coverage/exclusion/reasoning checks
+  --alpha <p>               Regression significance threshold (default: ${DEFAULT_ALPHA})
+  --no-save                 Do not auto-save full-corpus run JSON for rolling-baseline fuel
+
+Baselines/reports:
+  --update-baseline         Overwrite committed baseline (full corpus only)
+  --rolling-baseline [days] Compare against recent run reports (default: 7)
+  --report [path]           Write JSON scorecard
+  --html [path]             Write standalone HTML scorecard
+
+Other:
+  --help, -h                Show this help
+`;
+}
+
+async function main(): Promise<void> {
+  if (has("--help") || has("-h")) {
+    console.log(usage());
+    process.exit(0);
+  }
+
+  const runs = Number(arg("--runs") ?? 3);
+  if (!Number.isInteger(runs) || runs < 1) {
+    console.error(`--runs must be a positive integer (got "${arg("--runs")}")`);
+    process.exit(2);
+  }
+  const ruleFilter = arg("--rule");
+  if (ruleFilter && !hasRule(CASES, ruleFilter)) {
+    console.error(`No cases match --rule ${ruleFilter}`);
+    process.exit(2);
+  }
+  const caseFilter = arg("--case");
+  let tierFilter: 1 | 2 | undefined;
+  let componentFilter: "decompose" | "analyze" | undefined;
+  try {
+    tierFilter = parseTier(arg("--tier"));
+    componentFilter = parseComponent(arg("--component"));
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(2);
+  }
+  const listCases = has("--list-cases");
+  const updateBaseline = has("--update-baseline");
+  const noJudge = has("--no-judge");
+  const report = has("--report");
+  const html = has("--html");
+  const noSave = has("--no-save");
+  const alpha = Number(arg("--alpha") ?? DEFAULT_ALPHA);
+  if (!Number.isFinite(alpha) || alpha <= 0 || alpha >= 1) {
+    console.error(`--alpha must be a number between 0 and 1 (got "${arg("--alpha")}")`);
+    process.exit(2);
+  }
+  const rollingBaseline = has("--rolling-baseline");
+  const rollingBaselineDays = rollingBaseline ? Number(flagValue("--rolling-baseline") ?? 7) : null;
+  if (rollingBaselineDays !== null && (!Number.isFinite(rollingBaselineDays) || rollingBaselineDays <= 0)) {
+    console.error(`--rolling-baseline must be a positive number of days (got "${flagValue("--rolling-baseline")}")`);
+    process.exit(2);
+  }
+
+  const judge: Judge = noJudge
+    ? async () => true
+    : async (output, criteria) => {
+        try {
+          await assertLLM(output, criteria);
+          return true;
+        } catch {
+          return false;
+        }
+      };
+
+  const selected = selectCases(CASES, { rule: ruleFilter, caseId: caseFilter, component: componentFilter, tier: tierFilter });
+  const fullCorpus = !ruleFilter && !caseFilter && !componentFilter && tierFilter === undefined;
+  if (listCases) {
+    console.log(formatCaseList(selected));
+    process.exit(0);
+  }
+  if (selected.length === 0) {
+    console.error(`No cases match selected filters`);
+    process.exit(2);
+  }
+  if (updateBaseline && !fullCorpus) {
+    console.error(`--update-baseline requires a full-corpus run (remove --rule/--case/--component/--tier filters)`);
+    process.exit(2);
+  }
+
+  const deps = { decomposer: new PremiseDecomposer(), analyzer: new PremiseAnalyzer() };
+  const model = `${getModelName("premiseDecomposer")} / ${getModelName("premiseAnalyzer")}`;
+  console.log(`Running ${selected.length} case(s) × ${runs} run(s) against ${model}${noJudge ? " (judge off)" : ""}…`);
+
+  const results: CaseResult[] = [];
+  for (const c of selected) {
+    process.stdout.write(`  ${c.id} … `);
+    const details = await runCase(deps, c, runs);
+    const result = await scoreCase(c, details, judge);
+    results.push(result);
+    console.log(`${result.passes}/${result.runs}${result.flaky ? " (flaky)" : ""}`);
+  }
+
+  const scorecard = buildScorecard(results, { model, runs }) as Scorecard;
+  const baseline =
+    rollingBaselineDays !== null
+      ? await computeRollingBaseline(RUNS_DIR, rollingBaselineDays)
+      : await readBaseline<Scorecard>(BASELINE_PATH);
+  const { regressions, skippedCaseIds } = diffBaseline(scorecard, baseline, alpha);
+
+  if (rollingBaselineDays !== null) {
+    console.log(
+      baseline
+        ? `\nComparing against rolling ${rollingBaselineDays}-day baseline (${baseline.model}, α=${alpha}).`
+        : `\nNo rolling ${rollingBaselineDays}-day baseline found; skipping regression comparison.`,
+    );
+  }
+
+  console.log(formatConsole(scorecard, regressions, skippedCaseIds, { title: "Premise Quality Scorecard" }));
+
+  if (updateBaseline) {
+    await writeBaseline(BASELINE_PATH, scorecard, {
+      leanCase: (c) => ({ ...c, runResults: c.runResults.map(({ detail: _detail, ...rest }) => rest) }),
+    });
+    console.log(`\nBaseline updated at ${BASELINE_PATH}`);
+  }
+
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const autoRunPath = path.resolve(RUNS_DIR, `${stamp}.json`);
+  if (fullCorpus && !noSave) {
+    await writeRunReport(autoRunPath, scorecard);
+  }
+
+  if (report) {
+    const reportPath = flagValue("--report") ?? autoRunPath;
+    if (reportPath !== autoRunPath) await writeRunReport(reportPath, scorecard);
+    console.log(`\nRun report written to ${reportPath}`);
+  }
+
+  if (html) {
+    const htmlPath = flagValue("--html") ?? path.resolve(RUNS_DIR, `${stamp}.html`);
+    await writeHtmlReport(htmlPath, scorecard, regressions, CASES);
+    console.log(`\nHTML report written to ${htmlPath}`);
+  }
+
+  process.exit(regressions.length > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(2);
+});

--- a/packages/protocol/eval/premise/premise.reporter.ts
+++ b/packages/protocol/eval/premise/premise.reporter.ts
@@ -1,0 +1,85 @@
+import { htmlEscape, rateClass, htmlRateCI, renderRuleTable, renderScorecardShell, type Regression } from "../shared/index.js";
+import type { CaseResult, PremiseCase, PremiseRunDetail, Scorecard } from "./premise.types.js";
+
+/** Render the per-run detail (premises or felicity scores) behind a collapsible block. */
+function detailHtml(d: PremiseRunDetail, i: number): string {
+  if (d.component === "decompose") {
+    const items = (d.premises ?? [])
+      .map((p) => `<li>${htmlEscape(p.text)} <span class="muted">(${p.tier})</span></li>`)
+      .join("");
+    const body = items ? `<ul>${items}</ul>` : "<p class='muted'>no premises</p>";
+    return `<div class="reason"><span class="muted">run ${i + 1} · ${(d.premises ?? []).length} premise(s)</span>${body}<p class="muted">${htmlEscape(d.reasoning)}</p></div>`;
+  }
+  const f = d.felicity;
+  return `<div class="reason"><span class="muted">run ${i + 1} · ${htmlEscape(d.speechActType ?? "?")}</span><p>authority ${f?.authority ?? "?"} · sincerity ${f?.sincerity ?? "?"} · clarity ${f?.clarity ?? "?"} · entropy ${d.semanticEntropy ?? "?"}</p><p class="muted">${htmlEscape(d.reasoning)}</p></div>`;
+}
+
+/** Render failed assertions for a case. */
+function failedChecks(c: CaseResult): string {
+  const failed = c.runResults.flatMap((rr, i) =>
+    rr.assertions
+      .filter((a) => !a.passed)
+      .map((a) => `<li><span class="muted">run ${i + 1}</span> <span class="component">${htmlEscape(a.kind)}</span>: ${htmlEscape(a.detail)}</li>`),
+  );
+  if (failed.length === 0) return "";
+  return `<details class="failures" open><summary>failed checks (${failed.length})</summary><ul>${failed.join("")}</ul></details>`;
+}
+
+/** Render one case card. */
+function caseCard(c: CaseResult, meta: PremiseCase | undefined): string {
+  const tier = meta ? `<span class="badge">tier ${meta.tier}</span>` : "";
+  const comp = meta ? `<span class="badge">${htmlEscape(meta.component)}</span>` : "";
+  const flaky = c.flaky ? `<span class="badge flaky">flaky</span>` : "";
+  const desc = meta?.description ? `<p class="desc">${htmlEscape(meta.description)}</p>` : "";
+  const input = meta ? `<p class="desc"><span class="muted">input:</span> <code>${htmlEscape(meta.input)}</code></p>` : "";
+  const details = c.runResults.map((rr, i) => (rr.detail ? detailHtml(rr.detail, i) : "")).join("");
+  return `
+  <article class="case ${rateClass(c.passRate)}">
+    <header>
+      <code class="cid">${htmlEscape(c.caseId)}</code>
+      <span class="verdict ${rateClass(c.passRate)}" title="${c.passes}/${c.runs} runs">${htmlRateCI(c.passRate, c.passes, c.runs)}</span>
+      ${comp}${tier}${flaky}
+    </header>
+    ${desc}${input}
+    ${failedChecks(c)}
+    <details><summary>agent output (${c.runResults.length} run${c.runResults.length === 1 ? "" : "s"})</summary>${details}</details>
+  </article>`;
+}
+
+const INTRO = `<h2>What this report is measuring</h2>
+<p>This is a repeatability test for the premise agents. <strong>Decompose</strong> cases check that free text splits into atomic, first-person premises with the right tiering and no leaked intents. <strong>Analyze</strong> cases check speech-act classification (DECLARATIVE vs ASSERTIVE) and felicity-condition calibration (authority, sincerity, clarity, semantic entropy). Each case runs N times; a run passes only when every check passes.</p>`;
+
+/**
+ * Render a standalone HTML scorecard for a premise-eval run via the shared shell.
+ *
+ * @param sc - The scorecard to render (run-report grade, with per-run detail intact).
+ * @param regressions - Regressions vs the baseline.
+ * @param cases - The corpus, joined by id for input text, tier, and description.
+ */
+export function renderHtml(sc: Scorecard, regressions: Regression[], cases: PremiseCase[]): string {
+  const byId = new Map(cases.map((c) => [c.id, c]));
+  const caseCards = [...sc.rules]
+    .sort((x, y) => x.passRate - y.passRate)
+    .map((r) => {
+      const cards = sc.cases.filter((c) => c.rule === r.rule).map((c) => caseCard(c, byId.get(c.caseId))).join("");
+      return `<section class="rule"><h2>${htmlEscape(r.rule)}</h2>${cards}</section>`;
+    })
+    .join("");
+
+  return renderScorecardShell(sc, regressions, {
+    title: "Premise eval",
+    intro: INTRO,
+    sections: [{ heading: "By rule", html: renderRuleTable(sc) }],
+    caseCardsHtml: caseCards,
+  });
+}
+
+/** Write a standalone HTML scorecard to disk. */
+export async function writeHtmlReport(
+  path: string,
+  sc: Scorecard,
+  regressions: Regression[],
+  cases: PremiseCase[],
+): Promise<void> {
+  await Bun.write(path, renderHtml(sc, regressions, cases));
+}

--- a/packages/protocol/eval/premise/premise.reporter.ts
+++ b/packages/protocol/eval/premise/premise.reporter.ts
@@ -1,5 +1,70 @@
-import { htmlEscape, rateClass, htmlRateCI, renderRuleTable, renderScorecardShell, type Regression } from "../shared/index.js";
-import type { CaseResult, PremiseCase, PremiseRunDetail, Scorecard } from "./premise.types.js";
+import { htmlEscape, rateClass, htmlRateCI, renderRuleTable, renderScorecardShell, type HumanReport, type Regression } from "../shared/index.js";
+import type { AssertionKind, CaseResult, PremiseCase, Rule, Scorecard, PremiseRunDetail } from "./premise.types.js";
+
+// ─── Plain-language copy for the non-technical report ────────────────────────
+
+/** Ordered themes for "What we tested", each mapped to one or more rules. */
+const GROUPS: { ruleIds: Rule[]; label: string; blurb: string }[] = [
+  { ruleIds: ["atomicity"], label: "Breaking text into separate facts", blurb: "Splitting a run-on bio into one clear fact at a time, in the person's own voice." },
+  { ruleIds: ["tier_classification"], label: "Permanent facts vs current status", blurb: "Telling a lasting fact (a role) apart from a temporary one (currently fundraising)." },
+  { ruleIds: ["intent_exclusion"], label: "Keeping facts, dropping wishes", blurb: "Saving who a person is, and ignoring what they're looking for." },
+  { ruleIds: ["empty_input"], label: "Knowing when there's nothing to save", blurb: "Not inventing facts out of an empty greeting." },
+  { ruleIds: ["speech_act"], label: "Recognizing the kind of statement", blurb: "Telling an identity claim apart from a description of experience." },
+  { ruleIds: ["felicity_calibration"], label: "Judging how solid a claim is", blurb: "Scoring how specific and credible a self-description is." },
+  { ruleIds: ["entropy"], label: "Spotting vague vs specific", blurb: "Flagging a statement that's too vague to be useful." },
+];
+
+/** Plain-language name for each failing check, used in "what happened" notes. */
+const CHECK_COPY: Record<AssertionKind, string> = {
+  count: "split the text into the wrong number of facts",
+  empty: "invented facts from an empty message",
+  tier: "mislabeled a permanent fact as temporary, or vice versa",
+  first_person: "wrote a fact that wasn't in the person's own voice",
+  coverage: "missed one of the key facts",
+  exclusion: "kept something that was a wish, not a fact",
+  speech_act: "misjudged what kind of statement it was",
+  authority: "mis-scored how credible the claim is",
+  sincerity: "mis-scored how genuine the claim sounds",
+  clarity: "mis-scored how specific the claim is",
+  entropy: "mis-scored how vague the claim is",
+  reasoning: "its explanation didn't hold up",
+};
+
+/** Distinct plain-language reasons a case failed, across its runs. */
+function failNote(c: CaseResult): string | undefined {
+  const kinds = new Set<AssertionKind>();
+  for (const rr of c.runResults) for (const a of rr.assertions) if (!a.passed) kinds.add(a.kind);
+  if (kinds.size === 0) return undefined;
+  return [...kinds].map((k) => CHECK_COPY[k]).join("; ") + ".";
+}
+
+/** Build the plain-language report from the scorecard + corpus narratives. */
+function buildHumanReport(sc: Scorecard, cases: PremiseCase[]): HumanReport {
+  const byId = new Map(cases.map((c) => [c.id, c]));
+  const resultById = new Map(sc.cases.map((c) => [c.caseId, c]));
+  const groups = GROUPS.map((g) => ({
+    label: g.label,
+    blurb: g.blurb,
+    ruleIds: g.ruleIds as string[],
+    cases: sc.cases
+      .filter((c) => g.ruleIds.includes(c.rule))
+      .map((c) => {
+        const meta = byId.get(c.caseId);
+        const result = resultById.get(c.caseId);
+        return {
+          caseId: c.caseId,
+          scenario: meta?.human?.scenario ?? meta?.description ?? c.caseId,
+          expectation: meta?.human?.expectation ?? "behave correctly.",
+          failNote: result ? failNote(result) : undefined,
+        };
+      }),
+  })).filter((g) => g.cases.length > 0);
+  return {
+    subject: "the premise builder",
+    oneLiner: "It turns what someone says about themselves into clean, separate facts — and judges how clear and credible each one is.",
+    groups,
+  };
+}
 
 /** Render the per-run detail (premises or felicity scores) behind a collapsible block. */
 function detailHtml(d: PremiseRunDetail, i: number): string {
@@ -71,6 +136,7 @@ export function renderHtml(sc: Scorecard, regressions: Regression[], cases: Prem
     intro: INTRO,
     sections: [{ heading: "By rule", html: renderRuleTable(sc) }],
     caseCardsHtml: caseCards,
+    human: buildHumanReport(sc, cases),
   });
 }
 

--- a/packages/protocol/eval/premise/premise.runner.ts
+++ b/packages/protocol/eval/premise/premise.runner.ts
@@ -1,0 +1,64 @@
+import type { PremiseAnalyzerOutput } from "../../src/premise/premise.analyzer.js";
+import type { PremiseDecomposerOutput } from "../../src/premise/premise.decomposer.js";
+
+import { repeatRuns } from "../shared/index.js";
+import { PREMISE_EVAL_MAX_ATTEMPTS, PREMISE_EVAL_RETRY_DELAY_MS } from "./premise.constants.js";
+import type { PremiseCase, PremiseRunDetail } from "./premise.types.js";
+
+/** Minimal decomposer surface the runner needs (real PremiseDecomposer satisfies this). */
+export interface DecomposerLike {
+  invoke(input: string): Promise<PremiseDecomposerOutput>;
+}
+
+/** Minimal analyzer surface the runner needs (real PremiseAnalyzer satisfies this). */
+export interface AnalyzerLike {
+  invoke(premiseText: string, profileContext?: string): Promise<PremiseAnalyzerOutput>;
+}
+
+export interface PremiseDeps {
+  decomposer: DecomposerLike;
+  analyzer: AnalyzerLike;
+}
+
+export interface RunCaseOptions {
+  maxAttempts?: number;
+  retryDelayMs?: number;
+}
+
+/** Invoke the right agent for `c` once and normalize its output to a {@link PremiseRunDetail}. */
+async function invokeOnce(deps: PremiseDeps, c: PremiseCase): Promise<PremiseRunDetail> {
+  if (c.component === "decompose") {
+    const out = await deps.decomposer.invoke(c.input);
+    return { component: "decompose", reasoning: out.reasoning, premises: out.premises };
+  }
+  const out = await deps.analyzer.invoke(c.input, c.profileContext);
+  return {
+    component: "analyze",
+    reasoning: out.reasoning,
+    speechActType: out.speechActType,
+    felicity: { authority: out.felicityAuthority, sincerity: out.felicitySincerity, clarity: out.felicityClarity },
+    semanticEntropy: out.semanticEntropy,
+  };
+}
+
+/**
+ * Run a premise case `runs` times, retrying transient live-model failures.
+ *
+ * @param deps - The decomposer + analyzer under test.
+ * @param c - The case to run.
+ * @param runs - Number of repetitions.
+ * @param options - Retry tuning (defaults from premise constants).
+ * @returns One normalized detail per run.
+ */
+export async function runCase(
+  deps: PremiseDeps,
+  c: PremiseCase,
+  runs: number,
+  options: RunCaseOptions = {},
+): Promise<PremiseRunDetail[]> {
+  return repeatRuns(() => invokeOnce(deps, c), runs, {
+    maxAttempts: options.maxAttempts ?? PREMISE_EVAL_MAX_ATTEMPTS,
+    retryDelayMs: options.retryDelayMs ?? PREMISE_EVAL_RETRY_DELAY_MS,
+    label: "premise eval",
+  });
+}

--- a/packages/protocol/eval/premise/premise.scorer.ts
+++ b/packages/protocol/eval/premise/premise.scorer.ts
@@ -1,0 +1,151 @@
+import { meanRate } from "../shared/index.js";
+import type { AnalyzeCase, AssertionResult, Band, CaseResult, DecomposeCase, PremiseCase, PremiseRunDetail, RunResult } from "./premise.types.js";
+
+/** Grades a natural-language criterion. Returns true on pass. Injected for testability. */
+export type Judge = (output: unknown, criteria: string) => Promise<boolean>;
+
+const inBand = (value: number, [min, max]: Band): boolean => value >= min && value <= max;
+
+/** Heuristic first-person check: premise begins with "I " / "I'" (the decomposer contract). */
+function isFirstPerson(text: string): boolean {
+  return /^\s*I[\s'’]/.test(text);
+}
+
+/** Score a decomposer run. */
+async function scoreDecompose(c: DecomposeCase, d: PremiseRunDetail, judge: Judge): Promise<AssertionResult[]> {
+  const out: AssertionResult[] = [];
+  const premises = d.premises ?? [];
+  const { expect: e } = c;
+
+  if (e.expectEmpty) {
+    out.push({
+      kind: "empty",
+      passed: premises.length === 0,
+      detail: `expected no premises, got ${premises.length}`,
+    });
+    return out; // nothing else is meaningful for empty-input cases
+  }
+
+  if (e.minPremises !== undefined || e.maxPremises !== undefined) {
+    const min = e.minPremises ?? 0;
+    const max = e.maxPremises ?? Infinity;
+    out.push({
+      kind: "count",
+      passed: premises.length >= min && premises.length <= max,
+      detail: `expected ${min}–${max === Infinity ? "∞" : max} premises, got ${premises.length}`,
+    });
+  }
+
+  if (e.minAssertive !== undefined) {
+    const n = premises.filter((p) => p.tier === "assertive").length;
+    out.push({ kind: "tier", passed: n >= e.minAssertive, detail: `expected ≥${e.minAssertive} assertive, got ${n}` });
+  }
+  if (e.minContextual !== undefined) {
+    const n = premises.filter((p) => p.tier === "contextual").length;
+    out.push({ kind: "tier", passed: n >= e.minContextual, detail: `expected ≥${e.minContextual} contextual, got ${n}` });
+  }
+
+  // Structural: every premise must be first person per the decomposer contract.
+  const nonFirstPerson = premises.filter((p) => !isFirstPerson(p.text));
+  out.push({
+    kind: "first_person",
+    passed: nonFirstPerson.length === 0,
+    detail: nonFirstPerson.length === 0 ? "all premises first-person" : `non-first-person: ${nonFirstPerson.map((p) => `"${p.text}"`).join(", ")}`,
+  });
+
+  if (e.mustCover && e.mustCover.length > 0) {
+    const passed = await judge(
+      { premises: premises.map((p) => p.text) },
+      `The premise list must collectively cover ALL of these facts: ${e.mustCover.map((f) => `"${f}"`).join("; ")}. Pass only if every fact is represented by at least one premise.`,
+    );
+    out.push({ kind: "coverage", passed, detail: passed ? "judge: all facts covered" : "judge: missing facts" });
+  }
+
+  if (e.mustNotContain) {
+    const passed = await judge(
+      { premises: premises.map((p) => p.text) },
+      `None of these premises may express ${e.mustNotContain}. Pass only if NO premise contains that content.`,
+    );
+    out.push({ kind: "exclusion", passed, detail: passed ? "judge: excluded content absent" : "judge: excluded content present" });
+  }
+
+  if (e.reasoningCriteria) {
+    const passed = await judge({ reasoning: d.reasoning, premises }, e.reasoningCriteria);
+    out.push({ kind: "reasoning", passed, detail: passed ? "judge passed" : "judge failed" });
+  }
+
+  return out;
+}
+
+/** Score an analyzer run. */
+async function scoreAnalyze(c: AnalyzeCase, d: PremiseRunDetail, judge: Judge): Promise<AssertionResult[]> {
+  const out: AssertionResult[] = [];
+  const { expect: e } = c;
+
+  if (e.speechActType) {
+    out.push({
+      kind: "speech_act",
+      passed: d.speechActType === e.speechActType,
+      detail: `expected ${e.speechActType}, got ${d.speechActType ?? "none"}`,
+    });
+  }
+
+  const f = d.felicity;
+  if (e.authorityBand) {
+    out.push({ kind: "authority", passed: f !== undefined && inBand(f.authority, e.authorityBand), detail: `expected authority in [${e.authorityBand}], got ${f?.authority ?? "none"}` });
+  }
+  if (e.sincerityBand) {
+    out.push({ kind: "sincerity", passed: f !== undefined && inBand(f.sincerity, e.sincerityBand), detail: `expected sincerity in [${e.sincerityBand}], got ${f?.sincerity ?? "none"}` });
+  }
+  if (e.clarityBand) {
+    out.push({ kind: "clarity", passed: f !== undefined && inBand(f.clarity, e.clarityBand), detail: `expected clarity in [${e.clarityBand}], got ${f?.clarity ?? "none"}` });
+  }
+  if (e.entropyBand) {
+    out.push({ kind: "entropy", passed: d.semanticEntropy !== undefined && inBand(d.semanticEntropy, e.entropyBand), detail: `expected entropy in [${e.entropyBand}], got ${d.semanticEntropy ?? "none"}` });
+  }
+
+  if (e.reasoningCriteria) {
+    const passed = await judge({ reasoning: d.reasoning, speechActType: d.speechActType, felicity: f, semanticEntropy: d.semanticEntropy }, e.reasoningCriteria);
+    out.push({ kind: "reasoning", passed, detail: passed ? "judge passed" : "judge failed" });
+  }
+
+  return out;
+}
+
+/**
+ * Score a single run of a case. A run passes iff every assertion passes.
+ *
+ * @param c - The premise case being evaluated.
+ * @param detail - The normalized agent output for this run.
+ * @param judge - Injected LLM judge for coverage/exclusion/reasoning assertions.
+ */
+export async function scoreRun(c: PremiseCase, detail: PremiseRunDetail, judge: Judge): Promise<RunResult> {
+  const assertions =
+    c.component === "decompose" ? await scoreDecompose(c, detail, judge) : await scoreAnalyze(c, detail, judge);
+  return { passed: assertions.every((a) => a.passed), assertions, detail };
+}
+
+/**
+ * Aggregate N runs of a case into a CaseResult with pass-rate and flakiness.
+ *
+ * @param c - The premise case being evaluated.
+ * @param details - One normalized detail per run.
+ * @param judge - Injected LLM judge.
+ */
+export async function scoreCase(c: PremiseCase, details: PremiseRunDetail[], judge: Judge): Promise<CaseResult> {
+  const runResults = await Promise.all(details.map((d) => scoreRun(c, d, judge)));
+  const passes = runResults.filter((r) => r.passed).length;
+  const total = runResults.length;
+  return {
+    caseId: c.id,
+    rule: c.rule,
+    runs: total,
+    passes,
+    passRate: total === 0 ? 0 : passes / total,
+    flaky: passes > 0 && passes < total,
+    runResults,
+  };
+}
+
+/** Re-exported for parity with other harnesses' reporter usage. */
+export { meanRate };

--- a/packages/protocol/eval/premise/premise.selection.ts
+++ b/packages/protocol/eval/premise/premise.selection.ts
@@ -1,0 +1,74 @@
+import type { PremiseCase, PremiseComponent, Rule } from "./premise.types.js";
+
+export interface CaseFilters {
+  rule?: string;
+  caseId?: string;
+  component?: string;
+  tier?: number;
+}
+
+/** Parse and validate a tier CLI argument. */
+export function parseTier(value: string | undefined): 1 | 2 | undefined {
+  if (value === undefined) return undefined;
+  const n = Number(value);
+  if (n === 1 || n === 2) return n;
+  throw new Error(`--tier must be one of 1, 2 (got "${value}")`);
+}
+
+/** Parse and validate a component CLI argument. */
+export function parseComponent(value: string | undefined): PremiseComponent | undefined {
+  if (value === undefined) return undefined;
+  if (value === "decompose" || value === "analyze") return value;
+  throw new Error(`--component must be "decompose" or "analyze" (got "${value}")`);
+}
+
+/** Select premise eval cases by optional rule, id/prefix, component, and tier filters. */
+export function selectCases(cases: PremiseCase[], filters: CaseFilters): PremiseCase[] {
+  return cases.filter((c) => {
+    if (filters.rule && c.rule !== filters.rule) return false;
+    if (filters.component && c.component !== filters.component) return false;
+    if (filters.tier !== undefined && c.tier !== filters.tier) return false;
+    if (filters.caseId) {
+      const q = filters.caseId;
+      if (c.id !== q && !c.id.startsWith(q)) return false;
+    }
+    return true;
+  });
+}
+
+function countBy<T extends string | number>(values: T[]): Map<T, number> {
+  const out = new Map<T, number>();
+  for (const v of values) out.set(v, (out.get(v) ?? 0) + 1);
+  return out;
+}
+
+/** Format corpus counts by tier, component, and rule. */
+export function formatCaseSummary(cases: PremiseCase[]): string {
+  const byTier = [...countBy(cases.map((c) => c.tier)).entries()]
+    .sort((a, b) => Number(a[0]) - Number(b[0]))
+    .map(([tier, count]) => `t${tier}:${count}`)
+    .join("  ");
+  const byComponent = [...countBy(cases.map((c) => c.component)).entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([comp, count]) => `${comp}:${count}`)
+    .join("  ");
+  const byRule = [...countBy(cases.map((c) => c.rule)).entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([rule, count]) => `${rule}:${count}`)
+    .join("  ");
+  return `total:${cases.length}${byTier ? `\nby tier: ${byTier}` : ""}${byComponent ? `\nby component: ${byComponent}` : ""}${byRule ? `\nby rule: ${byRule}` : ""}`;
+}
+
+/** Format a case inventory for --list-cases. */
+export function formatCaseList(cases: PremiseCase[]): string {
+  const lines = ["Premise eval cases:", formatCaseSummary(cases), ""];
+  for (const c of [...cases].sort((a, b) => a.component.localeCompare(b.component) || a.rule.localeCompare(b.rule) || a.id.localeCompare(b.id))) {
+    lines.push(`  [t${c.tier}] [${c.component.padEnd(9)}] ${c.rule.padEnd(20)} ${c.id}`);
+  }
+  return lines.join("\n");
+}
+
+/** True when a string is a known rule value in the corpus. */
+export function hasRule(cases: PremiseCase[], rule: string): rule is Rule {
+  return cases.some((c) => c.rule === rule);
+}

--- a/packages/protocol/eval/premise/premise.types.ts
+++ b/packages/protocol/eval/premise/premise.types.ts
@@ -1,0 +1,122 @@
+import type { CaseResultLike, RuleResult as SharedRuleResult, ScorecardLike } from "../shared/index.js";
+
+/** Which premise agent a case exercises. */
+export type PremiseComponent = "decompose" | "analyze";
+
+/** Each rule maps to a distinct premise behaviour the corpus exercises. */
+export type Rule =
+  // decomposer
+  | "atomicity"
+  | "tier_classification"
+  | "intent_exclusion"
+  | "empty_input"
+  // analyzer
+  | "speech_act"
+  | "felicity_calibration"
+  | "entropy";
+
+/** Inclusive numeric band [min, max]. */
+export type Band = [min: number, max: number];
+
+/** Expectations for a decomposer case (`PremiseDecomposer.invoke`). */
+export interface DecomposeExpectation {
+  /** Minimum number of premises that must be extracted. */
+  minPremises?: number;
+  /** Maximum number of premises (guards against over-splitting). */
+  maxPremises?: number;
+  /** The input contains no extractable premises — expect an empty array. */
+  expectEmpty?: boolean;
+  /** Minimum number of premises with each tier, when the case is about tiering. */
+  minAssertive?: number;
+  minContextual?: number;
+  /** Facts the premise set must collectively cover (LLM-judged). */
+  mustCover?: string[];
+  /** Content that must NOT appear, e.g. leaked intents/desires (LLM-judged). */
+  mustNotContain?: string;
+  /** Free-form reasoning rubric graded by the judge. */
+  reasoningCriteria?: string;
+}
+
+/** Expectations for an analyzer case (`PremiseAnalyzer.invoke`). */
+export interface AnalyzeExpectation {
+  speechActType?: "DECLARATIVE" | "ASSERTIVE";
+  authorityBand?: Band;
+  sincerityBand?: Band;
+  clarityBand?: Band;
+  entropyBand?: Band;
+  reasoningCriteria?: string;
+}
+
+interface PremiseCaseBase {
+  id: string;
+  rule: Rule;
+  tier: 1 | 2;
+  description: string;
+}
+
+/** A decomposer corpus case. */
+export interface DecomposeCase extends PremiseCaseBase {
+  component: "decompose";
+  /** Free-text input handed to the decomposer. */
+  input: string;
+  expect: DecomposeExpectation;
+}
+
+/** An analyzer corpus case. */
+export interface AnalyzeCase extends PremiseCaseBase {
+  component: "analyze";
+  /** The premise text handed to the analyzer. */
+  input: string;
+  /** Optional speaker profile context. */
+  profileContext?: string;
+  expect: AnalyzeExpectation;
+}
+
+export type PremiseCase = DecomposeCase | AnalyzeCase;
+
+export type AssertionKind =
+  | "count"
+  | "empty"
+  | "tier"
+  | "first_person"
+  | "coverage"
+  | "exclusion"
+  | "speech_act"
+  | "authority"
+  | "sincerity"
+  | "clarity"
+  | "entropy"
+  | "reasoning";
+
+export interface AssertionResult {
+  kind: AssertionKind;
+  passed: boolean;
+  detail: string;
+}
+
+/** Normalized agent output for one run, captured for run reports (stripped from baselines). */
+export interface PremiseRunDetail {
+  component: PremiseComponent;
+  reasoning: string;
+  /** decompose */
+  premises?: { text: string; tier: "assertive" | "contextual" }[];
+  /** analyze */
+  speechActType?: "DECLARATIVE" | "ASSERTIVE";
+  felicity?: { authority: number; sincerity: number; clarity: number };
+  semanticEntropy?: number;
+}
+
+export interface RunResult {
+  passed: boolean;
+  assertions: AssertionResult[];
+  /** Present in run reports; stripped from the committed baseline to keep diffs lean. */
+  detail?: PremiseRunDetail;
+}
+
+export interface CaseResult extends CaseResultLike {
+  rule: Rule;
+  runResults: RunResult[];
+}
+
+export type RuleResult = SharedRuleResult;
+export type Scorecard = ScorecardLike<CaseResult>;

--- a/packages/protocol/eval/premise/premise.types.ts
+++ b/packages/protocol/eval/premise/premise.types.ts
@@ -51,7 +51,10 @@ interface PremiseCaseBase {
   id: string;
   rule: Rule;
   tier: 1 | 2;
+  /** Technical one-liner (for the engineer view). */
   description: string;
+  /** Plain-language narrative for the non-technical report. */
+  human?: { scenario: string; expectation: string };
 }
 
 /** A decomposer corpus case. */

--- a/packages/protocol/eval/premise/tests/premise.cases.spec.ts
+++ b/packages/protocol/eval/premise/tests/premise.cases.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "bun:test";
+
+import { CASES } from "../premise.cases.js";
+import { formatCaseList, formatCaseSummary, hasRule, parseComponent, parseTier, selectCases } from "../premise.selection.js";
+
+describe("corpus invariants", () => {
+  it("has unique case ids", () => {
+    const ids = CASES.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("every case declares matching component-specific expectations", () => {
+    for (const c of CASES) {
+      expect(c.id).toContain("/");
+      if (c.component === "analyze") {
+        const e = c.expect;
+        const hasAny = e.speechActType || e.authorityBand || e.sincerityBand || e.clarityBand || e.entropyBand || e.reasoningCriteria;
+        expect(Boolean(hasAny)).toBe(true);
+      } else {
+        const e = c.expect;
+        const hasAny = e.expectEmpty || e.minPremises !== undefined || e.maxPremises !== undefined || e.minAssertive !== undefined || e.minContextual !== undefined;
+        expect(Boolean(hasAny)).toBe(true);
+      }
+    }
+  });
+});
+
+describe("parseTier / parseComponent", () => {
+  it("accepts supported tiers and rejects others", () => {
+    expect(parseTier("1")).toBe(1);
+    expect(parseTier(undefined)).toBeUndefined();
+    expect(() => parseTier("3")).toThrow();
+  });
+
+  it("accepts known components and rejects others", () => {
+    expect(parseComponent("decompose")).toBe("decompose");
+    expect(parseComponent("analyze")).toBe("analyze");
+    expect(() => parseComponent("bogus")).toThrow();
+  });
+});
+
+describe("selectCases", () => {
+  it("filters by component, rule, tier, and id prefix", () => {
+    expect(selectCases(CASES, { component: "analyze" }).every((c) => c.component === "analyze")).toBe(true);
+    expect(selectCases(CASES, { rule: "speech_act" }).every((c) => c.rule === "speech_act")).toBe(true);
+    expect(selectCases(CASES, { tier: 1 }).every((c) => c.tier === 1)).toBe(true);
+    expect(selectCases(CASES, { caseId: "atomicity/" }).every((c) => c.id.startsWith("atomicity/"))).toBe(true);
+  });
+});
+
+describe("formatting + hasRule", () => {
+  it("summary and list render counts and ids", () => {
+    expect(formatCaseSummary(CASES)).toContain(`total:${CASES.length}`);
+    expect(formatCaseSummary(CASES)).toContain("by component");
+    expect(formatCaseList(CASES)).toContain(CASES[0].id);
+  });
+
+  it("hasRule detects known and unknown rules", () => {
+    expect(hasRule(CASES, "speech_act")).toBe(true);
+    expect(hasRule(CASES, "nope")).toBe(false);
+  });
+});

--- a/packages/protocol/eval/premise/tests/premise.scorer.spec.ts
+++ b/packages/protocol/eval/premise/tests/premise.scorer.spec.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "bun:test";
+
+import { scoreRun, scoreCase, type Judge } from "../premise.scorer.js";
+import type { AnalyzeCase, DecomposeCase, PremiseRunDetail } from "../premise.types.js";
+
+const yes: Judge = async () => true;
+const no: Judge = async () => false;
+
+const decompose = (expect: DecomposeCase["expect"]): DecomposeCase => ({
+  id: "d/case",
+  rule: "atomicity",
+  tier: 1,
+  component: "decompose",
+  description: "synthetic",
+  input: "x",
+  expect,
+});
+
+const analyze = (expect: AnalyzeCase["expect"]): AnalyzeCase => ({
+  id: "a/case",
+  rule: "speech_act",
+  tier: 1,
+  component: "analyze",
+  description: "synthetic",
+  input: "x",
+  expect,
+});
+
+const dDetail = (premises: { text: string; tier: "assertive" | "contextual" }[]): PremiseRunDetail => ({
+  component: "decompose",
+  reasoning: "r",
+  premises,
+});
+
+const aDetail = (over: Partial<PremiseRunDetail>): PremiseRunDetail => ({
+  component: "analyze",
+  reasoning: "r",
+  speechActType: "DECLARATIVE",
+  felicity: { authority: 80, sincerity: 80, clarity: 80 },
+  semanticEntropy: 0.2,
+  ...over,
+});
+
+describe("scoreRun — decompose", () => {
+  it("passes count, tier, and first-person checks", async () => {
+    const c = decompose({ minPremises: 2, maxPremises: 3, minAssertive: 1, minContextual: 1 });
+    const d = dDetail([
+      { text: "I am a founder", tier: "assertive" },
+      { text: "I am raising a Series A", tier: "contextual" },
+    ]);
+    const rr = await scoreRun(c, d, yes);
+    expect(rr.passed).toBe(true);
+    expect(rr.assertions.find((a) => a.kind === "count")!.passed).toBe(true);
+    expect(rr.assertions.filter((a) => a.kind === "tier").every((a) => a.passed)).toBe(true);
+    expect(rr.assertions.find((a) => a.kind === "first_person")!.passed).toBe(true);
+  });
+
+  it("fails count when over-split and flags non-first-person premises", async () => {
+    const c = decompose({ minPremises: 1, maxPremises: 1 });
+    const d = dDetail([
+      { text: "I am a founder", tier: "assertive" },
+      { text: "Works at Google", tier: "assertive" },
+    ]);
+    const rr = await scoreRun(c, d, yes);
+    expect(rr.passed).toBe(false);
+    expect(rr.assertions.find((a) => a.kind === "count")!.passed).toBe(false);
+    expect(rr.assertions.find((a) => a.kind === "first_person")!.passed).toBe(false);
+  });
+
+  it("only checks emptiness for empty-input cases", async () => {
+    const c = decompose({ expectEmpty: true });
+    const empty = await scoreRun(c, dDetail([]), yes);
+    expect(empty.passed).toBe(true);
+    expect(empty.assertions).toHaveLength(1);
+    const nonEmpty = await scoreRun(c, dDetail([{ text: "I am a founder", tier: "assertive" }]), yes);
+    expect(nonEmpty.passed).toBe(false);
+  });
+
+  it("routes coverage and exclusion through the judge", async () => {
+    const c = decompose({ minPremises: 1, mustCover: ["founder"], mustNotContain: "an intent" });
+    const d = dDetail([{ text: "I am a founder", tier: "assertive" }]);
+    expect((await scoreRun(c, d, yes)).passed).toBe(true);
+    const failed = await scoreRun(c, d, no);
+    expect(failed.passed).toBe(false);
+    expect(failed.assertions.find((a) => a.kind === "coverage")!.passed).toBe(false);
+    expect(failed.assertions.find((a) => a.kind === "exclusion")!.passed).toBe(false);
+  });
+});
+
+describe("scoreRun — analyze", () => {
+  it("passes speech-act and band checks within range", async () => {
+    const c = analyze({ speechActType: "DECLARATIVE", clarityBand: [65, 100], entropyBand: [0, 0.45] });
+    const rr = await scoreRun(c, aDetail({}), yes);
+    expect(rr.passed).toBe(true);
+  });
+
+  it("fails when the band is missed", async () => {
+    const c = analyze({ clarityBand: [65, 100] });
+    const rr = await scoreRun(c, aDetail({ felicity: { authority: 80, sincerity: 80, clarity: 30 } }), yes);
+    expect(rr.passed).toBe(false);
+    expect(rr.assertions.find((a) => a.kind === "clarity")!.passed).toBe(false);
+  });
+
+  it("fails on wrong speech-act type", async () => {
+    const c = analyze({ speechActType: "ASSERTIVE" });
+    const rr = await scoreRun(c, aDetail({ speechActType: "DECLARATIVE" }), yes);
+    expect(rr.assertions.find((a) => a.kind === "speech_act")!.passed).toBe(false);
+  });
+});
+
+describe("scoreCase", () => {
+  it("aggregates runs into pass-rate and flags flakiness", async () => {
+    const c = analyze({ speechActType: "DECLARATIVE" });
+    const result = await scoreCase(c, [aDetail({}), aDetail({ speechActType: "ASSERTIVE" })], yes);
+    expect(result.runs).toBe(2);
+    expect(result.passes).toBe(1);
+    expect(result.flaky).toBe(true);
+    expect(result.passRate).toBe(0.5);
+  });
+});

--- a/packages/protocol/eval/premise/tsconfig.json
+++ b/packages/protocol/eval/premise/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "composite": false,
+    "rootDir": "../../",
+    "types": ["node", "bun-types"]
+  },
+  "include": ["**/*.ts", "../../src/**/*.ts"],
+  "exclude": ["node_modules", "../../src/**/*.spec.ts", "../../src/**/*.test.ts"]
+}

--- a/packages/protocol/eval/profile/README.md
+++ b/packages/protocol/eval/profile/README.md
@@ -1,0 +1,63 @@
+# Profile Quality Eval Harness
+
+Measures whether the profile generator (`ProfileGenerator.invoke`) produces good
+structured profiles against a curated golden set, and — on every case — upholds the
+**privacy guarantee**. Standalone and opt-in — NOT part of `bun test`.
+
+## Run
+
+```bash
+# from packages/protocol
+bun run eval:profile                          # all cases, 3 runs, judge on, diff baseline
+bun run eval:profile -- --runs 5              # more runs = less noise
+bun run eval:profile -- --rule privacy         # one rule
+bun run eval:profile -- --case extraction/     # one case or id prefix
+bun run eval:profile -- --tier 1               # one tier
+bun run eval:profile -- --list-cases           # print selected cases and exit
+bun run eval:profile -- --no-judge             # skip LLM coverage/apply/preserve checks (free)
+bun run eval:profile -- --update-baseline      # overwrite the committed baseline
+bun run eval:profile -- --report [path]        # write a full run report incl. generated profiles
+bun run eval:profile -- --html [path]          # write a standalone HTML scorecard
+bun run eval:profile -- --rolling-baseline [d] # compare against trailing run average (default 7d)
+bun run eval:profile -- --alpha 0.01           # stricter regression significance threshold
+bun run eval:profile -- --no-save              # do not auto-save full-corpus run JSON
+```
+
+Requires `OPENROUTER_API_KEY` (loaded via `.env.test`). Exits non-zero on a regression
+versus `baselines/profile.baseline.json` (one-sided beta-binomial posterior-predictive
+test, default α=0.05). Shared machinery lives in [`eval/shared`](../shared).
+
+## Checks
+
+Deterministic: `name` and `location` substring match, `skills` / `interests` minimum
+counts, and **`privacy`** — public fields (name, bio, location, narrative.context,
+skills, interests) are scanned for email/phone PII via `profile.pii.ts`; any hit fails the
+run. Privacy is asserted on every case by default (opt out per-case with `noPII: false`).
+
+Judged (skipped with `--no-judge`): `coverage_skills` / `coverage_interests` (expected
+items captured, allowing synonyms), and for update cases `apply` (the requested change
+landed) + `preserve` (the rest of the profile is intact). An optional `reasoning` rubric
+grades the whole profile.
+
+## Adding a case
+
+Append a `ProfileCase` to `CASES` in `profile.cases.ts`. Set `rule`, `tier` (1 surgical, 2
+realistic), the raw `input`, and `expect`. Prefer deterministic expectations; reach for
+judged `mustHaveSkills` / `mustApply` / `mustPreserve` / `reasoningCriteria` only when a
+code check can't express it. Privacy cases should feed contact identifiers in the input and
+rely on the default `privacy` assertion to prove they were redacted. Re-run with
+`--update-baseline` after an intentional change.
+
+## Layout
+
+- `profile.cases.ts` — the golden corpus.
+- `profile.pii.ts` — deterministic email/phone PII detectors (privacy guarantee).
+- `profile.types.ts` — harness types (specializes the shared scorecard types).
+- `profile.runner.ts` — invokes the generator N times (shared retry loop).
+- `profile.scorer.ts` — per-run assertions → `CaseResult`.
+- `profile.reporter.ts` — HTML scorecard via the shared shell.
+- `profile.selection.ts` — `--rule` / `--case` / `--tier` filtering.
+- `profile.eval.ts` — CLI.
+- `baselines/profile.baseline.json` — committed baseline (per-run detail stripped).
+- `runs/*.json` — gitignored full run reports (rolling-baseline fuel).
+- `tests/` — unit tests (no live agents).

--- a/packages/protocol/eval/profile/baselines/profile.baseline.json
+++ b/packages/protocol/eval/profile/baselines/profile.baseline.json
@@ -1,0 +1,790 @@
+{
+  "generatedAt": "2026-06-16T15:32:16.555Z",
+  "model": "google/gemini-2.5-flash",
+  "runs": 3,
+  "aggregatePassRate": 1,
+  "rules": [
+    {
+      "rule": "extraction",
+      "caseCount": 2,
+      "passRate": 1
+    },
+    {
+      "rule": "location",
+      "caseCount": 1,
+      "passRate": 1
+    },
+    {
+      "rule": "privacy",
+      "caseCount": 3,
+      "passRate": 1
+    },
+    {
+      "rule": "skills_interests",
+      "caseCount": 1,
+      "passRate": 1
+    },
+    {
+      "rule": "update",
+      "caseCount": 1,
+      "passRate": 1
+    }
+  ],
+  "cases": [
+    {
+      "caseId": "extraction/clean-bio",
+      "rule": "extraction",
+      "runs": 3,
+      "passes": 3,
+      "passRate": 1,
+      "flaky": false,
+      "runResults": [
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "name",
+              "passed": true,
+              "detail": "expected name to contain \"Ada\", got \"Ada Lovelace\""
+            },
+            {
+              "kind": "location",
+              "passed": true,
+              "detail": "expected location to contain \"London\", got \"London, UK\""
+            },
+            {
+              "kind": "privacy",
+              "passed": true,
+              "detail": "no PII in public fields"
+            },
+            {
+              "kind": "skills",
+              "passed": true,
+              "detail": "expected ≥2 skills, got 3"
+            },
+            {
+              "kind": "interests",
+              "passed": true,
+              "detail": "expected ≥1 interests, got 2"
+            },
+            {
+              "kind": "coverage_skills",
+              "passed": true,
+              "detail": "judge: skills covered"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "name",
+              "passed": true,
+              "detail": "expected name to contain \"Ada\", got \"Ada Lovelace\""
+            },
+            {
+              "kind": "location",
+              "passed": true,
+              "detail": "expected location to contain \"London\", got \"London, UK\""
+            },
+            {
+              "kind": "privacy",
+              "passed": true,
+              "detail": "no PII in public fields"
+            },
+            {
+              "kind": "skills",
+              "passed": true,
+              "detail": "expected ≥2 skills, got 3"
+            },
+            {
+              "kind": "interests",
+              "passed": true,
+              "detail": "expected ≥1 interests, got 2"
+            },
+            {
+              "kind": "coverage_skills",
+              "passed": true,
+              "detail": "judge: skills covered"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "name",
+              "passed": true,
+              "detail": "expected name to contain \"Ada\", got \"Ada Lovelace\""
+            },
+            {
+              "kind": "location",
+              "passed": true,
+              "detail": "expected location to contain \"London\", got \"London, UK\""
+            },
+            {
+              "kind": "privacy",
+              "passed": true,
+              "detail": "no PII in public fields"
+            },
+            {
+              "kind": "skills",
+              "passed": true,
+              "detail": "expected ≥2 skills, got 3"
+            },
+            {
+              "kind": "interests",
+              "passed": true,
+              "detail": "expected ≥1 interests, got 2"
+            },
+            {
+              "kind": "coverage_skills",
+              "passed": true,
+              "detail": "judge: skills covered"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "caseId": "extraction/scraped-blob",
+      "rule": "extraction",
+      "runs": 3,
+      "passes": 3,
+      "passRate": 1,
+      "flaky": false,
+      "runResults": [
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "name",
+              "passed": true,
+              "detail": "expected name to contain \"Priya\", got \"Priya Nair\""
+            },
+            {
+              "kind": "location",
+              "passed": true,
+              "detail": "expected location to contain \"San Francisco\", got \"San Francisco Bay Area\""
+            },
+            {
+              "kind": "privacy",
+              "passed": true,
+              "detail": "no PII in public fields"
+            },
+            {
+              "kind": "skills",
+              "passed": true,
+              "detail": "expected ≥3 skills, got 4"
+            },
+            {
+              "kind": "coverage_skills",
+              "passed": true,
+              "detail": "judge: skills covered"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "name",
+              "passed": true,
+              "detail": "expected name to contain \"Priya\", got \"Priya Nair\""
+            },
+            {
+              "kind": "location",
+              "passed": true,
+              "detail": "expected location to contain \"San Francisco\", got \"San Francisco Bay Area\""
+            },
+            {
+              "kind": "privacy",
+              "passed": true,
+              "detail": "no PII in public fields"
+            },
+            {
+              "kind": "skills",
+              "passed": true,
+              "detail": "expected ≥3 skills, got 5"
+            },
+            {
+              "kind": "coverage_skills",
+              "passed": true,
+              "detail": "judge: skills covered"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "name",
+              "passed": true,
+              "detail": "expected name to contain \"Priya\", got \"Priya Nair\""
+            },
+            {
+              "kind": "location",
+              "passed": true,
+              "detail": "expected location to contain \"San Francisco\", got \"San Francisco Bay Area\""
+            },
+            {
+              "kind": "privacy",
+              "passed": true,
+              "detail": "no PII in public fields"
+            },
+            {
+              "kind": "skills",
+              "passed": true,
+              "detail": "expected ≥3 skills, got 6"
+            },
+            {
+              "kind": "coverage_skills",
+              "passed": true,
+              "detail": "judge: skills covered"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "caseId": "location/explicit-city",
+      "rule": "location",
+      "runs": 3,
+      "passes": 3,
+      "passRate": 1,
+      "flaky": false,
+      "runResults": [
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "name",
+              "passed": true,
+              "detail": "expected name to contain \"Lars\", got \"Lars Berg\""
+            },
+            {
+              "kind": "location",
+              "passed": true,
+              "detail": "expected location to contain \"Berlin\", got \"Berlin, Germany\""
+            },
+            {
+              "kind": "privacy",
+              "passed": true,
+              "detail": "no PII in public fields"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "name",
+              "passed": true,
+              "detail": "expected name to contain \"Lars\", got \"Lars Berg\""
+            },
+            {
+              "kind": "location",
+              "passed": true,
+              "detail": "expected location to contain \"Berlin\", got \"Berlin, Germany\""
+            },
+            {
+              "kind": "privacy",
+              "passed": true,
+              "detail": "no PII in public fields"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "name",
+              "passed": true,
+              "detail": "expected name to contain \"Lars\", got \"Lars Berg\""
+            },
+            {
+              "kind": "location",
+              "passed": true,
+              "detail": "expected location to contain \"Berlin\", got \"Berlin, Germany\""
+            },
+            {
+              "kind": "privacy",
+              "passed": true,
+              "detail": "no PII in public fields"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "caseId": "privacy/email-and-phone",
+      "rule": "privacy",
+      "runs": 3,
+      "passes": 3,
+      "passRate": 1,
+      "flaky": false,
+      "runResults": [
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "name",
+              "passed": true,
+              "detail": "expected name to contain \"John\", got \"John Park\""
+            },
+            {
+              "kind": "location",
+              "passed": true,
+              "detail": "expected location to contain \"Austin\", got \"Austin, TX\""
+            },
+            {
+              "kind": "privacy",
+              "passed": true,
+              "detail": "no PII in public fields"
+            },
+            {
+              "kind": "coverage_skills",
+              "passed": true,
+              "detail": "judge: skills covered"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "name",
+              "passed": true,
+              "detail": "expected name to contain \"John\", got \"John Park\""
+            },
+            {
+              "kind": "location",
+              "passed": true,
+              "detail": "expected location to contain \"Austin\", got \"Austin, TX\""
+            },
+            {
+              "kind": "privacy",
+              "passed": true,
+              "detail": "no PII in public fields"
+            },
+            {
+              "kind": "coverage_skills",
+              "passed": true,
+              "detail": "judge: skills covered"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "name",
+              "passed": true,
+              "detail": "expected name to contain \"John\", got \"John Park\""
+            },
+            {
+              "kind": "location",
+              "passed": true,
+              "detail": "expected location to contain \"Austin\", got \"Austin, TX\""
+            },
+            {
+              "kind": "privacy",
+              "passed": true,
+              "detail": "no PII in public fields"
+            },
+            {
+              "kind": "coverage_skills",
+              "passed": true,
+              "detail": "judge: skills covered"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "caseId": "privacy/contact-heavy",
+      "rule": "privacy",
+      "runs": 3,
+      "passes": 3,
+      "passRate": 1,
+      "flaky": false,
+      "runResults": [
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "name",
+              "passed": true,
+              "detail": "expected name to contain \"Maria\", got \"Maria Gomez\""
+            },
+            {
+              "kind": "location",
+              "passed": true,
+              "detail": "expected location to contain \"New York\", got \"New York\""
+            },
+            {
+              "kind": "privacy",
+              "passed": true,
+              "detail": "no PII in public fields"
+            },
+            {
+              "kind": "skills",
+              "passed": true,
+              "detail": "expected ≥2 skills, got 3"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "name",
+              "passed": true,
+              "detail": "expected name to contain \"Maria\", got \"Maria Gomez\""
+            },
+            {
+              "kind": "location",
+              "passed": true,
+              "detail": "expected location to contain \"New York\", got \"New York\""
+            },
+            {
+              "kind": "privacy",
+              "passed": true,
+              "detail": "no PII in public fields"
+            },
+            {
+              "kind": "skills",
+              "passed": true,
+              "detail": "expected ≥2 skills, got 3"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "name",
+              "passed": true,
+              "detail": "expected name to contain \"Maria\", got \"Maria Gomez\""
+            },
+            {
+              "kind": "location",
+              "passed": true,
+              "detail": "expected location to contain \"New York\", got \"New York\""
+            },
+            {
+              "kind": "privacy",
+              "passed": true,
+              "detail": "no PII in public fields"
+            },
+            {
+              "kind": "skills",
+              "passed": true,
+              "detail": "expected ≥2 skills, got 3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "caseId": "skills_interests/multi-skill",
+      "rule": "skills_interests",
+      "runs": 3,
+      "passes": 3,
+      "passRate": 1,
+      "flaky": false,
+      "runResults": [
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "name",
+              "passed": true,
+              "detail": "expected name to contain \"Sam\", got \"Sam Okafor\""
+            },
+            {
+              "kind": "privacy",
+              "passed": true,
+              "detail": "no PII in public fields"
+            },
+            {
+              "kind": "skills",
+              "passed": true,
+              "detail": "expected ≥4 skills, got 6"
+            },
+            {
+              "kind": "interests",
+              "passed": true,
+              "detail": "expected ≥2 interests, got 3"
+            },
+            {
+              "kind": "coverage_skills",
+              "passed": true,
+              "detail": "judge: skills covered"
+            },
+            {
+              "kind": "coverage_interests",
+              "passed": true,
+              "detail": "judge: interests covered"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "name",
+              "passed": true,
+              "detail": "expected name to contain \"Sam\", got \"Sam Okafor\""
+            },
+            {
+              "kind": "privacy",
+              "passed": true,
+              "detail": "no PII in public fields"
+            },
+            {
+              "kind": "skills",
+              "passed": true,
+              "detail": "expected ≥4 skills, got 5"
+            },
+            {
+              "kind": "interests",
+              "passed": true,
+              "detail": "expected ≥2 interests, got 3"
+            },
+            {
+              "kind": "coverage_skills",
+              "passed": true,
+              "detail": "judge: skills covered"
+            },
+            {
+              "kind": "coverage_interests",
+              "passed": true,
+              "detail": "judge: interests covered"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "name",
+              "passed": true,
+              "detail": "expected name to contain \"Sam\", got \"Sam Okafor\""
+            },
+            {
+              "kind": "privacy",
+              "passed": true,
+              "detail": "no PII in public fields"
+            },
+            {
+              "kind": "skills",
+              "passed": true,
+              "detail": "expected ≥4 skills, got 5"
+            },
+            {
+              "kind": "interests",
+              "passed": true,
+              "detail": "expected ≥2 interests, got 3"
+            },
+            {
+              "kind": "coverage_skills",
+              "passed": true,
+              "detail": "judge: skills covered"
+            },
+            {
+              "kind": "coverage_interests",
+              "passed": true,
+              "detail": "judge: interests covered"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "caseId": "update/add-and-remove",
+      "rule": "update",
+      "runs": 3,
+      "passes": 3,
+      "passRate": 1,
+      "flaky": false,
+      "runResults": [
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "name",
+              "passed": true,
+              "detail": "expected name to contain \"Dana\", got \"Dana Lee\""
+            },
+            {
+              "kind": "location",
+              "passed": true,
+              "detail": "expected location to contain \"Toronto\", got \"Toronto, Canada\""
+            },
+            {
+              "kind": "privacy",
+              "passed": true,
+              "detail": "no PII in public fields"
+            },
+            {
+              "kind": "apply",
+              "passed": true,
+              "detail": "judge: change applied"
+            },
+            {
+              "kind": "preserve",
+              "passed": true,
+              "detail": "judge: preserved"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "name",
+              "passed": true,
+              "detail": "expected name to contain \"Dana\", got \"Dana Lee\""
+            },
+            {
+              "kind": "location",
+              "passed": true,
+              "detail": "expected location to contain \"Toronto\", got \"Toronto, Canada\""
+            },
+            {
+              "kind": "privacy",
+              "passed": true,
+              "detail": "no PII in public fields"
+            },
+            {
+              "kind": "apply",
+              "passed": true,
+              "detail": "judge: change applied"
+            },
+            {
+              "kind": "preserve",
+              "passed": true,
+              "detail": "judge: preserved"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "name",
+              "passed": true,
+              "detail": "expected name to contain \"Dana\", got \"Dana Lee\""
+            },
+            {
+              "kind": "location",
+              "passed": true,
+              "detail": "expected location to contain \"Toronto\", got \"Toronto, Canada\""
+            },
+            {
+              "kind": "privacy",
+              "passed": true,
+              "detail": "no PII in public fields"
+            },
+            {
+              "kind": "apply",
+              "passed": true,
+              "detail": "judge: change applied"
+            },
+            {
+              "kind": "preserve",
+              "passed": true,
+              "detail": "judge: preserved"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "caseId": "privacy/no-contact-clean",
+      "rule": "privacy",
+      "runs": 3,
+      "passes": 3,
+      "passRate": 1,
+      "flaky": false,
+      "runResults": [
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "name",
+              "passed": true,
+              "detail": "expected name to contain \"Wei\", got \"Wei Chen\""
+            },
+            {
+              "kind": "location",
+              "passed": true,
+              "detail": "expected location to contain \"Boston\", got \"Boston\""
+            },
+            {
+              "kind": "privacy",
+              "passed": true,
+              "detail": "no PII in public fields"
+            },
+            {
+              "kind": "skills",
+              "passed": true,
+              "detail": "expected ≥2 skills, got 3"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "name",
+              "passed": true,
+              "detail": "expected name to contain \"Wei\", got \"Wei Chen\""
+            },
+            {
+              "kind": "location",
+              "passed": true,
+              "detail": "expected location to contain \"Boston\", got \"Boston\""
+            },
+            {
+              "kind": "privacy",
+              "passed": true,
+              "detail": "no PII in public fields"
+            },
+            {
+              "kind": "skills",
+              "passed": true,
+              "detail": "expected ≥2 skills, got 3"
+            }
+          ]
+        },
+        {
+          "passed": true,
+          "assertions": [
+            {
+              "kind": "name",
+              "passed": true,
+              "detail": "expected name to contain \"Wei\", got \"Wei Chen\""
+            },
+            {
+              "kind": "location",
+              "passed": true,
+              "detail": "expected location to contain \"Boston\", got \"Boston\""
+            },
+            {
+              "kind": "privacy",
+              "passed": true,
+              "detail": "no PII in public fields"
+            },
+            {
+              "kind": "skills",
+              "passed": true,
+              "detail": "expected ≥2 skills, got 3"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/protocol/eval/profile/profile.cases.ts
+++ b/packages/protocol/eval/profile/profile.cases.ts
@@ -17,6 +17,10 @@ export const CASES: ProfileCase[] = [
     rule: "extraction",
     tier: 1,
     description: "Clean bio → name, location, skills, and interests extracted.",
+    human: {
+      scenario: "a tidy bio about a mathematician and writer in London who works on analytical engines.",
+      expectation: "pull out the right name, city, skills, and interests into a structured profile.",
+    },
     input:
       "Ada Lovelace is a mathematician and writer based in London, UK. She works on analytical engines, and is skilled in mathematics, logic, and technical writing. She is interested in computing and poetry.",
     expect: {
@@ -32,6 +36,10 @@ export const CASES: ProfileCase[] = [
     rule: "extraction",
     tier: 2,
     description: "Messy scraped LinkedIn-style blob → coherent structured profile.",
+    human: {
+      scenario: "a messy, scraped LinkedIn-style blob full of separators and abbreviations.",
+      expectation: "make sense of it and produce a clean profile with the right name, location, and skills.",
+    },
     input:
       "PROFILE | Priya Nair · Senior Backend Engineer @ Stripe · San Francisco Bay Area · 9 yrs · Go, Kubernetes, distributed systems, PostgreSQL · ex-Google · open source maintainer · talks about: payments infra, reliability",
     expect: {
@@ -46,6 +54,10 @@ export const CASES: ProfileCase[] = [
     rule: "location",
     tier: 1,
     description: "Explicit city is captured in identity.location.",
+    human: {
+      scenario: "a designer whose bio plainly says they're based in Berlin, Germany.",
+      expectation: "capture Berlin as the person's location.",
+    },
     input:
       "Lars Berg, product designer. Based in Berlin, Germany. Skilled in UX design, Figma, and design systems. Interested in typography.",
     expect: { expectLocationContains: "Berlin", expectNameContains: "Lars" },
@@ -55,6 +67,10 @@ export const CASES: ProfileCase[] = [
     rule: "privacy",
     tier: 1,
     description: "Email and phone in raw data must NOT appear in any public field.",
+    human: {
+      scenario: "raw data that includes a personal email address and phone number alongside the professional facts.",
+      expectation: "build the profile from the professional facts and never copy the email or phone into any public field.",
+    },
     input:
       "John Park — senior backend engineer at Acme. Contact: john.park@acme.com, +1 415-555-0199. Based in Austin, TX. Skilled in Go and Postgres. Interested in databases.",
     expect: {
@@ -69,6 +85,10 @@ export const CASES: ProfileCase[] = [
     rule: "privacy",
     tier: 2,
     description: "Contact-identifier-heavy input still yields a PII-free public profile.",
+    human: {
+      scenario: "input stuffed with contact details — an email, a phone number, and a street address.",
+      expectation: "keep all of those private and out of the public profile entirely.",
+    },
     input:
       "Maria Gomez, growth marketer. Reach me at maria.gomez@gmail.com or (212) 555-0143. Office: 500 5th Ave, New York. Skilled in SEO, content strategy, and analytics. Loves running.",
     expect: { expectNameContains: "Maria", expectLocationContains: "New York", minSkills: 2 },
@@ -78,6 +98,10 @@ export const CASES: ProfileCase[] = [
     rule: "skills_interests",
     tier: 1,
     description: "A skill-dense bio yields multiple distinct skills and interests.",
+    human: {
+      scenario: "a full-stack engineer's bio listing many technologies and several interests.",
+      expectation: "capture the distinct skills and interests rather than collapsing them into one or two.",
+    },
     input:
       "Sam Okafor — full-stack engineer. Works with TypeScript, React, Node.js, Postgres, and AWS. Interested in developer tooling, open source, and climbing.",
     expect: {
@@ -93,6 +117,10 @@ export const CASES: ProfileCase[] = [
     rule: "update",
     tier: 2,
     description: "Existing profile + request: apply the change, preserve the rest.",
+    human: {
+      scenario: "an existing profile plus a request: \u201cadd Rust to my skills and remove poetry from my interests.\u201d",
+      expectation: "make exactly that change — add Rust, drop poetry — while leaving the name, location, and other skills untouched.",
+    },
     input: `EXISTING PROFILE:
 {
   "identity": { "name": "Dana Lee", "bio": "Backend engineer focused on payments.", "location": "Toronto, Canada" },
@@ -113,6 +141,10 @@ USER REQUEST: Add Rust to my skills and remove poetry from my interests.`,
     rule: "privacy",
     tier: 1,
     description: "Already-clean input stays clean (privacy never introduces false positives).",
+    human: {
+      scenario: "a clean research bio that contains no contact details at all.",
+      expectation: "build the profile normally — the privacy check shouldn't flag anything that isn't there.",
+    },
     input:
       "Wei Chen, research scientist in computational biology at a university lab in Boston. Skilled in Python, genomics, and statistics. Interested in protein folding.",
     expect: { expectNameContains: "Wei", expectLocationContains: "Boston", minSkills: 2 },

--- a/packages/protocol/eval/profile/profile.cases.ts
+++ b/packages/protocol/eval/profile/profile.cases.ts
@@ -1,0 +1,120 @@
+import type { ProfileCase } from "./profile.types.js";
+
+/**
+ * Profile eval golden corpus (starter set).
+ *
+ * Exercises `ProfileGenerator.invoke`: structured-profile extraction from raw
+ * data, location inference, skills/interests capture, the PII-redaction privacy
+ * guarantee, and update-request handling. Tier 1 = surgical, Tier 2 = realistic
+ * messy input. `noPII` defaults on for every case — privacy is always asserted.
+ *
+ * Grow by appending cases. Re-run with `--update-baseline` after an intentional
+ * change.
+ */
+export const CASES: ProfileCase[] = [
+  {
+    id: "extraction/clean-bio",
+    rule: "extraction",
+    tier: 1,
+    description: "Clean bio → name, location, skills, and interests extracted.",
+    input:
+      "Ada Lovelace is a mathematician and writer based in London, UK. She works on analytical engines, and is skilled in mathematics, logic, and technical writing. She is interested in computing and poetry.",
+    expect: {
+      expectNameContains: "Ada",
+      expectLocationContains: "London",
+      minSkills: 2,
+      minInterests: 1,
+      mustHaveSkills: ["mathematics"],
+    },
+  },
+  {
+    id: "extraction/scraped-blob",
+    rule: "extraction",
+    tier: 2,
+    description: "Messy scraped LinkedIn-style blob → coherent structured profile.",
+    input:
+      "PROFILE | Priya Nair · Senior Backend Engineer @ Stripe · San Francisco Bay Area · 9 yrs · Go, Kubernetes, distributed systems, PostgreSQL · ex-Google · open source maintainer · talks about: payments infra, reliability",
+    expect: {
+      expectNameContains: "Priya",
+      expectLocationContains: "San Francisco",
+      minSkills: 3,
+      mustHaveSkills: ["Go", "Kubernetes"],
+    },
+  },
+  {
+    id: "location/explicit-city",
+    rule: "location",
+    tier: 1,
+    description: "Explicit city is captured in identity.location.",
+    input:
+      "Lars Berg, product designer. Based in Berlin, Germany. Skilled in UX design, Figma, and design systems. Interested in typography.",
+    expect: { expectLocationContains: "Berlin", expectNameContains: "Lars" },
+  },
+  {
+    id: "privacy/email-and-phone",
+    rule: "privacy",
+    tier: 1,
+    description: "Email and phone in raw data must NOT appear in any public field.",
+    input:
+      "John Park — senior backend engineer at Acme. Contact: john.park@acme.com, +1 415-555-0199. Based in Austin, TX. Skilled in Go and Postgres. Interested in databases.",
+    expect: {
+      expectNameContains: "John",
+      expectLocationContains: "Austin",
+      mustHaveSkills: ["Go"],
+      // noPII defaults on — the email and phone must be redacted.
+    },
+  },
+  {
+    id: "privacy/contact-heavy",
+    rule: "privacy",
+    tier: 2,
+    description: "Contact-identifier-heavy input still yields a PII-free public profile.",
+    input:
+      "Maria Gomez, growth marketer. Reach me at maria.gomez@gmail.com or (212) 555-0143. Office: 500 5th Ave, New York. Skilled in SEO, content strategy, and analytics. Loves running.",
+    expect: { expectNameContains: "Maria", expectLocationContains: "New York", minSkills: 2 },
+  },
+  {
+    id: "skills_interests/multi-skill",
+    rule: "skills_interests",
+    tier: 1,
+    description: "A skill-dense bio yields multiple distinct skills and interests.",
+    input:
+      "Sam Okafor — full-stack engineer. Works with TypeScript, React, Node.js, Postgres, and AWS. Interested in developer tooling, open source, and climbing.",
+    expect: {
+      expectNameContains: "Sam",
+      minSkills: 4,
+      minInterests: 2,
+      mustHaveSkills: ["TypeScript", "React"],
+      mustHaveInterests: ["open source"],
+    },
+  },
+  {
+    id: "update/add-and-remove",
+    rule: "update",
+    tier: 2,
+    description: "Existing profile + request: apply the change, preserve the rest.",
+    input: `EXISTING PROFILE:
+{
+  "identity": { "name": "Dana Lee", "bio": "Backend engineer focused on payments.", "location": "Toronto, Canada" },
+  "narrative": { "context": "Dana is a backend engineer working on payments infrastructure." },
+  "attributes": { "interests": ["fintech", "poetry"], "skills": ["Java", "Spring"] }
+}
+
+USER REQUEST: Add Rust to my skills and remove poetry from my interests.`,
+    expect: {
+      expectNameContains: "Dana",
+      expectLocationContains: "Toronto",
+      mustApply: "Rust is present in skills and poetry is no longer in interests",
+      mustPreserve: "the name Dana Lee, the Toronto location, and the existing Java/Spring skills",
+    },
+  },
+  {
+    id: "privacy/no-contact-clean",
+    rule: "privacy",
+    tier: 1,
+    description: "Already-clean input stays clean (privacy never introduces false positives).",
+    input:
+      "Wei Chen, research scientist in computational biology at a university lab in Boston. Skilled in Python, genomics, and statistics. Interested in protein folding.",
+    expect: { expectNameContains: "Wei", expectLocationContains: "Boston", minSkills: 2 },
+  },
+];

--- a/packages/protocol/eval/profile/profile.constants.ts
+++ b/packages/protocol/eval/profile/profile.constants.ts
@@ -1,0 +1,4 @@
+/** Retry budget for transient live-model failures during a profile eval run. */
+export const PROFILE_EVAL_MAX_ATTEMPTS = 3;
+/** Base backoff between profile eval retries (doubles each attempt). */
+export const PROFILE_EVAL_RETRY_DELAY_MS = 1000;

--- a/packages/protocol/eval/profile/profile.eval.ts
+++ b/packages/protocol/eval/profile/profile.eval.ts
@@ -1,0 +1,198 @@
+#!/usr/bin/env bun
+/**
+ * Profile quality eval harness.
+ *
+ * Usage (from packages/protocol):
+ *   bun run eval:profile                          # all cases, 3 runs, judge on, diff baseline
+ *   bun run eval:profile -- --runs 5              # more runs = less noise
+ *   bun run eval:profile -- --rule privacy        # one rule
+ *   bun run eval:profile -- --case extraction/     # one case or id prefix
+ *   bun run eval:profile -- --tier 1               # one tier
+ *   bun run eval:profile -- --list-cases           # print selected cases and exit
+ *   bun run eval:profile -- --no-judge             # skip LLM coverage/apply/preserve checks
+ *   bun run eval:profile -- --update-baseline      # overwrite the committed baseline
+ *   bun run eval:profile -- --report [path]        # write a full run report (incl. generated profiles)
+ *   bun run eval:profile -- --html [path]          # write a standalone HTML scorecard
+ *   bun run eval:profile -- --rolling-baseline [d] # compare against recent runs (default 7d)
+ *   bun run eval:profile -- --alpha 0.01           # stricter regression significance threshold
+ *   bun run eval:profile -- --no-save              # do not auto-save full-corpus run JSON
+ *
+ * Requires OPENROUTER_API_KEY (loaded via --env-file=.env.test in the package script).
+ * Exits non-zero when a regression vs the committed baseline is detected.
+ */
+import path from "path";
+
+import { ProfileGenerator } from "../../src/profile/profile.generator.js";
+import { getModelName } from "../../src/shared/agent/model.config.js";
+import { assertLLM } from "../../src/shared/agent/tests/llm-assert.js";
+import { arg, buildScorecard, computeRollingBaseline, diffBaseline, flagValue, formatConsole, has, readBaseline, writeBaseline, writeRunReport } from "../shared/index.js";
+import { CASES } from "./profile.cases.js";
+import { runCase } from "./profile.runner.js";
+import { scoreCase, type Judge } from "./profile.scorer.js";
+import { writeHtmlReport } from "./profile.reporter.js";
+import { formatCaseList, hasRule, parseTier, selectCases } from "./profile.selection.js";
+import type { CaseResult, Scorecard } from "./profile.types.js";
+
+const DEFAULT_ALPHA = 0.05;
+const BASELINE_PATH = path.resolve(import.meta.dir, "baselines/profile.baseline.json");
+const RUNS_DIR = path.resolve(import.meta.dir, "runs");
+
+function usage(): string {
+  return `Profile quality eval harness
+
+Usage (from packages/protocol):
+  bun run eval:profile [-- options]
+
+Selection:
+  --rule <rule>             Run one rule (extraction|location|privacy|skills_interests|update)
+  --case <id-or-prefix>     Run one case or id prefix
+  --tier <1|2>              Run one tier
+  --list-cases              Print selected cases and exit
+
+Execution:
+  --runs <n>                Runs per case (default: 3)
+  --no-judge                Skip LLM coverage/apply/preserve/reasoning checks
+  --alpha <p>               Regression significance threshold (default: ${DEFAULT_ALPHA})
+  --no-save                 Do not auto-save full-corpus run JSON for rolling-baseline fuel
+
+Baselines/reports:
+  --update-baseline         Overwrite committed baseline (full corpus only)
+  --rolling-baseline [days] Compare against recent run reports (default: 7)
+  --report [path]           Write JSON scorecard
+  --html [path]             Write standalone HTML scorecard
+
+Other:
+  --help, -h                Show this help
+`;
+}
+
+async function main(): Promise<void> {
+  if (has("--help") || has("-h")) {
+    console.log(usage());
+    process.exit(0);
+  }
+
+  const runs = Number(arg("--runs") ?? 3);
+  if (!Number.isInteger(runs) || runs < 1) {
+    console.error(`--runs must be a positive integer (got "${arg("--runs")}")`);
+    process.exit(2);
+  }
+  const ruleFilter = arg("--rule");
+  if (ruleFilter && !hasRule(CASES, ruleFilter)) {
+    console.error(`No cases match --rule ${ruleFilter}`);
+    process.exit(2);
+  }
+  const caseFilter = arg("--case");
+  let tierFilter: 1 | 2 | undefined;
+  try {
+    tierFilter = parseTier(arg("--tier"));
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(2);
+  }
+  const listCases = has("--list-cases");
+  const updateBaseline = has("--update-baseline");
+  const noJudge = has("--no-judge");
+  const report = has("--report");
+  const html = has("--html");
+  const noSave = has("--no-save");
+  const alpha = Number(arg("--alpha") ?? DEFAULT_ALPHA);
+  if (!Number.isFinite(alpha) || alpha <= 0 || alpha >= 1) {
+    console.error(`--alpha must be a number between 0 and 1 (got "${arg("--alpha")}")`);
+    process.exit(2);
+  }
+  const rollingBaseline = has("--rolling-baseline");
+  const rollingBaselineDays = rollingBaseline ? Number(flagValue("--rolling-baseline") ?? 7) : null;
+  if (rollingBaselineDays !== null && (!Number.isFinite(rollingBaselineDays) || rollingBaselineDays <= 0)) {
+    console.error(`--rolling-baseline must be a positive number of days (got "${flagValue("--rolling-baseline")}")`);
+    process.exit(2);
+  }
+
+  const judge: Judge = noJudge
+    ? async () => true
+    : async (output, criteria) => {
+        try {
+          await assertLLM(output, criteria);
+          return true;
+        } catch {
+          return false;
+        }
+      };
+
+  const selected = selectCases(CASES, { rule: ruleFilter, caseId: caseFilter, tier: tierFilter });
+  const fullCorpus = !ruleFilter && !caseFilter && tierFilter === undefined;
+  if (listCases) {
+    console.log(formatCaseList(selected));
+    process.exit(0);
+  }
+  if (selected.length === 0) {
+    console.error(`No cases match selected filters`);
+    process.exit(2);
+  }
+  if (updateBaseline && !fullCorpus) {
+    console.error(`--update-baseline requires a full-corpus run (remove --rule/--case/--tier filters)`);
+    process.exit(2);
+  }
+
+  const generator = new ProfileGenerator();
+  const model = getModelName("profileGenerator");
+  console.log(`Running ${selected.length} case(s) × ${runs} run(s) against ${model}${noJudge ? " (judge off)" : ""}…`);
+
+  const results: CaseResult[] = [];
+  for (const c of selected) {
+    process.stdout.write(`  ${c.id} … `);
+    const details = await runCase(generator, c, runs);
+    const result = await scoreCase(c, details, judge);
+    results.push(result);
+    console.log(`${result.passes}/${result.runs}${result.flaky ? " (flaky)" : ""}`);
+  }
+
+  const scorecard = buildScorecard(results, { model, runs }) as Scorecard;
+  const baseline =
+    rollingBaselineDays !== null
+      ? await computeRollingBaseline(RUNS_DIR, rollingBaselineDays)
+      : await readBaseline<Scorecard>(BASELINE_PATH);
+  const { regressions, skippedCaseIds } = diffBaseline(scorecard, baseline, alpha);
+
+  if (rollingBaselineDays !== null) {
+    console.log(
+      baseline
+        ? `\nComparing against rolling ${rollingBaselineDays}-day baseline (${baseline.model}, α=${alpha}).`
+        : `\nNo rolling ${rollingBaselineDays}-day baseline found; skipping regression comparison.`,
+    );
+  }
+
+  console.log(formatConsole(scorecard, regressions, skippedCaseIds, { title: "Profile Quality Scorecard" }));
+
+  if (updateBaseline) {
+    await writeBaseline(BASELINE_PATH, scorecard, {
+      leanCase: (c) => ({ ...c, runResults: c.runResults.map(({ detail: _detail, ...rest }) => rest) }),
+    });
+    console.log(`\nBaseline updated at ${BASELINE_PATH}`);
+  }
+
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const autoRunPath = path.resolve(RUNS_DIR, `${stamp}.json`);
+  if (fullCorpus && !noSave) {
+    await writeRunReport(autoRunPath, scorecard);
+  }
+
+  if (report) {
+    const reportPath = flagValue("--report") ?? autoRunPath;
+    if (reportPath !== autoRunPath) await writeRunReport(reportPath, scorecard);
+    console.log(`\nRun report written to ${reportPath}`);
+  }
+
+  if (html) {
+    const htmlPath = flagValue("--html") ?? path.resolve(RUNS_DIR, `${stamp}.html`);
+    await writeHtmlReport(htmlPath, scorecard, regressions, CASES);
+    console.log(`\nHTML report written to ${htmlPath}`);
+  }
+
+  process.exit(regressions.length > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(2);
+});

--- a/packages/protocol/eval/profile/profile.pii.ts
+++ b/packages/protocol/eval/profile/profile.pii.ts
@@ -1,0 +1,31 @@
+/**
+ * Deterministic PII scanning for the profile privacy guarantee.
+ *
+ * The profile generator promises that public fields (bio, narrative.context, …)
+ * never embed contact identifiers. These detectors back the `privacy` assertion:
+ * any match in a public field is a leak. Kept conservative to avoid false
+ * positives — emails and phone numbers are the highest-signal contact leaks.
+ */
+
+const EMAIL_RE = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi;
+// 7+ digit runs allowing spaces, dashes, dots, parens, and an optional leading +.
+const PHONE_RE = /(?:\+?\d[\d\s().-]{7,}\d)/g;
+
+/** Strip obvious non-phone digit runs (years, counts) before phone matching. */
+function looksLikePhone(s: string): boolean {
+  const digits = s.replace(/\D/g, "");
+  return digits.length >= 8 && digits.length <= 15;
+}
+
+/** Return the distinct PII strings found across the given text fields. */
+export function findPII(fields: string[]): string[] {
+  const hits = new Set<string>();
+  for (const field of fields) {
+    if (!field) continue;
+    for (const m of field.match(EMAIL_RE) ?? []) hits.add(m.trim());
+    for (const m of field.match(PHONE_RE) ?? []) {
+      if (looksLikePhone(m)) hits.add(m.trim());
+    }
+  }
+  return [...hits];
+}

--- a/packages/protocol/eval/profile/profile.reporter.ts
+++ b/packages/protocol/eval/profile/profile.reporter.ts
@@ -1,5 +1,66 @@
-import { htmlEscape, rateClass, htmlRateCI, renderRuleTable, renderScorecardShell, type Regression } from "../shared/index.js";
-import type { CaseResult, ProfileCase, ProfileRunDetail, Scorecard } from "./profile.types.js";
+import { htmlEscape, rateClass, htmlRateCI, renderRuleTable, renderScorecardShell, type HumanReport, type Regression } from "../shared/index.js";
+import type { AssertionKind, CaseResult, ProfileCase, Rule, Scorecard, ProfileRunDetail } from "./profile.types.js";
+
+// ─── Plain-language copy for the non-technical report ────────────────────────
+
+/** Ordered themes for "What we tested", each mapped to one or more rules. */
+const GROUPS: { ruleIds: Rule[]; label: string; blurb: string }[] = [
+  { ruleIds: ["privacy"], label: "Privacy: never leaking contact info", blurb: "Emails, phone numbers, and addresses must never end up in the public profile." },
+  { ruleIds: ["extraction"], label: "Pulling the right facts from a bio", blurb: "Reading raw or messy text and getting the name, role, and details right." },
+  { ruleIds: ["location"], label: "Getting the location right", blurb: "Capturing where someone is based." },
+  { ruleIds: ["skills_interests"], label: "Capturing skills and interests", blurb: "Listing what someone can do and cares about, without collapsing them together." },
+  { ruleIds: ["update"], label: "Applying profile edits", blurb: "Making the change a user asks for while leaving everything else intact." },
+];
+
+/** Plain-language name for each failing check, used in "what happened" notes. */
+const CHECK_COPY: Record<AssertionKind, string> = {
+  name: "got the person's name wrong",
+  location: "got the location wrong",
+  privacy: "leaked an email or phone number into the public profile",
+  skills: "captured too few skills",
+  interests: "captured too few interests",
+  coverage_skills: "missed an expected skill",
+  coverage_interests: "missed an expected interest",
+  apply: "didn't apply the requested change",
+  preserve: "lost part of the existing profile",
+  reasoning: "the result didn't hold up",
+};
+
+/** Distinct plain-language reasons a case failed, across its runs. */
+function failNote(c: CaseResult): string | undefined {
+  const kinds = new Set<AssertionKind>();
+  for (const rr of c.runResults) for (const a of rr.assertions) if (!a.passed) kinds.add(a.kind);
+  if (kinds.size === 0) return undefined;
+  return [...kinds].map((k) => CHECK_COPY[k]).join("; ") + ".";
+}
+
+/** Build the plain-language report from the scorecard + corpus narratives. */
+function buildHumanReport(sc: Scorecard, cases: ProfileCase[]): HumanReport {
+  const byId = new Map(cases.map((c) => [c.id, c]));
+  const resultById = new Map(sc.cases.map((c) => [c.caseId, c]));
+  const groups = GROUPS.map((g) => ({
+    label: g.label,
+    blurb: g.blurb,
+    ruleIds: g.ruleIds as string[],
+    cases: sc.cases
+      .filter((c) => g.ruleIds.includes(c.rule))
+      .map((c) => {
+        const meta = byId.get(c.caseId);
+        const result = resultById.get(c.caseId);
+        return {
+          caseId: c.caseId,
+          scenario: meta?.human?.scenario ?? meta?.description ?? c.caseId,
+          expectation: meta?.human?.expectation ?? "behave correctly.",
+          failNote: result ? failNote(result) : undefined,
+        };
+      }),
+  })).filter((g) => g.cases.length > 0);
+  return {
+    subject: "the profile builder",
+    oneLiner: "It turns raw data about a person into a clean public profile — and must never leak their private contact details.",
+    groups,
+  };
+}
 
 /** Render one run's generated profile behind a collapsible block. */
 function detailHtml(d: ProfileRunDetail, i: number): string {
@@ -69,6 +130,7 @@ export function renderHtml(sc: Scorecard, regressions: Regression[], cases: Prof
     intro: INTRO,
     sections: [{ heading: "By rule", html: renderRuleTable(sc) }],
     caseCardsHtml: caseCards,
+    human: buildHumanReport(sc, cases),
   });
 }
 

--- a/packages/protocol/eval/profile/profile.reporter.ts
+++ b/packages/protocol/eval/profile/profile.reporter.ts
@@ -1,0 +1,83 @@
+import { htmlEscape, rateClass, htmlRateCI, renderRuleTable, renderScorecardShell, type Regression } from "../shared/index.js";
+import type { CaseResult, ProfileCase, ProfileRunDetail, Scorecard } from "./profile.types.js";
+
+/** Render one run's generated profile behind a collapsible block. */
+function detailHtml(d: ProfileRunDetail, i: number): string {
+  const pii = d.piiHits.length > 0 ? ` <span class="bad">PII: ${htmlEscape(d.piiHits.join(", "))}</span>` : "";
+  return `<div class="reason">
+    <span class="muted">run ${i + 1} · ${d.skills.length} skill(s) · ${d.interests.length} interest(s)</span>${pii}
+    <p><strong>${htmlEscape(d.name)}</strong> · ${htmlEscape(d.location)}</p>
+    <p class="muted">${htmlEscape(d.bio)}</p>
+    <p class="muted">skills: ${htmlEscape(d.skills.join(", "))}</p>
+    <p class="muted">interests: ${htmlEscape(d.interests.join(", "))}</p>
+  </div>`;
+}
+
+/** Render failed assertions for a case. */
+function failedChecks(c: CaseResult): string {
+  const failed = c.runResults.flatMap((rr, i) =>
+    rr.assertions
+      .filter((a) => !a.passed)
+      .map((a) => `<li><span class="muted">run ${i + 1}</span> <span class="component">${htmlEscape(a.kind)}</span>: ${htmlEscape(a.detail)}</li>`),
+  );
+  if (failed.length === 0) return "";
+  return `<details class="failures" open><summary>failed checks (${failed.length})</summary><ul>${failed.join("")}</ul></details>`;
+}
+
+/** Render one case card. */
+function caseCard(c: CaseResult, meta: ProfileCase | undefined): string {
+  const tier = meta ? `<span class="badge">tier ${meta.tier}</span>` : "";
+  const flaky = c.flaky ? `<span class="badge flaky">flaky</span>` : "";
+  const desc = meta?.description ? `<p class="desc">${htmlEscape(meta.description)}</p>` : "";
+  const input = meta ? `<p class="desc"><span class="muted">input:</span> <code>${htmlEscape(meta.input.slice(0, 240))}${meta.input.length > 240 ? "…" : ""}</code></p>` : "";
+  const details = c.runResults.map((rr, i) => (rr.detail ? detailHtml(rr.detail, i) : "")).join("");
+  return `
+  <article class="case ${rateClass(c.passRate)}">
+    <header>
+      <code class="cid">${htmlEscape(c.caseId)}</code>
+      <span class="verdict ${rateClass(c.passRate)}" title="${c.passes}/${c.runs} runs">${htmlRateCI(c.passRate, c.passes, c.runs)}</span>
+      ${tier}${flaky}
+    </header>
+    ${desc}${input}
+    ${failedChecks(c)}
+    <details><summary>generated profile (${c.runResults.length} run${c.runResults.length === 1 ? "" : "s"})</summary>${details}</details>
+  </article>`;
+}
+
+const INTRO = `<h2>What this report is measuring</h2>
+<p>This is a repeatability test for the profile generator. Cases check structured extraction (name, location, skills, interests) from raw data, update-request handling, and — on every case — the <strong>privacy guarantee</strong>: public fields (bio, narrative, location, …) must never embed contact identifiers (email/phone). Each case runs N times; a run passes only when every check passes, and any PII leak fails the run outright.</p>`;
+
+/**
+ * Render a standalone HTML scorecard for a profile-eval run via the shared shell.
+ *
+ * @param sc - The scorecard (run-report grade, with per-run detail intact).
+ * @param regressions - Regressions vs the baseline.
+ * @param cases - The corpus, joined by id for input text, tier, and description.
+ */
+export function renderHtml(sc: Scorecard, regressions: Regression[], cases: ProfileCase[]): string {
+  const byId = new Map(cases.map((c) => [c.id, c]));
+  const caseCards = [...sc.rules]
+    .sort((x, y) => x.passRate - y.passRate)
+    .map((r) => {
+      const cards = sc.cases.filter((c) => c.rule === r.rule).map((c) => caseCard(c, byId.get(c.caseId))).join("");
+      return `<section class="rule"><h2>${htmlEscape(r.rule)}</h2>${cards}</section>`;
+    })
+    .join("");
+
+  return renderScorecardShell(sc, regressions, {
+    title: "Profile eval",
+    intro: INTRO,
+    sections: [{ heading: "By rule", html: renderRuleTable(sc) }],
+    caseCardsHtml: caseCards,
+  });
+}
+
+/** Write a standalone HTML scorecard to disk. */
+export async function writeHtmlReport(
+  path: string,
+  sc: Scorecard,
+  regressions: Regression[],
+  cases: ProfileCase[],
+): Promise<void> {
+  await Bun.write(path, renderHtml(sc, regressions, cases));
+}

--- a/packages/protocol/eval/profile/profile.runner.ts
+++ b/packages/protocol/eval/profile/profile.runner.ts
@@ -1,0 +1,65 @@
+import { repeatRuns } from "../shared/index.js";
+import { PROFILE_EVAL_MAX_ATTEMPTS, PROFILE_EVAL_RETRY_DELAY_MS } from "./profile.constants.js";
+import { findPII } from "./profile.pii.js";
+import type { ProfileCase, ProfileRunDetail } from "./profile.types.js";
+
+/** Minimal generator surface the runner needs (real ProfileGenerator satisfies this). */
+export interface GeneratorLike {
+  invoke(input: string): Promise<{
+    output: {
+      identity: { name: string; bio: string; location: string };
+      narrative: { context: string };
+      attributes: { interests: string[]; skills: string[] };
+    };
+  }>;
+}
+
+export interface RunCaseOptions {
+  maxAttempts?: number;
+  retryDelayMs?: number;
+}
+
+/** Invoke the generator once and normalize its output (computing PII hits in public fields). */
+async function invokeOnce(generator: GeneratorLike, c: ProfileCase): Promise<ProfileRunDetail> {
+  const { output } = await generator.invoke(c.input);
+  const { identity, narrative, attributes } = output;
+  const piiHits = findPII([
+    identity.name,
+    identity.bio,
+    identity.location,
+    narrative.context,
+    ...attributes.skills,
+    ...attributes.interests,
+  ]);
+  return {
+    name: identity.name,
+    bio: identity.bio,
+    location: identity.location,
+    context: narrative.context,
+    interests: attributes.interests,
+    skills: attributes.skills,
+    piiHits,
+  };
+}
+
+/**
+ * Run a profile case `runs` times, retrying transient live-model failures.
+ *
+ * @param generator - The profile generator under test.
+ * @param c - The case to run.
+ * @param runs - Number of repetitions.
+ * @param options - Retry tuning (defaults from profile constants).
+ * @returns One normalized detail per run.
+ */
+export async function runCase(
+  generator: GeneratorLike,
+  c: ProfileCase,
+  runs: number,
+  options: RunCaseOptions = {},
+): Promise<ProfileRunDetail[]> {
+  return repeatRuns(() => invokeOnce(generator, c), runs, {
+    maxAttempts: options.maxAttempts ?? PROFILE_EVAL_MAX_ATTEMPTS,
+    retryDelayMs: options.retryDelayMs ?? PROFILE_EVAL_RETRY_DELAY_MS,
+    label: "profile eval",
+  });
+}

--- a/packages/protocol/eval/profile/profile.scorer.ts
+++ b/packages/protocol/eval/profile/profile.scorer.ts
@@ -1,0 +1,113 @@
+import type { AssertionResult, CaseResult, ProfileCase, ProfileRunDetail, RunResult } from "./profile.types.js";
+
+/** Grades a natural-language criterion. Returns true on pass. Injected for testability. */
+export type Judge = (output: unknown, criteria: string) => Promise<boolean>;
+
+const contains = (haystack: string, needle: string): boolean =>
+  haystack.toLowerCase().includes(needle.toLowerCase());
+
+/**
+ * Score a single run of a profile case. A run passes iff every assertion passes.
+ *
+ * @param c - The profile case being evaluated.
+ * @param d - The normalized generator output for this run.
+ * @param judge - Injected LLM judge for coverage/apply/preserve/reasoning checks.
+ */
+export async function scoreRun(c: ProfileCase, d: ProfileRunDetail, judge: Judge): Promise<RunResult> {
+  const out: AssertionResult[] = [];
+  const { expect: e } = c;
+
+  if (e.expectNameContains) {
+    out.push({
+      kind: "name",
+      passed: contains(d.name, e.expectNameContains),
+      detail: `expected name to contain "${e.expectNameContains}", got "${d.name}"`,
+    });
+  }
+
+  if (e.expectLocationContains) {
+    out.push({
+      kind: "location",
+      passed: contains(d.location, e.expectLocationContains),
+      detail: `expected location to contain "${e.expectLocationContains}", got "${d.location}"`,
+    });
+  }
+
+  // Privacy is the headline guarantee: any PII in public fields fails, on by default.
+  if (e.noPII !== false) {
+    out.push({
+      kind: "privacy",
+      passed: d.piiHits.length === 0,
+      detail: d.piiHits.length === 0 ? "no PII in public fields" : `PII leaked: ${d.piiHits.join(", ")}`,
+    });
+  }
+
+  if (e.minSkills !== undefined) {
+    out.push({ kind: "skills", passed: d.skills.length >= e.minSkills, detail: `expected ≥${e.minSkills} skills, got ${d.skills.length}` });
+  }
+  if (e.minInterests !== undefined) {
+    out.push({ kind: "interests", passed: d.interests.length >= e.minInterests, detail: `expected ≥${e.minInterests} interests, got ${d.interests.length}` });
+  }
+
+  if (e.mustHaveSkills && e.mustHaveSkills.length > 0) {
+    const passed = await judge(
+      { skills: d.skills },
+      `The skills list must capture ALL of these (allow synonyms/specializations): ${e.mustHaveSkills.map((s) => `"${s}"`).join("; ")}.`,
+    );
+    out.push({ kind: "coverage_skills", passed, detail: passed ? "judge: skills covered" : "judge: skills missing" });
+  }
+  if (e.mustHaveInterests && e.mustHaveInterests.length > 0) {
+    const passed = await judge(
+      { interests: d.interests },
+      `The interests list must capture ALL of these (allow synonyms): ${e.mustHaveInterests.map((s) => `"${s}"`).join("; ")}.`,
+    );
+    out.push({ kind: "coverage_interests", passed, detail: passed ? "judge: interests covered" : "judge: interests missing" });
+  }
+
+  if (e.mustApply) {
+    const passed = await judge(
+      { name: d.name, bio: d.bio, location: d.location, context: d.context, skills: d.skills, interests: d.interests },
+      `The updated profile must reflect this change: ${e.mustApply}.`,
+    );
+    out.push({ kind: "apply", passed, detail: passed ? "judge: change applied" : "judge: change not applied" });
+  }
+  if (e.mustPreserve) {
+    const passed = await judge(
+      { name: d.name, bio: d.bio, location: d.location, context: d.context, skills: d.skills, interests: d.interests },
+      `The updated profile must still preserve: ${e.mustPreserve}.`,
+    );
+    out.push({ kind: "preserve", passed, detail: passed ? "judge: preserved" : "judge: not preserved" });
+  }
+
+  if (e.reasoningCriteria) {
+    const passed = await judge(
+      { name: d.name, bio: d.bio, location: d.location, context: d.context, skills: d.skills, interests: d.interests },
+      e.reasoningCriteria,
+    );
+    out.push({ kind: "reasoning", passed, detail: passed ? "judge passed" : "judge failed" });
+  }
+
+  return { passed: out.every((a) => a.passed), assertions: out, detail: d };
+}
+
+/**
+ * Aggregate N runs of a case into a CaseResult with pass-rate and flakiness.
+ *
+ * @param c - The profile case being evaluated.
+ * @param details - One normalized detail per run.
+ * @param judge - Injected LLM judge.
+ */
+export async function scoreCase(c: ProfileCase, details: ProfileRunDetail[], judge: Judge): Promise<CaseResult> {
+  const runResults = await Promise.all(details.map((d) => scoreRun(c, d, judge)));
+  const passes = runResults.filter((r) => r.passed).length;
+  const total = runResults.length;
+  return {
+    caseId: c.id,
+    rule: c.rule,
+    runs: total,
+    passes,
+    passRate: total === 0 ? 0 : passes / total,
+    flaky: passes > 0 && passes < total,
+    runResults,
+  };
+}

--- a/packages/protocol/eval/profile/profile.selection.ts
+++ b/packages/protocol/eval/profile/profile.selection.ts
@@ -1,0 +1,61 @@
+import type { ProfileCase, Rule } from "./profile.types.js";
+
+export interface CaseFilters {
+  rule?: string;
+  caseId?: string;
+  tier?: number;
+}
+
+/** Parse and validate a tier CLI argument. */
+export function parseTier(value: string | undefined): 1 | 2 | undefined {
+  if (value === undefined) return undefined;
+  const n = Number(value);
+  if (n === 1 || n === 2) return n;
+  throw new Error(`--tier must be one of 1, 2 (got "${value}")`);
+}
+
+/** Select profile eval cases by optional rule, id/prefix, and tier filters. */
+export function selectCases(cases: ProfileCase[], filters: CaseFilters): ProfileCase[] {
+  return cases.filter((c) => {
+    if (filters.rule && c.rule !== filters.rule) return false;
+    if (filters.tier !== undefined && c.tier !== filters.tier) return false;
+    if (filters.caseId) {
+      const q = filters.caseId;
+      if (c.id !== q && !c.id.startsWith(q)) return false;
+    }
+    return true;
+  });
+}
+
+function countBy<T extends string | number>(values: T[]): Map<T, number> {
+  const out = new Map<T, number>();
+  for (const v of values) out.set(v, (out.get(v) ?? 0) + 1);
+  return out;
+}
+
+/** Format corpus counts by tier and rule. */
+export function formatCaseSummary(cases: ProfileCase[]): string {
+  const byTier = [...countBy(cases.map((c) => c.tier)).entries()]
+    .sort((a, b) => Number(a[0]) - Number(b[0]))
+    .map(([tier, count]) => `t${tier}:${count}`)
+    .join("  ");
+  const byRule = [...countBy(cases.map((c) => c.rule)).entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([rule, count]) => `${rule}:${count}`)
+    .join("  ");
+  return `total:${cases.length}${byTier ? `\nby tier: ${byTier}` : ""}${byRule ? `\nby rule: ${byRule}` : ""}`;
+}
+
+/** Format a case inventory for --list-cases. */
+export function formatCaseList(cases: ProfileCase[]): string {
+  const lines = ["Profile eval cases:", formatCaseSummary(cases), ""];
+  for (const c of [...cases].sort((a, b) => a.rule.localeCompare(b.rule) || a.id.localeCompare(b.id))) {
+    lines.push(`  [t${c.tier}] ${c.rule.padEnd(18)} ${c.id}`);
+  }
+  return lines.join("\n");
+}
+
+/** True when a string is a known rule value in the corpus. */
+export function hasRule(cases: ProfileCase[], rule: string): rule is Rule {
+  return cases.some((c) => c.rule === rule);
+}

--- a/packages/protocol/eval/profile/profile.types.ts
+++ b/packages/protocol/eval/profile/profile.types.ts
@@ -30,7 +30,10 @@ export interface ProfileCase {
   id: string;
   rule: Rule;
   tier: 1 | 2;
+  /** Technical one-liner (for the engineer view). */
   description: string;
+  /** Plain-language narrative for the non-technical report. */
+  human?: { scenario: string; expectation: string };
   /** Raw data (or existing-profile + request) handed to the generator. */
   input: string;
   expect: ProfileExpectation;

--- a/packages/protocol/eval/profile/profile.types.ts
+++ b/packages/protocol/eval/profile/profile.types.ts
@@ -1,0 +1,81 @@
+import type { CaseResultLike, RuleResult as SharedRuleResult, ScorecardLike } from "../shared/index.js";
+
+/** Each rule maps to a distinct profile-generator behaviour the corpus exercises. */
+export type Rule = "extraction" | "location" | "privacy" | "skills_interests" | "update";
+
+export interface ProfileExpectation {
+  // ── Deterministic ──────────────────────────────────────────────────────
+  /** `identity.name` must contain this (case-insensitive). */
+  expectNameContains?: string;
+  /** `identity.location` must contain this (case-insensitive). */
+  expectLocationContains?: string;
+  /** Public fields must contain no email/phone PII. Defaults to true. */
+  noPII?: boolean;
+  minSkills?: number;
+  minInterests?: number;
+  // ── Judged (LLM) ───────────────────────────────────────────────────────
+  /** Skills the profile must capture (judged coverage). */
+  mustHaveSkills?: string[];
+  /** Interests the profile must capture (judged coverage). */
+  mustHaveInterests?: string[];
+  /** For update cases: the change that must be applied (judged). */
+  mustApply?: string;
+  /** For update cases: existing content that must be preserved (judged). */
+  mustPreserve?: string;
+  /** Free-form rubric graded by the judge against the whole profile. */
+  reasoningCriteria?: string;
+}
+
+export interface ProfileCase {
+  id: string;
+  rule: Rule;
+  tier: 1 | 2;
+  description: string;
+  /** Raw data (or existing-profile + request) handed to the generator. */
+  input: string;
+  expect: ProfileExpectation;
+}
+
+export type AssertionKind =
+  | "name"
+  | "location"
+  | "privacy"
+  | "skills"
+  | "interests"
+  | "coverage_skills"
+  | "coverage_interests"
+  | "apply"
+  | "preserve"
+  | "reasoning";
+
+export interface AssertionResult {
+  kind: AssertionKind;
+  passed: boolean;
+  detail: string;
+}
+
+/** Normalized generator output for one run (stripped from baselines, kept in run reports). */
+export interface ProfileRunDetail {
+  name: string;
+  bio: string;
+  location: string;
+  context: string;
+  interests: string[];
+  skills: string[];
+  /** PII strings found in public fields, if any — the privacy assertion's evidence. */
+  piiHits: string[];
+}
+
+export interface RunResult {
+  passed: boolean;
+  assertions: AssertionResult[];
+  detail?: ProfileRunDetail;
+}
+
+export interface CaseResult extends CaseResultLike {
+  rule: Rule;
+  runResults: RunResult[];
+}
+
+export type RuleResult = SharedRuleResult;
+export type Scorecard = ScorecardLike<CaseResult>;

--- a/packages/protocol/eval/profile/tests/profile.cases.spec.ts
+++ b/packages/protocol/eval/profile/tests/profile.cases.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "bun:test";
+
+import { CASES } from "../profile.cases.js";
+import { formatCaseList, formatCaseSummary, hasRule, parseTier, selectCases } from "../profile.selection.js";
+
+describe("corpus invariants", () => {
+  it("has unique case ids", () => {
+    const ids = CASES.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("every case has an id with a prefix and a non-empty input", () => {
+    for (const c of CASES) {
+      expect(c.id).toContain("/");
+      expect(c.input.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("privacy is exercised by at least one dedicated rule case", () => {
+    expect(CASES.some((c) => c.rule === "privacy")).toBe(true);
+  });
+});
+
+describe("parseTier", () => {
+  it("accepts supported tiers and rejects others", () => {
+    expect(parseTier("1")).toBe(1);
+    expect(parseTier("2")).toBe(2);
+    expect(parseTier(undefined)).toBeUndefined();
+    expect(() => parseTier("3")).toThrow();
+  });
+});
+
+describe("selectCases", () => {
+  it("filters by rule, tier, and id prefix", () => {
+    expect(selectCases(CASES, { rule: "privacy" }).every((c) => c.rule === "privacy")).toBe(true);
+    expect(selectCases(CASES, { tier: 1 }).every((c) => c.tier === 1)).toBe(true);
+    expect(selectCases(CASES, { caseId: "extraction/" }).every((c) => c.id.startsWith("extraction/"))).toBe(true);
+  });
+});
+
+describe("formatting + hasRule", () => {
+  it("summary and list render counts and ids", () => {
+    expect(formatCaseSummary(CASES)).toContain(`total:${CASES.length}`);
+    expect(formatCaseList(CASES)).toContain(CASES[0].id);
+  });
+
+  it("hasRule detects known and unknown rules", () => {
+    expect(hasRule(CASES, "privacy")).toBe(true);
+    expect(hasRule(CASES, "nope")).toBe(false);
+  });
+});

--- a/packages/protocol/eval/profile/tests/profile.pii.spec.ts
+++ b/packages/protocol/eval/profile/tests/profile.pii.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "bun:test";
+
+import { findPII } from "../profile.pii.js";
+
+describe("findPII", () => {
+  it("detects emails", () => {
+    expect(findPII(["reach me at john.park@acme.com please"])).toContain("john.park@acme.com");
+  });
+
+  it("detects phone numbers in several formats", () => {
+    expect(findPII(["+1 415-555-0199"]).length).toBe(1);
+    expect(findPII(["call (212) 555-0143"]).length).toBe(1);
+  });
+
+  it("does not flag plain bios, years, or short numbers", () => {
+    expect(findPII(["Backend engineer with 9 years of experience since 2015."])).toEqual([]);
+    expect(findPII(["Skilled in Go and Postgres. Interested in databases."])).toEqual([]);
+  });
+
+  it("scans multiple fields and dedups", () => {
+    const hits = findPII(["a@b.com", "a@b.com", "clean text"]);
+    expect(hits).toEqual(["a@b.com"]);
+  });
+
+  it("ignores empty fields", () => {
+    expect(findPII(["", "clean"])).toEqual([]);
+  });
+});

--- a/packages/protocol/eval/profile/tests/profile.scorer.spec.ts
+++ b/packages/protocol/eval/profile/tests/profile.scorer.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "bun:test";
+
+import { scoreRun, scoreCase, type Judge } from "../profile.scorer.js";
+import type { ProfileCase, ProfileRunDetail } from "../profile.types.js";
+
+const yes: Judge = async () => true;
+const no: Judge = async () => false;
+
+const mkCase = (expect: ProfileCase["expect"], rule: ProfileCase["rule"] = "extraction"): ProfileCase => ({
+  id: "p/case",
+  rule,
+  tier: 1,
+  description: "synthetic",
+  input: "x",
+  expect,
+});
+
+const detail = (over: Partial<ProfileRunDetail> = {}): ProfileRunDetail => ({
+  name: "Ada Lovelace",
+  bio: "Mathematician and writer.",
+  location: "London, UK",
+  context: "Ada works on analytical engines.",
+  interests: ["computing", "poetry"],
+  skills: ["mathematics", "logic"],
+  piiHits: [],
+  ...over,
+});
+
+describe("scoreRun — deterministic", () => {
+  it("passes name, location, skills, interests, and privacy checks", async () => {
+    const c = mkCase({ expectNameContains: "Ada", expectLocationContains: "London", minSkills: 2, minInterests: 2 });
+    const rr = await scoreRun(c, detail(), yes);
+    expect(rr.passed).toBe(true);
+    expect(rr.assertions.find((a) => a.kind === "privacy")!.passed).toBe(true);
+  });
+
+  it("fails the privacy check when PII leaks into a public field", async () => {
+    const c = mkCase({ expectNameContains: "Ada" }, "privacy");
+    const rr = await scoreRun(c, detail({ piiHits: ["john@acme.com"] }), yes);
+    expect(rr.passed).toBe(false);
+    const privacy = rr.assertions.find((a) => a.kind === "privacy")!;
+    expect(privacy.passed).toBe(false);
+    expect(privacy.detail).toContain("john@acme.com");
+  });
+
+  it("asserts privacy by default even when noPII is unset", async () => {
+    const c = mkCase({});
+    const rr = await scoreRun(c, detail({ piiHits: ["+1 415-555-0199"] }), yes);
+    expect(rr.assertions.some((a) => a.kind === "privacy")).toBe(true);
+    expect(rr.passed).toBe(false);
+  });
+
+  it("can opt out of the privacy check with noPII:false", async () => {
+    const c = mkCase({ noPII: false });
+    const rr = await scoreRun(c, detail({ piiHits: ["leak@x.com"] }), yes);
+    expect(rr.assertions.some((a) => a.kind === "privacy")).toBe(false);
+    expect(rr.passed).toBe(true);
+  });
+
+  it("fails name and location mismatches", async () => {
+    const c = mkCase({ expectNameContains: "Grace", expectLocationContains: "Paris" });
+    const rr = await scoreRun(c, detail(), yes);
+    expect(rr.assertions.find((a) => a.kind === "name")!.passed).toBe(false);
+    expect(rr.assertions.find((a) => a.kind === "location")!.passed).toBe(false);
+  });
+});
+
+describe("scoreRun — judged", () => {
+  it("routes coverage, apply, and preserve through the judge", async () => {
+    const c = mkCase({ mustHaveSkills: ["mathematics"], mustApply: "x", mustPreserve: "y" }, "update");
+    expect((await scoreRun(c, detail(), yes)).passed).toBe(true);
+    const failed = await scoreRun(c, detail(), no);
+    expect(failed.passed).toBe(false);
+    expect(failed.assertions.find((a) => a.kind === "coverage_skills")!.passed).toBe(false);
+    expect(failed.assertions.find((a) => a.kind === "apply")!.passed).toBe(false);
+    expect(failed.assertions.find((a) => a.kind === "preserve")!.passed).toBe(false);
+  });
+});
+
+describe("scoreCase", () => {
+  it("aggregates runs into pass-rate and flags flakiness", async () => {
+    const c = mkCase({ expectNameContains: "Ada" });
+    const result = await scoreCase(c, [detail(), detail({ name: "Someone Else" })], yes);
+    expect(result.runs).toBe(2);
+    expect(result.passes).toBe(1);
+    expect(result.flaky).toBe(true);
+  });
+});

--- a/packages/protocol/eval/profile/tsconfig.json
+++ b/packages/protocol/eval/profile/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "composite": false,
+    "rootDir": "../../",
+    "types": ["node", "bun-types"]
+  },
+  "include": ["**/*.ts", "../../src/**/*.ts"],
+  "exclude": ["node_modules", "../../src/**/*.spec.ts", "../../src/**/*.test.ts"]
+}

--- a/packages/protocol/eval/shared/baseline.ts
+++ b/packages/protocol/eval/shared/baseline.ts
@@ -1,0 +1,114 @@
+import { predictivePValue } from "./stats.js";
+import type { CaseResultLike, Regression, ScorecardLike } from "./types.js";
+
+/**
+ * Compares a current scorecard against a baseline and returns any regressions.
+ *
+ * A regression is a case or rule where the current pass count is significantly
+ * lower than expected from the baseline evidence (one-sided beta-binomial
+ * posterior-predictive test at significance level alpha). New cases (absent from
+ * the baseline) are never regressions; they are reported in `skippedCaseIds`.
+ *
+ * @param current - The scorecard produced by the current run.
+ * @param baseline - The previously saved baseline scorecard, or `null` if none exists.
+ * @param alpha - Significance level for the one-sided test.
+ * @returns Detected regressions plus the ids of current cases absent from the baseline.
+ */
+export function diffBaseline(
+  current: ScorecardLike,
+  baseline: ScorecardLike | null,
+  alpha = 0.05,
+): { regressions: Regression[]; skippedCaseIds: string[] } {
+  if (!baseline) return { regressions: [], skippedCaseIds: [] };
+  const regressions: Regression[] = [];
+  const skippedCaseIds: string[] = [];
+
+  const baseCases = new Map(baseline.cases.map((c) => [c.caseId, c]));
+  for (const c of current.cases) {
+    const base = baseCases.get(c.caseId);
+    if (base === undefined) {
+      skippedCaseIds.push(c.caseId);
+      continue;
+    }
+    const pValue = predictivePValue(c.passes, c.runs, base.passes, base.runs);
+    if (pValue <= alpha) {
+      regressions.push({ id: c.caseId, kind: "case", before: base.passRate, after: c.passRate, pValue });
+    }
+  }
+
+  const baseByRule = new Map<string, { passes: number; runs: number }>();
+  for (const c of baseline.cases) {
+    const acc = baseByRule.get(c.rule) ?? { passes: 0, runs: 0 };
+    acc.passes += c.passes;
+    acc.runs += c.runs;
+    baseByRule.set(c.rule, acc);
+  }
+  const comparableByRule = new Map<string, { passes: number; runs: number }>();
+  for (const c of current.cases) {
+    if (!baseCases.has(c.caseId)) continue;
+    const acc = comparableByRule.get(c.rule) ?? { passes: 0, runs: 0 };
+    acc.passes += c.passes;
+    acc.runs += c.runs;
+    comparableByRule.set(c.rule, acc);
+  }
+  for (const [rule, acc] of comparableByRule.entries()) {
+    const base = baseByRule.get(rule);
+    if (base === undefined || acc.runs === 0 || base.runs === 0) continue;
+    const before = base.passes / base.runs;
+    const after = acc.passes / acc.runs;
+    const pValue = predictivePValue(acc.passes, acc.runs, base.passes, base.runs);
+    if (pValue <= alpha) {
+      regressions.push({ id: rule, kind: "rule", before, after, pValue });
+    }
+  }
+
+  return { regressions, skippedCaseIds };
+}
+
+/**
+ * Reads a baseline scorecard from a JSON file on disk.
+ *
+ * @param path - Absolute or relative path to the baseline JSON file.
+ * @returns The parsed scorecard, or `null` if the file does not exist.
+ */
+export async function readBaseline<T extends ScorecardLike>(path: string): Promise<T | null> {
+  const file = Bun.file(path);
+  if (!(await file.exists())) return null;
+  return (await file.json()) as T;
+}
+
+/**
+ * Writes a scorecard to disk as a formatted JSON baseline file.
+ *
+ * The committed baseline is a diff target, so verbose per-run detail (model
+ * reasoning, candidate outcomes) is best stripped to keep `--update-baseline`
+ * diffs lean. Pass `leanCase` to transform each case before writing (e.g. drop
+ * per-run candidate payloads); the full detail lives in the run report instead
+ * (see {@link writeRunReport}).
+ *
+ * @param path - Absolute or relative path to write to (created or overwritten).
+ * @param sc - The scorecard to persist.
+ * @param opts.leanCase - Optional per-case transform applied before serialization.
+ */
+export async function writeBaseline<C extends CaseResultLike>(
+  path: string,
+  sc: ScorecardLike<C>,
+  opts: { leanCase?: (c: C) => C } = {},
+): Promise<void> {
+  const leanCase = opts.leanCase ?? ((c: C) => c);
+  const lean: ScorecardLike<C> = { ...sc, cases: sc.cases.map(leanCase) };
+  await Bun.write(path, JSON.stringify(lean, null, 2) + "\n");
+}
+
+/**
+ * Writes a full run report to disk: the scorecard *including* every per-run
+ * detail. This is the explanatory artifact a reviewer or a report skill reads to
+ * see the agent's own justification for each score. Written on demand via the
+ * `--report` flag and auto-saved for full-corpus runs; never committed.
+ *
+ * @param path - Absolute or relative path to write to. Parent dirs are created by Bun.
+ * @param sc - The scorecard to persist, with detail intact.
+ */
+export async function writeRunReport(path: string, sc: ScorecardLike): Promise<void> {
+  await Bun.write(path, JSON.stringify(sc, null, 2) + "\n");
+}

--- a/packages/protocol/eval/shared/cli.ts
+++ b/packages/protocol/eval/shared/cli.ts
@@ -1,0 +1,21 @@
+/**
+ * Tiny argv helpers shared by every harness CLI. Each harness still owns its own
+ * flag set and validation; these just read process.argv consistently.
+ */
+
+/** The value following `flag` in argv, or undefined. */
+export function arg(flag: string, argv: string[] = process.argv): string | undefined {
+  const i = argv.indexOf(flag);
+  return i >= 0 ? argv[i + 1] : undefined;
+}
+
+/** True when `flag` is present in argv. */
+export function has(flag: string, argv: string[] = process.argv): boolean {
+  return argv.includes(flag);
+}
+
+/** A flag's value only when it's a real value, not the next flag (e.g. `--report --runs`). */
+export function flagValue(flag: string, argv: string[] = process.argv): string | undefined {
+  const v = arg(flag, argv);
+  return v && !v.startsWith("--") ? v : undefined;
+}

--- a/packages/protocol/eval/shared/console.ts
+++ b/packages/protocol/eval/shared/console.ts
@@ -1,0 +1,60 @@
+import { rateWithCI } from "./stats.js";
+import type { Regression, ScorecardLike } from "./types.js";
+
+const pct = (n: number): string => `${Math.round(n * 100)}%`;
+const fmtPValue = (p: number): string => (p < 0.001 ? "p<0.001" : `p=${p.toFixed(3)}`);
+
+export interface ConsoleOptions {
+  /** Scorecard heading, e.g. "Matching Quality Scorecard". */
+  title?: string;
+  /** Column width for the rule/group label. */
+  ruleWidth?: number;
+}
+
+/**
+ * Renders a human-readable scorecard for the console: aggregate pass-rate with
+ * 95% CI, per-rule rollup (worst first), flaky cases, regressions, and any cases
+ * absent from the baseline.
+ *
+ * @param sc - The scorecard to format.
+ * @param regressions - Regressions vs the baseline, surfaced with p-values.
+ * @param skippedCaseIds - Current case ids not present in the baseline.
+ * @param opts - Title and formatting options.
+ */
+export function formatConsole(
+  sc: ScorecardLike,
+  regressions: Regression[],
+  skippedCaseIds: string[] = [],
+  opts: ConsoleOptions = {},
+): string {
+  const title = opts.title ?? "Quality Scorecard";
+  const ruleWidth = opts.ruleWidth ?? 20;
+  const lines: string[] = [];
+  lines.push(`\n=== ${title} ===`);
+  lines.push(`model=${sc.model}  runs=${sc.runs}  cases=${sc.cases.length}`);
+  // Per-run observations drive the CI; case-level pass-rates drive the aggregate display.
+  lines.push(`aggregate pass-rate: ${rateWithCI(sc.cases.reduce((s, c) => s + c.passes, 0), sc.cases.length * sc.runs)}\n`);
+  lines.push(`Per rule:`);
+  for (const r of [...sc.rules].sort((a, b) => a.passRate - b.passRate)) {
+    const n = r.caseCount * sc.runs;
+    const passes = Math.round(r.passRate * n);
+    lines.push(`  ${r.rule.padEnd(ruleWidth)} ${rateWithCI(passes, n)}  (${r.caseCount} case(s))`);
+  }
+  const flaky = sc.cases.filter((c) => c.flaky);
+  if (flaky.length > 0) {
+    lines.push(`\nFlaky (passed some runs, failed others):`);
+    for (const c of flaky) lines.push(`  ${c.caseId}  ${c.passes}/${c.runs}`);
+  }
+  if (regressions.length > 0) {
+    lines.push(`\n⚠ Regressions vs baseline:`);
+    for (const r of regressions) {
+      lines.push(`  [${r.kind}] ${r.id}: ${pct(r.before)} → ${pct(r.after)} (${fmtPValue(r.pValue)})`);
+    }
+  }
+  if (skippedCaseIds.length > 0) {
+    lines.push(`\nℹ ${skippedCaseIds.length} case(s) absent from baseline; not regression-checked:`);
+    for (const id of skippedCaseIds.slice(0, 10)) lines.push(`  ${id}`);
+    if (skippedCaseIds.length > 10) lines.push(`  …and ${skippedCaseIds.length - 10} more`);
+  }
+  return lines.join("\n");
+}

--- a/packages/protocol/eval/shared/html.ts
+++ b/packages/protocol/eval/shared/html.ts
@@ -215,13 +215,66 @@ function caseOutcome(passes: number, runs: number): { tone: Tone; phrase: string
 }
 
 /**
+ * Build the hero's scenario-anchored sub-line and blurb. The sub-line reconciles
+ * with the "What we tested" list below it by counting *scenarios* (cases), not
+ * runs: "79% — 5 of 8 scenarios passed every time". The blurb names the standout
+ * failure (a single always-failing theme by label) and tallies the rest.
+ *
+ * @param sc - Scorecard (case-level pass counts).
+ * @param regressions - Regressions; when present, defer to the verdict's regression blurb.
+ * @param human - Human report, used to name a failing theme by its group label.
+ * @param fallbackBlurb - The verdict blurb to use when nothing failed or a regression dominates.
+ */
+function heroSummary(
+  sc: ScorecardLike,
+  regressions: Regression[],
+  human: HumanReport,
+  fallbackBlurb: string,
+): { subline: string; blurb: string } {
+  const total = sc.cases.length;
+  const fullPass = sc.cases.filter((c) => c.passes === c.runs).length;
+  const runsTotal = sc.cases.reduce((s, c) => s + c.runs, 0);
+  const passesTotal = sc.cases.reduce((s, c) => s + c.passes, 0);
+  const pct = runsTotal === 0 ? 0 : Math.round((passesTotal / runsTotal) * 100);
+  const subline = `${pct}% — ${fullPass} of ${total} scenario${total === 1 ? "" : "s"} passed every time`;
+
+  // A live regression is the headline; keep the verdict's regression wording.
+  if (regressions.length > 0) return { subline, blurb: fallbackBlurb };
+
+  const labelFor = (rule: string): string | undefined => human.groups.find((g) => g.ruleIds.includes(rule))?.label;
+  const alwaysFail = sc.cases.filter((c) => c.passes === 0);
+  const partial = sc.cases.filter((c) => c.passes > 0 && c.passes < c.runs);
+
+  const parts: string[] = [];
+  if (alwaysFail.length === 1) {
+    const label = labelFor(alwaysFail[0].rule);
+    parts.push(label ? `the “${label}” scenario failed every run` : "one scenario failed every run");
+  } else if (alwaysFail.length > 1) {
+    parts.push(`${alwaysFail.length} scenarios failed every run`);
+  }
+  if (partial.length > 0) {
+    let noun: string;
+    if (alwaysFail.length > 0) {
+      noun = partial.length === 1 ? "another was" : `${partial.length} others were`;
+    } else {
+      noun = partial.length === 1 ? "one was" : `${partial.length} were`;
+    }
+    parts.push(`${noun} occasionally off`);
+  }
+  if (parts.length === 0) return { subline, blurb: "Every scenario passed every run." };
+  const joined = parts.join("; ");
+  return { subline, blurb: joined.charAt(0).toUpperCase() + joined.slice(1) + "." };
+}
+
+/**
  * Renders the plain-language top section: a hero verdict, a "What we tested"
  * rollup with plain status words, and a "See the examples" block of per-case
  * scenario narratives. Self-contained HTML using the shared/HUMAN_CSS classes.
  */
 export function renderHumanReport(sc: ScorecardLike, regressions: Regression[], human: HumanReport): string {
   const v = computeVerdict(sc, regressions);
-  const hero = `<section class="hero ${v.tone}"><div class="vword ${v.tone}">${htmlEscape(v.word)}</div><div class="vsub">${v.passes} of ${v.total} checks passed</div><div class="vblurb">${htmlEscape(v.blurb)}</div></section>`;
+  const { subline, blurb } = heroSummary(sc, regressions, human, v.blurb);
+  const hero = `<section class="hero ${v.tone}"><div class="vword ${v.tone}">${htmlEscape(v.word)}</div><div class="vsub">${htmlEscape(subline)}</div><div class="vblurb">${htmlEscape(blurb)}</div></section>`;
 
   const tested = human.groups
     .map((g) => {

--- a/packages/protocol/eval/shared/html.ts
+++ b/packages/protocol/eval/shared/html.ts
@@ -1,0 +1,154 @@
+import { binomialCI } from "./stats.js";
+import type { Regression, ScorecardLike } from "./types.js";
+
+/** Minimal HTML-entity escaping for text interpolated into templates. */
+export function htmlEscape(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/** Pass-rate → quality class used for color-coding (≥90% good, ≥70% ok, else bad). */
+export function rateClass(rate: number): "good" | "ok" | "bad" {
+  return rate >= 0.9 ? "good" : rate >= 0.7 ? "ok" : "bad";
+}
+
+const pctText = (n: number): string => `${Math.round(n * 100)}%`;
+const fmtPValue = (p: number): string => (p < 0.001 ? "p<0.001" : `p=${p.toFixed(3)}`);
+
+/** Pass-rate cell text with a 95% Wilson CI tooltip for HTML tables. */
+export function htmlRateCI(rate: number, passes: number, total: number): string {
+  const [lo, hi] = binomialCI(passes, total);
+  const ci = `CI₉₅ ${Math.round(lo * 100)}%–${Math.round(hi * 100)}%`;
+  return `<span title="${ci}">${pctText(rate)}</span>`;
+}
+
+/** Shared CSS for standalone, self-contained scorecard documents. */
+export const SCORECARD_CSS = `
+  :root{--good:#16a34a;--ok:#d97706;--bad:#dc2626;--bg:#0f172a;--card:#1e293b;--line:#334155;--fg:#e2e8f0;--muted:#94a3b8}
+  *{box-sizing:border-box}
+  body{margin:0;font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:var(--bg);color:var(--fg)}
+  .wrap{max-width:1000px;margin:0 auto;padding:24px}
+  h1{font-size:22px;margin:0 0 4px}
+  h2{font-size:16px;border-bottom:1px solid var(--line);padding-bottom:6px;margin:28px 0 12px}
+  .muted{color:var(--muted)}
+  code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.85em}
+  .good{color:var(--good)} .ok{color:var(--ok)} .bad{color:var(--bad)}
+  .banner{background:var(--card);border:1px solid var(--line);border-radius:12px;padding:20px;display:flex;align-items:center;gap:24px;flex-wrap:wrap}
+  .score{font-size:46px;font-weight:700;line-height:1}
+  .meta{color:var(--muted);font-size:13px}
+  table{width:100%;border-collapse:collapse;margin:6px 0}
+  th,td{text-align:left;padding:6px 8px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{color:var(--muted);font-weight:600;font-size:12px;text-transform:uppercase;letter-spacing:.04em}
+  .summary{display:flex;gap:24px;flex-wrap:wrap;align-items:flex-start}
+  .summary>div{flex:1 1 300px}
+  .explain{background:rgba(30,41,59,.72);border:1px solid var(--line);border-radius:12px;padding:14px 18px;margin:14px 0}
+  .explain h2{margin-top:0}
+  .explain p,.explain ol{color:var(--muted);margin:8px 0}
+  .explain strong{color:var(--fg)}
+  .case{background:var(--card);border:1px solid var(--line);border-left-width:4px;border-radius:10px;padding:14px 16px;margin:12px 0}
+  .case.good{border-left-color:var(--good)} .case.ok{border-left-color:var(--ok)} .case.bad{border-left-color:var(--bad)}
+  .case header{display:flex;align-items:center;gap:10px;flex-wrap:wrap}
+  .cid{font-size:13px;color:var(--fg)}
+  .verdict{font-weight:700;margin-left:auto}
+  .badge{font-size:11px;padding:2px 7px;border-radius:99px;border:1px solid var(--line);color:var(--muted)}
+  .badge.flaky{color:var(--ok);border-color:var(--ok)}
+  .desc{color:var(--muted);margin:8px 0 4px}
+  .tag{font-size:11px;padding:1px 6px;border-radius:5px}
+  .tag.yes{background:rgba(22,163,74,.18);color:#4ade80} .tag.no{background:rgba(220,38,38,.18);color:#f87171}
+  details summary{cursor:pointer;color:var(--muted);font-size:12px;padding:4px 0}
+  .failures{margin:8px 0;padding:8px 10px;background:rgba(220,38,38,.08);border:1px solid rgba(220,38,38,.45);border-radius:8px}
+  .failures ul{margin:6px 0 0;padding-left:18px}
+  .failures li{margin:3px 0}
+  .regressions{background:rgba(220,38,38,.08);border:1px solid var(--bad);border-radius:10px;padding:8px 16px}
+  .ci{font-size:11px;color:var(--muted)}
+`;
+
+/** A named section in the scorecard summary area. `html` is the section body (already escaped). */
+export interface ShellSection {
+  heading: string;
+  html: string;
+}
+
+export interface ShellOptions {
+  /** Document & banner title, e.g. "Premise eval". */
+  title: string;
+  /** Optional explanatory block (raw HTML) rendered under the banner. */
+  intro?: string;
+  /** Extra summary sections (e.g. by-rule, by-tier) rendered before case cards. */
+  sections?: ShellSection[];
+  /** Pre-rendered case-card HTML, supplied by the harness. */
+  caseCardsHtml?: string;
+  /** Extra CSS appended after the shared stylesheet. */
+  extraCss?: string;
+}
+
+/** Render the by-rule rollup table (worst rule first) — a sensible default section. */
+export function renderRuleTable(sc: ScorecardLike): string {
+  const rows = [...sc.rules]
+    .sort((x, y) => x.passRate - y.passRate)
+    .map((r) => {
+      const n = r.caseCount * sc.runs;
+      const passes = Math.round(r.passRate * n);
+      return `<tr><td>${htmlEscape(r.rule)}</td><td>${r.caseCount}</td><td class="${rateClass(r.passRate)}">${htmlRateCI(r.passRate, passes, n)}</td></tr>`;
+    })
+    .join("");
+  return `<table><thead><tr><th>rule</th><th>cases</th><th>pass</th></tr></thead><tbody>${rows}</tbody></table>`;
+}
+
+/**
+ * Renders a complete, standalone, self-contained scorecard HTML document: banner
+ * with the aggregate pass-rate + CI, an optional intro, a regression banner, the
+ * harness-supplied summary sections, and the harness-supplied case cards. No
+ * external assets, no JS — openable straight from disk.
+ *
+ * @param sc - The scorecard to render.
+ * @param regressions - Regressions vs the baseline, shown in a red banner.
+ * @param opts - Title, intro, summary sections, and case-card HTML.
+ * @returns A full HTML document string.
+ */
+export function renderScorecardShell(sc: ScorecardLike, regressions: Regression[], opts: ShellOptions): string {
+  const agg = rateClass(sc.aggregatePassRate);
+  const totalObs = sc.cases.length * sc.runs;
+  const totalPasses = sc.cases.reduce((s, c) => s + c.passes, 0);
+
+  const regressionBlock =
+    regressions.length > 0
+      ? `<section class="regressions"><h2>⚠ Regressions vs baseline</h2><ul>${regressions
+          .map(
+            (r) =>
+              `<li>[${r.kind}] <code>${htmlEscape(r.id)}</code>: ${pctText(r.before)} → ${pctText(r.after)} <span class="muted">(${fmtPValue(r.pValue)})</span></li>`,
+          )
+          .join("")}</ul></section>`
+      : "";
+
+  const intro = opts.intro ? `<section class="explain">${opts.intro}</section>` : "";
+  const sections =
+    (opts.sections ?? [])
+      .map((s) => `<div><h2>${htmlEscape(s.heading)}</h2>${s.html}</div>`)
+      .join("") || "";
+  const summary = sections ? `<section class="summary">${sections}</section>` : "";
+
+  return `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${htmlEscape(opts.title)} — ${pctText(sc.aggregatePassRate)} (${htmlEscape(sc.model)})</title>
+<style>${SCORECARD_CSS}${opts.extraCss ?? ""}</style></head>
+<body><div class="wrap">
+  <div class="banner">
+    <div><div class="score ${agg}">${pctText(sc.aggregatePassRate)}</div><div class="meta">aggregate pass-rate</div><div class="ci">${htmlRateCI(sc.aggregatePassRate, totalPasses, totalObs)}</div></div>
+    <div class="meta">
+      <div><strong>${htmlEscape(opts.title)}</strong></div>
+      <div><strong>${htmlEscape(sc.model)}</strong></div>
+      <div>${sc.cases.length} case${sc.cases.length === 1 ? "" : "s"} × ${sc.runs} run${sc.runs === 1 ? "" : "s"}</div>
+      <div>generated ${htmlEscape(sc.generatedAt)}</div>
+      <div>${regressions.length} regression${regressions.length === 1 ? "" : "s"} vs baseline</div>
+    </div>
+  </div>
+  ${intro}
+  ${regressionBlock}
+  ${summary}
+  ${opts.caseCardsHtml ?? ""}
+</div></body></html>`;
+}

--- a/packages/protocol/eval/shared/html.ts
+++ b/packages/protocol/eval/shared/html.ts
@@ -25,8 +25,8 @@ export function htmlRateCI(rate: number, passes: number, total: number): string 
   return `<span title="${ci}">${pctText(rate)}</span>`;
 }
 
-/** Shared CSS for standalone, self-contained scorecard documents. */
-export const SCORECARD_CSS = `
+/** Base CSS for the technical scorecard view. */
+const BASE_CSS = `
   :root{--good:#16a34a;--ok:#d97706;--bad:#dc2626;--bg:#0f172a;--card:#1e293b;--line:#334155;--fg:#e2e8f0;--muted:#94a3b8}
   *{box-sizing:border-box}
   body{margin:0;font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:var(--bg);color:var(--fg)}
@@ -66,6 +66,40 @@ export const SCORECARD_CSS = `
   .ci{font-size:11px;color:var(--muted)}
 `;
 
+/** Plain-language (non-technical) report styling: hero verdict, status pills, scenario cards. */
+export const HUMAN_CSS = `
+  .hero{border-radius:14px;padding:22px 26px;margin:0 0 18px;border:1px solid var(--line)}
+  .hero.good{background:linear-gradient(135deg,rgba(22,163,74,.18),rgba(22,163,74,.03));border-color:rgba(22,163,74,.5)}
+  .hero.ok{background:linear-gradient(135deg,rgba(217,119,6,.18),rgba(217,119,6,.03));border-color:rgba(217,119,6,.5)}
+  .hero.bad{background:linear-gradient(135deg,rgba(220,38,38,.18),rgba(220,38,38,.03));border-color:rgba(220,38,38,.5)}
+  .hero .vword{font-size:30px;font-weight:800;line-height:1.1}
+  .hero .vword.good{color:#4ade80}.hero .vword.ok{color:#fbbf24}.hero .vword.bad{color:#f87171}
+  .hero .vsub{font-size:15px;margin-top:6px;color:var(--fg)}
+  .hero .vblurb{color:var(--muted);margin-top:8px;max-width:62ch}
+  .pill{display:inline-block;font-size:12px;font-weight:600;padding:2px 10px;border-radius:99px;white-space:nowrap}
+  .pill.good{background:rgba(22,163,74,.18);color:#4ade80}
+  .pill.ok{background:rgba(217,119,6,.2);color:#fbbf24}
+  .pill.bad{background:rgba(220,38,38,.18);color:#f87171}
+  ul.tested{list-style:none;margin:10px 0 0;padding:0}
+  ul.tested li{display:flex;gap:14px;align-items:baseline;padding:11px 0;border-top:1px solid var(--line)}
+  ul.tested li:first-child{border-top:none}
+  ul.tested .t-label{font-weight:600}
+  ul.tested .t-blurb{color:var(--muted);font-size:13px;margin-top:2px}
+  h3.group{font-size:15px;margin:20px 0 8px;color:var(--fg)}
+  .story{border:1px solid var(--line);border-left-width:4px;border-radius:10px;padding:12px 15px;margin:10px 0;background:var(--card)}
+  .story.good{border-left-color:var(--good)}.story.ok{border-left-color:var(--ok)}.story.bad{border-left-color:var(--bad)}
+  .story .s-row{margin-bottom:8px}
+  .story p{margin:5px 0}
+  .story .lead{display:inline-block;min-width:84px;color:var(--muted);font-weight:600;font-size:11px;text-transform:uppercase;letter-spacing:.04em}
+  .story .whathappened{color:#f87171}
+  details.tech>summary{font-size:14px;font-weight:600;color:var(--fg);padding:10px 0;border-top:1px solid var(--line);margin-top:22px}
+  details.tech[open]>summary{margin-bottom:6px}
+  details.human-details>summary{font-size:15px;font-weight:600;color:var(--fg);padding:8px 0;margin-top:8px}
+`;
+
+/** Full stylesheet for standalone scorecard documents (technical + human views). */
+export const SCORECARD_CSS = BASE_CSS + HUMAN_CSS;
+
 /** A named section in the scorecard summary area. `html` is the section body (already escaped). */
 export interface ShellSection {
   heading: string;
@@ -83,6 +117,144 @@ export interface ShellOptions {
   caseCardsHtml?: string;
   /** Extra CSS appended after the shared stylesheet. */
   extraCss?: string;
+  /**
+   * Plain-language report for non-technical readers. When supplied, it renders
+   * at the top and the technical banner/sections/cards collapse beneath it.
+   */
+  human?: HumanReport;
+}
+
+// ─── Plain-language (human-readable) report ─────────────────────────────────
+//
+// Translates the statistical scorecard into something a non-technical reader
+// understands: a top-line verdict, a "what we tested" rollup with plain status
+// words instead of CIs/p-values, and concrete per-case scenario narratives.
+// Harnesses supply the plain-language strings; this module computes status from
+// the scorecard's aggregate pass counts.
+
+type Tone = "good" | "ok" | "bad";
+
+/** One plain-language scenario narrative for a single case. */
+export interface HumanCase {
+  caseId: string;
+  /** What we showed the system, in plain words. */
+  scenario: string;
+  /** What the system should do, in plain words. Optional — omitted, the "It should" line is skipped. */
+  expectation?: string;
+  /** Plain "what went wrong" note, shown only when a run failed (harness-computed). */
+  failNote?: string;
+}
+
+/** A plain-language theme grouping one or more scorecard rules. */
+export interface HumanGroup {
+  /** Plain-language theme name, e.g. "Privacy: never leaking contact info". */
+  label: string;
+  /** Optional one-line explanation of the theme. */
+  blurb?: string;
+  /** Scorecard rule ids this theme covers (status is aggregated across them). */
+  ruleIds: string[];
+  /** Plain narratives for the cases in this theme. */
+  cases: HumanCase[];
+}
+
+/** The full plain-language report a harness hands to the shell. */
+export interface HumanReport {
+  /** What the system under test is, in plain words, e.g. "the profile builder". */
+  subject: string;
+  /** One plain sentence describing what it does / what this report covers. */
+  oneLiner: string;
+  groups: HumanGroup[];
+}
+
+export interface Verdict {
+  word: string;
+  tone: Tone;
+  blurb: string;
+  passes: number;
+  total: number;
+}
+
+/** Plain-language overall verdict derived from the aggregate pass count + regressions. */
+export function computeVerdict(sc: ScorecardLike, regressions: Regression[]): Verdict {
+  const total = sc.cases.length * sc.runs;
+  const passes = sc.cases.reduce((s, c) => s + c.passes, 0);
+  const rate = total === 0 ? 0 : passes / total;
+  const hasReg = regressions.length > 0;
+  if (hasReg) {
+    return { word: "Needs attention", tone: "bad", blurb: "Something that worked before is now failing — worth a look before relying on it.", passes, total };
+  }
+  if (rate >= 0.97) return { word: "Looking good", tone: "good", blurb: "The system behaved correctly on almost every check.", passes, total };
+  if (rate >= 0.85) return { word: "Mostly working", tone: "ok", blurb: "Generally correct, with a few spots that were inconsistent.", passes, total };
+  return { word: "Needs attention", tone: "bad", blurb: "Several checks did not pass reliably.", passes, total };
+}
+
+/** Plain-language status for a theme, aggregated across its rules' cases. */
+export function groupStatus(
+  sc: ScorecardLike,
+  ruleIds: string[],
+  regressions: Regression[],
+): { tone: Tone; phrase: string } {
+  const cases = sc.cases.filter((c) => ruleIds.includes(c.rule));
+  const passes = cases.reduce((s, c) => s + c.passes, 0);
+  const runs = cases.reduce((s, c) => s + c.runs, 0);
+  const regressed = regressions.some(
+    (r) => (r.kind === "rule" && ruleIds.includes(r.id)) || (r.kind === "case" && cases.some((c) => c.caseId === r.id)),
+  );
+  const rate = runs === 0 ? 0 : passes / runs;
+  if (regressed) return { tone: "bad", phrase: "newly slipping" };
+  if (rate === 1) return { tone: "good", phrase: "works reliably" };
+  if (rate >= 0.5) return { tone: "ok", phrase: `inconsistent — missed ${runs - passes} of ${runs}` };
+  return { tone: "bad", phrase: `often wrong — missed ${runs - passes} of ${runs}` };
+}
+
+/** Plain-language outcome for a single case across its repeated runs. */
+function caseOutcome(passes: number, runs: number): { tone: Tone; phrase: string } {
+  if (passes === runs) return { tone: "good", phrase: runs === 1 ? "Correct" : `Correct all ${runs} times` };
+  if (passes === 0) return { tone: "bad", phrase: runs === 1 ? "Incorrect" : `Missed all ${runs} times` };
+  return { tone: "ok", phrase: `Missed ${runs - passes} of ${runs} times` };
+}
+
+/**
+ * Renders the plain-language top section: a hero verdict, a "What we tested"
+ * rollup with plain status words, and a "See the examples" block of per-case
+ * scenario narratives. Self-contained HTML using the shared/HUMAN_CSS classes.
+ */
+export function renderHumanReport(sc: ScorecardLike, regressions: Regression[], human: HumanReport): string {
+  const v = computeVerdict(sc, regressions);
+  const hero = `<section class="hero ${v.tone}"><div class="vword ${v.tone}">${htmlEscape(v.word)}</div><div class="vsub">${v.passes} of ${v.total} checks passed</div><div class="vblurb">${htmlEscape(v.blurb)}</div></section>`;
+
+  const tested = human.groups
+    .map((g) => {
+      const s = groupStatus(sc, g.ruleIds, regressions);
+      const blurb = g.blurb ? `<div class="t-blurb">${htmlEscape(g.blurb)}</div>` : "";
+      return `<li><span class="pill ${s.tone}">${htmlEscape(s.phrase)}</span><div><span class="t-label">${htmlEscape(g.label)}</span>${blurb}</div></li>`;
+    })
+    .join("");
+  const whatWeTested = `<section class="explain"><h2>What we tested</h2><p class="muted">${htmlEscape(human.oneLiner)}</p><ul class="tested">${tested}</ul></section>`;
+
+  const byId = new Map(sc.cases.map((c) => [c.caseId, c]));
+  const examples = human.groups
+    .map((g) => {
+      const stories = g.cases
+        .map((hc) => {
+          const c = byId.get(hc.caseId);
+          if (!c) return "";
+          const o = caseOutcome(c.passes, c.runs);
+          const fail = o.tone !== "good" && hc.failNote
+            ? `<p class="whathappened"><span class="lead">What happened</span> ${htmlEscape(hc.failNote)}</p>`
+            : "";
+          const should = hc.expectation
+            ? `<p><span class="lead">It should</span> ${htmlEscape(hc.expectation)}</p>`
+            : "";
+          return `<div class="story ${o.tone}"><div class="s-row"><span class="pill ${o.tone}">${htmlEscape(o.phrase)}</span></div><p><span class="lead">We tried</span> ${htmlEscape(hc.scenario)}</p>${should}${fail}</div>`;
+        })
+        .join("");
+      return stories ? `<h3 class="group">${htmlEscape(g.label)}</h3>${stories}` : "";
+    })
+    .join("");
+  const examplesBlock = `<details class="human-details" open><summary>See the examples</summary>${examples}</details>`;
+
+  return `${hero}${whatWeTested}${examplesBlock}`;
 }
 
 /** Render the by-rule rollup table (worst rule first) — a sensible default section. */
@@ -131,12 +303,7 @@ export function renderScorecardShell(sc: ScorecardLike, regressions: Regression[
       .join("") || "";
   const summary = sections ? `<section class="summary">${sections}</section>` : "";
 
-  return `<!doctype html>
-<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-<title>${htmlEscape(opts.title)} — ${pctText(sc.aggregatePassRate)} (${htmlEscape(sc.model)})</title>
-<style>${SCORECARD_CSS}${opts.extraCss ?? ""}</style></head>
-<body><div class="wrap">
-  <div class="banner">
+  const banner = `<div class="banner">
     <div><div class="score ${agg}">${pctText(sc.aggregatePassRate)}</div><div class="meta">aggregate pass-rate</div><div class="ci">${htmlRateCI(sc.aggregatePassRate, totalPasses, totalObs)}</div></div>
     <div class="meta">
       <div><strong>${htmlEscape(opts.title)}</strong></div>
@@ -145,10 +312,20 @@ export function renderScorecardShell(sc: ScorecardLike, regressions: Regression[
       <div>generated ${htmlEscape(sc.generatedAt)}</div>
       <div>${regressions.length} regression${regressions.length === 1 ? "" : "s"} vs baseline</div>
     </div>
-  </div>
-  ${intro}
-  ${regressionBlock}
-  ${summary}
-  ${opts.caseCardsHtml ?? ""}
+  </div>`;
+
+  const technical = `${banner}${intro}${regressionBlock}${summary}${opts.caseCardsHtml ?? ""}`;
+  // When a plain-language report is supplied, it leads and the technical view
+  // collapses beneath it; otherwise the technical view is the whole document.
+  const bodyHtml = opts.human
+    ? `${renderHumanReport(sc, regressions, opts.human)}<details class="tech"><summary>Technical details (for engineers)</summary>${technical}</details>`
+    : technical;
+
+  return `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${htmlEscape(opts.title)} — ${pctText(sc.aggregatePassRate)} (${htmlEscape(sc.model)})</title>
+<style>${SCORECARD_CSS}${opts.extraCss ?? ""}</style></head>
+<body><div class="wrap">
+  ${bodyHtml}
 </div></body></html>`;
 }

--- a/packages/protocol/eval/shared/index.ts
+++ b/packages/protocol/eval/shared/index.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared eval-harness library.
+ *
+ * Harness-agnostic machinery every eval reuses: scorecard aggregation, baseline
+ * I/O + regression detection, rolling baselines, the repeat/retry runner,
+ * console + HTML reporting, statistics, and argv helpers. Harnesses
+ * (`eval/matching`, `eval/premise`, `eval/profile`, …) own only their corpus,
+ * scorer, and harness-specific types; everything generic lives here.
+ *
+ * See `eval/README.md` for the harness anatomy and how to add a new one.
+ */
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+export type { CaseResultLike, RuleResult, ScorecardLike, Regression } from "./types.js";
+
+// ─── Statistics ───────────────────────────────────────────────────────────
+export { binomialCI, binomialPValue, predictivePValue, binomialSignificance, mean, rateWithCI } from "./stats.js";
+
+// ─── Scorecard + baseline ──────────────────────────────────────────────────
+export { buildScorecard, meanRate } from "./scorecard.js";
+export { diffBaseline, readBaseline, writeBaseline, writeRunReport } from "./baseline.js";
+export { computeRollingBaseline } from "./rolling.js";
+
+// ─── Reporting ─────────────────────────────────────────────────────────────
+export { formatConsole, type ConsoleOptions } from "./console.js";
+export {
+  htmlEscape,
+  rateClass,
+  htmlRateCI,
+  renderRuleTable,
+  renderScorecardShell,
+  SCORECARD_CSS,
+  type ShellOptions,
+  type ShellSection,
+} from "./html.js";
+
+// ─── Execution ─────────────────────────────────────────────────────────────
+export { repeatRuns, invokeWithRetry, type RetryOptions } from "./runner.js";
+export { arg, has, flagValue } from "./cli.js";

--- a/packages/protocol/eval/shared/index.ts
+++ b/packages/protocol/eval/shared/index.ts
@@ -29,9 +29,17 @@ export {
   htmlRateCI,
   renderRuleTable,
   renderScorecardShell,
+  renderHumanReport,
+  computeVerdict,
+  groupStatus,
   SCORECARD_CSS,
+  HUMAN_CSS,
   type ShellOptions,
   type ShellSection,
+  type HumanReport,
+  type HumanGroup,
+  type HumanCase,
+  type Verdict,
 } from "./html.js";
 
 // ─── Execution ─────────────────────────────────────────────────────────────

--- a/packages/protocol/eval/shared/rolling.ts
+++ b/packages/protocol/eval/shared/rolling.ts
@@ -1,0 +1,91 @@
+import { readdir } from "node:fs/promises";
+
+import { buildScorecard } from "./scorecard.js";
+import type { CaseResultLike, ScorecardLike } from "./types.js";
+
+interface RollingCaseAcc {
+  caseId: string;
+  rule: string;
+  passes: number;
+  runs: number;
+}
+
+/** Reads all JSON scorecards in a run directory, ignoring missing dirs and malformed files. */
+async function readRunScorecards(runsDir: string): Promise<ScorecardLike[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(runsDir);
+  } catch {
+    return [];
+  }
+
+  const out: ScorecardLike[] = [];
+  for (const entry of entries) {
+    if (!entry.endsWith(".json")) continue;
+    try {
+      const file = Bun.file(`${runsDir}/${entry}`);
+      const sc = (await file.json()) as ScorecardLike;
+      if (sc.generatedAt && Array.isArray(sc.cases)) out.push(sc);
+    } catch {
+      // Run reports are diagnostic artifacts; one malformed file should not
+      // disable rolling-baseline computation for every other run.
+    }
+  }
+  return out;
+}
+
+/**
+ * Computes a rolling baseline from recent run reports in `runsDir`.
+ *
+ * The resulting scorecard is synthetic: each case's baseline pass-rate is the
+ * pass-weighted average across all recent scorecards containing that case. This
+ * means filtered reports still contribute to the subset of cases they ran, while
+ * absent cases simply fall back to no comparison.
+ *
+ * @param runsDir - Directory containing JSON scorecards written by `writeRunReport`.
+ * @param days - Lookback window in days.
+ * @param now - Clock injection for tests.
+ * @returns A synthetic scorecard, or `null` when no reports fall in the window.
+ */
+export async function computeRollingBaseline(
+  runsDir: string,
+  days: number,
+  now = new Date(),
+): Promise<ScorecardLike<CaseResultLike> | null> {
+  const cutoff = now.getTime() - days * 24 * 60 * 60 * 1000;
+  const scorecards = (await readRunScorecards(runsDir)).filter((sc) => {
+    const t = Date.parse(sc.generatedAt);
+    return Number.isFinite(t) && t >= cutoff && t < now.getTime();
+  });
+  if (scorecards.length === 0) return null;
+
+  const byCase = new Map<string, RollingCaseAcc>();
+  for (const sc of scorecards) {
+    for (const c of sc.cases) {
+      const acc = byCase.get(c.caseId) ?? { caseId: c.caseId, rule: c.rule, passes: 0, runs: 0 };
+      acc.passes += c.passes;
+      acc.runs += c.runs;
+      byCase.set(c.caseId, acc);
+    }
+  }
+
+  const cases: CaseResultLike[] = [...byCase.values()].map((acc) => {
+    const passRate = acc.runs === 0 ? 0 : acc.passes / acc.runs;
+    return {
+      caseId: acc.caseId,
+      rule: acc.rule,
+      runs: acc.runs,
+      passes: acc.passes,
+      passRate,
+      flaky: passRate > 0 && passRate < 1,
+    };
+  });
+
+  return {
+    ...buildScorecard(cases, {
+      model: `rolling:${days}d:${scorecards.length}run${scorecards.length === 1 ? "" : "s"}`,
+      runs: 1,
+    }),
+    generatedAt: now.toISOString(),
+  };
+}

--- a/packages/protocol/eval/shared/runner.ts
+++ b/packages/protocol/eval/shared/runner.ts
@@ -1,0 +1,66 @@
+/**
+ * Generic repeat-with-retry runner shared by every harness.
+ *
+ * Each harness supplies a zero-arg `invoke` closure that calls its agent once;
+ * `repeatRuns` calls it `runs` times, retrying transient live-model/API failures
+ * with exponential backoff so long full-corpus runs are less brittle.
+ */
+
+export interface RetryOptions {
+  maxAttempts?: number;
+  retryDelayMs?: number;
+  /** Label used in retry warnings, e.g. "matching eval". */
+  label?: string;
+}
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_RETRY_DELAY_MS = 1000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function describeError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Invoke once, retrying transient failures with exponential backoff. */
+export async function invokeWithRetry<T>(invoke: () => Promise<T>, options: Required<RetryOptions>): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= options.maxAttempts; attempt++) {
+    try {
+      return await invoke();
+    } catch (err) {
+      lastError = err;
+      if (attempt >= options.maxAttempts) break;
+      const delay = options.retryDelayMs * 2 ** (attempt - 1);
+      console.warn(
+        `[${options.label}] call failed (attempt ${attempt}/${options.maxAttempts}); retrying in ${delay}ms: ${describeError(err)}`,
+      );
+      await sleep(delay);
+    }
+  }
+  throw lastError;
+}
+
+/**
+ * Calls `invoke` `runs` times sequentially, collecting each output. Each call is
+ * retried independently per {@link RetryOptions}.
+ *
+ * @param invoke - Zero-arg closure that runs the agent once and resolves to its output.
+ * @param runs - Number of repetitions.
+ * @param options - Retry tuning.
+ * @returns One output per run, in order.
+ */
+export async function repeatRuns<T>(invoke: () => Promise<T>, runs: number, options: RetryOptions = {}): Promise<T[]> {
+  const resolved: Required<RetryOptions> = {
+    maxAttempts: options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
+    retryDelayMs: options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS,
+    label: options.label ?? "eval",
+  };
+  const outputs: T[] = [];
+  for (let i = 0; i < runs; i++) {
+    outputs.push(await invokeWithRetry(invoke, resolved));
+  }
+  return outputs;
+}

--- a/packages/protocol/eval/shared/scorecard.ts
+++ b/packages/protocol/eval/shared/scorecard.ts
@@ -1,0 +1,42 @@
+import { mean } from "./stats.js";
+import type { CaseResultLike, RuleResult, ScorecardLike } from "./types.js";
+
+/** Mean of case pass-rates within a list (0 for empty). */
+export function meanRate(list: CaseResultLike[]): number {
+  return mean(list.map((c) => c.passRate));
+}
+
+/**
+ * Aggregates raw case results into a scorecard with per-rule and aggregate pass-rates.
+ *
+ * Generic over the concrete case type `C` so each harness keeps its richer
+ * CaseResult (with assertions / candidate detail) in the returned scorecard.
+ *
+ * @param results - The individual case results to aggregate.
+ * @param meta - Run metadata: the model name and number of runs per case.
+ * @returns A scorecard with per-rule breakdowns, aggregate pass-rate, and a generation timestamp.
+ */
+export function buildScorecard<C extends CaseResultLike>(
+  results: C[],
+  meta: { model: string; runs: number },
+): ScorecardLike<C> {
+  const byRule = new Map<string, C[]>();
+  for (const r of results) {
+    const list = byRule.get(r.rule) ?? [];
+    list.push(r);
+    byRule.set(r.rule, list);
+  }
+  const rules: RuleResult[] = [...byRule.entries()].map(([rule, list]) => ({
+    rule,
+    caseCount: list.length,
+    passRate: meanRate(list),
+  }));
+  return {
+    generatedAt: new Date().toISOString(),
+    model: meta.model,
+    runs: meta.runs,
+    aggregatePassRate: meanRate(results),
+    rules,
+    cases: results,
+  };
+}

--- a/packages/protocol/eval/shared/stats.ts
+++ b/packages/protocol/eval/shared/stats.ts
@@ -1,0 +1,94 @@
+/**
+ * Pure statistical helpers shared by every eval harness.
+ *
+ * No I/O, no domain knowledge — just the binomial / beta-binomial math behind
+ * confidence intervals and regression significance. Unit-tested in
+ * `eval/shared/tests/stats.spec.ts`.
+ */
+
+/** Wilson score interval without continuity correction. Returns [lo, hi]. */
+export function binomialCI(passes: number, total: number, z = 1.96): [number, number] {
+  if (total === 0) return [0, 1];
+  const p = passes / total;
+  const denom = 1 + (z * z) / total;
+  const centre = (p + (z * z) / (2 * total)) / denom;
+  const margin = (z * Math.sqrt((p * (1 - p) + (z * z) / (4 * total)) / total)) / denom;
+  return [Math.max(0, centre - margin), Math.min(1, centre + margin)];
+}
+
+/** ln(n!) computed exactly enough for the small-n exact binomial CDF path. */
+function lnFactorial(n: number): number {
+  let out = 0;
+  for (let i = 2; i <= n; i++) out += Math.log(i);
+  return out;
+}
+
+/** Natural log of binomial coefficient C(n, k). */
+function lnChoose(n: number, k: number): number {
+  return lnFactorial(n) - lnFactorial(k) - lnFactorial(n - k);
+}
+
+/** Natural log of the Beta function for integer args, B(a, b) = (a-1)!(b-1)!/(a+b-1)!. */
+function lnBetaInt(a: number, b: number): number {
+  return lnFactorial(a - 1) + lnFactorial(b - 1) - lnFactorial(a + b - 1);
+}
+
+/**
+ * One-sided binomial point-null p-value.
+ * H₀: true pass-rate = nullRate; Ha: true pass-rate < nullRate (regression).
+ */
+export function binomialPValue(observedPasses: number, total: number, nullRate: number): number {
+  if (total === 0) return 1;
+  if (nullRate <= 0) return 1;
+  if (nullRate >= 1) return observedPasses < total ? 0 : 1;
+  let cumulative = 0;
+  for (let k = 0; k <= observedPasses; k++) {
+    const logP = lnChoose(total, k) + k * Math.log(nullRate) + (total - k) * Math.log1p(-nullRate);
+    cumulative += Math.exp(logP);
+  }
+  return Math.min(1, Math.max(0, cumulative));
+}
+
+/**
+ * One-sided beta-binomial posterior-predictive p-value.
+ *
+ * This treats the committed baseline as observed evidence rather than a perfect
+ * point estimate. With a uniform Beta(1,1) prior, baseline x/n gives posterior
+ * Beta(x+1, n-x+1), and we ask how likely the current pass count or lower is
+ * under that posterior predictive distribution. This prevents 7/7 baselines
+ * from making a single future miss mathematically impossible.
+ */
+export function predictivePValue(
+  observedPasses: number,
+  observedRuns: number,
+  baselinePasses: number,
+  baselineRuns: number,
+): number {
+  if (observedRuns === 0 || baselineRuns === 0) return 1;
+  const a = baselinePasses + 1;
+  const b = baselineRuns - baselinePasses + 1;
+  const base = lnBetaInt(a, b);
+  let cumulative = 0;
+  for (let k = 0; k <= observedPasses; k++) {
+    const logP = lnChoose(observedRuns, k) + lnBetaInt(k + a, observedRuns - k + b) - base;
+    cumulative += Math.exp(logP);
+  }
+  return Math.min(1, Math.max(0, cumulative));
+}
+
+/** True when the one-sided binomial point-null p-value is at or below alpha. */
+export function binomialSignificance(observedPasses: number, total: number, nullRate: number, alpha = 0.05): boolean {
+  return binomialPValue(observedPasses, total, nullRate) <= alpha;
+}
+
+/** Arithmetic mean of a number list (0 for empty). */
+export function mean(xs: number[]): number {
+  return xs.length === 0 ? 0 : xs.reduce((a, b) => a + b, 0) / xs.length;
+}
+
+/** Rate string with 95% confidence, e.g. `92% (CI₉₅ 78%–98%)`. */
+export function rateWithCI(passes: number, total: number): string {
+  if (total === 0) return "n/a";
+  const [lo, hi] = binomialCI(passes, total);
+  return `${Math.round((passes / total) * 100)}% (CI₉₅ ${Math.round(lo * 100)}%–${Math.round(hi * 100)}%)`;
+}

--- a/packages/protocol/eval/shared/tests/baseline.spec.ts
+++ b/packages/protocol/eval/shared/tests/baseline.spec.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "bun:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mkdir, rm, unlink } from "node:fs/promises";
+
+import { buildScorecard } from "../scorecard.js";
+import { diffBaseline, readBaseline, writeBaseline, writeRunReport } from "../baseline.js";
+import { computeRollingBaseline } from "../rolling.js";
+import type { CaseResultLike, ScorecardLike } from "../types.js";
+
+const R = 7;
+const BS = 0.8;
+
+/** Aggregate-only case fixture (runResults omitted — shared layer never reads them). */
+const s = (caseId: string, rule: string, passRate: number, runs = R): CaseResultLike => {
+  const passes = Math.round(passRate * runs);
+  return { caseId, rule, runs, passes, passRate, flaky: passRate > 0 && passRate < 1 };
+};
+
+describe("buildScorecard", () => {
+  it("computes per-rule and aggregate pass-rates over a free-string rule label", () => {
+    const sc = buildScorecard(
+      [s("a", "groupX", 1, 3), s("b", "groupX", 0, 3), s("c", "groupY", 1, 3)],
+      { model: "m", runs: 3 },
+    );
+    expect(sc.aggregatePassRate).toBeCloseTo((1 + 0 + 1) / 3, 5);
+    const gx = sc.rules.find((r) => r.rule === "groupX")!;
+    expect(gx.caseCount).toBe(2);
+    expect(gx.passRate).toBeCloseTo(0.5, 5);
+  });
+});
+
+describe("diffBaseline", () => {
+  it("flags a severe drop", () => {
+    const current = buildScorecard([s("a", "g", 0)], { model: "m", runs: R });
+    const baseline = buildScorecard([s("a", "g", BS)], { model: "m", runs: R });
+    expect(diffBaseline(current, baseline, 0.05).regressions.some((r) => r.id === "a" && r.kind === "case")).toBe(true);
+  });
+
+  it("returns nothing without a baseline", () => {
+    const current = buildScorecard([s("a", "g", 0.71)], { model: "m", runs: R });
+    const { regressions, skippedCaseIds } = diffBaseline(current, null, 0.05);
+    expect(regressions).toHaveLength(0);
+    expect(skippedCaseIds).toHaveLength(0);
+  });
+
+  it("reports current cases absent from the baseline", () => {
+    const current = buildScorecard([s("new", "g", 0)], { model: "m", runs: R });
+    const baseline = buildScorecard([s("old", "g", BS)], { model: "m", runs: R });
+    const { regressions, skippedCaseIds } = diffBaseline(current, baseline, 0.05);
+    expect(regressions).toHaveLength(0);
+    expect(skippedCaseIds).toEqual(["new"]);
+  });
+
+  it("ignores typical-performance variance", () => {
+    const current = buildScorecard([s("a", "g", 0.71)], { model: "m", runs: R });
+    const baseline = buildScorecard([s("a", "g", BS)], { model: "m", runs: R });
+    expect(diffBaseline(current, baseline, 0.05).regressions).toHaveLength(0);
+  });
+
+  it("flags a rule-level regression when combined evidence is strong", () => {
+    const current = buildScorecard([s("a", "g", 0.43), s("b", "g", 0.43)], { model: "m", runs: R });
+    const baseline = buildScorecard([s("a", "g", BS), s("b", "g", BS)], { model: "m", runs: R });
+    expect(diffBaseline(current, baseline, 0.05).regressions.some((r) => r.kind === "rule" && r.id === "g")).toBe(true);
+  });
+});
+
+describe("writeBaseline leanCase transform", () => {
+  interface RichCase extends CaseResultLike {
+    runResults: { passed: boolean; detail?: string }[];
+  }
+  const rich = (): ScorecardLike<RichCase> =>
+    buildScorecard<RichCase>(
+      [{ caseId: "a", rule: "g", runs: 1, passes: 1, passRate: 1, flaky: false, runResults: [{ passed: true, detail: "verbose" }] }],
+      { model: "m", runs: 1 },
+    );
+
+  it("applies the per-case transform before serializing", async () => {
+    const p = join(tmpdir(), `shared-baseline-${Date.now()}.json`);
+    await writeBaseline(p, rich(), {
+      leanCase: (c) => ({ ...c, runResults: c.runResults.map(({ detail: _d, ...rest }) => rest) }),
+    });
+    const back = await readBaseline<ScorecardLike<RichCase>>(p);
+    expect(back!.cases[0].runResults[0].detail).toBeUndefined();
+    await unlink(p);
+  });
+
+  it("keeps detail verbatim with the default (identity) transform", async () => {
+    const p = join(tmpdir(), `shared-report-${Date.now()}.json`);
+    await writeRunReport(p, rich());
+    const back = JSON.parse(await Bun.file(p).text()) as ScorecardLike<RichCase>;
+    expect(back.cases[0].runResults[0].detail).toBe("verbose");
+    await unlink(p);
+  });
+
+  it("readBaseline returns null when the file is missing", async () => {
+    const back = await readBaseline(join(tmpdir(), `missing-${Date.now()}.json`));
+    expect(back).toBeNull();
+  });
+});
+
+describe("computeRollingBaseline", () => {
+  it("returns null when the run directory is missing", async () => {
+    const rolling = await computeRollingBaseline(join(tmpdir(), `missing-rolling-${Date.now()}`), 7, new Date("2026-05-28T00:00:00.000Z"));
+    expect(rolling).toBeNull();
+  });
+
+  it("averages recent run reports and ignores old ones", async () => {
+    const dir = join(tmpdir(), `shared-rolling-${Date.now()}`);
+    await mkdir(dir);
+    const now = new Date("2026-05-28T00:00:00.000Z");
+    const mk = (passRate: number, at: string): ScorecardLike => ({
+      ...buildScorecard([s("a", "g", passRate, 3)], { model: "m", runs: 3 }),
+      generatedAt: at,
+    });
+    await writeRunReport(join(dir, "recent-perfect.json"), mk(1, "2026-05-27T00:00:00.000Z"));
+    await writeRunReport(join(dir, "recent-partial.json"), mk(0.33, "2026-05-26T00:00:00.000Z"));
+    await writeRunReport(join(dir, "old.json"), mk(0, "2026-05-01T00:00:00.000Z"));
+
+    const rolling = await computeRollingBaseline(dir, 7, now);
+    expect(rolling).not.toBeNull();
+    expect(rolling!.model).toContain("rolling:7d:2runs");
+    expect(rolling!.cases).toHaveLength(1);
+    // 3/3 + 1/3 → 4/6.
+    expect(rolling!.cases[0].passRate).toBeCloseTo(4 / 6, 5);
+    await rm(dir, { recursive: true, force: true });
+  });
+});

--- a/packages/protocol/eval/shared/tests/cli.spec.ts
+++ b/packages/protocol/eval/shared/tests/cli.spec.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "bun:test";
+
+import { arg, has, flagValue } from "../cli.js";
+
+describe("cli helpers", () => {
+  const argv = ["bun", "eval.ts", "--runs", "5", "--report", "--html", "out.html", "--rolling-baseline", "--alpha"];
+
+  it("arg reads the value after a flag", () => {
+    expect(arg("--runs", argv)).toBe("5");
+    expect(arg("--missing", argv)).toBeUndefined();
+  });
+
+  it("has detects presence", () => {
+    expect(has("--report", argv)).toBe(true);
+    expect(has("--nope", argv)).toBe(false);
+  });
+
+  it("flagValue ignores a following flag as a value", () => {
+    expect(flagValue("--html", argv)).toBe("out.html");
+    expect(flagValue("--report", argv)).toBeUndefined(); // followed by --html
+    expect(flagValue("--rolling-baseline", argv)).toBeUndefined(); // followed by --alpha
+  });
+});

--- a/packages/protocol/eval/shared/tests/reporting.spec.ts
+++ b/packages/protocol/eval/shared/tests/reporting.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "bun:test";
 
 import { buildScorecard } from "../scorecard.js";
 import { formatConsole } from "../console.js";
-import { renderScorecardShell, renderRuleTable, htmlEscape, rateClass } from "../html.js";
+import { renderScorecardShell, renderRuleTable, htmlEscape, rateClass, computeVerdict, groupStatus, renderHumanReport, type HumanReport } from "../html.js";
 import type { CaseResultLike } from "../types.js";
 
 const s = (caseId: string, rule: string, passRate: number, runs = 3): CaseResultLike => ({
@@ -58,5 +58,59 @@ describe("html shell", () => {
     expect(html).toContain("By rule");
     expect(html).toContain("card");
     expect(html).toContain("CI₉₅");
+  });
+});
+
+describe("human-readable report", () => {
+  const human: HumanReport = {
+    subject: "the thing",
+    oneLiner: "It does a thing and we checked it.",
+    groups: [
+      { label: "Telling things apart", blurb: "can it distinguish X from Y", ruleIds: ["g"], cases: [
+        { caseId: "c1", scenario: "we showed it X", expectation: "keep X and Y apart" },
+        { caseId: "c2", scenario: "we showed it Y", expectation: "keep X and Y apart", failNote: "it confused them" },
+      ] },
+    ],
+  };
+
+  it("computeVerdict translates pass-rate and regressions into plain words", () => {
+    const good = buildScorecard([s("c1", "g", 1), s("c2", "g", 1)], { model: "m", runs: 3 });
+    expect(computeVerdict(good, []).word).toBe("Looking good");
+    expect(computeVerdict(good, []).tone).toBe("good");
+    const reg = computeVerdict(good, [{ id: "g", kind: "rule", before: 1, after: 0.5, pValue: 0.01 }]);
+    expect(reg.tone).toBe("bad");
+    expect(reg.word).toBe("Needs attention");
+  });
+
+  it("groupStatus phrases reliability, inconsistency, and regressions plainly", () => {
+    const sc = buildScorecard([s("c1", "g", 1), s("c2", "g", 0.5)], { model: "m", runs: 3 });
+    expect(groupStatus(sc, ["g"], []).phrase).toContain("missed");
+    const perfect = buildScorecard([s("c1", "g", 1)], { model: "m", runs: 3 });
+    expect(groupStatus(perfect, ["g"], []).phrase).toBe("works reliably");
+    expect(groupStatus(perfect, ["g"], [{ id: "g", kind: "rule", before: 1, after: 0.5, pValue: 0.01 }]).phrase).toBe("newly slipping");
+  });
+
+  it("renderHumanReport shows verdict, what-we-tested, and scenario narratives with fail notes", () => {
+    const sc = buildScorecard([s("c1", "g", 1), s("c2", "g", 0)], { model: "m", runs: 3 });
+    const html = renderHumanReport(sc, [], human);
+    expect(html).toContain("What we tested");
+    expect(html).toContain("Telling things apart");
+    expect(html).toContain("we showed it X");
+    expect(html).toContain("See the examples");
+    expect(html).toContain("it confused them"); // failNote shown for the failing case
+    expect(html).not.toContain("CI₉₅"); // no statistics in the human view
+  });
+
+  it("renderScorecardShell puts the human report on top and collapses the technical view", () => {
+    const sc = buildScorecard([s("c1", "g", 1), s("c2", "g", 0)], { model: "m", runs: 3 });
+    const html = renderScorecardShell(sc, [], {
+      title: "Demo eval",
+      sections: [{ heading: "By rule", html: renderRuleTable(sc) }],
+      caseCardsHtml: "<article class='case'>card</article>",
+      human,
+    });
+    expect(html).toContain("What we tested");
+    expect(html).toContain("Technical details (for engineers)");
+    expect(html.indexOf("What we tested")).toBeLessThan(html.indexOf("Technical details"));
   });
 });

--- a/packages/protocol/eval/shared/tests/reporting.spec.ts
+++ b/packages/protocol/eval/shared/tests/reporting.spec.ts
@@ -101,6 +101,29 @@ describe("human-readable report", () => {
     expect(html).not.toContain("CI₉₅"); // no statistics in the human view
   });
 
+  it("hero sub-line counts scenarios (not runs) and reconciles with the themes below", () => {
+    const sc = buildScorecard([s("c1", "g", 1), s("c2", "g", 0)], { model: "m", runs: 3 });
+    const html = renderHumanReport(sc, [], human);
+    expect(html).toContain("50% — 1 of 2 scenarios passed every time");
+    expect(html).not.toContain("checks passed");
+    // The single always-failing theme is named by its group label.
+    expect(html).toContain("The “Telling things apart” scenario failed every run.");
+  });
+
+  it("hero blurb tallies occasionally-off scenarios when nothing fails outright", () => {
+    const sc = buildScorecard([s("c1", "g", 1), s("c2", "g", 0.5)], { model: "m", runs: 3 });
+    const html = renderHumanReport(sc, [], human);
+    expect(html).toContain("of 2 scenarios passed every time");
+    expect(html).toContain("One was occasionally off.");
+  });
+
+  it("hero reports a clean sweep when every scenario passes every run", () => {
+    const sc = buildScorecard([s("c1", "g", 1), s("c2", "g", 1)], { model: "m", runs: 3 });
+    const html = renderHumanReport(sc, [], human);
+    expect(html).toContain("2 of 2 scenarios passed every time");
+    expect(html).toContain("Every scenario passed every run.");
+  });
+
   it("renderScorecardShell puts the human report on top and collapses the technical view", () => {
     const sc = buildScorecard([s("c1", "g", 1), s("c2", "g", 0)], { model: "m", runs: 3 });
     const html = renderScorecardShell(sc, [], {

--- a/packages/protocol/eval/shared/tests/reporting.spec.ts
+++ b/packages/protocol/eval/shared/tests/reporting.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "bun:test";
+
+import { buildScorecard } from "../scorecard.js";
+import { formatConsole } from "../console.js";
+import { renderScorecardShell, renderRuleTable, htmlEscape, rateClass } from "../html.js";
+import type { CaseResultLike } from "../types.js";
+
+const s = (caseId: string, rule: string, passRate: number, runs = 3): CaseResultLike => ({
+  caseId,
+  rule,
+  runs,
+  passes: Math.round(passRate * runs),
+  passRate,
+  flaky: passRate > 0 && passRate < 1,
+});
+
+describe("formatConsole", () => {
+  it("uses a custom title and surfaces rule, aggregate, regressions, and skipped cases", () => {
+    const sc = buildScorecard([s("c1", "g", 1), s("c2", "g", 0)], { model: "test-model", runs: 3 });
+    const out = formatConsole(
+      sc,
+      [{ id: "g", kind: "rule", before: 1, after: 0.5, pValue: 0.001 }],
+      ["new/case"],
+      { title: "Premise eval" },
+    );
+    expect(out).toContain("=== Premise eval ===");
+    expect(out).toContain("aggregate pass-rate");
+    expect(out).toContain("⚠");
+    expect(out).toContain("p=");
+    expect(out).toContain("absent from baseline");
+  });
+
+  it("defaults the title when none is given", () => {
+    const sc = buildScorecard([s("c1", "g", 1)], { model: "m", runs: 1 });
+    expect(formatConsole(sc, [])).toContain("=== Quality Scorecard ===");
+  });
+});
+
+describe("html shell", () => {
+  it("escapes text and classifies rates", () => {
+    expect(htmlEscape("a<b>&\"c")).toBe("a&lt;b&gt;&amp;&quot;c");
+    expect(rateClass(0.95)).toBe("good");
+    expect(rateClass(0.8)).toBe("ok");
+    expect(rateClass(0.5)).toBe("bad");
+  });
+
+  it("renders a standalone document with banner, sections, and case cards", () => {
+    const sc = buildScorecard([s("c1", "g", 1), s("c2", "g", 0)], { model: "m", runs: 3 });
+    const html = renderScorecardShell(sc, [{ id: "g", kind: "rule", before: 1, after: 0.5, pValue: 0.02 }], {
+      title: "Premise eval",
+      intro: "<h2>About</h2><p>hi</p>",
+      sections: [{ heading: "By rule", html: renderRuleTable(sc) }],
+      caseCardsHtml: "<article class='case'>card</article>",
+    });
+    expect(html).toContain("<!doctype html>");
+    expect(html).toContain("Premise eval");
+    expect(html).toContain("Regressions vs baseline");
+    expect(html).toContain("By rule");
+    expect(html).toContain("card");
+    expect(html).toContain("CI₉₅");
+  });
+});

--- a/packages/protocol/eval/shared/tests/runner.spec.ts
+++ b/packages/protocol/eval/shared/tests/runner.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "bun:test";
+
+import { repeatRuns } from "../runner.js";
+
+describe("repeatRuns", () => {
+  it("invokes exactly `runs` times and collects outputs in order", async () => {
+    let n = 0;
+    const out = await repeatRuns(async () => ++n, 3);
+    expect(out).toEqual([1, 2, 3]);
+  });
+
+  it("retries transient failures up to maxAttempts then succeeds", async () => {
+    let attempts = 0;
+    const out = await repeatRuns(
+      async () => {
+        attempts++;
+        if (attempts < 3) throw new Error("transient");
+        return "ok";
+      },
+      1,
+      { maxAttempts: 3, retryDelayMs: 1 },
+    );
+    expect(out).toEqual(["ok"]);
+    expect(attempts).toBe(3);
+  });
+
+  it("throws the last error after exhausting attempts", async () => {
+    let attempts = 0;
+    await expect(
+      repeatRuns(
+        async () => {
+          attempts++;
+          throw new Error(`fail-${attempts}`);
+        },
+        1,
+        { maxAttempts: 2, retryDelayMs: 1 },
+      ),
+    ).rejects.toThrow("fail-2");
+    expect(attempts).toBe(2);
+  });
+});

--- a/packages/protocol/eval/shared/tests/stats.spec.ts
+++ b/packages/protocol/eval/shared/tests/stats.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "bun:test";
+
+import { binomialCI, binomialPValue, binomialSignificance, predictivePValue, mean, rateWithCI } from "../stats.js";
+
+describe("binomialCI", () => {
+  it("returns [0,1] when total is zero", () => {
+    const [lo, hi] = binomialCI(0, 0);
+    expect(lo).toBe(0);
+    expect(hi).toBe(1);
+  });
+
+  it("centres on 0.5 for 1/2 with wide CI", () => {
+    const [lo] = binomialCI(1, 2);
+    expect(lo).toBeLessThan(0.16);
+    expect(lo).toBeGreaterThan(0);
+  });
+
+  it("tightens dramatically as n grows — lower bound lifts", () => {
+    const [lo3, hi3] = binomialCI(3, 3);
+    const [lo7, hi7] = binomialCI(7, 7);
+    expect(hi3).toBe(1);
+    expect(hi7).toBe(1);
+    expect(lo7).toBeGreaterThan(lo3);
+    expect(lo3).toBeLessThan(0.5);
+  });
+
+  it("is symmetric within rounding for moderate p", () => {
+    const [lo, hi] = binomialCI(21, 30); // 70%
+    const spread = hi - lo;
+    expect(spread).toBeGreaterThan(0.2);
+    expect(spread).toBeLessThan(0.5);
+  });
+});
+
+describe("binomial / predictive p-values", () => {
+  it("returns interpretable p-values", () => {
+    expect(binomialPValue(2, 7, 0.8)).toBeCloseTo(0.00467, 3);
+    expect(binomialPValue(5, 7, 0.8)).toBeGreaterThan(0.4);
+  });
+
+  it("does not flag when the baseline is zero", () => {
+    expect(binomialPValue(0, 7, 0)).toBe(1);
+    expect(binomialSignificance(0, 7, 0, 0.05)).toBe(false);
+  });
+
+  it("flags any miss against a perfect point-null baseline", () => {
+    expect(binomialPValue(6, 7, 1)).toBe(0);
+    expect(binomialSignificance(6, 7, 1, 0.05)).toBe(true);
+  });
+
+  it("does not flag perfect current performance against a perfect baseline", () => {
+    expect(binomialSignificance(7, 7, 1, 0.05)).toBe(false);
+  });
+
+  it("posterior predictive accounts for baseline uncertainty", () => {
+    // Point-null treats 6/7 after a 7/7 baseline as impossible; predictive treats it as plausible noise.
+    expect(binomialPValue(6, 7, 1)).toBe(0);
+    expect(predictivePValue(6, 7, 7, 7)).toBeGreaterThan(0.05);
+  });
+
+  it("returns 1 for degenerate run counts", () => {
+    expect(predictivePValue(0, 0, 7, 7)).toBe(1);
+    expect(predictivePValue(5, 7, 0, 0)).toBe(1);
+  });
+});
+
+describe("mean / rateWithCI", () => {
+  it("mean is 0 for empty and averages otherwise", () => {
+    expect(mean([])).toBe(0);
+    expect(mean([1, 0, 1])).toBeCloseTo(2 / 3, 5);
+  });
+
+  it("rateWithCI is n/a for zero total and a percent+CI otherwise", () => {
+    expect(rateWithCI(0, 0)).toBe("n/a");
+    expect(rateWithCI(7, 7)).toContain("100%");
+    expect(rateWithCI(7, 7)).toContain("CI₉₅");
+  });
+});

--- a/packages/protocol/eval/shared/tsconfig.json
+++ b/packages/protocol/eval/shared/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "composite": false,
+    "rootDir": "../../",
+    "types": ["node", "bun-types"]
+  },
+  "include": ["**/*.ts", "../../src/**/*.ts"],
+  "exclude": ["node_modules", "../../src/**/*.spec.ts", "../../src/**/*.test.ts"]
+}

--- a/packages/protocol/eval/shared/types.ts
+++ b/packages/protocol/eval/shared/types.ts
@@ -1,0 +1,49 @@
+/**
+ * Harness-agnostic scorecard types.
+ *
+ * These describe only the *aggregate* shape the shared scorecard / baseline /
+ * console / rolling functions read. Each harness defines its own richer per-run
+ * and per-case types (assertions, candidate outcomes, expectations) that
+ * structurally extend {@link CaseResultLike} / {@link ScorecardLike}. The shared
+ * layer never reads into harness-specific run internals, so harness types stay
+ * fully owned by their harness while reusing all the aggregation machinery.
+ */
+
+/** Per-rule (a.k.a. group) rollup of case pass-rates. `rule` is a free string label. */
+export interface RuleResult {
+  rule: string;
+  caseCount: number;
+  passRate: number;
+}
+
+/** Minimal per-case fields every shared function reads. Harness CaseResult types extend this. */
+export interface CaseResultLike {
+  caseId: string;
+  /** Group label the case belongs to (each harness uses its own string union). */
+  rule: string;
+  runs: number;
+  passes: number;
+  passRate: number;
+  /** True when the case passed some runs and failed others. */
+  flaky: boolean;
+}
+
+/** Minimal scorecard shape. Harness Scorecard types extend this with their CaseResult. */
+export interface ScorecardLike<C extends CaseResultLike = CaseResultLike> {
+  generatedAt: string;
+  model: string;
+  runs: number;
+  aggregatePassRate: number;
+  rules: RuleResult[];
+  cases: C[];
+}
+
+/** A single detected regression of a case or rule vs a baseline. */
+export interface Regression {
+  id: string;
+  kind: "case" | "rule";
+  before: number;
+  after: number;
+  /** One-sided posterior-predictive p-value for the current pass count or lower under the baseline. */
+  pValue: number;
+}

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -19,7 +19,8 @@
     "prepublishOnly": "bun run build",
     "eval:matching": "bun --env-file=.env.test ./eval/matching/matching.eval.ts",
     "eval:premise": "bun --env-file=.env.test ./eval/premise/premise.eval.ts",
-    "eval:profile": "bun --env-file=.env.test ./eval/profile/profile.eval.ts"
+    "eval:profile": "bun --env-file=.env.test ./eval/profile/profile.eval.ts",
+    "eval:opportunity": "bun --env-file=.env.test ./eval/opportunity/opportunity.eval.ts"
   },
   "dependencies": {
     "@langchain/core": "^1.1.17",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -17,7 +17,9 @@
     "test": "bun test",
     "test:isolated": "bun scripts/test.ts",
     "prepublishOnly": "bun run build",
-    "eval:matching": "bun --env-file=.env.test ./eval/matching/matching.eval.ts"
+    "eval:matching": "bun --env-file=.env.test ./eval/matching/matching.eval.ts",
+    "eval:premise": "bun --env-file=.env.test ./eval/premise/premise.eval.ts",
+    "eval:profile": "bun --env-file=.env.test ./eval/profile/profile.eval.ts"
   },
   "dependencies": {
     "@langchain/core": "^1.1.17",


### PR DESCRIPTION
Reorganizes `packages/protocol/eval/` from a single matching harness into a shared-library + thin-harness layout, adds three new quality harnesses, and makes every eval report readable by a non-technical stakeholder.

## New Features
- **Shared eval harness library** (`eval/shared/`): generic runner, scorecard aggregation, baseline diff + rolling baseline, stats/CI, CLI flag parsing, console + HTML reporting. Each harness keeps its own rich case/scorecard types while reusing the plumbing.
- **`eval/premise/` harness** — decomposer + analyzer quality (atomicity, tier classification, intent exclusion, empty input, speech act, felicity calibration, entropy). 10-case baseline, 100%.
- **`eval/profile/` harness** — profile generation with a hard PII/privacy guarantee (`profile.pii.ts`). 8-case baseline, 100%.
- **`eval/opportunity/` harness** — quality of the user-facing card written by `OpportunityPresenter.present` (headline, personalized summary, suggested action, intro greeting). Deterministic second-person + no-leakage checks always on; greeting checks opt-in; grounding/framing/tone judged. Runner retries past the presenter's timeout fallback so it measures real model output.
- **Plain-language HTML reports** — every harness report now leads with a stakeholder-readable summary (verdict banner + "What we tested" + per-scenario narratives), with the technical scorecard collapsed below. Built generically in `eval/shared/html.ts`.
- Wired `eval:premise` / `eval:profile` / `eval:opportunity` package scripts; gitignored per-harness `runs/`.

## Bug Fixes
- Report banner now counts **scenarios** a reader can see (`79% — 5 of 8 scenarios passed every time`) instead of `19 of 24 checks`, which conflated cases×runs and didn't reconcile with the themes listed below it. Blurb names a single always-failing theme and tallies the rest.

## Notable finding
- The opportunity harness immediately surfaced a real defect: `OpportunityPresenter` prepends a `Hi {Name},` salutation to the intro greeting on most runs, which its own prompt forbids. Captured cleanly in the `greeting/plain-prose` case (not fixed in this PR — eval only).

## Tests
- 161 eval unit tests across the four harnesses (shared lib, premise, profile, opportunity), all green. Evals themselves remain opt-in (require `OPENROUTER_API_KEY`), not part of `bun test`.

## Version
- `@indexnetwork/protocol` 3.6.3 → 3.7.0 (eval tooling only; `files: ["dist"]` unchanged).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784227998&installation_id=140549914&pr_number=977&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F977&signature=8b36af88bf982c940ad59ab021962733cdeff77097efcc4717caa499abbb3c3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->