### PR TITLE
chore(skills): add cleaning-up-codebases cleanup-audit skill

### DIFF
--- a/.pi/skills/cleaning-up-codebases/SKILL.md
+++ b/.pi/skills/cleaning-up-codebases/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: cleaning-up-codebases
+description: "Systematically audit and clean a package in the index monorepo for dead code, unused exports, scope creep, anti-patterns, and architectural drift. Asks 'should this exist?' before 'how do I improve this?', classifies findings into tiers (T1 safe deletes through T4 architectural), negotiates scope with the owner, and verifies lint/test/build before and after every change. Use when reviewing or cleaning a backend/frontend/protocol/cli package, removing cruft from a rapidly-developed feature, or doing a pre-refactor audit. Not for greenfield code or single targeted bug fixes."
+---
+
+# cleaning-up-codebases
+
+Systematic cleanup that asks **"should this exist?"** before **"how do I improve this?"**
+The core failure mode is refactoring code that should be deleted, or adding new
+abstractions to an already over-abstracted mess.
+
+**Core principle:** Removal over refactoring. Simplification over restructuring. Verify
+before and after every change. Cleanup means *less* code, not different code.
+
+## Repo guardrails (read first)
+
+- **Branch guard:** the canonical root `/Users/yanek/Projects/index` must stay on `dev`
+  and is read-only for the assistant. Do all mutating work in a worktree. Create one with
+  `git worktree add` + `bun run worktree:setup` per `.pi/skills/git-worktree-workflow/SKILL.md`.
+- **Layer architecture is enforced** by `eslint-plugin-boundaries`. `packages/protocol`
+  never imports backend/frontend; respect the dependency flow when deleting/moving code.
+- **Schema is canonical** at `backend/src/schemas/database.schema.ts`. Removing a column
+  or table is a destructive migration (T4) — never a casual delete.
+
+## When to use
+
+- A feature/package that grew organically and accumulated cruft
+- Suspected dead code, half-finished features, unused exports, or scope creep
+- Code that drifted from the architecture guidance
+- Pre-refactor audit to decide what is worth keeping
+
+**When NOT to use:** greenfield code, a single targeted bug fix, or performance work.
+
+## Process
+
+### 1. Understand intent
+Read in order: relevant `.rpiv/guidance/**/architecture.md` and `CLAUDE.md`, recent
+`git log` for the package, and the package's `package.json` (actual scope/deps). You are
+hunting the gap between stated intent and actual code. Code that exists but isn't
+mentioned anywhere is a removal candidate.
+
+### 2. Establish a clean baseline
+Run the package's checks and **record numbers** before touching anything:
+- Lint: `bun run lint` (root, `eslint .`) or `cd <pkg> && eslint src/`
+- Test: `cd backend && bun test [path]` · `packages/protocol` and `frontend` have their own suites
+- Build: `bun run build:<pkg>` (e.g. `build:backend`) or `cd <pkg> && bun run build`
+
+If a check is already broken, **that is your first finding** — fix the baseline before
+adding cleanup on top.
+
+### 3. Survey with automated scans (count, don't eyeball)
+See `references/audit-signals.md` for the full monorepo-specific signal list (dead code,
+unused exports, TS/React/Drizzle/protocol-specific smells, scope creep). Produce concrete
+counts ("14 unused exports, 3 orphaned files"), not vague impressions.
+
+### 4. Question existence
+For every major module/feature ask: does it align with stated purpose? Is it reachable
+from an entry point? Could it be a separate package? Was it fully finished? **Never
+default to "refactor to be better" — first ask "should this exist at all?"**
+
+### 5. Classify into tiers (never mix)
+
+| Tier | What it is | Examples | Effort |
+|---|---|---|---|
+| **T1** Safe deletes | Dead code, unused files/exports, abandoned experiments | Orphaned `*_v2.ts`, unused export, commented-out blocks | Minutes |
+| **T2** Quick fixes | Isolated, no architectural impact | Add missing error handling, remove stale TODO, fix lint warning, drop `console.log` | Hours |
+| **T3** Focused refactors | Targeted module improvements | Split a god service, consolidate duplicated logic | Days |
+| **T4** Architectural / schema | Structural or destructive | Change a layer boundary, drop a column/table (needs backfill + migration) | Weeks |
+
+### 6. Negotiate scope with the owner
+Present findings before changing anything: "N things I can safely delete now — proceed?",
+"These features look outside the package's purpose — keep which?", "These T3/T4 items need
+your call on direction." **Never assume what the owner values.**
+
+### 7. Execute safe→dangerous, in a worktree
+T1 → T2 → T3 → T4. **After each change:** rerun lint/test/build for the touched package;
+if broken, revert and investigate. Commit each working state. T4/destructive-migration
+work belongs on its own branch and must follow `release-prod-safety` (a stale root
+`bun.lock` or an unrun backfill will break/lose prod data).
+
+## Red flags — you're doing it wrong
+- You're writing more code than you're deleting
+- You're creating new files or adding an abstraction during a *cleanup*
+- Your plan has 5+ phases spanning weeks (start with T1, reassess)
+- You flagged something dead without grepping for all usages first
+- You haven't verified the build passes, or haven't asked the owner what to keep
+
+## See also
+- `.pi/skills/git-worktree-workflow/SKILL.md` — mandatory for any mutating work
+- `.pi/skills/release-prod-safety/SKILL.md` — before any destructive migration reaches main
+- `references/audit-signals.md` — full scan/grep signal catalogue for this monorepo

