### PR TITLE
test(enrichment): gate live-LLM generator spec behind RUN_LLM_TESTS

### DIFF
--- a/packages/protocol/src/enrichment/tests/enrichment.generator.spec.ts
+++ b/packages/protocol/src/enrichment/tests/enrichment.generator.spec.ts
@@ -20,6 +20,20 @@ const FIXTURE_RESULTS = JSON.stringify([
   }
 ], null, 2);
 
+/**
+ * Live-LLM smoke test (real OpenRouter call) — OPT-IN via RUN_LLM_TESTS=1.
+ *
+ * It is gated off by default for two reasons: (1) it makes a real, slow,
+ * non-deterministic model call, and (2) sibling specs in this directory
+ * (`enrichment.{decompose,public-lookup,privacy-tools}.spec.ts`) replace the
+ * `enrichment.generator.js` module via `mock.module`, which bun applies
+ * process-globally with no per-file restore — so under a batch run
+ * (`bun test src/enrichment/tests/`) this spec would import the leaked stub
+ * instead of the real generator and flake. Run it in isolation:
+ *   RUN_LLM_TESTS=1 bun test src/enrichment/tests/enrichment.generator.spec.ts
+ */
+const RUN_LLM_TESTS = process.env.RUN_LLM_TESTS === '1';
+
 describe('Profile Generator', () => {
   let profileGenerator: EnrichmentGenerator;
 
@@ -27,7 +41,7 @@ describe('Profile Generator', () => {
     profileGenerator = new EnrichmentGenerator();
   })
 
-  it('should generate a profile', async () => {
+  it.skipIf(!RUN_LLM_TESTS)('should generate a profile (live LLM; set RUN_LLM_TESTS=1)', async () => {
     const result = await profileGenerator.invoke(FIXTURE_RESULTS);
     expect(!!result.output.identity.bio).toBe(true);
     expect(!!result.output.identity.location).toBe(true);


### PR DESCRIPTION
### Tests
`enrichment.generator.spec.ts` is the only genuinely live-LLM test in its directory and flaked under batch runs (`bun test src/enrichment/tests/`). Sibling specs (decompose/public-lookup/privacy-tools) replace `enrichment.generator.js` via `mock.module`, which **bun applies process-globally with no per-file restore** (verified `mock.restore()` does not undo it). The generator spec then imported a leaked stub and passed/failed by file ordering — the privacy/public stubs omit `textToEmbed`, which the spec asserts.

**Fix:** gate the live call behind `RUN_LLM_TESTS=1` (`it.skipIf`). Default suite runs now skip it (deterministic + fast); run it explicitly in isolation:
```
RUN_LLM_TESTS=1 bun test src/enrichment/tests/enrichment.generator.spec.ts`
```
Verified: default dir run = 0 fail / 1 skip; opt-in isolated = real ~2s call passes.

No product or version change. (This is the pre-existing `ProfileGenerator > should generate a profile` failure flagged in #1010.)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1011"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784478258&installation_id=140549914&pr_number=1011&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1011&signature=36a96acc275e16198790b6d5d1cc5b63e3953f6d903e22d455b07b3ce9a00977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->