### PR TITLE
fix: reconcile root bun.lock with package versions (dev)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -108,11 +108,11 @@
     },
     "packages/claude-plugin": {
       "name": "@indexnetwork/claude-plugin",
-      "version": "0.1.5",
+      "version": "0.1.6",
     },
     "packages/cli": {
       "name": "@indexnetwork/cli",
-      "version": "0.10.10",
+      "version": "0.10.12",
       "bin": {
         "index": "bin/index.cjs",
       },
@@ -120,15 +120,15 @@
         "@types/bun": "latest",
       },
       "optionalDependencies": {
-        "@indexnetwork/cli-darwin-arm64": "0.10.10",
-        "@indexnetwork/cli-darwin-x64": "0.10.10",
-        "@indexnetwork/cli-linux-arm64": "0.10.10",
-        "@indexnetwork/cli-linux-x64": "0.10.10",
+        "@indexnetwork/cli-darwin-arm64": "0.10.12",
+        "@indexnetwork/cli-darwin-x64": "0.10.12",
+        "@indexnetwork/cli-linux-arm64": "0.10.12",
+        "@indexnetwork/cli-linux-x64": "0.10.12",
       },
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "3.7.1",
+      "version": "4.1.1",
       "dependencies": {
         "@langchain/core": "^1.1.17",
         "@langchain/langgraph": "^1.1.2",
@@ -406,14 +406,6 @@
     "@indexnetwork/claude-plugin": ["@indexnetwork/claude-plugin@workspace:packages/claude-plugin"],
 
     "@indexnetwork/cli": ["@indexnetwork/cli@workspace:packages/cli"],
-
-    "@indexnetwork/cli-darwin-arm64": ["@indexnetwork/cli-darwin-arm64@0.10.10", "", { "os": "darwin", "cpu": "arm64", "bin": { "index": "bin/index" } }, "sha512-db5lVeSb5pBMBBHa8Oh/+bZx5XkmP2XUZvvlKdCtKzr5M5En/r8uSiMZCOzAipcL5roRzWCSAS46NSHGNjkzhw=="],
-
-    "@indexnetwork/cli-darwin-x64": ["@indexnetwork/cli-darwin-x64@0.10.10", "", { "os": "darwin", "cpu": "x64", "bin": { "index": "bin/index" } }, "sha512-qHhudIJnuDMVKvPexawst/ClibsffuTl32bjbRS1oCP4oXCP7piHDH5rlp1yREdChZTcNYQ2M8dbRG+rupqNlg=="],
-
-    "@indexnetwork/cli-linux-arm64": ["@indexnetwork/cli-linux-arm64@0.10.10", "", { "os": "linux", "cpu": "arm64", "bin": { "index": "bin/index" } }, "sha512-cte5BUcrq/pR71zabgE5G3BNSeXWQlkuJZD76xsoeC6l9xCvWSyTqbZniAo7xwWufwVya0BDfInVcFRuvUHzMw=="],
-
-    "@indexnetwork/cli-linux-x64": ["@indexnetwork/cli-linux-x64@0.10.10", "", { "os": "linux", "cpu": "x64", "bin": { "index": "bin/index" } }, "sha512-EzuMP1+MuthfzChKIWAta1ffGcLLz2JPIj2MV4sOwceGCECYETMCxFzNCZMPFGuV+jaUkBYS8m011XP4bAiqoQ=="],
 
     "@indexnetwork/protocol": ["@indexnetwork/protocol@workspace:packages/protocol"],
 


### PR DESCRIPTION
Applies the #1006 stale-lockfile fix to dev. dev's committed bun.lock had drifted from the epic/IND-369 version bumps (CLI 0.10.12 + optionalDeps, claude-plugin 0.1.6, protocol 4.1.1); dev never failed only because CLI-only changes don't rebuild the protocol service there. Prevents the next protocol rebuild on dev from failing `bun install --frozen-lockfile`. Version-only diff, frozen verified locally.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784473665&installation_id=140549914&pr_number=1007&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1007&signature=13baaeb0e279ed295500af6ef3f667766ceaa8103b67f1cb6a00903194d70cc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->