### PR TITLE
feat(cli): backfill global user_contexts from premises (IND-360)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -21,6 +21,10 @@
     "neon": {
       "type": "http",
       "url": "https://mcp.neon.tech/mcp"
+    },
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
     }
   }
 }

--- a/.pi/extensions/root-dev-guard.ts
+++ b/.pi/extensions/root-dev-guard.ts
@@ -1,8 +1,37 @@
+import { execSync } from "node:child_process";
 import path from "node:path";
 
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 
-const CANONICAL_ROOT = process.env.INDEX_CANONICAL_ROOT ?? "/Users/aposto/Projects/index";
+/**
+ * Resolve the canonical (main) worktree root.
+ * Priority: explicit env override > git's main worktree > current working directory.
+ * `git worktree list` always lists the main worktree first, so we read that rather
+ * than `rev-parse --show-toplevel` (which would point at a linked worktree when cwd
+ * is itself a worktree).
+ */
+function resolveCanonicalRoot(): string {
+	if (process.env.INDEX_CANONICAL_ROOT) {
+		return path.resolve(process.env.INDEX_CANONICAL_ROOT);
+	}
+	try {
+		const firstLine = execSync("git worktree list --porcelain", {
+			cwd: process.cwd(),
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "ignore"],
+		})
+			.split("\n")
+			.find((line) => line.startsWith("worktree "));
+		if (firstLine) {
+			return path.resolve(firstLine.slice("worktree ".length).trim());
+		}
+	} catch {
+		// git not available or not a repo; fall through to cwd.
+	}
+	return path.resolve(process.cwd());
+}
+
+const CANONICAL_ROOT = resolveCanonicalRoot();
 const REQUIRED_BRANCH = process.env.INDEX_ROOT_BRANCH ?? "dev";
 const WORKTREES_DIR = path.join(CANONICAL_ROOT, ".worktrees");
 

--- a/.pi/skills/debug-negotiation-summary-silent/SKILL.md
+++ b/.pi/skills/debug-negotiation-summary-silent/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: debug-negotiation-summary-silent
+description: Diagnose why the Edge/AgentVillage afternoon negotiation-summary cron "triggered but sent no Telegram message" on a tenant sidecar. Use when a user manually triggered the negotiation summary and nothing arrived. Walks the dedup-by-design check (heartbeat-state reportedCompletedIds), a non-mutating sidecar probe of the data script, and rules out OpenRouter/Telegram/index-MCP causes. The usual cause is correct anti-spam dedup, not a bug.
+---
+
+# debug-negotiation-summary-silent
+
+The negotiation-summary cron (`Edge — negotiation summary`, ~14:00 staggered, delivered via `--deliver telegram`) is **silent by design** when there's nothing *new* to report. A user who manually re-triggers it after a previous successful run will usually get **no message** — and that is correct, not broken.
+
+The script is `skills/index-network/scripts/summarize-negotiations.ts` (in the `Edge-City/agentvillage` submodule). It buckets negotiations into `needsAttention` (active + your turn), `waiting` (active + their turn), `newlyResolved` (completed, updated ≤7d, **not already reported**), and emits `[SILENT]` when all three are empty. Completed negotiations already announced are tracked in `memory/heartbeat-state.json` → `negotiationSummary.reportedCompletedIds`, so the same concluded thread is never re-sent.
+
+## First: rule out the scary causes (control-plane, read-only)
+
+Get control-plane creds from its Railway vars (`CONTROL_PLANE_API_KEY`, domain `control-plane-production-b752.up.railway.app`) — see `railway-mcp-edge-city` for the snake_case IDs. Then for the tenant (look up by email):
+
+```bash
+CP="https://control-plane-production-b752.up.railway.app"; KEY="<CONTROL_PLANE_API_KEY>"
+curl -sf "$CP/tenants" -H "Authorization: Bearer $KEY" | jq -r '(.tenants//.results//.)[]|[.id,.email]|@tsv' | grep <email>
+curl -sf "$CP/tenants/<tenantId>?detail=1" -H "Authorization: Bearer $KEY" | jq '{status,sidecarReady,gatewayReady,telegramUserId,approvedTelegramUsers,openrouter}'
+```
+
+Healthy tenant = `status:"live"`, `sidecarReady/gatewayReady:true`, `openrouter.disabled:false` with credit, Telegram user id present in `approvedTelegramUsers`. If those are green, it is **not** a deploy/credits/Telegram-config failure.
+
+> Railway deploy logs for these sidecars are unreliable for this: the stream only shows gateway/process noise and is often frozen hours behind; the cron session stdout is **not** surfaced. Don't try to confirm the run from `railway_get_logs` — probe the script directly instead.
+
+## Then: probe + reset on the sidecar (decisive)
+
+The Railway MCP has **no exec/file tool**, and pool sidecars (`hermes-pool-<hex>`) have only an internal domain. So the user (or anyone with the Railway CLI) must shell in. Find the tenant's sidecar via `railwayServiceId` in the `?detail=1` payload.
+
+```bash
+railway ssh        # agentvillage-controlplane → production → hermes-pool-<hex>
+cd /opt/data
+
+# 1. What does the cron actually see? Throwaway state = no dedup, no mutation:
+bun skills/index-network/scripts/summarize-negotiations.ts --state-file /tmp/probe.json; echo
+#   [SILENT]  -> nothing to report (dedup, or index-MCP fetch failed) — data side
+#   {JSON...} -> data is fine; problem is delivery or the trigger ran a DIFFERENT cron
+
+# 2. Confirm the real dedup state:
+jq '.negotiationSummary.reportedCompletedIds' memory/heartbeat-state.json
+
+# 3. To force a re-render of an already-reported (connected) thread, clear ONLY that list:
+jq '.negotiationSummary.reportedCompletedIds = []' memory/heartbeat-state.json > /tmp/h.json \
+  && mv /tmp/h.json memory/heartbeat-state.json
+```
+
+Then **re-trigger** and the summary lands (verified: clearing the list re-qualifies a connected thread as `newlyResolved`). Emptying the array (vs deleting the file) preserves sibling state like the digest dedup.
+
+## Gotchas
+
+- **Wrong cron**: the tenant dashboard "Generate" button triggers the **morning digest**, NOT the negotiation summary. Confirm how the user triggered — if it's the dashboard, that alone explains the missing negotiation summary.
+- **Timing**: the cron composes via an LLM session then delivers; allow 1–2 min before declaring it silent.
+- **`[SILENT]` is success**, not an error — both an empty bucket set and an index-MCP fetch failure produce it (the script swallows fetch errors → `silent: "mcp-fetch-failed"`).
+- Don't run the script against the real `memory/heartbeat-state.json` for a probe — it persists `reportedCompletedIds` and re-arms the dedup. Use a `/tmp` state file.
+
+See also: `railway-mcp-edge-city` (sidecar IDs + the snake_case gotcha), `audit-digests` (digest card quality).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ bun run maintenance:update:embeddings       # Regenerate embeddings
 bun run maintenance:decompose-profiles      # Backfill: decompose profiles into premises
 bun run maintenance:backfill-premises       # Backfill: enqueue enrichment for users in a network
 bun run maintenance:backfill-context-hyde   # Backfill: generate HyDE docs for user contexts
