### PR TITLE
fix(root-guard): allow fast-forward-only pull on canonical root

### DIFF
--- a/.pi/extensions/root-dev-guard.ts
+++ b/.pi/extensions/root-dev-guard.ts
@@ -92,6 +92,20 @@ function commandTargetsWorktree(command: string): boolean {
 		|| new RegExp(`^git\\s+-C\\s+${absoluteWorktreeArg}/`).test(normalized);
 }
 
+/**
+ * A fast-forward-only pull is the sanctioned way to keep the canonical root current
+ * with its upstream (e.g. after a PR merges into dev). It cannot create a merge commit
+ * or diverge the branch — git aborts harmlessly when a fast-forward is not possible —
+ * so it is safe to allow on the root. A bare `git pull` (which may synthesize a merge
+ * commit) stays blocked. Only a standalone pull is allowed: any shell chaining,
+ * piping, or redirection disqualifies it so the exception cannot smuggle other commands.
+ */
+function isAllowedFastForwardPull(command: string): boolean {
+	const normalized = normalizeCommand(command);
+	if (/(?:&&|;|\||>|`|\$\()/.test(normalized)) return false;
+	return /^git(?:\s+-C\s+\S+)?\s+pull\b/.test(normalized) && /(?:^|\s)--ff-only(?:\s|$)/.test(normalized);
+}
+
 function isLikelyRootMutation(command: string): boolean {
 	if (!isRunningFromCanonicalRoot()) return false;
 	const normalized = normalizeCommand(command);
@@ -99,6 +113,11 @@ function isLikelyRootMutation(command: string): boolean {
 	// Creating/removing worktrees is the sanctioned way to make changes off the root worktree.
 	// Commands that explicitly run inside .worktrees/* are also allowed.
 	if (/^git\s+worktree\s+/.test(normalized) || /^bun\s+run\s+worktree:/.test(normalized) || commandTargetsWorktree(command)) {
+		return false;
+	}
+
+	// A fast-forward-only pull is allowed: it keeps the root in sync without mutating history.
+	if (isAllowedFastForwardPull(command)) {
 		return false;
 	}
 

--- a/.pi/skills/git-worktree-workflow/SKILL.md
+++ b/.pi/skills/git-worktree-workflow/SKILL.md
@@ -71,6 +71,12 @@ the skill documents the convention; the extension makes it non-bypassable. It:
 - Any command that targets a worktree — `cd .worktrees/<name> && ...` or
   `git -C .worktrees/<name> ...`.
 - Read-only git against the root via `-C` from outside it (see below).
+- `git pull --ff-only` from the root — the sanctioned way to bring the root current
+  with `origin/dev` after a PR merges. It is allowed *only* with `--ff-only` (a
+  fast-forward cannot create a merge commit or diverge the branch, and aborts harmlessly
+  when no fast-forward is possible) and *only* as a standalone command — any chaining
+  (`&&`, `;`, `|`), redirect, or command substitution disqualifies it. A bare `git pull`
+  stays blocked.
 
 Overridable via env: `INDEX_CANONICAL_ROOT` (root path), `INDEX_ROOT_BRANCH` (default `dev`).
 


### PR DESCRIPTION
## Bug Fixes
- **`root-dev-guard` blocked keeping the root current.** The guard's mutating-command matcher listed `pull` alongside `commit`/`merge`/etc., so *every* `git pull` from the canonical root was rejected — including the harmless fast-forward sync needed after a PR merges into `dev`. Operators were forced to run pulls via `git -C <root>` from `/tmp`, which is awkward and undiscoverable.

## What changed
- Added `isAllowedFastForwardPull()` and an early allow-return in `isLikelyRootMutation()`. A pull is permitted only when:
  - it is fast-forward-only (`--ff-only` present) — a fast-forward cannot create a merge commit or diverge the branch, and git aborts harmlessly when no fast-forward is possible; and
  - it is a standalone command — any chaining (`&&`, `;`, `|`), redirect (`>`), backtick, or `$()` substitution disqualifies it, so the exception can't smuggle other commands.
- A bare `git pull` (which may synthesize a merge commit) stays blocked.

## Documentation
- Documented the new sanctioned escape in the `git-worktree-workflow` skill.

## Verification
- Logic table tested (12 cases: ff-only/`-C` forms allowed; bare pull, non-ff, chained/piped/redirected/substituted forms blocked) — all pass.
- `bun build` of the extension succeeds; pre-commit eslint passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1026"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784533104&installation_id=140549914&pr_number=1026&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1026&signature=6d2bf496fdb36e707a246635c372148f65bbcf5f04f588279be8eac86618616d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->