### PR TITLE
chore(submodules): track main branch for agentvillage submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "packages/edge-city/agentvillage"]
 	path = packages/edge-city/agentvillage
 	url = https://github.com/Edge-City/agentvillage.git
+	branch = main
 [submodule "packages/edge-city/agentvillage-landing"]
 	path = packages/edge-city/agentvillage-landing
 	url = git@github.com:Edge-City/agentvillage-landing.git


### PR DESCRIPTION
## Chores

Adds the missing `branch = main` line to the `agentvillage` submodule entry in `.gitmodules`, bringing it in line with `agentvillage-landing` and `agentvillage-controlplane` (which already declare `branch = main`).

### Why
Without an explicit `branch`, `git submodule update --remote` relies on an implicit default. Declaring `main` makes the tracked branch explicit and consistent across all three Edge-City submodules, so `--remote` updates behave identically for each.

### Impact
- No code or runtime change.
- `git submodule sync` has been run so local config reflects the new tracked branch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784530760&installation_id=140549914&pr_number=1023&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1023&signature=49586c385b43f50a717bf16467a22fa73c62abdc5e18e037b96dc52e133f82f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->