### PR TITLE
feat(negotiation): add detail:narrative mode to list_negotiations (EDG-48)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "backend": {
       "name": "protocol",
-      "version": "0.27.5",
+      "version": "0.27.6",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.939.0",
         "@aws-sdk/s3-request-presigner": "^3.983.0",
@@ -111,7 +111,7 @@
     },
     "packages/cli": {
       "name": "@indexnetwork/cli",
-      "version": "0.10.9",
+      "version": "0.10.10",
       "bin": {
         "index": "bin/index.cjs",
       },
@@ -119,15 +119,15 @@
         "@types/bun": "latest",
       },
       "optionalDependencies": {
-        "@indexnetwork/cli-darwin-arm64": "0.10.9",
-        "@indexnetwork/cli-darwin-x64": "0.10.9",
-        "@indexnetwork/cli-linux-arm64": "0.10.9",
-        "@indexnetwork/cli-linux-x64": "0.10.9",
+        "@indexnetwork/cli-darwin-arm64": "0.10.10",
+        "@indexnetwork/cli-darwin-x64": "0.10.10",
+        "@indexnetwork/cli-linux-arm64": "0.10.10",
+        "@indexnetwork/cli-linux-x64": "0.10.10",
       },
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "3.6.3",
+      "version": "3.7.1",
       "dependencies": {
         "@langchain/core": "^1.1.17",
         "@langchain/langgraph": "^1.1.2",
@@ -405,6 +405,14 @@
     "@indexnetwork/claude-plugin": ["@indexnetwork/claude-plugin@workspace:packages/claude-plugin"],
 
     "@indexnetwork/cli": ["@indexnetwork/cli@workspace:packages/cli"],
+
+    "@indexnetwork/cli-darwin-arm64": ["@indexnetwork/cli-darwin-arm64@0.10.10", "", { "os": "darwin", "cpu": "arm64", "bin": { "index": "bin/index" } }, "sha512-db5lVeSb5pBMBBHa8Oh/+bZx5XkmP2XUZvvlKdCtKzr5M5En/r8uSiMZCOzAipcL5roRzWCSAS46NSHGNjkzhw=="],
+
+    "@indexnetwork/cli-darwin-x64": ["@indexnetwork/cli-darwin-x64@0.10.10", "", { "os": "darwin", "cpu": "x64", "bin": { "index": "bin/index" } }, "sha512-qHhudIJnuDMVKvPexawst/ClibsffuTl32bjbRS1oCP4oXCP7piHDH5rlp1yREdChZTcNYQ2M8dbRG+rupqNlg=="],
+
+    "@indexnetwork/cli-linux-arm64": ["@indexnetwork/cli-linux-arm64@0.10.10", "", { "os": "linux", "cpu": "arm64", "bin": { "index": "bin/index" } }, "sha512-cte5BUcrq/pR71zabgE5G3BNSeXWQlkuJZD76xsoeC6l9xCvWSyTqbZniAo7xwWufwVya0BDfInVcFRuvUHzMw=="],
+
+    "@indexnetwork/cli-linux-x64": ["@indexnetwork/cli-linux-x64@0.10.10", "", { "os": "linux", "cpu": "x64", "bin": { "index": "bin/index" } }, "sha512-EzuMP1+MuthfzChKIWAta1ffGcLLz2JPIj2MV4sOwceGCECYETMCxFzNCZMPFGuV+jaUkBYS8m011XP4bAiqoQ=="],
 
     "@indexnetwork/protocol": ["@indexnetwork/protocol@workspace:packages/protocol"],
 

--- a/packages/protocol/src/negotiation/negotiation.tools.ts
+++ b/packages/protocol/src/negotiation/negotiation.tools.ts
@@ -79,6 +79,15 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
         .describe('Maximum negotiations to return per page (1-100). Omit to return all.'),
       page: z.number().int().min(1).optional()
         .describe('Page number (1-based). Only used when limit is provided. Defaults to 1.'),
+      detail: z.enum(['summary', 'narrative']).optional()
+        .describe(
+          'Response detail level. Omit or use "summary" for the default fields. ' +
+          'Use "narrative" to receive additional context per negotiation suitable for ' +
+          'composing a digest or field report: indexContext (the community/network prompt ' +
+          'that seeded the negotiation), recentTurns (last 3 turns with action + message), ' +
+          'and outcome (for completed negotiations). These fields are populated from data ' +
+          'already loaded for the listing, so the extra cost is minimal.',
+        ),
     }),
     handler: async ({ context, query }) => {
       try {
@@ -99,7 +108,7 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
             type?: string;
             maxTurns?: number;
             networkId?: string;
-            turnContext?: { indexContext?: { networkId?: string } };
+            turnContext?: { indexContext?: { networkId?: string; prompt?: string } };
             isContinuation?: boolean;
             priorTurnCount?: number;
           } | null;
@@ -116,7 +125,7 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
           const isSource = meta.sourceUserId === context.userId;
           const counterpartyId = isSource ? meta.candidateUserId : meta.sourceUserId;
 
-          // Get latest message for preview
+          // Get messages for preview (and turns when narrative detail requested)
           const messages = await negotiationDatabase.getMessagesForConversation(task.conversationId);
           const lastMessage = messages[messages.length - 1];
           const lastTurnData = lastMessage
@@ -136,7 +145,7 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
           const isUsersTurn = status !== 'completed' &&
             ((isSource && currentSpeaker === 'source') || (!isSource && currentSpeaker === 'candidate'));
 
-          return {
+          const base = {
             id: task.id,
             counterpartyId: counterpartyId ?? 'unknown',
             role: isSource ? 'source' : 'candidate',
@@ -150,6 +159,39 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
             createdAt: task.createdAt,
             updatedAt: task.updatedAt,
           };
+
+          if (query.detail !== 'narrative') return base;
+
+          // ── Narrative extras (messages already loaded — no extra DB cost) ──
+
+          const RECENT_TURNS_LIMIT = 3;
+          const recentMessages = messages.slice(-RECENT_TURNS_LIMIT);
+          const recentTurns = recentMessages.map((m, sliceIdx) => {
+            const absoluteIdx = messages.length - recentMessages.length + sliceIdx;
+            const speaker = absoluteIdx % 2 === 0 ? 'source' : 'candidate';
+            const td = ((m.parts as Array<{ kind?: string; data?: unknown }>)?.find(p => p.kind === 'data')?.data as { action?: string; message?: string | null } | undefined);
+            return {
+              turnNumber: absoluteIdx + 1,
+              speaker,
+              role: speaker === (isSource ? 'source' : 'candidate') ? 'own' : 'other',
+              action: td?.action ?? 'unknown',
+              message: td?.message ?? null,
+            };
+          });
+
+          const indexContext = meta.turnContext?.indexContext ?? null;
+
+          // Outcome artifact — only meaningful for completed negotiations
+          let outcome: unknown = null;
+          if (status === 'completed') {
+            const artifacts = await negotiationDatabase.getArtifactsForTask(task.id);
+            const outcomeArtifact = artifacts.find(a => a.name === 'negotiation-outcome');
+            outcome = outcomeArtifact
+              ? ((outcomeArtifact.parts as Array<{ kind?: string; data?: unknown }>)?.find(p => p.kind === 'data')?.data ?? null)
+              : null;
+          }
+
+          return { ...base, indexContext, recentTurns, outcome };
         }));
 
         let filtered = negotiations.filter(Boolean);

