### PR TITLE
Release 2026-06-19 (promotion 2): EDG-50/51 opportunity legibility + negotiation link

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -26,6 +26,13 @@
       "type": "http",
       "url": "https://mcp.context7.com/mcp"
     },
+    "sentry": {
+      "url": "https://mcp.sentry.dev/mcp",
+      "auth": "oauth",
+      "oauth": {
+        "clientName": "Pi Sentry"
+      }
+    },
     "index-main": {
       "url": "https://protocol.index.network/mcp",
       "auth": "oauth",

--- a/.pi/skills/finish-pr/SKILL.md
+++ b/.pi/skills/finish-pr/SKILL.md
@@ -39,6 +39,7 @@ Use other rpiv skills when they fit the situation:
 - `code-review`: use for an independent final review when the diff is large, risky, or has had multiple review rounds.
 - `changelog`: use if the PR changes a released package or the user wants release notes updated before merge.
 - `commit`: use if local finishing changes are needed and should be committed before push.
+- `release-prod-safety`: use when the PR is a dev→main RELEASE. Apply its two checks — confirm the root `bun.lock` is in sync (a stale lockfile fails the prod build under `--frozen-lockfile` even when dev/CI are green), and run the destructive-migration data-preservation pre-flight before merge (a `DROP` runs no backfill; auto-`db:migrate` leaves no window after).
 
 Do not invoke heavyweight skills for trivial PRs with already-green checks and no open review threads.
 

--- a/.pi/skills/release-prod-safety/SKILL.md
+++ b/.pi/skills/release-prod-safety/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: release-prod-safety
+description: Pre-merge and post-merge safety checks for promoting a dev→main release in this monorepo, capturing two non-obvious ways a release can break or lose data: (1) a stale root bun.lock fails the prod build under --frozen-lockfile even though dev never caught it, and (2) a destructive Drizzle migration (e.g. DROP TABLE) silently loses prod data when the operational backfill never ran on prod. Use when cutting/merging a release PR to main, when a prod deploy build fails on "lockfile is frozen", or before merging any PR carrying a DROP/destructive migration.
+---
+
+# release-prod-safety
+
+Two production-release foot-guns observed shipping the `user_profiles` removal epic. Both passed CI and dev yet threatened prod. Check these when promoting `dev`→`main` (pairs with `finish-pr` for the merge/verify and `open-release-pr` for cutting the PR).
+
+## 1. Stale root `bun.lock` breaks the prod build (not dev)
+
+**Symptom:** the Railway prod (main) deploy fails at build with:
+```
+error: lockfile had changes, but lockfile is frozen
+```
+Build fails BEFORE the release/`db:migrate` phase, so no migration runs and the previous deployment keeps serving (no downtime, no partial migration).
+
+**Why dev never caught it:** Railway only rebuilds a service when its watched paths change. A package version bump in `packages/cli` (or `claude-plugin`/`protocol`) that isn't reflected in the root `bun.lock` won't trigger a protocol rebuild on dev, so dev never re-runs `bun install --frozen-lockfile`. The merge to `main` rebuilds everything and surfaces the drift. CI (`check`/`lint`/`typecheck`) does NOT run a frozen install, so it stays green too.
+
+**Prevent / fix:** whenever you bump any workspace `package.json` version (incl. `optionalDependencies` like the CLI platform packages), regenerate and commit `bun.lock`. Verify before merging a release:
+```bash
+bun install --frozen-lockfile   # must print "no changes" / not error
+```
+If prod already failed: regenerate the lockfile, hotfix it to `main` (then sync the identical fix to `dev` — it is equally stale), and the next deploy proceeds to build → migrate → boot.
+
+## 2. Destructive migration without a verified prod data backfill
+
+A `DROP TABLE`/column migration is a blind schema op — it does **no** data backfill. If the replacement representation is populated by a separate **operational** step (a backfill CLI, a decompose job) that ran on dev but **never on prod**, merging the release drops real prod data on deploy (`db:migrate` runs automatically).
+
+**Before merging a PR that carries a destructive migration:**
+1. Identify what the dropped table/column uniquely holds that is NOT already on the surviving tables.
+2. Audit **prod** (read-only) for rows whose content is not yet captured by the replacement — e.g. `users with a <dropped> row but no <replacement> row`, excluding ghost/deleted.
+3. If any real rows are at risk, **remediate while the source still exists** (decompose/copy into the replacement), then re-verify the at-risk count is 0.
+4. Only then merge. After deploy, run any eager backfills (and embedding backfills for SQL-inserted rows, since direct inserts bypass the graph's embedding step).
+
+**Gotchas:**
+- Migrations are sequential — you usually can't "skip" the destructive one mid-sequence, so pre-flight remediation beats splitting the release.
+- Auto-`db:migrate` on deploy means there's no window to backfill *after* the drop — do it before.
+- Successful MCP tool calls may not be logged by name; for "is the old thing still used?" prefer a **persisted** signal (a runs/operations table) over app-log greps.
+
+## See also
+- `finish-pr` — merge + post-merge deploy/Railway verification (run these checks as part of finishing a release PR).
+- `open-release-pr` — cut the dated `release/<date>` PR into `main`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,6 @@ bun run maintenance:trigger-integration     # Manually trigger integration sync
 bun run maintenance:export-slack            # Export Slack data
 bun run maintenance:import-slack-export     # Import Slack export files
 bun run maintenance:reset-brokers           # Reset context brokers
-bun run maintenance:update:embeddings       # Regenerate embeddings
 bun run maintenance:backfill-premises       # Backfill: enqueue enrichment for users in a network
 bun run maintenance:backfill-context-hyde   # Backfill: generate HyDE docs for user contexts
 bun run maintenance:backfill-global-user-contexts # Backfill: generate the global user_context (networkId=null) for every user, synthesized from active premises

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,7 +20,6 @@
     "maintenance:export-slack": "bun ./src/cli/export-slack.ts",
     "maintenance:import-slack-export": "bun ./src/cli/import-slack-export.ts",
     "maintenance:reset-brokers": "bun ./src/cli/reset-brokers.ts",
-    "maintenance:update:embeddings": "bun ./src/cli/update-embeddings.ts",
     "maintenance:fix-migrations": "bash ./scripts/fix-migrations.sh",
     "maintenance:reset-remote-db": "bun ./src/cli/db-reset-remote.ts",
     "maintenance:migrate-chat": "bun ./src/cli/migrate-chat-to-conversations.ts",

--- a/backend/src/cli/backfill-global-user-contexts.ts
+++ b/backend/src/cli/backfill-global-user-contexts.ts
@@ -9,8 +9,11 @@
  * Users WITH active premises but no global `user_context` row are synthesized
  * directly via {@link ensureGlobalUserContext} (no HyDE; the global row is
  * intentionally excluded from context-to-intent discovery). Users with no active
- * premises have no source material and are skipped (WS7 already decomposed legacy
- * profiles into premises before `user_profiles` was dropped in WS8).
+ * premises have no source material and are skipped — they self-heal lazily via
+ * `ensureGlobalUserContext` on their next read/enrichment. NOTE: the one-off
+ * profile->premises decompose CLI was removed when `user_profiles` was dropped
+ * (WS8/IND-365), so this backfill only sources from premises; a user with a
+ * legacy profile but no premises is skipped here, not decomposed.
  *
  * Idempotent + resumable: users that already have a global row are excluded by the
  * candidate query, so re-running only processes what's left. Runs entirely

--- a/bun.lock
+++ b/bun.lock
@@ -108,11 +108,11 @@
     },
     "packages/claude-plugin": {
       "name": "@indexnetwork/claude-plugin",
-      "version": "0.1.5",
+      "version": "0.1.6",
     },
     "packages/cli": {
       "name": "@indexnetwork/cli",
-      "version": "0.10.10",
+      "version": "0.10.12",
       "bin": {
         "index": "bin/index.cjs",
       },
@@ -120,15 +120,15 @@
         "@types/bun": "latest",
       },
       "optionalDependencies": {
-        "@indexnetwork/cli-darwin-arm64": "0.10.10",
-        "@indexnetwork/cli-darwin-x64": "0.10.10",
-        "@indexnetwork/cli-linux-arm64": "0.10.10",
-        "@indexnetwork/cli-linux-x64": "0.10.10",
+        "@indexnetwork/cli-darwin-arm64": "0.10.12",
+        "@indexnetwork/cli-darwin-x64": "0.10.12",
+        "@indexnetwork/cli-linux-arm64": "0.10.12",
+        "@indexnetwork/cli-linux-x64": "0.10.12",
       },
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "3.7.1",
+      "version": "4.1.1",
       "dependencies": {
         "@langchain/core": "^1.1.17",
         "@langchain/langgraph": "^1.1.2",
@@ -406,14 +406,6 @@
     "@indexnetwork/claude-plugin": ["@indexnetwork/claude-plugin@workspace:packages/claude-plugin"],
 
     "@indexnetwork/cli": ["@indexnetwork/cli@workspace:packages/cli"],
-
-    "@indexnetwork/cli-darwin-arm64": ["@indexnetwork/cli-darwin-arm64@0.10.10", "", { "os": "darwin", "cpu": "arm64", "bin": { "index": "bin/index" } }, "sha512-db5lVeSb5pBMBBHa8Oh/+bZx5XkmP2XUZvvlKdCtKzr5M5En/r8uSiMZCOzAipcL5roRzWCSAS46NSHGNjkzhw=="],
-
-    "@indexnetwork/cli-darwin-x64": ["@indexnetwork/cli-darwin-x64@0.10.10", "", { "os": "darwin", "cpu": "x64", "bin": { "index": "bin/index" } }, "sha512-qHhudIJnuDMVKvPexawst/ClibsffuTl32bjbRS1oCP4oXCP7piHDH5rlp1yREdChZTcNYQ2M8dbRG+rupqNlg=="],
-
-    "@indexnetwork/cli-linux-arm64": ["@indexnetwork/cli-linux-arm64@0.10.10", "", { "os": "linux", "cpu": "arm64", "bin": { "index": "bin/index" } }, "sha512-cte5BUcrq/pR71zabgE5G3BNSeXWQlkuJZD76xsoeC6l9xCvWSyTqbZniAo7xwWufwVya0BDfInVcFRuvUHzMw=="],
-
-    "@indexnetwork/cli-linux-x64": ["@indexnetwork/cli-linux-x64@0.10.10", "", { "os": "linux", "cpu": "x64", "bin": { "index": "bin/index" } }, "sha512-EzuMP1+MuthfzChKIWAta1ffGcLLz2JPIj2MV4sOwceGCECYETMCxFzNCZMPFGuV+jaUkBYS8m011XP4bAiqoQ=="],
 
     "@indexnetwork/protocol": ["@indexnetwork/protocol@workspace:packages/protocol"],
 

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -138,6 +138,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const shouldRedirectToHome = !authenticated && (isProtectedPage || (!isHomePage && !isPublicPage));
 
     if (shouldRedirectToHome) {
+      // Preserve the destination so the user returns to it after authenticating,
+      // instead of being stranded on the home page. This makes protected deep
+      // links work when opened while logged out — e.g. the negotiation-trace
+      // link (`/chat/:conversationId`) surfaced in the daily digest. The
+      // captured URL is forwarded to Better Auth as `callbackURL`, mirroring the
+      // public `/u/:id/chat` page's `openLoginModal(window.location.href)` flow.
+      if (typeof window !== 'undefined') {
+        // Guarded one-shot: we open the modal and immediately redirect+return, so
+        // this does not cascade renders despite the set-state-in-effect lint.
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        openLoginModal(window.location.href);
+      }
       navigate('/');
       return;
     }
@@ -149,7 +161,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
 
     setIsLoading(false);
-  }, [authenticated, ready, navigate, pathname, user, userLoading, userFetchAttempted]);
+  }, [authenticated, ready, navigate, pathname, user, userLoading, userFetchAttempted, openLoginModal]);
 
   return (
     <AuthContext.Provider

--- a/frontend/tests/auth-context.test.tsx
+++ b/frontend/tests/auth-context.test.tsx
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => {
     clearJwtToken: vi.fn(),
     signOut: vi.fn(),
     useSession: vi.fn(),
+    authModal: vi.fn(),
   };
 });
 
