### PR TITLE
feat(frontend): convert sidebar questions dropdown into a dedicated page

### DIFF
--- a/frontend/src/app/questions/page.tsx
+++ b/frontend/src/app/questions/page.tsx
@@ -1,0 +1,67 @@
+import { useMemo } from 'react';
+import { CircleHelp } from 'lucide-react';
+import { useQuestions } from '@/contexts/QuestionsContext';
+import { QuestionGroup, groupKey, groupLabel } from '@/components/PendingQuestions/QuestionGroup';
+import ClientLayout from '@/components/ClientLayout';
+import { ContentContainer } from '@/components/layout';
+
+/**
+ * Full-page view of all pending questions, grouped by entity type.
+ * Replaces the former sidebar dropdown panel.
+ */
+export function QuestionsPage() {
+  const { questions, answer, dismiss, loading } = useQuestions();
+
+  const groups = useMemo(() => {
+    const map = new Map<string, typeof questions>();
+    for (const q of questions) {
+      const key = groupKey(q);
+      const list = map.get(key) ?? [];
+      list.push(q);
+      map.set(key, list);
+    }
+    return Array.from(map.entries()).map(([key, items]) => ({
+      key,
+      label: groupLabel(items[0].detection.sourceType, items[0].detection.mode),
+      questions: items,
+    }));
+  }, [questions]);
+
+  return (
+    <ClientLayout>
+      <div className="px-6 lg:px-8 py-8">
+        <ContentContainer>
+          <h1 className="text-2xl font-bold text-black font-ibm-plex-mono mb-8">Questions</h1>
+
+          {loading && questions.length === 0 ? (
+            <div className="text-sm text-gray-400 py-12 text-center">Loading…</div>
+          ) : questions.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-20 text-center">
+              <CircleHelp className="w-10 h-10 text-gray-300 mb-3" />
+              <p className="text-sm text-gray-500">No pending questions</p>
+              <p className="text-xs text-gray-400 mt-1">
+                We&apos;ll surface questions here when your agent needs your input.
+              </p>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-8 max-w-2xl">
+              {groups.map((g) => (
+                <QuestionGroup
+                  key={g.key}
+                  label={g.label}
+                  questions={g.questions}
+                  onAnswer={answer}
+                  onDismiss={dismiss}
+                />
+              ))}
+            </div>
+          )}
+        </ContentContainer>
+      </div>
+    </ClientLayout>
+  );
+}
+
+export const Component = QuestionsPage;
+
+export default QuestionsPage;

--- a/frontend/src/components/ClientWrapper.tsx
+++ b/frontend/src/components/ClientWrapper.tsx
@@ -18,7 +18,7 @@ export default function ClientWrapper({ children }: PropsWithChildren) {
     setMobileSidebarOpen(false);
   }, [pathname]);
 
-  const appRoutes = ['/', '/d', '/i', '/u', '/library', '/networks', '/mynetwork', '/chat', '/settings', '/agents', '/agent'];
+  const appRoutes = ['/', '/d', '/i', '/u', '/library', '/networks', '/mynetwork', '/chat', '/settings', '/agents', '/agent', '/questions'];
   const publicRoutes = ['/c', '/l', '/index'];
   const bareRoutes = ['/', '/onboarding', '/oauth/callback', '/found-in-translation', '/blog', '/about', '/pages'];
 

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -16,7 +16,6 @@ import { useNotifications } from '@/contexts/NotificationContext';
 import CreateNetworkModal from '@/components/modals/CreateIndexModal';
 import MasterKeyDialog from '@/components/MasterKeyDialog';
 import { useQuestions } from '@/contexts/QuestionsContext';
