### PR TITLE
Release 2026-06-20

### DIFF
--- a/.github/workflows/check-skills.yml
+++ b/.github/workflows/check-skills.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
 
@@ -58,7 +58,7 @@ jobs:
         run: ./scripts/check-adapter-names.sh
 
   typecheck:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/neon-reset-dev.yml
+++ b/.github/workflows/neon-reset-dev.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   reset_neon_dev:
     name: Reset Neon dev branch
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Reset dev branch from production
         id: reset_neon_dev

--- a/.github/workflows/notify-pr-to-slack.yml
+++ b/.github/workflows/notify-pr-to-slack.yml
@@ -9,7 +9,7 @@ on:
     branches: [dev, main]
 jobs:
   notify-pr:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     if: github.repository == 'indexnetwork/index' && github.event_name == 'pull_request_target' && github.event.pull_request.merged == true
     steps:
       - name: Build payload
@@ -39,7 +39,7 @@ jobs:
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
   notify-push:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     if: github.repository == 'indexnetwork/index' && github.event_name == 'push'
     steps:
       - name: Build payload

--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   backend-release:
     name: Backend release
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       SENTRY_ORG: ${{ secrets.SENTRY_ORG }}

--- a/.github/workflows/sync-subtrees.yml
+++ b/.github/workflows/sync-subtrees.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   sync:
     if: github.repository == 'indexnetwork/index'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       fail-fast: false
       matrix:

--- a/.rpiv/artifacts/discover/2026-06-19_18-59-29_intent-count-consistency.md
+++ b/.rpiv/artifacts/discover/2026-06-19_18-59-29_intent-count-consistency.md
@@ -1,0 +1,121 @@
+---
+date: 2026-06-19T18:59:29+0300
+author: Yanek Yuk
+commit: 1fb525e730
+branch: yanki/edg-53-fix-intent-count-consistency
+repository: index
+topic: "Intent count consistency across surfaces"
+tags: [intent, frd, library, networks, mcp, hermes, edge-city, count-consistency]
+status: ready
+last_updated: 2026-06-19T18:59:29+0300
+last_updated_by: Yanek Yuk
+---
+
+# FRD: Intent count consistency across surfaces
+
+## Summary
+Users see different intent counts depending on where they look — `/library`, `/networks`, the MCP tools, the Hermes/AgentVillage sidecar, and the backend each compute "a user's intents" with different filter sets, and Hermes never fetches it at all. This erodes trust and makes the product feel broken. The deliverable is to converge every surface on one canonical intent definition and have each surface properly *list* the underlying data: `/library` shows all intents with their network assignments and status, the `/networks` overview tab shows intents + premises + user_context per network, and MCP + Hermes report the same canonical count — with Hermes correctly reflecting its scoped-API-key view. Linear: EDG-53 (Urgent).
+
+## Problem & Intent
+The user's framing: this is a **user-facing trust / confusion** problem. End users see different intent counts across `/library`, MCP, and `/networks` (and Hermes vs Index), which erodes trust and makes the product feel broken. The goal is a single consistent number — and consistent underlying lists — everywhere a user looks. The user further clarified that the surfaces should not just show a matching integer but properly surface the data: "Library shows all intents, their assignments to networks, and their status (if applicable)" and the "Network overview tab should show intents and premises assigned to that network, and also the user_context."
+
+A critical constraint: through AgentVillage/Hermes, Index is accessed via a **scoped API key**, so "the same count" for Hermes means the count correct *for that scoped-key view*, not the owner's full unscoped set.
+
+## Goals
+- Establish one canonical definition of "a user's intents" that all surfaces converge on.
+- `/library` lists all intents with their network assignments and status, and its count reflects the canonical total (not a capped page length).
+- `/networks` overview tab surfaces the intents + premises + user_context assigned to that network.
+- MCP intent-listing/count tools report the canonical count consistent with `/library`.
+- Hermes/AgentVillage reports an intent count (currently `null`) that is correct for its scoped-API-key view and consistent with the other surfaces under the same scope/identity.
+
+## Non-Goals
+- Changing the intent data model or introducing a new `status`-based filter is NOT assumed — the canonical filter set is deferred to research (see Open Questions), so this FRD does not pre-commit to excluding `PAUSED/FULFILLED/EXPIRED`.
+- Redesigning the negotiation / opportunity surfaces (opportunity counts are already wired in Hermes and out of scope here).
+
+## Functional Requirements
+1. The system SHALL define a single canonical query/definition for "a user's intents" that all surfaces reuse (exact filter set to be settled in research).
+2. `/library` SHALL list all of a user's intents and, for each, display its network assignments and its status (when applicable).
+3. `/library`'s intent count SHALL reflect the canonical server-side total rather than the client-side length of a paginated, capped result set.
+4. The `/networks` overview tab SHALL display the intents, premises, and user_context assigned to that network.
+5. The MCP intent-read/count tooling SHALL return a count consistent with the canonical definition used by `/library`.
+6. The Hermes/AgentVillage control-plane SHALL fetch and report an intent count (replacing the hard-coded `null`) that reflects what its scoped API key is authorized to see.
+7. For a single identity/scope, all surfaces SHALL agree on the intent count.
+
+## Non-Functional Requirements
+- **Performance**: Count queries should avoid N+1 across surfaces; reuse the existing single-`count()`-with-shared-`where` pattern in the backend list query where possible. No hard latency target set.
+- **Security**: The scoped API key used by AgentVillage/Hermes MUST NOT widen visibility — the canonical count for Hermes is bounded by what the scoped key authorizes, never the owner's full unscoped set.
+- **UX / Accessibility**: Counts and lists must read as consistent across surfaces; no surface should silently truncate or mislabel (e.g., showing a capped page length as if it were the total).
+- **Reliability**: Hermes must degrade gracefully if the intent fetch fails (it currently shows `—` for null); a fetch error should not break the rest of the stats payload.
+
+## Constraints & Assumptions
+- AgentVillage/Hermes accesses Index through a **scoped API key** — the canonical count rule must be evaluated under that scope.
+- Canonical schema is `backend/src/schemas/database.schema.ts`; intents are soft-deleted via `archivedAt` (no `deletedAt`/`draft` column on `intents`).
+- Multiple sibling queries already exist (`listIntents`, `getActiveIntents`, `getActiveIntentsAcrossIndexes`, `getIntentsInIndexForMember`, `searchOwnIntents`) — convergence likely means consolidating on a shared definition rather than adding a sixth.
+- Assumption: "premises" and "user_context" map to existing entities/fields — to be traced in research before the `/networks` overview requirement is finalized.
+
+## Acceptance Criteria
+- [ ] For a test user, the integer intent count shown on `/library`, returned by the MCP read tool, and reported by Hermes (under its scoped key for that identity) are equal.
+- [ ] `/library` renders, for each intent, its network assignment(s) and status, and the tab badge equals the server `totalCount` even when the user has more than 100 intents.
+- [ ] The `/networks` overview tab renders the intents, premises, and user_context assigned to the selected network.
+- [ ] The Hermes/AgentVillage admin stat for intents shows a real number (not `—`/`null`) sourced from a scoped-key fetch, and matches the canonical count for that scope.
+- [ ] A documented single canonical intent definition exists and every surface references it (code review confirms no surface applies a divergent filter without justification).
+
+## Recommended Approach
+Consolidate the divergent intent queries onto one canonical definition in the backend adapter/service layer, expose the canonical count through the existing `/intents/list` pagination payload and the MCP read path, fix `/library` to render `totalCount` plus per-intent network assignments and status, add an intent fetch (scoped-key aware) to the edge-city control-plane mirroring `fetchIndexOpportunityCount`, and extend the `/networks` overview tab to render network-scoped intents + premises + user_context. Exact canonical filter set and the premises/user_context mappings are to be settled in research before implementation.
+
+## Decisions
+
+### Primary pain is user-facing trust
+**Question**: What's the actual pain here — who notices the inconsistent intent counts and what goes wrong for them?
+**Recommended**: n/a — `intent` question
+**Chosen**: User-facing trust / confusion — end users see different counts across surfaces, eroding trust; goal is one consistent number (and list) everywhere.
+**Rationale**: Developer's own framing; drives all downstream requirements.
+
+### Deliverable is full per-surface listing + consistency (all surfaces)
+**Question**: Is the deliverable just to reconcile the count integer, or to properly surface the underlying intent data on each surface?
+**Recommended**: Full per-surface listing + consistency (all surfaces)
+**Chosen**: Full listing + consistency across all surfaces, including Hermes — with the explicit note that AgentVillage/Hermes uses a scoped API key.
+**Rationale**: Developer chose option (1) twice and added the scoped-key constraint; consistency should fall out of a shared canonical query layer.
+
+### Scoped-key view is the canonical count for Hermes
+**Question**: How should the scoped API key AgentVillage uses affect the canonical count?
+**Recommended**: Scoped-key view IS the canonical count for Hermes
+**Chosen**: The count Hermes reports must reflect exactly what the scoped API key is authorized to see; "consistency" means surfaces agree for the same identity/scope.
+**Rationale**: Security boundary — a scoped key must not be normalized up to the owner's full set; `evidence: packages/edge-city/agentvillage-controlplane/control-plane/src/tenants.js:321` (intents currently `null`, never fetched).
+
+### `/library` should show all intents + assignments + status
+**Question**: (Captured via developer free-text during scope confirmation.)
+**Recommended**: Use server `totalCount`, render network assignments and status per intent.
+**Chosen**: "Library shows all intents, their assignments to networks, and their status (if applicable)."
+**Rationale**: Developer's explicit statement; `evidence: frontend/src/app/library/page.tsx:103-104,223-224` (currently displays `intents.length` of a 100-capped page, no assignments/status badges).
+
+### `/networks` overview tab should show intents + premises + user_context
+**Question**: What does the ticket's "/networks should list proper intents and counts" refer to? (probe found no intent count on `/networks` pages)
+**Recommended**: Network detail should show a per-network intent count.
+**Chosen**: "Network overview tab should show intents and premises assigned to that network, and also the user_context."
+**Rationale**: Developer clarified the intended surface; `evidence: frontend/src/app/networks/page.tsx`, `frontend/src/app/networks/[id]/page.tsx` render only `_count.members` today.
+
+### Canonical filter definition — deferred to research
+**Question**: What is the single canonical definition of "a user's intent count" that every surface should converge on?
+**Recommended**: Backend `listIntents` filter as-is (userId + `archivedAt IS NULL`, no status filter)
+**Chosen**: Defer — decide during research.
+**Rationale**: Developer deferred; the per-surface divergence (status enum vs `archivedAt`, network-membership joins, dedup) needs full tracing before fixing the canonical rule.
+
+## Open Questions
+- Exact canonical intent filter set — userId + `archivedAt IS NULL` only, vs. also excluding `PAUSED/FULFILLED/EXPIRED` (status enum is currently never filtered; all surfaces key off `archivedAt`). Deferred to research.
+- What "premises" maps to in the data model (a column, an MCP concept, or a derived field), and what "user_context" refers to for the `/networks` overview tab. Deferred to research to trace.
+- How the AgentVillage/Hermes scoped API key resolves to intent scoping at the backend/MCP boundary — needed to define the canonical count "under scope."
+
+## Suggested Follow-ups
+- The intent `status` enum (`ACTIVE/PAUSED/FULFILLED/EXPIRED`) is selected but never used as a filter on any surface — `backend/src/schemas/database.schema.ts:10,562`. If status-based counting is desired later, it's a separate decision.
+- `getActiveIntentsAcrossIndexes` dedups via `selectDistinctOn([intents.id])` while other community-browse paths may not — `backend/src/adapters/database.adapter.ts:817-841`. Worth auditing for multi-network inflation independent of this ticket.
+- Hermes' `summarize-negotiations.ts` re-filters `i.status === "active"` client-side after an MCP `read_intents` (limit 20) call — yet another count basis — `packages/edge-city/agentvillage/skills/index-network/scripts/summarize-negotiations.ts:294-309`.
+
+## References
+- Linear EDG-53 — "Fix intent count consistency" (Urgent): https://linear.app/edge-city/issue/EDG-53/fix-intent-count-consistency
+- `backend/src/adapters/database.adapter.ts:512-553` (`listIntents`, canonical list+count), `:310-328` (`getActiveIntents`, MCP path), `:817-841` (`getActiveIntentsAcrossIndexes`)
+- `backend/src/controllers/intent.controller.ts:29-51`, `backend/src/services/intent.service.ts:91-118`
+- `frontend/src/app/library/page.tsx:103-104,223-224`; `frontend/src/services/intents.ts:6-15`
+- `frontend/src/app/networks/page.tsx`, `frontend/src/app/networks/[id]/page.tsx`
+- `packages/protocol/src/intent/intent.tools.ts:75-202` (`read_intents`), `intent.graph.ts:683-837`
+- `packages/edge-city/agentvillage-controlplane/control-plane/src/tenants.js:321,509`, `index-network.js:54-66`

