### PR TITLE
fix(cli): handle flat user-context identity shape in introduction flow

### DIFF
--- a/packages/cli/npm/darwin-arm64/package.json
+++ b/packages/cli/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/cli-darwin-arm64",
-  "version": "0.10.6",
+  "version": "0.10.12",
   "description": "Platform-specific binary for @indexnetwork/cli (macOS arm64)",
   "license": "MIT",
   "os": [

--- a/packages/cli/npm/darwin-x64/package.json
+++ b/packages/cli/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/cli-darwin-x64",
-  "version": "0.10.6",
+  "version": "0.10.12",
   "description": "Platform-specific binary for @indexnetwork/cli (macOS x64)",
   "license": "MIT",
   "os": [

--- a/packages/cli/npm/linux-arm64/package.json
+++ b/packages/cli/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/cli-linux-arm64",
-  "version": "0.10.6",
+  "version": "0.10.12",
   "description": "Platform-specific binary for @indexnetwork/cli (Linux arm64)",
   "license": "MIT",
   "os": [

--- a/packages/cli/npm/linux-x64/package.json
+++ b/packages/cli/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/cli-linux-x64",
-  "version": "0.10.6",
+  "version": "0.10.12",
   "description": "Platform-specific binary for @indexnetwork/cli (Linux x64)",
   "license": "MIT",
   "os": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/cli",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "Command-line interface for Index Network",
   "license": "MIT",
   "type": "module",
@@ -20,10 +20,10 @@
     "publish:all": "bun scripts/publish.ts"
   },
   "optionalDependencies": {
-    "@indexnetwork/cli-linux-x64": "0.10.10",
-    "@indexnetwork/cli-linux-arm64": "0.10.10",
-    "@indexnetwork/cli-darwin-x64": "0.10.10",
-    "@indexnetwork/cli-darwin-arm64": "0.10.10"
+    "@indexnetwork/cli-linux-x64": "0.10.12",
+    "@indexnetwork/cli-linux-arm64": "0.10.12",
+    "@indexnetwork/cli-darwin-x64": "0.10.12",
+    "@indexnetwork/cli-darwin-arm64": "0.10.12"
   },
   "devDependencies": {
     "@types/bun": "latest"

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -27,7 +27,7 @@ import * as output from "./output";
 
 const DEFAULT_API_URL = "https://protocol.index.network";
 const DEFAULT_APP_URL = "https://index.network";
-const VERSION = "0.10.6";
+const VERSION = "0.10.12";
 
 /** Unicode box-drawing (rounded), same style as Honcho CLI. */
 const BOX = { tl: "\u256d", tr: "\u256e", bl: "\u2570", br: "\u256f", h: "\u2500", v: "\u2502" } as const;

--- a/packages/cli/src/opportunity.command.ts
+++ b/packages/cli/src/opportunity.command.ts
@@ -226,12 +226,20 @@ async function discoverIntroduction(
 
   const extractProfile = (result: { success: boolean; data?: Record<string, unknown> }) => {
     if (!result.success || !result.data) return undefined;
-    // Single-user profile response has a profile object at top level or nested
     const d = result.data as Record<string, unknown>;
+    // Legacy nested single-user shape (pre-WS11 protocol): { profile: {...} }.
     if (d.profile) return d.profile as Record<string, unknown>;
-    // Multi-profile response (from query mode) — take first
-    const profiles = d.profiles as Array<{ profile?: Record<string, unknown> }> | undefined;
-    return profiles?.[0]?.profile;
+    // Multi-profile response (query mode) — take first; entries may be flat or nested.
+    const profiles = d.profiles as Array<Record<string, unknown>> | undefined;
+    if (profiles?.length) {
+      const first = profiles[0];
+      return (first.profile as Record<string, unknown> | undefined) ?? first;
+    }
+    // Flat single-user identity shape (WS11+ protocol): { id, name, bio, location, context }.
+    if (typeof d.name === "string" || typeof d.context === "string") {
+      return { name: d.name, bio: d.bio, location: d.location, context: d.context };
+    }
+    return undefined;
   };
 
   const extractIntents = (result: { success: boolean; data?: Record<string, unknown> }) => {


### PR DESCRIPTION
## Fix: CLI introduction flow broke on the WS11 flat user-context payload

WS11 (IND-368) flattened the **single-user** `read_user_profiles` / `read_user_contexts` MCP response from a nested `{ profile: { name, bio, location, skills, interests } }` to a flat `{ id, name, bio, location, context }` (skills/interests dropped). This surfaced during a dev-vs-prod MCP audit of the recently-deployed protocol.

`opportunity.command.ts`'s `extractProfile` only read the nested `data.profile`, so against the WS11+ protocol both parties' profiles resolved to `undefined` and the **introduction flow lost all profile context** (the `entities` passed to `discover_opportunities` had empty profiles). Latent — only fires once the new protocol reaches the environment the CLI targets (prod). Guarded (no crash), degrades silently.

### Bug Fixes
- `extractProfile` now falls back to the flat single-user shape, and unwraps query-mode entries whether flat or nested. Backward-compatible with the legacy nested shape during the transition. The **list/query** read shape (`data.profiles[]`) was unchanged by WS11, so the `profile search` path was unaffected.

### Chores
- Synced the CLI version across the main package, the four platform packages, `optionalDependencies`, and the `src/main.ts` `VERSION` constant — bumped to **0.10.12**. These had drifted apart on dev (0.10.11 / 0.10.10 / 0.10.6); the local version-sync tests (`tests/npm-packages.spec.ts`) were red as a result and are now green.

### Tests
- `cd packages/cli && bun test` → **335 pass / 0 fail** (was 6 failing on the version-sync drift). `bunx tsc --noEmit` clean.

### Context
Companion to the agentvillage fix (Edge-City/agentvillage#115), which has the identical single-user-shape fix for its negotiation-summary script. Both were found auditing the three `read_user_*` consumer surfaces (frontend was clear — it uses backend REST, not MCP).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784466946&installation_id=140549914&pr_number=1002&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1002&signature=57d99547ceffd269a563fcfb2d56b829eb381ea0ddfe5e80786d4315a462f19e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->