### PR TITLE
fix(skills): quote release-prod-safety description to fix YAML parse

### DIFF
--- a/.pi/skills/pi-skill-authoring/SKILL.md
+++ b/.pi/skills/pi-skill-authoring/SKILL.md
@@ -28,6 +28,23 @@ description: What it does AND when to use it. Be specific.
 - Optional: `license`, `compatibility`, `metadata`, `allowed-tools`,
   `disable-model-invocation` (`true` hides it from the prompt; only `/skill:name` runs it).
 
+**YAML safety — quote any value containing a colon.** A plain (unquoted) scalar that
+contains a `: ` (colon followed by space) makes the YAML loader read it as a nested
+mapping and the skill fails to load with `Nested mappings are not allowed in compact
+mappings`. This bites long `description` values that enumerate (`...lose data: (1) ...,
+and (2) ...`) or use `e.g.`-style asides. Wrap the whole value in double quotes and
+switch any inner double quotes to single quotes:
+
+```yaml
+# breaks: colon-space parsed as a nested map
+description: Checks two things: (1) the lockfile, and (2) the migration.
+# works
+description: "Checks two things: (1) the lockfile, and (2) the migration."
+```
+
+The same rule applies to any colon-bearing value (`metadata`, etc.), not just
+`description`.
+
 ## Structure
 
 A skill is a directory with `SKILL.md`; everything else is freeform.

--- a/.pi/skills/release-prod-safety/SKILL.md
+++ b/.pi/skills/release-prod-safety/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release-prod-safety
-description: Pre-merge and post-merge safety checks for promoting a dev→main release in this monorepo, capturing two non-obvious ways a release can break or lose data: (1) a stale root bun.lock fails the prod build under --frozen-lockfile even though dev never caught it, and (2) a destructive Drizzle migration (e.g. DROP TABLE) silently loses prod data when the operational backfill never ran on prod. Use when cutting/merging a release PR to main, when a prod deploy build fails on "lockfile is frozen", or before merging any PR carrying a DROP/destructive migration.
+description: "Pre-merge and post-merge safety checks for promoting a dev→main release in this monorepo, capturing two non-obvious ways a release can break or lose data: (1) a stale root bun.lock fails the prod build under --frozen-lockfile even though dev never caught it, and (2) a destructive Drizzle migration (e.g. DROP TABLE) silently loses prod data when the operational backfill never ran on prod. Use when cutting/merging a release PR to main, when a prod deploy build fails on 'lockfile is frozen', or before merging any PR carrying a DROP/destructive migration."
 ---
 
 # release-prod-safety


### PR DESCRIPTION
## Bug Fixes
- **`release-prod-safety` skill failed to load.** Its `description` frontmatter value was an unquoted YAML scalar containing colon-space sequences (`...lose data: (1) ...`), which YAML parses as a nested mapping. The skill errored with `Nested mappings are not allowed in compact mappings`. Wrapped the value in double quotes (and switched the inner `"lockfile is frozen"` to single quotes) so it parses as a plain string.

## Documentation
- **`pi-skill-authoring` skill** now documents the gotcha: quote any frontmatter value containing a colon, with a before/after example, so future hand-authored skills avoid the same trap.

Both files pass `skillctl validate`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784531879&installation_id=140549914&pr_number=1025&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1025&signature=8402a212e31fe39bdd452359c2ff7601f359dcfc47e374f5bb9e6ac5b721a2ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->