+bun run maintenance:backfill-global-user-contexts # Backfill: generate the global user_context (networkId=null) for every user from premises (decomposes legacy profiles first)
 bun run maintenance:backfill-profile-questions # Backfill: enqueue profile-gap question generation for existing users
 bun run maintenance:backfill-intent-questions # Backfill: enqueue intent-refinement question generation (most recent active intent per user)
 bun run maintenance:compare-discovery       # Compare profile-HyDE vs context discovery strategies

--- a/backend/package.json
+++ b/backend/package.json
@@ -36,6 +36,7 @@
     "maintenance:backfill-premises": "bun ./src/cli/backfill-premises.ts",
     "maintenance:compare-discovery": "bun ./src/cli/compare-discovery.ts",
     "maintenance:backfill-context-hyde": "bun ./src/cli/backfill-context-hyde.ts",
+    "maintenance:backfill-global-user-contexts": "bun ./src/cli/backfill-global-user-contexts.ts",
     "maintenance:backfill-profile-questions": "bun ./src/cli/backfill-profile-questions.ts",
     "maintenance:backfill-intent-questions": "bun ./src/cli/backfill-intent-questions.ts",
     "maintenance:backfill-personal-index-prompts": "bun ./src/cli/backfill-personal-index-prompts.ts",

--- a/backend/src/cli/backfill-global-user-contexts.ts
+++ b/backend/src/cli/backfill-global-user-contexts.ts
@@ -26,31 +26,33 @@
  *
  * Usage:
  *   bun run maintenance:backfill-global-user-contexts [--limit N] [--dry-run] [--no-decompose]
+ *
+ * The orchestration core ({@link classifyCandidates}, {@link runBackfill},
+ * {@link buildProfileText}) is exported and dependency-injected so it can be unit
+ * tested without a live DB or LLM (see `tests/backfill-global-user-contexts.spec.ts`).
  */
 import dotenv from 'dotenv';
 import path from 'path';
 
-// Safe default: development unless NODE_ENV is *explicitly* production.
-const envFile = process.env.NODE_ENV === 'production' ? '.env.production' : '.env.development';
-dotenv.config({ path: path.resolve(process.cwd(), envFile) });
+// Side-effecting env load + adapter wiring only run when this file is the entrypoint,
+// so importing the pure orchestration core from a test never touches the DB/LLM.
+const isEntrypoint = import.meta.main;
 
-import { sql } from 'drizzle-orm';
-import { PremiseDecomposer, PremiseGraphFactory } from '@indexnetwork/protocol';
-import type { PremiseGraphDatabase } from '@indexnetwork/protocol';
-
-import db, { closeDb } from '../lib/drizzle/drizzle';
-import { ChatDatabaseAdapter } from '../adapters/database.adapter';
-import { EmbedderAdapter } from '../adapters/embedder.adapter';
-import { ensureGlobalUserContext } from '../lib/usercontext/global-context';
+if (isEntrypoint) {
+  // Safe default: development unless NODE_ENV is *explicitly* production.
+  const envFile = process.env.NODE_ENV === 'production' ? '.env.production' : '.env.development';
+  dotenv.config({ path: path.resolve(process.cwd(), envFile) });
+}
 
 /** Enrichment-path confidence — mirrors decompose-profiles (derived from profile text, not explicit). */
 const ENRICHMENT_CONFIDENCE = 0.85;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
-interface ProfileIdentity { name: string; bio: string; location: string }
-interface ProfileNarrative { context: string }
-interface ProfileAttributes { interests: string[]; skills: string[] }
+export interface ProfileIdentity { name: string; bio: string; location: string }
+export interface ProfileNarrative { context: string }
+export interface ProfileAttributes { interests: string[]; skills: string[] }
 
