### PR TITLE
chore(backend): clean up gateways & guards

### DIFF
--- a/backend/src/gateways/telegram.gateway.ts
+++ b/backend/src/gateways/telegram.gateway.ts
@@ -35,7 +35,7 @@ export interface GatewayStreamEvent {
 
 // ── Dependency interface (injected in tests, resolved from singletons in prod) ─
 
-export interface GatewayDeps {
+interface GatewayDeps {
   getTelegramPrefs(userId: string): Promise<TelegramPrefs | null>;
   updateTelegramPrefs(userId: string, prefs: TelegramPrefs): Promise<void>;
   findByTelegramChatId(chatId: string): Promise<{ userId: string; sessionId?: string } | null>;
@@ -43,10 +43,9 @@ export interface GatewayDeps {
   setUserSocials(userId: string, socials: { label: string; value: string }[]): Promise<void>;
   createChatSession(data: { id: string; userId: string; title?: string }): Promise<void>;
   createChatMessage(data: { id: string; sessionId: string; role: 'user' | 'assistant' | 'system'; content: string }): Promise<void>;
-  processMessage(userId: string, text: string): Promise<{ responseText: string; error?: string }>;
   sendTelegramMessage(chatId: string, text: string, keyboard?: Array<Array<{ text: string; url: string }>>, parseMode?: 'HTML' | 'MarkdownV2'): Promise<void>;
   sendChatAction(chatId: string): Promise<void>;
-  streamMessage?(userId: string, text: string, sessionId: string): AsyncGenerator<GatewayStreamEvent>;
+  streamMessage(userId: string, text: string, sessionId: string): AsyncGenerator<GatewayStreamEvent>;
 }
 
 /**
@@ -68,7 +67,6 @@ function productionDeps(): GatewayDeps {
     setUserSocials: (userId, socials) => userDatabaseAdapter.setSocials(userId, socials),
     createChatSession: (data) => conversationDatabaseAdapter.createChatSession(data),
     createChatMessage: (data) => conversationDatabaseAdapter.createChatMessage(data),
-    processMessage: (userId, text) => chatSessionService.processMessage(userId, text),
     sendTelegramMessage: sendMessage,
     sendChatAction: (chatId) => sendChatAction(chatId),
     streamMessage: async function* (userId, text, sessionId) {
@@ -255,8 +253,7 @@ async function sendFormattedResponse(
 
 /**
  * Handle an update received from Telegram (text message or /start command).
- * Uses the streaming graph interface when available, falling back to
- * the blocking `processMessage` path otherwise.
+ * Routes the message through the streaming graph interface.
  *
  * While the graph runs the user sees a typing indicator and short
  * status messages as tools execute (e.g. "Looking at your signals...").
@@ -310,10 +307,7 @@ export async function handleInbound(
     content: text,
   }).catch((err) => logger.warn('Failed to write user message to conversation', { error: err }));
 
-  // Choose streaming or blocking path
-  const responseText = deps.streamMessage
-    ? await handleInboundStreaming(chatId, userId, text, sessionId, deps)
-    : await handleInboundBlocking(chatId, userId, text, deps);
+  const responseText = await handleInboundStreaming(chatId, userId, text, sessionId, deps);
 
   // Write assistant response (best-effort)
   await deps.createChatMessage({
@@ -378,7 +372,7 @@ async function handleInboundStreaming(
       }
     };
 
-    const stream = deps.streamMessage!(userId, text, sessionId);
+    const stream = deps.streamMessage(userId, text, sessionId);
 
     // Race the stream against a hard timeout
     const timeoutPromise = new Promise<never>((_, reject) => {
@@ -433,34 +427,6 @@ function agentStatusText(agentName: string): string | undefined {
   const lower = agentName.toLowerCase();
   if (lower.includes('negotiat')) return 'Evaluating a potential connection...';
   return undefined;
-}
-
-/**
- * Blocking fallback path: calls processMessage with a timeout.
- * Used when streamMessage is not available (e.g. in tests without streaming deps).
- */
-async function handleInboundBlocking(
-  chatId: string,
-  userId: string,
-  text: string,
-  deps: GatewayDeps,
-): Promise<string> {
-  const stopTyping = startTypingIndicator(chatId, deps);
-
-  try {
-    const result = await Promise.race([
-      deps.processMessage(userId, text),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('processMessage timed out')), PROCESS_TIMEOUT_MS),
-      ),
-    ]);
-    return result.responseText || 'Sorry, I could not process your message.';
-  } catch (err) {
-    logger.error('processMessage failed for Telegram user', { userId, chatId, error: err });
-    return 'Sorry, something went wrong. Please try again.';
-  } finally {
-    stopTyping();
-  }
 }
 
 /**

--- a/backend/src/gateways/tests/telegram.gateway.spec.ts
+++ b/backend/src/gateways/tests/telegram.gateway.spec.ts
@@ -37,7 +37,9 @@ function defaultDeps() {
     setUserSocials: mock(async (userId: string, socials: { label: string; value: string }[]) => { userSocials.set(userId, socials); }),
     createChatSession: async (data: { id: string; userId: string; title?: string }) => { sessions.set(data.id, data); },
     createChatMessage: async (data: { id: string; sessionId: string; role: string; content: string }) => { messages.push(data); },
-    processMessage: async (_userId: string, _text: string) => ({ responseText: 'Hello from Index!' }),
+    streamMessage: async function* (_userId: string, _text: string, _sessionId: string): AsyncGenerator<GatewayStreamEvent> {
+      yield { type: 'response_complete', response: 'Hello from Index!' };
+    },
     sendTelegramMessage: async (chatId: string, text: string, keyboard?: unknown, parseMode?: string) => { sent.push({ chatId, text, keyboard, parseMode }); },
     sendChatAction: async (chatId: string) => { chatActions.push(chatId); },
     seedTelegramUser: (userId: string, prefs: TelegramPrefs) => {
@@ -123,9 +125,9 @@ describe('handleOutbound', () => {
   });
 });
 
-// ── Tests: handleInbound (blocking fallback) ────────────────────────────────
+// ── Tests: handleInbound (connection & message routing) ─────────────────────
 
-describe('handleInbound (blocking)', () => {
+describe('handleInbound (routing)', () => {
   let deps: ReturnType<typeof makeDeps>;
   let redisFake: Map<string, string>;
 

--- a/backend/src/guards/tests/experiment.guard.spec.ts
+++ b/backend/src/guards/tests/experiment.guard.spec.ts
@@ -2,7 +2,7 @@ import { config } from 'dotenv';
 config({ path: '.env.test', override: true });
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { eq, inArray } from 'drizzle-orm';
+import { inArray } from 'drizzle-orm';
 
 import db from '../../lib/drizzle/drizzle';
 import * as schema from '../../schemas/database.schema';


### PR DESCRIPTION
## Summary

Targeted cleanup of `backend/src/gateways` and `backend/src/guards`. Both directories were already in good shape — no dead files, stray `console.log`, `TODO`s, `any` escapes, empty catches, or layer violations. Three findings fixed.

## Refactors

- **Remove unused `eq` import** in `guards/tests/experiment.guard.spec.ts` — the only lint warning in scope.
- **Un-export `GatewayDeps`** — it was referenced only within `telegram.gateway.ts` (the spec uses `ReturnType<typeof defaultDeps>`).
- **Remove dead-in-production blocking path** from `telegram.gateway.ts`. `productionDeps()` always provides `streamMessage`, so `handleInboundBlocking` + the `processMessage` dep were only reachable in tests. `streamMessage` is now required and inbound messages route straight through the streaming graph.

Net: **43 deletions / 11 insertions** — cleanup means less code, not different code.

## Tests

- ESLint clean on both directories (was 1 warning).
- 42/42 gateway + guard tests pass.
- Full backend `tsc --noEmit` exits 0.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1033"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784557706&installation_id=140549914&pr_number=1033&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1033&signature=47c32f72db04a479c13f00b60c208a9165f2beddb34015675056882e972c7c14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->