### PR TITLE
Temporarily disable pending questions in Sidebar

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -283,7 +283,8 @@ export default function Sidebar() {
           )}
         </div>
 
-        {pendingQuestionsCount > 0 && (
+        {/* Questions temporarily disabled — re-enable by restoring this condition. */}
+        {false && pendingQuestionsCount > 0 && (
           <div className="relative" ref={questionsRef}>
             <button
               type="button"


### PR DESCRIPTION
Prevent the pending questions UI from rendering by replacing the conditional `{pendingQuestionsCount > 0}` with a hard `false` guard and adding a comment explaining how to re-enable it. Keeps the existing block in place so it can be restored later by restoring the original condition.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784248721&installation_id=140549914&pr_number=982&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F982&signature=48503891ad98dcc74ef21a316f59dbd3835f4d28ad75bb3c9a6e04d3b72425f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->