### PR TITLE
feat(profile): source frontend intro from users.intro, off typed profile (IND-362)

### DIFF
--- a/backend/src/services/profile.service.ts
+++ b/backend/src/services/profile.service.ts
@@ -33,7 +33,8 @@ export class ProfileService {
    * Invokes the profile graph to create or update the user's profile.
    * 
    * @param userId - The user ID
-   * @returns Graph execution result with profile data
+   * @returns Graph execution result with profile data, plus a flat `intro` field
+   *   sourced from `users.intro` (the canonical identity bio home).
    */
   async syncProfile(userId: string): Promise<Record<string, unknown>> {
     logger.verbose('[ProfileService] Syncing profile', { userId });
@@ -41,7 +42,11 @@ export class ProfileService {
     const graph = this.factory.createGraph();
     const result = await graph.invoke({ userId });
 
-    return result;
+    // The profile graph persists the identity bio to `users.intro`. Surface it as a
+    // flat field so callers (e.g. the frontend intro display) read the canonical
+    // users-table value instead of the soon-to-be-removed `profile.identity.bio`.
+    const user = await this.db.getUser(userId);
+    return { ...result, intro: user?.intro ?? null };
   }
 
   /**

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -18,11 +18,13 @@ export const createAuthService = (api: ReturnType<typeof useAuthenticatedAPI>) =
     return response.user;
   },
 
-  // Generate intro via profile sync
+  // Generate intro via profile sync. The sync endpoint returns a flat `intro`
+  // sourced from `users.intro` (the canonical identity bio home), so we no longer
+  // read the typed `profile.identity.bio` structure.
   generateIntro: async (): Promise<string | null> => {
     const result = await api.post<Record<string, unknown>>('/profiles/sync');
-    const profile = result?.profile as { identity?: { bio?: string } } | undefined;
-    return profile?.identity?.bio ?? null;
+    const intro = result?.intro as string | undefined;
+    return intro ?? null;
   },
 
   // Permanently delete the authenticated user's account (soft delete)


### PR DESCRIPTION
## WS4 — Resolve Category B typed-structure dependencies (IND-362)

Part of the "Remove user_profiles" epic (IND-357). Blocked-by WS1 (IND-358), now unblocked.

WS3 handled the **Category A** consumers (prose flatteners). WS4 resolves the **Category B** sites that wanted typed structure. After tracing, only **one** is a genuine structural read of the typed profile; the rest already depend on `users` + socials or on the adapter return shape (WS5).

### Change
- **Frontend bio → `users.intro`.** `frontend/src/services/auth.ts` `generateIntro` no longer reads `result.profile.identity.bio`. `ProfileService.syncProfile` (`backend/src/services/profile.service.ts`) now returns a flat `intro` field sourced from `users.intro` (the identity bio home the profile graph already writes to), and the frontend reads `result.intro`.

### Confirmed compliant — no change needed
- **External enrichment sync** (`profile.tools.ts`): `enrichFromUserRecord` builds the Parallel request from `users` + socials only; `buildProfileInput` reads the Parallel `EnrichmentResult` (not `user_profiles`) and flattens to text → premises; `persistApprovedProfileContext` writes the identity triple to the **`users`** table (`name`/`intro`/`location`).

### Deferred (correct boundary)
- **`create_user_profile` "alreadyExists" response** reads `getProfile()`'s typed return shape (the adapter), not `user_profiles` columns — it stays working when WS5 repoints the adapter. Left to **WS5**.
- The `narrative`/`attributes` **column drop** can't happen here — the adapter `getProfile`/`saveProfile` still select/write them. That's **WS5** (adapter collapse) → **WS8** (table drop).

### Verification
- backend `tsc` 0 errors · `auth.controller.spec` 7/7 · eslint 0 errors on changed files
- Frontend `auth.ts` change is type-clean (the repo's pre-existing frontend `tsc` noise is unrelated and not a CI gate)

No `packages/protocol`/`cli` change → no version bump.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784328385&installation_id=140549914&pr_number=993&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F993&signature=293df7d32f36206c944225a95894a5384934b58179a2ec4e13ef008b01963152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->