### PR TITLE
feat(backend): invitation-link regenerate endpoint + close invite test gaps

### DIFF
--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -2228,6 +2228,18 @@ export class ChatDatabaseAdapter {
 
     await db.update(networks).set(updateData).where(eq(networks.id, networkId));
 
+    return this.loadNetworkSettingsDTO(networkId);
+  }
+
+  /**
+   * Re-select a network after a settings/permissions mutation and map it to the
+   * canonical settings DTO (owner info, permissions, member/intent counts).
+   * Shared by {@link updateIndexSettings} and {@link regenerateInvitationLink}.
+   * @param networkId - The network to load
+   * @returns The canonical network settings DTO
+   * @throws Error if the network cannot be found after the update
+   */
+  private async loadNetworkSettingsDTO(networkId: string) {
     const [updatedRow] = await db
       .select({
         id: networks.id,
@@ -2291,6 +2303,44 @@ export class ChatDatabaseAdapter {
       user: { id: updatedRow.ownerId, name: updatedRow.userName, avatar: updatedRow.userAvatar },
       _count: { members: memberCount },
     };
+  }
+
+  /**
+   * Rotate a network's invitation link, issuing a fresh UUID code. Owner-only.
+   * Works regardless of join policy and preserves all other permission fields.
+   * Once rotated, any previously shared link stops resolving.
+   * @param networkId - The network whose invitation code should be rotated
+   * @param requestingUserId - The caller; must be an owner of the network
+   * @returns The updated network settings DTO carrying the new invitation code
+   * @throws Error if the caller is not an owner or the network does not exist
+   */
+  async regenerateInvitationLink(networkId: string, requestingUserId: string) {
+    const isOwner = await this.isIndexOwner(networkId, requestingUserId);
+    if (!isOwner) {
+      throw new Error('Access denied: Not an owner of this index');
+    }
+
+    const [existing] = await db.select().from(networks).where(eq(networks.id, networkId)).limit(1);
+    if (!existing) {
+      throw new Error('Index not found');
+    }
+
+    const currentPerms = (existing.permissions as schema.NetworkPermissionsState | null) ?? {
+      joinPolicy: 'invite_only',
+      invitationLink: null,
+      allowGuestVibeCheck: false,
+    };
+    const updatedPermissions: schema.NetworkPermissionsState = {
+      ...currentPerms,
+      invitationLink: { code: crypto.randomUUID() },
+    };
+
+    await db
+      .update(networks)
+      .set({ permissions: updatedPermissions, updatedAt: new Date() })
+      .where(eq(networks.id, networkId));
+
+    return this.loadNetworkSettingsDTO(networkId);
   }
 
   async softDeleteNetwork(networkId: string): Promise<void> {

--- a/backend/src/controllers/network.controller.ts
+++ b/backend/src/controllers/network.controller.ts
@@ -850,6 +850,36 @@ export class NetworkController {
   }
 
   /**
+   * Rotate a network's invitation link, issuing a fresh code. Owner-only.
+   * The previously shared link stops resolving once rotated.
+   */
+  @Patch('/:id/regenerate-invitation')
+  @UseGuards(RateLimit('write'), AuthOrApiKeyGuard)
+  async regenerateInvitation(req: Request, user: AuthenticatedUser, params: Record<string, string>) {
+    try {
+      await assertAgentNetworkScope(req, params.id);
+      const result = await networkService.regenerateInvitationLink(params.id, user.id);
+      logger.verbose('Invitation link regenerated for network', { networkId: params.id });
+      return Response.json({ network: result });
+    } catch (err: unknown) {
+      const msg = errorMessage(err);
+      if (msg.includes('Access denied')) {
+        return new Response(JSON.stringify({ error: msg }), {
+          status: 403,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (msg.includes('not found')) {
+        return new Response(JSON.stringify({ error: 'Network not found' }), {
+          status: 404,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      throw err;
+    }
+  }
+
+  /**
    * Get public networks that the user has not joined (discovery).
    * IMPORTANT: This must come before GET /:id to avoid route collision.
    */

--- a/backend/src/controllers/tests/invitation-gaps.controller.spec.ts
+++ b/backend/src/controllers/tests/invitation-gaps.controller.spec.ts
@@ -1,0 +1,228 @@
+/** Config */
+import { config } from "dotenv";
+config({ path: '.env.test', override: true });
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { NetworkController } from "../network.controller";
+import { UserDatabaseAdapter, NetworkGraphDatabaseAdapter } from "../../adapters/database.adapter";
+import type { AuthenticatedUser } from "../../guards/auth.guard";
+
+/**
+ * Coverage for previously-untested backend invitation behaviors:
+ *  - PATCH /networks/:id/regenerate-invitation (rotation, owner-only, any policy)
+ *  - join-policy transitions and invitation-code persistence
+ *  - share/accept edge cases (malformed/empty codes, owner self-accept, non-expiry)
+ */
+describe("Invitation Backend Gaps", () => {
+  const controller = new NetworkController();
+  const userAdapter = new UserDatabaseAdapter();
+  const indexAdapter = new NetworkGraphDatabaseAdapter();
+
+  let ownerUserId: string;
+  let outsiderUserId: string;
+  const createdIndexIds: string[] = [];
+
+  const ownerEmail = `test-gaps-owner-${Date.now()}@example.com`;
+  const outsiderEmail = `test-gaps-outsider-${Date.now()}@example.com`;
+
+  const mockOwner = (): AuthenticatedUser => ({ id: ownerUserId, email: ownerEmail, name: "Gaps Owner" });
+  const mockOutsider = (): AuthenticatedUser => ({ id: outsiderUserId, email: outsiderEmail, name: "Gaps Outsider" });
+
+  type CreatedNetwork = {
+    id: string;
+    permissions?: { joinPolicy?: string; invitationLink?: { code: string } | null };
+  };
+
+  /** Create a network as the owner and track it for cleanup. */
+  async function createNetwork(body: Record<string, unknown>): Promise<CreatedNetwork> {
+    const req = new Request("http://localhost/networks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const res = await controller.create(req, mockOwner());
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { network: CreatedNetwork };
+    expect(data.network?.id).toBeTruthy();
+    createdIndexIds.push(data.network.id);
+    return data.network;
+  }
+
+  async function regenerate(networkId: string, user: AuthenticatedUser) {
+    const req = new Request(`http://localhost/networks/${networkId}/regenerate-invitation`, { method: "PATCH" });
+    return controller.regenerateInvitation(req, user, { id: networkId });
+  }
+
+  async function shareLookup(code: string) {
+    const req = new Request(`http://localhost/networks/share/${code}`);
+    return controller.getNetworkByShareCode(req, null, { code });
+  }
+
+  async function acceptInvite(code: string, user: AuthenticatedUser) {
+    const req = new Request(`http://localhost/networks/invitation/${code}/accept`, { method: "POST" });
+    return controller.acceptInvitation(req, user, { code });
+  }
+
+  beforeAll(async () => {
+    for (const email of [ownerEmail, outsiderEmail]) {
+      const existing = await userAdapter.findByEmail(email);
+      if (existing) await userAdapter.deleteByEmail(email);
+    }
+    const owner = await userAdapter.create({ email: ownerEmail, name: "Gaps Owner", intro: "Test", location: "City" });
+    ownerUserId = owner.id;
+    const outsider = await userAdapter.create({ email: outsiderEmail, name: "Gaps Outsider", intro: "Test", location: "City" });
+    outsiderUserId = outsider.id;
+  });
+
+  afterAll(async () => {
+    for (const id of createdIndexIds) await indexAdapter.deleteNetworkAndMembers(id);
+    if (ownerUserId) await userAdapter.deleteById(ownerUserId);
+    if (outsiderUserId) await userAdapter.deleteById(outsiderUserId);
+  });
+
+  describe("PATCH /:id/regenerate-invitation", () => {
+    test("rotates the code: the old link stops resolving and the new link resolves", async () => {
+      const network = await createNetwork({ title: "Rotate Me", prompt: "p", joinPolicy: "invite_only" });
+      const oldCode = network.permissions?.invitationLink?.code;
+      expect(oldCode).toBeTruthy();
+
+      // Old code resolves before rotation.
+      expect((await shareLookup(oldCode!)).status).toBe(200);
+
+      const res = await regenerate(network.id, mockOwner());
+      const data = (await res.json()) as { network?: { permissions?: { invitationLink?: { code: string } } } };
+      expect(res.status).toBe(200);
+      const newCode = data.network?.permissions?.invitationLink?.code;
+      expect(newCode).toBeTruthy();
+      expect(newCode).not.toBe(oldCode);
+
+      // Old code no longer resolves; new code does.
+      expect((await shareLookup(oldCode!)).status).toBe(404);
+      expect((await shareLookup(newCode!)).status).toBe(200);
+    });
+
+    test("is owner-only: a non-member receives 403", async () => {
+      const network = await createNetwork({ title: "Owner Only", prompt: "p", joinPolicy: "invite_only" });
+      const res = await regenerate(network.id, mockOutsider());
+      const data = (await res.json()) as { error?: string };
+      expect(res.status).toBe(403);
+      expect(data.error).toContain("Access denied");
+    });
+
+    test("works for a public (anyone) network too", async () => {
+      const network = await createNetwork({ title: "Public Rotate", prompt: "p", joinPolicy: "anyone" });
+      const res = await regenerate(network.id, mockOwner());
+      const data = (await res.json()) as { network?: { permissions?: { joinPolicy?: string; invitationLink?: { code: string } } } };
+      expect(res.status).toBe(200);
+      expect(data.network?.permissions?.joinPolicy).toBe("anyone");
+      expect(data.network?.permissions?.invitationLink?.code).toBeTruthy();
+    });
+
+    test("returns 403 for a non-existent network (existence not leaked)", async () => {
+      const res = await regenerate("00000000-0000-0000-0000-000000000000", mockOwner());
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("join-policy transitions & code persistence", () => {
+    test("switching anyone → invite_only preserves the existing invitation code", async () => {
+      const network = await createNetwork({ title: "Transition", prompt: "p", joinPolicy: "anyone" });
+      const codeBefore = network.permissions?.invitationLink?.code;
+      expect(codeBefore).toBeTruthy();
+
+      const req = new Request(`http://localhost/networks/${network.id}/permissions`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ joinPolicy: "invite_only" }),
+      });
+      const res = await controller.updatePermissions(req, mockOwner(), { id: network.id });
+      const data = (await res.json()) as { network?: { permissions?: { joinPolicy?: string; invitationLink?: { code: string } } } };
+      expect(res.status).toBe(200);
+      expect(data.network?.permissions?.joinPolicy).toBe("invite_only");
+      // Same code persisted across the transition (not regenerated).
+      expect(data.network?.permissions?.invitationLink?.code).toBe(codeBefore);
+      expect((await shareLookup(codeBefore!)).status).toBe(200);
+    });
+
+    test("invitation code survives a non-permission update (title/prompt change)", async () => {
+      const network = await createNetwork({ title: "Persist On Edit", prompt: "p", joinPolicy: "invite_only" });
+      const code = network.permissions?.invitationLink?.code;
+      expect(code).toBeTruthy();
+
+      const req = new Request(`http://localhost/networks/${network.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: "Renamed", prompt: "new prompt" }),
+      });
+      const res = await controller.update(req, mockOwner(), { id: network.id });
+      expect(res.status).toBe(200);
+
+      // Same code still resolves after editing unrelated fields.
+      const lookup = await shareLookup(code!);
+      const lookupData = (await lookup.json()) as { network?: { id: string; title: string } };
+      expect(lookup.status).toBe(200);
+      expect(lookupData.network?.id).toBe(network.id);
+      expect(lookupData.network?.title).toBe("Renamed");
+    });
+
+    test("invitation code survives an unrelated permissions update (contextInjection)", async () => {
+      const network = await createNetwork({ title: "Persist On Perms", prompt: "p", joinPolicy: "invite_only" });
+      const code = network.permissions?.invitationLink?.code;
+      expect(code).toBeTruthy();
+
+      const req = new Request(`http://localhost/networks/${network.id}/permissions`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ contextInjection: { discovery: true } }),
+      });
+      const res = await controller.updatePermissions(req, mockOwner(), { id: network.id });
+      const data = (await res.json()) as { network?: { permissions?: { invitationLink?: { code: string }; contextInjection?: { discovery: boolean } } } };
+      expect(res.status).toBe(200);
+      expect(data.network?.permissions?.contextInjection?.discovery).toBe(true);
+      expect(data.network?.permissions?.invitationLink?.code).toBe(code);
+      expect((await shareLookup(code!)).status).toBe(200);
+    });
+  });
+
+  describe("share/accept edge cases", () => {
+    test("share lookup returns 404 for an empty code", async () => {
+      const res = await shareLookup("");
+      expect(res.status).toBe(404);
+    });
+
+    test("share lookup returns 404 for a malformed code", async () => {
+      const res = await shareLookup("not-a-real-code-12345");
+      const data = (await res.json()) as { error?: string };
+      expect(res.status).toBe(404);
+      expect(data.error).toBe("Invalid or expired invitation link");
+    });
+
+    test("accept returns 400 for a malformed code", async () => {
+      const res = await acceptInvite("not-a-real-code-12345", mockOutsider());
+      const data = (await res.json()) as { error?: string };
+      expect(res.status).toBe(400);
+      expect(data.error).toBe("Invalid or expired invitation link");
+    });
+
+    test("owner accepting their own invitation link returns alreadyMember=true", async () => {
+      const network = await createNetwork({ title: "Self Accept", prompt: "p", joinPolicy: "invite_only" });
+      const code = network.permissions?.invitationLink?.code;
+      expect(code).toBeTruthy();
+
+      const res = await acceptInvite(code!, mockOwner());
+      const data = (await res.json()) as { index?: { id: string }; alreadyMember?: boolean };
+      expect(res.status).toBe(200);
+      expect(data.index?.id).toBe(network.id);
+      expect(data.alreadyMember).toBe(true);
+    });
+
+    test("invitation code does not expire: repeated lookups keep resolving", async () => {
+      const network = await createNetwork({ title: "No Expiry", prompt: "p", joinPolicy: "invite_only" });
+      const code = network.permissions?.invitationLink?.code;
+      expect(code).toBeTruthy();
+
+      expect((await shareLookup(code!)).status).toBe(200);
+      expect((await shareLookup(code!)).status).toBe(200);
+    });
+  });
+});

--- a/backend/src/services/network.service.ts
+++ b/backend/src/services/network.service.ts
@@ -169,6 +169,20 @@ export class NetworkService {
   }
 
   /**
+   * Rotate a network's invitation link, issuing a fresh code. Owner-only.
+   * Works regardless of join policy; previously shared links stop resolving.
+   * @param networkId - The network whose invitation link should be rotated
+   * @param userId - The caller; must be an owner of the network
+   * @returns The updated network with the new invitation code
+   * @throws Error if the network is personal or the caller is not an owner
+   */
+  async regenerateInvitationLink(networkId: string, userId: string) {
+    await this.assertNotPersonal(networkId);
+    logger.verbose('[NetworkService] Regenerating invitation link', { networkId, userId });
+    return this.adapter.regenerateInvitationLink(networkId, userId);
+  }
+
+  /**
    * Search users within the caller's personal index members,
    * optionally excluding existing members of a target index.
    */


### PR DESCRIPTION
## Summary

Closes the notable backend gaps in the non-public-network invite-link feature surfaced during a coverage audit:

- **Builds the missing regenerate endpoint** — the frontend's `networks.regenerateInvitationLink` was calling `PATCH /networks/:id/regenerate-invitation`, which did not exist (no controller/service/adapter). That call now works.
- **Adds tests** for previously-uncovered backend invite behaviors (regenerate, join-policy transitions, code persistence, share/accept edge cases).

## New Features

- `PATCH /networks/:id/regenerate-invitation` — owner-only; rotates `permissions.invitationLink.code` to a fresh UUID **regardless of join policy**, preserving all other permission fields. Returns `{ network }` (matches the frontend's expected `APIResponse<Network>`). Once rotated, any previously shared link stops resolving.

## Refactors

- Extracted the post-update settings DTO build duplicated in `updateIndexSettings` into a shared private `loadNetworkSettingsDTO` helper; both `updateIndexSettings` and the new `regenerateInvitationLink` reuse it.

## Tests

New isolated spec `backend/src/controllers/tests/invitation-gaps.controller.spec.ts` (own user/network harness, full cleanup) — 12 cases:

- **Regenerate**: rotation (old link 404s, new link resolves), owner-only → 403, works for `anyone` networks, non-existent network → 403 (existence not leaked).
- **Policy transition & persistence**: `anyone → invite_only` preserves the existing code; code survives a title/prompt update; code survives an unrelated permissions update (`contextInjection`).
- **Edge cases**: empty code → 404, malformed code → 404 (share) / 400 (accept), owner self-accept → `alreadyMember=true`, non-expiry (repeated lookups keep resolving).

## Notes

- **Expiry intentionally not built** — there is no expiry field in `NetworkPermissionsState`, so tests cover the actual behavior (codes don't expire) rather than invent schema.
- Non-existent network on regenerate returns **403, not 404** (owner check runs first, deliberately not leaking existence). The 404 branch remains as defense for the rare "owner but row vanished" path.

## Verification

- New + existing invitation specs: **19/19 pass**, no regressions.
- `tsc --noEmit` clean; `eslint` on changed files clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784229378&installation_id=140549914&pr_number=978&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F978&signature=13c030ab1e1cede173192d28682070056e5ce0217a722498a9ea1800f7e79b14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->