### PR TITLE
fix(contacts): stop orchestrator advertising contact import when CONTACTS_ENABLED is off

### DIFF
--- a/packages/protocol/src/chat/chat.agent.ts
+++ b/packages/protocol/src/chat/chat.agent.ts
@@ -254,6 +254,7 @@ export class ChatAgent {
       userId: context.userId,
       networkId: context.networkId,
       sessionId: context.sessionId,
+      contactsEnabled: context.contactsEnabled,
     });
     const tools = await createChatTools(context, resolved);
     return new ChatAgent(resolved, tools, context.modelConfig);

--- a/packages/protocol/src/chat/chat.prompt.modules.ts
+++ b/packages/protocol/src/chat/chat.prompt.modules.ts
@@ -310,6 +310,11 @@ Index and community membership is background: handle it without talking about in
 const contactsModule: PromptModule = {
   id: "contacts",
   triggers: ["import_gmail_contacts", "add_contact", "list_contacts", "remove_contact"],
+  // Gate on the CONTACTS_ENABLED flag (fail-closed: only `true` enables). When
+  // contacts are disabled the import/add tools are de-registered, so this module
+  // must not be injected — otherwise the orchestrator keeps advertising Gmail
+  // import / add_contact and offers an action that then fails as "Unknown tool".
+  triggerFilter: (iterCtx) => iterCtx.ctx.contactsEnabled === true,
   content: () => `
 ### 9. Import contacts from Gmail
 

--- a/packages/protocol/src/chat/chat.prompt.ts
+++ b/packages/protocol/src/chat/chat.prompt.ts
@@ -117,7 +117,7 @@ ${ctx.hasName ? `   - Call \`create_user_profile()\` with no arguments to look t
    - If user provides a rewrite → call \`create_user_profile(bioOrDescription="[their rewritten text]", confirm=true)\` to generate and save the updated profile
    - Do NOT use \`update_user_profile()\` during onboarding — the profile doesn't exist yet until confirmed
 
-5. **Connect Gmail**
+${ctx.contactsEnabled ? `5. **Connect Gmail**
    - Call \`import_gmail_contacts()\` immediately to obtain the auth URL
    - If not connected (tool returns \`requiresAuth: true\` + \`authUrl\`): present the message below with the button embedded, then WAIT for the user's response:
      "Let's start by discovering latent opportunities inside your network.
@@ -126,7 +126,8 @@ ${ctx.hasName ? `   - Call \`create_user_profile()\` with no arguments to look t
    - The button is how the user says "yes" — clicking it opens OAuth in a new window. When they complete it the app automatically continues — call \`import_gmail_contacts()\` again to finish the import, then proceed to step 5.5
    - If user says "skip", "skip for now", "no", "later", or any variant → proceed directly to step 5.5
    - If already connected (tool returns import stats immediately on the first call — user never went through the auth button): **skip to step 5.5 immediately. Do NOT write any text about Gmail, contacts, or the import. Your next sentence must be the step 5.5 intro.**
-   - If the user just completed OAuth (you called \`import_gmail_contacts()\` a second time after auth): acknowledge the import with a brief summary, then proceed to step 5.5
+   - If the user just completed OAuth (you called \`import_gmail_contacts()\` a second time after auth): acknowledge the import with a brief summary, then proceed to step 5.5` : `5. **Connect Gmail (skipped — contact import is disabled)**
+   - Contact import is turned off in this environment. Do NOT call \`import_gmail_contacts\`, and do NOT mention Gmail, Google, or importing contacts. Proceed directly to step 5.5.`}
 
 5.5. **Collect location**
    - Ask the user where they are based: "Where are you based? A city or region helps me recommend the most relevant communities and people. (e.g. 'Berlin', 'San Francisco', 'Remote' — or skip if you'd prefer not to share)"