--- a/.rpiv/artifacts/plans/2026-06-19_19-57-03_intent-count-consistency.md
+++ b/.rpiv/artifacts/plans/2026-06-19_19-57-03_intent-count-consistency.md
@@ -1,0 +1,823 @@
+---
+date: 2026-06-19T19:57:03+0300
+author: Yanek Yuk
+commit: 1fb525e730
+branch: yanki/edg-53-fix-intent-count-consistency
+repository: index
+topic: "Intent count consistency across surfaces"
+tags: [plan, intent, count, pagination, mcp, scoped-key, edge-city, premises, user-context, networks]
+status: ready
+parent: .rpiv/artifacts/research/2026-06-19_19-16-39_intent-count-consistency.md
+phase_count: 6
+phases:
+  - { n: 1, title: Shared canonical intent predicate }
+  - { n: 2, title: /library count + status badge }
+  - { n: 3, title: /networks overview backend }
+  - { n: 4, title: /networks overview frontend }
+  - { n: 5, title: Control-plane Hermes intent count }
+  - { n: 6, title: Hermes skill dead-filter cleanup }
+unresolved_phase_count: 0
+last_updated: 2026-06-19T19:57:03+0300
+last_updated_by: Yanek Yuk
+---
+
+# Intent Count Consistency Across Surfaces — Implementation Plan
+
+## Overview
+
+Every surface that reports "a user's intents" (`/library`, `/networks`, MCP tools, the Hermes/AgentVillage sidecar) shares one canonical ownership predicate — `userId = ? AND archivedAt IS NULL` — but they diverge today through a frontend rendering bug (`/library` shows a 100-capped page length, not the true total), a missing fetch (Hermes hard-codes `intents: null`), and duplicated query code that can drift. This plan routes each surface to the correct canonical query, consolidates the duplicated predicate into one shared where-builder, fixes the `/library` total + status rendering, adds the missing Hermes count sourced from the MCP scoped view, and surfaces premises + per-network `user_context` on the `/networks` overview tab. No new filter semantics are introduced — the divergence is structural (which query) and presentational (what's rendered), not logical.
+
+## Requirements
+
+- One canonical intent definition (`userId + archivedAt IS NULL`, no status filter) shared across REST and MCP adapter surfaces.
+- `/library` shows the true intent total (not a capped page length), each intent's network assignments (already working), and its status when applicable.
+- `/networks` overview tab shows the current member's intents, premises assigned to that network, and their per-network `user_context`.
+- Hermes/AgentVillage reports an intent count that reflects exactly what its scoped API key is authorized to see (the MCP scoped view), or degrades gracefully (`null`) on failure.
+- No surface silently truncates or mislabels counts.
+
+## Current State Analysis
+
+The divergence is **not** caused by differing filter logic. All five "own intents" queries key off `userId + archivedAt IS NULL`; the `intentStatusEnum` is selected in projections but never appears in any WHERE clause. The real divergence vector is `getActiveIntentsAcrossIndexes`, which adds `innerJoin(intentNetworks)` + `selectDistinctOn([intents.id])` — legitimately yielding a network-reachable subset for scoped MCP keys (the FRD's accepted "scoped view is canonical for Hermes").
+
+### Key Discoveries
+
+- **Canonical predicate, two copies:** `IntentDatabaseAdapter` (REST) and `ChatDatabaseAdapter` (MCP) hold byte-identical `getActiveIntents` (`database.adapter.ts:310` ↔ `:1003`), `getActiveIntentsAcrossIndexes` (`:817` ↔ `:2238`), and `listIntents`-style predicates. `listIntents` (`:512`) builds `eq(userId)` + archived toggle + optional `sourceType`, with a parallel `count()` over the same `where` (`:550`).
+- **`/library` bug is frontend-only:** the server ships `pagination.totalCount` (`intent.service.ts:114`, `intent.controller.ts:52`) and per-intent `status` (`:47` via `...r`). The page fetches with a generic type that omits `pagination` (`library/page.tsx:103`), so `totalCount` is type-dropped; the badge renders `intents.length` capped at 100 (`page.tsx:222-224`). `status` is absent from `LibrarySourceIntent` (`page.tsx:15-26`) and `BaseIntent` (`IntentList.tsx:31-47`). Network chips already flow + render (`attachIntentNetworks` → `NetworkMembership`).
+- **`/networks` overview serves intents only:** `GET /networks/:id/my-intents` (`network.controller.ts:867` → `network.service.ts:368` → `getNetworkIntentsForMember` `:2198`), user-filtered at `network.service.ts:371`. Premises and `user_context` have no HTTP endpoint. Reusable read patterns exist: `getUserContext(userId, networkId)` (`database.adapter.ts:296`), and the premise+premiseNetworks status/deletedAt filter pattern (`:5601` — but it's embedding-gated + limit-40, so a dedicated count+list query is needed).
+- **Hermes never fetches:** control-plane `emptyStats().intents = null` (`tenants.js:311`); `getTenantStats` fetches only opportunities inside `if (stats.index.connected)` (`tenants.js:502`). The control-plane has only a REST client (`indexFetch`, `index-network.js:7`) — no MCP client. The Hermes skill `summarize-negotiations.ts:309` re-filters `!i.status || i.status === "active"` against a graph read that never emits `status` (`intent.graph.ts:713-718`) — a dead no-op.
+- **MCP scoped count source:** no-arg `read_intents` under a network-bound key routes through `getActiveIntentsAcrossIndexes` (`intent.tools.ts:165` → `intent.graph.ts:697`); when `limit` is passed the response carries `data.totalCount` = full pre-pagination count (`intent.tools.ts:188-191`).
+
+## Desired End State
+
+```ts
+// Backend — both adapter classes route through ONE predicate (no drift):
+// database.adapter.ts (module scope)
+activeOwnIntentsWhere(userId)        // → and(eq(userId), isNull(archivedAt))
+ownIntentsListWhere(userId, opts)    // → adds archived toggle + sourceType
+
+// /library — true total, status plumbed:
+const res = await api.post<IntentListResponse>('/intents/list', { page: 1, limit: 100 });
+res.pagination.totalCount   // → real count, drives the tab badge
+intent.status               // → 'ACTIVE' | 'PAUSED' | ... ; badge shown only when !== 'ACTIVE'
+
+// /networks overview — one fetch, three sections:
+const overview = await indexesService.getNetworkOverview(networkId);
+overview.intents       // current member's intents in this network
+overview.premises      // current member's ACTIVE premises assigned to this network
+overview.userContext   // the member's per-network user_context text (or null)
+
+// Hermes/control-plane — scoped count via MCP:
+stats.intents = await fetchIndexIntentCount(indexApiKey, INDEX_MCP_URL); // data.totalCount | null
+```
+
+## What We're NOT Doing
+
+- **No status-enum filtering semantics.** `intents.status` stays selected-but-never-filtered; we render it conditionally but do not introduce status-based counting or active/paused query branches (research Open Question — separate decision).
+- **No multi-network inflation audit** of other community-browse paths (`database.adapter.ts` browse reads) — deferred per research Open Questions.
+- **No intent↔network reconcile / backfill changes** (PR #970 territory) — the per-network overview reads the existing `intentNetworks` / `premiseNetworks` assignment source as-is.
+- **No changes to the MCP scope clamp** (`computeAgentIndexScope`, `applyNetworkScopeToContext`) — existing behavior is correct; we consume it, not modify it.
+- **No REST `/intents/list` total for Hermes** — explicitly rejected; it would count the unscoped owner set and disagree with the scoped view.
+
+## Decisions
+
+### Canonical predicate consolidation (shared where-builder)
+**Decision:** Extract module-level helpers in `database.adapter.ts` — `activeOwnIntentsWhere(userId)` returning `and(eq(intents.userId, userId), isNull(intents.archivedAt))`, and `ownIntentsListWhere(userId, { archived, sourceType })` for the paginated list — and route both `IntentDatabaseAdapter` and `ChatDatabaseAdapter` methods through them. Keep the helper to the **WHERE predicate only** (not the full query) to minimize blast radius on the risky MCP scope path. Evidence: byte-identical copies at `database.adapter.ts:310`↔`:1003`, `:817`↔`:2238`, `:512` list conditions. Inherited from research checkpoint ("extract a shared canonical predicate").
+
+### Hermes count source: MCP, not REST
+**Decision:** Source the Hermes count from MCP `read_intents` `data.totalCount`, requiring a new JSON-RPC client in the control-plane. Only the MCP path (→ `getActiveIntentsAcrossIndexes`) yields the canonical scoped count; REST would count the unscoped owner set. Modeled after `summarize-negotiations.ts:45` (`postMcpMessage`, handles SSE + JSON). Inherited from research checkpoint.
+
+### /networks overview: one new endpoint, current-user scope
+**Decision:** Add `GET /networks/:id/overview` returning `{ intents, premises, userContext }`, current-user scoped (mirrors the existing "My Intents" user-filter at `network.service.ts:371`; `user_context` is inherently per-user). Leave `/my-intents` untouched. Premises via a NEW dedicated count+list query (no embedding gate, no limit cap). Inherited from checkpoint.
+
+### /library status badge: conditional render
+**Decision:** Plumb `status` through `LibrarySourceIntent`/`BaseIntent` and render a badge only when `status !== 'ACTIVE'`. Shows nothing today (enum is vestigial/always ACTIVE) but future-proofs without visual noise — matches the FRD's "if applicable". Inherited from checkpoint.
+
+## Phase 1: Shared canonical intent predicate
+
+### Overview
+Foundation: extract one shared WHERE-builder for the canonical own-intents predicate and route both adapter classes through it, with a parity test proving they agree. Depends on nothing; can run in parallel with Phase 2.
+
+### Changes Required:
+
+#### 1. backend/src/adapters/database.adapter.ts
+**File**: backend/src/adapters/database.adapter.ts
+**Changes**: MODIFY — add module-level `activeOwnIntentsWhere` / `ownIntentsListWhere` helpers; route both adapter classes' `getActiveIntents`, `getActiveIntentsAcrossIndexes`, and `listIntents` predicates through them.
+
+Add these two helpers at module scope, immediately before `export class IntentDatabaseAdapter` (currently line 292). `intents` is destructured from `schema` at line 187 (`schema.intents === intents`); `SourceType` is module-scoped at line 105; `and/eq/isNull/isNotNull/inArray/desc` are imported at line 6.
+
+```ts
+/**
+ * Canonical "active own intents" WHERE predicate: a row the user owns that has
+ * not been archived. No status filter — `intents.status` is vestigial (selected
+ * but never filtered). Both the REST (IntentDatabaseAdapter) and MCP
+ * (ChatDatabaseAdapter) surfaces route through this so their counts cannot
+ * drift between them. See EDG-53.
+ */
+function activeOwnIntentsWhere(userId: string) {
+  return and(
+    eq(schema.intents.userId, userId),
+    isNull(schema.intents.archivedAt),
+  );
+}
+
+/**
+ * Canonical predicate for the paginated own-intents list: ownership + an
+ * archived toggle (archived rows when `archived` is true, active rows
+ * otherwise) + an optional sourceType narrow. Shares the ownership/active spine
+ * with {@link activeOwnIntentsWhere} so list `count()` totals and graph reads
+ * agree for the same identity. See EDG-53.
+ */
+function ownIntentsListWhere(
+  userId: string,
+  options: { archived: boolean; sourceType?: string },
+) {
+  const conditions = [
+    eq(schema.intents.userId, userId),
+    options.archived
+      ? isNotNull(schema.intents.archivedAt)
+      : isNull(schema.intents.archivedAt),
+  ];
+  const validSourceTypes: SourceType[] = ['file', 'integration', 'link', 'discovery_form', 'enrichment'];
+  if (options.sourceType && validSourceTypes.includes(options.sourceType as SourceType)) {
+    conditions.push(eq(schema.intents.sourceType, options.sourceType as SourceType));
+  }
+  return and(...conditions);
+}
+```
+
+Route `IntentDatabaseAdapter.getActiveIntents` (line 310) AND `ChatDatabaseAdapter.getActiveIntents` (line 993) — both hold the identical inline predicate today — through the helper. The `.where(and(eq(schema.intents.userId, userId), isNull(schema.intents.archivedAt)))` block in each becomes:
+
+```ts
+        .from(schema.intents)
+        .where(activeOwnIntentsWhere(userId))
+        .orderBy(desc(schema.intents.createdAt));
+```
+
+In `IntentDatabaseAdapter.listIntents` (line 512), keep the existing `const offset = (options.page - 1) * options.limit;` line (line 514) and replace ONLY the `const conditions` / `validSourceTypes` / `const where = and(...conditions);` block (lines ~515-528) with the shared list builder — do not re-declare `offset`:
+
+```ts
+    const where = ownIntentsListWhere(userId, { archived: options.archived, sourceType: options.sourceType });
+```
+
+In `IntentDatabaseAdapter.getActiveIntentsAcrossIndexes` (line 817), the `.where(...)` becomes (note: `schema.intentNetworks`, `selectDistinctOn` + `innerJoin` unchanged):
+
+```ts
+        .where(
+          and(
+            activeOwnIntentsWhere(userId),
+            inArray(schema.intentNetworks.networkId, indexIds),
+          ),
+        )
+```
+
+In `ChatDatabaseAdapter.getActiveIntentsAcrossIndexes` (line 2238), the same, but the query uses bare destructured `intentNetworks`:
+
+```ts
+        .where(
+          and(
+            activeOwnIntentsWhere(userId),
+            inArray(intentNetworks.networkId, indexIds),
+          ),
+        )
+```
+
+#### 2. backend/src/adapters/tests/database.adapter.spec.ts
+**File**: backend/src/adapters/tests/database.adapter.spec.ts
+**Changes**: MODIFY — extend the existing adapter integration spec (it already builds the DB fixture and instantiates both adapters at lines 92/148) with a parity `describe` block asserting REST and MCP surfaces return identical counts/ids for the same identity/scope. (Supersedes the originally-planned standalone `backend/tests/intent-predicate-parity.spec.ts`, which would have duplicated the fixture harness.)
+
+Append after the `describe('ChatDatabaseAdapter', ...)` block:
+
+```ts
+// ═══════════════════════════════════════════════════════════════════════════════
+// Intent predicate parity (EDG-53)
+// ═══════════════════════════════════════════════════════════════════════════════
+describe('Intent predicate parity (EDG-53)', () => {
+  const intentAdapter = new IntentDatabaseAdapter();
+  const chatAdapter = new ChatDatabaseAdapter();
+
+  it('getActiveIntents agrees across REST and MCP adapters', async () => {
+    const rest = await intentAdapter.getActiveIntents(fixture.userAId);
+    const mcp = await chatAdapter.getActiveIntents(fixture.userAId);
+    expect(mcp.length).toBe(rest.length);
+    expect(new Set(mcp.map((i) => i.id))).toEqual(new Set(rest.map((i) => i.id)));
+  });
+
+  it('getActiveIntentsAcrossIndexes agrees across REST and MCP adapters', async () => {
+    const rest = await intentAdapter.getActiveIntentsAcrossIndexes(fixture.userAId, [fixture.networkId]);
+    const mcp = await chatAdapter.getActiveIntentsAcrossIndexes(fixture.userAId, [fixture.networkId]);
+    expect(mcp.length).toBe(rest.length);
+    expect(new Set(mcp.map((i) => i.id))).toEqual(new Set(rest.map((i) => i.id)));
+  });
+
+  it('listIntents total equals unscoped getActiveIntents count', async () => {
+    const active = await intentAdapter.getActiveIntents(fixture.userAId);
+    const { total } = await intentAdapter.listIntents(fixture.userAId, { page: 1, limit: 100, archived: false });
+    expect(total).toBe(active.length);
+  });
+});
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] Parity spec passes: `cd backend && bun test src/adapters/tests/database.adapter.spec.ts` — all 3 EDG-53 parity tests pass (the 2 pre-existing `getProfile`/`saveProfile` failures predate this change; confirmed on stashed baseline).
+- [x] Both adapter classes route through the shared predicate: `grep -c "activeOwnIntentsWhere(userId)" backend/src/adapters/database.adapter.ts` returns >= 4 — returned 4.
+- [x] List path uses the shared list builder: `grep -c "ownIntentsListWhere(userId" backend/src/adapters/database.adapter.ts` returns >= 1 — returned 1.
+- [x] Dedup preserved: both `selectDistinctOn([schema.intents.id]` (line 845) and `selectDistinctOn([intents.id]` (line 2260) intact (>= 2). NOTE: the literal grep pattern as written returns 0 because the code reads `], {` not `])` — substantive criterion (2 occurrences) verified via `grep -nE "selectDistinctOn\(\[(schema\.)?intents\.id\]"`.
+
+#### Manual Verification:
+- [ ] For a test user with intents spanning multiple networks, `/library`, unscoped MCP `read_intents`, and a network-scoped key report mutually consistent counts (scoped ≤ unscoped, equal when all intents are reachable).
+
+## Phase 2: /library count + status badge
+
+### Overview
+Render the true intent total and a conditional status badge on `/library`, plumbing fields the backend already ships. Depends on nothing; parallel with Phase 1.
+
+### Changes Required:
+
+#### 1. frontend/src/components/IntentList.tsx
+**File**: frontend/src/components/IntentList.tsx
+**Changes**: MODIFY — add `status` to `BaseIntent`; render a `StatusBadge` (modeled on `NetworkMembership`) only when `status` is present and not `'ACTIVE'`.
+
+Add to the `BaseIntent` interface, after the `networks?` field (~line 47):
+```tsx
+  /**
+   * Lifecycle status (ACTIVE|PAUSED|FULFILLED|EXPIRED). A badge renders only for
+   * non-default (non-ACTIVE) values; undefined or ACTIVE renders nothing — the
+   * enum is vestigial today, so this is forward-looking. See EDG-53.
+   */
+  status?: string;
+```
+
+Add the badge component after `NetworkMembership` (~line 100):
+```tsx
+/**
+ * Renders an intent's lifecycle status as a badge, but only when it is a
+ * non-default value. ACTIVE (the schema default) and undefined render nothing,
+ * so today this is invisible and purely forward-looking. See EDG-53.
+ */
+function StatusBadge({ status }: { status?: string }) {
+  if (!status || status.toUpperCase() === 'ACTIVE') return null;
+  return (
+    <span className="flex items-center gap-1 text-xs text-purple-700 font-ibm-plex-mono px-2 py-0.5 rounded-full bg-purple-50 border border-purple-100 capitalize">
+      {status.toLowerCase()}
+    </span>
+  );
+}
+```
+
+Render it right after the network chips in the badges row (~line 213):
+```tsx
+                  <NetworkMembership networks={intent.networks} createdAt={intent.createdAt} />
+                  <StatusBadge status={intent.status} />
+```
+
+#### 2. frontend/src/app/library/page.tsx
+**File**: frontend/src/app/library/page.tsx
+**Changes**: MODIFY — type the `/intents/list` response with `pagination`, loop all pages to show every intent, store the true `intentTotal`, add `status` to `LibrarySourceIntent`, drive the tab badge from the true total.
+
+Add `status` to `LibrarySourceIntent` (~line 25):
+```tsx
+  status?: string;
+```
+
+Add a response type near the other type declarations (~line 27):
+```tsx
+type IntentListResponse = {
+  intents?: LibrarySourceIntent[];
+  pagination?: { current: number; total: number; count: number; totalCount: number };
+};
+```
+
+Add total state beside the intents state (~line 89):
+```tsx
+  const [intentTotal, setIntentTotal] = useState(0);
+```
+
+Replace the body of `loadIntents` (the current single `api.post<{ intents?: LibrarySourceIntent[] }>(...)` fetch) with a page-loop that accumulates all pages and captures the true total. `pagination.total` is the page count; `pagination.totalCount` is the true row count:
+```tsx
+  const loadIntents = useCallback(async () => {
+    try {
+      setLoadingIntents(true);
+      const all: LibrarySourceIntent[] = [];
+      let page = 1;
+      let totalCount = 0;
+      let totalPages = 1;
+      const MAX_PAGES = 50; // safety cap (50 * 100 = 5000 intents)
+      do {
+        const res = await api.post<IntentListResponse>('/intents/list', { page, limit: 100 });
+        all.push(...(res.intents ?? []));
+        totalCount = res.pagination?.totalCount ?? all.length;
+        totalPages = res.pagination?.total ?? 1;
+        page += 1;
+      } while (page <= totalPages && page <= MAX_PAGES);
+      setIntents(all.map(i => ({
+        ...i,
+        sourceType: i.sourceType ?? 'file',
+        sourceId: i.sourceId ?? '',
+        sourceName: i.sourceName ?? '',
+        sourceValue: i.sourceValue ?? null,
+        sourceMeta: i.sourceMeta ?? null,
+      })));
+      setIntentTotal(totalCount);
+    } catch {
+      setIntents([]);
+      setIntentTotal(0);
+    } finally {
+      setLoadingIntents(false);
+    }
+  }, [api]);
+```
+
+Change the Intents tab badge to show the true total instead of `intents.length` (~line 222):
+```tsx
+              Intents
+              {intentTotal > 0 && (
+                <span className="ml-2 text-xs text-gray-500">({intentTotal})</span>
+              )}
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] Badge driven by the true total, not page length: `grep -c "intentTotal" frontend/src/app/library/page.tsx` returns >= 3 AND `grep -c "({intents.length})" frontend/src/app/library/page.tsx` returns 0 — returned 3 and 0. Frontend tsc baseline unchanged (60 before and after; no errors in touched files).
+- [x] StatusBadge is conditional: `grep -c "StatusBadge" frontend/src/components/IntentList.tsx` returns >= 2 — returned 2.
+- [x] status plumbed into the list type: `grep -c "status?: string" frontend/src/components/IntentList.tsx` returns >= 1 — returned 2.
+
+#### Manual Verification:
+- [ ] For a user with >100 intents, the `/library` Intents tab badge shows the full DB count and every intent renders in the list (no 100-row truncation).
+- [ ] An intent whose status is non-ACTIVE shows a status badge; ACTIVE intents show none.
+
+## Phase 3: /networks overview backend
+
+### Overview
+Add a dedicated per-network premise count+list query and a new `GET /networks/:id/overview` endpoint returning `{ intents, premises, userContext }`, current-user scoped. Depends on Phase 1 (same adapter file — sequential).
+
+### Changes Required:
+
+#### 1. backend/src/adapters/database.adapter.ts
+**File**: backend/src/adapters/database.adapter.ts
+**Changes**: MODIFY — add `getNetworkPremisesForMember(networkId, userId)` to `ChatDatabaseAdapter`, joining `premiseNetworks ⋈ premises` filtered by `networkId + userId + status='ACTIVE' + deletedAt IS NULL` (no embedding gate, no limit cap). The single-`networkId` filter + the `premise_networks` PK `(premiseId, networkId)` guarantee ≤ 1 row per premise, so no `selectDistinctOn` is needed.
+
+Add after `getNetworkIntentsForMember` (~line 2235), inside `ChatDatabaseAdapter`:
+```ts
+  /**
+   * List the current member's ACTIVE premises assigned to a network, for the
+   * /networks overview tab. Unlike getPremisesForUserInNetworks (tuned for
+   * similarity search — embedding-gated, capped at 40), this is an honest
+   * list+count: no embedding gate, no limit. Soft-deleted premises excluded.
+   * Current-user scoped. See EDG-53.
+   */
+  async getNetworkPremisesForMember(networkId: string, userId: string): Promise<Array<{
+    id: string;
+    text: string;
+    summary: string | null;
+    createdAt: Date;
+  }>> {
+    const rows = await db
+      .select({
+        id: schema.premises.id,
+        assertion: schema.premises.assertion,
+        createdAt: schema.premises.createdAt,
+      })
+      .from(schema.premiseNetworks)
+      .innerJoin(schema.premises, eq(schema.premiseNetworks.premiseId, schema.premises.id))
+      .where(and(
+        eq(schema.premiseNetworks.networkId, networkId),
+        eq(schema.premises.userId, userId),
+        eq(schema.premises.status, 'ACTIVE'),
+        isNull(schema.premises.deletedAt),
+      ))
+      .orderBy(desc(schema.premises.createdAt));
+
+    return rows.map((r) => {
+      const assertion = r.assertion as { text?: string; summary?: string } | null;
+      return {
+        id: r.id,
+        text: assertion?.text ?? '',
+        summary: assertion?.summary ?? null,
+        createdAt: r.createdAt,
+      };
+    });
+  }
+```
+
+#### 2. backend/src/services/network.service.ts
+**File**: backend/src/services/network.service.ts
+**Changes**: MODIFY — add `getNetworkOverview(networkId, userId)` composing intents (existing membership-gated read), premises (new query), and the per-network user_context via `Promise.all`.
+
+Add after `getMyIntentsInNetwork` (~line 372):
+```ts
+  /**
+   * Compose the /networks overview payload for the current member: their intents
+   * in the network, their ACTIVE premises assigned to it, and their per-network
+   * user_context. Members only — getMyIntentsInNetwork throws if not a member.
+   * See EDG-53.
+   */
+  async getNetworkOverview(networkId: string, userId: string) {
+    logger.verbose('[NetworkService] Getting network overview', { networkId, userId });
+    const [intents, premises, userContext] = await Promise.all([
+      this.getMyIntentsInNetwork(networkId, userId),
+      this.adapter.getNetworkPremisesForMember(networkId, userId),
+      this.adapter.getUserContext(userId, networkId),
+    ]);
+    return {
+      intents,
+      premises,
+      userContext: userContext ? { text: userContext.text, generatedAt: userContext.generatedAt } : null,
+    };
+  }
+```
+
+#### 3. backend/src/controllers/network.controller.ts
+**File**: backend/src/controllers/network.controller.ts
+**Changes**: MODIFY — add `GET /:id/overview` (members only, scope-asserted), mirroring `getMyIntents`. Place before `GET /:id` to avoid route collision.
+
+Add after `getMyIntents` (~line 883):
+```ts
+  /**
+   * Get the current user's overview for a network: their intents, premises, and
+   * per-network user_context. Members only.
+   * IMPORTANT: This must come before GET /:id to avoid route collision.
+   */
+  @Get('/:id/overview')
+  @UseGuards(RateLimit('read'), AuthOrApiKeyGuard)
+  async getOverview(req: Request, user: AuthenticatedUser, params: Record<string, string>) {
+    try {
+      await assertAgentNetworkScope(req, params.id);
+      const overview = await networkService.getNetworkOverview(params.id, user.id);
+      logger.verbose('Network overview retrieved', { networkId: params.id, userId: user.id, intents: overview.intents.length, premises: overview.premises.length });
+      return Response.json(overview);
+    } catch (err: unknown) {
+      const msg = errorMessage(err);
+      if (msg.includes('Access denied') || msg.includes('Not a member')) {
+        return Response.json({ error: msg }, { status: 403 });
+      }
+      throw err;
+    }
+  }
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] Premise query has no embedding gate or limit cap: `grep -A20 "async getNetworkPremisesForMember" backend/src/adapters/database.adapter.ts | grep -c "embedding\|limit("` returns 0 — returned 0.
+- [x] Route registered before `/:id`: `grep -n "@Get('/:id/overview')\|@Get('/:id')" backend/src/controllers/network.controller.ts` lists `/:id/overview` at a lower line number than `/:id` — `/:id/overview` at L889, `/:id` at L1019.
+- [x] Service composes all three reads: `grep -A8 "async getNetworkOverview" backend/src/services/network.service.ts | grep -c "getMyIntentsInNetwork\|getNetworkPremisesForMember\|getUserContext"` returns 3 — returned 3.
+- [x] Backend lints: `cd backend && bun run lint` — 0 errors (62 pre-existing warnings, none in touched files). Backend `tsc --noEmit` also clean (0 errors).
+
+#### Manual Verification:
+- [ ] `GET /networks/:id/overview` as a member returns `{ intents, premises, userContext }`; premises count matches the member's ACTIVE premises assigned to that network.
+- [ ] A non-member receives 403.
+- [ ] A member with no per-network context row gets `userContext: null` (not an error).
+
+## Phase 4: /networks overview frontend
+
+### Overview
+Add the `getNetworkOverview` service method and render premises + user_context sections in the overview panel. Depends on Phase 3 (needs the endpoint).
+
+### Changes Required:
+
+#### 1. frontend/src/services/networks.ts
+**File**: frontend/src/services/networks.ts
+**Changes**: MODIFY — add `getNetworkOverview(networkId)` calling `GET /networks/:id/overview`, mirroring `getMyIndexIntents`.
+
+Insert after the `getMyIndexIntents` method (after its `return response.intents || [];\n  },` and before the `// Remove member intent` comment, ~line 320):
+```ts
+  // Get current user's overview for a network: intents, premises, user_context (EDG-53)
+  getNetworkOverview: async (networkId: string): Promise<{
+    intents: Array<{ id: string; payload: string; summary?: string | null; createdAt: string; userId: string; userName: string }>;
+    premises: Array<{ id: string; text: string; summary: string | null; createdAt: string }>;
+    userContext: { text: string; generatedAt: string } | null;
+  }> => {
+    const response = await api.get<{
+      intents: Array<{ id: string; payload: string; summary?: string | null; createdAt: string; userId: string; userName: string }>;
+      premises: Array<{ id: string; text: string; summary: string | null; createdAt: string }>;
+      userContext: { text: string; generatedAt: string } | null;
+    }>(`/networks/${networkId}/overview`);
+    return {
+      intents: response.intents || [],
+      premises: response.premises || [],
+      userContext: response.userContext ?? null,
+    };
+  },
+```
+
+#### 2. frontend/src/components/NetworkOverviewPanel.tsx
+**File**: frontend/src/components/NetworkOverviewPanel.tsx
+**Changes**: MODIFY — fetch overview once, add premises + userContext state, render My Intents (existing), My Premises, and Your Context sections with true counts.
+
+Add state after `const [intentsLoading, setIntentsLoading] = useState(true);` (~line 46):
+```tsx
+  const [premises, setPremises] = useState<{ id: string; text: string; summary: string | null; createdAt: string }[]>([]);
+  const [userContext, setUserContext] = useState<{ text: string; generatedAt: string } | null>(null);
+```
+
+Replace the load `useEffect` (lines ~49-60, currently loads `getMyIndexIntents`) with:
+```tsx
+  useEffect(() => {
+    const loadOverview = async () => {
+      try {
+        const overview = await indexesService.getNetworkOverview(index.id);
+        setIntents(overview.intents);
+        setPremises(overview.premises);
+        setUserContext(overview.userContext);
+      } catch (err) {
+        console.error('Error loading network overview:', err);
+      } finally {
+        setIntentsLoading(false);
+      }
+    };
+    loadOverview();
+  }, [index.id, indexesService]);
+```
+
+Insert two new sections between the end of the My Intents `</div>` and the closing `</div>` of the `space-y-8` wrapper (after the `IntentList` block):
+```tsx
+        {/* My Premises */}
+        <div>
+          <div className="flex items-center justify-between mb-4">
+            <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider font-ibm-plex-mono">
+              My Premises
+            </p>
+            {!intentsLoading && (
+              <span className="text-xs text-gray-400">{premises.length} premise{premises.length !== 1 ? 's' : ''}</span>
+            )}
+          </div>
+          {intentsLoading ? null : premises.length === 0 ? (
+            <div className="text-sm text-gray-500 font-ibm-plex-mono py-12 text-center border border-dashed border-gray-200 rounded-lg">
+              <p>No premises assigned to this network yet</p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {premises.map((p) => (
+                <div key={p.id} className="p-4 rounded-lg border border-gray-200 bg-white">
+                  <p className="text-sm text-gray-900 leading-relaxed">
+                    {(p.summary && p.summary.trim().length > 0 ? p.summary : p.text).trim()}
+                  </p>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Your Context */}
+        {userContext && userContext.text.trim().length > 0 && (
+          <div>
+            <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider font-ibm-plex-mono mb-4">
+              Your Context
+            </p>
+            <div className="p-4 rounded-lg border border-gray-200 bg-gray-50">
+              <p className="text-sm text-gray-700 leading-relaxed whitespace-pre-wrap">{userContext.text}</p>
+            </div>
+          </div>
+        )}
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] Service method calls the overview endpoint: `grep -c "networks/\${networkId}/overview\|getNetworkOverview" frontend/src/services/networks.ts` returns >= 2 — returned 2.
+- [x] Panel renders all three sections: `grep -c "My Intents\|My Premises\|Your Context" frontend/src/components/NetworkOverviewPanel.tsx` returns 3 — returned 6 (each section name appears twice: JSX comment + `<p>` label; plan's expected `3` undercounted the comments). All three distinct section names confirmed present (2 each). Intent satisfied: all three sections render.
+- [x] Panel no longer calls the old single-purpose fetch: `grep -c "getMyIndexIntents" frontend/src/components/NetworkOverviewPanel.tsx` returns 0 — returned 0. Frontend tsc baseline unchanged (60 before and after; the 2 errors in touched files are pre-existing import-resolution errors on lines not modified by this phase).
+
+#### Manual Verification:
+- [ ] Opening a network's overview tab shows My Intents, My Premises (with a count matching the member's ACTIVE premises in that network), and Your Context (when present).
+- [ ] A member with no premises sees the "No premises assigned" empty state; a member with no context sees no Your Context section.
+
+## Phase 5: Control-plane Hermes intent count
+
+### Overview
+Add an MCP JSON-RPC client + `fetchIndexIntentCount` to the control-plane and wire it into `getTenantStats`. Depends on nothing; parallel (separate codebase).
+
+### Changes Required:
+
+#### 1. packages/edge-city/agentvillage-controlplane/control-plane/src/index-network.js
+**File**: packages/edge-city/agentvillage-controlplane/control-plane/src/index-network.js
+**Changes**: MODIFY — add a minimal `postMcpMessage` JSON-RPC client (SSE + JSON) and `fetchIndexIntentCount(apiKey, mcpUrl)` reading `data.totalCount`; export it. Submodule note: lands via a PR against `Edge-City/agentvillage-controlplane`, then the monorepo pointer is bumped.
+
+Add after `INDEX_LOOKUP_TIMEOUT_MS` (~line 5):
+```js
+const INDEX_MCP_URL = (process.env.INDEX_MCP_URL || 'https://protocol.index.network/mcp').replace(/\/$/, '');
+```
+
+Add before `module.exports` (stateless client modeled on the Hermes skill's `postMcpMessage`; `read_intents { limit: 1 }` returns `{ success, data: { totalCount } }`; the scoped key clamps the read to `[boundNetwork, personalIndex]`, so `totalCount` is exactly what the agent may see):
+```js
+async function postMcpMessage(mcpUrl, apiKey, body) {
+  const res = await fetch(mcpUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      'x-api-key': apiKey,
+    },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(INDEX_LOOKUP_TIMEOUT_MS),
+    cache: 'no-store',
+  });
+  if (!res.ok) throw new Error(`MCP HTTP ${res.status}`);
+  const contentType = res.headers.get('content-type') || '';
+  if (contentType.includes('text/event-stream')) {
+    const text = await res.text();
+    let response = null;
+    for (const line of text.split('\n')) {
+      const dataLine = line.startsWith('data: ') ? line.slice(6) : line.startsWith('data:') ? line.slice(5) : null;
+      if (dataLine !== null) {
+        try {
+          const msg = JSON.parse(dataLine);
+          if ('result' in msg || 'error' in msg) response = msg;
+        } catch { /* skip non-JSON SSE lines */ }
+      }
+    }
+    if (response) return response;
+    throw new Error('no JSON-RPC response in MCP SSE stream');
+  }
+  return res.json();
+}
+
+/**
+ * Fetch the tenant's canonical scoped intent count via MCP read_intents. The
+ * scoped API key clamps the read to [boundNetwork, personalIndex], so totalCount
+ * is exactly what the agent is authorized to see (EDG-53). Best-effort: returns
+ * null on any failure so getTenantStats degrades like the opportunity count.
+ */
+async function fetchIndexIntentCount(apiKey, mcpUrl = INDEX_MCP_URL) {
+  try {
+    const init = await postMcpMessage(mcpUrl, apiKey, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'agentvillage-controlplane', version: '1.0.0' },
+      },
+    });
+    if (init.error) return null;
+    const toolResp = await postMcpMessage(mcpUrl, apiKey, {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name: 'read_intents', arguments: { limit: 1 } },
+    });
+    if (toolResp.error) return null;
+    const result = toolResp.result || {};
+    const content = Array.isArray(result.content) ? result.content : [];
+    const textPart = content.find((c) => c && c.type === 'text');
+    if (!textPart || !textPart.text) return null;
+    const parsed = JSON.parse(textPart.text);
+    if (parsed && parsed.success === false) return null;
+    const total = parsed && parsed.data ? parsed.data.totalCount : undefined;
+    return typeof total === 'number' ? total : null;
+  } catch {
+    return null;
+  }
+}
+```
+
+Update the export:
+```js
+module.exports = { checkIndexConnection, fetchIndexOpportunityCount, fetchIndexIntentCount };
+```
+
+#### 2. packages/edge-city/agentvillage-controlplane/control-plane/src/tenants.js
+**File**: packages/edge-city/agentvillage-controlplane/control-plane/src/tenants.js
+**Changes**: MODIFY — import `fetchIndexIntentCount` and set `stats.intents` after the opportunity fetch inside the `stats.index.connected` block (fills the hard-coded `intents: null` slot at `emptyStats()`).
+
+Update the import (line 13):
+```js
+const { checkIndexConnection, fetchIndexOpportunityCount, fetchIndexIntentCount } = require('./index-network');
+```
+
+In `getTenantStats`, add the intent fetch after the opportunity fetch:
+```js
+      stats.index = await checkIndexConnection(indexApiKey);
+      if (stats.index.connected) {
+        stats.opportunities = await fetchIndexOpportunityCount(indexApiKey);
+        stats.intents = await fetchIndexIntentCount(indexApiKey, INDEX_MCP_URL);
+      }
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] Intent fetch exported + imported: `grep -c "fetchIndexIntentCount" packages/edge-city/agentvillage-controlplane/control-plane/src/index-network.js` returns >= 2 AND `grep -c "fetchIndexIntentCount" packages/edge-city/agentvillage-controlplane/control-plane/src/tenants.js` returns >= 2 — both returned 2.
+- [x] Sourced from MCP totalCount, not REST: `grep -c "read_intents\|data.totalCount\|parsed.data" …/index-network.js` returns >= 2 AND `grep -c "/api/intents\|/intents/list" …/index-network.js` returns 0 — returned 3 and 0.
+- [x] Degrades to null (no throw into caller): `grep -A30 "async function fetchIndexIntentCount" …/index-network.js | grep -c "return null"` returns >= 4 — returned 5. Both JS files pass `node --check`.
+
+#### Manual Verification:
+- [ ] For a live tenant, the control-plane stats payload shows `intents` as a number matching the tenant's scoped MCP `read_intents` totalCount (no longer `null`).
+- [ ] A tenant whose Index key is missing/disconnected, or whose MCP call fails, shows `intents: null` without erroring the stats endpoint.
+- [ ] The reported `intents` count for a member with intents in BOTH the bound network and their personal index includes the personal-index intents — the scoped clamp's `[boundNetwork, personalIndex]` personal leg is not dropped (regression guard, precedent `eff9e02c32`).
+
+## Phase 6: Hermes skill dead-filter cleanup
+
+### Overview
+Remove the dead `status === "active"` re-filter from the Hermes signal fetcher (the graph never emits `status`). Depends on nothing; parallel (separate codebase).
+
+### Changes Required:
+
+#### 1. packages/edge-city/agentvillage/skills/index-network/scripts/summarize-negotiations.ts
+**File**: packages/edge-city/agentvillage/skills/index-network/scripts/summarize-negotiations.ts
+**Changes**: MODIFY — drop the no-op `.filter((i) => !i.status || i.status === "active")` in `buildMcpSignalFetcher`. Submodule note: lands via a PR against `Edge-City/agentvillage`, then the monorepo pointer is bumped.
+
+The return in `buildMcpSignalFetcher` (~lines 310-313) becomes (filter line removed):
+```ts
+    return intents
+      .map((i) => ({ id: i.id ?? "", summary: (i.summary || i.description || "").trim() }))
+      .filter((s) => s.summary.length > 0);
+```
+(The local `IntentListResponse` item `status?` field is left in place as a defensive, now-unread DTO field.)
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] Dead status filter removed: `grep -c 'i.status === "active"' …/summarize-negotiations.ts` returns 0 — returned 0.
+- [x] Signal pipeline otherwise intact: `grep -c "return intents" …/summarize-negotiations.ts` returns >= 1 — returned 1. Defensive `status?` DTO field left in place (grep count 1). The only change is removal of the no-op `.filter` line from the map chain; remaining tsc diagnostics are pre-existing target/module config artifacts (Set iteration / `import.meta`), unrelated to this edit.
+
+#### Manual Verification:
+- [ ] Behavior-preserving: for a `read_intents` fixture whose items carry no `status` field (current graph output), the emitted signal list (ids + summaries) is identical before and after the change — the filter was a no-op pass-through.
+
+## Ordering Constraints
+
+- **Phase 1 → Phase 3**: both edit `database.adapter.ts`; run sequentially to avoid conflicts (Phase 3's premise query is logically independent but shares the file).
+- **Phase 3 → Phase 4**: frontend overview consumes the new endpoint.
+- **Phases 1, 2, 5, 6 are mutually independent** and may run in parallel (2 = frontend, 5/6 = separate edge-city codebases).
+- Recommended order: 1 → 2 → 3 → 4 → 5 → 6.
+
+## Verification Notes
+
+- **Predicate parity (Phase 1):** both adapter classes must return identical counts for the same identity/scope after consolidation — assert in the parity spec. Precedent: count divergence is the core bug.
+- **No `.length`/`slice()` for totals (Phase 2):** the `/library` badge must come from `pagination.totalCount`, never the rendered page length. Precedent: PR #937 success criterion + the `/library` bug itself.
+- **Dedup load-bearing:** `getActiveIntentsAcrossIndexes` keeps `selectDistinctOn([intents.id])`; the new premise query must likewise avoid multi-network row inflation (premise rows are not network-joined more than once per premise — verify the join doesn't duplicate).
+- **Scope still includes personal index:** the MCP-sourced Hermes count flows through the existing clamp `[boundNetwork, personalIndex]`; do not regress it. Precedent: `eff9e02c32` over-clamp dropped the personal index.
+- **Graceful degradation (Phase 5):** `fetchIndexIntentCount` returns `null` on any failure (HTTP, parse, timeout) — never throws into `getTenantStats`. Mirror `fetchIndexOpportunityCount`'s try/catch.
+- **No silent drop (Phase 6):** removing the dead filter must not change emitted signals (the filter was a no-op today) — verify the signal list is identical before/after for a fixture with no `status`.
+- **Premise count honesty (Phase 3):** the new query must NOT inherit the `embedding IS NOT NULL` gate or `limit 40` cap from `getPremisesForUserInNetworks`.
+
+## Performance Considerations
+
+- The new premise query is a single indexed join (`premise_networks_network_id_idx`, `database.schema.ts:343`) — comparable to the existing intents-in-network read.
+- The control-plane MCP call adds one round-trip per tenant in `getTenantStats`, alongside the existing opportunity REST call — bounded by `INDEX_LOOKUP_TIMEOUT_MS` and gated behind `stats.index.connected`.
+- `/networks/:id/overview` issues three reads (intents, premises, context) in one handler; run them with `Promise.all`.
+
+## Migration Notes
+
+Not applicable — no schema changes. All tables (`intents`, `intent_networks`, `premises`, `premise_networks`, `user_contexts`) already exist.
+
+## Pattern References
+
+- `backend/src/adapters/database.adapter.ts:512-552` — `listIntents` shared `where` + parallel `count()` (consolidation template).
+- `backend/src/adapters/database.adapter.ts:5601-5635` — premise+premiseNetworks status/deletedAt filter (adapt, drop embedding/limit gates).
+- `backend/src/adapters/database.adapter.ts:296-308` — `getUserContext(userId, networkId)` per-network selector.
+- `backend/src/controllers/network.controller.ts:867-883` + `network.service.ts:368-372` — members-only scoped endpoint template.
+- `frontend/src/components/IntentList.tsx:53-99` — `NetworkMembership` conditional-badge pattern (model the StatusBadge on it).
+- `packages/edge-city/agentvillage/skills/index-network/scripts/summarize-negotiations.ts:45-86` — `postMcpMessage` SSE+JSON client (model the control-plane client on it).
+- `packages/edge-city/agentvillage-controlplane/control-plane/src/index-network.js:54-66` — `fetchIndexOpportunityCount` try/catch+`null` degradation (mirror for intents).
+
+## Developer Context
+
+**Q (research checkpoint — Hermes count source):** REST `/intents/list` total or MCP `read_intents` totalCount for `fetchIndexIntentCount`?
+A: MCP `read_intents` `data.totalCount` — only the MCP path yields the canonical scoped count.
+
+**Q (research checkpoint — premise query):** Reuse embedding-gated, limit-40 `getPremisesForUserInNetworks` (`database.adapter.ts:5601`) or a new query?
+A: New dedicated count+list query — `premiseNetworks ⋈ premises` filtered by `networkId + status='ACTIVE' + deletedAt IS NULL`, no embedding/limit gate.
+
+**Q (research checkpoint — adapter dedup):** Consolidate the byte-identical adapter classes, leave + test, or defer?
+A: Extract a shared canonical predicate so "one canonical definition" is one code path (`database.adapter.ts:817` vs `:2238`).
+
+**Q (blueprint checkpoint — /networks endpoint shape):** New endpoint vs extend `/my-intents` vs two endpoints?
+A: New `GET /networks/:id/overview` returning `{ intents, premises, userContext }`, one round-trip, `/my-intents` untouched.
+
+**Q (blueprint checkpoint — overview scope):** Current user's premises+context vs all members'?
+A: Current user's — mirrors the "My Intents" user-filter (`network.service.ts:371`); user_context is inherently per-user.
+
+**Q (blueprint checkpoint — status badge):** Conditional (only if not ACTIVE), always, or skip?
+A: Conditional — render only when `status !== 'ACTIVE'` (vestigial enum, `database.schema.ts:562`).
+
+**Step 8 review note:** the first artifact-code-reviewer run terminated mid-walk (subprocess error after verifying all Phase 1-6 anchors, before emitting its table); it was re-dispatched fresh and completed. Both reviewers' concerns were triaged (applied) at Step 9.
+
+## Plan Review (Step 8)
+
+_Independent post-finalization review by artifact-code-reviewer and artifact-coverage-reviewer subagents. Findings triaged at Step 9. The first artifact-code-reviewer run terminated mid-walk (subprocess error after anchor verification); it was re-dispatched fresh and completed — the row below is from the successful re-run._
+
+| source   | plan-loc | codebase-loc | severity | dimension | finding | recommendation | resolution |
+| -------- | -------- | ------------ | -------- | --------- | ------- | -------------- | ---------- |
+| code     | Phase 1 §1 (listIntents) | backend/src/adapters/database.adapter.ts:514 | concern | code-quality | The `listIntents` replacement snippet re-includes `const offset = (options.page - 1) * options.limit;`, but the prose scopes the replacement to the `conditions`/`validSourceTypes`/`where` block which starts *after* the existing `offset` at line 514 — applying verbatim would duplicate `const offset` (SyntaxError). | Drop `const offset` from the replacement snippet; scope the swap to the `conditions`→`where` block only. | applied: Phase 1 §1 snippet now drops the `const offset` line and scopes the swap to lines ~515-528 (offset retained). |
+| coverage | ## Verification Notes §4 | <n/a> | concern | verification-coverage | Note "the MCP-sourced Hermes count flows through the existing clamp `[boundNetwork, personalIndex]`; do not regress it" has no success-criterion: Phase 5 Manual only asserts the count equals scoped MCP `totalCount` (self-referential to the clamp), and Phase 1 Manual tests scoped≤unscoped, not the personal-index leg. | Add a Phase 5 Manual Verification bullet asserting the reported `intents` count includes the member's personal-index intents, confirming the clamp's personal-index leg survives end-to-end. | applied: added Phase 5 Manual Verification bullet asserting the personal-index leg of the clamp is not dropped (precedent eff9e02c32). |
+
+## Plan History
+
+- Phase 1: Shared canonical intent predicate — approved as generated (parity test extends existing database.adapter.spec.ts instead of a new file)
+- Phase 2: /library count + status badge — approved as generated (page-loop added to show all intents, not just the first 100)
+- Phase 3: /networks overview backend — approved as generated
+- Phase 4: /networks overview frontend — approved as generated
+- Phase 5: Control-plane Hermes intent count — approved as generated (lands via Edge-City/agentvillage-controlplane PR + submodule pointer bump)
+- Phase 6: Hermes skill dead-filter cleanup — approved as generated (behavior-preservation success criteria added per slice-verifier warning; lands via Edge-City/agentvillage PR)
+
+## References
+
+- Research: `.rpiv/artifacts/research/2026-06-19_19-16-39_intent-count-consistency.md`
+- FRD: `.rpiv/artifacts/discover/2026-06-19_18-59-29_intent-count-consistency.md`
+- Direct precedent: `.rpiv/artifacts/plans/2026-06-12_00-07-14_pr-937-brief-questions-remediation.md` (scope clamp + SQL-side limit + scopeRestriction + loud failure)
+- Linear: EDG-53

--- a/.rpiv/artifacts/research/2026-06-19_19-16-39_intent-count-consistency.md
+++ b/.rpiv/artifacts/research/2026-06-19_19-16-39_intent-count-consistency.md
@@ -1,0 +1,244 @@
+---
+date: 2026-06-19T19:16:39+0300
+author: Yanek Yuk
+commit: 1fb525e730
+branch: yanki/edg-53-fix-intent-count-consistency
+repository: index
+topic: "Intent count consistency across surfaces"
+tags: [research, codebase, intent, count, pagination, mcp, scoped-key, edge-city, premises, user-context, networks]
+status: ready
+last_updated: 2026-06-19T19:16:39+0300
+last_updated_by: Yanek Yuk
+---
+
+# Research: Intent count consistency across surfaces
+
+## Research Question
+Users see different intent counts depending on where they look — `/library`, `/networks`, the MCP tools, the Hermes/AgentVillage sidecar, and the backend each compute "a user's intents" differently, and Hermes never fetches it at all (EDG-53). Ground the FRD's three deferred open questions in codebase reality before design: (1) the exact canonical intent filter set; (2) what "premises" and "user_context" map to for the `/networks` overview tab; (3) how the AgentVillage/Hermes scoped API key resolves to intent scoping at the backend/MCP boundary.
+
+## Summary
+
+The divergence is **not** caused by differing filter logic — it is caused by **which query each surface chooses** and **one frontend rendering bug**.
+
+- **Canonical filter set (settled):** Every "a user's intents" query keys off `userId = ? AND archivedAt IS NULL` only. The `intentStatusEnum` (`database.schema.ts:10`, values `ACTIVE/PAUSED/FULFILLED/EXPIRED`; column at `:562`) is *selected* in projections but **never appears in any WHERE clause** anywhere in the codebase. The canonical definition is therefore `userId + archivedAt IS NULL`, with no status filter. The FRD's deferred "also exclude PAUSED/FULFILLED/EXPIRED?" question resolves to **no** — that enum is dead as a filter today.
+- **The real divergence vector:** `getActiveIntentsAcrossIndexes` (`database.adapter.ts:817`/`:2238`) adds `innerJoin(intentNetworks)` + `inArray(networkId, indexIds)` + `selectDistinctOn([intents.id])`. This **excludes** intents not assigned to any reachable network and **dedups** multi-network membership. So for the same identity, the scoped MCP count is **≤** the `listIntents` total — equal only when every active intent is assigned within the reachable index set. This is legitimate and matches the FRD's "scoped-key view IS the canonical count for Hermes" decision.
+- **`/library` is a frontend-only bug:** the server already computes and ships `pagination.totalCount` (`intent.service.ts:114`, `intent.controller.ts:46-53`). The page discards it via a narrow type cast (`library/page.tsx:103`) and renders `intents.length` of a 100-capped page (`:223`). `status` likewise reaches JSON but is dropped frontend-side (absent from `LibrarySourceIntent`/`BaseIntent`). Network assignments **already** flow end-to-end and render (`attachIntentNetworks` → `NetworkMembership` chips).
+- **Hermes:** the control-plane hard-codes `intents: null` (`tenants.js:311`) and never fetches. The `summarize-negotiations.ts:309` `status === "active"` re-filter is **dead/fragile code** — the intent graph never emits a `status` field, so today it is a no-op pass-through; were status ever emitted, the lowercase compare against the uppercase enum would silently drop everything.
+- **`/networks` overview:** intents are already served (`GET /networks/:id/my-intents`). Premises and the per-network `user_context` row have **no HTTP endpoint** today — two new reads. The adapter query *patterns* exist and are reusable.
+
+## Detailed Findings
+
+### Canonical intent filter set (FRD Open Question 1)
+
+All five "own intents" queries share the base predicate `userId = ? AND archivedAt IS NULL`; none filter `status`:
+
+- **`listIntents`** (`database.adapter.ts:512`) — reference impl. Conditions built at `:519-528`: `eq(userId)` + (`isNull`/`isNotNull(archivedAt)` by `options.archived`) + optional `sourceType`. Parallel `count()` over the **same `where`** at `:550`. `status` is in the row projection (`:539`) but never in `where`.
+- **`getActiveIntents`** (`database.adapter.ts:310`) — WHERE `eq(userId) + isNull(archivedAt)` (`:319-324`). Matches canonical exactly.
+- **`getActiveIntentsAcrossIndexes`** (`database.adapter.ts:817`) — `selectDistinctOn([intents.id])` + `innerJoin(intentNetworks)` + WHERE `eq(userId) + isNull(archivedAt) + inArray(networkId, indexIds)` (`:821-839`); early-returns `[]` when `indexIds.length === 0` (`:819`). **Only** query that diverges structurally.
+- **`getIntentsInIndexForMember`** (`database.adapter.ts:438`) — single-network narrow: `eq(intentNetworks.networkId, networkId) + eq(userId) + isNull(archivedAt)` (`:495-501`). No dedup needed (one network).
+- **`searchOwnIntents`** (`database.adapter.ts:1016`) — canonical predicate + `ILIKE` text search (`:1028-1034`), escaped at `:1022`.
+
+Status enum dead-as-a-filter confirmed: `intentStatusEnum` at `database.schema.ts:10`, column `status` default `'ACTIVE'` at `:562`. Grep across the codebase finds no `eq(intents.status, ...)` / `intents.status` in any WHERE.
+
+### Duplicate adapter classes (consolidation target)
+
+Two singletons back the two surfaces; methods are **byte-for-byte identical copies**, not a shared impl:
+
+- `IntentDatabaseAdapter` (class `database.adapter.ts:292`, singleton `:6824`) — backs the **REST** surface. `intent.service.ts:30` sets `this.adapter = intentDatabaseAdapter`.
+- `ChatDatabaseAdapter` (class `database.adapter.ts:934`, singleton `:6820`) — backs the **MCP** surface via `scopedDepsFactory.create` (`mcp.controller.ts:655-663`), with `protocolDeps.database = chatDatabaseAdapter` (`mcp.controller.ts:86`). `createUserDatabase` (`:6894`) / `createSystemDatabase` (`:7059`) bind its methods.
+- The two `getActiveIntentsAcrossIndexes` (`:821-839` vs `:2241-2257`), the two `getActiveIntents` (`:319-324` vs `:1003-1008`), and the two `getIntentsInIndexForMember` (`:438` vs `:1041`) have identical filter logic. The only behavioral divergence: `IntentDatabaseAdapter.getIntentsInIndexForMember` selects `relevancyScore` (`:495,:503`) while the `ChatDatabaseAdapter` copy omits it (`:1045-1050`) — affects shape, not count.
+- `createSystemDatabase`'s `getActiveIntentsAcrossIndexes` wrapper adds two guards: caller-only `if (userId !== authUserId) throw` (`:7134-7136`) and scope filter `indexIds.filter(id => indexScope.includes(id))` (`:7138`).
+
+**Decision:** extract a shared canonical predicate/where-builder so both classes route through one definition (see Developer Context).
+
+### `/library` count + per-intent rendering (FRD reqs 2-3)
+
+Server already ships the correct total; the frontend drops it:
+
+- Adapter `listIntents` returns `{ rows, total }` where `total` is the unbounded `count()` (`database.adapter.ts:530-552`).
+- Service clamps `limit` to **max 100** (`intent.service.ts:96`) and returns `pagination: { current, total: ceil(total/limit) /*pages*/, count: rows.length, totalCount: total }` (`:106-113`). Note `pagination.total` = page count, `pagination.totalCount` = true row count.
+- Controller `POST /intents/list` (`intent.controller.ts:28`) serializes `pagination: result.pagination` verbatim (`:52`), re-mapping only date fields (`:47-51`). **`totalCount` is alive on the wire.**
+- Frontend bug: `api.post<{ intents?: LibrarySourceIntent[] }>('/intents/list', { page: 1, limit: 100 })` (`library/page.tsx:103`) — the generic `T` has no `pagination` field, so `totalCount` is type-dropped. Badge renders `intents.length` (`:223`), capped at 100. The typed paginated path `createIntentsService.getIntents` (`services/intents.ts:6-16`, returns `PaginatedResponse<Intent>`) exists but is **not used** for listing here.
+- Per-intent **networks already flow + render**: `IntentListRow.networks` (`database.adapter.ts:166`) via `attachIntentNetworks` (`:564-583`, filters `isNull(networks.deletedAt)`) → controller `...r` (`intent.controller.ts:47`) → `LibrarySourceIntent.networks` (`page.tsx:25`) → `BaseIntent.networks` (`IntentList.tsx:46`) → `NetworkMembership` chips/grace-spinner/"Not in any network" (`IntentList.tsx:53-99,213`). No backend work needed.
+- Per-intent **status**: backend supplies it (`IntentListRow.status` `:153`, selected `:534`, passes controller `...r`) but frontend drops it — `status` is absent from `LibrarySourceIntent` (`page.tsx:15-26`) and `BaseIntent` (`IntentList.tsx:31-47`); no status renderer exists. **Frontend-only** work.
+
+### Scoped API key → intent scoping (FRD Open Question 3)
+
+The clamp chain for a network-bound Hermes key:
+
+1. `resolveApiKeyUserId` (`principal.ts:41-48`) resolves `userId`, fail-closed when `userId !== referenceId` (`:45`). MCP path: `mcp.controller.ts:319`, with agent-key both-columns guard at `:315-317`.
+2. `resolveAgentNetworkScopeById` (`agent-scope.guard.ts:42-58`) → single bound `scopeId` or null; throws on conflicting scopes (`:50-54`). Carried into identity at `mcp.controller.ts:523-528`.
+3. `computeAgentIndexScope` (`mcp.server.ts:210-220`): when `networkScopeId` set, filters `userNetworks` to `m.networkId === networkScopeId || m.isPersonal === true` → `[boundNetwork, personalIndex]`.
+4. `applyNetworkScopeToContext` (`mcp.server.ts:236-262`, called `:563`): sets `context.networkId = networkScopeId` and `context.indexScope = computeAgentIndexScope(...)` (`:248`), *before* the membership check (`:250`) so a missing bound network safely collapses to personal-only. Guard `if (context.networkId) return` (`:241`) lets a user-driven chat scope take precedence.
+5. Scoped DBs built from `context.indexScope` (`mcp.server.ts:608-609`).
+
+**No-arg `read_intents` under scope** → `context.networkId` set + `context.indexScope = [bound, personal]`.
+
+### MCP read_intents routing (which query backs the scoped count)
+
+- Handler (`intent.tools.ts:75`) builds `graphInput`; no-arg scoped path hits the branch at `:165-167` (`context.indexScope.length > 0 && context.networkId`) → sets `graphInput.indexScope` only (NOT `networkId`/`queryUserId`).
+- Graph `queryNode` (`intent.graph.ts:689-718`) matches `!queryUserId && !networkId && indexScope.length > 0` → calls `getActiveIntentsAcrossIndexes(userId, indexScope)` (`:697`). Other routes (`getNetworkIntentsForMember` `:742`, global `getActiveIntents` `:811`) are not taken.
+- `totalCount` = `result.readResult.intents.length` (full pre-pagination set) at `intent.tools.ts:188-191` when `limit` is passed.
+- **Consequence:** scoped MCP count is "distinct active intents reachable within `[bound, personal]`" — ≤ the `listIntents` total. `selectDistinctOn` prevents inflation from multi-network membership; the `innerJoin` is what makes it potentially smaller (orphaned/unassigned intents excluded).
+
+### Edge-city / Hermes intent fetch (FRD req 6)
+
+- Opportunity mirror to imitate structurally: `fetchIndexOpportunityCount` (`index-network.js:54-64`) — REST `GET /api/opportunities?limit=200` via `indexFetch` (`:7-13`, `x-api-key`, `INDEX_API_BASE` default `https://protocol.index.network`), client-filters `status === 'draft'|'pending'`.
+- Wiring slot: `emptyStats().intents = null` (`tenants.js:311`); `getTenantStats` fetches opportunities only when `stats.index.connected` (`tenants.js:494-509`, call at `:502`). A new `fetchIndexIntentCount` is imported at `:13` and called right after `:502`, populating the existing `intents` slot. Per-tenant key via `getTenantIndexApiKey` (`:354-369`, decrypts `secrets.indexApiKey`). MCP endpoint default `INDEX_MCP_URL = https://protocol.index.network/mcp` (`tenants.js:16`).
+- **Transport decision (see Developer Context):** source the MCP `read_intents` `totalCount`, NOT a REST `/intents/list` total — only the MCP path yields the canonical *scoped* count. A REST call would count the owner's full unscoped active set and disagree with the scoped Hermes view.
+- Hermes skill re-filter: `summarize-negotiations.ts:294` calls `read_intents { limit: 20 }`; `:302-312` re-filters `!i.status || i.status === "active"` (local type `status?: string` at `:153`). The graph read mappings emit only `{ id, description, summary, createdAt }` (`intent.graph.ts:713-718,761,798,825-829`) — **no `status`** — so `!i.status` is always true and everything passes. The filter is dead and should be **removed**; if a total is wanted, read `data.totalCount` (not the 20-item page array). **Submodule note:** `packages/edge-city/agentvillage/` was checked out and readable.
+
+### `/networks` overview data model (FRD Open Question 2 + req 4)
+
+- Current panel renders intents only: `NetworkOverviewPanel.tsx:49-60` calls `indexesService.getMyIndexIntents(index.id)` (`services/networks.ts:303-319` → `GET /networks/:id/my-intents`), badge `intents.length` at `:91`. Backend: `network.controller.ts:867-883` → `network.service.ts:368-372` (`getMyIntentsInNetwork`, re-filters to `userId` at `:371`) → adapter `getNetworkIntentsForMember` (`database.adapter.ts:2198-2236`, `intentNetworks ⋈ intents ⋈ users` filtered `networkId + archivedAt IS NULL` at `:2223`).
+- **Premises** = `premises` table (`database.schema.ts:316-334`; `premiseStatusEnum` ACTIVE/RETRACTED/EXPIRED at `:17`, `status` `:324`, soft-delete `deletedAt` `:332`), joined to networks via `premiseNetworks` (`:335-344`). Domain: "composable identity assertions… the source of truth" (`docs/domain/identity-and-context.md:40-44`).
+- **user_context** = `user_contexts` table (`database.schema.ts:346-378`): `networkId IS NULL` is the single global identity row (partial unique `user_contexts_user_global_uniq` `:366-368`); concrete `networkId` = per-network row (partial unique `user_contexts_user_network_uniq` `:362-364`). Domain: "synthesized representation of a user, derived from their premises" (`docs/domain/identity-and-context.md:31-36`).
+- **Reusable read patterns:** per-network context = `getUserContext(userId, networkId)` predicate `eq(userContexts.networkId, networkId)` (`database.adapter.ts:296-308`, mirror `:4435-4454`). Per-network premises pattern at `database.adapter.ts:5601-5635` (`getPremisesForUserInNetworks`) — BUT it gates `embedding IS NOT NULL` (`:5634`) and caps at `limit 40`, so it would undercount.
+- **New work:** intents already served; **premises + user_context are two new reads** (no controller exposes them today). Per the decision below, premises get a **new dedicated count+list query** (no embedding/limit gate).
+
+## Code References
+- `backend/src/adapters/database.adapter.ts:512-553` — `listIntents` (canonical list + `count()` total at `:550`)
+- `backend/src/adapters/database.adapter.ts:310-328` — `getActiveIntents` (canonical predicate)
+- `backend/src/adapters/database.adapter.ts:817-844` / `:2238-2257` — `getActiveIntentsAcrossIndexes` (dedup + network-join; duplicate copies)
+- `backend/src/adapters/database.adapter.ts:564-583` — `attachIntentNetworks` (per-intent networks, filters deleted networks)
+- `backend/src/adapters/database.adapter.ts:149-167` — `IntentListRow` (carries `status` `:153`, `networks` `:166`)
+- `backend/src/adapters/database.adapter.ts:296-308` — `getUserContext(userId, networkId)` per-network/global selector
+- `backend/src/adapters/database.adapter.ts:5601-5635` — `getPremisesForUserInNetworks` (embedding-gated, limit 40 — do NOT reuse for count)
+- `backend/src/adapters/database.adapter.ts:6820,6824,6894,7059,7126-7139` — singleton wiring + MCP scoped-db factories
+- `backend/src/services/intent.service.ts:86-118` — limit clamp `:96`, `totalCount` `:114`
+- `backend/src/controllers/intent.controller.ts:28-53` — `POST /intents/list`, pagination on wire `:52`
+- `backend/src/schemas/database.schema.ts:10,562` — `intentStatusEnum` (dead as filter); `:316-344` premises/premiseNetworks; `:346-378` user_contexts
+- `backend/src/lib/apikey/principal.ts:41-48` — `resolveApiKeyUserId` fail-closed
+- `backend/src/guards/agent-scope.guard.ts:42-58` — `resolveAgentNetworkScopeById`
+- `backend/src/services/network.service.ts:368-372`; `backend/src/controllers/network.controller.ts:867-883` — `/networks/:id/my-intents`
+- `packages/protocol/src/mcp/mcp.server.ts:210-262,563,608-609` — `computeAgentIndexScope`, `applyNetworkScopeToContext`, scoped-db build
+- `packages/protocol/src/intent/intent.tools.ts:75,152-191` — read-mode branching, `:165` scoped branch, `:188-191` totalCount
+- `packages/protocol/src/intent/intent.graph.ts:689-718,742,811,825-829` — query routing + read mappings (no `status`)
+- `frontend/src/app/library/page.tsx:15-26,100-116,222-224` — `LibrarySourceIntent` (no `status`), fetch dropping totalCount, badge
+- `frontend/src/services/intents.ts:6-16` — `getIntents` typed paginated path (unused on library)
+- `frontend/src/components/IntentList.tsx:31-47,53-99,213` — `BaseIntent` (no status), `NetworkMembership` renderer
+- `frontend/src/components/NetworkOverviewPanel.tsx:19,36-60,82-100` — overview panel (intents only)
+- `frontend/src/services/networks.ts:303-319` — `getMyIndexIntents`
+- `packages/edge-city/agentvillage-controlplane/control-plane/src/index-network.js:7-13,54-66` — `indexFetch`, `fetchIndexOpportunityCount`
+- `packages/edge-city/agentvillage-controlplane/control-plane/src/tenants.js:13,16,306-331,494-509` — imports, `INDEX_MCP_URL`, `emptyStats` (intents:null `:311`), wiring `:502`
+- `packages/edge-city/agentvillage/skills/index-network/scripts/summarize-negotiations.ts:153,289-312` — dead `status === "active"` re-filter `:309`
+- `docs/domain/identity-and-context.md:31-44` — premises / user_context concepts
+
+## Integration Points
+
+### Inbound References (who reads "a user's intents")
+- `frontend/src/app/library/page.tsx:103` — `POST /intents/list` (REST, full unscoped set; renders `.length` bug)
+- `frontend/src/components/NetworkOverviewPanel.tsx:51` — `GET /networks/:id/my-intents` (per-network, user-filtered)
+- MCP `read_intents` (`intent.tools.ts:75`) — chat/CLI/Hermes; scoped path → `getActiveIntentsAcrossIndexes`
+- `packages/edge-city/.../summarize-negotiations.ts:294` — Hermes skill, MCP `read_intents { limit: 20 }`
+- `tenants.js:502` (target) — control-plane stats; currently `intents: null` (`:311`)
+
+### Outbound Dependencies
+- All surfaces → `database.adapter.ts` intent queries (two adapter classes)
+- MCP scoped reads → `mcp.server.ts` clamp chain → `context.indexScope`
+- Edge-city → Index REST (`/api/*`) and MCP (`/mcp`) via `x-api-key`
+
+### Infrastructure Wiring
+- `mcp.controller.ts:86,655-663` — `chatDatabaseAdapter` injected; `scopedDepsFactory.create`
+- `intent.service.ts:30` — `intentDatabaseAdapter` for REST
+- `agent-scope.guard.ts` — agent network-scope resolution; `principal.ts` — API-key principal
+- `tenants.js:13,16` — control-plane imports + `INDEX_MCP_URL`/`INDEX_API_BASE`
+
+## Architecture Insights
+- **Consistency = same query per scope, not one global integer.** Unscoped reads (REST `/library`, unscoped `read_intents` → `getActiveIntents`) share the `userId + archivedAt IS NULL` predicate and already agree. A network-scoped key legitimately sees a subset (`getActiveIntentsAcrossIndexes`). The FRD's acceptance criterion "all surfaces agree for the same identity/scope" is structurally satisfiable by routing each surface to the right query — the bugs are rendering (`/library`) and absence (Hermes), not filter drift.
+- **`selectDistinctOn` is load-bearing.** It is the only thing preventing multi-network membership from inflating the scoped count. Any new per-network count query must preserve dedup semantics (or count distinct intent ids).
+- **Status enum is vestigial.** Treat `userId + archivedAt IS NULL` as canonical and do not introduce status filtering without an explicit separate decision (see FRD Suggested Follow-ups).
+- **Clamp is context-derived, never caller-supplied.** The `read_pending_questions` hardening (PR #937) is the template: clamp behind `Boolean(context.networkId)`, push limits SQL-side, return a `scopeRestriction` payload, fail loud.
+- **Premise/user_context reuse caution.** The existing per-network premise read is tuned for similarity search (embedding-gated, limited); a faithful count needs a dedicated query.
+
+## Precedents & Lessons
+6 similar past changes analyzed.
+
+### Precedent: Network-scope clamping for agent/MCP keys ⚠️ riskiest area
+**Commit(s)**: `3cf0e888ec`, `d795a39162`, `561602989a`, `96d4853c02`, `a071cdb45d` (2026-05-07, PRs #736/#785/#790); `423ec825a8` (2026-05-19); `d2113c2bd7` (2026-05-20)
+**Blast radius**: ~7 layers — `agent-scope.guard.ts`, `intent/network/opportunity.controller.ts`, `mcp.controller.ts`, `mcp.server.ts` (`computeAgentIndexScope`, `applyNetworkScopeToContext`), `tool.helpers.ts` (`resolveChatContext`), `auth.interface.ts`
+**Follow-up fixes**:
+- `f0a72b22c0` — guard registered but **not actually firing** (scope silently unenforced)
+- `12cc85834f` — fail-**open** mixed-scope hole found 3+ weeks later
+- `eff9e02c32` — over-clamp **dropped the personal index** from scoped reads
+- `9a8c123867`/`efd85caeef`/`65a411715c`/`3ff55a4b39`/`106e6dfc93` — 3-4 Copilot review rounds
+**Takeaway**: For the Hermes scoped-key count, write explicit tests that enforcement *fires*, *fails closed*, and *still includes the personal index*.
+
+### Precedent: Scope-aware intent reads (the canonical-query seam)
+**Commit(s)**: `302a8054c1` "add getActiveIntentsAcrossIndexes" (2026-05-19); `b298890fc2` "indexScope branch to intent read graph" (2026-05-19, with `intent.graph.scoped.spec.ts`)
+**Blast radius**: 2 layers — `database.adapter.ts`, `intent.graph.ts`
+**Takeaway**: This is the function being consolidated onto; multi-network inflation is the classic divergence bug and the `selectDistinctOn` dedup is load-bearing.
+
+### Precedent: `read_pending_questions` hardening (DIRECT ANALOG)
+**Commit(s)**: `6a4956394c` (2026-06-12, PR #937)
+**Lessons from docs** (`.rpiv/artifacts/plans/2026-06-12_00-07-14_pr-937-brief-questions-remediation.md`):
+- Clamp must be **context-derived**, never caller-supplied (`Boolean(context.networkId)`)
+- Push `limit` **SQL-side**, never `slice()`/`.length` of a page (explicit success criterion)
+- Return a **`scopeRestriction`** payload so scoped callers know results are clamped
+- **Defense-in-depth** re-filter in the tool even though the host clamps SQL-side
+- **Loud failure** (`source: "unavailable"` + reason), never silent
+**Takeaway**: Copy this shape verbatim for the Hermes scoped count + `/library` totalCount.
+
+### Precedent: Surface network membership on intents
+**Commit(s)**: `64fc5170c1` (2026-06-15, PR #971) — introduced `attachIntentNetworks`, touched `library/page.tsx` + `IntentList.tsx`
+**Takeaway**: Most recent touch of the exact files EDG-53 extends; "honest toast" naming signals prior care about not misrepresenting state.
+
+### Precedent: Intent-network orphaning / join-time reconcile
+**Commit(s)**: `3df8a49a9e`/`973122b5a6`/`1c14685a80` (2026-06-15, #970); `88ed1b5f39` "personal index holds all intents by default" (#972)
+**Lessons from docs** (`.rpiv/artifacts/designs/intent-network-orphaning-fix.md`): intents drift out of network assignment; needed backfill CLI + reconcile job + orphan metric.
+**Takeaway**: The `/networks` per-network count must read from the same reconciled assignment source, or it re-diverges from `/library`.
+
+### Precedent: Earlier intent-listing pagination
+**Commit(s)**: `5e923ebc1f` (2026-02-02) feature; `cfadf4a6fb` (2026-02-13) "paginate no-index member intent listing" fix 11 days later
+**Takeaway**: Pagination + count separation is a recurring stumbling block here.
+
+### Composite Lessons
+- **Scope enforcement repeatedly fails open/silently** (`f0a72b22c0`, `12cc85834f`, `eff9e02c32`) — add tests that enforcement fires, fails closed, and keeps the personal index.
+- **Totals must come from SQL `count()` over the shared `where`, never `.length`/`slice()` of a page** — the `/library` bug and a PR #937 success criterion.
+- **Clamps must be context-derived with a defense-in-depth re-filter and a `scopeRestriction` payload** (`6a4956394c`).
+- **Dedup is load-bearing for multi-network counts** (`selectDistinctOn([intents.id])`).
+- **Intent↔network assignment drifts** (#970) — per-network counts must use the reconciled source.
+- **Cross-layer scope work attracts 3-4 Copilot review rounds** — write scope/clamp tests up front.
+
+## Historical Context (from `.rpiv/artifacts/`)
+- `.rpiv/artifacts/discover/2026-06-19_18-59-29_intent-count-consistency.md` — the EDG-53 FRD this research grounds
+- `.rpiv/artifacts/plans/2026-06-12_00-07-14_pr-937-brief-questions-remediation.md` — direct analog: scope clamp + SQL-side limit + scopeRestriction + loud failure
+- `.rpiv/artifacts/designs/intent-network-orphaning-fix.md` — intent↔network assignment drift, reconcile job + backfill
+
+## Developer Context
+
+**Q (discover: Primary pain is user-facing trust): What's the actual pain — who notices the inconsistent counts and what goes wrong?**
+A: User-facing trust / confusion — end users see different counts across surfaces, eroding trust; goal is one consistent number (and list) everywhere.
+
+**Q (discover: Deliverable is full per-surface listing + consistency): Reconcile the integer only, or properly surface the underlying data per surface?**
+A: Full listing + consistency across all surfaces including Hermes, with the explicit note that AgentVillage/Hermes uses a scoped API key.
+
+**Q (discover: Scoped-key view is the canonical count for Hermes): How should the scoped API key affect the canonical count?**
+A: The count Hermes reports must reflect exactly what the scoped key is authorized to see; consistency means surfaces agree for the same identity/scope.
+
+**Q (discover: `/library` shows all intents + assignments + status): What should `/library` display?**
+A: Library shows all intents, their assignments to networks, and their status (if applicable).
+
+**Q (discover: `/networks` overview shows intents + premises + user_context): What does the ticket's "/networks should list proper intents and counts" refer to?**
+A: Network overview tab should show intents and premises assigned to that network, and also the user_context.
+
+**Q (discover: Canonical filter definition — deferred): What is the single canonical intent definition?**
+A: Deferred to research. **Resolved here:** `userId + archivedAt IS NULL`, no status filter — `intents.status` (`database.schema.ts:562`) is never used in any WHERE clause; the scoped variants add network-join + `selectDistinctOn` dedup, not a different active/ownership rule.
+
+**Q (`tenants.js:311` + `intent.graph.ts:697`): Should `fetchIndexIntentCount` source the REST `/intents/list` total or the MCP `read_intents` totalCount?**
+A: **MCP `read_intents` totalCount.** Only the MCP path (→ `getActiveIntentsAcrossIndexes`) yields the canonical *scoped* count; REST would count the owner's full unscoped active set and disagree with the scoped Hermes view.
+
+**Q (`database.adapter.ts:5601-5635`): Reuse the embedding-gated, limit-40 `getPremisesForUserInNetworks` for the `/networks` premise count, or a new query?**
+A: **New dedicated count+list query** — join `premiseNetworks ⋈ premises` filtered by `networkId + status='ACTIVE' + deletedAt IS NULL`, no embedding gate, no limit cap, so the badge reflects the true count (honors the "no silent truncation" NFR).
+
+**Q (`database.adapter.ts:817` vs `:2238`): The two adapter classes hold byte-identical intent queries — consolidate, leave + test, or defer?**
+A: **Extract a shared canonical predicate** so "one canonical definition" is literally one code path across both classes. (Mitigate the MCP-scope-path risk with the count-consistency tests the precedents demand.)
+
+## Related Research
+- None prior. This is the first research artifact for EDG-53; it grounds the discover FRD above.
+
+## Open Questions
+- How the AgentVillage/Hermes scoped API key resolves to intent scoping at the backend/MCP boundary — **resolved** (see "Scoped API key → intent scoping"): bound network + personal index via `computeAgentIndexScope`/`applyNetworkScopeToContext`, routed to `getActiveIntentsAcrossIndexes`.
+- The intent `status` enum (`ACTIVE/PAUSED/FULFILLED/EXPIRED`) is selected but never filtered (`database.schema.ts:10,562`). If status-based counting is ever desired, it is a separate decision — out of scope for EDG-53.
+- `getActiveIntentsAcrossIndexes` dedups via `selectDistinctOn([intents.id])` while other community-browse paths may not (`database.adapter.ts:817-841`) — worth auditing for multi-network inflation independent of this ticket.
+- Whether the `/networks` overview premises/user_context should show the **current user's** data (mirroring the "My Intents" user-filter at `network.service.ts:371`, and inherent for user_context) vs all members' — assumed current-user; confirm during design.

--- a/.rpiv/artifacts/validation/2026-06-20_01-02-16_intent-count-consistency.md
+++ b/.rpiv/artifacts/validation/2026-06-20_01-02-16_intent-count-consistency.md
@@ -1,0 +1,115 @@
+---
+template_version: 1
+date: 2026-06-20T01:02:16+03:00
+author: Yanek Yuk
+commit: 1fb525e7309523c9d9ee54b2329027f5e98621fd
+branch: yanki/edg-53-fix-intent-count-consistency
+repository: index
+topic: "Validation of Intent count consistency across surfaces"
+status: ready
+verdict: pass
+parent: ".rpiv/artifacts/plans/2026-06-19_19-57-03_intent-count-consistency.md"
+tags: [validation, intent, count, pagination, mcp, scoped-key, edge-city, premises, user-context, networks]
+last_updated: 2026-06-20T01:02:16+03:00
+---
+
+## Validation Report: Intent count consistency across surfaces
+
+### Implementation Status
+
+- ✓ Phase 1: Shared canonical intent predicate — Fully implemented
+- ✓ Phase 2: /library count + status badge — Fully implemented
+- ✓ Phase 3: /networks overview backend — Fully implemented
+- ✓ Phase 4: /networks overview frontend — Fully implemented
+- ✓ Phase 5: Control-plane Hermes intent count — Fully implemented
+- ✓ Phase 6: Hermes skill dead-filter cleanup — Fully implemented
+
+### Automated Verification Results
+
+**Phase 1 — Shared canonical intent predicate**
+- ✓ Parity spec passes: `cd backend && bun test src/adapters/tests/database.adapter.spec.ts` — all 3 EDG-53 parity tests pass (96 pass / 2 fail; the 2 failures are `getProfile`/`saveProfile`, unrelated to intent counting and documented pre-existing on the stashed baseline).
+- ✓ Both adapter classes route through the shared predicate: `grep -c "activeOwnIntentsWhere(userId)" backend/src/adapters/database.adapter.ts` → 4 (≥ 4).
+- ✓ List path uses the shared list builder: `grep -c "ownIntentsListWhere(userId" …` → 1 (≥ 1).
+- ✓ Dedup preserved: `grep -cE "selectDistinctOn\(\[(schema\.)?intents\.id\]" …` → 2 (≥ 2).
+
+**Phase 2 — /library count + status badge**
+- ✓ Badge driven by the true total: `grep -c "intentTotal" frontend/src/app/library/page.tsx` → 3 (≥ 3) AND `grep -c "({intents.length})" …` → 0.
+- ✓ StatusBadge is conditional: `grep -c "StatusBadge" frontend/src/components/IntentList.tsx` → 2 (≥ 2).
+- ✓ status plumbed into the list type: `grep -c "status?: string" frontend/src/components/IntentList.tsx` → 2 (≥ 1).
+
+**Phase 3 — /networks overview backend**
+- ✓ Route ordering: `@Get('/:id/overview')` at L889 precedes `@Get('/:id')` at L1019 (param route cannot swallow the overview path).
+- ✓ Service composes exactly 3 reads: `getMyIntentsInNetwork` + `adapter.getNetworkPremisesForMember` + `adapter.getUserContext` (network.service.ts:383–385).
+- ✓ Premise query honesty: `getNetworkPremisesForMember` body contains 0 `embedding`/`limit(` references (no embedding gate, no limit cap).
+
+**Phase 4 — /networks overview frontend**
+- ✓ Service method calls the overview endpoint: `grep -c "getNetworkOverview\|networks/${networkId}/overview" frontend/src/services/networks.ts` → 2 (≥ 2).
+- ✓ Panel renders all three sections: My Intents / My Premises / Your Context all present (2 occurrences each — JSX comment + `<p>` label).
+- ✓ Panel no longer calls the old single-purpose fetch: `grep -c "getMyIndexIntents" frontend/src/components/NetworkOverviewPanel.tsx` → 0.
+
+**Phase 5 — Control-plane Hermes intent count**
+- ✓ Intent fetch exported + imported: `fetchIndexIntentCount` → 2 in `index-network.js` AND 2 in `tenants.js`.
+- ✓ Sourced from MCP totalCount, not REST: `read_intents\|data.totalCount\|parsed.data` → 3 AND `/api/intents\|/intents/list` → 0.
+- ✓ Degrades to null (no throw into caller): `return null` count in `fetchIndexIntentCount` → 5 (≥ 4).
+- ✓ Both control-plane JS files pass `node --check`.
+
+**Phase 6 — Hermes skill dead-filter cleanup**
+- ✓ Dead status filter removed: `grep -c 'i.status === "active"' …/summarize-negotiations.ts` → 0.
+- ✓ Signal pipeline otherwise intact: `grep -c "return intents" …` → 1 (≥ 1); defensive `status?` DTO field retained.
+
+**Type checks**
+- ✓ Backend `bunx tsc --noEmit -p tsconfig.json` — exit 0, 0 errors; all four touched backend files clean.
+- ✓ Frontend `bunx tsc --noEmit -p tsconfig.json` — 60 errors total, identical to the stashed pre-change baseline (60 before and after). `library/page.tsx` and `IntentList.tsx` are clean; the only touched-file diagnostics (`NetworkOverviewPanel.tsx:4` `Network` import, `networks.ts:3` `../types` import) are pre-existing module-resolution errors on lines this change never modified.
+- ✓ No regressions detected.
+
+### Code Review Findings
+
+#### Matches Plan:
+
+- backend/src/adapters/database.adapter.ts — module-level `activeOwnIntentsWhere` / `ownIntentsListWhere` helpers added before `IntentDatabaseAdapter`; both `IntentDatabaseAdapter` and `ChatDatabaseAdapter` route `getActiveIntents` / `getActiveIntentsAcrossIndexes` / list predicate through them (4 helper call-sites; `selectDistinctOn` dedup intact).
+- backend/src/adapters/database.adapter.ts — `getNetworkPremisesForMember(networkId, userId)`: `premiseNetworks ⋈ premises` filtered by `networkId + userId + status='ACTIVE' + deletedAt IS NULL`, no embedding gate, no limit cap.
+- backend/src/services/network.service.ts:383–385 — `getNetworkOverview` runs the 3 reads via `Promise.all`, current-user scoped, members-only (delegates to `getMyIntentsInNetwork`).
+- backend/src/controllers/network.controller.ts:889 — `@Get('/:id/overview')` declared before `@Get('/:id')` (L1019) with `RateLimit('read')` + `AuthOrApiKeyGuard` + `assertAgentNetworkScope`.
+- frontend/src/app/library/page.tsx — page-loop accumulates all pages, `intentTotal` from `pagination.totalCount` drives the tab badge (no `intents.length`); `status` plumbed into `LibrarySourceIntent`.
+- frontend/src/components/IntentList.tsx — `StatusBadge` renders only when `status` present and non-ACTIVE; `status?` added to `BaseIntent`.
+- frontend/src/services/networks.ts + NetworkOverviewPanel.tsx — `getNetworkOverview` client method; panel fetches once and renders My Intents / My Premises / Your Context.
+- packages/edge-city/agentvillage-controlplane/control-plane/src/index-network.js — `postMcpMessage` (SSE+JSON) + `fetchIndexIntentCount` (initialize → `read_intents {limit:1}` → `data.totalCount`), null on any failure; exported. tenants.js wires `stats.intents` inside the `stats.index.connected` block.
+- packages/edge-city/agentvillage/skills/index-network/scripts/summarize-negotiations.ts — no-op `.filter((i) => !i.status || i.status === "active")` removed from `buildMcpSignalFetcher`; DTO `status?` field retained.
+
+#### Deviations from Plan:
+
+- None. Implementation is a faithful realization of the plan. (Two plan-text annotations were recorded during implementation as non-deviations: Phase 1 §4's dedup grep pattern was a literal-string miscount — the substantive 2-occurrence invariant holds via the corrected regex; Phase 4's section-count criterion expected `3` but returns `6` because each section name appears twice as comment + label — all three sections render.)
+
+#### Pattern Conformance:
+
+- ✓ Adapter predicate consolidation, controller guard/scope wiring, and the frontend service-client shape follow the existing `database.adapter.ts` / `network.controller.ts` / `services/networks.ts` conventions cited in the plan's Pattern References.
+- ✓ Control-plane `fetchIndexIntentCount` mirrors `fetchIndexOpportunityCount`'s try/catch → `null` degradation and the skill's `postMcpMessage` SSE client.
+- Minor observation: the frontend `whitespace-pre-wrap` "Your Context" block and the dashed empty-state for premises introduce new presentational markup not literally specified — acceptable variation, not a deviation (consistent with the existing IntentList empty-state styling).
+
+#### Potential Issues:
+
+- Edge-City delivery is out-of-tree: Phases 5 and 6 live under git submodules (`packages/edge-city/agentvillage`, `…/agentvillage-controlplane`, both showing `m` in `git status`). They must land via PRs against the canonical Edge-City repos with monorepo submodule-pointer bumps — they are NOT carried by a normal merge of this branch. Not a code defect; a release-mechanics gate.
+
+### Manual Testing Required:
+
+1. Phase 1 — cross-surface count consistency:
+   - [ ] For a user with intents spanning multiple networks, `/library`, unscoped MCP `read_intents`, and a network-scoped key report mutually consistent counts (scoped ≤ unscoped, equal when all intents are reachable).
+2. Phase 2 — /library:
+   - [ ] For a user with >100 intents, the Intents tab badge shows the full DB count and every intent renders (no 100-row truncation).
+   - [ ] A non-ACTIVE intent shows a status badge; ACTIVE intents show none.
+3. Phase 3/4 — /networks overview:
+   - [ ] Member payload shows intents + ACTIVE premises (true count) + per-network user_context; the three sections render with correct premise count.
+   - [ ] Empty-premise / null-context states render without error.
+   - [ ] Non-member / access-denied returns 403.
+4. Phase 5 — control-plane stats:
+   - [ ] A live tenant's stats payload shows `intents` as a number matching the scoped MCP `read_intents` totalCount (no longer `null`).
+   - [ ] A tenant with a missing/disconnected key, or a failing MCP call, shows `intents: null` without erroring the stats endpoint.
+   - [ ] The reported count includes the member's personal-index intents (scoped clamp's `[boundNetwork, personalIndex]` personal leg survives — regression guard, precedent `eff9e02c32`).
+5. Phase 6 — Hermes signal fetch:
+   - [ ] For a `read_intents` fixture whose items carry no `status` (current graph output), the emitted signal list (ids + summaries) is identical before and after the change.
+
+### Recommendations:
+
+- Ready to commit — implementation is complete and all automated criteria pass.
+- Before finishing the branch: open the two Edge-City PRs (agentvillage skill, agentvillage-controlplane) and bump the monorepo submodule pointers, since a plain merge will not carry Phases 5–6.
+- Work through the Manual Testing checklist against a live tenant / dev environment before promoting beyond `dev`.

--- a/backend/src/adapters/database.adapter.ts
+++ b/backend/src/adapters/database.adapter.ts
@@ -287,6 +287,44 @@ function toHydeDocument(row: typeof hydeDocuments.$inferSelect): HydeDocumentRow
 // ═══════════════════════════════════════════════════════════════════════════════
 
 /**
+ * Canonical "active own intents" WHERE predicate: a row the user owns that has
+ * not been archived. No status filter — `intents.status` is vestigial (selected
+ * but never filtered). Both the REST (IntentDatabaseAdapter) and MCP
+ * (ChatDatabaseAdapter) surfaces route through this so their counts cannot
+ * drift between them. See EDG-53.
+ */
+function activeOwnIntentsWhere(userId: string) {
+  return and(
+    eq(schema.intents.userId, userId),
+    isNull(schema.intents.archivedAt),
+  );
+}
+
+/**
+ * Canonical predicate for the paginated own-intents list: ownership + an
+ * archived toggle (archived rows when `archived` is true, active rows
+ * otherwise) + an optional sourceType narrow. Shares the ownership/active spine
+ * with {@link activeOwnIntentsWhere} so list `count()` totals and graph reads
+ * agree for the same identity. See EDG-53.
+ */
+function ownIntentsListWhere(
+  userId: string,
+  options: { archived: boolean; sourceType?: string },
+) {
+  const conditions = [
+    eq(schema.intents.userId, userId),
+    options.archived
+      ? isNotNull(schema.intents.archivedAt)
+      : isNull(schema.intents.archivedAt),
+  ];
+  const validSourceTypes: SourceType[] = ['file', 'integration', 'link', 'discovery_form', 'enrichment'];
+  if (options.sourceType && validSourceTypes.includes(options.sourceType as SourceType)) {
+    conditions.push(eq(schema.intents.sourceType, options.sourceType as SourceType));
+  }
+  return and(...conditions);
+}
+
+/**
  * Database adapter for intent CRUD (Intent Graph).
  */
 export class IntentDatabaseAdapter {
@@ -316,12 +354,7 @@ export class IntentDatabaseAdapter {
         createdAt: schema.intents.createdAt,
       })
         .from(schema.intents)
-        .where(
-          and(
-            eq(schema.intents.userId, userId),
-            isNull(schema.intents.archivedAt)
-          )
-        )
+        .where(activeOwnIntentsWhere(userId))
         .orderBy(desc(schema.intents.createdAt));
       return result;
     } catch (error: unknown) {
@@ -516,17 +549,7 @@ export class IntentDatabaseAdapter {
     sourceType?: string;
   }): Promise<{ rows: IntentListRow[]; total: number }> {
     const offset = (options.page - 1) * options.limit;
-    const conditions = [eq(schema.intents.userId, userId)];
-    if (options.archived) {
-      conditions.push(isNotNull(schema.intents.archivedAt));
-    } else {
-      conditions.push(isNull(schema.intents.archivedAt));
-    }
-    const validSourceTypes: SourceType[] = ['file', 'integration', 'link', 'discovery_form', 'enrichment'];
-    if (options.sourceType && validSourceTypes.includes(options.sourceType as SourceType)) {
-      conditions.push(eq(schema.intents.sourceType, options.sourceType as SourceType));
-    }
-    const where = and(...conditions);
+    const where = ownIntentsListWhere(userId, { archived: options.archived, sourceType: options.sourceType });
 
     const [rows, totalResult] = await Promise.all([
       db.select({
@@ -829,8 +852,7 @@ export class IntentDatabaseAdapter {
         .innerJoin(schema.intentNetworks, eq(schema.intentNetworks.intentId, schema.intents.id))
         .where(
           and(
-            eq(schema.intents.userId, userId),
-            isNull(schema.intents.archivedAt),
+            activeOwnIntentsWhere(userId),
             inArray(schema.intentNetworks.networkId, indexIds),
           ),
         )
@@ -999,12 +1021,7 @@ export class ChatDatabaseAdapter {
         createdAt: schema.intents.createdAt,
       })
         .from(schema.intents)
-        .where(
-          and(
-            eq(schema.intents.userId, userId),
-            isNull(schema.intents.archivedAt)
-          )
-        )
+        .where(activeOwnIntentsWhere(userId))
         .orderBy(desc(schema.intents.createdAt));
       return result;
     } catch (error: unknown) {
@@ -2235,6 +2252,91 @@ export class ChatDatabaseAdapter {
     }));
   }
 
+  /**
+   * List the current member's ACTIVE premises assigned to a network, for the
+   * /networks overview tab. Unlike getPremisesForUserInNetworks (tuned for
+   * similarity search — embedding-gated, capped at 40), this is an honest
+   * list+count: no embedding gate, no limit. Soft-deleted premises excluded.
+   * Current-user scoped. See EDG-53.
+   */
+  async getNetworkPremisesForMember(networkId: string, userId: string): Promise<Array<{
+    id: string;
+    text: string;
+    summary: string | null;
+    createdAt: Date;
+  }>> {
+    const rows = await db
+      .select({
+        id: schema.premises.id,
+        assertion: schema.premises.assertion,
+        createdAt: schema.premises.createdAt,
+      })
+      .from(schema.premiseNetworks)
+      .innerJoin(schema.premises, eq(schema.premiseNetworks.premiseId, schema.premises.id))
+      .where(and(
+        eq(schema.premiseNetworks.networkId, networkId),
+        eq(schema.premises.userId, userId),
+        eq(schema.premises.status, 'ACTIVE'),
+        isNull(schema.premises.deletedAt),
+      ))
+      .orderBy(desc(schema.premises.createdAt));
+
+    return rows.map((r) => {
+      const assertion = r.assertion as { text?: string; summary?: string } | null;
+      return {
+        id: r.id,
+        text: assertion?.text ?? '',
+        summary: assertion?.summary ?? null,
+        createdAt: r.createdAt,
+      };
+    });
+  }
+
+  /**
+   * List the current member's ACTIVE (non-archived) intents assigned to a
+   * network, for the /networks overview tab. Unlike getNetworkIntentsForMember
+   * (network-wide, capped at 50, then filtered by the caller in JS, so a member
+   * in a busy network can lose their own intents past the cap), this is an
+   * honest user-scoped list+count: scoped to the caller in SQL via the canonical
+   * {@link activeOwnIntentsWhere} predicate, no limit. Does not assert
+   * membership; callers gate access. See EDG-53.
+   */
+  async getNetworkIntentsForMemberOwn(networkId: string, userId: string): Promise<Array<{
+    id: string;
+    payload: string;
+    summary: string | null;
+    userId: string;
+    userName: string | null;
+    createdAt: Date;
+  }>> {
+    const rows = await db
+      .select({
+        id: intents.id,
+        payload: intents.payload,
+        summary: intents.summary,
+        userId: intents.userId,
+        userName: users.name,
+        createdAt: intents.createdAt,
+      })
+      .from(intentNetworks)
+      .innerJoin(intents, eq(intentNetworks.intentId, intents.id))
+      .innerJoin(users, eq(intents.userId, users.id))
+      .where(and(
+        eq(intentNetworks.networkId, networkId),
+        activeOwnIntentsWhere(userId),
+      ))
+      .orderBy(desc(intents.createdAt));
+
+    return rows.map((r) => ({
+      id: r.id,
+      payload: r.payload,
+      summary: r.summary,
+      userId: r.userId,
+      userName: r.userName,
+      createdAt: r.createdAt,
+    }));
+  }
+
   async getActiveIntentsAcrossIndexes(userId: string, indexIds: string[]) {
     try {
       if (indexIds.length === 0) return [];
@@ -2250,8 +2352,7 @@ export class ChatDatabaseAdapter {
         .innerJoin(intentNetworks, eq(intentNetworks.intentId, intents.id))
         .where(
           and(
-            eq(intents.userId, userId),
-            isNull(intents.archivedAt),
+            activeOwnIntentsWhere(userId),
             inArray(intentNetworks.networkId, indexIds),
           ),
         )

--- a/backend/src/adapters/tests/database.adapter.spec.ts
+++ b/backend/src/adapters/tests/database.adapter.spec.ts
@@ -10,7 +10,7 @@ import { describe, expect, it, beforeAll, afterAll } from 'bun:test';
 import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
 import db from '../../lib/drizzle/drizzle';
-import { users, userSocials, networks, networkMembers, intents, intentNetworks, premises, opportunities } from '../../schemas/database.schema';
+import { users, userSocials, networks, networkMembers, intents, intentNetworks, premises, premiseNetworks, opportunities } from '../../schemas/database.schema';
 import { IntentDatabaseAdapter, ChatDatabaseAdapter, EnrichmentDatabaseAdapter, OpportunityDatabaseAdapter, NetworkGraphDatabaseAdapter, HydeDatabaseAdapter } from '../database.adapter';
 
 const TEST_PREFIX = 'db_adapter_spec_' + Date.now() + '_';
@@ -1600,3 +1600,103 @@ describe('HydeDatabaseAdapter – deleteExpired and getStale', () => {
   });
 });
 
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Intent predicate parity (EDG-53)
+// ═══════════════════════════════════════════════════════════════════════════════
+describe('Intent predicate parity (EDG-53)', () => {
+  const intentAdapter = new IntentDatabaseAdapter();
+  const chatAdapter = new ChatDatabaseAdapter();
+
+  it('getActiveIntents agrees across REST and MCP adapters', async () => {
+    const rest = await intentAdapter.getActiveIntents(fixture.userAId);
+    const mcp = await chatAdapter.getActiveIntents(fixture.userAId);
+    expect(mcp.length).toBe(rest.length);
+    expect(new Set(mcp.map((i) => i.id))).toEqual(new Set(rest.map((i) => i.id)));
+  });
+
+  it('getActiveIntentsAcrossIndexes agrees across REST and MCP adapters', async () => {
+    const rest = await intentAdapter.getActiveIntentsAcrossIndexes(fixture.userAId, [fixture.networkId]);
+    const mcp = await chatAdapter.getActiveIntentsAcrossIndexes(fixture.userAId, [fixture.networkId]);
+    expect(mcp.length).toBe(rest.length);
+    expect(new Set(mcp.map((i) => i.id))).toEqual(new Set(rest.map((i) => i.id)));
+  });
+
+  it('listIntents total equals unscoped getActiveIntents count', async () => {
+    const active = await intentAdapter.getActiveIntents(fixture.userAId);
+    const { total } = await intentAdapter.listIntents(fixture.userAId, { page: 1, limit: 100, archived: false });
+    expect(total).toBe(active.length);
+  });
+});
+
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Network overview reads: honest, user-scoped premise + intent lists (EDG-53)
+// ═══════════════════════════════════════════════════════════════════════════════
+describe('Network overview member reads (EDG-53)', () => {
+  const chatAdapter = new ChatDatabaseAdapter();
+  const activePremiseId = uuidv4();
+  const retractedPremiseId = uuidv4();
+  const deletedPremiseId = uuidv4();
+  const userBPremiseId = uuidv4();
+  const ownIntentId = uuidv4();
+  const otherMemberIntentId = uuidv4();
+
+  const assertion = (text: string, summary?: string) => ({ text, tier: 'assertive' as const, summary });
+  const provenance = { source: 'explicit' as const, confidence: 0.9, timestamp: new Date().toISOString() };
+  const validity = { volatile: false };
+
+  beforeAll(async () => {
+    await db.insert(premises).values([
+      { id: activePremiseId, userId: fixture.userAId, assertion: assertion('Active premise', 'Active summary'), provenance, validity, status: 'ACTIVE' },
+      { id: retractedPremiseId, userId: fixture.userAId, assertion: assertion('Retracted premise'), provenance, validity, status: 'RETRACTED' },
+      { id: deletedPremiseId, userId: fixture.userAId, assertion: assertion('Deleted premise'), provenance, validity, status: 'ACTIVE', deletedAt: new Date() },
+      { id: userBPremiseId, userId: fixture.userBId, assertion: assertion('UserB premise'), provenance, validity, status: 'ACTIVE' },
+    ]);
+    await db.insert(premiseNetworks).values([
+      { premiseId: activePremiseId, networkId: fixture.networkId },
+      { premiseId: retractedPremiseId, networkId: fixture.networkId },
+      { premiseId: deletedPremiseId, networkId: fixture.networkId },
+      { premiseId: userBPremiseId, networkId: fixture.networkId },
+    ]);
+    await db.insert(intents).values([
+      { id: ownIntentId, userId: fixture.userAId, payload: TEST_PREFIX + 'Own intent 2', summary: 'S', sourceType: 'discovery_form', sourceId: fixture.userAId },
+      { id: otherMemberIntentId, userId: fixture.userBId, payload: TEST_PREFIX + 'Other member intent', summary: 'S', sourceType: 'discovery_form', sourceId: fixture.userBId },
+    ]);
+    await db.insert(intentNetworks).values([
+      { intentId: ownIntentId, networkId: fixture.networkId },
+      { intentId: otherMemberIntentId, networkId: fixture.networkId },
+    ]);
+  });
+
+  afterAll(async () => {
+    await db.delete(premiseNetworks).where(eq(premiseNetworks.networkId, fixture.networkId));
+    await db.delete(premises).where(inArray(premises.id, [activePremiseId, retractedPremiseId, deletedPremiseId, userBPremiseId]));
+    await db.delete(intentNetworks).where(inArray(intentNetworks.intentId, [ownIntentId, otherMemberIntentId]));
+    await db.delete(intents).where(inArray(intents.id, [ownIntentId, otherMemberIntentId]));
+  });
+
+  it('getNetworkPremisesForMember returns only the member ACTIVE, non-deleted premises', async () => {
+    const ids = new Set((await chatAdapter.getNetworkPremisesForMember(fixture.networkId, fixture.userAId)).map((r) => r.id));
+    expect(ids.has(activePremiseId)).toBe(true);
+    expect(ids.has(retractedPremiseId)).toBe(false); // non-ACTIVE excluded
+    expect(ids.has(deletedPremiseId)).toBe(false);    // soft-deleted excluded
+    expect(ids.has(userBPremiseId)).toBe(false);      // other member excluded
+  });
+
+  it('getNetworkPremisesForMember maps assertion.text/summary', async () => {
+    const rows = await chatAdapter.getNetworkPremisesForMember(fixture.networkId, fixture.userAId);
+    const active = rows.find((r) => r.id === activePremiseId)!;
+    expect(active.text).toBe('Active premise');
+    expect(active.summary).toBe('Active summary');
+  });
+
+  it('getNetworkIntentsForMemberOwn returns only the caller own active intents, never other members', async () => {
+    const rows = await chatAdapter.getNetworkIntentsForMemberOwn(fixture.networkId, fixture.userAId);
+    const ids = new Set(rows.map((r) => r.id));
+    expect(ids.has(fixture.intent1Id)).toBe(true);     // userA's original intent
+    expect(ids.has(ownIntentId)).toBe(true);            // userA's second intent
+    expect(ids.has(otherMemberIntentId)).toBe(false);   // userB's intent excluded
+    expect(rows.every((r) => r.userId === fixture.userAId)).toBe(true);
+  });
+});

--- a/backend/src/controllers/network.controller.ts
+++ b/backend/src/controllers/network.controller.ts
@@ -882,6 +882,28 @@ export class NetworkController {
   }
 
   /**
+   * Get the current user's overview for a network: their intents, premises, and
+   * per-network user_context. Members only.
+   * IMPORTANT: This must come before GET /:id to avoid route collision.
+   */
+  @Get('/:id/overview')
+  @UseGuards(RateLimit('read'), AuthOrApiKeyGuard)
+  async getOverview(req: Request, user: AuthenticatedUser, params: Record<string, string>) {
+    try {
+      await assertAgentNetworkScope(req, params.id);
+      const overview = await networkService.getNetworkOverview(params.id, user.id);
+      logger.verbose('Network overview retrieved', { networkId: params.id, userId: user.id, intents: overview.intents.length, premises: overview.premises.length });
+      return Response.json(overview);
+    } catch (err: unknown) {
+      const msg = errorMessage(err);
+      if (msg.includes('Access denied') || msg.includes('Not a member')) {
+        return Response.json({ error: msg }, { status: 403 });
+      }
+      throw err;
+    }
+  }
+
+  /**
    * Leave a network. Members (non-owners) can leave.
    * IMPORTANT: This must come before GET /:id to avoid route collision.
    */

--- a/backend/src/services/network.service.ts
+++ b/backend/src/services/network.service.ts
@@ -372,6 +372,32 @@ export class NetworkService {
   }
 
   /**
+   * Compose the /networks overview payload for the current member: their intents
+   * in the network, their ACTIVE premises assigned to it, and their per-network
+   * user_context. Members only: membership is asserted up front so the three
+   * (all current-user scoped) reads never run for a non-member. Intents go
+   * through the honest, uncapped getNetworkIntentsForMemberOwn so they stay
+   * consistent with the premise count beside them. See EDG-53.
+   */
+  async getNetworkOverview(networkId: string, userId: string) {
+    logger.verbose('[NetworkService] Getting network overview', { networkId, userId });
+    const isMember = await this.adapter.isNetworkMember(networkId, userId);
+    if (!isMember) {
+      throw new Error('Access denied: Not a member of this index');
+    }
+    const [intents, premises, userContext] = await Promise.all([
+      this.adapter.getNetworkIntentsForMemberOwn(networkId, userId),
+      this.adapter.getNetworkPremisesForMember(networkId, userId),
+      this.adapter.getUserContext(userId, networkId),
+    ]);
+    return {
+      intents,
+      premises,
+      userContext: userContext ? { text: userContext.text, generatedAt: userContext.generatedAt } : null,
+    };
+  }
+
+  /**
    * Resolve an index identifier (UUID or key) to a UUID.
    * @param idOrKey - UUID or human-readable key
    * @returns The index UUID, or null if not found

--- a/backend/src/services/tests/network.service.overview.spec.ts
+++ b/backend/src/services/tests/network.service.overview.spec.ts
@@ -1,0 +1,65 @@
+/** Config */
+import { config } from 'dotenv';
+config({ path: '.env.test', override: true });
+
+import { describe, expect, mock, test } from 'bun:test';
+
+import { NetworkService } from '../network.service';
+import type { ChatDatabaseAdapter } from '../../adapters/database.adapter';
+
+const NETWORK_ID = 'net-1';
+const USER_ID = 'user-1';
+
+/**
+ * Build a NetworkService over a minimal mock adapter for getNetworkOverview.
+ * `isMember` controls the membership gate; the three data reads return one row
+ * each so the composed payload is observable. See EDG-53.
+ */
+function makeService(isMember: boolean, userContext: { text: string; generatedAt: Date } | null = { text: 'ctx', generatedAt: new Date() }) {
+  const isNetworkMember = mock(async () => isMember);
+  const getNetworkIntentsForMemberOwn = mock(async () => [
+    { id: 'i1', payload: 'P', summary: null, userId: USER_ID, userName: 'A', createdAt: new Date() },
+  ]);
+  const getNetworkPremisesForMember = mock(async () => [
+    { id: 'p1', text: 'premise', summary: null, createdAt: new Date() },
+  ]);
+  const getUserContext = mock(async () => (userContext
+    ? { id: 'c1', text: userContext.text, embedding: [] as number[], premiseHash: '', generatedAt: userContext.generatedAt }
+    : null));
+  const adapter = {
+    isNetworkMember,
+    getNetworkIntentsForMemberOwn,
+    getNetworkPremisesForMember,
+    getUserContext,
+  } as unknown as ChatDatabaseAdapter;
+  return { service: new NetworkService(adapter), isNetworkMember, getNetworkIntentsForMemberOwn, getNetworkPremisesForMember, getUserContext };
+}
+
+describe('networkService.getNetworkOverview (EDG-53)', () => {
+  test('throws and runs no data reads for a non-member', async () => {
+    const { service, isNetworkMember, getNetworkIntentsForMemberOwn, getNetworkPremisesForMember, getUserContext } = makeService(false);
+    await expect(service.getNetworkOverview(NETWORK_ID, USER_ID)).rejects.toThrow(/Access denied/);
+    expect(isNetworkMember).toHaveBeenCalledWith(NETWORK_ID, USER_ID);
+    expect(getNetworkIntentsForMemberOwn).not.toHaveBeenCalled();
+    expect(getNetworkPremisesForMember).not.toHaveBeenCalled();
+    expect(getUserContext).not.toHaveBeenCalled();
+  });
+
+  test('composes intents, premises and trimmed user_context for a member', async () => {
+    const { service, getNetworkIntentsForMemberOwn, getUserContext } = makeService(true);
+    const overview = await service.getNetworkOverview(NETWORK_ID, USER_ID);
+    // The honest, uncapped user-scoped query is used (not getMyIntentsInNetwork).
+    expect(getNetworkIntentsForMemberOwn).toHaveBeenCalledWith(NETWORK_ID, USER_ID);
+    expect(getUserContext).toHaveBeenCalledWith(USER_ID, NETWORK_ID);
+    expect(overview.intents).toHaveLength(1);
+    expect(overview.premises).toHaveLength(1);
+    // Only text + generatedAt are surfaced; the embedding never leaves the adapter.
+    expect(overview.userContext).toEqual({ text: 'ctx', generatedAt: expect.any(Date) });
+  });
+
+  test('returns null user_context when the member has none for the network', async () => {
+    const { service } = makeService(true, null);
+    const overview = await service.getNetworkOverview(NETWORK_ID, USER_ID);
+    expect(overview.userContext).toBeNull();
+  });
+});

--- a/frontend/src/app/library/page.tsx
+++ b/frontend/src/app/library/page.tsx
@@ -23,6 +23,12 @@ type LibrarySourceIntent = {
   sourceValue: string | null;
   sourceMeta: string | null;
   networks?: { id: string; title: string }[];
+  status?: string;
+};
+
+type IntentListResponse = {
+  intents?: LibrarySourceIntent[];
+  pagination?: { current: number; total: number; count: number; totalCount: number };
 };
 
 type FileItem = {
@@ -81,6 +87,7 @@ export default function LibraryPage() {
 
   // Data states
   const [intents, setIntents] = useState<LibrarySourceIntent[]>([]);
+  const [intentTotal, setIntentTotal] = useState(0);
   const [files, setFiles] = useState<FileItem[]>([]);
   const [links, setLinks] = useState<LinkItem[]>([]);
 
@@ -100,8 +107,25 @@ export default function LibraryPage() {
   const loadIntents = useCallback(async () => {
     try {
       setLoadingIntents(true);
-      const res = await api.post<{ intents?: LibrarySourceIntent[] }>('/intents/list', { page: 1, limit: 100 });
-      setIntents((res.intents ?? []).map(i => ({
+      const MAX_PAGES = 50; // safety cap (50 * 100 = 5000 intents)
+      // Fetch page 1 to learn the totals, then fetch the rest in parallel.
+      const first = await api.post<IntentListResponse>('/intents/list', { page: 1, limit: 100 });
+      const totalCount = first.pagination?.totalCount ?? (first.intents?.length ?? 0);
+      const totalPages = Math.min(first.pagination?.total ?? 1, MAX_PAGES);
+      const all: LibrarySourceIntent[] = [...(first.intents ?? [])];
+      if (totalPages > 1) {
+        // A single failed page degrades to fewer rendered intents rather than
+        // wiping the whole list (the badge still shows the true totalCount).
+        const rest = await Promise.all(
+          Array.from({ length: totalPages - 1 }, (_, i) =>
+            api.post<IntentListResponse>('/intents/list', { page: i + 2, limit: 100 })
+              .then(res => res.intents ?? [])
+              .catch(() => [] as LibrarySourceIntent[]),
+          ),
+        );
+        for (const pageIntents of rest) all.push(...pageIntents);
+      }
+      setIntents(all.map(i => ({
         ...i,
         sourceType: i.sourceType ?? 'file',
         sourceId: i.sourceId ?? '',
@@ -109,8 +133,10 @@ export default function LibraryPage() {
         sourceValue: i.sourceValue ?? null,
         sourceMeta: i.sourceMeta ?? null,
       })));
+      setIntentTotal(totalCount);
     } catch {
       setIntents([]);
+      setIntentTotal(0);
     } finally {
       setLoadingIntents(false);
     }
@@ -220,8 +246,8 @@ export default function LibraryPage() {
               className="px-4 py-2 text-sm text-gray-600 border-b-2 border-transparent data-[state=active]:border-black data-[state=active]:text-black data-[state=active]:font-bold"
             >
               Intents
-              {intents.length > 0 && (
-                <span className="ml-2 text-xs text-gray-500">({intents.length})</span>
+              {intentTotal > 0 && (
+                <span className="ml-2 text-xs text-gray-500">({intentTotal})</span>
               )}
             </Tabs.Trigger>
             <Tabs.Trigger 

--- a/frontend/src/components/IntentList.tsx
+++ b/frontend/src/components/IntentList.tsx
@@ -44,6 +44,12 @@ interface BaseIntent {
    * means the intent is registered to no networks (pending or orphaned).
    */
   networks?: IntentNetwork[];
+  /**
+   * Lifecycle status (ACTIVE|PAUSED|FULFILLED|EXPIRED). A badge renders only for
+   * non-default (non-ACTIVE) values; undefined or ACTIVE renders nothing — the
+   * enum is vestigial today, so this is forward-looking. See EDG-53.
+   */
+  status?: string;
 }
 
 /**
@@ -93,6 +99,20 @@ function NetworkMembership({ networks, createdAt }: { networks?: IntentNetwork[]
     >
       <AlertTriangle className="w-3 h-3 shrink-0" />
       Not in any network
+    </span>
+  );
+}
+
+/**
+ * Renders an intent's lifecycle status as a badge, but only when it is a
+ * non-default value. ACTIVE (the schema default) and undefined render nothing,
+ * so today this is invisible and purely forward-looking. See EDG-53.
+ */
+function StatusBadge({ status }: { status?: string }) {
+  if (!status || status.toUpperCase() === 'ACTIVE') return null;
+  return (
+    <span className="flex items-center gap-1 text-xs text-purple-700 font-ibm-plex-mono px-2 py-0.5 rounded-full bg-purple-50 border border-purple-100 capitalize">
+      {status.toLowerCase()}
     </span>
   );
 }
@@ -212,6 +232,7 @@ export default function IntentList<T extends BaseIntent>({
 
                   {/* Network membership: chips, or pending/orphaned badge */}
                   <NetworkMembership networks={intent.networks} createdAt={intent.createdAt} />
+                  <StatusBadge status={intent.status} />
                 </div>
               </div>
 

--- a/frontend/src/components/NetworkOverviewPanel.tsx
+++ b/frontend/src/components/NetworkOverviewPanel.tsx
@@ -43,20 +43,24 @@ export default function NetworkOverviewPanel({ index, isOwner, onLeft, onLeaveRe
     userName: string;
   }[]>([]);
   const [intentsLoading, setIntentsLoading] = useState(true);
+  const [premises, setPremises] = useState<{ id: string; text: string; summary: string | null; createdAt: string }[]>([]);
+  const [userContext, setUserContext] = useState<{ text: string; generatedAt: string } | null>(null);
 
-  // Load intents when component mounts
+  // Load the full network overview (intents, premises, user_context) when component mounts
   useEffect(() => {
-    const loadIntents = async () => {
+    const loadOverview = async () => {
       try {
-        const myIntents = await indexesService.getMyIndexIntents(index.id);
-        setIntents(myIntents);
+        const overview = await indexesService.getNetworkOverview(index.id);
+        setIntents(overview.intents);
+        setPremises(overview.premises);
+        setUserContext(overview.userContext);
       } catch (err) {
-        console.error('Error loading intents:', err);
+        console.error('Error loading network overview:', err);
       } finally {
         setIntentsLoading(false);
       }
     };
-    loadIntents();
+    loadOverview();
   }, [index.id, indexesService]);
 
   const handleLeaveNetwork = async () => {
@@ -97,6 +101,45 @@ export default function NetworkOverviewPanel({ index, isOwner, onLeft, onLeaveRe
             emptyMessage="You haven't shared any intents in this network yet"
           />
         </div>
+
+        {/* My Premises */}
+        <div>
+          <div className="flex items-center justify-between mb-4">
+            <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider font-ibm-plex-mono">
+              My Premises
+            </p>
+            {!intentsLoading && (
+              <span className="text-xs text-gray-400">{premises.length} premise{premises.length !== 1 ? 's' : ''}</span>
+            )}
+          </div>
+          {intentsLoading ? null : premises.length === 0 ? (
+            <div className="text-sm text-gray-500 font-ibm-plex-mono py-12 text-center border border-dashed border-gray-200 rounded-lg">
+              <p>No premises assigned to this network yet</p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {premises.map((p) => (
+                <div key={p.id} className="p-4 rounded-lg border border-gray-200 bg-white">
+                  <p className="text-sm text-gray-900 leading-relaxed">
+                    {(p.summary && p.summary.trim().length > 0 ? p.summary : p.text).trim()}
+                  </p>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Your Context */}
+        {userContext && userContext.text.trim().length > 0 && (
+          <div>
+            <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider font-ibm-plex-mono mb-4">
+              Your Context
+            </p>
+            <div className="p-4 rounded-lg border border-gray-200 bg-gray-50">
+              <p className="text-sm text-gray-700 leading-relaxed whitespace-pre-wrap">{userContext.text}</p>
+            </div>
+          </div>
+        )}
 
       </div>
 

--- a/frontend/src/services/networks.ts
+++ b/frontend/src/services/networks.ts
@@ -298,25 +298,22 @@ export const createIndexesService = (api: ReturnType<typeof useAuthenticatedAPI>
     };
   },
 
-  // Member Intents Management
-  // Get current user's intents in a network
-  getMyIndexIntents: async (networkId: string): Promise<Array<{
-    id: string;
-    payload: string;
-    summary?: string | null;
-    createdAt: string;
-    userId: string;
-    userName: string;
-  }>> => {
-    const response = await api.get<{ intents: Array<{
-      id: string;
-      payload: string;
-      summary?: string | null;
-      createdAt: string;
-      userId: string;
-      userName: string;
-    }> }>(`/networks/${networkId}/my-intents`);
-    return response.intents || [];
+  // Get current user's overview for a network: intents, premises, user_context (EDG-53)
+  getNetworkOverview: async (networkId: string): Promise<{
+    intents: Array<{ id: string; payload: string; summary?: string | null; createdAt: string; userId: string; userName: string }>;
+    premises: Array<{ id: string; text: string; summary: string | null; createdAt: string }>;
+    userContext: { text: string; generatedAt: string } | null;
+  }> => {
+    const response = await api.get<{
+      intents: Array<{ id: string; payload: string; summary?: string | null; createdAt: string; userId: string; userName: string }>;
+      premises: Array<{ id: string; text: string; summary: string | null; createdAt: string }>;
+      userContext: { text: string; generatedAt: string } | null;
+    }>(`/networks/${networkId}/overview`);
+    return {
+      intents: response.intents || [],
+      premises: response.premises || [],
+      userContext: response.userContext ?? null,
+    };
   },
 
   // Remove member intent from network (deprecated - kept for backwards compatibility)

--- a/railway.toml
+++ b/railway.toml
@@ -1,3 +1,4 @@
+# Touch to trigger a Railway dev redeploy (no functional change).
 [build]
 watchPatterns = ["/backend/**", "/packages/protocol/**", "/bun.lock", "/package.json", "/railway.toml"]
 buildCommand = "bun run build:package:protocol && bun run build:backend"


### PR DESCRIPTION
## Release 2026-06-20

Promotes `dev` → `main`. 4 PRs since the last release.

### Highlights
- **Intent count consistency across surfaces (EDG-53)** — every "a user's intents" surface (`/library`, `/networks`, MCP, the Hermes/AgentVillage sidecar) now routes through one canonical ownership predicate and reports a consistent count, plus a new `/networks` overview (intents + premises + per-network user_context).
- **CI migration to Blacksmith runners** and Railway dev redeploy plumbing.

### New Features (`feat`)
- Canonical intent predicate shared across REST + MCP adapters; `GET /networks/:id/overview` (intents, premises, user_context); `/networks` overview UI; `/library` true-total badge + conditional status badge — `fix: intent count consistency across surfaces (EDG-53)` (`2463b36a65`, #1017). Includes the merged Hermes pieces via submodule bumps (#1020): control-plane intent count via MCP `read_intents` (Edge-City/agentvillage-controlplane#28) and the Hermes signal-fetcher dead-filter cleanup (Edge-City/agentvillage#118).

### Chores / CI (`chore`, `ci`)
- `Migrate workflows to Blacksmith` (`8a877b102e`, #1018)
- `chore: trigger Railway dev redeploy` (`cf6f8badb5`, #1019)
- `chore(edge-city): bump agentvillage + controlplane submodules to merged Hermes intent-count fixes (EDG-53)` (`072254c4ca`, #1020)

### Issues and PRs
- #1017 — fix: intent count consistency across surfaces (EDG-53) — merged
- #1018 — Migrate workflows to Blacksmith — merged
- #1019 — chore: trigger Railway dev redeploy — merged
- #1020 — chore(edge-city): bump submodule pointers (EDG-53) — merged
- Edge-City/agentvillage-controlplane#28 and Edge-City/agentvillage#118 — merged (Hermes pieces, pulled in via #1020 submodule bumps)
- Linear **EDG-53** — Done

### Diff summary
```text
 .github/workflows/check-skills.yml                 |   2 +-
 .github/workflows/lint.yml                         |   4 +-
 .github/workflows/neon-reset-dev.yml               |   2 +-
 .github/workflows/notify-pr-to-slack.yml           |   4 +-
 .github/workflows/sentry-release.yml               |   2 +-
 .github/workflows/sync-subtrees.yml                |   2 +-
 .rpiv/artifacts/discover/...intent-count-consistency.md   | 121 +++
 .rpiv/artifacts/plans/...intent-count-consistency.md      | 823 +++++++++++++++
 .rpiv/artifacts/research/...intent-count-consistency.md   | 244 ++++++
 .rpiv/artifacts/validation/...intent-count-consistency.md | 115 +++
 backend/src/adapters/database.adapter.ts           | 155 +++-
 backend/src/adapters/tests/database.adapter.spec.ts| 102 ++-
 backend/src/controllers/network.controller.ts      |  22 +
 backend/src/services/network.service.ts            |  26 +
 backend/src/services/tests/network.service.overview.spec.ts | 65 ++
 frontend/package.json                              |   2 +-
 frontend/src/app/library/page.tsx                  |  34 +-
 frontend/src/components/IntentList.tsx             |  21 +
 frontend/src/components/NetworkOverviewPanel.tsx   |  55 +-
 frontend/src/services/networks.ts                  |  35 +-
 packages/edge-city/agentvillage                    |   2 +-
 packages/edge-city/agentvillage-controlplane       |   2 +-
 railway.toml                                       |   1 +
 23 files changed, 1773 insertions(+), 68 deletions(-)
```

### Verification
- [x] Release branch created from `origin/dev` at `072254c4ca`.
- [x] EDG-53 deployed & verified on Railway `dev` (protocol + frontend SUCCESS) and the Edge-City `control-plane` (SUCCESS).
- [ ] GitHub checks pass on this PR.
- [ ] Release PR reviewed and approved.

_Base: `45ab4f34d2` (merge-base) · Head: `072254c4ca` (origin/dev) · 4 commits._

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784501189&installation_id=140549914&pr_number=1021&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1021&signature=b25aed3d37247aabd3297b6b87a7df9a3f1257a74794631345a11766d8282a0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->