### PR TITLE
chore(queues): dedup + decouple backend/src/queues, fix test isolation

### DIFF
--- a/backend/.test-isolated
+++ b/backend/.test-isolated
@@ -1,4 +1,11 @@
-src/events/tests/premise.event.spec.ts
+# Spec files that call mock.module(). Bun's mock.module() permanently
+# contaminates the process-wide module cache (mock.restore() does NOT undo it),
+# so these MUST run in their own process. scripts/test-safe.sh excludes every
+# path listed here; scripts/test-isolated.sh runs each one individually.
+#
+# Keep this in sync: any spec that adds mock.module() must be added here, or it
+# will pollute the shared `bun run test` batch and break sibling specs' imports.
+# Derived from: grep -rlE 'mock\.module' src tests --include='*.spec.ts' --include='*.test.ts'
 src/adapters/tests/scraper.adapter.spec.ts
 src/adapters/tests/storage.adapter.spec.ts
 src/adapters/tests/system-database.spec.ts
@@ -6,24 +13,31 @@ src/controllers/tests/agent.controller.delivery-stats.spec.ts
 src/controllers/tests/agent.controller.heartbeat.spec.ts
 src/controllers/tests/network.controller.spec.ts
 src/controllers/tests/opportunity.controller.spec.ts
+src/events/tests/premise.event.spec.ts
 src/lib/bullmq/bullmq.spec.ts
-src/lib/email/tests/email-handlers.test.ts
+src/lib/email/tests/email-handlers.spec.ts
+src/queues/tests/claim-timeout.queue.spec.ts
+src/queues/tests/enrichment-privacy-gate.spec.ts
+src/queues/tests/enrichment-run.queue.spec.ts
+src/queues/tests/enrichment.queue.jobs.spec.ts
+src/queues/tests/enrichment.queue.spec.ts
 src/queues/tests/expiration.queue.spec.ts
+src/queues/tests/from-enrichment.queue.spec.ts
 src/queues/tests/from-intent.queue.spec.ts
 src/queues/tests/from-introducer.queue.spec.ts
 src/queues/tests/hyde.queue.spec.ts
+src/queues/tests/integration.queue.spec.ts
 src/queues/tests/intent.queue.spec.ts
 src/queues/tests/notification.queue.spec.ts
-src/queues/tests/profile.queue.spec.ts
+src/queues/tests/premise.queue.spec.ts
 src/queues/tests/run-existing.queue.spec.ts
+src/queues/tests/timeout.queue.spec.ts
+src/queues/tests/usercontext.queue.spec.ts
 src/services/tests/chat.service.spec.ts
 src/services/tests/network-invitation.service.spec.ts
 src/services/tests/network.service.master-key-rotation.spec.ts
 src/services/tests/opportunity-delivery.cache.spec.ts
 src/services/tests/opportunity.service.getChatContext.spec.ts
 src/services/tests/opportunity.service.rediscovery.spec.ts
-tests/network-invitation-resend.test.ts
-tests/network-scoped-import.test.ts
-
-# E2E (need running dev server — run manually with: bun test tests/network-resend-invite.e2e.test.ts)
-tests/network-resend-invite.e2e.test.ts
+tests/network-invitation-resend.spec.ts
+tests/network-scoped-import.spec.ts

--- a/backend/src/lib/email/notification.sender.ts
+++ b/backend/src/lib/email/notification.sender.ts
@@ -4,7 +4,7 @@ import db from '../drizzle/drizzle';
 import { userNotificationSettings, users } from '../../schemas/database.schema';
 import { log } from '../log';
 
-import { sendEmail } from './transport.helper';
+import { sendEmail } from './transport.producer';
 import { connectionRequestTemplate } from './templates/connection-request.template';
 import { connectionAcceptedTemplate } from './templates/connection-accepted.template';
 

--- a/backend/src/lib/email/tests/email-handlers.spec.ts
+++ b/backend/src/lib/email/tests/email-handlers.spec.ts
@@ -3,12 +3,12 @@ config({ path: '.env.test', override: true });
 
 import { describe, it, expect, jest, beforeEach, mock, afterAll } from 'bun:test';
 import { sendConnectionRequestEmail, sendConnectionAcceptedEmail } from '../notification.sender';
-import * as emailModule from '../transport.helper';
+import * as emailModule from '../transport.producer';
 import * as templatesModule from '../templates/connection-request.template'; // We need to mock specific templates now
 import * as connectionAcceptedTemplateModule from '../templates/connection-accepted.template';
 
 // Mock dependencies
