### PR TITLE
fix(enrichment): gate onboarding create on real enrichment signal, not getProfile()

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/enrichment/enrichment.tools.ts
+++ b/packages/protocol/src/enrichment/enrichment.tools.ts
@@ -813,16 +813,28 @@ export function createEnrichmentTools(defineTool: DefineTool, deps: ToolDeps) {
 
       const isOnboarding = !(context.user.onboarding?.completedAt);
       if (isOnboarding) {
-        const existingProfile = await userDb.getProfile();
-        if (existingProfile) {
+        // "Already enriched?" must key on a real enrichment signal, not getProfile():
+        // post-WS11 getProfile() returns a presentation row for EVERY existing user, so
+        // it would always short-circuit onboarding and refuse to enrich. The global
+        // user_context is the canonical signal (non-empty <=> the user has premises /
+        // has been enriched), mirroring findWithGraph's `hasProfile`.
+        const existingContext = getUserContextText
+          ? (await getUserContextText(context.userId)).trim()
+          : '';
+        if (existingContext) {
+          const existingProfile = await userDb.getProfile();
           return success({
             alreadyExists: true,
             message: "Profile already exists. If the user confirmed it, call complete_onboarding() to finish setup. If they want changes, use create_user_context(bioOrDescription=\"...\", confirm=true).",
-            profile: {
-              name: existingProfile.identity.name,
-              bio: existingProfile.identity.bio,
-              location: existingProfile.identity.location,
-            },
+            ...(existingProfile
+              ? {
+                  profile: {
+                    name: existingProfile.identity.name,
+                    bio: existingProfile.identity.bio,
+                    location: existingProfile.identity.location,
+                  },
+                }
+              : {}),
           });
         }
 

--- a/packages/protocol/src/enrichment/tests/enrichment.create-gate.spec.ts
+++ b/packages/protocol/src/enrichment/tests/enrichment.create-gate.spec.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, mock } from "bun:test";
+import { z } from "zod";
+
+import { createEnrichmentTools } from "../enrichment.tools.js";
+import type { ToolDeps, ResolvedToolContext } from "../../shared/agent/tool.helpers.js";
+
+/**
+ * Regression: the onboarding "already exists" gate in create_user_context must
+ * key on a real enrichment signal (the global user_context via getUserContextText),
+ * NOT userDb.getProfile(). Post-WS11 getProfile() returns a presentation row for
+ * EVERY existing user, so gating on it always short-circuited onboarding and
+ * refused to enrich.
+ */
+
+interface CapturedTool {
+  name: string;
+  handler: (input: { context: ResolvedToolContext; query: unknown }) => Promise<string>;
+}
+
+function captureCreateTool(deps: ToolDeps): CapturedTool {
+  const defs: Array<{ name: string; querySchema: z.ZodType; handler: CapturedTool["handler"] }> = [];
+  const defineTool = (def: { name: string; querySchema: z.ZodType; handler: CapturedTool["handler"] }) => {
+    defs.push(def);
+    return def;
+  };
+  createEnrichmentTools(defineTool as unknown as Parameters<typeof createEnrichmentTools>[0], deps);
+  return defs.find((t) => t.name === "create_user_context")!;
+}
+
+// Onboarding context: no completedAt → isOnboarding === true.
+const onboardingContext = {
+  userId: "u1",
+  user: { onboarding: {} },
+} as unknown as ResolvedToolContext;
+
+function buildDeps(getUserContextText: (id: string) => Promise<string>): ToolDeps {
+  return {
+    userDb: {
+      // Post-WS11: getProfile() returns a presentation row for EVERY existing user.
+      getProfile: mock(async () => ({
+        identity: { name: "U", bio: "", location: "" },
+        attributes: { skills: [], interests: [] },
+      })),
+      getUser: mock(async () => ({ id: "u1", name: "U", email: "u@example.com", socials: [] })),
+      getUserSocials: mock(async () => []),
+      setUserSocials: mock(async () => {}),
+      updateUser: mock(async () => ({})),
+      getActiveIntents: mock(async () => []),
+    },
+    systemDb: {},
+    database: {},
+    graphs: { profile: { invoke: mock(async () => ({ readResult: { hasProfile: false } })) } },
+    enricher: { enrichUserProfile: async () => null },
+    grantDefaultSystemPermissions: async () => undefined,
+    getUserContextText,
+  } as unknown as ToolDeps;
+}
+
+describe("create_user_context onboarding already-enriched gate (WS11 signal)", () => {
+  it("returns alreadyExists when the user already has a global context", async () => {
+    const tool = captureCreateTool(buildDeps(async () => "An existing synthesized identity paragraph."));
+    const out = JSON.parse(await tool.handler({ context: onboardingContext, query: {} }));
+    expect(out.success).toBe(true);
+    expect(out.data.alreadyExists).toBe(true);
+  });
+
+  it("does NOT short-circuit when there is no global context, even though getProfile() returns a row", async () => {
+    const tool = captureCreateTool(buildDeps(async () => ""));
+    const out = JSON.parse(await tool.handler({ context: onboardingContext, query: {} }));
+    // Gate skipped → falls through to the preview path; with no enrichment/info it asks for clarification.
+    expect(out.data?.alreadyExists).toBeUndefined();
+    expect(out.needsClarification).toBe(true);
+    expect(out.missingFields).toContain("bio_or_social_urls");
+  });
+});


### PR DESCRIPTION
### Bug Fix
`create_user_context`/`create_user_profile` short-circuited onboarding with `alreadyExists: true` for **any** existing user. The gate keyed on `userDb.getProfile()`, which post-WS11 returns a presentation row for *every* existing user (built from `users`; null only when the user doesn't exist) — so the legacy create path during onboarding always refused to enrich.

Now gates on the canonical *has-been-enriched* signal — the global `user_context` via `getUserContextText` (non-empty ⇔ the user has premises), mirroring `findWithGraph`'s `hasProfile: globalContext.length > 0`. With no global context the handler falls through to the preview/enrich path as intended.

### Tests
- New `enrichment.create-gate.spec.ts` — **fails on the old gate, passes on the fix** (2 cases: enriched → alreadyExists; not-enriched → falls through to clarification despite getProfile() returning a row). Full enrichment suite: 90 pass / 0 new failures (the 1 remaining `ProfileGenerator > should generate a profile` failure is **pre-existing on dev**, unrelated to this change).

protocol 4.1.1 → 4.1.2 (behavior fix, non-breaking).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1010"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784477661&installation_id=140549914&pr_number=1010&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1010&signature=b1cd5373311955e60d11064e294dec21aae24119e210fb7f826d0ea20f6f091a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->