@@ -295,11 +296,11 @@ All tools are simple read/write operations. No hidden logic.
 | **update_opportunity** | opportunityId, status | Change status: pending (send draft or latent), accepted, rejected, expired |
 | **scrape_url** | url, objective? | Extract text from web page |
 | **read_docs** | topic? | Protocol documentation |
-| **import_gmail_contacts** | — | Import Gmail contacts to user's network. Handles auth if needed, returns auth URL or import stats |
+${ctx.contactsEnabled ? `| **import_gmail_contacts** | — | Import Gmail contacts to user's network. Handles auth if needed, returns auth URL or import stats |
 | **import_contacts** | contacts[], source | Import contacts array to user's network. Contacts become ghost users if no account exists |
-| **list_contacts** | limit? | List user's network contacts |
-| **add_contact** | email, name? | Manually add single contact to network |
-| **remove_contact** | contactId | Remove contact from network |
+` : ``}| **list_contacts** | limit? | List user's network contacts |
+${ctx.contactsEnabled ? `| **add_contact** | email, name? | Manually add single contact to network |
+` : ``}| **remove_contact** | contactId | Remove contact from network |
 `;
 }
 

--- a/packages/protocol/src/chat/chat.prompt.ts
+++ b/packages/protocol/src/chat/chat.prompt.ts
@@ -168,7 +168,7 @@ ${ctx.networkId ? `6. **Community discovery (skipped — already in scoped commu
 ### CRITICAL: Profile Confirmation Handling
 When the user says "yes", "looks good", "that's right", "correct", or any affirmation after you show them their profile:
 1. Call \`create_user_profile(confirm=true)\` to save the profile
-2. Proceed to the Gmail connect step (step 5)
+2. Proceed to ${ctx.contactsEnabled ? `the Gmail connect step (step 5)` : `step 5.5 (collect location)`}
 3. Do NOT call \`complete_onboarding()\` yet — it must only be called at step 8 (wrap up), after intent capture
 
 ### Onboarding Rules

--- a/packages/protocol/src/chat/tests/chat.prompt.modules.spec.ts
+++ b/packages/protocol/src/chat/tests/chat.prompt.modules.spec.ts
@@ -101,7 +101,7 @@ describe("extractRecentToolCalls", () => {
 });
 
 // Minimal mock for ResolvedToolContext — only fields needed by resolution logic
-function mockCtx(overrides: Partial<{ networkId: string; isOwner: boolean; isOnboarding: boolean }> = {}): IterationContext["ctx"] {
+function mockCtx(overrides: Partial<{ networkId: string; isOwner: boolean; isOnboarding: boolean; contactsEnabled: boolean }> = {}): IterationContext["ctx"] {
   return {
     userId: "test-user",
     userEmail: "test@example.com",
@@ -116,6 +116,7 @@ function mockCtx(overrides: Partial<{ networkId: string; isOwner: boolean; isOnb
     isOwner: overrides.isOwner ?? false,
     isOnboarding: overrides.isOnboarding ?? false,
     hasName: true,
+    contactsEnabled: "contactsEnabled" in overrides ? overrides.contactsEnabled : true,
   } as unknown as IterationContext["ctx"];
 }
 
@@ -233,11 +234,32 @@ describe("resolveModules", () => {
   test("activates contacts module on import_gmail_contacts trigger", () => {
     const iterCtx: IterationContext = {
       recentTools: [{ name: "import_gmail_contacts", args: {} }],
-      ctx: mockCtx(),
+      ctx: mockCtx({ contactsEnabled: true }),
     };
     const result = resolveModules(iterCtx);
     expect(result).toContain("### 9. Import contacts from Gmail");
     expect(result).toContain("### 10. Add or manage contacts manually");
+  });
+
+  test("does NOT activate contacts module when contactsEnabled is false (even on list_contacts)", () => {
+    const iterCtx: IterationContext = {
+      recentTools: [{ name: "list_contacts", args: {} }],
+      ctx: mockCtx({ contactsEnabled: false }),
+    };
+    const result = resolveModules(iterCtx);
+    expect(result).not.toContain("### 9. Import contacts from Gmail");
+    expect(result).not.toContain("### 10. Add or manage contacts manually");
+    expect(result).not.toContain("import_gmail_contacts");
+  });
+
+  test("does NOT activate contacts module when contactsEnabled is unset (fail-closed)", () => {
+    const iterCtx: IterationContext = {
+      recentTools: [{ name: "import_gmail_contacts", args: {} }, { name: "add_contact", args: {} }],
+      // contactsEnabled omitted → undefined, must be treated as disabled
+      ctx: mockCtx({ contactsEnabled: undefined as unknown as boolean }),
+    };
+    const result = resolveModules(iterCtx);
+    expect(result).not.toContain("### 9. Import contacts from Gmail");
   });
 
   test("activates shared-context module on read_network_memberships trigger", () => {
@@ -356,6 +378,7 @@ function makeCtx(overrides: Partial<ResolvedToolContext> = {}): ResolvedToolCont
     indexScope: ["idx-personal", "idx-community"],
     isOnboarding: false,
     hasName: true,
+    contactsEnabled: true,
     ...overrides,
   };
 }
@@ -491,7 +514,7 @@ describe("buildSystemContent snapshot identity", () => {
   });
 
   test("with all modules active, full prompt is snapshot-stable", () => {
-    const ctx = makeCtx();
+    const ctx = makeCtx({ contactsEnabled: true });
     // Craft iterCtx that triggers all 10 modules (introduction excludes discovery,
     // so use discovery-style args to get discovery + skip introduction)
     const iterCtx: IterationContext = {
@@ -527,5 +550,54 @@ describe("buildSystemContent snapshot identity", () => {
     expect(output).toContain("You are Index.");
     expect(output).toContain("### Index Scope");
     expect(output).toContain("### Output Format");
+  });
+});
+
+describe("CONTACTS_ENABLED gating in buildSystemContent", () => {
+  describe("tool reference table", () => {
+    test("includes contact-import tools when contactsEnabled is true", () => {
+      const output = buildSystemContent(makeCtx({ contactsEnabled: true }));
+      expect(output).toContain("**import_gmail_contacts**");
+      expect(output).toContain("**import_contacts**");
+      expect(output).toContain("**add_contact**");
+      // read-path tools always present
+      expect(output).toContain("**list_contacts**");
+      expect(output).toContain("**remove_contact**");
+    });
+
+    test("omits contact-import tools but keeps list/remove when contactsEnabled is false", () => {
+      const output = buildSystemContent(makeCtx({ contactsEnabled: false }));
+      expect(output).not.toContain("**import_gmail_contacts**");
+      expect(output).not.toContain("**import_contacts**");
+      expect(output).not.toContain("**add_contact**");
+      // read-path tools remain available
+      expect(output).toContain("**list_contacts**");
+      expect(output).toContain("**remove_contact**");
+    });
+
+    test("fail-closed: omits import tools when contactsEnabled is unset", () => {
+      const output = buildSystemContent(makeCtx({ contactsEnabled: undefined }));
+      expect(output).not.toContain("**import_gmail_contacts**");
+      expect(output).not.toContain("**add_contact**");
+    });
+  });
+
+  describe("onboarding Gmail step", () => {
+    test("renders the Connect Gmail step when onboarding and contactsEnabled is true", () => {
+      const output = buildSystemContent(makeCtx({ isOnboarding: true, contactsEnabled: true }));
+      expect(output).toContain("ONBOARDING MODE (ACTIVE)");
+      expect(output).toContain("5. **Connect Gmail**");
+      expect(output).toContain("[Connect Gmail](authUrl)");
+    });
+
+    test("skips the Connect Gmail step when onboarding but contactsEnabled is false", () => {
+      const output = buildSystemContent(makeCtx({ isOnboarding: true, contactsEnabled: false }));
+      expect(output).toContain("ONBOARDING MODE (ACTIVE)");
+      expect(output).toContain("skipped — contact import is disabled");
+      expect(output).not.toContain("[Connect Gmail](authUrl)");
+      expect(output).not.toContain("Connect your Google account so I can learn from your Gmail");
+      // onboarding still flows to the next steps
+      expect(output).toContain("5.5. **Collect location**");
+    });
   });
 });

--- a/packages/protocol/src/mcp/mcp.server.ts
+++ b/packages/protocol/src/mcp/mcp.server.ts
@@ -537,7 +537,7 @@ export function createMcpServer(
           }
 
           // Resolve chat context for the user (mark as MCP — no interactive UI available)
-          const context = await resolveChatContext({ database: deps.database, userId });
+          const context = await resolveChatContext({ database: deps.database, userId, contactsEnabled: deps.contactsEnabled });
           reportContext = context;
           context.isMcp = true;
           if (agentId) {

--- a/packages/protocol/src/shared/agent/tests/tool.helpers.spec.ts
+++ b/packages/protocol/src/shared/agent/tests/tool.helpers.spec.ts
@@ -74,6 +74,24 @@ describe("resolveChatContext", () => {
     expect(ctx.userEmail).toBe("test@example.com");
   });
 
+  test("propagates contactsEnabled onto the resolved context (true)", async () => {
+    const db = createContextDatabase();
+    const ctx = await resolveChatContext({ database: db, userId, contactsEnabled: true });
+    expect(ctx.contactsEnabled).toBe(true);
+  });
+
+  test("propagates contactsEnabled onto the resolved context (false)", async () => {
+    const db = createContextDatabase();
+    const ctx = await resolveChatContext({ database: db, userId, contactsEnabled: false });
+    expect(ctx.contactsEnabled).toBe(false);
+  });
+
+  test("leaves contactsEnabled undefined when not provided (fail-closed at consumers)", async () => {
+    const db = createContextDatabase();
+    const ctx = await resolveChatContext({ database: db, userId });
+    expect(ctx.contactsEnabled).toBeUndefined();
+  });
+
   test("clamps indexScope to [scopedIndex, personalIndex] when networkId is provided", async () => {
     const personalIndexId = "00000000-0000-0000-0000-000000000099";
     const otherIndexId = "00000000-0000-0000-0000-000000000088";

--- a/packages/protocol/src/shared/agent/tool.factory.ts
+++ b/packages/protocol/src/shared/agent/tool.factory.ts
@@ -62,6 +62,7 @@ export async function createChatTools(
       userId: deps.userId,
       networkId: deps.networkId,
       sessionId: deps.sessionId,
+      contactsEnabled: deps.contactsEnabled,
     }));
 
   // Allow callers (e.g. MCP server, tests) to override the computed indexScope

--- a/packages/protocol/src/shared/agent/tool.helpers.ts
+++ b/packages/protocol/src/shared/agent/tool.helpers.ts
@@ -104,6 +104,14 @@ export interface ResolvedToolContext {
    * `mintConnectLink` so the click-time redirect can branch.
    */
   clientSurface?: 'telegram' | 'web';
+  /**
+   * True when the CONTACTS_ENABLED feature flag is on. Carried from the
+   * composition root so prompt modules can gate contact-import guidance —
+   * when false/unset, the contacts prompt module is not injected, so the
+   * orchestrator never advertises Gmail import / add_contact (whose tools
+   * are also de-registered). Fail-closed: treat only `true` as enabled.
+   */
+  contactsEnabled?: boolean;
 }
 
 /**
@@ -283,8 +291,10 @@ export async function resolveChatContext(params: {
   networkId?: string;
   /** Chat session ID for draft opportunities (stored as context.conversationId). */
   sessionId?: string;
+  /** CONTACTS_ENABLED flag, forwarded onto the resolved context for prompt gating. */
+  contactsEnabled?: boolean;
 }): Promise<ResolvedToolContext> {
-  const { database, userId, networkId, sessionId } = params;
+  const { database, userId, networkId, sessionId, contactsEnabled } = params;
 
   const [user, rawProfile, userNetworks] = await Promise.all([
     database.getUser(userId),
@@ -377,6 +387,7 @@ export async function resolveChatContext(params: {
     scopedMembershipRole,
     isOnboarding: !(user.onboarding?.completedAt),
     hasName,
+    contactsEnabled,
     ...(sessionId !== undefined ? { sessionId } : {}),
   };
 }


### PR DESCRIPTION
## Summary

Follow-up to #979. That PR de-registered the contact-import tools when `CONTACTS_ENABLED` is off, but the chat **orchestrator's system prompt** still advertised them — so it offered "connect your Gmail to import contacts", the user accepted, and the call failed with **"Unknown tool"** (observed in a real session). This gates every prompt surface that taught the orchestrator about contact import on the same env flag.

## Root cause

`CONTACTS_ENABLED` gated tool *registration* and the HTTP/service layers, but three prompt surfaces in `packages/protocol/src/chat/` are independent of the tool registry and kept advertising the import capability:

1. `contactsModule` prompt module (sections 9 & 10) — triggered by `list_contacts` (still available), so it fired even when import tools were gone.
2. Onboarding **step 5 "Connect Gmail"** — a hardcoded onboarding step.
3. The **tool reference table** — listed `import_gmail_contacts` / `import_contacts` / `add_contact`.

The flag also wasn't reaching the prompt layer: `contactsEnabled` existed on `ToolContext`/`ProtocolDeps` but was dropped before `resolveChatContext`, so it never landed on `ResolvedToolContext` (what the prompt builders see).

## Changes

- **Thread the flag to the prompt layer**: add `contactsEnabled` to `ResolvedToolContext`, populate it in `resolveChatContext`, and forward it from the three call sites that have it in scope — web chat orchestrator (`ChatAgent.create`), MCP (`mcp.server`), and the `tool.factory` fallback.
- **Gate the prompt module**: `contactsModule.triggerFilter = (iterCtx) => iterCtx.ctx.contactsEnabled === true` (fail-closed).
- **Gate onboarding**: when disabled, step 5 renders a "skipped — contact import is disabled" instruction that flows straight to step 5.5; no Gmail offer.
- **Gate the tool table**: omit the import/add rows when disabled; `list_contacts` and `remove_contact` (read paths) always remain.

Fail-closed everywhere: only the literal `true` enables, matching the rest of the flag.

## Behavior

| | Enabled | Disabled (unset / not `"true"`) |
|---|---|---|
| `contactsModule` (sections 9 & 10) | injected | **not injected** |
| Onboarding "Connect Gmail" step | shown | **skipped → step 5.5** |
| Tool table: import / import_contacts / add_contact | listed | **omitted** |
| Tool table: list_contacts / remove_contact | listed | listed |

## Tests

`chat.prompt.modules.spec.ts`:
- contacts module not injected when `contactsEnabled` is false / unset (fail-closed), still injected when true.
- tool table omits import tools but keeps list/remove when disabled.
- onboarding "Connect Gmail" step skipped when disabled, present when enabled.
- existing "all modules active" + identity snapshots kept stable (test ctx defaults to enabled).

Protocol build, backend typecheck, and eslint clean. (Pre-existing unrelated failures unchanged: `chat.prompt.spec.ts` fails at module load on `dev` too; the 4 `contact.tools`/`integration.tools` "returns error when X throws" specs likewise.)

## Versioning

Bumps `@indexnetwork/protocol` 3.7.0 → 3.7.1.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784231215&installation_id=140549914&pr_number=980&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F980&signature=d52d14835bf90ac15f975abbd35c0888aa3cda717557a5400406dd378d6f07ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->