### PR TITLE
docs+chore: fix stale maintenance-CLI refs; capture release-prod-safety skill

### DIFF
--- a/.pi/skills/finish-pr/SKILL.md
+++ b/.pi/skills/finish-pr/SKILL.md
@@ -39,6 +39,7 @@ Use other rpiv skills when they fit the situation:
 - `code-review`: use for an independent final review when the diff is large, risky, or has had multiple review rounds.
 - `changelog`: use if the PR changes a released package or the user wants release notes updated before merge.
 - `commit`: use if local finishing changes are needed and should be committed before push.
+- `release-prod-safety`: use when the PR is a dev→main RELEASE. Apply its two checks — confirm the root `bun.lock` is in sync (a stale lockfile fails the prod build under `--frozen-lockfile` even when dev/CI are green), and run the destructive-migration data-preservation pre-flight before merge (a `DROP` runs no backfill; auto-`db:migrate` leaves no window after).
 
 Do not invoke heavyweight skills for trivial PRs with already-green checks and no open review threads.
 

--- a/.pi/skills/release-prod-safety/SKILL.md
+++ b/.pi/skills/release-prod-safety/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: release-prod-safety
+description: Pre-merge and post-merge safety checks for promoting a dev→main release in this monorepo, capturing two non-obvious ways a release can break or lose data: (1) a stale root bun.lock fails the prod build under --frozen-lockfile even though dev never caught it, and (2) a destructive Drizzle migration (e.g. DROP TABLE) silently loses prod data when the operational backfill never ran on prod. Use when cutting/merging a release PR to main, when a prod deploy build fails on "lockfile is frozen", or before merging any PR carrying a DROP/destructive migration.
+---
+
+# release-prod-safety
+
+Two production-release foot-guns observed shipping the `user_profiles` removal epic. Both passed CI and dev yet threatened prod. Check these when promoting `dev`→`main` (pairs with `finish-pr` for the merge/verify and `open-release-pr` for cutting the PR).
+
+## 1. Stale root `bun.lock` breaks the prod build (not dev)
+
+**Symptom:** the Railway prod (main) deploy fails at build with:
+```
+error: lockfile had changes, but lockfile is frozen
+```
+Build fails BEFORE the release/`db:migrate` phase, so no migration runs and the previous deployment keeps serving (no downtime, no partial migration).
+
+**Why dev never caught it:** Railway only rebuilds a service when its watched paths change. A package version bump in `packages/cli` (or `claude-plugin`/`protocol`) that isn't reflected in the root `bun.lock` won't trigger a protocol rebuild on dev, so dev never re-runs `bun install --frozen-lockfile`. The merge to `main` rebuilds everything and surfaces the drift. CI (`check`/`lint`/`typecheck`) does NOT run a frozen install, so it stays green too.
+
+**Prevent / fix:** whenever you bump any workspace `package.json` version (incl. `optionalDependencies` like the CLI platform packages), regenerate and commit `bun.lock`. Verify before merging a release:
+```bash
+bun install --frozen-lockfile   # must print "no changes" / not error
+```
+If prod already failed: regenerate the lockfile, hotfix it to `main` (then sync the identical fix to `dev` — it is equally stale), and the next deploy proceeds to build → migrate → boot.
+
+## 2. Destructive migration without a verified prod data backfill
+
+A `DROP TABLE`/column migration is a blind schema op — it does **no** data backfill. If the replacement representation is populated by a separate **operational** step (a backfill CLI, a decompose job) that ran on dev but **never on prod**, merging the release drops real prod data on deploy (`db:migrate` runs automatically).
+
+**Before merging a PR that carries a destructive migration:**
+1. Identify what the dropped table/column uniquely holds that is NOT already on the surviving tables.
+2. Audit **prod** (read-only) for rows whose content is not yet captured by the replacement — e.g. `users with a <dropped> row but no <replacement> row`, excluding ghost/deleted.
+3. If any real rows are at risk, **remediate while the source still exists** (decompose/copy into the replacement), then re-verify the at-risk count is 0.
+4. Only then merge. After deploy, run any eager backfills (and embedding backfills for SQL-inserted rows, since direct inserts bypass the graph's embedding step).
+
+**Gotchas:**
+- Migrations are sequential — you usually can't "skip" the destructive one mid-sequence, so pre-flight remediation beats splitting the release.
+- Auto-`db:migrate` on deploy means there's no window to backfill *after* the drop — do it before.
+- Successful MCP tool calls may not be logged by name; for "is the old thing still used?" prefer a **persisted** signal (a runs/operations table) over app-log greps.
+
+## See also
+- `finish-pr` — merge + post-merge deploy/Railway verification (run these checks as part of finishing a release PR).
+- `open-release-pr` — cut the dated `release/<date>` PR into `main`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,6 @@ bun run maintenance:trigger-integration     # Manually trigger integration sync
 bun run maintenance:export-slack            # Export Slack data
 bun run maintenance:import-slack-export     # Import Slack export files
 bun run maintenance:reset-brokers           # Reset context brokers
-bun run maintenance:update:embeddings       # Regenerate embeddings
 bun run maintenance:backfill-premises       # Backfill: enqueue enrichment for users in a network
 bun run maintenance:backfill-context-hyde   # Backfill: generate HyDE docs for user contexts
 bun run maintenance:backfill-global-user-contexts # Backfill: generate the global user_context (networkId=null) for every user, synthesized from active premises

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,7 +20,6 @@
     "maintenance:export-slack": "bun ./src/cli/export-slack.ts",
     "maintenance:import-slack-export": "bun ./src/cli/import-slack-export.ts",
     "maintenance:reset-brokers": "bun ./src/cli/reset-brokers.ts",
-    "maintenance:update:embeddings": "bun ./src/cli/update-embeddings.ts",
     "maintenance:fix-migrations": "bash ./scripts/fix-migrations.sh",
     "maintenance:reset-remote-db": "bun ./src/cli/db-reset-remote.ts",
     "maintenance:migrate-chat": "bun ./src/cli/migrate-chat-to-conversations.ts",

--- a/backend/src/cli/backfill-global-user-contexts.ts
+++ b/backend/src/cli/backfill-global-user-contexts.ts
@@ -9,8 +9,11 @@
  * Users WITH active premises but no global `user_context` row are synthesized
  * directly via {@link ensureGlobalUserContext} (no HyDE; the global row is
  * intentionally excluded from context-to-intent discovery). Users with no active
- * premises have no source material and are skipped (WS7 already decomposed legacy
- * profiles into premises before `user_profiles` was dropped in WS8).
+ * premises have no source material and are skipped — they self-heal lazily via
+ * `ensureGlobalUserContext` on their next read/enrichment. NOTE: the one-off
+ * profile->premises decompose CLI was removed when `user_profiles` was dropped
+ * (WS8/IND-365), so this backfill only sources from premises; a user with a
+ * legacy profile but no premises is skipped here, not decomposed.
  *
  * Idempotent + resumable: users that already have a global row are excluded by the
  * candidate query, so re-running only processes what's left. Runs entirely


### PR DESCRIPTION
### Documentation / Chore
- Remove dead `maintenance:update:embeddings` script (target `update-embeddings.ts` doesn't exist) from `backend/package.json` + the matching `CLAUDE.md` line.
- Correct `backfill-global-user-contexts.ts` TSDoc: the profile→premises `decompose-profiles` CLI was removed in WS8/IND-365, so the backfill sources only from premises; a user with a legacy profile but no premises is skipped (self-heals on next read/enrichment), not decomposed. (This stale claim is what masked the prod data-loss risk during release #1005.)

### Skill capture (learn-skill)
New project-local `.pi/skills/release-prod-safety` capturing two non-obvious release foot-guns from the user_profiles epic, cross-linked from `finish-pr`:
1. **Stale root `bun.lock`** fails the prod build under `--frozen-lockfile` even though dev never rebuilds the service and CI doesn't run a frozen install (root cause of the #1005 first-deploy failure, fixed by #1006/#1007).
2. **Destructive-migration data-preservation pre-flight** — a `DROP` runs no backfill and auto-`db:migrate` leaves no post-deploy window; audit + remediate prod before merge (the 12-user / 237-premise save this session).

No runtime code change; docs + skills only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784476951&installation_id=140549914&pr_number=1009&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1009&signature=59c2ecbe472a04133c69c4f53dcd81e44cdeb5f11f545c8e705fe15d460f1dc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->