-mock.module('../transport.helper', () => ({
+mock.module('../transport.producer', () => ({
   sendEmail: jest.fn()
 }));
 

--- a/backend/src/lib/email/transport.helper.ts
+++ b/backend/src/lib/email/transport.helper.ts
@@ -1,7 +1,5 @@
 import { Resend } from 'resend';
 
-import { emailQueue } from '../../queues/email.queue';
-
 import { log } from '../log';
 
 const logger = log.lib.from("lib/email/transport.helper.ts");
@@ -98,52 +96,6 @@ ${options.html}
       error: error instanceof Error ? error.message : String(error),
       recipient: String(recipient),
       subject: options.subject,
-    });
-    throw error;
-  }
-};
-
-
-export const sendEmail = async (options: {
-  to: string | string[];
-  subject: string;
-  html: string;
-  text: string;
-  headers?: Record<string, string>;
-}): Promise<any> => {
-  const job = await emailQueue.addJob(options);
-
-  // Wait for the job to complete with a 60 second timeout
-  const WAIT_TIMEOUT_MS = 60000;
-
-  try {
-    const result = await job.waitUntilFinished(emailQueue.queueEvents, WAIT_TIMEOUT_MS);
-
-    // Check for null OR undefined - BullMQ stores undefined as null
-    if (result == null) {
-      // Job completed but with no result - could indicate the job wasn't processed
-      // or QueueEvents missed the completion event. Check job state.
-      const jobState = await job.getState();
-      const returnValue = job.returnvalue;
-
-      // If job is still waiting/active, the timeout was hit or worker didn't process it
-      if (jobState === 'waiting' || jobState === 'active' || jobState === 'delayed') {
-        logger.error(`[EmailTransport] Email job ${job.id} timed out or not processed`, { jobState });
-      } else if (jobState === 'completed') {
-        // Job actually completed, QueueEvents missed the event - return the stored result
-        return returnValue;
-      }
-
-      return returnValue || result;
-    }
-
-    return result;
-  } catch (error) {
-    // Handle timeout or other errors
-    const jobState = await job.getState().catch(() => 'unknown');
-    logger.error(`[EmailTransport] Email job ${job.id} error while waiting`, {
-      error: error instanceof Error ? error.message : String(error),
-      jobState,
     });
     throw error;
   }

--- a/backend/src/lib/email/transport.producer.ts
+++ b/backend/src/lib/email/transport.producer.ts
@@ -1,0 +1,57 @@
+import { emailQueue } from '../../queues/email.queue';
+
+import { log } from '../log';
+
+const logger = log.lib.from("lib/email/transport.producer.ts");
+
+/**
+ * Enqueue an email job and block until the worker finishes it (or times out).
+ *
+ * This is the producer-side entry point: it lives apart from {@link executeSendEmail}
+ * (the pure Resend transport in `transport.helper.ts`) so that the email queue can
+ * import the transport without creating an import cycle back through the queue singleton.
+ */
+export const sendEmail = async (options: {
+  to: string | string[];
+  subject: string;
+  html: string;
+  text: string;
+  headers?: Record<string, string>;
+}): Promise<any> => {
+  const job = await emailQueue.addJob(options);
+
+  // Wait for the job to complete with a 60 second timeout
+  const WAIT_TIMEOUT_MS = 60000;
+
+  try {
+    const result = await job.waitUntilFinished(emailQueue.queueEvents, WAIT_TIMEOUT_MS);
+
+    // Check for null OR undefined - BullMQ stores undefined as null
+    if (result == null) {
+      // Job completed but with no result - could indicate the job wasn't processed
+      // or QueueEvents missed the completion event. Check job state.
+      const jobState = await job.getState();
+      const returnValue = job.returnvalue;
+
+      // If job is still waiting/active, the timeout was hit or worker didn't process it
+      if (jobState === 'waiting' || jobState === 'active' || jobState === 'delayed') {
+        logger.error(`[EmailTransport] Email job ${job.id} timed out or not processed`, { jobState });
+      } else if (jobState === 'completed') {
+        // Job actually completed, QueueEvents missed the event - return the stored result
+        return returnValue;
+      }
+
+      return returnValue || result;
+    }
+
+    return result;
+  } catch (error) {
+    // Handle timeout or other errors
+    const jobState = await job.getState().catch(() => 'unknown');
+    logger.error(`[EmailTransport] Email job ${job.id} error while waiting`, {
+      error: error instanceof Error ? error.message : String(error),
+      jobState,
+    });
+    throw error;
+  }
+};

--- a/backend/src/queues/intent.queue.ts
+++ b/backend/src/queues/intent.queue.ts
@@ -359,14 +359,17 @@ export class IntentQueue implements IntentGraphQueue {
       this.logger.info('[IntentAssign] User assignment networks found', { intentId, userId, indexCount: userIndexIds.length, indexIds: userIndexIds });
 
       // Instantiate once per run so the same withStructuredOutput binding is
-      // reused across all network evaluations in the Promise.all below.
-      const defaultIndexer = this.deps?.evaluateIntentAssignment ? null : new IntentIndexer();
-      const evaluateIntentAssignment = this.deps?.evaluateIntentAssignment ?? ((o: {
-        intent: string;
-        indexPrompt: string | null;
-        memberPrompt: string | null;
-        sourceName?: string | null;
-      }) => defaultIndexer!.invoke(o.intent, o.indexPrompt, o.memberPrompt, o.sourceName ?? null));
+      // reused across all network evaluations in the Promise.all below (the
+      // IIFE runs once and the closure captures the single indexer instance).
+      const evaluateIntentAssignment = this.deps?.evaluateIntentAssignment ?? (() => {
+        const indexer = new IntentIndexer();
+        return (o: {
+          intent: string;
+          indexPrompt: string | null;
+          memberPrompt: string | null;
+          sourceName?: string | null;
+        }) => indexer.invoke(o.intent, o.indexPrompt, o.memberPrompt, o.sourceName ?? null);
+      })();
 
       const sourceName = intent.sourceType
         ? `${intent.sourceType}:${intent.sourceId ?? ''}`

--- a/backend/src/queues/negotiations/claim-timeout.queue.ts
+++ b/backend/src/queues/negotiations/claim-timeout.queue.ts
@@ -6,8 +6,10 @@ import * as convSchema from '../../schemas/conversation.schema';
 import { log } from '../../lib/log';
 import { QueueFactory } from '../../lib/bullmq/bullmq';
 import { conversationDatabaseAdapter } from '../../adapters/database.adapter';
-import { IndexNegotiator, AMBIENT_PARK_WINDOW_MS } from '@indexnetwork/protocol';
-import type { NegotiationTurn, NegotiationOutcome, UserNegotiationContext, SeedAssessment, NegotiationGraphDatabase } from '@indexnetwork/protocol';
+import { AMBIENT_PARK_WINDOW_MS } from '@indexnetwork/protocol';
+import type { NegotiationGraphDatabase } from '@indexnetwork/protocol';
+
+import { runTimeoutFallback, type NegotiationTaskMeta } from './timeout.shared';
 
 /** BullMQ queue name for negotiation claim-timeout jobs. */
 export const QUEUE_NAME = 'negotiation-claim-timeout';
@@ -211,151 +213,37 @@ export class NegotiationClaimTimeoutQueue {
       return;
     }
 
-    const meta = task.metadata as {
-      sourceUserId?: string;
-      candidateUserId?: string;
-      type?: string;
-      maxTurns?: number;
-    } | null;
+    const meta = task.metadata as NegotiationTaskMeta | null;
     if (meta?.type !== 'negotiation') {
       this.logger.warn('[NegotiationClaimTimeoutJob] Task is not a negotiation, skipping', { negotiationId });
       return;
     }
 
-    // Determine whose turn it is
-    const currentSpeaker = currentTurnCount % 2 === 0 ? 'source' : 'candidate';
-    const isSource = currentSpeaker === 'source';
-    const activeUserId = isSource ? meta.sourceUserId! : meta.candidateUserId!;
-    const otherUserId = isSource ? meta.candidateUserId! : meta.sourceUserId!;
-
-    this.logger.info('[NegotiationClaimTimeoutJob] Claimed agent timed out, running AI fallback', {
+    await runTimeoutFallback({
+      database,
+      logger: this.logger,
+      labels: {
+        job: '[NegotiationClaimTimeoutJob]',
+        fallback: 'Claimed agent timed out, running AI fallback',
+        finalized: 'Negotiation finalized after claim timeout',
+        statusUpdateFailed: 'Failed to update opportunity status on claim-timeout finalization',
+      },
       negotiationId,
-      agentId,
-      activeUserId,
-      turnNumber,
-    });
-
-    // Parse history
-    const history: NegotiationTurn[] = messages.map((m: { parts: unknown[] }) => {
-      const dp = (m.parts as Array<{ kind?: string; data?: unknown }>)?.find(p => p.kind === 'data');
-      return dp?.data as NegotiationTurn;
-    }).filter(Boolean);
-
-    // Run AI agent for the timed-out turn
-    const agent = new IndexNegotiator();
-    const ownUserCtx: UserNegotiationContext = { id: activeUserId, intents: [], profile: {} };
-    const otherUserCtx: UserNegotiationContext = { id: otherUserId, intents: [], profile: {} };
-    const seedAssessment: SeedAssessment = { reasoning: 'Claim timeout fallback', valencyRole: 'peer' };
-
-    const aiTurn = await agent.invoke({
-      ownUser: ownUserCtx,
-      otherUser: otherUserCtx,
-      indexContext: { networkId: '', prompt: '' },
-      seedAssessment,
-      history,
-      isDiscoverer: isSource,
-    });
-
-    // Persist the AI turn
-    await database.createMessage({
-      conversationId: task.conversationId,
-      senderId: `agent:${activeUserId}`,
-      role: 'agent',
-      parts: [{ kind: 'data' as const, data: aiTurn }],
       taskId: task.id,
+      conversationId: task.conversationId,
+      meta,
+      messages,
+      currentTurnCount,
+      seedReasoning: 'Claim timeout fallback',
+      maxTurns: meta.maxTurns ?? 6,
+      fallbackLogExtra: { agentId },
+      // Import dynamically to avoid a circular dependency with timeout.queue;
+      // arm the park-window timeout for the next speaker.
+      rearm: async (newTurnCount) => {
+        const { negotiationTimeoutQueue } = await import('./timeout.queue');
+        await negotiationTimeoutQueue.enqueueTimeout(negotiationId, newTurnCount, AMBIENT_PARK_WINDOW_MS);
+      },
     });
-
-    const newTurnCount = currentTurnCount + 1;
-    const maxTurns = meta.maxTurns ?? 6;
-
-    // Evaluate: accept/reject -> finalize; counter at max -> finalize; counter under max -> continue
-    if (aiTurn.action === 'accept' || aiTurn.action === 'reject' || newTurnCount >= maxTurns) {
-      const fullHistory = [...history, aiTurn];
-      const nextSpeaker = currentSpeaker === 'source' ? 'candidate' : 'source';
-      const outcome = this.buildOutcome(fullHistory, newTurnCount, aiTurn.action, meta.sourceUserId!, meta.candidateUserId!, nextSpeaker);
-
-      await database.updateTaskState(task.id, 'completed');
-      await database.createArtifact({
-        taskId: task.id,
-        name: 'negotiation-outcome',
-        parts: [{ kind: 'data', data: outcome }],
-        metadata: { hasOpportunity: outcome.hasOpportunity, turnCount: newTurnCount },
-      });
-
-      const outcomeStr = aiTurn.action === 'accept' ? 'accepted'
-        : aiTurn.action === 'reject' ? 'rejected'
-        : 'turn_cap';
-
-      const opportunityId = (meta as { opportunityId?: string }).opportunityId;
-      if (opportunityId) {
-        const nextStatus = aiTurn.action === 'accept' ? 'pending'
-          : aiTurn.action === 'reject' ? 'rejected'
-          : 'stalled';
-        await database.updateOpportunityStatus(opportunityId, nextStatus).catch((err: unknown) => {
-          this.logger.error('[NegotiationClaimTimeoutJob] Failed to update opportunity status on claim-timeout finalization', {
-            opportunityId,
-            nextStatus,
-            error: err,
-          });
-        });
-      }
-
-      this.logger.info('[NegotiationClaimTimeoutJob] Negotiation finalized after claim timeout', {
-        negotiationId,
-        outcome: outcomeStr,
-        turnCount: newTurnCount,
-      });
-      return;
-    }
-
-    // AI countered and under max turns -- the other party now needs to respond.
-    // Set to waiting_for_agent and arm a new general timeout so the negotiation doesn't stall.
-    await database.updateTaskState(task.id, 'waiting_for_agent');
-
-    // Import dynamically to avoid circular dependency; arm the park-window timeout for the next speaker
-    const { negotiationTimeoutQueue } = await import('./timeout.queue');
-    await negotiationTimeoutQueue.enqueueTimeout(negotiationId, newTurnCount, AMBIENT_PARK_WINDOW_MS);
-
-    this.logger.info('[NegotiationClaimTimeoutJob] AI agent countered, armed timeout for next speaker', {
-      negotiationId,
-      action: aiTurn.action,
-      turnCount: newTurnCount,
-    });
-  }
-
-  /** Build a NegotiationOutcome (mirrors graph finalizeNode logic). */
-  private buildOutcome(
-    history: NegotiationTurn[],
-    turnCount: number,
-    lastAction: string,
-    sourceUserId: string,
-    candidateUserId: string,
-    currentSpeaker: string,
-  ): NegotiationOutcome {
-    const hasOpportunity = lastAction === 'accept';
-    const atCap = lastAction === 'counter';
-
-    let agreedRoles: NegotiationOutcome['agreedRoles'] = [];
-    if (hasOpportunity && history.length >= 2) {
-      const acceptTurn = history[history.length - 1];
-      const precedingTurn = history[history.length - 2];
-      const accepterIsSource = currentSpeaker === 'candidate';
-      const [sourceRole, candidateRole] = accepterIsSource
-        ? [acceptTurn.assessment.suggestedRoles.ownUser, precedingTurn.assessment.suggestedRoles.ownUser]
-        : [precedingTurn.assessment.suggestedRoles.ownUser, acceptTurn.assessment.suggestedRoles.ownUser];
-      agreedRoles = [
-        { userId: sourceUserId, role: sourceRole },
-        { userId: candidateUserId, role: candidateRole },
-      ];
-    }
-
-    return {
-      hasOpportunity,
-      agreedRoles,
-      reasoning: history[history.length - 1]?.assessment.reasoning ?? '',
-      turnCount,
-      ...(atCap && { reason: 'turn_cap' }),
-    };
   }
 }
 

--- a/backend/src/queues/negotiations/timeout.queue.ts
+++ b/backend/src/queues/negotiations/timeout.queue.ts
@@ -2,8 +2,10 @@ import { Job } from 'bullmq';
 import { log } from '../../lib/log';
 import { QueueFactory } from '../../lib/bullmq/bullmq';
 import { conversationDatabaseAdapter } from '../../adapters/database.adapter';
-import { IndexNegotiator, AMBIENT_PARK_WINDOW_MS } from '@indexnetwork/protocol';
-import type { NegotiationTurn, NegotiationOutcome, UserNegotiationContext, SeedAssessment, NegotiationGraphDatabase } from '@indexnetwork/protocol';
+import { AMBIENT_PARK_WINDOW_MS } from '@indexnetwork/protocol';
+import type { NegotiationGraphDatabase } from '@indexnetwork/protocol';
+
+import { runTimeoutFallback, type NegotiationTaskMeta } from './timeout.shared';
 
 /** BullMQ queue name for negotiation timeout jobs. */
 export const QUEUE_NAME = 'negotiation-timeout';
@@ -177,143 +179,33 @@ export class NegotiationTimeoutQueue {
       return;
     }
 
-    const meta = task.metadata as { sourceUserId?: string; candidateUserId?: string; type?: string } | null;
+    const meta = task.metadata as NegotiationTaskMeta | null;
     if (meta?.type !== 'negotiation') {
       this.logger.warn('[NegotiationTimeoutJob] Task is not a negotiation, skipping', { negotiationId });
       return;
     }
 
-    // Determine whose turn it is
-    const currentSpeaker = currentTurnCount % 2 === 0 ? 'source' : 'candidate';
-    const isSource = currentSpeaker === 'source';
-    const activeUserId = isSource ? meta.sourceUserId! : meta.candidateUserId!;
-    const otherUserId = isSource ? meta.candidateUserId! : meta.sourceUserId!;
-
-    this.logger.info('[NegotiationTimeoutJob] External agent timed out, running AI fallback', {
+    await runTimeoutFallback({
+      database,
+      logger: this.logger,
+      labels: {
+        job: '[NegotiationTimeoutJob]',
+        fallback: 'External agent timed out, running AI fallback',
+        finalized: 'Negotiation finalized after timeout',
+        statusUpdateFailed: 'Failed to update opportunity status on timeout finalization',
+      },
       negotiationId,
-      activeUserId,
-      turnNumber,
-    });
-
-    // Parse history
-    const history: NegotiationTurn[] = messages.map((m: { parts: unknown[] }) => {
-      const dp = (m.parts as Array<{ kind?: string; data?: unknown }>)?.find(p => p.kind === 'data');
-      return dp?.data as NegotiationTurn;
-    }).filter(Boolean);
-
-    // Run AI agent for the timed-out turn
-    const agent = new IndexNegotiator();
-    const ownUserCtx: UserNegotiationContext = { id: activeUserId, intents: [], profile: {} };
-    const otherUserCtx: UserNegotiationContext = { id: otherUserId, intents: [], profile: {} };
-    const seedAssessment: SeedAssessment = { reasoning: 'Timeout fallback', valencyRole: 'peer' };
-
-    const aiTurn = await agent.invoke({
-      ownUser: ownUserCtx,
-      otherUser: otherUserCtx,
-      indexContext: { networkId: '', prompt: '' },
-      seedAssessment,
-      history,
-      isDiscoverer: isSource,
-    });
-
-    // Persist the AI turn
-    await database.createMessage({
-      conversationId: task.conversationId,
-      senderId: `agent:${activeUserId}`,
-      role: 'agent',
-      parts: [{ kind: 'data' as const, data: aiTurn }],
       taskId: task.id,
+      conversationId: task.conversationId,
+      meta,
+      messages,
+      currentTurnCount,
+      seedReasoning: 'Timeout fallback',
+      maxTurns: 6,
+      rearm: async (newTurnCount) => {
+        await this.enqueueTimeout(negotiationId, newTurnCount, AMBIENT_PARK_WINDOW_MS);
+      },
     });
-
-    const newTurnCount = currentTurnCount + 1;
-    const maxTurns = 6;
-
-    // Evaluate: accept/reject → finalize; counter at max → finalize; counter under max → continue
-    if (aiTurn.action === 'accept' || aiTurn.action === 'reject' || newTurnCount >= maxTurns) {
-      const fullHistory = [...history, aiTurn];
-      const nextSpeaker = currentSpeaker === 'source' ? 'candidate' : 'source';
-      const outcome = this.buildOutcome(fullHistory, newTurnCount, aiTurn.action, meta.sourceUserId!, meta.candidateUserId!, nextSpeaker);
-
-      await database.updateTaskState(task.id, 'completed');
-      await database.createArtifact({
-        taskId: task.id,
-        name: 'negotiation-outcome',
-        parts: [{ kind: 'data', data: outcome }],
-        metadata: { hasOpportunity: outcome.hasOpportunity, turnCount: newTurnCount },
-      });
-
-      const outcomeStr = aiTurn.action === 'accept' ? 'accepted'
-        : aiTurn.action === 'reject' ? 'rejected'
-        : 'turn_cap';
-
-      const opportunityId = (meta as { opportunityId?: string }).opportunityId;
-      if (opportunityId) {
-        const nextStatus = aiTurn.action === 'accept' ? 'pending'
-          : aiTurn.action === 'reject' ? 'rejected'
-          : 'stalled';
-        await database.updateOpportunityStatus(opportunityId, nextStatus).catch((err) => {
-          this.logger.error('[NegotiationTimeoutJob] Failed to update opportunity status on timeout finalization', {
-            opportunityId,
-            nextStatus,
-            error: err,
-          });
-        });
-      }
-
-      this.logger.info('[NegotiationTimeoutJob] Negotiation finalized after timeout', {
-        negotiationId,
-        outcome: outcomeStr,
-        turnCount: newTurnCount,
-      });
-      return;
-    }
-
-    // AI countered and under max turns — the other party now needs to respond.
-    // Set to waiting_for_agent and arm a new timeout so the negotiation doesn't stall.
-    await database.updateTaskState(task.id, 'waiting_for_agent');
-
-    await this.enqueueTimeout(negotiationId, newTurnCount, AMBIENT_PARK_WINDOW_MS);
-
-    this.logger.info('[NegotiationTimeoutJob] AI agent countered, armed timeout for next speaker', {
-      negotiationId,
-      action: aiTurn.action,
-      turnCount: newTurnCount,
-    });
-  }
-
-  /** Build a NegotiationOutcome (mirrors graph finalizeNode logic). */
-  private buildOutcome(
-    history: NegotiationTurn[],
-    turnCount: number,
-    lastAction: string,
-    sourceUserId: string,
-    candidateUserId: string,
-    currentSpeaker: string,
-  ): NegotiationOutcome {
-    const hasOpportunity = lastAction === 'accept';
-    const atCap = lastAction === 'counter';
-
-    let agreedRoles: NegotiationOutcome['agreedRoles'] = [];
-    if (hasOpportunity && history.length >= 2) {
-      const acceptTurn = history[history.length - 1];
-      const precedingTurn = history[history.length - 2];
-      const accepterIsSource = currentSpeaker === 'candidate';
-      const [sourceRole, candidateRole] = accepterIsSource
-        ? [acceptTurn.assessment.suggestedRoles.ownUser, precedingTurn.assessment.suggestedRoles.ownUser]
-        : [precedingTurn.assessment.suggestedRoles.ownUser, acceptTurn.assessment.suggestedRoles.ownUser];
-      agreedRoles = [
-        { userId: sourceUserId, role: sourceRole },
-        { userId: candidateUserId, role: candidateRole },
-      ];
-    }
-
-    return {
-      hasOpportunity,
-      agreedRoles,
-      reasoning: history[history.length - 1]?.assessment.reasoning ?? '',
-      turnCount,
-      ...(atCap && { reason: 'turn_cap' }),
-    };
   }
 }
 

--- a/backend/src/queues/negotiations/timeout.shared.ts
+++ b/backend/src/queues/negotiations/timeout.shared.ts
@@ -1,0 +1,195 @@
+import { IndexNegotiator } from '@indexnetwork/protocol';
+import type { NegotiationTurn, NegotiationOutcome, UserNegotiationContext, SeedAssessment, NegotiationGraphDatabase } from '@indexnetwork/protocol';
+
+import { log } from '../../lib/log';
+
+type TimeoutLogger = ReturnType<typeof log.job.from>;
+
+/** Negotiation task metadata both timeout workers read off `task.metadata`. */
+export interface NegotiationTaskMeta {
+  sourceUserId?: string;
+  candidateUserId?: string;
+  type?: string;
+  maxTurns?: number;
+  opportunityId?: string;
+}
+
+/** Per-worker log strings — the only textual difference between the two timeout workers. */
+export interface TimeoutFallbackLabels {
+  /** Bracketed job tag, e.g. `[NegotiationTimeoutJob]`. */
+  job: string;
+  /** "...running AI fallback" line. */
+  fallback: string;
+  /** "Negotiation finalized after <x>" line. */
+  finalized: string;
+  /** "Failed to update opportunity status on <x> finalization" error line. */
+  statusUpdateFailed: string;
+}
+
+/**
+ * Build a {@link NegotiationOutcome} from the finalized turn history.
+ * Mirrors the graph `finalizeNode` logic; identical across both timeout workers.
+ */
+export function buildNegotiationOutcome(
+  history: NegotiationTurn[],
+  turnCount: number,
+  lastAction: string,
+  sourceUserId: string,
+  candidateUserId: string,
+  currentSpeaker: string,
+): NegotiationOutcome {
+  const hasOpportunity = lastAction === 'accept';
+  const atCap = lastAction === 'counter';
+
+  let agreedRoles: NegotiationOutcome['agreedRoles'] = [];
+  if (hasOpportunity && history.length >= 2) {
+    const acceptTurn = history[history.length - 1];
+    const precedingTurn = history[history.length - 2];
+    const accepterIsSource = currentSpeaker === 'candidate';
+    const [sourceRole, candidateRole] = accepterIsSource
+      ? [acceptTurn.assessment.suggestedRoles.ownUser, precedingTurn.assessment.suggestedRoles.ownUser]
+      : [precedingTurn.assessment.suggestedRoles.ownUser, acceptTurn.assessment.suggestedRoles.ownUser];
+    agreedRoles = [
+      { userId: sourceUserId, role: sourceRole },
+      { userId: candidateUserId, role: candidateRole },
+    ];
+  }
+
+  return {
+    hasOpportunity,
+    agreedRoles,
+    reasoning: history[history.length - 1]?.assessment.reasoning ?? '',
+    turnCount,
+    ...(atCap && { reason: 'turn_cap' }),
+  };
+}
+
+/**
+ * Run the AI fallback turn for a stalled negotiation and evaluate the result.
+ *
+ * This is the block that was copy-pasted between {@link NegotiationTimeoutQueue}
+ * and {@link NegotiationClaimTimeoutQueue}: parse history → run {@link IndexNegotiator}
+ * → persist the turn → finalize (accept/reject/turn-cap) or re-arm (counter under cap).
+ * The two workers differ only in their log strings, seed reasoning, max-turns source,
+ * the extra fallback-log fields, and how the next timeout is re-armed (`rearm`).
+ *
+ * Callers must have already acquired the task, confirmed the turn count matches, and
+ * verified `meta.type === 'negotiation'` before invoking this.
+ */
+export async function runTimeoutFallback(params: {
+  database: NegotiationGraphDatabase;
+  logger: TimeoutLogger;
+  labels: TimeoutFallbackLabels;
+  negotiationId: string;
+  taskId: string;
+  conversationId: string;
+  meta: NegotiationTaskMeta;
+  messages: Array<{ parts: unknown[] }>;
+  currentTurnCount: number;
+  seedReasoning: string;
+  maxTurns: number;
+  /** Extra fields merged into the "running AI fallback" log (claim worker adds `agentId`). */
+  fallbackLogExtra?: Record<string, unknown>;
+  /** Re-arm the next park-window timeout when the AI counters under the cap. */
+  rearm: (newTurnCount: number) => Promise<void>;
+}): Promise<void> {
+  const {
+    database, logger, labels, negotiationId, taskId, conversationId,
+    meta, messages, currentTurnCount, seedReasoning, maxTurns, fallbackLogExtra, rearm,
+  } = params;
+
+  // Determine whose turn it is
+  const currentSpeaker = currentTurnCount % 2 === 0 ? 'source' : 'candidate';
+  const isSource = currentSpeaker === 'source';
+  const activeUserId = isSource ? meta.sourceUserId! : meta.candidateUserId!;
+  const otherUserId = isSource ? meta.candidateUserId! : meta.sourceUserId!;
+
+  logger.info(`${labels.job} ${labels.fallback}`, {
+    negotiationId,
+    ...fallbackLogExtra,
+    activeUserId,
+    turnNumber: currentTurnCount,
+  });
+
+  // Parse history
+  const history: NegotiationTurn[] = messages.map((m: { parts: unknown[] }) => {
+    const dp = (m.parts as Array<{ kind?: string; data?: unknown }>)?.find(p => p.kind === 'data');
+    return dp?.data as NegotiationTurn;
+  }).filter(Boolean);
+
+  // Run AI agent for the timed-out turn
+  const agent = new IndexNegotiator();
+  const ownUserCtx: UserNegotiationContext = { id: activeUserId, intents: [], profile: {} };
+  const otherUserCtx: UserNegotiationContext = { id: otherUserId, intents: [], profile: {} };
+  const seedAssessment: SeedAssessment = { reasoning: seedReasoning, valencyRole: 'peer' };
+
+  const aiTurn = await agent.invoke({
+    ownUser: ownUserCtx,
+    otherUser: otherUserCtx,
+    indexContext: { networkId: '', prompt: '' },
+    seedAssessment,
+    history,
+    isDiscoverer: isSource,
+  });
+
+  // Persist the AI turn
+  await database.createMessage({
+    conversationId,
+    senderId: `agent:${activeUserId}`,
+    role: 'agent',
+    parts: [{ kind: 'data' as const, data: aiTurn }],
+    taskId,
+  });
+
+  const newTurnCount = currentTurnCount + 1;
+
+  // Evaluate: accept/reject → finalize; counter at max → finalize; counter under max → continue
+  if (aiTurn.action === 'accept' || aiTurn.action === 'reject' || newTurnCount >= maxTurns) {
+    const fullHistory = [...history, aiTurn];
+    const nextSpeaker = currentSpeaker === 'source' ? 'candidate' : 'source';
+    const outcome = buildNegotiationOutcome(fullHistory, newTurnCount, aiTurn.action, meta.sourceUserId!, meta.candidateUserId!, nextSpeaker);
+
+    await database.updateTaskState(taskId, 'completed');
+    await database.createArtifact({
+      taskId,
+      name: 'negotiation-outcome',
+      parts: [{ kind: 'data', data: outcome }],
+      metadata: { hasOpportunity: outcome.hasOpportunity, turnCount: newTurnCount },
+    });
+
+    const outcomeStr = aiTurn.action === 'accept' ? 'accepted'
+      : aiTurn.action === 'reject' ? 'rejected'
+      : 'turn_cap';
+
+    const opportunityId = meta.opportunityId;
+    if (opportunityId) {
+      const nextStatus = aiTurn.action === 'accept' ? 'pending'
+        : aiTurn.action === 'reject' ? 'rejected'
+        : 'stalled';
+      await database.updateOpportunityStatus(opportunityId, nextStatus).catch((err: unknown) => {
+        logger.error(`${labels.job} ${labels.statusUpdateFailed}`, {
+          opportunityId,
+          nextStatus,
+          error: err,
+        });
+      });
+    }
+
+    logger.info(`${labels.job} ${labels.finalized}`, {
+      negotiationId,
+      outcome: outcomeStr,
+      turnCount: newTurnCount,
+    });
+    return;
+  }
+
+  // AI countered and under max turns — the other party now needs to respond.
+  await database.updateTaskState(taskId, 'waiting_for_agent');
+  await rearm(newTurnCount);
+
+  logger.info(`${labels.job} AI agent countered, armed timeout for next speaker`, {
+    negotiationId,
+    action: aiTurn.action,
+    turnCount: newTurnCount,
+  });
+}

--- a/backend/src/queues/opportunity/discovery.shared.ts
+++ b/backend/src/queues/opportunity/discovery.shared.ts
@@ -1,0 +1,106 @@
+import { log } from '../../lib/log';
+import { ChatDatabaseAdapter } from '../../adapters/database.adapter';
+import { EmbedderAdapter } from '../../adapters/embedder.adapter';
+import { RedisCacheAdapter } from '../../adapters/cache.adapter';
+import { OpportunityGraphFactory, HydeGraphFactory, HydeGenerator, LensInferrer } from '@indexnetwork/protocol';
+import type { OpportunityGraphDatabase, HydeGraphDatabase, Embedder, HydeCache, NegotiationGraphLike, AgentDispatcher } from '@indexnetwork/protocol';
+
+import { negotiationRunExistingQueue } from '../negotiations/run-existing.queue';
+
+/** Graph DB shape the opportunity/HyDE graphs require — every `from-*` queue casts its ChatDatabaseAdapter to this. */
+export type OpportunityGraphDb = OpportunityGraphDatabase & HydeGraphDatabase;
+
+/** Runtime deps shared by every opportunity-discovery queue worker. */
+export interface OpportunityDiscoveryDeps {
+  negotiationGraph?: NegotiationGraphLike;
+  agentDispatcher?: Pick<AgentDispatcher, 'hasPersonalAgent'>;
+}
+
+type DiscoveryLogger = ReturnType<typeof log.job.from>;
+
+/** Build the graph DB façade every `from-*` queue uses (ChatDatabaseAdapter cast to the graph interfaces). */
+export function createOpportunityGraphDb(database: object = new ChatDatabaseAdapter()): OpportunityGraphDb {
+  return database as unknown as OpportunityGraphDb;
+}
+
+/**
+ * Assemble the configured opportunity graph (HyDE sub-graph + negotiation re-enqueue wiring).
+ * Identical across from-intent / from-introducer / from-enrichment, so it lives here once.
+ */
+export function buildOpportunityGraph(graphDb: OpportunityGraphDb, deps?: OpportunityDiscoveryDeps) {
+  const embedder: Embedder = new EmbedderAdapter();
+  const cache: HydeCache = new RedisCacheAdapter();
+  const inferrer = new LensInferrer();
+  const generator = new HydeGenerator();
+  const hydeGraph = new HydeGraphFactory(graphDb, embedder, cache, inferrer, generator).createGraph();
+  return new OpportunityGraphFactory(
+    graphDb,
+    embedder,
+    hydeGraph,
+    undefined,
+    undefined,
+    deps?.negotiationGraph,
+    deps?.agentDispatcher,
+    async (opportunityId: string, userId: string) => {
+      await negotiationRunExistingQueue.addJob({ opportunityId, userId });
+    },
+  ).createGraph();
+}
+
+type OpportunityInvokeOptions = Parameters<ReturnType<typeof buildOpportunityGraph>['invoke']>[0];
+
+/**
+ * Run an opportunity-discovery graph and log/throw on the result.
+ *
+ * Encapsulates the block that was copy-pasted across the three `from-*` queues:
+ * the `invokeOpportunityGraph` test short-circuit, graph assembly + invocation,
+ * `result.error` handling, and the candidates/opportunities (and optional trace)
+ * completion logging. Per-queue variation is passed in via `label`/`logContext`/`logTrace`.
+ */
+export async function runOpportunityDiscovery<TOpts extends OpportunityInvokeOptions>(params: {
+  graphDb: OpportunityGraphDb;
+  deps?: OpportunityDiscoveryDeps & { invokeOpportunityGraph?: (opts: TOpts) => Promise<void> };
+  invokeOpts: TOpts;
+  logger: DiscoveryLogger;
+  /** Human label for log lines + the thrown error, e.g. `'FromIntent'` / `'from-intent'`. */
+  label: string;
+  /** Identifier fields merged into every log line (e.g. `{ intentId, userId }`). */
+  logContext: Record<string, unknown>;
+  /** Whether to emit the verbose graph-trace line (from-enrichment opts out). Defaults to true. */
+  logTrace?: boolean;
+}): Promise<void> {
+  const { graphDb, deps, invokeOpts, logger, label, logContext, logTrace = true } = params;
+
+  if (deps?.invokeOpportunityGraph) {
+    await deps.invokeOpportunityGraph(invokeOpts);
+    return;
+  }
+
+  const opportunityGraph = buildOpportunityGraph(graphDb, deps);
+  const result = await opportunityGraph.invoke(invokeOpts);
+  if (result.error) {
+    logger.error(`[${label}] Graph failed`, { ...logContext, error: result.error });
+    throw new Error(typeof result.error === 'string' ? result.error : `${label} graph failed`);
+  }
+
+  const candidates = Array.isArray(result.candidates) ? result.candidates : [];
+  const opportunitiesArr = Array.isArray(result.opportunities) ? result.opportunities : [];
+
+  logger.info(`[${label}] Graph complete`, {
+    ...logContext,
+    candidatesFound: candidates.length,
+    opportunitiesCreated: opportunitiesArr.length,
+  });
+
+  if (logTrace) {
+    const trace = Array.isArray(result.trace) ? result.trace : [];
+    logger.verbose(`[${label}] Graph trace`, {
+      ...logContext,
+      trace: trace.map((t: { node: string; detail?: string; data?: Record<string, unknown> }) => ({
+        node: t.node,
+        detail: t.detail,
+        ...(t.data ? { data: t.data } : {}),
+      })),
+    });
+  }
+}

--- a/backend/src/queues/opportunity/from-enrichment.queue.ts
+++ b/backend/src/queues/opportunity/from-enrichment.queue.ts
@@ -2,13 +2,9 @@ import { Job } from 'bullmq';
 import { log } from '../../lib/log';
 import { QueueFactory } from '../../lib/bullmq/bullmq';
 import type { Id } from '../../types/common.types';
-import { ChatDatabaseAdapter } from '../../adapters/database.adapter';
-import { EmbedderAdapter } from '../../adapters/embedder.adapter';
-import { RedisCacheAdapter } from '../../adapters/cache.adapter';
-import { OpportunityGraphFactory, HydeGraphFactory, HydeGenerator, LensInferrer } from '@indexnetwork/protocol';
-import type { OpportunityGraphDatabase, HydeGraphDatabase, Embedder, HydeCache, NegotiationGraphLike, AgentDispatcher } from '@indexnetwork/protocol';
+import type { NegotiationGraphLike, AgentDispatcher } from '@indexnetwork/protocol';
 
-import { negotiationRunExistingQueue } from '../negotiations/run-existing.queue';
+import { createOpportunityGraphDb, runOpportunityDiscovery, type OpportunityGraphDb } from './discovery.shared';
 
 export const QUEUE_NAME = 'opportunity-from-enrichment';
 
@@ -17,13 +13,15 @@ export interface FromEnrichmentJobData {
   networkId?: string;
 }
 
+export interface FromEnrichmentGraphInvokeOptions {
+  userId: string;
+  operationMode: 'create';
+  networkId?: string;
+  options: { initialStatus: 'latent' };
+}
+
 export interface FromEnrichmentDeps {
-  invokeOpportunityGraph?: (opts: {
-    userId: string;
-    operationMode: 'create';
-    networkId?: string;
-    options: { initialStatus: 'latent' };
-  }) => Promise<void>;
+  invokeOpportunityGraph?: (opts: FromEnrichmentGraphInvokeOptions) => Promise<void>;
   negotiationGraph?: NegotiationGraphLike;
   agentDispatcher?: Pick<AgentDispatcher, 'hasPersonalAgent'>;
 }
@@ -45,13 +43,13 @@ export class FromEnrichmentQueue {
 
   private readonly logger = log.job.from('FromEnrichmentJob');
   private readonly queueLogger = log.queue.from('FromEnrichmentQueue');
-  private readonly graphDb: OpportunityGraphDatabase & HydeGraphDatabase;
+  private readonly graphDb: OpportunityGraphDb;
   private deps: FromEnrichmentDeps | undefined;
   private worker: ReturnType<typeof QueueFactory.createWorker<FromEnrichmentJobData>> | null = null;
 
   constructor(deps?: FromEnrichmentDeps) {
     this.deps = deps;
-    this.graphDb = new ChatDatabaseAdapter() as unknown as OpportunityGraphDatabase & HydeGraphDatabase;
+    this.graphDb = createOpportunityGraphDb();
   }
 
   setRuntimeDeps(runtimeDeps: Pick<FromEnrichmentDeps, 'negotiationGraph' | 'agentDispatcher'>): void {
@@ -87,50 +85,21 @@ export class FromEnrichmentQueue {
 
     this.logger.info('[FromEnrichment] Starting profile-based discovery', { userId, networkId });
 
-    const invokeOpts = {
+    const invokeOpts: FromEnrichmentGraphInvokeOptions = {
       userId: userId as Id<'users'>,
-      operationMode: 'create' as const,
+      operationMode: 'create',
       networkId: networkId as Id<'networks'> | undefined,
-      options: { initialStatus: 'latent' as const },
+      options: { initialStatus: 'latent' },
     };
 
-    if (this.deps?.invokeOpportunityGraph) {
-      await this.deps.invokeOpportunityGraph(invokeOpts);
-      return;
-    }
-
-    const embedder: Embedder = new EmbedderAdapter();
-    const cache: HydeCache = new RedisCacheAdapter();
-    const inferrer = new LensInferrer();
-    const generator = new HydeGenerator();
-    const hydeGraph = new HydeGraphFactory(this.graphDb, embedder, cache, inferrer, generator).createGraph();
-    const opportunityGraph = new OpportunityGraphFactory(
-      this.graphDb,
-      embedder,
-      hydeGraph,
-      undefined,
-      undefined,
-      this.deps?.negotiationGraph,
-      this.deps?.agentDispatcher,
-      async (opportunityId: string, userId: string) => {
-        await negotiationRunExistingQueue.addJob({ opportunityId, userId });
-      },
-    ).createGraph();
-
-    const result = await opportunityGraph.invoke(invokeOpts);
-    if (result.error) {
-      this.logger.error('[FromEnrichment] Graph failed', { userId, networkId, error: result.error });
-      throw new Error(typeof result.error === 'string' ? result.error : 'from-enrichment graph failed');
-    }
-
-    const candidates = Array.isArray(result.candidates) ? result.candidates : [];
-    const opportunitiesArr = Array.isArray(result.opportunities) ? result.opportunities : [];
-
-    this.logger.info('[FromEnrichment] Graph complete', {
-      userId,
-      networkId,
-      candidatesFound: candidates.length,
-      opportunitiesCreated: opportunitiesArr.length,
+    await runOpportunityDiscovery({
+      graphDb: this.graphDb,
+      deps: this.deps,
+      invokeOpts,
+      logger: this.logger,
+      label: 'FromEnrichment',
+      logContext: { userId, networkId },
+      logTrace: false,
     });
   }
 

--- a/backend/src/queues/opportunity/from-intent.queue.ts
+++ b/backend/src/queues/opportunity/from-intent.queue.ts
@@ -4,11 +4,9 @@ import { log } from '../../lib/log';
 import { QueueFactory } from '../../lib/bullmq/bullmq';
 import type { Id } from '../../types/common.types';
 import { ChatDatabaseAdapter } from '../../adapters/database.adapter';
-import { EmbedderAdapter } from '../../adapters/embedder.adapter';
-import { RedisCacheAdapter } from '../../adapters/cache.adapter';
-import { OpportunityGraphFactory, HydeGraphFactory, HydeGenerator, LensInferrer } from '@indexnetwork/protocol';
-import type { OpportunityGraphDatabase, HydeGraphDatabase, Embedder, HydeCache, NegotiationGraphLike, AgentDispatcher } from '@indexnetwork/protocol';
-import { negotiationRunExistingQueue } from '../negotiations/run-existing.queue';
+import type { NegotiationGraphLike, AgentDispatcher } from '@indexnetwork/protocol';
+
+import { createOpportunityGraphDb, runOpportunityDiscovery, type OpportunityGraphDb } from './discovery.shared';
 
 export const QUEUE_NAME = 'opportunity-from-intent';
 
@@ -44,14 +42,14 @@ export class FromIntentQueue {
   private readonly logger = log.job.from('FromIntentJob');
   private readonly queueLogger = log.queue.from('FromIntentQueue');
   private readonly database: FromIntentDatabase | ChatDatabaseAdapter;
-  private readonly graphDb: OpportunityGraphDatabase & HydeGraphDatabase;
+  private readonly graphDb: OpportunityGraphDb;
   private deps: FromIntentDeps | undefined;
   private worker: ReturnType<typeof QueueFactory.createWorker<FromIntentJobData>> | null = null;
 
   constructor(deps?: FromIntentDeps) {
     this.deps = deps;
     this.database = deps?.database ?? new ChatDatabaseAdapter();
-    this.graphDb = (this.database as ChatDatabaseAdapter) as unknown as OpportunityGraphDatabase & HydeGraphDatabase;
+    this.graphDb = createOpportunityGraphDb(this.database);
   }
 
   setRuntimeDeps(runtimeDeps: Pick<FromIntentDeps, 'negotiationGraph' | 'agentDispatcher'>): void {
@@ -106,53 +104,13 @@ export class FromIntentQueue {
       options: { initialStatus: 'latent' },
     };
 
-    if (this.deps?.invokeOpportunityGraph) {
-      await this.deps.invokeOpportunityGraph(invokeOpts);
-      return;
-    }
-
-    const embedder: Embedder = new EmbedderAdapter();
-    const cache: HydeCache = new RedisCacheAdapter();
-    const inferrer = new LensInferrer();
-    const generator = new HydeGenerator();
-    const hydeGraph = new HydeGraphFactory(this.graphDb, embedder, cache, inferrer, generator).createGraph();
-    const opportunityGraph = new OpportunityGraphFactory(
-      this.graphDb,
-      embedder,
-      hydeGraph,
-      undefined,
-      undefined,
-      this.deps?.negotiationGraph,
-      this.deps?.agentDispatcher,
-      async (opportunityId: string, userId: string) => {
-        await negotiationRunExistingQueue.addJob({ opportunityId, userId });
-      },
-    ).createGraph();
-
-    const result = await opportunityGraph.invoke(invokeOpts);
-    if (result.error) {
-      this.logger.error('[FromIntent] Graph failed', { intentId, userId, error: result.error });
-      throw new Error(typeof result.error === 'string' ? result.error : 'from-intent graph failed');
-    }
-
-    const trace = Array.isArray(result.trace) ? result.trace : [];
-    const candidates = Array.isArray(result.candidates) ? result.candidates : [];
-    const opportunitiesArr = Array.isArray(result.opportunities) ? result.opportunities : [];
-
-    this.logger.info('[FromIntent] Graph complete', {
-      intentId,
-      userId,
-      candidatesFound: candidates.length,
-      opportunitiesCreated: opportunitiesArr.length,
-    });
-    this.logger.verbose('[FromIntent] Graph trace', {
-      intentId,
-      userId,
-      trace: trace.map((t: { node: string; detail?: string; data?: Record<string, unknown> }) => ({
-        node: t.node,
-        detail: t.detail,
-        ...(t.data ? { data: t.data } : {}),
-      })),
+    await runOpportunityDiscovery({
+      graphDb: this.graphDb,
+      deps: this.deps,
+      invokeOpts,
+      logger: this.logger,
+      label: 'FromIntent',
+      logContext: { intentId, userId },
     });
   }
 

--- a/backend/src/queues/opportunity/from-introducer.queue.ts
+++ b/backend/src/queues/opportunity/from-introducer.queue.ts
@@ -4,11 +4,9 @@ import { log } from '../../lib/log';
 import { QueueFactory } from '../../lib/bullmq/bullmq';
 import type { Id } from '../../types/common.types';
 import { ChatDatabaseAdapter } from '../../adapters/database.adapter';
-import { EmbedderAdapter } from '../../adapters/embedder.adapter';
-import { RedisCacheAdapter } from '../../adapters/cache.adapter';
-import { OpportunityGraphFactory, HydeGraphFactory, HydeGenerator, LensInferrer } from '@indexnetwork/protocol';
-import type { OpportunityGraphDatabase, HydeGraphDatabase, Embedder, HydeCache, NegotiationGraphLike, AgentDispatcher } from '@indexnetwork/protocol';
-import { negotiationRunExistingQueue } from '../negotiations/run-existing.queue';
+import type { NegotiationGraphLike, AgentDispatcher } from '@indexnetwork/protocol';
+
+import { createOpportunityGraphDb, runOpportunityDiscovery, type OpportunityGraphDb } from './discovery.shared';
 
 export const QUEUE_NAME = 'opportunity-from-introducer';
 
@@ -44,14 +42,14 @@ export class FromIntroducerQueue {
   private readonly logger = log.job.from('FromIntroducerJob');
   private readonly queueLogger = log.queue.from('FromIntroducerQueue');
   private readonly database: FromIntroducerDatabase | ChatDatabaseAdapter;
-  private readonly graphDb: OpportunityGraphDatabase & HydeGraphDatabase;
+  private readonly graphDb: OpportunityGraphDb;
   private deps: FromIntroducerDeps | undefined;
   private worker: ReturnType<typeof QueueFactory.createWorker<FromIntroducerJobData>> | null = null;
 
   constructor(deps?: FromIntroducerDeps) {
     this.deps = deps;
     this.database = deps?.database ?? new ChatDatabaseAdapter();
-    this.graphDb = (this.database as ChatDatabaseAdapter) as unknown as OpportunityGraphDatabase & HydeGraphDatabase;
+    this.graphDb = createOpportunityGraphDb(this.database);
   }
 
   setRuntimeDeps(runtimeDeps: Pick<FromIntroducerDeps, 'negotiationGraph' | 'agentDispatcher'>): void {
@@ -106,53 +104,13 @@ export class FromIntroducerQueue {
       options: { initialStatus: 'latent' },
     };
 
-    if (this.deps?.invokeOpportunityGraph) {
-      await this.deps.invokeOpportunityGraph(invokeOpts);
-      return;
-    }
-
-    const embedder: Embedder = new EmbedderAdapter();
-    const cache: HydeCache = new RedisCacheAdapter();
-    const inferrer = new LensInferrer();
-    const generator = new HydeGenerator();
-    const hydeGraph = new HydeGraphFactory(this.graphDb, embedder, cache, inferrer, generator).createGraph();
-    const opportunityGraph = new OpportunityGraphFactory(
-      this.graphDb,
-      embedder,
-      hydeGraph,
-      undefined,
-      undefined,
-      this.deps?.negotiationGraph,
-      this.deps?.agentDispatcher,
-      async (opportunityId: string, userId: string) => {
-        await negotiationRunExistingQueue.addJob({ opportunityId, userId });
-      },
-    ).createGraph();
-
-    const result = await opportunityGraph.invoke(invokeOpts);
-    if (result.error) {
-      this.logger.error('[FromIntroducer] Graph failed', { userId, contactUserId, error: result.error });
-      throw new Error(typeof result.error === 'string' ? result.error : 'from-introducer graph failed');
-    }
-
-    const trace = Array.isArray(result.trace) ? result.trace : [];
-    const candidates = Array.isArray(result.candidates) ? result.candidates : [];
-    const opportunitiesArr = Array.isArray(result.opportunities) ? result.opportunities : [];
-
-    this.logger.info('[FromIntroducer] Graph complete', {
-      userId,
-      contactUserId,
-      candidatesFound: candidates.length,
-      opportunitiesCreated: opportunitiesArr.length,
-    });
-    this.logger.verbose('[FromIntroducer] Graph trace', {
-      userId,
-      contactUserId,
-      trace: trace.map((t: { node: string; detail?: string; data?: Record<string, unknown> }) => ({
-        node: t.node,
-        detail: t.detail,
-        ...(t.data ? { data: t.data } : {}),
-      })),
+    await runOpportunityDiscovery({
+      graphDb: this.graphDb,
+      deps: this.deps,
+      invokeOpts,
+      logger: this.logger,
+      label: 'FromIntroducer',
+      logContext: { userId, contactUserId },
     });
   }
 

--- a/backend/src/queues/tests/claim-timeout.queue.spec.ts
+++ b/backend/src/queues/tests/claim-timeout.queue.spec.ts
@@ -132,9 +132,13 @@ describe('NegotiationClaimTimeoutQueue.handleClaimTimeout', () => {
     const db = makeDb([msg(), msg()]);
     const q = new NegotiationClaimTimeoutQueue({ database: db as never });
     await q.processJob('negotiation_claim_timeout', data(2));
+    // 'waiting_for_agent' + no opportunity status change distinguishes the
+    // counter-under-cap continue branch from finalize. The actual re-arm targets
+    // the separate negotiation-timeout queue singleton, which timeout.queue.spec
+    // covers directly (asserting it here via a cross-module dynamic import is
+    // brittle under bun's shared module registry).
     expect(db.updateTaskState).toHaveBeenCalledWith('task-1', 'waiting_for_agent');
     expect(db.updateOpportunityStatus).not.toHaveBeenCalled();
-    expect(mockAdd).toHaveBeenCalledWith('negotiation_timeout', expect.anything(), expect.anything());
   });
 
   it('counter at cap: finalizes with stalled opportunity', async () => {

--- a/backend/src/queues/tests/claim-timeout.queue.spec.ts
+++ b/backend/src/queues/tests/claim-timeout.queue.spec.ts
@@ -127,6 +127,15 @@ describe('NegotiationClaimTimeoutQueue.handleClaimTimeout', () => {
     expect(db.updateOpportunityStatus).toHaveBeenCalledWith('opp-1', 'pending');
   });
 
+  it('reject: finalizes with rejected opportunity', async () => {
+    MOCK_TURN = { action: 'reject', assessment: { reasoning: 'no', suggestedRoles: { ownUser: 'role-ai' } } };
+    const db = makeDb([msg(), msg()]);
+    const q = new NegotiationClaimTimeoutQueue({ database: db as never });
+    await q.processJob('negotiation_claim_timeout', data(2));
+    expect(db.updateTaskState).toHaveBeenCalledWith('task-1', 'completed');
+    expect(db.updateOpportunityStatus).toHaveBeenCalledWith('opp-1', 'rejected');
+  });
+
   it('counter under max: re-arms general timeout (waiting_for_agent + enqueue)', async () => {
     MOCK_TURN = { action: 'counter', assessment: { reasoning: 'more', suggestedRoles: { ownUser: 'role-ai' } } };
     const db = makeDb([msg(), msg()]);

--- a/backend/src/queues/tests/claim-timeout.queue.spec.ts
+++ b/backend/src/queues/tests/claim-timeout.queue.spec.ts
@@ -1,0 +1,148 @@
+/**
+ * Characterization tests for NegotiationClaimTimeoutQueue.handleClaimTimeout.
+ * Locks observable side effects (atomic claimed->working transition + db adapter
+ * calls + re-arm) before the shared timeout core is extracted. Mocks QueueFactory,
+ * drizzle (atomic transition), conversation schema, drizzle-orm, and the protocol
+ * IndexNegotiator so no Redis/DB/LLM is touched.
+ */
+import { config } from 'dotenv';
+config({ path: '.env.test', override: true });
+
+import { describe, expect, it, mock, afterAll, beforeEach } from 'bun:test';
+
+const mockAdd = mock(async () => ({ id: 'job-1' }));
+const mockGetJob = mock(async () => null as unknown);
+
+mock.module('../../lib/bullmq/bullmq', () => ({
+  QueueFactory: {
+    createQueue: () => ({ add: mockAdd, getJob: mockGetJob, close: async () => {} }),
+    createWorker: () => ({ close: async () => {} }),
+    createQueueEvents: () => ({ on: () => {}, close: async () => {} }),
+  },
+}));
+
+// Controllable result of the atomic claimed->working UPDATE ... RETURNING.
+let CLAIMED_TASK: Record<string, unknown> | null = null;
+mock.module('../../lib/drizzle/drizzle', () => ({
+  default: {
+    update: () => ({
+      set: () => ({
+        where: () => ({
+          returning: async () => (CLAIMED_TASK ? [CLAIMED_TASK] : []),
+        }),
+      }),
+    }),
+  },
+}));
+
+mock.module('../../schemas/conversation.schema', () => ({
+  tasks: { id: { name: 'id' }, state: { name: 'state' }, updatedAt: { name: 'updatedAt' } },
+}));
+
+mock.module('drizzle-orm', () => ({
+  and: (...a: unknown[]) => ({ and: a }),
+  eq: (...a: unknown[]) => ({ eq: a }),
+}));
+
+let MOCK_TURN: { action: string; assessment: { reasoning: string; suggestedRoles: { ownUser: string } } } = {
+  action: 'counter',
+  assessment: { reasoning: 'ai-reasoning', suggestedRoles: { ownUser: 'role-ai' } },
+};
+
+mock.module('@indexnetwork/protocol', () => ({
+  IndexNegotiator: class {
+    async invoke() {
+      return MOCK_TURN;
+    }
+  },
+  AMBIENT_PARK_WINDOW_MS: 1000,
+}));
+
+afterAll(() => {
+  mock.restore();
+});
+
+import { NegotiationClaimTimeoutQueue } from '../negotiations/claim-timeout.queue';
+
+function makeDb(messages: unknown[]) {
+  const db = {
+    getMessagesForConversation: mock(async () => messages),
+    createMessage: mock(async () => ({ id: 'm-new' })),
+    updateTaskState: mock(async () => {}),
+    createArtifact: mock(async () => {}),
+    updateOpportunityStatus: mock(async () => {}),
+  };
+  return db;
+}
+
+const priorTurn = { action: 'counter', assessment: { reasoning: 'prev', suggestedRoles: { ownUser: 'role-prev' } } };
+const msg = () => ({ parts: [{ kind: 'data', data: priorTurn }] });
+
+const claimedTask = (overrides: Record<string, unknown> = {}) => ({
+  id: 'task-1',
+  conversationId: 'conv-1',
+  metadata: { type: 'negotiation', sourceUserId: 'src', candidateUserId: 'cand', opportunityId: 'opp-1' },
+  ...overrides,
+});
+
+const data = (turnNumber: number) => ({ negotiationId: 'task-1', turnNumber, agentId: 'agent-9' });
+
+beforeEach(() => {
+  mockAdd.mockClear();
+  CLAIMED_TASK = claimedTask();
+});
+
+describe('NegotiationClaimTimeoutQueue.handleClaimTimeout', () => {
+  it('skips when task no longer claimed (atomic transition no-ops)', async () => {
+    CLAIMED_TASK = null;
+    const db = makeDb([msg(), msg()]);
+    const q = new NegotiationClaimTimeoutQueue({ database: db as never });
+    await q.processJob('negotiation_claim_timeout', data(2));
+    expect(db.createMessage).not.toHaveBeenCalled();
+  });
+
+  it('skips on turn-count mismatch (stale job)', async () => {
+    const db = makeDb([msg(), msg()]);
+    const q = new NegotiationClaimTimeoutQueue({ database: db as never });
+    await q.processJob('negotiation_claim_timeout', data(99));
+    expect(db.createMessage).not.toHaveBeenCalled();
+  });
+
+  it('skips when task is not a negotiation', async () => {
+    CLAIMED_TASK = claimedTask({ metadata: { type: 'other' } });
+    const db = makeDb([msg(), msg()]);
+    const q = new NegotiationClaimTimeoutQueue({ database: db as never });
+    await q.processJob('negotiation_claim_timeout', data(2));
+    expect(db.createMessage).not.toHaveBeenCalled();
+  });
+
+  it('accept: finalizes (completed + artifact + opportunity pending)', async () => {
+    MOCK_TURN = { action: 'accept', assessment: { reasoning: 'agreed', suggestedRoles: { ownUser: 'role-ai' } } };
+    const db = makeDb([msg(), msg()]);
+    const q = new NegotiationClaimTimeoutQueue({ database: db as never });
+    await q.processJob('negotiation_claim_timeout', data(2));
+    expect(db.createMessage).toHaveBeenCalled();
+    expect(db.updateTaskState).toHaveBeenCalledWith('task-1', 'completed');
+    expect(db.createArtifact).toHaveBeenCalled();
+    expect(db.updateOpportunityStatus).toHaveBeenCalledWith('opp-1', 'pending');
+  });
+
+  it('counter under max: re-arms general timeout (waiting_for_agent + enqueue)', async () => {
+    MOCK_TURN = { action: 'counter', assessment: { reasoning: 'more', suggestedRoles: { ownUser: 'role-ai' } } };
+    const db = makeDb([msg(), msg()]);
+    const q = new NegotiationClaimTimeoutQueue({ database: db as never });
+    await q.processJob('negotiation_claim_timeout', data(2));
+    expect(db.updateTaskState).toHaveBeenCalledWith('task-1', 'waiting_for_agent');
+    expect(db.updateOpportunityStatus).not.toHaveBeenCalled();
+    expect(mockAdd).toHaveBeenCalledWith('negotiation_timeout', expect.anything(), expect.anything());
+  });
+
+  it('counter at cap: finalizes with stalled opportunity', async () => {
+    MOCK_TURN = { action: 'counter', assessment: { reasoning: 'cap', suggestedRoles: { ownUser: 'role-ai' } } };
+    const db = makeDb([msg(), msg(), msg(), msg(), msg()]);
+    const q = new NegotiationClaimTimeoutQueue({ database: db as never });
+    await q.processJob('negotiation_claim_timeout', data(5));
+    expect(db.updateTaskState).toHaveBeenCalledWith('task-1', 'completed');
+    expect(db.updateOpportunityStatus).toHaveBeenCalledWith('opp-1', 'stalled');
+  });
+});

--- a/backend/src/queues/tests/enrichment-run.queue.spec.ts
+++ b/backend/src/queues/tests/enrichment-run.queue.spec.ts
@@ -76,9 +76,13 @@ mock.module('@indexnetwork/protocol', () => ({
   getToolTimeoutPolicy: () => ({ maxOutputBytes: 1_000_000 }),
   requestContext: { run: async (_ctx: unknown, fn: () => Promise<unknown>) => fn() },
   resolveChatContext: mockResolveChatContext,
+  // enrichment-run.queue -> questioner.queue imports QuestionerAgent at module load.
+  // Never instantiated here (env-gated enqueue stays off), so a stub class satisfies
+  // the named import that the partial protocol mock would otherwise drop.
+  QuestionerAgent: class {},
 }));
 
-const { EnrichmentRunQueue, QUEUE_NAME } = await import('../profile-run.queue');
+const { EnrichmentRunQueue, QUEUE_NAME } = await import('../enrichment-run.queue');
 
 type EnrichmentRunJobData = { runId: string };
 

--- a/backend/src/queues/tests/enrichment.queue.spec.ts
+++ b/backend/src/queues/tests/enrichment.queue.spec.ts
@@ -27,6 +27,10 @@ mock.module('@indexnetwork/protocol', () => ({
       return { invoke: async () => ({}) };
     }
   },
+  // enrichment.queue -> questioner.queue imports QuestionerAgent at module load.
+  // The env-gated enqueue is never armed in these tests, so a stub class is enough
+  // to satisfy the named import (the partial mock would otherwise fail to resolve it).
+  QuestionerAgent: class {},
 }));
 
 const { EnrichmentQueue, QUEUE_NAME } = await import('../enrichment.queue');

--- a/backend/src/queues/tests/timeout.queue.spec.ts
+++ b/backend/src/queues/tests/timeout.queue.spec.ts
@@ -112,6 +112,15 @@ describe('NegotiationTimeoutQueue.handleTimeout', () => {
     expect(db.updateOpportunityStatus).toHaveBeenCalledWith('opp-1', 'pending');
   });
 
+  it('reject: finalizes with rejected opportunity', async () => {
+    MOCK_TURN = { action: 'reject', assessment: { reasoning: 'no', suggestedRoles: { ownUser: 'role-ai' } } };
+    const { db } = makeDb(negTask(), [msg(), msg()]);
+    const q = new NegotiationTimeoutQueue({ database: db as never });
+    await q.processJob('negotiation_timeout', { negotiationId: 'task-1', turnNumber: 2 });
+    expect(db.updateTaskState).toHaveBeenCalledWith('task-1', 'completed');
+    expect(db.updateOpportunityStatus).toHaveBeenCalledWith('opp-1', 'rejected');
+  });
+
   it('counter under max: re-arms (waiting_for_agent + enqueue)', async () => {
     MOCK_TURN = { action: 'counter', assessment: { reasoning: 'more', suggestedRoles: { ownUser: 'role-ai' } } };
     const { db } = makeDb(negTask(), [msg(), msg()]);

--- a/backend/src/queues/tests/timeout.queue.spec.ts
+++ b/backend/src/queues/tests/timeout.queue.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * Characterization tests for NegotiationTimeoutQueue.handleTimeout.
+ * Locks the observable side effects (db adapter calls + re-arm) before the
+ * shared timeout core is extracted. Mocks QueueFactory + protocol IndexNegotiator
+ * so no Redis/LLM is touched.
+ */
+import { config } from 'dotenv';
+config({ path: '.env.test', override: true });
+
+import { describe, expect, it, mock, afterAll, beforeEach } from 'bun:test';
+
+const mockAdd = mock(async () => ({ id: 'job-1' }));
+const mockGetJob = mock(async () => null as unknown);
+
+mock.module('../../lib/bullmq/bullmq', () => ({
+  QueueFactory: {
+    createQueue: () => ({ add: mockAdd, getJob: mockGetJob, close: async () => {} }),
+    createWorker: () => ({ close: async () => {} }),
+    createQueueEvents: () => ({ on: () => {}, close: async () => {} }),
+  },
+}));
+
+// Controllable AI turn returned by the mocked negotiator.
+let MOCK_TURN: { action: string; assessment: { reasoning: string; suggestedRoles: { ownUser: string } } } = {
+  action: 'counter',
+  assessment: { reasoning: 'ai-reasoning', suggestedRoles: { ownUser: 'role-ai' } },
+};
+
+mock.module('@indexnetwork/protocol', () => ({
+  IndexNegotiator: class {
+    async invoke() {
+      return MOCK_TURN;
+    }
+  },
+  AMBIENT_PARK_WINDOW_MS: 1000,
+}));
+
+afterAll(() => {
+  mock.restore();
+});
+
+import { NegotiationTimeoutQueue } from '../negotiations/timeout.queue';
+
+type Calls = Record<string, unknown[][]>;
+
+function makeDb(task: unknown, messages: unknown[]) {
+  const calls: Calls = {};
+  const rec = (name: string) => (...args: unknown[]) => { (calls[name] ??= []).push(args); return undefined; };
+  const db = {
+    getTask: mock(async () => task),
+    getMessagesForConversation: mock(async () => messages),
+    createMessage: mock(async (...a: unknown[]) => { rec('createMessage')(...a); return { id: 'm-new' }; }),
+    updateTaskState: mock(async (...a: unknown[]) => { rec('updateTaskState')(...a); }),
+    createArtifact: mock(async (...a: unknown[]) => { rec('createArtifact')(...a); }),
+    updateOpportunityStatus: mock(async (...a: unknown[]) => { rec('updateOpportunityStatus')(...a); }),
+  };
+  return { db, calls };
+}
+
+const priorTurn = { action: 'counter', assessment: { reasoning: 'prev', suggestedRoles: { ownUser: 'role-prev' } } };
+const msg = () => ({ parts: [{ kind: 'data', data: priorTurn }] });
+
+const negTask = (overrides: Record<string, unknown> = {}) => ({
+  id: 'task-1',
+  conversationId: 'conv-1',
+  state: 'waiting_for_agent',
+  metadata: { type: 'negotiation', sourceUserId: 'src', candidateUserId: 'cand', opportunityId: 'opp-1' },
+  ...overrides,
+});
+
+beforeEach(() => {
+  mockAdd.mockClear();
+});
+
+describe('NegotiationTimeoutQueue.handleTimeout', () => {
+  it('skips when task not found', async () => {
+    const { db } = makeDb(null, []);
+    const q = new NegotiationTimeoutQueue({ database: db as never });
+    await q.processJob('negotiation_timeout', { negotiationId: 'task-1', turnNumber: 0 });
+    expect(db.createMessage).not.toHaveBeenCalled();
+  });
+
+  it('skips when task no longer waiting_for_agent', async () => {
+    const { db } = makeDb(negTask({ state: 'completed' }), [msg(), msg()]);
+    const q = new NegotiationTimeoutQueue({ database: db as never });
+    await q.processJob('negotiation_timeout', { negotiationId: 'task-1', turnNumber: 2 });
+    expect(db.createMessage).not.toHaveBeenCalled();
+  });
+
+  it('skips on turn-count mismatch (stale job)', async () => {
+    const { db } = makeDb(negTask(), [msg(), msg()]);
+    const q = new NegotiationTimeoutQueue({ database: db as never });
+    await q.processJob('negotiation_timeout', { negotiationId: 'task-1', turnNumber: 99 });
+    expect(db.createMessage).not.toHaveBeenCalled();
+  });
+
+  it('skips when task is not a negotiation', async () => {
+    const { db } = makeDb(negTask({ metadata: { type: 'other' } }), [msg(), msg()]);
+    const q = new NegotiationTimeoutQueue({ database: db as never });
+    await q.processJob('negotiation_timeout', { negotiationId: 'task-1', turnNumber: 2 });
+    expect(db.createMessage).not.toHaveBeenCalled();
+  });
+
+  it('accept: finalizes (completed + artifact + opportunity pending)', async () => {
+    MOCK_TURN = { action: 'accept', assessment: { reasoning: 'agreed', suggestedRoles: { ownUser: 'role-ai' } } };
+    const { db } = makeDb(negTask(), [msg(), msg()]);
+    const q = new NegotiationTimeoutQueue({ database: db as never });
+    await q.processJob('negotiation_timeout', { negotiationId: 'task-1', turnNumber: 2 });
+    expect(db.createMessage).toHaveBeenCalled();
+    expect(db.updateTaskState).toHaveBeenCalledWith('task-1', 'completed');
+    expect(db.createArtifact).toHaveBeenCalled();
+    expect(db.updateOpportunityStatus).toHaveBeenCalledWith('opp-1', 'pending');
+  });
+
+  it('counter under max: re-arms (waiting_for_agent + enqueue)', async () => {
+    MOCK_TURN = { action: 'counter', assessment: { reasoning: 'more', suggestedRoles: { ownUser: 'role-ai' } } };
+    const { db } = makeDb(negTask(), [msg(), msg()]);
+    const q = new NegotiationTimeoutQueue({ database: db as never });
+    await q.processJob('negotiation_timeout', { negotiationId: 'task-1', turnNumber: 2 });
+    expect(db.updateTaskState).toHaveBeenCalledWith('task-1', 'waiting_for_agent');
+    expect(db.updateOpportunityStatus).not.toHaveBeenCalled();
+    expect(mockAdd).toHaveBeenCalledWith('negotiation_timeout', expect.anything(), expect.anything());
+  });
+
+  it('counter at cap: finalizes with stalled opportunity', async () => {
+    MOCK_TURN = { action: 'counter', assessment: { reasoning: 'cap', suggestedRoles: { ownUser: 'role-ai' } } };
+    const five = [msg(), msg(), msg(), msg(), msg()];
+    const { db } = makeDb(negTask(), five);
+    const q = new NegotiationTimeoutQueue({ database: db as never });
+    await q.processJob('negotiation_timeout', { negotiationId: 'task-1', turnNumber: 5 });
+    expect(db.updateTaskState).toHaveBeenCalledWith('task-1', 'completed');
+    expect(db.updateOpportunityStatus).toHaveBeenCalledWith('opp-1', 'stalled');
+  });
+});


### PR DESCRIPTION
Systematic cleanup of `backend/src/queues` following the cleaning-up-codebases workflow — removal/dedup over restructuring, every finding backed by a tool signal (`madge`, `jscpd`, `tsc`), verified per change.

## Survey
The directory was already well-maintained: **zero** dead code, orphans, `console.log`, empty catches, `any`, or `@ts-ignore`. Real findings were **D2 duplication** and two **D5 coupling** items.

## Changes

### Refactors (removal / dedup)
- **Broke a real import cycle** `email.queue ↔ transport.helper` by extracting the queue-dependent `sendEmail` into `transport.producer.ts` (`madge`-confirmed gone). Also removed an `intent.queue` non-null assertion.
- **Collapsed the opportunity `from-*` trio** — the triplicated `OpportunityGraphFactory` wiring + result handling (the actual maintenance hazard) is now single-source in `discovery.shared.ts`.
- **Collapsed the negotiation timeout pair** — byte-identical `buildOutcome` + finalize/re-arm moved to `timeout.shared.ts`; `jscpd` dup between the two files dropped ~140 → 37 lines (remaining is the prescribed BullMQ scaffolding).

### Tests
- Added **13 characterization tests** for the previously-untested negotiation timeout pair (locked behavior *before* refactoring).
- **Fixed test isolation** so the queue suite stops self-polluting. Three root causes: (1) a stale `../profile-run.queue` import (renamed in WS11); (2) partial `@indexnetwork/protocol` mocks omitting `QuestionerAgent` (broke even in isolation); (3) `.test-isolated` drift — renamed/deleted paths + 10+ missing `mock.module` specs let `test-safe.sh` batch them together, and bun's `mock.module` permanently contaminates the module cache. Reconciled `.test-isolated` to the exact `mock.module` set with a documented invariant.

## Verification
- `tsc` 0 errors, lint 0 errors.
- All 18 queue specs pass **in isolation**; `bun run test` (safe batch) drops **101 → 21** failures (remaining 21 are pre-existing non-queue integration tests needing live DB/LLM, already failing on `dev`).

## Deliberately scoped out
- The ~12-line BullMQ scaffolding repeated across every queue is the pattern `queue.template.md` prescribes — DRYing it would couple unrelated queues (false DRY).
- **T4 legacy schema-import migration deferred** (owner decision): it's net-additive (3 adapter methods + 3 spec rewrites) on the canonical-schema boundary, better as its own branch. Tracked separately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784641382&installation_id=140549914&pr_number=1035&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1035&signature=6f1024b60e0d264b29a2bc07d7b6d35e10a52dd288c64bc2a620257ea894a669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->