### PR TITLE
chore: trigger Railway dev redeploy

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -1,3 +1,4 @@
+# Touch to trigger a Railway dev redeploy (no functional change).
 [build]
 watchPatterns = ["/backend/**", "/packages/protocol/**", "/bun.lock", "/package.json", "/railway.toml"]
 buildCommand = "bun run build:package:protocol && bun run build:backend"


### PR DESCRIPTION
Adds a no-op comment to `railway.toml` so the push touches a Railway watch path (`/railway.toml`), forcing a Railway dev redeploy of the backend service (build + `db:migrate` + healthcheck).

This is a follow-up to #1018 (Blacksmith runner migration). The migration itself was CI-runner-only and does not affect Railway, but this touch exercises the Railway dev deploy pipeline on the latest `dev` so we can confirm the environment is healthy. No functional change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->