-import { PendingQuestions } from '@/components/PendingQuestions/PendingQuestions';
 
 
 interface ChatSession {
@@ -50,8 +49,6 @@ export default function Sidebar() {
   const [historyExpanded, setHistoryExpanded] = useState(true);
   const userDropdownRef = useRef<HTMLDivElement>(null);
   const { count: pendingQuestionsCount } = useQuestions();
-  const [questionsOpen, setQuestionsOpen] = useState(false);
-  const questionsRef = useRef<HTMLDivElement>(null);
 
   const isMessagesView = pathname === '/chat' || (pathname?.includes('/chat') && pathname?.startsWith('/u/'));
   const isLibraryView = pathname?.startsWith('/library');
@@ -60,7 +57,8 @@ export default function Sidebar() {
   const isSettingsView = pathname?.startsWith('/settings');
   const isAgentsView = pathname?.startsWith('/agents') || pathname?.startsWith('/agent');
   const isMyNetworkView = pathname?.startsWith('/mynetwork');
-  const isHomeView = !isMessagesView && !isLibraryView && !isNetworksView && !isHistoryView && !isSettingsView && !isAgentsView && !isMyNetworkView;
+  const isQuestionsView = pathname?.startsWith('/questions');
+  const isHomeView = !isMessagesView && !isLibraryView && !isNetworksView && !isHistoryView && !isSettingsView && !isAgentsView && !isMyNetworkView && !isQuestionsView;
 
   // Get current AI session ID from pathname (e.g., /d/abc123 -> abc123)
   const currentSessionId = pathname?.match(/^\/d\/([^/]+)/)?.[1] || null;
@@ -174,18 +172,6 @@ export default function Sidebar() {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [userDropdownOpen]);
 
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (questionsRef.current && !questionsRef.current.contains(event.target as Node)) {
-        setQuestionsOpen(false);
-      }
-    };
-    if (questionsOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
-    }
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [questionsOpen]);
-
   return (
     <div className="flex flex-col h-full overflow-hidden">
       {/* Logo */}
@@ -283,32 +269,23 @@ export default function Sidebar() {
           )}
         </div>
 
-        {/* Questions temporarily disabled — re-enable by restoring this condition. */}
-        {false && pendingQuestionsCount > 0 && (
-          <div className="relative" ref={questionsRef}>
-            <button
-              type="button"
-              aria-expanded={questionsOpen}
-              onClick={() => setQuestionsOpen(!questionsOpen)}
-              className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-md text-sm transition-colors ${
-                questionsOpen
-                  ? 'bg-gray-100 text-black font-bold'
-                  : 'text-black font-medium hover:bg-gray-50'
-              }`}
-            >
-              <CircleHelp className="w-5 h-5" />
-              <span className="flex-1 text-left">Questions</span>
-              <span className="bg-[#041729] text-white text-xs px-2 py-0.5 rounded-full min-w-[20px] text-center">
-                {pendingQuestionsCount > 99 ? '99+' : pendingQuestionsCount}
-              </span>
-            </button>
-
-            {questionsOpen && (
-              <div className="absolute left-0 right-0 bottom-full mb-2 bg-white border border-gray-200 rounded-lg shadow-lg z-50 w-[340px]">
-                <PendingQuestions />
-              </div>
-            )}
-          </div>
+        {/* Questions — links to the dedicated Questions page. */}
+        {pendingQuestionsCount > 0 && (
+          <button
+            type="button"
+            onClick={() => navigate('/questions')}
+            className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-md text-sm transition-colors ${
+              isQuestionsView
+                ? 'bg-gray-100 text-black font-bold'
+                : 'text-black font-medium hover:bg-gray-50'
+            }`}
+          >
+            <CircleHelp className="w-5 h-5" />
+            <span className="flex-1 text-left">Questions</span>
+            <span className="bg-[#041729] text-white text-xs px-2 py-0.5 rounded-full min-w-[20px] text-center">
+              {pendingQuestionsCount > 99 ? '99+' : pendingQuestionsCount}
+            </span>
+          </button>
         )}
       </nav>
 

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -122,6 +122,10 @@ export const router = createBrowserRouter([
         lazy: () => import("@/app/settings/page"),
       },
       {
+        path: "/questions",
+        lazy: () => import("@/app/questions/page"),
+      },
+      {
         path: "/profile",
         element: <Navigate to="/settings" replace />,
       },


### PR DESCRIPTION
## Summary

The Questions component in the sidebar was a dropdown panel. This converts it into a dedicated `/questions` page instead.

## Changes

### New Features
- **New `/questions` page** (`frontend/src/app/questions/page.tsx`) — a full-page view of all pending questions, grouped by entity type. Uses the standard `ClientLayout` + `ContentContainer` page shell (matching the settings page) and reuses the existing `QuestionGroup` grouping logic (`groupKey`/`groupLabel`). Includes loading and empty states.
- Registered the lazy `/questions` route in `routes.tsx` and added it to `ClientWrapper`'s `appRoutes` so it renders inside the authenticated sidebar shell.

### Refactors
- **Sidebar** (`components/Sidebar.tsx`) — replaced the dropdown panel (and its `questionsOpen`/`questionsRef` state, click-outside effect, and `PendingQuestions` import) with a nav button that navigates to `/questions`. Kept the pending-count badge and added active-route highlighting (`isQuestionsView`).
- Re-enabled the Questions sidebar entry (was previously gated behind `false &&`); it now appears whenever there are pending questions.

## Notes
- The existing `PendingQuestions`/`QuestionGroup`/`QuestionCard` components are left intact — `QuestionGroup`/`QuestionCard` are still used inline in chat via `InjectedQuestions`.
- `tsc --noEmit` and `eslint` on the changed files report no new errors (remaining warnings are pre-existing on `dev`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1036"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784647796&installation_id=140549914&pr_number=1036&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1036&signature=b325999d467bb672ad35e63abbaeb72b665c320fc0ecd74da5985876a8e8356c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->