--- a/packages/protocol/src/negotiation/tests/negotiation.tools.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.tools.spec.ts
@@ -525,6 +525,247 @@ describe("list_negotiations — network scope", () => {
   });
 });
 
+// ── list_negotiations — detail:"narrative" ──────────────────────────────────
+
+describe('list_negotiations — detail:"narrative"', () => {
+  function makeTaskWithContext(
+    state: string,
+    sourceUserId: string,
+    candidateUserId: string,
+    opts: { networkId?: string; id?: string; indexContextPrompt?: string } = {},
+  ) {
+    return {
+      id: opts.id ?? "task-1",
+      conversationId: "conv-1",
+      state,
+      metadata: {
+        type: "negotiation",
+        sourceUserId,
+        candidateUserId,
+        maxTurns: 6,
+        ...(opts.networkId ? { networkId: opts.networkId } : {}),
+        turnContext: {
+          indexContext: { networkId: opts.networkId ?? "net-1", prompt: opts.indexContextPrompt ?? "A community for AI researchers." },
+          sourceUser: {},
+          candidateUser: {},
+          seedAssessment: {},
+        },
+      },
+      createdAt: new Date("2026-01-01"),
+      updatedAt: new Date("2026-01-02"),
+    };
+  }
+
+  test('summary mode (default) does not include narrative fields', async () => {
+    const task = makeTask('working', 'user-src', 'user-cand');
+
+    const deps = {
+      negotiationDatabase: {
+        getTasksForUser: async () => [task],
+        getMessagesForConversation: async () => [],
+      },
+    };
+
+    const tool = captureTool('list_negotiations', deps);
+    const result = JSON.parse(
+      await tool.handler({ context: makeContext('user-src'), query: {} })
+    );
+
+    const item = result.data.negotiations[0];
+    expect(item.indexContext).toBeUndefined();
+    expect(item.recentTurns).toBeUndefined();
+    expect(item.outcome).toBeUndefined();
+  });
+
+  test('narrative mode includes indexContext from task metadata', async () => {
+    const task = makeTaskWithContext('working', 'user-src', 'user-cand', {
+      indexContextPrompt: 'Frontier biotech research community.',
+    });
+
+    const deps = {
+      negotiationDatabase: {
+        getTasksForUser: async () => [task],
+        getMessagesForConversation: async () => [],
+      },
+    };
+
+    const tool = captureTool('list_negotiations', deps);
+    const result = JSON.parse(
+      await tool.handler({ context: makeContext('user-src'), query: { detail: 'narrative' } })
+    );
+
+    const item = result.data.negotiations[0];
+    expect(item.indexContext).not.toBeNull();
+    expect(item.indexContext.prompt).toBe('Frontier biotech research community.');
+  });
+
+  test('narrative mode returns indexContext:null for legacy tasks without turnContext', async () => {
+    const task = makeTask('working', 'user-src', 'user-cand'); // no turnContext
+
+    const deps = {
+      negotiationDatabase: {
+        getTasksForUser: async () => [task],
+        getMessagesForConversation: async () => [],
+      },
+    };
+
+    const tool = captureTool('list_negotiations', deps);
+    const result = JSON.parse(
+      await tool.handler({ context: makeContext('user-src'), query: { detail: 'narrative' } })
+    );
+
+    expect(result.data.negotiations[0].indexContext).toBeNull();
+  });
+
+  test('narrative mode includes recentTurns — last 3 when more than 3 messages exist', async () => {
+    const task = makeTask('working', 'user-src', 'user-cand');
+    const messages = [
+      makeMessage('propose', 'r1', 'turn 1'),
+      makeMessage('counter', 'r2', 'turn 2'),
+      makeMessage('counter', 'r3', 'turn 3'),
+      makeMessage('counter', 'r4', 'turn 4'),
+      makeMessage('question', 'r5', 'turn 5'),
+    ];
+
+    const deps = {
+      negotiationDatabase: {
+        getTasksForUser: async () => [task],
+        getMessagesForConversation: async () => messages,
+      },
+    };
+
+    const tool = captureTool('list_negotiations', deps);
+    const result = JSON.parse(
+      await tool.handler({ context: makeContext('user-src'), query: { detail: 'narrative' } })
+    );
+
+    const turns = result.data.negotiations[0].recentTurns;
+    expect(turns).toHaveLength(3);
+    expect(turns[0].turnNumber).toBe(3);
+    expect(turns[0].message).toBe('turn 3');
+    expect(turns[2].turnNumber).toBe(5);
+    expect(turns[2].message).toBe('turn 5');
+  });
+
+  test('narrative mode recentTurns — fewer than 3 messages returns all', async () => {
+    const task = makeTask('working', 'user-src', 'user-cand');
+    const messages = [
+      makeMessage('propose', 'r1', 'only turn'),
+    ];
+
+    const deps = {
+      negotiationDatabase: {
+        getTasksForUser: async () => [task],
+        getMessagesForConversation: async () => messages,
+      },
+    };
+
+    const tool = captureTool('list_negotiations', deps);
+    const result = JSON.parse(
+      await tool.handler({ context: makeContext('user-src'), query: { detail: 'narrative' } })
+    );
+
+    const turns = result.data.negotiations[0].recentTurns;
+    expect(turns).toHaveLength(1);
+    expect(turns[0].turnNumber).toBe(1);
+    expect(turns[0].action).toBe('propose');
+    expect(turns[0].message).toBe('only turn');
+  });
+
+  test('narrative mode recentTurns — assigns own/other role relative to caller', async () => {
+    const task = makeTask('working', 'user-src', 'user-cand');
+    // turn 1: source speaks (index 0, even → source). Caller is source → own
+    // turn 2: candidate speaks (index 1, odd → candidate). Caller is source → other
+    const messages = [
+      makeMessage('propose', 'r1', 'source speaks'),
+      makeMessage('counter', 'r2', 'candidate speaks'),
+    ];
+
+    const deps = {
+      negotiationDatabase: {
+        getTasksForUser: async () => [task],
+        getMessagesForConversation: async () => messages,
+      },
+    };
+
+    const tool = captureTool('list_negotiations', deps);
+    const result = JSON.parse(
+      await tool.handler({ context: makeContext('user-src'), query: { detail: 'narrative' } })
+    );
+
+    const turns = result.data.negotiations[0].recentTurns;
+    expect(turns[0].role).toBe('own');   // source calling for source → own
+    expect(turns[1].role).toBe('other'); // candidate speaking → other
+  });
+
+  test('narrative mode — active negotiation has outcome:null without hitting artifacts DB', async () => {
+    const task = makeTask('working', 'user-src', 'user-cand');
+    let artifactsCalled = false;
+
+    const deps = {
+      negotiationDatabase: {
+        getTasksForUser: async () => [task],
+        getMessagesForConversation: async () => [],
+        getArtifactsForTask: async () => { artifactsCalled = true; return []; },
+      },
+    };
+
+    const tool = captureTool('list_negotiations', deps);
+    const result = JSON.parse(
+      await tool.handler({ context: makeContext('user-src'), query: { detail: 'narrative' } })
+    );
+
+    expect(result.data.negotiations[0].outcome).toBeNull();
+    expect(artifactsCalled).toBe(false);
+  });
+
+  test('narrative mode — completed negotiation includes outcome from artifact', async () => {
+    const task = makeTask('completed', 'user-src', 'user-cand');
+    const outcomeData = { hasOpportunity: true, reasoning: 'Strong alignment.', turnCount: 4 };
+    const artifact = {
+      name: 'negotiation-outcome',
+      parts: [{ kind: 'data', data: outcomeData }],
+    };
+
+    const deps = {
+      negotiationDatabase: {
+        getTasksForUser: async () => [task],
+        getMessagesForConversation: async () => [],
+        getArtifactsForTask: async () => [artifact],
+      },
+    };
+
+    const tool = captureTool('list_negotiations', deps);
+    const result = JSON.parse(
+      await tool.handler({ context: makeContext('user-src'), query: { detail: 'narrative' } })
+    );
+
+    const item = result.data.negotiations[0];
+    expect(item.outcome).not.toBeNull();
+    expect(item.outcome.hasOpportunity).toBe(true);
+    expect(item.outcome.reasoning).toBe('Strong alignment.');
+  });
+
+  test('narrative mode — completed negotiation with no artifact has outcome:null', async () => {
+    const task = makeTask('completed', 'user-src', 'user-cand');
+
+    const deps = {
+      negotiationDatabase: {
+        getTasksForUser: async () => [task],
+        getMessagesForConversation: async () => [],
+        getArtifactsForTask: async () => [],
+      },
+    };
+
+    const tool = captureTool('list_negotiations', deps);
+    const result = JSON.parse(
+      await tool.handler({ context: makeContext('user-src'), query: { detail: 'narrative' } })
+    );
+
+    expect(result.data.negotiations[0].outcome).toBeNull();
+  });
+});
+
 describe("get_negotiation — network scope", () => {
   test("returns access denied when task is in a different network than caller's scope", async () => {
     const task = makeTask("working", "user-src", "user-cand", { networkId: "net-B" });


### PR DESCRIPTION
## Summary

Adds `detail: "narrative"` to `list_negotiations` so digest and field-report use cases can compose a meaningful narrative in one MCP call instead of N round-trips to `get_negotiation`.

## Why

The afternoon negotiation cron (EDG-48, agentvillage PR #108) needed richer per-negotiation context for the LLM to write Seref's field-report style output. Without this, the cron would need to call `get_negotiation` for every active negotiation — N extra round-trips. With `detail:"narrative"` it gets everything in one call.

## Changes — `packages/protocol/src/negotiation/negotiation.tools.ts`

### New query parameter

```ts
detail: z.enum(['summary', 'narrative']).optional()
```

- **`summary`** (default, current behaviour) — unchanged
- **`narrative`** — adds per negotiation:
  - `indexContext: { networkId, prompt? } | null` — the community/network prompt that seeded the negotiation. Source: `meta.turnContext.indexContext` (already loaded from metadata — no extra DB call)
  - `recentTurns: { turnNumber, speaker, role, action, message }[]` — last 3 turns. Source: messages already loaded for `latestMessagePreview` — no extra DB call
  - `outcome: ... | null` — populated for completed negotiations only. Source: one `getArtifactsForTask` query per completed item

### Cost

- Active negotiations: zero extra DB calls (messages and metadata already loaded)
- Completed negotiations: one artifact query each (only when `detail:"narrative"`)

## Related

- agentvillage PR: https://github.com/Edge-City/agentvillage/pull/108
- Linear: EDG-48

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784288205&installation_id=140549914&pr_number=983&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F983&signature=2b19906aa4cf4d4fb2bba4d1cfe02b2a2728985c2b1e272578bf5b52c1451be6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->