### PR TITLE
feat(opportunity): extend same-person dedup window to 1 month

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -61,8 +61,8 @@ import { mergeOpportunityEvidence, withCandidateEvidence, withMatchedStrategies 
 
 const logger = protocolLogger('OpportunityGraph');
 
-/** Time window for persist-node dedup. Parallel jobs arrive within seconds; 10 min catches those while allowing new opportunities for long-connected pairs. */
-const DEDUP_WINDOW_MS = 10 * 60 * 1000;
+/** Time window for persist-node dedup. Suppresses a second opportunity with the same person while a recent one (within 30 days) is still in flight, so a person is not re-surfaced multiple times within a month (EDG-23). */
+const DEDUP_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
 
 /** Default cap for source premises used by premise-to-premise discovery. Prevents BACKEND-5-style fan-out. */
 const DEFAULT_SOURCE_PREMISE_DISCOVERY_LIMIT = 40;
@@ -2944,7 +2944,7 @@ export class OpportunityGraphFactory {
                   });
                   continue;
                 }
-                // Else: existing opportunity is old enough (>10 min), allow new opportunity creation
+                // Else: existing opportunity is old enough (outside the 30-day dedup window), allow new opportunity creation
                 logger.verbose('[Graph:Persist] Allowing new opportunity; existing is outside dedup window', {
                   candidateUserId,
                   existingStatus: existing.status,

--- a/packages/protocol/src/opportunity/tests/opportunity.graph.dedup.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.graph.dedup.spec.ts
@@ -1,6 +1,6 @@
 /**
  * Opportunity Graph: time-based dedup tests.
- * Tests the DEDUP_WINDOW_MS (10 min) gate in the Persist node.
+ * Tests the DEDUP_WINDOW_MS (30 days) gate in the Persist node.
  *
  * Run with: OPENROUTER_API_KEY=test bun test opportunity.graph.dedup.spec.ts
  * The env var must be set BEFORE Bun loads this file because ESM static imports
@@ -176,7 +176,7 @@ const discoveryInput = {
 
 describe('opportunity graph — time-based dedup (Persist node)', () => {
   test('parallel job dedup: recent existing opp skips creation (IND-166 regression)', async () => {
-    // Existing opportunity created 2 minutes ago — within the 10-minute window.
+    // Existing opportunity created 2 minutes ago — within the 30-day window.
     const recentCreatedAt = new Date(Date.now() - 2 * 60 * 1000);
     const existingOpp = makeOpportunity({ status: 'pending', createdAt: recentCreatedAt });
 
@@ -198,8 +198,8 @@ describe('opportunity graph — time-based dedup (Persist node)', () => {
   });
 
   test('old accepted pair allows new opportunity creation (outside dedup window)', async () => {
-    // Existing accepted opportunity created 20 minutes ago — outside the 10-minute window.
-    const oldCreatedAt = new Date(Date.now() - 20 * 60 * 1000);
+    // Existing accepted opportunity created 31 days ago — outside the 30-day window.
+    const oldCreatedAt = new Date(Date.now() - 31 * 24 * 60 * 60 * 1000);
     const oldOpp = makeOpportunity({ status: 'accepted', createdAt: oldCreatedAt });
 
     let createCalled = false;
@@ -277,7 +277,8 @@ describe('opportunity graph — time-based dedup (Persist node)', () => {
   });
 
   test('stuck negotiating fix: orphaned negotiating opp is reactivated instead of creating new', async () => {
-    // Existing negotiating opportunity created 15 minutes ago — outside the 10-minute window.
+    // Existing negotiating opportunity created 15 minutes ago — within the 30-day window,
+    // but the orphan-heal path reactivates regardless of age when no active task exists.
     // getNegotiationTaskForOpportunity returns null (no active task), so persist node
     // reactivates the orphaned opp via updateOpportunityStatus instead of creating a new one.
     const oldNegotiatingOpp = makeOpportunity({
@@ -310,6 +311,7 @@ describe('opportunity graph — time-based dedup (Persist node)', () => {
 
   test('introduction path: recent existing opp skips creation (onBehalfOfUserId dedup)', async () => {
     // Discovery running on behalf of USER_A — USER_B already has a recent pending opp with USER_A.
+    // Created 2 minutes ago — well within the 30-day dedup window.
     const recentCreatedAt = new Date(Date.now() - 2 * 60 * 1000);
     const existingOpp = makeOpportunity({ status: 'pending', createdAt: recentCreatedAt });
 


### PR DESCRIPTION
Closes EDG-23.

## Summary
Prevents multiple opportunities with the same person being created in quick succession by extending the persist-node dedup window from **10 minutes to 30 days**. Once a person has been surfaced in an opportunity, discovery will not re-mint a new opportunity with them for a month.

> Note: the issue described the current window as "3 days", but the actual per-person gate (`DEDUP_WINDOW_MS`) was 10 minutes. Confirmed with the assignee that extending this gate to 1 month (30 days) is the intended fix.

## Changes
- **`opportunity.graph.ts`**: `DEDUP_WINDOW_MS` 10 min -> 30 days; updated doc/inline comments. Gate applies in both the discovery path and introducer (on-behalf-of) path.
- **`opportunity.graph.dedup.spec.ts`**: updated the "old accepted pair allows new creation" fixture (20 min -> 31 days, since 20 min is now inside the window) and refreshed window comments.
- **`packages/protocol/package.json`**: bump 4.1.1 -> 4.2.0 (published subtree).

## Tests
- All 6 dedup specs pass; 82 other opportunity/digest specs pass.
- One unrelated pre-existing failure (`OpportunityEvaluator` live-LLM test) fails only because it needs a real `OPENROUTER_API_KEY` (401 Missing Authentication header) — not affected by this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1016"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784496524&installation_id=140549914&pr_number=1016&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1016&signature=d4bd1087a182d600df1fda623b2b40c1fac9a8ee541fbcb6313ffb64287ce696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->