-type CandidateRow = {
+export type CandidateRow = {
   user_id: string;
   email: string;
   premise_count: number;
@@ -59,42 +61,68 @@ type CandidateRow = {
   attributes: ProfileAttributes | null;
 };
 
-// ---------------------------------------------------------------------------
-// Arg parsing
-// ---------------------------------------------------------------------------
+/** A decomposed premise as produced by `PremiseDecomposer`. */
+export interface DecomposedPremise {
+  text: string;
+  tier: 'assertive' | 'contextual';
+  validityDays?: number;
+}
 
-function parseArgs(): { limit: number | null; dryRun: boolean; decompose: boolean } {
-  const args = process.argv.slice(2);
+/** Input passed to {@link BackfillDeps.createPremise} (provenance is fixed by the caller). */
+export interface CreatePremiseInput {
+  userId: string;
+  assertionText: string;
+  tier: 'assertive' | 'contextual';
+  volatile: boolean;
+  validUntil?: string;
+}
 
-  let limit: number | null = null;
-  const limitIdx = args.indexOf('--limit');
-  if (limitIdx !== -1) {
-    limit = Number(args[limitIdx + 1]);
-  } else {
-    const eqArg = args.find((a) => a.startsWith('--limit='));
-    if (eqArg) limit = Number(eqArg.split('=')[1]);
-  }
-  if (limit !== null && (!Number.isInteger(limit) || limit <= 0)) {
-    console.error('--limit must be a positive integer');
-    process.exit(1);
-  }
+/**
+ * Injectable seams for {@link runBackfill}. The CLI binds these to the real
+ * decomposer / premise graph / global-context helper; tests pass mocks so the
+ * branching (idempotent skip, decompose path, no-data skip, failure counting) is
+ * exercised without a DB or LLM. Mirrors the `EnsureGlobalUserContextDeps` pattern.
+ */
+export interface BackfillDeps {
+  /** Decompose legacy profile text into atomic premises. */
+  decomposeProfile: (text: string) => Promise<DecomposedPremise[]>;
+  /** Persist one premise; resolves `true` when a new premise was created (not a near-duplicate). */
+  createPremise: (input: CreatePremiseInput) => Promise<boolean>;
+  /** Synthesize + upsert the global context from ACTIVE premises; '' on no premises / failure. */
+  ensureGlobalContext: (userId: string) => Promise<string>;
+  log?: (msg: string) => void;
+  logError?: (msg: string) => void;
+}
 
-  return {
-    limit,
-    dryRun: args.includes('--dry-run'),
-    decompose: !args.includes('--no-decompose'),
-  };
+export interface BackfillOptions {
+  limit: number | null;
+  dryRun: boolean;
+  decompose: boolean;
+}
+
+export interface BackfillResult {
+  generated: number;
+  decomposedUsers: number;
+  skipped: number;
+  failed: number;
+}
+
+export interface Classification {
+  total: number;
+  withPremises: number;
+  needDecompose: number;
+  noData: number;
 }
 
 // ---------------------------------------------------------------------------
-// Profile text builder (mirrors decompose-profiles.buildProfileText)
+// Pure helpers (exported for testing)
 // ---------------------------------------------------------------------------
 
 /**
  * Assembles a text blob from legacy profile fields, skipping empty values.
  * @returns A newline-joined text suitable for premise decomposition, or '' when empty.
  */
-function buildProfileText(
+export function buildProfileText(
   identity: ProfileIdentity | null,
   narrative: ProfileNarrative | null,
   attributes: ProfileAttributes | null,
@@ -109,148 +137,223 @@ function buildProfileText(
   return lines.join('\n');
 }
 
-// ---------------------------------------------------------------------------
-// Main
-// ---------------------------------------------------------------------------
-
-const main = async (): Promise<void> => {
-  const { limit, dryRun, decompose } = parseArgs();
-  console.log(
-    `backfill-global-user-contexts: env=${envFile} limit=${limit ?? 'none'} dry-run=${dryRun} decompose=${decompose}`,
-  );
-
-  // Idempotent candidate set: live, non-ghost users WITHOUT a global context row
-  // (networkId IS NULL). Ordered by premise count so the cheap, high-signal users
-  // (already have premises) go first.
-  const candidates = await db.execute<CandidateRow>(sql`
-    SELECT
-      u.id AS user_id,
-      u.email,
-      (
-        SELECT count(*)::int FROM premises p
-        WHERE p.user_id = u.id AND p.deleted_at IS NULL AND p.status = 'ACTIVE'
-      ) AS premise_count,
-      up.identity,
-      up.narrative,
-      up.attributes
-    FROM users u
-    LEFT JOIN user_profiles up ON up.user_id = u.id
-    WHERE u.deleted_at IS NULL
-      AND u.is_ghost = false
-      AND NOT EXISTS (
-        SELECT 1 FROM user_contexts uc
-        WHERE uc.user_id = u.id AND uc.network_id IS NULL
-      )
-    ORDER BY premise_count DESC
-    ${limit !== null ? sql`LIMIT ${limit}` : sql``}
-  `);
-
-  console.log(`Users without a global user_context: ${candidates.length}`);
-  if (candidates.length === 0) return;
-
-  if (dryRun) {
-    let withPremises = 0;
-    let needDecompose = 0;
-    let noData = 0;
-    for (const c of candidates) {
-      if (c.premise_count > 0) withPremises++;
-      else if (buildProfileText(c.identity, c.narrative, c.attributes).trim()) needDecompose++;
-      else noData++;
-    }
-    console.log(`  [dry-run] ${withPremises} have active premises -> generate global context directly`);
-    console.log(`  [dry-run] ${needDecompose} have no premises but legacy profile text -> decompose first${decompose ? '' : ' (SKIPPED: --no-decompose)'}`);
-    console.log(`  [dry-run] ${noData} have no premises and no profile text -> skipped (nothing to synthesize)`);
-    return;
+/**
+ * Classify candidates for the `--dry-run` preview without any side effects.
+ * @param candidates - Users missing a global context row.
+ * @param decompose - Whether the no-premises population would be decomposed.
+ * @returns Counts of each disposition.
+ */
+export function classifyCandidates(candidates: CandidateRow[], decompose: boolean): Classification {
+  let withPremises = 0;
+  let needDecompose = 0;
+  let noData = 0;
+  for (const c of candidates) {
+    if (c.premise_count > 0) withPremises++;
+    else if (decompose && buildProfileText(c.identity, c.narrative, c.attributes).trim()) needDecompose++;
+    else noData++;
   }
+  return { total: candidates.length, withPremises, needDecompose, noData };
+}
 
-  const database = new ChatDatabaseAdapter();
-  const embedder = new EmbedderAdapter();
-  const decomposer = new PremiseDecomposer();
-  const premiseGraph = new PremiseGraphFactory(
-    database as unknown as PremiseGraphDatabase,
-    embedder,
-  ).createGraph();
+// ---------------------------------------------------------------------------
+// Orchestration core (exported for testing, dependency-injected)
+// ---------------------------------------------------------------------------
 
-  let generated = 0;
-  let decomposedUsers = 0;
-  let skipped = 0;
-  let failed = 0;
+/**
+ * Process the candidate set: for each user, decompose their legacy profile into
+ * premises when they have none (population 2), then synthesize + upsert the global
+ * context. Pure orchestration — all IO is injected via {@link BackfillDeps}.
+ *
+ * @param candidates - Users missing a global context row.
+ * @param opts - `decompose` controls whether population 2 is decomposed; `limit`/`dryRun` are handled by the caller.
+ * @param deps - Injected decomposer / premise writer / global-context synthesizer.
+ * @returns Tallies of generated, decomposed, skipped, and failed users.
+ */
+export async function runBackfill(
+  candidates: CandidateRow[],
+  opts: Pick<BackfillOptions, 'decompose'>,
+  deps: BackfillDeps,
+): Promise<BackfillResult> {
+  const log = deps.log ?? (() => {});
+  const logError = deps.logError ?? (() => {});
+  const result: BackfillResult = { generated: 0, decomposedUsers: 0, skipped: 0, failed: 0 };
 
   for (const [i, c] of candidates.entries()) {
     const label = `[${i + 1}/${candidates.length}] ${c.email}`;
     try {
       // Population 2: no premises yet — decompose the legacy profile into premises first.
       if (c.premise_count === 0) {
-        if (!decompose) {
-          skipped++;
-          console.log(`  ${label} — no premises, --no-decompose -> skipped`);
+        if (!opts.decompose) {
+          result.skipped++;
+          log(`  ${label} — no premises, --no-decompose -> skipped`);
           continue;
         }
         const profileText = buildProfileText(c.identity, c.narrative, c.attributes);
         if (!profileText.trim()) {
-          skipped++;
-          console.log(`  ${label} — no premises, no profile text -> skipped`);
+          result.skipped++;
+          log(`  ${label} — no premises, no profile text -> skipped`);
           continue;
         }
 
-        const result = await decomposer.invoke(profileText);
+        const premises = await deps.decomposeProfile(profileText);
         let created = 0;
-        for (const p of result.premises) {
-          // Mirror decompose-profiles / decomposePremisesNode: contextual premises
-          // carry an LLM-inferred validity window and are volatile; assertive don't expire.
+        for (const p of premises) {
+          // Mirror decompose-profiles / decomposePremisesNode: contextual premises carry
+          // an LLM-inferred validity window and are volatile; assertive don't expire.
           const isContextual = p.tier === 'contextual';
           const validUntil = isContextual && p.validityDays
-            ? new Date(Date.now() + p.validityDays * 24 * 60 * 60 * 1000).toISOString()
+            ? new Date(Date.now() + p.validityDays * MS_PER_DAY).toISOString()
             : undefined;
-          const premiseResult = await premiseGraph.invoke({
+          const wasCreated = await deps.createPremise({
             userId: c.user_id,
             assertionText: p.text,
-            tier: p.tier as 'assertive' | 'contextual',
+            tier: p.tier,
             volatile: isContextual,
             ...(validUntil ? { validUntil } : {}),
-            provenanceSource: 'enrichment' as const,
-            provenanceConfidence: ENRICHMENT_CONFIDENCE,
           });
-          if (premiseResult.premise) created++;
+          if (wasCreated) created++;
         }
-        decomposedUsers++;
-        console.log(`  ${label} — decomposed legacy profile -> ${created} premise(s)`);
+        result.decomposedUsers++;
+        log(`  ${label} — decomposed legacy profile -> ${created} premise(s)`);
         if (created === 0) {
-          skipped++;
-          console.log(`  ${label} — no premises created -> skipped global context`);
+          result.skipped++;
+          log(`  ${label} — no premises created -> skipped global context`);
           continue;
         }
       }
 
       // Both populations: synthesize + upsert the global context from ACTIVE premises.
-      // ensureGlobalUserContext is idempotent and swallows errors (returns ''), so an
-      // empty result here means generation failed or there were no usable premises.
-      const text = await ensureGlobalUserContext(c.user_id);
+      // ensureGlobalContext is idempotent and swallows errors (returns ''), so an empty
+      // result here means generation failed or there were no usable premises.
+      const text = await deps.ensureGlobalContext(c.user_id);
       if (text) {
-        generated++;
-        console.log(`  ${label} — global context generated (${text.length} chars)`);
+        result.generated++;
+        log(`  ${label} — global context generated (${text.length} chars)`);
       } else {
-        failed++;
-        console.error(`  ${label} — FAILED: empty global context (no usable premises or generation error)`);
+        result.failed++;
+        logError(`  ${label} — FAILED: empty global context (no usable premises or generation error)`);
       }
     } catch (err) {
-      failed++;
-      const msg = err instanceof Error ? err.message : `${err}`;
-      console.error(`  ${label} — FAILED: ${msg}`);
+      result.failed++;
+      logError(`  ${label} — FAILED: ${err instanceof Error ? err.message : `${err}`}`);
     }
   }
 
-  console.log(
-    `\nDone. ${generated} global context(s) generated (${decomposedUsers} required profile decomposition first), ${skipped} skipped, ${failed} failed.`,
-  );
-  if (failed > 0) process.exitCode = 1;
-};
+  return result;
+}
 
-main()
-  .then(() => closeDb())
-  .catch(async (err: unknown) => {
-    const msg = err instanceof Error ? err.message : `${err}`;
-    console.error('backfill-global-user-contexts failed:', msg);
+// ---------------------------------------------------------------------------
+// Arg parsing
+// ---------------------------------------------------------------------------
+
+export function parseArgs(argv: string[]): BackfillOptions {
+  let limit: number | null = null;
+  const limitIdx = argv.indexOf('--limit');
+  if (limitIdx !== -1) {
+    limit = Number(argv[limitIdx + 1]);
+  } else {
+    const eqArg = argv.find((a) => a.startsWith('--limit='));
+    if (eqArg) limit = Number(eqArg.split('=')[1]);
+  }
+  if (limit !== null && (!Number.isInteger(limit) || limit <= 0)) {
+    console.error('--limit must be a positive integer');
+    process.exit(1);
+  }
+  return { limit, dryRun: argv.includes('--dry-run'), decompose: !argv.includes('--no-decompose') };
+}
+
+// ---------------------------------------------------------------------------
+// Main (entrypoint only — wires real adapters)
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const { sql } = await import('drizzle-orm');
+  const { PremiseDecomposer, PremiseGraphFactory } = await import('@indexnetwork/protocol');
+  type PremiseGraphDatabase = import('@indexnetwork/protocol').PremiseGraphDatabase;
+  const { default: db, closeDb } = await import('../lib/drizzle/drizzle');
+  const { ChatDatabaseAdapter } = await import('../adapters/database.adapter');
+  const { EmbedderAdapter } = await import('../adapters/embedder.adapter');
+  const { ensureGlobalUserContext } = await import('../lib/usercontext/global-context');
+
+  const opts = parseArgs(process.argv.slice(2));
+  const envFile = process.env.NODE_ENV === 'production' ? '.env.production' : '.env.development';
+  console.log(
+    `backfill-global-user-contexts: env=${envFile} limit=${opts.limit ?? 'none'} dry-run=${opts.dryRun} decompose=${opts.decompose}`,
+  );
+
+  try {
+    // Idempotent candidate set: live, non-ghost users WITHOUT a global context row
+    // (networkId IS NULL). Ordered by premise count so cheap high-signal users go first.
+    const candidates = await db.execute<CandidateRow>(sql`
+      SELECT
+        u.id AS user_id,
+        u.email,
+        (
+          SELECT count(*)::int FROM premises p
+          WHERE p.user_id = u.id AND p.deleted_at IS NULL AND p.status = 'ACTIVE'
+        ) AS premise_count,
+        up.identity,
+        up.narrative,
+        up.attributes
+      FROM users u
+      LEFT JOIN user_profiles up ON up.user_id = u.id
+      WHERE u.deleted_at IS NULL
+        AND u.is_ghost = false
+        AND NOT EXISTS (
+          SELECT 1 FROM user_contexts uc
+          WHERE uc.user_id = u.id AND uc.network_id IS NULL
+        )
+      ORDER BY premise_count DESC
+      ${opts.limit !== null ? sql`LIMIT ${opts.limit}` : sql``}
+    `);
+
+    console.log(`Users without a global user_context: ${candidates.length}`);
+    if (candidates.length === 0) return;
+
+    if (opts.dryRun) {
+      const c = classifyCandidates(candidates, opts.decompose);
+      console.log(`  [dry-run] ${c.withPremises} have active premises -> generate global context directly`);
+      console.log(`  [dry-run] ${c.needDecompose} have no premises but legacy profile text -> decompose first`);
+      console.log(`  [dry-run] ${c.noData} have no premises and no usable profile text -> skipped${opts.decompose ? '' : ' (--no-decompose)'}`);
+      return;
+    }
+
+    const database = new ChatDatabaseAdapter();
+    const embedder = new EmbedderAdapter();
+    const decomposer = new PremiseDecomposer();
+    const premiseGraph = new PremiseGraphFactory(
+      database as unknown as PremiseGraphDatabase,
+      embedder,
+    ).createGraph();
+
+    const deps: BackfillDeps = {
+      decomposeProfile: async (text) => (await decomposer.invoke(text)).premises as DecomposedPremise[],
+      createPremise: async (input) => {
+        const res = await premiseGraph.invoke({
+          ...input,
+          provenanceSource: 'enrichment' as const,
+          provenanceConfidence: ENRICHMENT_CONFIDENCE,
+        });
+        return !!res.premise;
+      },
+      ensureGlobalContext: ensureGlobalUserContext,
+      log: (m) => console.log(m),
+      logError: (m) => console.error(m),
+    };
+
+    const r = await runBackfill(candidates, opts, deps);
+    console.log(
+      `\nDone. ${r.generated} global context(s) generated (${r.decomposedUsers} required profile decomposition first), ${r.skipped} skipped, ${r.failed} failed.`,
+    );
+    if (r.failed > 0) process.exitCode = 1;
+  } finally {
     await closeDb().catch(() => {});
+  }
+}
+
+if (isEntrypoint) {
+  main().catch((err: unknown) => {
+    console.error('backfill-global-user-contexts failed:', err instanceof Error ? err.message : `${err}`);
     process.exit(1);
   });
+}

--- a/backend/src/cli/backfill-global-user-contexts.ts
+++ b/backend/src/cli/backfill-global-user-contexts.ts
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+/**
+ * Backfill CLI: generate the missing **global** `user_context` row (networkId = null)
+ * for every user, synthesized from their ACTIVE premises. The global row is the
+ * profile-replacing identity projection (WS7 of the `user_profiles` removal epic,
+ * IND-360) and must exist before the WS6 surface cutover, otherwise legacy users
+ * read blank.
+ *
+ * Two legacy populations are migrated in a single resumable pass:
+ *   1. Users WITH active premises but no global `user_context` row — synthesize the
+ *      global context directly via {@link ensureGlobalUserContext} (no HyDE; the
+ *      global row is intentionally excluded from context-to-intent discovery).
+ *   2. Users with NO active premises but a legacy `user_profiles` row — decompose the
+ *      profile text into premises first (same path as `decompose-profiles` / WS2),
+ *      then synthesize the global context. Disable with `--no-decompose`.
+ *
+ * Idempotent + resumable: users that already have a global row are excluded by the
+ * candidate query, so re-running only processes what's left. Runs entirely
+ * in-process — no Redis worker required.
+ *
+ * Requires LLM/embedding env vars (OPENROUTER_API_KEY + embedding config), since
+ * context synthesis and premise creation run in-process.
+ *
+ * Safety: defaults to the **development** environment. Targeting production requires
+ * explicitly setting `NODE_ENV=production` (no accidental prod writes from an unset env).
+ *
+ * Usage:
+ *   bun run maintenance:backfill-global-user-contexts [--limit N] [--dry-run] [--no-decompose]
+ */
+import dotenv from 'dotenv';
+import path from 'path';
+
+// Safe default: development unless NODE_ENV is *explicitly* production.
+const envFile = process.env.NODE_ENV === 'production' ? '.env.production' : '.env.development';
+dotenv.config({ path: path.resolve(process.cwd(), envFile) });
+
+import { sql } from 'drizzle-orm';
+import { PremiseDecomposer, PremiseGraphFactory } from '@indexnetwork/protocol';
+import type { PremiseGraphDatabase } from '@indexnetwork/protocol';
+
+import db, { closeDb } from '../lib/drizzle/drizzle';
+import { ChatDatabaseAdapter } from '../adapters/database.adapter';
+import { EmbedderAdapter } from '../adapters/embedder.adapter';
+import { ensureGlobalUserContext } from '../lib/usercontext/global-context';
+
+/** Enrichment-path confidence — mirrors decompose-profiles (derived from profile text, not explicit). */
+const ENRICHMENT_CONFIDENCE = 0.85;
+
+interface ProfileIdentity { name: string; bio: string; location: string }
+interface ProfileNarrative { context: string }
+interface ProfileAttributes { interests: string[]; skills: string[] }
+
+type CandidateRow = {
+  user_id: string;
+  email: string;
+  premise_count: number;
+  identity: ProfileIdentity | null;
+  narrative: ProfileNarrative | null;
+  attributes: ProfileAttributes | null;
+};
+
+// ---------------------------------------------------------------------------
+// Arg parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs(): { limit: number | null; dryRun: boolean; decompose: boolean } {
+  const args = process.argv.slice(2);
+
+  let limit: number | null = null;
+  const limitIdx = args.indexOf('--limit');
+  if (limitIdx !== -1) {
+    limit = Number(args[limitIdx + 1]);
+  } else {
+    const eqArg = args.find((a) => a.startsWith('--limit='));
+    if (eqArg) limit = Number(eqArg.split('=')[1]);
+  }
+  if (limit !== null && (!Number.isInteger(limit) || limit <= 0)) {
+    console.error('--limit must be a positive integer');
+    process.exit(1);
+  }
+
+  return {
+    limit,
+    dryRun: args.includes('--dry-run'),
+    decompose: !args.includes('--no-decompose'),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Profile text builder (mirrors decompose-profiles.buildProfileText)
+// ---------------------------------------------------------------------------
+
+/**
+ * Assembles a text blob from legacy profile fields, skipping empty values.
+ * @returns A newline-joined text suitable for premise decomposition, or '' when empty.
+ */
+function buildProfileText(
+  identity: ProfileIdentity | null,
+  narrative: ProfileNarrative | null,
+  attributes: ProfileAttributes | null,
+): string {
+  const lines: string[] = [];
+  if (identity?.name) lines.push(`My name is ${identity.name}.`);
+  if (identity?.location) lines.push(`I am based in ${identity.location}.`);
+  if (identity?.bio) lines.push(identity.bio);
+  if (narrative?.context) lines.push(narrative.context);
+  if (attributes?.skills?.length) lines.push(`My skills include ${attributes.skills.join(', ')}.`);
+  if (attributes?.interests?.length) lines.push(`My interests include ${attributes.interests.join(', ')}.`);
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+const main = async (): Promise<void> => {
+  const { limit, dryRun, decompose } = parseArgs();
+  console.log(
+    `backfill-global-user-contexts: env=${envFile} limit=${limit ?? 'none'} dry-run=${dryRun} decompose=${decompose}`,
+  );
+
+  // Idempotent candidate set: live, non-ghost users WITHOUT a global context row
+  // (networkId IS NULL). Ordered by premise count so the cheap, high-signal users
+  // (already have premises) go first.
+  const candidates = await db.execute<CandidateRow>(sql`
+    SELECT
+      u.id AS user_id,
+      u.email,
+      (
+        SELECT count(*)::int FROM premises p
+        WHERE p.user_id = u.id AND p.deleted_at IS NULL AND p.status = 'ACTIVE'
+      ) AS premise_count,
+      up.identity,
+      up.narrative,
+      up.attributes
+    FROM users u
+    LEFT JOIN user_profiles up ON up.user_id = u.id
+    WHERE u.deleted_at IS NULL
+      AND u.is_ghost = false
+      AND NOT EXISTS (
+        SELECT 1 FROM user_contexts uc
+        WHERE uc.user_id = u.id AND uc.network_id IS NULL
+      )
+    ORDER BY premise_count DESC
+    ${limit !== null ? sql`LIMIT ${limit}` : sql``}
+  `);
+
+  console.log(`Users without a global user_context: ${candidates.length}`);
+  if (candidates.length === 0) return;
+
+  if (dryRun) {
+    let withPremises = 0;
+    let needDecompose = 0;
+    let noData = 0;
+    for (const c of candidates) {
+      if (c.premise_count > 0) withPremises++;
+      else if (buildProfileText(c.identity, c.narrative, c.attributes).trim()) needDecompose++;
+      else noData++;
+    }
+    console.log(`  [dry-run] ${withPremises} have active premises -> generate global context directly`);
+    console.log(`  [dry-run] ${needDecompose} have no premises but legacy profile text -> decompose first${decompose ? '' : ' (SKIPPED: --no-decompose)'}`);
+    console.log(`  [dry-run] ${noData} have no premises and no profile text -> skipped (nothing to synthesize)`);
+    return;
+  }
+
+  const database = new ChatDatabaseAdapter();
+  const embedder = new EmbedderAdapter();
+  const decomposer = new PremiseDecomposer();
+  const premiseGraph = new PremiseGraphFactory(
+    database as unknown as PremiseGraphDatabase,
+    embedder,
+  ).createGraph();
+
+  let generated = 0;
+  let decomposedUsers = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const [i, c] of candidates.entries()) {
+    const label = `[${i + 1}/${candidates.length}] ${c.email}`;
+    try {
+      // Population 2: no premises yet — decompose the legacy profile into premises first.
+      if (c.premise_count === 0) {
+        if (!decompose) {
+          skipped++;
+          console.log(`  ${label} — no premises, --no-decompose -> skipped`);
+          continue;
+        }
+        const profileText = buildProfileText(c.identity, c.narrative, c.attributes);
+        if (!profileText.trim()) {
+          skipped++;
+          console.log(`  ${label} — no premises, no profile text -> skipped`);
+          continue;
+        }
+
+        const result = await decomposer.invoke(profileText);
+        let created = 0;
+        for (const p of result.premises) {
+          // Mirror decompose-profiles / decomposePremisesNode: contextual premises
+          // carry an LLM-inferred validity window and are volatile; assertive don't expire.
+          const isContextual = p.tier === 'contextual';
+          const validUntil = isContextual && p.validityDays
+            ? new Date(Date.now() + p.validityDays * 24 * 60 * 60 * 1000).toISOString()
+            : undefined;
+          const premiseResult = await premiseGraph.invoke({
+            userId: c.user_id,
+            assertionText: p.text,
+            tier: p.tier as 'assertive' | 'contextual',
+            volatile: isContextual,
+            ...(validUntil ? { validUntil } : {}),
+            provenanceSource: 'enrichment' as const,
+            provenanceConfidence: ENRICHMENT_CONFIDENCE,
+          });
+          if (premiseResult.premise) created++;
+        }
+        decomposedUsers++;
+        console.log(`  ${label} — decomposed legacy profile -> ${created} premise(s)`);
+        if (created === 0) {
+          skipped++;
+          console.log(`  ${label} — no premises created -> skipped global context`);
+          continue;
+        }
+      }
+
+      // Both populations: synthesize + upsert the global context from ACTIVE premises.
+      // ensureGlobalUserContext is idempotent and swallows errors (returns ''), so an
+      // empty result here means generation failed or there were no usable premises.
+      const text = await ensureGlobalUserContext(c.user_id);
+      if (text) {
+        generated++;
+        console.log(`  ${label} — global context generated (${text.length} chars)`);
+      } else {
+        failed++;
+        console.error(`  ${label} — FAILED: empty global context (no usable premises or generation error)`);
+      }
+    } catch (err) {
+      failed++;
+      const msg = err instanceof Error ? err.message : `${err}`;
+      console.error(`  ${label} — FAILED: ${msg}`);
+    }
+  }
+
+  console.log(
+    `\nDone. ${generated} global context(s) generated (${decomposedUsers} required profile decomposition first), ${skipped} skipped, ${failed} failed.`,
+  );
+  if (failed > 0) process.exitCode = 1;
+};
+
+main()
+  .then(() => closeDb())
+  .catch(async (err: unknown) => {
+    const msg = err instanceof Error ? err.message : `${err}`;
+    console.error('backfill-global-user-contexts failed:', msg);
+    await closeDb().catch(() => {});
+    process.exit(1);
+  });

--- a/backend/src/cli/tests/backfill-global-user-contexts.spec.ts
+++ b/backend/src/cli/tests/backfill-global-user-contexts.spec.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+import { buildProfileText, classifyCandidates, parseArgs, runBackfill, type BackfillDeps, type CandidateRow } from '../backfill-global-user-contexts';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+let seq = 0;
+function candidate(overrides: Partial<CandidateRow> = {}): CandidateRow {
+  seq += 1;
+  return {
+    user_id: overrides.user_id ?? `user-${seq}`,
+    email: overrides.email ?? `user-${seq}@example.com`,
+    premise_count: overrides.premise_count ?? 0,
+    identity: overrides.identity ?? null,
+    narrative: overrides.narrative ?? null,
+    attributes: overrides.attributes ?? null,
+  };
+}
+
+/** Deps with sensible defaults; override per test. */
+function makeDeps(overrides: Partial<BackfillDeps> = {}) {
+  const decomposeProfile = mock(async () => [
+    { text: 'I build distributed systems.', tier: 'assertive' as const },
+  ]);
+  const createPremise = mock(async () => true);
+  const ensureGlobalContext = mock(async () => 'A GENERATED GLOBAL CONTEXT PARAGRAPH.');
+  return {
+    decomposeProfile,
+    createPremise,
+    ensureGlobalContext,
+    ...overrides,
+  } satisfies BackfillDeps;
+}
+
+// ---------------------------------------------------------------------------
+// buildProfileText
+// ---------------------------------------------------------------------------
+
+describe('buildProfileText', () => {
+  it('joins only the non-empty fields', () => {
+    const text = buildProfileText(
+      { name: 'Ada', bio: 'Mathematician.', location: 'London' },
+      { context: 'Working on engines.' },
+      { skills: ['math', 'logic'], interests: ['poetry'] },
+    );
+    expect(text).toBe(
+      'My name is Ada.\nI am based in London.\nMathematician.\nWorking on engines.\nMy skills include math, logic.\nMy interests include poetry.',
+    );
+  });
+
+  it('returns empty string when every field is empty/missing', () => {
+    expect(buildProfileText(null, null, null)).toBe('');
+    expect(buildProfileText({ name: '', bio: '', location: '' }, { context: '' }, { skills: [], interests: [] })).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyCandidates (dry-run preview)
+// ---------------------------------------------------------------------------
+
+describe('classifyCandidates', () => {
+  it('buckets has-premises / needs-decompose / no-data', () => {
+    const candidates = [
+      candidate({ premise_count: 3 }),
+      candidate({ premise_count: 0, identity: { name: 'Bo', bio: '', location: '' } }),
+      candidate({ premise_count: 0 }), // no premises, no profile text
+    ];
+    expect(classifyCandidates(candidates, true)).toEqual({
+      total: 3,
+      withPremises: 1,
+      needDecompose: 1,
+      noData: 1,
+    });
+  });
+
+  it('counts profile-bearing no-premises users as noData when --no-decompose', () => {
+    const candidates = [candidate({ premise_count: 0, identity: { name: 'Bo', bio: '', location: '' } })];
+    expect(classifyCandidates(candidates, false)).toEqual({
+      total: 1,
+      withPremises: 0,
+      needDecompose: 0,
+      noData: 1,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseArgs
+// ---------------------------------------------------------------------------
+
+describe('parseArgs', () => {
+  it('defaults: no limit, not dry-run, decompose on', () => {
+    expect(parseArgs([])).toEqual({ limit: null, dryRun: false, decompose: true });
+  });
+
+  it('parses --limit N and --limit=N, --dry-run, --no-decompose', () => {
+    expect(parseArgs(['--limit', '10', '--dry-run'])).toEqual({ limit: 10, dryRun: true, decompose: true });
+    expect(parseArgs(['--limit=25', '--no-decompose'])).toEqual({ limit: 25, dryRun: false, decompose: false });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runBackfill — orchestration branches
+// ---------------------------------------------------------------------------
+
+describe('runBackfill', () => {
+  it('generates directly for users with active premises (no decompose)', async () => {
+    const deps = makeDeps();
+    const result = await runBackfill([candidate({ premise_count: 5 })], { decompose: true }, deps);
+
+    expect(deps.decomposeProfile).not.toHaveBeenCalled();
+    expect(deps.createPremise).not.toHaveBeenCalled();
+    expect(deps.ensureGlobalContext).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ generated: 1, decomposedUsers: 0, skipped: 0, failed: 0 });
+  });
+
+  it('decomposes the legacy profile first when the user has no premises, then generates', async () => {
+    const deps = makeDeps({
+      decomposeProfile: mock(async () => [
+        { text: 'I am assertive.', tier: 'assertive' as const },
+        { text: 'I am contextual.', tier: 'contextual' as const, validityDays: 30 },
+      ]),
+    });
+    const result = await runBackfill(
+      [candidate({ premise_count: 0, identity: { name: 'Bo', bio: 'Builder.', location: 'NYC' } })],
+      { decompose: true },
+      deps,
+    );
+
+    expect(deps.decomposeProfile).toHaveBeenCalledTimes(1);
+    expect(deps.createPremise).toHaveBeenCalledTimes(2);
+    expect(deps.ensureGlobalContext).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ generated: 1, decomposedUsers: 1, skipped: 0, failed: 0 });
+  });
+
+  it('sets validUntil only for contextual premises, leaves assertive open-ended', async () => {
+    const calls: Array<{ tier: string; volatile: boolean; validUntil?: string }> = [];
+    const deps = makeDeps({
+      decomposeProfile: mock(async () => [
+        { text: 'assertive', tier: 'assertive' as const },
+        { text: 'contextual', tier: 'contextual' as const, validityDays: 7 },
+      ]),
+      createPremise: mock(async (input) => {
+        calls.push({ tier: input.tier, volatile: input.volatile, validUntil: input.validUntil });
+        return true;
+      }),
+    });
+    await runBackfill(
+      [candidate({ premise_count: 0, identity: { name: 'Bo', bio: 'x', location: '' } })],
+      { decompose: true },
+      deps,
+    );
+
+    const assertive = calls.find((c) => c.tier === 'assertive')!;
+    const contextual = calls.find((c) => c.tier === 'contextual')!;
+    expect(assertive.volatile).toBe(false);
+    expect(assertive.validUntil).toBeUndefined();
+    expect(contextual.volatile).toBe(true);
+    expect(typeof contextual.validUntil).toBe('string');
+  });
+
+  it('skips no-premises users with no profile text (never calls ensureGlobalContext)', async () => {
+    const deps = makeDeps();
+    const result = await runBackfill([candidate({ premise_count: 0 })], { decompose: true }, deps);
+
+    expect(deps.decomposeProfile).not.toHaveBeenCalled();
+    expect(deps.ensureGlobalContext).not.toHaveBeenCalled();
+    expect(result).toEqual({ generated: 0, decomposedUsers: 0, skipped: 1, failed: 0 });
+  });
+
+  it('skips no-premises users under --no-decompose without touching the profile', async () => {
+    const deps = makeDeps();
+    const result = await runBackfill(
+      [candidate({ premise_count: 0, identity: { name: 'Bo', bio: 'x', location: '' } })],
+      { decompose: false },
+      deps,
+    );
+
+    expect(deps.decomposeProfile).not.toHaveBeenCalled();
+    expect(deps.ensureGlobalContext).not.toHaveBeenCalled();
+    expect(result).toEqual({ generated: 0, decomposedUsers: 0, skipped: 1, failed: 0 });
+  });
+
+  it('counts an empty context result as failed (generation error / no usable premises)', async () => {
+    const deps = makeDeps({ ensureGlobalContext: mock(async () => '') });
+    const result = await runBackfill([candidate({ premise_count: 2 })], { decompose: true }, deps);
+
+    expect(result).toEqual({ generated: 0, decomposedUsers: 0, skipped: 0, failed: 1 });
+  });
+
+  it('skips context generation when decomposition created zero premises', async () => {
+    const deps = makeDeps({
+      decomposeProfile: mock(async () => [{ text: 'dup', tier: 'assertive' as const }]),
+      createPremise: mock(async () => false), // all near-duplicates
+    });
+    const result = await runBackfill(
+      [candidate({ premise_count: 0, identity: { name: 'Bo', bio: 'x', location: '' } })],
+      { decompose: true },
+      deps,
+    );
+
+    expect(deps.ensureGlobalContext).not.toHaveBeenCalled();
+    expect(result).toEqual({ generated: 0, decomposedUsers: 1, skipped: 1, failed: 0 });
+  });
+
+  it('isolates a thrown error to one user and continues (resumable)', async () => {
+    let call = 0;
+    const deps = makeDeps({
+      ensureGlobalContext: mock(async () => {
+        call += 1;
+        if (call === 1) throw new Error('boom');
+        return 'OK CONTEXT';
+      }),
+    });
+    const result = await runBackfill(
+      [candidate({ premise_count: 1 }), candidate({ premise_count: 1 })],
+      { decompose: true },
+      deps,
+    );
+
+    expect(result).toEqual({ generated: 1, decomposedUsers: 0, skipped: 0, failed: 1 });
+  });
+});


### PR DESCRIPTION
## WS7 — Backfill global `user_contexts` from premises (IND-360)

Part of the "Remove user_profiles" epic (IND-357). **Sequenced before WS6**: after WS5, profile reads + `read_user_profiles` source from the global `user_context`, which `ensureGlobalUserContext` only synthesizes *from existing ACTIVE premises*. Legacy users without a global row (or without premises) would read blank until this backfill runs.

### What this adds
A new idempotent, resumable maintenance CLI — `backend/src/cli/backfill-global-user-contexts.ts` (`maintenance:backfill-global-user-contexts`) — that ensures every live, non-ghost user has a **global** `user_context` row (`networkId = null`).

The existing `backfill-user-contexts.ts` is **per-network only** (`--network <id>` required, enumerates `network_members`, fills `uc.network_id = <id>`) and never covers the global row or users who belong to no networks. This fills that gap.

### One-pass migration of two legacy populations
1. **Has active premises, no global row** → synthesize directly via `ensureGlobalUserContext` (no HyDE — the global row is intentionally excluded from context-to-intent discovery).
2. **No premises, legacy `user_profiles` row** → decompose the profile text into premises first (reusing `PremiseDecomposer` + the premise graph, same path as `decompose-profiles`/WS2), then synthesize. Disable with `--no-decompose`.

### Idempotent + safe
- Candidate query excludes users that already have a global row (`NOT EXISTS ... network_id IS NULL`) — re-running only does what's left.
- Runs in-process; no Redis worker needed.
- **Defaults to `.env.development`**; production requires an explicit `NODE_ENV=production` (no accidental prod writes from an unset env).
- Flags: `--limit N`, `--dry-run`, `--no-decompose`.

### Verification (local dev DB — never prod)
- `--dry-run` classifies candidates (has-premises / needs-decompose / no-data) correctly.
- `--limit 1` generated a real **1186-char** global context end-to-end (LLM synthesis + upsert).
- Re-run confirms the processed user drops out of the candidate set → **idempotent**.
- backend `tsc` 0 · eslint 0 errors.

Backend-only — **no version bump, no DB migration**. The actual full backfill run is an operator action (dev first).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784360891&installation_id=140549914&pr_number=996&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F996&signature=616289adc721ab6b73c2c8e1ac7da7bbbd09af84d3751d8850a04e23a1904e52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->