### PR TITLE
feat(opportunity): explain why opportunities surface + link negotiation trace (EDG-50, EDG-51)

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -138,6 +138,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const shouldRedirectToHome = !authenticated && (isProtectedPage || (!isHomePage && !isPublicPage));
 
     if (shouldRedirectToHome) {
+      // Preserve the destination so the user returns to it after authenticating,
+      // instead of being stranded on the home page. This makes protected deep
+      // links work when opened while logged out — e.g. the negotiation-trace
+      // link (`/chat/:conversationId`) surfaced in the daily digest. The
+      // captured URL is forwarded to Better Auth as `callbackURL`, mirroring the
+      // public `/u/:id/chat` page's `openLoginModal(window.location.href)` flow.
+      if (typeof window !== 'undefined') {
+        // Guarded one-shot: we open the modal and immediately redirect+return, so
+        // this does not cascade renders despite the set-state-in-effect lint.
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        openLoginModal(window.location.href);
+      }
       navigate('/');
       return;
     }
@@ -149,7 +161,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
 
     setIsLoading(false);
-  }, [authenticated, ready, navigate, pathname, user, userLoading, userFetchAttempted]);
+  }, [authenticated, ready, navigate, pathname, user, userLoading, userFetchAttempted, openLoginModal]);
 
   return (
     <AuthContext.Provider

--- a/frontend/tests/auth-context.test.tsx
+++ b/frontend/tests/auth-context.test.tsx
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => {
     clearJwtToken: vi.fn(),
     signOut: vi.fn(),
     useSession: vi.fn(),
+    authModal: vi.fn(),
   };
 });
 