--- a/.pi/skills/cleaning-up-codebases/references/audit-signals.md
+++ b/.pi/skills/cleaning-up-codebases/references/audit-signals.md
@@ -1,0 +1,90 @@
+# Audit signals — index monorepo
+
+Scan catalogue for step 3 of `cleaning-up-codebases`. Run these from a worktree (or
+read-only against the root). Always **grep for all usages before flagging anything as
+dead**, and produce concrete counts.
+
+## Dead code
+
+```bash
+# Files nothing imports (orphans). Adjust <pkg>/src as needed.
+comm -23 \
+  <(git ls-files '<pkg>/src/**/*.ts' '<pkg>/src/**/*.tsx' | sort) \
+  <(grep -rhoE "from ['\"][^'\"]+['\"]" <pkg>/src | sed -E "s/.*from ['\"]//; s/['\"].*//" | sort -u)
+
+# Alternate / abandoned implementations
+git ls-files | grep -iE '(_v[0-9]|_old|_new|_copy|\.bak|deprecated|legacy)'
+
+# Commented-out code blocks (TS/TSX)
+grep -rnE '^\s*//\s*(import|export|const|function|class|return|await|if|for)\b' <pkg>/src
+
+# Coming-soon / placeholder stubs
+grep -rniE 'coming soon|not implemented|placeholder|stub|wip' <pkg>/src
+```
+
+**Unused exports** (no knip in this repo yet). Either:
+- Add `knip` ad-hoc: `bunx knip --workspace <pkg>` (don't commit config unless asked), or
+- Manual: for each `export`, grep the symbol across `backend frontend packages` — a symbol
+  exported but referenced only at its definition is dead. The eslint config
+  (`no-unused-vars`) already flags unused *locals*, not unused exports.
+
+## Code quality
+
+```bash
+grep -rnE 'TODO|FIXME|HACK|XXX' <pkg>/src              # count, triage stale ones (T2)
+grep -rn 'console\.log' <pkg>/src                       # leftover debug (T2)
+grep -rnE 'catch\s*\([^)]*\)\s*\{\s*\}' <pkg>/src       # empty catch — swallowed errors (T2)
+grep -rn ': any\b\|as any\b' <pkg>/src                  # eslint bans no-explicit-any; these are escapes
+grep -rn '@ts-ignore\|@ts-expect-error\|eslint-disable' <pkg>/src  # suppressed checks — why?
+awk 'END{print NR}' <file>                              # files >500 lines = god-file smell
+```
+
+Run the toolchain and record numbers:
+- `bun run lint` (root `eslint .`) or `cd <pkg> && eslint src/`
+- `cd backend && bun test [path]` (targeted; full suite is slow)
+- `bun run build:<pkg>`
+
+A baseline that doesn't lint/test/build clean is **finding #1** — fix it before cleanup.
+
+## Architecture drift (this repo enforces layers)
+
+`eslint-plugin-boundaries` already enforces Controllers → Services → Adapters and the
+self-contained `packages/protocol`. When auditing, confirm by grep and treat violations
+as real findings:
+
+```bash
+# Controllers importing adapters (forbidden)
+grep -rn "adapters/" backend/src/controllers
+# Services importing other services (forbidden — use events/queues)
+grep -rn "services/" backend/src/services
+# protocol importing app code (forbidden — must be injected)
+grep -rnE "from ['\"].*(backend|frontend)" packages/protocol/src
+```
+
+Macro checks: does the directory layout still match
+`.rpiv/guidance/**/architecture.md`? Are there overlapping-responsibility modules? Stale
+config (CI steps `allow_failure`, disabled lint rules, dead tools in `package.json`)?
+
+## Stack-specific smells
+
+- **TypeScript:** `any`/`as any`, non-null `!` abuse, manual types where Drizzle inference
+  exists, imports from `lib/schema` instead of `src/schemas/database.schema.ts`.
+- **React (frontend):** unused props, `useEffect` with missing deps (eslint
+  `react-hooks`), dead lazy-loaded routes in `src/app/`, components nothing renders.
+- **Drizzle / schema:** columns/tables with no read or write path. **Removing one is T4** —
+  it needs a generated+renamed migration, `_journal.json` tag update, and per
+  `release-prod-safety` an operational backfill before any `DROP` reaches prod. Prefer
+  soft delete (`deletedAt`) per repo convention; never hard-delete casually.
+- **Generated artifacts:** never hand-edit `packages/claude-plugin/skills/**/SKILL.md` —
+  edit the protocol templates and run `bun run build:skills`. Flag hand-edits as drift.
+
+## Scope creep
+
+```bash
+git log --oneline -30 -- <pkg>            # what's actually active vs. abandoned
+cat <pkg>/package.json                    # deps pulled in for a single non-core feature?
+```
+
+Ask per module: aligned with the package's stated purpose? Reachable from an entry point
+(`backend/src/main.ts`, frontend routes, CLI `main.ts`)? Could it be its own package?
+Fully finished, or a half-built feature to remove unless the owner wants it completed?


### PR DESCRIPTION
## What

Adds a new project-local skill **`cleaning-up-codebases`** under `.pi/skills/`, porting the "should this exist?" tiered cleanup methodology and adapting it to this Bun/TS monorepo.

## Why

Gives the agent a repeatable, repo-aware playbook for auditing a package for dead code, unused exports, scope creep, anti-patterns, and architectural drift — instead of vague "clean this up" prompts.

## Files

- `.pi/skills/cleaning-up-codebases/SKILL.md` — lean playbook (validated; description 581/1024 chars, colon-safe quoted)
- `.pi/skills/cleaning-up-codebases/references/audit-signals.md` — full scan/grep catalogue, loaded on demand

## What it encodes

- **Core principle:** removal over refactoring; ask "should this exist?" before "how do I improve this?"
- **Tiered findings:** T1 safe deletes → T2 quick fixes → T3 focused refactors → T4 architectural/schema — never mixed, executed safe→dangerous.
- **Owner scope negotiation** before any change; verify lint/test/build before *and* after each change.
- **"Red flags — you're doing it wrong"** guardrails against over-engineering during cleanup.

## Monorepo adaptations

- Real tooling: `bun run lint` (`eslint .`), `cd backend && bun test`, `bun run build:<pkg>`.
- Leans on `eslint-plugin-boundaries` layer enforcement (Controllers→Services→Adapters, self-contained `packages/protocol`) with grep checks.
- Drizzle/schema column/table removal classified **T4 destructive** and gated behind the migration ritual + `release-prod-safety` (backfill before any `DROP` reaches prod).
- Branch guard baked in (all mutating work in a worktree; cross-links `git-worktree-workflow`).
- `build:skills` generated-artifact rule (never hand-edit `claude-plugin/skills/**`).
- knip note: no knip in-repo, so an ad-hoc `bunx knip` path + manual grep fallback for unused exports.

Docs/config-only — no runtime code touched. Diff vs \`dev\` is +181 lines, 0 deletions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1027"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784533787&installation_id=140549914&pr_number=1027&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1027&signature=1f626feebdc5c541b0734a7a593607186c060396ba66b4bc914410e653cdac9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->