@@ -39,7 +40,10 @@ vi.mock('@/services/auth', () => ({
 }));
 
 vi.mock('@/components/AuthModal', () => ({
-  default: () => null,
+  default: (props: { isOpen: boolean; callbackURL?: string }) => {
+    mocks.authModal(props);
+    return null;
+  },
 }));
 
 function incompleteUser() {
@@ -96,5 +100,23 @@ describe('AuthProvider onboarding routing', () => {
 
     expect(await screen.findByTestId('location')).toHaveTextContent('/');
     expect(mocks.apiClient.get).not.toHaveBeenCalled();
+  });
+
+  test('opens the login modal with a preserved callbackURL when an unauthenticated user hits a protected deep link', async () => {
+    mocks.useSession.mockReturnValue({ data: null, isPending: false });
+
+    // A negotiation-trace deep link from the daily digest, opened while logged out.
+    renderAuthProviderAt('/chat/abc-123');
+
+    // The user is bounced to home, but the login modal is opened so that after
+    // authenticating Better Auth redirects them back to the captured URL
+    // (real browser URL via createBrowserRouter; jsdom reports the origin).
+    expect(await screen.findByTestId('location')).toHaveTextContent('/');
+    const lastCall = mocks.authModal.mock.calls.at(-1)?.[0] as
+      | { isOpen: boolean; callbackURL?: string }
+      | undefined;
+    expect(lastCall?.isOpen).toBe(true);
+    expect(typeof lastCall?.callbackURL).toBe('string');
+    expect(lastCall?.callbackURL).toBeTruthy();
   });
 });

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/enrichment/enrichment.tools.ts
+++ b/packages/protocol/src/enrichment/enrichment.tools.ts
@@ -813,16 +813,28 @@ export function createEnrichmentTools(defineTool: DefineTool, deps: ToolDeps) {
 
       const isOnboarding = !(context.user.onboarding?.completedAt);
       if (isOnboarding) {
-        const existingProfile = await userDb.getProfile();
-        if (existingProfile) {
+        // "Already enriched?" must key on a real enrichment signal, not getProfile():
+        // post-WS11 getProfile() returns a presentation row for EVERY existing user, so
+        // it would always short-circuit onboarding and refuse to enrich. The global
+        // user_context is the canonical signal (non-empty <=> the user has premises /
+        // has been enriched), mirroring findWithGraph's `hasProfile`.
+        const existingContext = getUserContextText
+          ? (await getUserContextText(context.userId)).trim()
+          : '';
+        if (existingContext) {
+          const existingProfile = await userDb.getProfile();
           return success({
             alreadyExists: true,
             message: "Profile already exists. If the user confirmed it, call complete_onboarding() to finish setup. If they want changes, use create_user_context(bioOrDescription=\"...\", confirm=true).",
-            profile: {
-              name: existingProfile.identity.name,
-              bio: existingProfile.identity.bio,
-              location: existingProfile.identity.location,
-            },
+            ...(existingProfile
+              ? {
+                  profile: {
+                    name: existingProfile.identity.name,
+                    bio: existingProfile.identity.bio,
+                    location: existingProfile.identity.location,
+                  },
+                }
+              : {}),
           });
         }
 

--- a/packages/protocol/src/enrichment/tests/enrichment.create-gate.spec.ts
+++ b/packages/protocol/src/enrichment/tests/enrichment.create-gate.spec.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, mock } from "bun:test";
+import { z } from "zod";
+
+import { createEnrichmentTools } from "../enrichment.tools.js";
+import type { ToolDeps, ResolvedToolContext } from "../../shared/agent/tool.helpers.js";
+
+/**
+ * Regression: the onboarding "already exists" gate in create_user_context must
+ * key on a real enrichment signal (the global user_context via getUserContextText),
+ * NOT userDb.getProfile(). Post-WS11 getProfile() returns a presentation row for
+ * EVERY existing user, so gating on it always short-circuited onboarding and
+ * refused to enrich.
+ */
+
+interface CapturedTool {
+  name: string;
+  handler: (input: { context: ResolvedToolContext; query: unknown }) => Promise<string>;
+}
+
+function captureCreateTool(deps: ToolDeps): CapturedTool {
+  const defs: Array<{ name: string; querySchema: z.ZodType; handler: CapturedTool["handler"] }> = [];
+  const defineTool = (def: { name: string; querySchema: z.ZodType; handler: CapturedTool["handler"] }) => {
+    defs.push(def);
+    return def;
+  };
+  createEnrichmentTools(defineTool as unknown as Parameters<typeof createEnrichmentTools>[0], deps);
+  return defs.find((t) => t.name === "create_user_context")!;
+}
+
+// Onboarding context: no completedAt → isOnboarding === true.
+const onboardingContext = {
+  userId: "u1",
+  user: { onboarding: {} },
+} as unknown as ResolvedToolContext;
+
+function buildDeps(getUserContextText: (id: string) => Promise<string>): ToolDeps {
+  return {
+    userDb: {
+      // Post-WS11: getProfile() returns a presentation row for EVERY existing user.
+      getProfile: mock(async () => ({
+        identity: { name: "U", bio: "", location: "" },
+        attributes: { skills: [], interests: [] },
+      })),
+      getUser: mock(async () => ({ id: "u1", name: "U", email: "u@example.com", socials: [] })),
+      getUserSocials: mock(async () => []),
+      setUserSocials: mock(async () => {}),
+      updateUser: mock(async () => ({})),
+      getActiveIntents: mock(async () => []),
+    },
+    systemDb: {},
+    database: {},
+    graphs: { profile: { invoke: mock(async () => ({ readResult: { hasProfile: false } })) } },
+    enricher: { enrichUserProfile: async () => null },
+    grantDefaultSystemPermissions: async () => undefined,
+    getUserContextText,
+  } as unknown as ToolDeps;
+}
+
+describe("create_user_context onboarding already-enriched gate (WS11 signal)", () => {
+  it("returns alreadyExists when the user already has a global context", async () => {
+    const tool = captureCreateTool(buildDeps(async () => "An existing synthesized identity paragraph."));
+    const out = JSON.parse(await tool.handler({ context: onboardingContext, query: {} }));
+    expect(out.success).toBe(true);
+    expect(out.data.alreadyExists).toBe(true);
+  });
+
+  it("does NOT short-circuit when there is no global context, even though getProfile() returns a row", async () => {
+    const tool = captureCreateTool(buildDeps(async () => ""));
+    const out = JSON.parse(await tool.handler({ context: onboardingContext, query: {} }));
+    // Gate skipped → falls through to the preview path; with no enrichment/info it asks for clarification.
+    expect(out.data?.alreadyExists).toBeUndefined();
+    expect(out.needsClarification).toBe(true);
+    expect(out.missingFields).toContain("bio_or_social_urls");
+  });
+});

--- a/packages/protocol/src/enrichment/tests/enrichment.generator.spec.ts
+++ b/packages/protocol/src/enrichment/tests/enrichment.generator.spec.ts
@@ -20,6 +20,20 @@ const FIXTURE_RESULTS = JSON.stringify([
   }
 ], null, 2);
 
+/**
+ * Live-LLM smoke test (real OpenRouter call) — OPT-IN via RUN_LLM_TESTS=1.
+ *
+ * It is gated off by default for two reasons: (1) it makes a real, slow,
+ * non-deterministic model call, and (2) sibling specs in this directory
+ * (`enrichment.{decompose,public-lookup,privacy-tools}.spec.ts`) replace the
+ * `enrichment.generator.js` module via `mock.module`, which bun applies
+ * process-globally with no per-file restore — so under a batch run
+ * (`bun test src/enrichment/tests/`) this spec would import the leaked stub
+ * instead of the real generator and flake. Run it in isolation:
+ *   RUN_LLM_TESTS=1 bun test src/enrichment/tests/enrichment.generator.spec.ts
+ */
+const RUN_LLM_TESTS = process.env.RUN_LLM_TESTS === '1';
+
 describe('Profile Generator', () => {
   let profileGenerator: EnrichmentGenerator;
 
@@ -27,7 +41,7 @@ describe('Profile Generator', () => {
     profileGenerator = new EnrichmentGenerator();
   })
 
-  it('should generate a profile', async () => {
+  it.skipIf(!RUN_LLM_TESTS)('should generate a profile (live LLM; set RUN_LLM_TESTS=1)', async () => {
     const result = await profileGenerator.invoke(FIXTURE_RESULTS);
     expect(!!result.output.identity.bio).toBe(true);
     expect(!!result.output.identity.location).toBe(true);

--- a/packages/protocol/src/opportunity/negotiation-context.loader.ts
+++ b/packages/protocol/src/opportunity/negotiation-context.loader.ts
@@ -36,6 +36,12 @@ export type NegotiationContextDatabase = Pick<
  */
 export interface NegotiationContext {
   status: OpportunityStatus;
+  /**
+   * Conversation/task id of the A2A negotiation that produced this opportunity.
+   * Lets callers deep-link to the negotiation trace (e.g. `/chat/:conversationId`).
+   * Present whenever a negotiation task exists (i.e. context is non-null).
+   */
+  conversationId: string;
   turnCount: number;
   /** Max turns allowed for this negotiation (0 = unlimited). */
   turnCap: number;
@@ -80,7 +86,7 @@ export async function loadNegotiationContext(
   const turnCount = turns.length;
 
   if (opportunityStatus === 'negotiating') {
-    return { status: opportunityStatus, turnCount, turnCap };
+    return { status: opportunityStatus, conversationId: task.conversationId, turnCount, turnCap };
   }
 
   const artifacts = await db.getArtifactsForTask(task.id);
@@ -88,6 +94,7 @@ export async function loadNegotiationContext(
 
   return {
     status: opportunityStatus,
+    conversationId: task.conversationId,
     turnCount,
     turnCap,
     ...(outcome ? { outcome } : {}),

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -61,8 +61,8 @@ import { mergeOpportunityEvidence, withCandidateEvidence, withMatchedStrategies 
 
 const logger = protocolLogger('OpportunityGraph');
 
-/** Time window for persist-node dedup. Parallel jobs arrive within seconds; 10 min catches those while allowing new opportunities for long-connected pairs. */
-const DEDUP_WINDOW_MS = 10 * 60 * 1000;
+/** Time window for persist-node dedup. Suppresses a second opportunity with the same person while a recent one (within 30 days) is still in flight, so a person is not re-surfaced multiple times within a month (EDG-23). */
+const DEDUP_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
 
 /** Default cap for source premises used by premise-to-premise discovery. Prevents BACKEND-5-style fan-out. */
 const DEFAULT_SOURCE_PREMISE_DISCOVERY_LIMIT = 40;
@@ -2944,7 +2944,7 @@ export class OpportunityGraphFactory {
                   });
                   continue;
                 }
-                // Else: existing opportunity is old enough (>10 min), allow new opportunity creation
+                // Else: existing opportunity is old enough (outside the 30-day dedup window), allow new opportunity creation
                 logger.verbose('[Graph:Persist] Allowing new opportunity; existing is outside dedup window', {
                   candidateUserId,
                   existingStatus: existing.status,

--- a/packages/protocol/src/opportunity/opportunity.presenter.ts
+++ b/packages/protocol/src/opportunity/opportunity.presenter.ts
@@ -398,7 +398,7 @@ Produce headline, personalizedSummary (2-3 sentences in "you" language), suggest
     // *because* the negotiation happened. Trailing the block lets weaker
     // models lean on surface signals and ignore the transcript entirely.
     const negotiationDirective = negotiationBlock
-      ? `\nIMPORTANT: This opportunity surfaced because the agents negotiated and converged. Your personalizedSummary MUST reference at least one specific signal from the NEGOTIATION CONTEXT block below — what concern was raised, what was confirmed, what the agents agreed on. Do not produce a generic skill-complementarity summary; that's what every card looked like before this negotiation happened. Use the transcript to explain *why this specific match* surfaced now.\n`
+      ? `\nIMPORTANT: This opportunity surfaced because the agents negotiated and converged. Both your personalizedSummary AND your digestSummary MUST reference at least one specific signal from the NEGOTIATION CONTEXT block below — what concern was raised, what was confirmed, what the agents agreed on. The digestSummary is the one-line morning-brief sentence a user reads before deciding to act, so it must communicate *why this specific match* surfaced now (the negotiation that led to it), not a generic skill-complementarity line. Do not produce the generic summary every card looked like before this negotiation happened.\n`
       : "";
     const humanContent = `
 ${negotiationBlock}${negotiationDirective}

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -8,6 +8,7 @@ import { MINIMAL_MAIN_TEXT_MAX_CHARS, getPrimaryActionLabel, SECONDARY_ACTION_LA
 import { viewerCentricCardSummary, narratorRemarkFromReasoning, stripUuids } from "./opportunity.presentation.js";
 import { runDiscoverFromQuery, continueDiscovery } from "./opportunity.discover.js";
 import { OpportunityPresenter, gatherPresenterContext, type PresenterDatabase } from "./opportunity.presenter.js";
+import { loadNegotiationContext } from "./negotiation-context.loader.js";
 
 function stripLeadingNarratorName(remark: string, narratorName: string): string {
   let t = remark.trim();
@@ -106,6 +107,25 @@ export function buildProfileUrl(
   if (!frontendUrl) return undefined;
   const base = frontendUrl.replace(/\/+$/, "");
   return `${base}/u/${counterpartUserId}?link_preview=false`;
+}
+
+/**
+ * Build the deep-link to an opportunity's A2A negotiation trace
+ * (`/chat/:conversationId`) so users can see *what negotiation led to* the
+ * surfaced opportunity (EDG-50/EDG-51). Returns `undefined` when `frontendUrl`
+ * is unset or there is no negotiation conversation to link to.
+ *
+ * The `?link_preview=false` hint mirrors `buildProfileUrl` — chat-gateway
+ * runtimes (e.g. Telegram delivery) strip link previews when it is present.
+ * Trailing slashes on `frontendUrl` are stripped before concatenation.
+ */
+export function buildNegotiationUrl(
+  conversationId: string | undefined,
+  frontendUrl: string | undefined,
+): string | undefined {
+  if (!frontendUrl || !conversationId) return undefined;
+  const base = frontendUrl.replace(/\/+$/, "");
+  return `${base}/chat/${conversationId}?link_preview=false`;
 }
 
 /**
@@ -342,6 +362,8 @@ type OpportunityCardLike = Record<string, unknown> & {
   feedCategory?: string | undefined;
   acceptUrl?: string | undefined;
   profileUrl?: string | undefined;
+  /** Deep-link to the A2A negotiation trace that produced this opportunity. */
+  negotiationUrl?: string | undefined;
   score?: number | undefined;
   /** Digest-mode cooldown re-show — the user has seen this card before. */
   redelivery?: boolean | undefined;
@@ -391,6 +413,7 @@ export function buildOpportunityPresentation(
         if (card.status) lines.push(`   status: ${card.status}`);
         if (card.profileUrl) lines.push(`   profileUrl: ${card.profileUrl}`);
         if (card.acceptUrl) lines.push(`   acceptUrl: ${card.acceptUrl}`);
+        if (opts.includeDigestMarkers && card.negotiationUrl) lines.push(`   negotiationUrl: ${card.negotiationUrl}`);
         if (card.feedCategory) lines.push(`   feedCategory: ${card.feedCategory}`);
         if (opts.includeDigestMarkers && card.score != null) lines.push(`   confidence: ${Math.round(card.score * 100)}`);
         if (opts.includeDigestMarkers && card.redelivery) lines.push(`   redelivery: true`);
@@ -1818,17 +1841,32 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
                 const isCounterpartGhost = counterpartUser?.isGhost ?? false;
 
                 try {
-                  const ctx = await gatherOpportunityPresenterContext(
-                    presenterDb,
-                    opp,
-                    context.userId,
-                    counterpartUserId,
-                  );
+                  // Load the negotiation context alongside presenter context so
+                  // the digest copy can explain *why* the opportunity surfaced
+                  // (EDG-50) — the presenter grounds `digestSummary` in concrete
+                  // negotiation turns when this is present. The same context
+                  // yields the conversationId for the negotiation-trace link
+                  // (EDG-51).
+                  const [ctx, negotiationContext] = await Promise.all([
+                    gatherOpportunityPresenterContext(
+                      presenterDb,
+                      opp,
+                      context.userId,
+                      counterpartUserId,
+                    ),
+                    loadNegotiationContext(deps.negotiationDatabase, opp.id, opp.status),
+                  ]);
 
                   const presentation = await presenter.presentHomeCard({
                     ...ctx,
                     opportunityStatus: opp.status,
+                    ...(negotiationContext ? { negotiationContext } : {}),
                   });
+
+                  const negotiationUrl = buildNegotiationUrl(
+                    negotiationContext?.conversationId,
+                    deps.frontendUrl,
+                  );
 
                   // Build narrator chip from presenter output
                   let narratorChip: { name: string; text: string; avatar?: string | null; userId?: string };
@@ -1854,6 +1892,9 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
                     avatar: counterpartUser?.avatar ?? null,
                     mainText: stripUuids(presentation.personalizedSummary),
                     digestSummary: stripUuids(presentation.digestSummary),
+                    // Deep-link to the negotiation trace that produced this card
+                    // (EDG-51). Only present when a negotiation conversation exists.
+                    ...(negotiationUrl ? { negotiationUrl } : {}),
                     cta: presentation.suggestedAction,
                     headline: viewerIsIntroducerHere && secondPartyNameForHeadline
                       ? `${counterpartName} → ${secondPartyNameForHeadline}`

--- a/packages/protocol/src/opportunity/tests/negotiation-context.loader.spec.ts
+++ b/packages/protocol/src/opportunity/tests/negotiation-context.loader.spec.ts
@@ -120,6 +120,7 @@ describe("loadNegotiationContext", () => {
 
     expect(result).not.toBeNull();
     expect(result!.status).toBe("negotiating");
+    expect(result!.conversationId).toBe("conv-1");
     expect(result!.turnCount).toBe(2);
     expect(result!.turnCap).toBe(8);
     expect(result!.turns).toBeUndefined();
@@ -148,6 +149,7 @@ describe("loadNegotiationContext", () => {
 
     expect(result).not.toBeNull();
     expect(result!.status).toBe("pending");
+    expect(result!.conversationId).toBe("conv-1");
     expect(result!.turnCount).toBe(2);
     expect(result!.turnCap).toBe(6);
     expect(result!.turns).toHaveLength(2);

--- a/packages/protocol/src/opportunity/tests/opportunity.graph.dedup.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.graph.dedup.spec.ts
@@ -1,6 +1,6 @@
 /**
  * Opportunity Graph: time-based dedup tests.
- * Tests the DEDUP_WINDOW_MS (10 min) gate in the Persist node.
+ * Tests the DEDUP_WINDOW_MS (30 days) gate in the Persist node.
  *
  * Run with: OPENROUTER_API_KEY=test bun test opportunity.graph.dedup.spec.ts
  * The env var must be set BEFORE Bun loads this file because ESM static imports
@@ -176,7 +176,7 @@ const discoveryInput = {
 
 describe('opportunity graph — time-based dedup (Persist node)', () => {
   test('parallel job dedup: recent existing opp skips creation (IND-166 regression)', async () => {
-    // Existing opportunity created 2 minutes ago — within the 10-minute window.
+    // Existing opportunity created 2 minutes ago — within the 30-day window.
     const recentCreatedAt = new Date(Date.now() - 2 * 60 * 1000);
     const existingOpp = makeOpportunity({ status: 'pending', createdAt: recentCreatedAt });
 
@@ -198,8 +198,8 @@ describe('opportunity graph — time-based dedup (Persist node)', () => {
   });
 
   test('old accepted pair allows new opportunity creation (outside dedup window)', async () => {
-    // Existing accepted opportunity created 20 minutes ago — outside the 10-minute window.
-    const oldCreatedAt = new Date(Date.now() - 20 * 60 * 1000);
+    // Existing accepted opportunity created 31 days ago — outside the 30-day window.
+    const oldCreatedAt = new Date(Date.now() - 31 * 24 * 60 * 60 * 1000);
     const oldOpp = makeOpportunity({ status: 'accepted', createdAt: oldCreatedAt });
 
     let createCalled = false;
@@ -277,7 +277,8 @@ describe('opportunity graph — time-based dedup (Persist node)', () => {
   });
 
   test('stuck negotiating fix: orphaned negotiating opp is reactivated instead of creating new', async () => {
-    // Existing negotiating opportunity created 15 minutes ago — outside the 10-minute window.
+    // Existing negotiating opportunity created 15 minutes ago — within the 30-day window,
+    // but the orphan-heal path reactivates regardless of age when no active task exists.
     // getNegotiationTaskForOpportunity returns null (no active task), so persist node
     // reactivates the orphaned opp via updateOpportunityStatus instead of creating a new one.
     const oldNegotiatingOpp = makeOpportunity({
@@ -310,6 +311,7 @@ describe('opportunity graph — time-based dedup (Persist node)', () => {
 
   test('introduction path: recent existing opp skips creation (onBehalfOfUserId dedup)', async () => {
     // Discovery running on behalf of USER_A — USER_B already has a recent pending opp with USER_A.
+    // Created 2 minutes ago — well within the 30-day dedup window.
     const recentCreatedAt = new Date(Date.now() - 2 * 60 * 1000);
     const existingOpp = makeOpportunity({ status: 'pending', createdAt: recentCreatedAt });
 

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.digest-dedup.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.digest-dedup.spec.ts
@@ -142,7 +142,11 @@ function makeDeps(opts: {
     contactService: {} as unknown as ToolDeps['contactService'],
     integrationImporter: {} as unknown as ToolDeps['integrationImporter'],
     enricher: {} as unknown as ToolDeps['enricher'],
-    negotiationDatabase: {} as unknown as ToolDeps['negotiationDatabase'],
+    negotiationDatabase: {
+      getNegotiationTaskForOpportunity: async () => null,
+      getMessagesForConversation: async () => [],
+      getArtifactsForTask: async () => [],
+    } as unknown as ToolDeps['negotiationDatabase'],
     deliveryLedger: deliveryLedger as unknown as ToolDeps['deliveryLedger'],
     opportunityPresentation: {
       createPresenter: () => ({ presentHomeCard: (input: unknown) => presentHomeCardMock(input) }),

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts
@@ -81,6 +81,20 @@ const getOppsForUser = mock(async (_userId: string, filter?: { statuses?: string
 let getUser = mock(async () => ({ id: testUserId, name: 'Test User' }) as UserRecord | null);
 let getProfile = mock(async () => (null) as UserIdentity | null);
 
+// Negotiation task returned by the negotiation-context loader. Default: no
+// negotiation has happened (loadNegotiationContext returns null), so digest
+// cards carry no negotiationUrl unless a test opts into one.
+type NegotiationTask = {
+  id: string;
+  conversationId: string;
+  state: string;
+  metadata: Record<string, unknown> | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+let negotiationTask: NegotiationTask | null = null;
+const getNegotiationTaskForOpportunity = mock(async () => negotiationTask);
+
 const noopGraph = { invoke: async () => ({}) };
 
 function makeDeps(overrides: Partial<Parameters<typeof createOpportunityTools>[1]> = {}): ToolDeps {
@@ -113,7 +127,12 @@ function makeDeps(overrides: Partial<Parameters<typeof createOpportunityTools>[1
     contactService: {} as unknown as ToolDeps["contactService"],
     integrationImporter: {} as unknown as ToolDeps["integrationImporter"],
     enricher: {} as unknown as ToolDeps["enricher"],
-    negotiationDatabase: {} as unknown as ToolDeps["negotiationDatabase"],
+    frontendUrl: 'https://index.network',
+    negotiationDatabase: {
+      getNegotiationTaskForOpportunity,
+      getMessagesForConversation: mock(async () => []),
+      getArtifactsForTask: mock(async () => []),
+    } as unknown as ToolDeps["negotiationDatabase"],
     graphs: {
       profile: noopGraph,
       intent: noopGraph,
@@ -162,6 +181,57 @@ describe('list_opportunities digest presenter path', () => {
     expect(presentHomeCardMock).toHaveBeenCalled();
     expect(String(result.data?.message)).toContain('You might like meeting Alice because she matches your current interests.');
     expect(String(result.data?.message)).not.toContain('Test personalized summary');
+  });
+
+  it('emits a negotiationUrl marker and feeds negotiationContext to the presenter when a negotiation exists', async () => {
+    candidateOpps = [makeOpp('opp-neg', 'c-neg', 'pending')];
+    getUser = mock(async () => ({ id: testUserId, name: 'Viewer' }) as UserRecord | null);
+    getProfile = mock(async () => ({ identity: { name: 'Carol', bio: '', location: '' }, userId: 'c-neg' }) as unknown as UserIdentity | null);
+    negotiationTask = {
+      id: 'task-neg',
+      conversationId: 'conv-xyz',
+      state: 'completed',
+      metadata: { type: 'negotiation', opportunityId: 'opp-neg', maxTurns: 6 },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    // Capture the presenter input so we can assert negotiationContext threading.
+    presentHomeCardMock = mock(async () => ({
+      headline: 'Test Headline',
+      personalizedSummary: 'Agents agreed you both want to ship privacy tooling.',
+      digestSummary: 'You might like meeting Carol because your agents agreed on shared privacy-tooling goals.',
+      suggestedAction: 'Test action',
+      narratorRemark: 'Test narrator remark',
+      mutualIntentsLabel: undefined,
+      greeting: '',
+    }));
+
+    const deps = makeDeps();
+    const tools = createOpportunityTools(defineTool as unknown as DefineTool, deps);
+    const listTool = tools.find((t: { name: string }) => t.name === 'list_opportunities')!;
+
+    const result = parseResult(
+      await listTool.handler({
+        context: {
+          userId: testUserId,
+          isMcp: true,
+          networkId: undefined,
+          sessionId: undefined,
+          userName: 'Viewer',
+          userNetworks: [],
+        },
+        query: { includeDigestMarkers: true },
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    // EDG-51: digest marker carries the negotiation-trace deep link.
+    expect(String(result.data?.message)).toContain('negotiationUrl: https://index.network/chat/conv-xyz?link_preview=false');
+    // EDG-50: presenter received the negotiation context so digestSummary can be grounded.
+    const lastCall = presentHomeCardMock.mock.calls.at(-1)?.[0] as { negotiationContext?: { conversationId?: string } } | undefined;
+    expect(lastCall?.negotiationContext?.conversationId).toBe('conv-xyz');
+
+    negotiationTask = null;
   });
 
   it('skips digest cards instead of surfacing raw fallback when presenter throws', async () => {


### PR DESCRIPTION
## Release 2026-06-19 (promotion 2)

Promotes `dev` → `main`. This is the **second** release cut today; it carries everything merged to `dev` after PR #1005, headlined by the EDG-50/EDG-51 opportunity-legibility + negotiation-trace-link feature and the matching agentvillage submodule bump.

### Highlights
- **Opportunity legibility + negotiation traces (EDG-50 / EDG-51)** — digest opportunity cards now explain *why* an opportunity surfaced (negotiation-grounded summary) and link to the `/chat/{conversationId}` negotiation trace; protocol bumped to **4.2.0**.
- **Post-login redirect-back** — auth flow returns the user to the protected deep link (e.g. a trace URL) after sign-in instead of dropping them on `/`.
- **agentvillage submodule promoted to #116** — pointer advanced `222ee7e → 5af6e5de` so the digest consumer (parse `negotiationUrl`, allowlist `/chat/<uuid>`, render link) ships alongside the protocol producer.
- **Enrichment onboarding gate fix** — onboarding create now keys on a real enrichment signal (ACTIVE premises / global user_context) instead of `getProfile()`, which always returns a row.

### New Features (`feat`)
- `feat(opportunity): explain why opportunities surface + link negotiation trace` (`9ca4385`) — EDG-50 / EDG-51

### Bug Fixes (`fix`)
- `fix(enrichment): gate onboarding create on real enrichment signal, not getProfile()` (#1010)
- `fix(auth): redirect back to protected deep links after login` (`8d0adf7`) — EDG-51
- `fix: reconcile root bun.lock with package versions` (#1007)

### Chores (`chore`)
- `chore(agentvillage): bump submodule to merged #116 (digest negotiation-trace link)` (`e2d6c2c`) — `222ee7e → 5af6e5de`
- `chore(agentvillage): bump submodule to negotiation-summary preamble fix #117` (#1013)
- `chore(agentvillage): bump submodule pointer to merged #115 (canonical MCP tool names)` (#1008)
- `chore(protocol): bump to 4.2.0 for opportunity legibility + negotiation links` (`c2be19e`)

### Tests (`test`)
- `test(enrichment): gate live-LLM generator spec behind RUN_LLM_TESTS (fix suite flake)` (#1011)

### Docs (`docs`)
- `docs+chore: fix stale maintenance-CLI refs; capture release-prod-safety skill` (#1009)
- `Update .mcp.json` (`1fb525e`)

### Merge commits
- `Merge pull request #1012 from indexnetwork/yanki/edg-50-51-opportunity-legibility` (`d510ded`)

### Issues and PRs
- index PRs included: #1007, #1008, #1009, #1010, #1011, #1012, #1013
- agentvillage (Edge-City/agentvillage) PRs referenced via submodule bumps: #115, #116, #117
- Linear: **EDG-50**, **EDG-51** (opportunity legibility / negotiation link — kept In Progress until this release reaches prod); IND-365 referenced in CLAUDE.md context

### Diff summary
```text
 .mcp.json                                          |  7 ++
 .pi/skills/finish-pr/SKILL.md                      |  1 +
 .pi/skills/release-prod-safety/SKILL.md            | 43 +++++++++++++
 CLAUDE.md                                          |  1 -
 backend/package.json                               |  1 -
 backend/src/cli/backfill-global-user-contexts.ts   |  7 +-
 bun.lock                                           | 22 ++-----
 frontend/src/contexts/AuthContext.tsx              | 14 +++-
 frontend/tests/auth-context.test.tsx               | 24 ++++++-
 packages/edge-city/agentvillage                    |  2 +-
 packages/protocol/package.json                     |  2 +-
 packages/protocol/src/enrichment/enrichment.tools.ts            | 26 ++++++--
 packages/protocol/src/enrichment/tests/enrichment.create-gate.spec.ts | 75 +++++++++++++++++
 packages/protocol/src/enrichment/tests/enrichment.generator.spec.ts   | 16 ++++-
 packages/protocol/src/opportunity/negotiation-context.loader.ts       |  9 ++-
 packages/protocol/src/opportunity/opportunity.presenter.ts            |  2 +-
 packages/protocol/src/opportunity/opportunity.tools.ts                | 53 ++++++++++--
 packages/protocol/src/opportunity/tests/negotiation-context.loader.spec.ts        |  2 +
 packages/protocol/src/opportunity/tests/opportunity.tools.digest-dedup.spec.ts    |  6 +-
 packages/protocol/src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts | 72 +++++++++++++++++-
 20 files changed, 344 insertions(+), 41 deletions(-)
```

### Verification
- [x] Release branch created from `origin/dev` at `61d4774`, plus one submodule-bump commit `e2d6c2c`.
- [x] agentvillage submodule pointer advanced `222ee7e → 5af6e5de` (Edge-City/agentvillage `main` tip, PR #116).
- [x] #1012 CI green on dev (lint/typecheck, subtree-sync); Railway `dev` protocol + frontend deployments SUCCESS.
- [ ] GitHub checks pass on this release PR.
- [ ] Release PR reviewed and approved.

> Range: `5be5300..e2d6c2c` (13 commits). This PR only opens the release for review — it does not ship until merged to `main` and deployed to prod.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784484166&installation_id=140549914&pr_number=1014&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1014&signature=38b35ba360133f411c203bb295c01828b27f263e14d96dc58dbff37f8ff9643d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->