@@ -39,7 +40,10 @@ vi.mock('@/services/auth', () => ({
 }));
 
 vi.mock('@/components/AuthModal', () => ({
-  default: () => null,
+  default: (props: { isOpen: boolean; callbackURL?: string }) => {
+    mocks.authModal(props);
+    return null;
+  },
 }));
 
 function incompleteUser() {
@@ -96,5 +100,23 @@ describe('AuthProvider onboarding routing', () => {
 
     expect(await screen.findByTestId('location')).toHaveTextContent('/');
     expect(mocks.apiClient.get).not.toHaveBeenCalled();
+  });
+
+  test('opens the login modal with a preserved callbackURL when an unauthenticated user hits a protected deep link', async () => {
+    mocks.useSession.mockReturnValue({ data: null, isPending: false });
+
+    // A negotiation-trace deep link from the daily digest, opened while logged out.
+    renderAuthProviderAt('/chat/abc-123');
+
+    // The user is bounced to home, but the login modal is opened so that after
+    // authenticating Better Auth redirects them back to the captured URL
+    // (real browser URL via createBrowserRouter; jsdom reports the origin).
+    expect(await screen.findByTestId('location')).toHaveTextContent('/');
+    const lastCall = mocks.authModal.mock.calls.at(-1)?.[0] as
+      | { isOpen: boolean; callbackURL?: string }
+      | undefined;
+    expect(lastCall?.isOpen).toBe(true);
+    expect(typeof lastCall?.callbackURL).toBe('string');
+    expect(lastCall?.callbackURL).toBeTruthy();
   });
 });

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/opportunity/negotiation-context.loader.ts
+++ b/packages/protocol/src/opportunity/negotiation-context.loader.ts
@@ -36,6 +36,12 @@ export type NegotiationContextDatabase = Pick<
  */
 export interface NegotiationContext {
   status: OpportunityStatus;
+  /**
+   * Conversation/task id of the A2A negotiation that produced this opportunity.
+   * Lets callers deep-link to the negotiation trace (e.g. `/chat/:conversationId`).
+   * Present whenever a negotiation task exists (i.e. context is non-null).
+   */
+  conversationId: string;
   turnCount: number;
   /** Max turns allowed for this negotiation (0 = unlimited). */
   turnCap: number;
@@ -80,7 +86,7 @@ export async function loadNegotiationContext(
   const turnCount = turns.length;
 
   if (opportunityStatus === 'negotiating') {
-    return { status: opportunityStatus, turnCount, turnCap };
+    return { status: opportunityStatus, conversationId: task.conversationId, turnCount, turnCap };
   }
 
   const artifacts = await db.getArtifactsForTask(task.id);
@@ -88,6 +94,7 @@ export async function loadNegotiationContext(
 
   return {
     status: opportunityStatus,
+    conversationId: task.conversationId,
     turnCount,
     turnCap,
     ...(outcome ? { outcome } : {}),

--- a/packages/protocol/src/opportunity/opportunity.presenter.ts
+++ b/packages/protocol/src/opportunity/opportunity.presenter.ts
@@ -398,7 +398,7 @@ Produce headline, personalizedSummary (2-3 sentences in "you" language), suggest
     // *because* the negotiation happened. Trailing the block lets weaker
     // models lean on surface signals and ignore the transcript entirely.
     const negotiationDirective = negotiationBlock
-      ? `\nIMPORTANT: This opportunity surfaced because the agents negotiated and converged. Your personalizedSummary MUST reference at least one specific signal from the NEGOTIATION CONTEXT block below — what concern was raised, what was confirmed, what the agents agreed on. Do not produce a generic skill-complementarity summary; that's what every card looked like before this negotiation happened. Use the transcript to explain *why this specific match* surfaced now.\n`
+      ? `\nIMPORTANT: This opportunity surfaced because the agents negotiated and converged. Both your personalizedSummary AND your digestSummary MUST reference at least one specific signal from the NEGOTIATION CONTEXT block below — what concern was raised, what was confirmed, what the agents agreed on. The digestSummary is the one-line morning-brief sentence a user reads before deciding to act, so it must communicate *why this specific match* surfaced now (the negotiation that led to it), not a generic skill-complementarity line. Do not produce the generic summary every card looked like before this negotiation happened.\n`
       : "";
     const humanContent = `
 ${negotiationBlock}${negotiationDirective}

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -8,6 +8,7 @@ import { MINIMAL_MAIN_TEXT_MAX_CHARS, getPrimaryActionLabel, SECONDARY_ACTION_LA
 import { viewerCentricCardSummary, narratorRemarkFromReasoning, stripUuids } from "./opportunity.presentation.js";
 import { runDiscoverFromQuery, continueDiscovery } from "./opportunity.discover.js";
 import { OpportunityPresenter, gatherPresenterContext, type PresenterDatabase } from "./opportunity.presenter.js";
+import { loadNegotiationContext } from "./negotiation-context.loader.js";
 
 function stripLeadingNarratorName(remark: string, narratorName: string): string {
   let t = remark.trim();
@@ -106,6 +107,25 @@ export function buildProfileUrl(
   if (!frontendUrl) return undefined;
   const base = frontendUrl.replace(/\/+$/, "");
   return `${base}/u/${counterpartUserId}?link_preview=false`;
+}
+
+/**
+ * Build the deep-link to an opportunity's A2A negotiation trace
+ * (`/chat/:conversationId`) so users can see *what negotiation led to* the
+ * surfaced opportunity (EDG-50/EDG-51). Returns `undefined` when `frontendUrl`
+ * is unset or there is no negotiation conversation to link to.
+ *
+ * The `?link_preview=false` hint mirrors `buildProfileUrl` — chat-gateway
+ * runtimes (e.g. Telegram delivery) strip link previews when it is present.
+ * Trailing slashes on `frontendUrl` are stripped before concatenation.
+ */
+export function buildNegotiationUrl(
+  conversationId: string | undefined,
+  frontendUrl: string | undefined,
+): string | undefined {
+  if (!frontendUrl || !conversationId) return undefined;
+  const base = frontendUrl.replace(/\/+$/, "");
+  return `${base}/chat/${conversationId}?link_preview=false`;
 }
 
 /**
@@ -342,6 +362,8 @@ type OpportunityCardLike = Record<string, unknown> & {
   feedCategory?: string | undefined;
   acceptUrl?: string | undefined;
   profileUrl?: string | undefined;
+  /** Deep-link to the A2A negotiation trace that produced this opportunity. */
+  negotiationUrl?: string | undefined;
   score?: number | undefined;
   /** Digest-mode cooldown re-show — the user has seen this card before. */
   redelivery?: boolean | undefined;
@@ -391,6 +413,7 @@ export function buildOpportunityPresentation(
         if (card.status) lines.push(`   status: ${card.status}`);
         if (card.profileUrl) lines.push(`   profileUrl: ${card.profileUrl}`);
         if (card.acceptUrl) lines.push(`   acceptUrl: ${card.acceptUrl}`);
+        if (opts.includeDigestMarkers && card.negotiationUrl) lines.push(`   negotiationUrl: ${card.negotiationUrl}`);
         if (card.feedCategory) lines.push(`   feedCategory: ${card.feedCategory}`);
         if (opts.includeDigestMarkers && card.score != null) lines.push(`   confidence: ${Math.round(card.score * 100)}`);
         if (opts.includeDigestMarkers && card.redelivery) lines.push(`   redelivery: true`);
@@ -1818,17 +1841,32 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
                 const isCounterpartGhost = counterpartUser?.isGhost ?? false;
 
                 try {
-                  const ctx = await gatherOpportunityPresenterContext(
-                    presenterDb,
-                    opp,
-                    context.userId,
-                    counterpartUserId,
-                  );
+                  // Load the negotiation context alongside presenter context so
+                  // the digest copy can explain *why* the opportunity surfaced
+                  // (EDG-50) — the presenter grounds `digestSummary` in concrete
+                  // negotiation turns when this is present. The same context
+                  // yields the conversationId for the negotiation-trace link
+                  // (EDG-51).
+                  const [ctx, negotiationContext] = await Promise.all([
+                    gatherOpportunityPresenterContext(
+                      presenterDb,
+                      opp,
+                      context.userId,
+                      counterpartUserId,
+                    ),
+                    loadNegotiationContext(deps.negotiationDatabase, opp.id, opp.status),
+                  ]);
 
                   const presentation = await presenter.presentHomeCard({
                     ...ctx,
                     opportunityStatus: opp.status,
+                    ...(negotiationContext ? { negotiationContext } : {}),
                   });
+
+                  const negotiationUrl = buildNegotiationUrl(
+                    negotiationContext?.conversationId,
+                    deps.frontendUrl,
+                  );
 
                   // Build narrator chip from presenter output
                   let narratorChip: { name: string; text: string; avatar?: string | null; userId?: string };
@@ -1854,6 +1892,9 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
                     avatar: counterpartUser?.avatar ?? null,
                     mainText: stripUuids(presentation.personalizedSummary),
                     digestSummary: stripUuids(presentation.digestSummary),
+                    // Deep-link to the negotiation trace that produced this card
+                    // (EDG-51). Only present when a negotiation conversation exists.
+                    ...(negotiationUrl ? { negotiationUrl } : {}),
                     cta: presentation.suggestedAction,
                     headline: viewerIsIntroducerHere && secondPartyNameForHeadline
                       ? `${counterpartName} → ${secondPartyNameForHeadline}`

--- a/packages/protocol/src/opportunity/tests/negotiation-context.loader.spec.ts
+++ b/packages/protocol/src/opportunity/tests/negotiation-context.loader.spec.ts
@@ -120,6 +120,7 @@ describe("loadNegotiationContext", () => {
 
     expect(result).not.toBeNull();
     expect(result!.status).toBe("negotiating");
+    expect(result!.conversationId).toBe("conv-1");
     expect(result!.turnCount).toBe(2);
     expect(result!.turnCap).toBe(8);
     expect(result!.turns).toBeUndefined();
@@ -148,6 +149,7 @@ describe("loadNegotiationContext", () => {
 
     expect(result).not.toBeNull();
     expect(result!.status).toBe("pending");
+    expect(result!.conversationId).toBe("conv-1");
     expect(result!.turnCount).toBe(2);
     expect(result!.turnCap).toBe(6);
     expect(result!.turns).toHaveLength(2);

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.digest-dedup.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.digest-dedup.spec.ts
@@ -142,7 +142,11 @@ function makeDeps(opts: {
     contactService: {} as unknown as ToolDeps['contactService'],
     integrationImporter: {} as unknown as ToolDeps['integrationImporter'],
     enricher: {} as unknown as ToolDeps['enricher'],
-    negotiationDatabase: {} as unknown as ToolDeps['negotiationDatabase'],
+    negotiationDatabase: {
+      getNegotiationTaskForOpportunity: async () => null,
+      getMessagesForConversation: async () => [],
+      getArtifactsForTask: async () => [],
+    } as unknown as ToolDeps['negotiationDatabase'],
     deliveryLedger: deliveryLedger as unknown as ToolDeps['deliveryLedger'],
     opportunityPresentation: {
       createPresenter: () => ({ presentHomeCard: (input: unknown) => presentHomeCardMock(input) }),

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts
@@ -81,6 +81,20 @@ const getOppsForUser = mock(async (_userId: string, filter?: { statuses?: string
 let getUser = mock(async () => ({ id: testUserId, name: 'Test User' }) as UserRecord | null);
 let getProfile = mock(async () => (null) as UserIdentity | null);
 
+// Negotiation task returned by the negotiation-context loader. Default: no
+// negotiation has happened (loadNegotiationContext returns null), so digest
+// cards carry no negotiationUrl unless a test opts into one.
+type NegotiationTask = {
+  id: string;
+  conversationId: string;
+  state: string;
+  metadata: Record<string, unknown> | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+let negotiationTask: NegotiationTask | null = null;
+const getNegotiationTaskForOpportunity = mock(async () => negotiationTask);
+
 const noopGraph = { invoke: async () => ({}) };
 
 function makeDeps(overrides: Partial<Parameters<typeof createOpportunityTools>[1]> = {}): ToolDeps {
@@ -113,7 +127,12 @@ function makeDeps(overrides: Partial<Parameters<typeof createOpportunityTools>[1
     contactService: {} as unknown as ToolDeps["contactService"],
     integrationImporter: {} as unknown as ToolDeps["integrationImporter"],
     enricher: {} as unknown as ToolDeps["enricher"],
-    negotiationDatabase: {} as unknown as ToolDeps["negotiationDatabase"],
+    frontendUrl: 'https://index.network',
+    negotiationDatabase: {
+      getNegotiationTaskForOpportunity,
+      getMessagesForConversation: mock(async () => []),
+      getArtifactsForTask: mock(async () => []),
+    } as unknown as ToolDeps["negotiationDatabase"],
     graphs: {
       profile: noopGraph,
       intent: noopGraph,
@@ -162,6 +181,57 @@ describe('list_opportunities digest presenter path', () => {
     expect(presentHomeCardMock).toHaveBeenCalled();
     expect(String(result.data?.message)).toContain('You might like meeting Alice because she matches your current interests.');
     expect(String(result.data?.message)).not.toContain('Test personalized summary');
+  });
+
+  it('emits a negotiationUrl marker and feeds negotiationContext to the presenter when a negotiation exists', async () => {
+    candidateOpps = [makeOpp('opp-neg', 'c-neg', 'pending')];
+    getUser = mock(async () => ({ id: testUserId, name: 'Viewer' }) as UserRecord | null);
+    getProfile = mock(async () => ({ identity: { name: 'Carol', bio: '', location: '' }, userId: 'c-neg' }) as unknown as UserIdentity | null);
+    negotiationTask = {
+      id: 'task-neg',
+      conversationId: 'conv-xyz',
+      state: 'completed',
+      metadata: { type: 'negotiation', opportunityId: 'opp-neg', maxTurns: 6 },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    // Capture the presenter input so we can assert negotiationContext threading.
+    presentHomeCardMock = mock(async () => ({
+      headline: 'Test Headline',
+      personalizedSummary: 'Agents agreed you both want to ship privacy tooling.',
+      digestSummary: 'You might like meeting Carol because your agents agreed on shared privacy-tooling goals.',
+      suggestedAction: 'Test action',
+      narratorRemark: 'Test narrator remark',
+      mutualIntentsLabel: undefined,
+      greeting: '',
+    }));
+
+    const deps = makeDeps();
+    const tools = createOpportunityTools(defineTool as unknown as DefineTool, deps);
+    const listTool = tools.find((t: { name: string }) => t.name === 'list_opportunities')!;
+
+    const result = parseResult(
+      await listTool.handler({
+        context: {
+          userId: testUserId,
+          isMcp: true,
+          networkId: undefined,
+          sessionId: undefined,
+          userName: 'Viewer',
+          userNetworks: [],
+        },
+        query: { includeDigestMarkers: true },
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    // EDG-51: digest marker carries the negotiation-trace deep link.
+    expect(String(result.data?.message)).toContain('negotiationUrl: https://index.network/chat/conv-xyz?link_preview=false');
+    // EDG-50: presenter received the negotiation context so digestSummary can be grounded.
+    const lastCall = presentHomeCardMock.mock.calls.at(-1)?.[0] as { negotiationContext?: { conversationId?: string } } | undefined;
+    expect(lastCall?.negotiationContext?.conversationId).toBe('conv-xyz');
+
+    negotiationTask = null;
   });
 
   it('skips digest cards instead of surfacing raw fallback when presenter throws', async () => {


### PR DESCRIPTION
## Summary

Improves opportunity **legibility** in the Telegram daily digest and makes the underlying negotiation **accessible** via a trace link. Closes EDG-50 and EDG-51.

**Root cause:** chat/home-feed cards already inject negotiation context into the presenter, but the `list_opportunities` digest path never loaded it — so morning-brief copy was generic and carried no link back to the negotiation that produced the match.

## Changes

### New Features
- **EDG-50 — why it surfaced:** the digest path now loads negotiation context in parallel with presenter context and feeds it to `presentHomeCard`. The presenter negotiation directive now requires **`digestSummary`** (the one line users read in the brief) — not just `personalizedSummary` — to reference a concrete negotiation signal.
- **EDG-51 — negotiation trace link:** `NegotiationContext` now carries `conversationId`; new `buildNegotiationUrl()` builds a `/chat/:conversationId` deep-link, emitted as a `negotiationUrl` digest marker for the brief tooling to render.

### Tests
- Extended `negotiation-context.loader.spec.ts` (conversationId) and `opportunity.tools.digest-presenter.spec.ts` (negotiationUrl marker + negotiationContext threading).
- Fixed `negotiationDatabase` stubs in two digest specs.
- 648 protocol tests pass; build + lint clean.

### Chore
- Bump `@indexnetwork/protocol` 4.1.1 → 4.2.0.

## Companion change
The digest **consumer** lives in `Edge-City/agentvillage` (separate PR): it parses the `negotiationUrl` marker, allowlists the `/chat/<uuid>` path in the digest URL sanitizer, and lets the prepare prompt offer a "see how this came up" link.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1012"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784480280&installation_id=140549914&pr_number=1012&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1012&signature=e5c1762939774acc99e4862a3d977d4539964317e705fa9f0883f60e93c70f6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->