### PR TITLE
chore(queues): route legacy queue schema imports through adapters

### DIFF
--- a/backend/.test-isolated
+++ b/backend/.test-isolated
@@ -6,6 +6,7 @@
 # Keep this in sync: any spec that adds mock.module() must be added here, or it
 # will pollute the shared `bun run test` batch and break sibling specs' imports.
 # Derived from: grep -rlE 'mock\.module' src tests --include='*.spec.ts' --include='*.test.ts'
+src/adapters/tests/enrichment.database.adapter.privacy.spec.ts
 src/adapters/tests/scraper.adapter.spec.ts
 src/adapters/tests/storage.adapter.spec.ts
 src/adapters/tests/system-database.spec.ts

--- a/backend/src/adapters/chat.database.adapter.ts
+++ b/backend/src/adapters/chat.database.adapter.ts
@@ -383,6 +383,26 @@ export class ChatDatabaseAdapter {
   }
 
   /**
+   * IDs of all non-personal (community) networks the user is an active member of.
+   * Excludes soft-deleted memberships, soft-deleted networks, and personal indexes.
+   * @param userId - The user whose community memberships to resolve
+   * @returns Array of network IDs (possibly empty)
+   */
+  async getNonPersonalNetworkIds(userId: string): Promise<string[]> {
+    const rows = await db
+      .select({ networkId: schema.networkMembers.networkId })
+      .from(schema.networkMembers)
+      .innerJoin(schema.networks, eq(schema.networkMembers.networkId, schema.networks.id))
+      .where(and(
+        eq(schema.networkMembers.userId, userId),
+        isNull(schema.networkMembers.deletedAt),
+        isNull(schema.networks.deletedAt),
+        eq(schema.networks.isPersonal, false),
+      ));
+    return rows.map((r) => r.networkId);
+  }
+
+  /**
    * Check whether an index is a personal index.
    * @param networkId - The index to check
    * @returns true if the index has isPersonal = true

--- a/backend/src/adapters/enrichment.database.adapter.ts
+++ b/backend/src/adapters/enrichment.database.adapter.ts
@@ -31,6 +31,45 @@ export class EnrichmentDatabaseAdapter {
   }
 
   /**
+   * Reads needed to make a public-enrichment privacy decision for (user, network):
+   * the user's onboarding/ghost flags, the network's permissions JSON, and whether the
+   * user has any ACTIVE premise. "Has been enriched?" keys on ACTIVE premises — the
+   * source of truth — not a user_profiles row (WS10/IND-367). Returns null user/network
+   * when the row is absent or soft-deleted.
+   * @param userId - The user being enriched
+   * @param networkId - The network whose enrichment policy gates the decision
+   * @returns user (onboarding + ghost flag), network (permissions), and hasActivePremise
+   */
+  async getEnrichmentPrivacyContext(userId: string, networkId: string): Promise<{
+    user: { onboarding: OnboardingState | null | undefined; isGhost: boolean } | null;
+    network: { permissions: Record<string, unknown> | null } | null;
+    hasActivePremise: boolean;
+  }> {
+    const [[user], [network], [premise]] = await Promise.all([
+      db
+        .select({ onboarding: schema.users.onboarding, isGhost: schema.users.isGhost })
+        .from(schema.users)
+        .where(and(eq(schema.users.id, userId), isNull(schema.users.deletedAt)))
+        .limit(1),
+      db
+        .select({ permissions: schema.networks.permissions })
+        .from(schema.networks)
+        .where(and(eq(schema.networks.id, networkId), isNull(schema.networks.deletedAt)))
+        .limit(1),
+      db
+        .select({ id: schema.premises.id })
+        .from(schema.premises)
+        .where(and(eq(schema.premises.userId, userId), eq(schema.premises.status, 'ACTIVE')))
+        .limit(1),
+    ]);
+    return {
+      user: user ? { onboarding: user.onboarding as OnboardingState | null | undefined, isGhost: user.isGhost } : null,
+      network: network ? { permissions: network.permissions as unknown as Record<string, unknown> | null } : null,
+      hasActivePremise: !!premise,
+    };
+  }
+
+  /**
    * Update user account fields (name, intro, location).
    */
   async updateUser(

--- a/backend/src/adapters/tests/enrichment.database.adapter.privacy.spec.ts
+++ b/backend/src/adapters/tests/enrichment.database.adapter.privacy.spec.ts
@@ -1,0 +1,74 @@
+import { config } from 'dotenv';
+config({ path: '.env.test', override: true });
+
+import { afterAll, describe, expect, it, mock } from 'bun:test';
+
+import { premises, users, networks } from '../../schemas/database.schema';
+
+// ---------------------------------------------------------------------------
+// Fake drizzle db: getEnrichmentPrivacyContext issues three parallel reads
+// (users, networks, premises). We branch on the `.from(table)` reference and
+// let each test control what the premises read returns. We also record which
+// tables were queried so we can assert the gate reads `premises`, NOT
+// `user_profiles` (the WS10/IND-367 repoint — user_profiles was dropped in WS8).
+// `db` is sourced by the adapter from database.shared, which re-exports the
+// default import of lib/drizzle/drizzle — so mocking that path here propagates.
+// ---------------------------------------------------------------------------
+const fromTables: unknown[] = [];
+let premiseRows: Array<{ id: string }> = [];
+const userRows = [{ onboarding: null, isGhost: false }];
+const networkRows = [{ permissions: [] as unknown }];
+
+function makeQuery(rows: unknown[]) {
+  const builder = {
+    from(table: unknown) {
+      fromTables.push(table);
+      if (table === premises) builder._rows = premiseRows;
+      else if (table === users) builder._rows = userRows;
+      else if (table === networks) builder._rows = networkRows;
+      else builder._rows = rows;
+      return builder;
+    },
+    where() { return builder; },
+    // getEnrichmentPrivacyContext awaits the builder after .limit(1)
+    limit() { return Promise.resolve(builder._rows); },
+    _rows: rows as unknown[],
+  };
+  return builder;
+}
+
+mock.module('../../lib/drizzle/drizzle', () => ({
+  default: { select: () => makeQuery([]) },
+  closeDb: async () => {},
+}));
+
+const { EnrichmentDatabaseAdapter } = await import('../enrichment.database.adapter');
+
+afterAll(() => mock.restore());
+
+describe('EnrichmentDatabaseAdapter.getEnrichmentPrivacyContext — enrichment signal (WS10)', () => {
+  it('reports hasActivePremise=true and reads `premises`, not user_profiles', async () => {
+    fromTables.length = 0;
+    premiseRows = [{ id: 'premise-1' }];
+
+    const ctx = await new EnrichmentDatabaseAdapter().getEnrichmentPrivacyContext('u1', 'n1');
+
+    expect(ctx.hasActivePremise).toBe(true);
+    expect(ctx.user).toEqual({ onboarding: null, isGhost: false });
+    expect(ctx.network).toEqual({ permissions: [] });
+    // The "has been enriched?" signal keys on `premises` (WS8 dropped user_profiles).
+    expect(fromTables).toContain(premises);
+    expect(fromTables).toContain(users);
+    expect(fromTables).toContain(networks);
+  });
+
+  it('reports hasActivePremise=false when the user has no ACTIVE premise', async () => {
+    fromTables.length = 0;
+    premiseRows = [];
+
+    const ctx = await new EnrichmentDatabaseAdapter().getEnrichmentPrivacyContext('u2', 'n1');
+
+    expect(ctx.hasActivePremise).toBe(false);
+    expect(fromTables).toContain(premises);
+  });
+});

--- a/backend/src/cli/expire-opportunities.ts
+++ b/backend/src/cli/expire-opportunities.ts
@@ -11,29 +11,12 @@ import path from 'path';
 const envFile = process.env.NODE_ENV === 'development' ? '.env.development' : '.env.production';
 dotenv.config({ path: path.resolve(process.cwd(), envFile) });
 
-import db, { closeDb } from '../lib/drizzle/drizzle';
-import { opportunities } from '../schemas/database.schema';
-import { and, isNotNull, lte, notInArray } from 'drizzle-orm';
-
-async function expireStaleOpportunities(): Promise<number> {
-  const now = new Date();
-  const updated = await db
-    .update(opportunities)
-    .set({ status: 'expired', updatedAt: now })
-    .where(
-      and(
-        isNotNull(opportunities.expiresAt),
-        lte(opportunities.expiresAt, now),
-        notInArray(opportunities.status, ['accepted', 'rejected', 'expired'])
-      )
-    )
-    .returning({ id: opportunities.id });
-  return updated.length;
-}
+import { closeDb } from '../lib/drizzle/drizzle';
+import { OpportunityDatabaseAdapter } from '../adapters/opportunity.database.adapter';
 
 async function main() {
   console.log('[expire-opportunities] Starting...');
-  const count = await expireStaleOpportunities();
+  const count = await new OpportunityDatabaseAdapter().expireStaleOpportunities();
   console.log(`[expire-opportunities] Expired ${count} opportunit${count === 1 ? 'y' : 'ies'}.`);
   await closeDb();
   process.exit(0);

--- a/backend/src/queues/enrichment.queue.ts
+++ b/backend/src/queues/enrichment.queue.ts
@@ -1,5 +1,4 @@
 import { Job } from 'bullmq';
-import { and, eq, isNull } from 'drizzle-orm';
 
 import { log } from '../lib/log';
 import { QueueFactory } from '../lib/bullmq/bullmq';
@@ -9,11 +8,9 @@ import { EnrichmentGraphFactory, PremiseGraphFactory } from '@indexnetwork/proto
 import type { PremiseGraphDatabase } from '@indexnetwork/protocol';
 import { enrichUserProfile } from '../lib/parallel/parallel';
 import { EmbedderAdapter } from '../adapters/embedder.adapter';
-import db from '../lib/drizzle/drizzle';
 import { questionerEnqueueIfEnabled } from './questioner.queue';
 import { canRunPublicEnrichment, getEnrichmentPolicy } from '../lib/privacy/enrichment-policy';
-import { networks, premises, users } from '../schemas/database.schema';
-import type { OnboardingState, ProfileEnrichmentPolicy } from '../schemas/database.schema';
+import type { ProfileEnrichmentPolicy } from '../schemas/database.schema';
 
 /** BullMQ queue name for profile HyDE (ensure profile + HyDE) jobs. */
 export const QUEUE_NAME = 'profile-hyde-queue';
@@ -268,29 +265,14 @@ export class EnrichmentQueue {
       return { allowed: true, policy: 'auto', reason: 'no_network_policy', hasExistingProfile: false };
     }
 
-    const [[user], [network], [premise]] = await Promise.all([
-      db
-        .select({ onboarding: users.onboarding, isGhost: users.isGhost })
-        .from(users)
-        .where(and(eq(users.id, data.userId), isNull(users.deletedAt)))
-        .limit(1),
-      db
-        .select({ permissions: networks.permissions })
-        .from(networks)
-        .where(and(eq(networks.id, data.networkId), isNull(networks.deletedAt)))
-        .limit(1),
-      // "Has been enriched?" keys on ACTIVE premises, not a `user_profiles` row
-      // (WS10/IND-367 — same existence-via-user_profiles anti-pattern WS5 removed from
-      // profile.graph). `getProfile` returns a users-sourced row for every user, so it
-      // can't signal enrichment; the premise graph is the source of truth.
-      db
-        .select({ id: premises.id })
-        .from(premises)
-        .where(and(eq(premises.userId, data.userId), eq(premises.status, 'ACTIVE')))
-        .limit(1),
-    ]);
+    // "Has been enriched?" keys on ACTIVE premises, not a `user_profiles` row
+    // (WS10/IND-367 — same existence-via-user_profiles anti-pattern WS5 removed from
+    // profile.graph). `getProfile` returns a users-sourced row for every user, so it
+    // can't signal enrichment; the premise graph is the source of truth.
+    const { user, network, hasActivePremise } = await new EnrichmentDatabaseAdapter()
+      .getEnrichmentPrivacyContext(data.userId, data.networkId);
 
-    const hasExistingProfile = !!premise;
+    const hasExistingProfile = hasActivePremise;
     if (!network) {
       return { allowed: false, policy: 'disabled', reason: 'network_not_found', hasExistingProfile };
     }
@@ -306,7 +288,7 @@ export class EnrichmentQueue {
 
     const allowed = canRunPublicEnrichment({
       policy,
-      onboarding: user.onboarding as OnboardingState | null | undefined,
+      onboarding: user.onboarding,
       isGhost: user.isGhost,
     });
 

--- a/backend/src/queues/opportunity/expiration.queue.ts
+++ b/backend/src/queues/opportunity/expiration.queue.ts
@@ -1,28 +1,24 @@
 // backend/src/queues/opportunity/expiration.queue.ts
 import cron from 'node-cron';
-import { and, isNotNull, lte, notInArray } from 'drizzle-orm';
 import { log } from '../../lib/log';
-import db from '../../lib/drizzle/drizzle';
-import { opportunities } from '../../schemas/database.schema';
+import { OpportunityDatabaseAdapter } from '../../adapters/opportunity.database.adapter';
+
+/** The persistence surface the cron needs: a single stale-opportunity sweep. */
+export interface OpportunityExpirationDeps {
+  expireStaleOpportunities: () => Promise<number>;
+}
 
 export class OpportunityExpirationCron {
   private readonly logger = log.queue.from('OpportunityExpiration');
   private task: ReturnType<typeof cron.schedule> | null = null;
+  private readonly deps: OpportunityExpirationDeps;
+
+  constructor(deps?: OpportunityExpirationDeps) {
+    this.deps = deps ?? new OpportunityDatabaseAdapter();
+  }
 
   async expireStale(): Promise<number> {
-    const now = new Date();
-    const updated = await db
-      .update(opportunities)
-      .set({ status: 'expired', updatedAt: now })
-      .where(
-        and(
-          isNotNull(opportunities.expiresAt),
-          lte(opportunities.expiresAt, now),
-          notInArray(opportunities.status, ['accepted', 'rejected', 'expired']),
-        ),
-      )
-      .returning({ id: opportunities.id });
-    return updated.length;
+    return this.deps.expireStaleOpportunities();
   }
 
   start(): void {

--- a/backend/src/queues/tests/enrichment-privacy-gate.spec.ts
+++ b/backend/src/queues/tests/enrichment-privacy-gate.spec.ts
@@ -2,43 +2,34 @@ import { config } from 'dotenv';
 config({ path: '.env.test', override: true });
 process.env.OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY || 'test-key';
 
-import { afterAll, describe, expect, it, mock } from 'bun:test';
+import { afterAll, describe, expect, it } from 'bun:test';
 
-import { premises, users, networks } from '../../schemas/database.schema';
+import { mock } from 'bun:test';
 
 // ---------------------------------------------------------------------------
-// Fake drizzle db: resolvePrivacyDecision issues three parallel reads
-// (users, networks, premises). We branch on the `.from(table)` reference and
-// let each test control what the premises read returns. We also record which
-// tables were queried so we can assert the gate reads `premises`, NOT
-// `user_profiles` (the WS10/IND-367 repoint).
+// The three privacy reads (users, networks, premises) now live in
+// EnrichmentDatabaseAdapter.getEnrichmentPrivacyContext — see
+// `src/adapters/tests/enrichment.database.adapter.privacy.spec.ts` for the
+// data-source guard (reads `premises`, NOT `user_profiles`; WS10/IND-367).
+// Here we stub that adapter method so the REAL gate DECISION logic runs (the
+// path enrichment.queue.spec bypasses by injecting checkPrivacy) and assert how
+// the gate maps the privacy context onto a decision.
 // ---------------------------------------------------------------------------
-const fromTables: unknown[] = [];
-let premiseRows: Array<{ id: string }> = [];
-const userRows = [{ onboarding: null, isGhost: false }];
-const networkRows = [{ permissions: [] as unknown }];
+let privacyContext: {
+  user: { onboarding: unknown; isGhost: boolean } | null;
+  network: { permissions: unknown } | null;
+  hasActivePremise: boolean;
+} = { user: { onboarding: null, isGhost: false }, network: { permissions: [] }, hasActivePremise: false };
+const privacyContextCalls: Array<[string, string]> = [];
 
-function makeQuery(rows: unknown[]) {
-  const builder = {
-    from(table: unknown) {
-      fromTables.push(table);
-      if (table === premises) builder._rows = premiseRows;
-      else if (table === users) builder._rows = userRows;
-      else if (table === networks) builder._rows = networkRows;
-      else builder._rows = rows;
-      return builder;
-    },
-    where() { return builder; },
-    // resolvePrivacyDecision awaits the builder after .limit(1)
-    limit() { return Promise.resolve(builder._rows); },
-    _rows: rows as unknown[],
-  };
-  return builder;
-}
-
-mock.module('../../lib/drizzle/drizzle', () => ({
-  default: { select: () => makeQuery([]) },
-  closeDb: async () => {},
+mock.module('../../adapters/database.adapter', () => ({
+  EnrichmentDatabaseAdapter: class {
+    async getEnrichmentPrivacyContext(userId: string, networkId: string) {
+      privacyContextCalls.push([userId, networkId]);
+      return privacyContext;
+    }
+  },
+  ChatDatabaseAdapter: class {},
 }));
 
 // Heavy transitive imports that would otherwise eagerly construct LLM models /
@@ -55,7 +46,6 @@ mock.module('@indexnetwork/protocol', () => ({
   PremiseGraphFactory: class { createGraph() { return { invoke: async () => ({}) }; } },
   QuestionerAgent: class {},
 }));
-mock.module('../../adapters/database.adapter', () => ({ EnrichmentDatabaseAdapter: class {}, ChatDatabaseAdapter: class {} }));
 mock.module('../../adapters/scraper.adapter', () => ({ ScraperAdapter: class {} }));
 mock.module('../../adapters/embedder.adapter', () => ({ EmbedderAdapter: class {} }));
 mock.module('../../lib/parallel/parallel', () => ({ enrichUserProfile: async () => ({}) }));
@@ -76,9 +66,9 @@ function callGate(data: { userId: string; networkId?: string }) {
 }
 
 describe('EnrichmentQueue.resolvePrivacyDecision — enrichment signal (WS10)', () => {
-  it('keys hasExistingProfile on ACTIVE premises, not user_profiles', async () => {
-    fromTables.length = 0;
-    premiseRows = [{ id: 'premise-1' }];
+  it('keys hasExistingProfile on the adapter-reported ACTIVE premise', async () => {
+    privacyContextCalls.length = 0;
+    privacyContext = { user: { onboarding: null, isGhost: false }, network: { permissions: [] }, hasActivePremise: true };
 
     const decision = await callGate({ userId: 'u1', networkId: 'n1' });
 
@@ -86,29 +76,29 @@ describe('EnrichmentQueue.resolvePrivacyDecision — enrichment signal (WS10)', 
     // ensure_profile_hyde short-circuits once the user has been enriched.
     expect(decision.reason).toBe('existing_profile_no_public_enrichment_needed');
     expect(decision.allowed).toBe(true);
-    // The gate keys enrichment-existence on `premises` (user_profiles was dropped in WS8).
-    expect(fromTables).toContain(premises);
+    // The gate delegates the (user, network) reads to the adapter.
+    expect(privacyContextCalls).toContainEqual(['u1', 'n1']);
   });
 
   it('treats a user with no ACTIVE premises as not-yet-enriched', async () => {
-    fromTables.length = 0;
-    premiseRows = [];
+    privacyContextCalls.length = 0;
+    privacyContext = { user: { onboarding: null, isGhost: false }, network: { permissions: [] }, hasActivePremise: false };
 
     const decision = await callGate({ userId: 'u2', networkId: 'n1' });
 
     expect(decision.hasExistingProfile).toBe(false);
     // Not short-circuited; falls through to the policy decision.
     expect(decision.reason).not.toBe('existing_profile_no_public_enrichment_needed');
-    expect(fromTables).toContain(premises);
+    expect(privacyContextCalls).toContainEqual(['u2', 'n1']);
   });
 
-  it('short-circuits before any DB read when the job has no network', async () => {
-    fromTables.length = 0;
-    premiseRows = [{ id: 'premise-1' }];
+  it('short-circuits before any adapter read when the job has no network', async () => {
+    privacyContextCalls.length = 0;
+    privacyContext = { user: { onboarding: null, isGhost: false }, network: { permissions: [] }, hasActivePremise: true };
 
     const decision = await callGate({ userId: 'u3' });
 
     expect(decision.reason).toBe('no_network_policy');
-    expect(fromTables).toHaveLength(0);
+    expect(privacyContextCalls).toHaveLength(0);
   });
 });

--- a/backend/src/queues/tests/expiration.queue.spec.ts
+++ b/backend/src/queues/tests/expiration.queue.spec.ts
@@ -1,5 +1,6 @@
 /**
- * Unit tests for OpportunityExpirationCron. node-cron and drizzle are mocked so no DB/Redis needed.
+ * Unit tests for OpportunityExpirationCron. node-cron is mocked and the persistence
+ * sweep is injected via deps, so no DB/Redis/drizzle is touched.
  */
 import { config } from 'dotenv';
 config({ path: '.env.test', override: true });
@@ -22,41 +23,18 @@ mock.module('node-cron', () => ({
   },
 }));
 
-// ---------------------------------------------------------------------------
-// drizzle mock — exposes a chainable stub whose terminal .returning() resolves
-// to a controlled array of rows.
-// ---------------------------------------------------------------------------
-let mockReturningRows: Array<{ id: string }> = [];
-
-const mockReturning = mock(async () => mockReturningRows);
-const mockWhere = mock(() => ({ returning: mockReturning }));
-const mockSet = mock(() => ({ where: mockWhere }));
-const mockUpdate = mock(() => ({ set: mockSet }));
-
-mock.module('../../lib/drizzle/drizzle', () => ({
-  default: { update: mockUpdate },
-}));
-
-// drizzle-orm helpers are used for building the where-clause; mock them as
-// identity functions so the real import doesn't attempt a DB connection.
-mock.module('drizzle-orm', () => ({
-  and: (...args: unknown[]) => ({ _type: 'and', args }),
-  isNotNull: (col: unknown) => ({ _type: 'isNotNull', col }),
-  lte: (col: unknown, val: unknown) => ({ _type: 'lte', col, val }),
-  notInArray: (col: unknown, vals: unknown) => ({ _type: 'notInArray', col, vals }),
-}));
-
 afterAll(() => {
   mock.restore();
 });
 
 import { OpportunityExpirationCron } from '../opportunity/expiration.queue';
+import type { OpportunityExpirationDeps } from '../opportunity/expiration.queue';
 
 // ---------------------------------------------------------------------------
-// helpers
+// helpers — an injectable stub for the persistence sweep
 // ---------------------------------------------------------------------------
-const makeRows = (n: number): Array<{ id: string }> =>
-  Array.from({ length: n }, (_, i) => ({ id: `opp-${i + 1}` }));
+const mockExpire = mock(async () => 0);
+const deps: OpportunityExpirationDeps = { expireStaleOpportunities: mockExpire };
 
 // ---------------------------------------------------------------------------
 // tests
@@ -66,89 +44,68 @@ describe('OpportunityExpirationCron', () => {
     cronCallbacks.length = 0;
     mockCronSchedule.mockClear();
     mockCronStop.mockClear();
-    mockUpdate.mockClear();
-    mockSet.mockClear();
-    mockWhere.mockClear();
-    mockReturning.mockClear();
-    mockReturningRows = [];
+    mockExpire.mockClear();
+    mockExpire.mockImplementation(async () => 0);
   });
 
   describe('expireStale', () => {
-    it('returns 0 when no rows are updated', async () => {
-      mockReturningRows = [];
-      const cron = new OpportunityExpirationCron();
+    it('returns 0 when the adapter reports no rows updated', async () => {
+      mockExpire.mockImplementation(async () => 0);
+      const cron = new OpportunityExpirationCron(deps);
       const count = await cron.expireStale();
       expect(count).toBe(0);
     });
 
-    it('returns the count of updated rows', async () => {
-      mockReturningRows = makeRows(3);
-      const cron = new OpportunityExpirationCron();
+    it('returns the count the adapter reports', async () => {
+      mockExpire.mockImplementation(async () => 3);
+      const cron = new OpportunityExpirationCron(deps);
       const count = await cron.expireStale();
       expect(count).toBe(3);
     });
 
-    it('calls db.update on the opportunities table and sets status to expired', async () => {
-      mockReturningRows = makeRows(1);
-      const cron = new OpportunityExpirationCron();
+    it('delegates to deps.expireStaleOpportunities exactly once', async () => {
+      const cron = new OpportunityExpirationCron(deps);
       await cron.expireStale();
-      expect(mockUpdate).toHaveBeenCalledTimes(1);
-      // set() receives an object with status:'expired' and updatedAt
-      const setArg = mockSet.mock.calls[0]?.[0] as { status: string; updatedAt: Date } | undefined;
-      expect(setArg?.status).toBe('expired');
-      expect(setArg?.updatedAt).toBeInstanceOf(Date);
-    });
-
-    it('passes a compound where-clause (isNotNull + lte + notInArray)', async () => {
-      mockReturningRows = [];
-      const cron = new OpportunityExpirationCron();
-      await cron.expireStale();
-      // where() is called exactly once with the composed predicate
-      expect(mockWhere).toHaveBeenCalledTimes(1);
-      const whereArg = mockWhere.mock.calls[0]?.[0] as { _type: string; args: unknown[] } | undefined;
-      // The top-level combinator is 'and'
-      expect(whereArg?._type).toBe('and');
+      expect(mockExpire).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('start', () => {
     it('is idempotent: calling start twice schedules only one cron task', () => {
-      const cron = new OpportunityExpirationCron();
+      const cron = new OpportunityExpirationCron(deps);
       cron.start();
       cron.start();
       expect(mockCronSchedule).toHaveBeenCalledTimes(1);
     });
 
     it('schedules cron with a 15-minute expression', () => {
-      const cron = new OpportunityExpirationCron();
+      const cron = new OpportunityExpirationCron(deps);
       cron.start();
       const expr = mockCronSchedule.mock.calls[0]?.[0] as string | undefined;
       expect(expr).toBe('*/15 * * * *');
     });
 
     it('cron callback does not throw when expireStale resolves', async () => {
-      mockReturningRows = makeRows(2);
+      mockExpire.mockImplementation(async () => 2);
       cronCallbacks.length = 0;
-      const cron = new OpportunityExpirationCron();
+      const cron = new OpportunityExpirationCron(deps);
       cron.start();
       expect(cronCallbacks.length).toBe(1);
       // The cron callback is fire-and-forget (.then().catch()); it returns void synchronously.
-      // We just verify it does not throw and that expireStale was eventually called.
       cronCallbacks[0]();
       // Give microtasks a chance to flush
       await new Promise((r) => setTimeout(r, 10));
-      expect(mockUpdate).toHaveBeenCalled();
+      expect(mockExpire).toHaveBeenCalled();
     });
 
     it('cron callback catches and does not rethrow when expireStale rejects', async () => {
-      mockReturning.mockImplementationOnce(async () => {
+      mockExpire.mockImplementationOnce(async () => {
         throw new Error('db down');
       });
       cronCallbacks.length = 0;
-      const cron = new OpportunityExpirationCron();
+      const cron = new OpportunityExpirationCron(deps);
       cron.start();
       // The catch handler should swallow the error — no unhandled rejection
-      // The callback itself returns void (fire-and-forget), so we call it and wait for microtasks.
       cronCallbacks[0]();
       await new Promise((r) => setTimeout(r, 10));
       // If we reach here without an unhandled rejection, the test passes
@@ -157,14 +114,14 @@ describe('OpportunityExpirationCron', () => {
 
   describe('stop', () => {
     it('calls task.stop() and clears the internal task reference', () => {
-      const cron = new OpportunityExpirationCron();
+      const cron = new OpportunityExpirationCron(deps);
       cron.start();
       cron.stop();
       expect(mockCronStop).toHaveBeenCalledTimes(1);
     });
 
     it('stop() after stop() is a no-op (does not double-stop)', () => {
-      const cron = new OpportunityExpirationCron();
+      const cron = new OpportunityExpirationCron(deps);
       cron.start();
       cron.stop();
       cron.stop();
@@ -172,12 +129,20 @@ describe('OpportunityExpirationCron', () => {
     });
 
     it('start() after stop() re-registers a new cron task', () => {
-      const cron = new OpportunityExpirationCron();
+      const cron = new OpportunityExpirationCron(deps);
       cron.start();
       cron.stop();
       mockCronSchedule.mockClear();
       cron.start();
       expect(mockCronSchedule).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('default construction', () => {
+    it('constructs without deps (wires the real OpportunityDatabaseAdapter)', () => {
+      // Smoke: no-arg construction must not throw; the adapter is lazily used only on expireStale().
+      const cron = new OpportunityExpirationCron();
+      expect(cron).toBeInstanceOf(OpportunityExpirationCron);
     });
   });
 });

--- a/backend/src/queues/usercontext.queue.ts
+++ b/backend/src/queues/usercontext.queue.ts
@@ -1,5 +1,4 @@
 import { Job } from 'bullmq';
-import { and, eq, isNull } from 'drizzle-orm';
 
 import { UserContextGenerator, HydeGraphFactory, HydeGenerator, LensInferrer } from '@indexnetwork/protocol';
 import type { HydeGraphDatabase } from '@indexnetwork/protocol';
@@ -7,8 +6,6 @@ import type { HydeGraphDatabase } from '@indexnetwork/protocol';
 import { log } from '../lib/log';
 import { computePremiseHash, type ContextPremise } from '../lib/usercontext/premise-hash';
 import { QueueFactory } from '../lib/bullmq/bullmq';
-import db from '../lib/drizzle/drizzle';
-import { networkMembers, networks } from '../schemas/database.schema';
 import { chatDatabaseAdapter } from '../adapters/database.adapter';
 import { embedderAdapter } from '../adapters/embedder.adapter';
 import { RedisCacheAdapter } from '../adapters/cache.adapter';
@@ -254,17 +251,7 @@ export class UserContextQueue {
 
   /** All non-personal network IDs the user is a member of. */
   private async defaultGetUserNetworkIds(userId: string): Promise<string[]> {
-    const rows = await db
-      .select({ networkId: networkMembers.networkId })
-      .from(networkMembers)
-      .innerJoin(networks, eq(networkMembers.networkId, networks.id))
-      .where(and(
-        eq(networkMembers.userId, userId),
-        isNull(networkMembers.deletedAt),
-        isNull(networks.deletedAt),
-        eq(networks.isPersonal, false),
-      ));
-    return rows.map((r) => r.networkId);
+    return chatDatabaseAdapter.getNonPersonalNetworkIds(userId);
   }
 
   /** The user's ACTIVE premises, narrowed to the fields contexts need. */


### PR DESCRIPTION
## Summary

Follow-up to #1035 (the deferred T4 item). The three queue files that still reached for `db` + canonical schema tables directly now go through the `*.database.adapter` boundary, per the queues guidance: *"direct Drizzle/schema imports are legacy and should not be copied."* Every moved query is **identical SQL** — behavior-preserving.

## Refactors
- **`opportunity/expiration.queue.ts`** — `expireStale` delegates to the existing `OpportunityDatabaseAdapter.expireStaleOpportunities()` (the queue's copy was byte-for-byte identical). The cron gains an injectable `OpportunityExpirationDeps` seam. **`cli/expire-opportunities.ts`** — a *third* copy of the same query — now calls the same adapter method. Net: 3 duplicates → 1 canonical.
- **`usercontext.queue.ts`** — `defaultGetUserNetworkIds` delegates to new `ChatDatabaseAdapter.getNonPersonalNetworkIds()` (no new imports; the adapter already owns the networks/members tables).
- **`enrichment.queue.ts`** — `resolvePrivacyDecision`'s three parallel reads move into new `EnrichmentDatabaseAdapter.getEnrichmentPrivacyContext()`. The queue drops its `db` + `{networks, premises, users}` value imports, keeping only a type-only `ProfileEnrichmentPolicy` import.

## Tests
- `expiration.queue.spec` rewritten to mock the injected adapter seam (it previously asserted drizzle chain internals).
- `enrichment-privacy-gate.spec` rewritten to stub the adapter method and assert the **gate decision logic**.
- The WS10/IND-367 regression guard ("reads `premises`, not `user_profiles`") relocates to a new **`enrichment.database.adapter.privacy.spec`** at the layer where those reads now live (registered in `.test-isolated`).
- All three migrated queries verified **live against the dev schema** (`.env.test`).

## Verification
- `bun run build` (protocol + `tsc`) — 0 errors
- ESLint on all changed files — clean
- 41 tests across the 6 affected specs — all green (run individually per `.test-isolated`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1037"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784648243&installation_id=140549914&pr_number=1037&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1037&signature=4b2ba6a410283d4b211955b9242518adee2b1a41323a5e82f780c339c9a7d1c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->