### PR TITLE
docs(protocol): public-contract docs + explicit exports (v4.3.0)

### DIFF
--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -1,0 +1,91 @@
+# Changelog
+
+All notable changes to `@indexnetwork/protocol` are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
+
+> History before `2.0.0` was reconstructed from git and is summarized rather than
+> itemized. From `2.0.0` onward, keep this file updated as part of every release
+> (bump `package.json` and the `[Unreleased]` section before promoting to `main`).
+
+## [Unreleased]
+
+### Added
+- `STABILITY.md` defining the public contract, stability tiers (Stable vs
+  `@experimental`), SemVer policy, and the deprecation path.
+- Port-contract doc-comments on the `ChatSessionReader`, `DiscoveryRunStore`/
+  `DiscoveryRunQueue`, `EnrichmentRunStore`/`EnrichmentRunQueue`, and `Embedder`
+  interfaces (ownership scoping, null-vs-empty-array, lifecycle idempotency).
+- Tier annotations and an entry-point header in `src/index.ts`.
+
+### Changed
+- Replaced all `export type *` wildcard re-exports in `src/index.ts` with explicit
+  named exports so the public surface is fully enumerated and reviewable. No
+  symbols added or removed — the exported surface is unchanged.
+- Expanded `README.md` to document the full public surface (graph factories,
+  agents, MCP, tools) and link the stability policy.
+
+## [4.2.0] - 2026-06-19
+
+### Added
+- Opportunity legibility: cards explain *why* an opportunity surfaced.
+- Negotiation trace links on surfaced opportunities.
+
+## [4.1.0] - 2026-06
+
+### Added
+- Canonical user-context / enrichment MCP tools; `discoverySource` rename
+  (IND-372, IND-371, IND-374).
+- Context-derived `read_user_profiles` payload (IND-364).
+
+### Changed
+- Category A prompt consumers repointed at the global `user_context` (IND-361).
+- Premise pipeline ownership: dedup, LLM validity, richer provenance (IND-359).
+
+## [4.0.0] - 2026-06-18
+
+### Changed
+- **BREAKING:** Eliminated the "profile" concept — the pipeline, files, service,
+  controller, adapter, and exported types were renamed to `enrichment`
+  (`ProfileDocument` → `UserIdentity`, `read_user_profiles` returns a flat
+  identity+context payload, questioner `profile` mode → `enrichment`). Update any
+  imports of the removed `Profile*` exports. (IND-368)
+
+### Removed
+- **BREAKING:** `user_profiles` table and the profile generate/aggregate/save path
+  retired (IND-365).
+
+## [3.6.0] - 2026-06-12
+
+### Added
+- `read_pending_questions` MCP tool, registered in the tool registry.
+
+## [2.0.1] - 2026-06
+
+### Fixed
+- Post-`2.0.0` fixes and stabilization.
+
+## [2.0.0] - 2026-06-08
+
+### Changed
+- **BREAKING:** Removed `configureProtocol` startup call — model configuration is
+  read from the environment and `ModelConfig` is injected per-request via
+  `ToolContext`. See README for migration.
+
+## [1.0.0 - 1.23.3] - 2026-04 to 2026-06
+
+Pre-2.0 line: established the adapter-injected LangGraph architecture (chat,
+intent, opportunity, negotiation, premise, enrichment domains), the MCP server,
+the matching/opportunity/premise eval harnesses, premise source tracking and
+cascade retraction, network-scoped agents, and the agent registry. Reconstructed
+from git history; not itemized.
+
+[Unreleased]: https://github.com/indexnetwork/protocol/compare/v4.2.0...HEAD
+[4.2.0]: https://github.com/indexnetwork/protocol/compare/v4.1.0...v4.2.0
+[4.1.0]: https://github.com/indexnetwork/protocol/compare/v4.0.0...v4.1.0
+[4.0.0]: https://github.com/indexnetwork/protocol/compare/v3.6.0...v4.0.0
+[3.6.0]: https://github.com/indexnetwork/protocol/compare/v2.0.1...v3.6.0
+[2.0.1]: https://github.com/indexnetwork/protocol/compare/v2.0.0...v2.0.1
+[2.0.0]: https://github.com/indexnetwork/protocol/releases/tag/v2.0.0

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -12,6 +12,8 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
 
 ## [Unreleased]
 
+## [4.3.0] - 2026-06-21
+
 ### Added
 - `STABILITY.md` defining the public contract, stability tiers (Stable vs
   `@experimental`), SemVer policy, and the deprecation path.
@@ -82,7 +84,8 @@ the matching/opportunity/premise eval harnesses, premise source tracking and
 cascade retraction, network-scoped agents, and the agent registry. Reconstructed
 from git history; not itemized.
 
-[Unreleased]: https://github.com/indexnetwork/protocol/compare/v4.2.0...HEAD
+[Unreleased]: https://github.com/indexnetwork/protocol/compare/v4.3.0...HEAD
+[4.3.0]: https://github.com/indexnetwork/protocol/compare/v4.2.0...v4.3.0
 [4.2.0]: https://github.com/indexnetwork/protocol/compare/v4.1.0...v4.2.0
 [4.1.0]: https://github.com/indexnetwork/protocol/compare/v4.0.0...v4.1.0
 [4.0.0]: https://github.com/indexnetwork/protocol/compare/v3.6.0...v4.0.0

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -2,6 +2,21 @@
 
 The agent orchestration layer for Index Network. Implements LangGraph-based workflows for intent processing, opportunity discovery, and chat — decoupled from any specific infrastructure via adapter injection.
 
+## Stability & versioning
+
+This package follows [Semantic Versioning](https://semver.org/). The **only**
+supported entry point is the package root (`import { ... } from "@indexnetwork/protocol"`);
+deep imports are not part of the contract. Every symbol is re-exported explicitly from
+`src/index.ts` and tagged with a stability tier:
+
+- **Stable** — interfaces, graph factories, agents, `createChatTools`, the
+  tool/runtime helpers, and shared schemas. Breaking changes require a major bump.
+- **Experimental** (`@experimental`) — advanced graph-state types and internal
+  helpers; may change in a minor release.
+
+See [STABILITY.md](./STABILITY.md) for the full policy and the deprecation path,
+and [CHANGELOG.md](./CHANGELOG.md) for release history.
+
 ## Install
 
 ```bash
@@ -59,7 +74,7 @@ The package defines interfaces — your application provides the concrete implem
 | `McpAuthResolver` | Resolves `{ userId, agentId }` from an incoming MCP HTTP request (MCP server only) |
 | `DeliveryLedger` | Commits OpenClaw opportunity-delivery rows |
 | `DiscoveryRunStore` / `DiscoveryRunQueue` | Persist and execute async MCP discovery runs |
-| `ProfileRunStore` / `ProfileRunQueue` | Persist and execute async MCP profile builds |
+| `EnrichmentRunStore` / `EnrichmentRunQueue` | Persist and execute async MCP enrichment runs |
 | `MintConnectLink` | Mints short connect links for opportunity accepts |
 | `ChatSummaryReader` | Read-through chat-session digest |
 | `ChatMessageWriter` | Writes user messages into the most-recent chat session (MCP elicitation) |
@@ -102,8 +117,8 @@ const tools = await createChatTools({
   agentDatabase,        // AgentDatabase — agent registry
   agentDispatcher,      // AgentDispatcher — routes negotiation turns to personal agents
   deliveryLedger,       // DeliveryLedger — OpenClaw delivery commits
-  discoveryRuns,        // DiscoveryRunStore + discoveryRunQueue — async MCP discovery
-  profileRuns,          // ProfileRunStore + profileRunQueue — async MCP profile builds
+  discoveryRuns,        // DiscoveryRunStore (+ discoveryRunQueue) — async MCP discovery
+  enrichmentRuns,       // EnrichmentRunStore (+ enrichmentRunQueue) — async MCP enrichment runs
   mintConnectLink,      // short connect links for opportunity accepts
   modelConfig,          // override chat model / reasoning effort (see above)
 });
@@ -126,7 +141,7 @@ import {
   ChatGraphFactory,
   IntentGraphFactory,
   OpportunityGraphFactory,
-  ProfileGraphFactory,
+  EnrichmentGraphFactory,
   PremiseGraphFactory,
   NegotiationGraphFactory,
   HydeGraphFactory,
@@ -146,7 +161,7 @@ Each factory takes its typed dependencies in the constructor and exposes a
 | `ChatGraphFactory` | ReAct chat loop — LLM calls tools, responds to the user |
 | `IntentGraphFactory` | Clarify, infer, verify felicity, reconcile, and persist intents |
 | `OpportunityGraphFactory` | HyDE-based discovery: search, evaluate (valency), rank, persist |
-| `ProfileGraphFactory` | Generate/update user profiles with scraping and embedding |
+| `EnrichmentGraphFactory` | Enrich users (scrape + embed) and decompose into premises |
 | `PremiseGraphFactory` | Decompose and index a user's premises |
 | `NegotiationGraphFactory` | Multi-turn bilateral negotiation flows |
 | `HydeGraphFactory` | Generate hypothetical documents and embed them (cache-aware) |

--- a/packages/protocol/STABILITY.md
+++ b/packages/protocol/STABILITY.md
@@ -1,0 +1,92 @@
+# Stability & Versioning Policy
+
+`@indexnetwork/protocol` is a published, versioned package consumed by the Index
+Network backend and by external integrators. This document defines what the
+public contract **is**, which parts are stable, and what counts as a breaking
+change. It is the reference behind the tier annotations in `src/index.ts`.
+
+## The public contract
+
+- The **only** supported entry point is the package root:
+  `import { ... } from "@indexnetwork/protocol"`.
+- Deep imports (`@indexnetwork/protocol/dist/...` or `/src/...`) are **not** part
+  of the contract and may change or disappear in any release — do not rely on them.
+- The contract is exactly the set of symbols re-exported from `src/index.ts`.
+  Exports are listed explicitly (no `export *` wildcards), so the surface is
+  reviewable and additions are always intentional.
+
+## Stability tiers
+
+Each section of the barrel carries one of two tiers.
+
+### Stable
+
+Covered by SemVer below. Breaking changes require a **major** bump.
+
+| Barrel section | What it is |
+|---|---|
+| **Public API** | `createChatTools`, model config helpers, tool/runtime helpers (`ToolContext`, `ToolDeps`, `invokeToolRuntime`, …), `requestContext`. |
+| **Interfaces** | Every `*.interface.ts` port you implement to inject infrastructure (databases, embedder, cache, scraper, queues, integration, agent dispatcher, …). |
+| **Shared schemas** | Zod schemas + inferred types that cross the boundary (questions, identity, network-assignment, chat-context, …). |
+| **Graph factories** | `*GraphFactory` classes (`ChatGraphFactory`, `OpportunityGraphFactory`, `NegotiationGraphFactory`, …). |
+| **Agents** | Structured LLM agents (`UserContextGenerator`, `IndexNegotiator`, `OpportunityEvaluator`, …). |
+| **MCP** | `createMcpServer` and its supporting types. |
+
+### Experimental
+
+Marked `@experimental` in `src/index.ts`. May change in a **minor** release without
+a major bump. Use at your own risk and pin a version if you depend on them.
+
+| Area | What it is |
+|---|---|
+| **States** | Advanced graph-state shapes (`UserNegotiationContext`, `NegotiationTurn`, `NegotiationGraphLike`, …) exposed for advanced graph consumers. |
+| **Internal helpers** | Low-level support utilities re-exported for the backend's own use (selection/eval/evidence helpers) that are not part of the recommended integration surface. |
+
+> Most symbols in the barrel are consumed by the Index Network backend itself; a
+> symbol being absent from the backend's imports does **not** make it dead — it may
+> serve external integrators. Removal therefore follows the deprecation path below,
+> never an ad-hoc delete.
+
+## SemVer policy
+
+This package follows [Semantic Versioning 2.0.0](https://semver.org/).
+
+**MAJOR** — incompatible changes to the Stable surface:
+- Removing or renaming a stable export.
+- Adding a required method/field to an implemented interface, or tightening a
+  return type (e.g. `T | null` → `T` is fine; `T` → `T | null` is breaking).
+- Changing the runtime behavior a documented port contract guarantees
+  (ownership scoping, null-vs-throw semantics, lifecycle idempotency).
+
+**MINOR** — backward-compatible additions:
+- New exports; new **optional** interface members; new graph factories/agents.
+- Any change to an `@experimental` symbol.
+
+**PATCH** — backward-compatible fixes:
+- Bug fixes, performance, prompt/model tuning, doc and type-comment changes that
+  do not alter the contract.
+
+### Port-contract semantics count
+
+Interface ports document invariants in their TSDoc/banner comments — ownership
+scoping (return `null` for missing **or** non-owned rows), null-vs-empty-array
+conventions, and lifecycle idempotency (`mark*` transitions are no-ops once
+terminal). These guarantees are part of the Stable contract: breaking them is a
+**major** change even if the TypeScript signature is unchanged.
+
+## Deprecation path
+
+1. Mark the symbol `@deprecated` in TSDoc with the replacement and target removal version.
+2. Note it under `### Deprecated` in `CHANGELOG.md`.
+3. Keep it working for at least one minor release.
+4. Remove only in a subsequent **major** release.
+
+## Release & publish
+
+- Pushes to `dev` publish an `-rc.<n>` prerelease under the npm `rc` tag.
+- Pushes to `main` publish the stable version under `latest` when the
+  `package.json` version is new (already-published versions are skipped).
+- Bump `package.json` and update `CHANGELOG.md` **before** promoting to `main`.
+
+See `.github/workflows/publish.yml` for the automation and `CHANGELOG.md` for the
+release history.

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1,3 +1,18 @@
+// =============================================================================
+// @indexnetwork/protocol — public API barrel
+//
+// This file is the ONLY supported entry point. Deep imports
+// ("@indexnetwork/protocol/src/...") are not part of the contract and may break
+// in any release. Every symbol is re-exported explicitly (no wildcards) so the
+// surface is reviewable and changes are intentional.
+//
+// Stability tiers are defined in STABILITY.md. In short:
+//   • Stable       — Interfaces, Graph factories, Agents, createChatTools,
+//                    the tool/runtime helpers, and shared schemas.
+//   • Experimental — Sections marked @experimental below (advanced graph state
+//                    types and internal helpers); may change in a minor release.
+// =============================================================================
+
 // ─── Public API (recommended for external consumers) ──────────────────────────
 
 export { createChatTools } from "./shared/agent/tool.factory.js";
@@ -13,9 +28,9 @@ export type { ToolRuntimeErrorCode, ToolTimeoutClass, ToolTimeoutPolicy } from "
 
 // ─── Interfaces (implement these to wire up your infrastructure) ───────────────
 
-export type * from "./shared/interfaces/auth.interface.js";
-export type * from "./shared/interfaces/cache.interface.js";
-export type * from "./shared/interfaces/chat-session.interface.js";
+export type { McpAuthResolver } from "./shared/interfaces/auth.interface.js";
+export type { Cache, CacheOptions, HydeCache, OpportunityCache } from "./shared/interfaces/cache.interface.js";
+export type { ChatSessionReader, ChatSessionDetail, ChatSessionSummary } from "./shared/interfaces/chat-session.interface.js";
 export type { ChatSummaryReader } from "./shared/interfaces/chat-summary.interface.js";
 export type { ChatMessageWriter } from "./shared/interfaces/chat-message-writer.interface.js";
 export type { QuestionGeneratorReader } from "./shared/interfaces/question-generator.interface.js";
@@ -23,19 +38,44 @@ export type { QuestionerDatabase, PersistableQuestion, PersistedQuestion, Questi
 export type { NegotiationSummaryReader } from "./shared/interfaces/negotiation-summary.interface.js";
 export type { DiscoveryNegotiationDigest } from "./shared/schemas/negotiation-digest.schema.js";
 export { NegotiationSummarizer, buildFallbackDigest } from "./negotiation/negotiation.summarizer.js";
-export type * from "./shared/interfaces/contact.interface.js";
-export type * from "./shared/interfaces/database.interface.js";
-export type * from "./shared/interfaces/embedder.interface.js";
-export type * from "./shared/interfaces/enrichment.interface.js";
-export type * from "./shared/interfaces/integration.interface.js";
-export type * from "./shared/interfaces/queue.interface.js";
-export type * from "./shared/interfaces/scraper.interface.js";
-export type * from "./shared/interfaces/storage.interface.js";
-export type * from "./shared/interfaces/delivery-ledger.interface.js";
-export type * from "./shared/interfaces/connect-link.interface.js";
-export type * from "./shared/interfaces/discovery-run.interface.js";
-export type * from "./shared/interfaces/enrichment-run.interface.js";
-export type * from "./shared/interfaces/negotiation-events.interface.js";
+export type { ContactServiceAdapter, ContactEntry, ContactImportResult, ContactInput, ContactResult, ContactSearchResult } from "./shared/interfaces/contact.interface.js";
+export type {
+  ChatGraphCompositeDatabase, UserDatabase, SystemDatabase, Database,
+  OpportunityGraphDatabase, OpportunityControllerDatabase, HomeGraphDatabase,
+  IntentGraphDatabase, IntentNetworkGraphDatabase, NetworkGraphDatabase, NetworkMembershipGraphDatabase,
+  HydeGraphDatabase, EnrichmentGraphDatabase, PremiseGraphDatabase, NegotiationGraphDatabase,
+  NegotiationQueries, NegotiationUserAnswer,
+  Opportunity, OpportunityActor, OpportunityContext, OpportunityDetection, OpportunityInterpretation,
+  OpportunityQueryOptions, OpportunitySignal, OpportunityStatus,
+  ActiveIntent, CreatedIntent, CreateIntentData, UpdateIntentData, IntentRecord, SimilarIntent, SimilarIntentSearchOptions,
+  IndexedIntentDetails, IndexMemberDetails, NetworkAssignmentContext, NetworkMembership, OwnedIndex,
+  CreateHydeDocumentData, HydeDocument, HydeSourceType, CreateOpportunityData,
+  PremiseAnalysis, PremiseAssertion, PremiseProvenance, PremiseRecord, PremiseValidity,
+  OnboardingPrivacyState, OnboardingProfileSeed, OnboardingState, PrivacyConsentDecision, PrivacyConsentSource,
+  UpdateIndexSettingsData, UserRecord, UserSocial, ArchiveResult, Id,
+} from "./shared/interfaces/database.interface.js";
+export type {
+  Embedder, EmbeddingGenerator, EmbeddingGenerateOptions,
+  VectorStore, VectorStoreOption, VectorSearchResult,
+  HydeCandidate, HydeSearchOptions, LensEmbedding,
+} from "./shared/interfaces/embedder.interface.js";
+export type { ProfileEnricher, EnrichmentRequest, EnrichmentResult } from "./shared/interfaces/enrichment.interface.js";
+export type { IntegrationAdapter, IntegrationConnection, IntegrationSession, IntegrationSessionOptions, ToolActionResponse } from "./shared/interfaces/integration.interface.js";
+export type { IntentGraphQueue } from "./shared/interfaces/queue.interface.js";
+export type { Scraper, ExtractUrlContentOptions } from "./shared/interfaces/scraper.interface.js";
+export type { Storage } from "./shared/interfaces/storage.interface.js";
+export type { DeliveryLedger, DeliveredOpportunityRow } from "./shared/interfaces/delivery-ledger.interface.js";
+export type { MintConnectLink, ConnectLinkKind } from "./shared/interfaces/connect-link.interface.js";
+export type {
+  DiscoveryRunStore, DiscoveryRunQueue, DiscoveryRunInput, CreateDiscoveryRunInput,
+  DiscoveryRunRecord, DiscoveryRunStatus,
+} from "./shared/interfaces/discovery-run.interface.js";
+export type {
+  EnrichmentRunStore, EnrichmentRunQueue, EnrichmentRunInput, CreateEnrichmentRunInput,
+  UpdateUserEnrichmentRunInput, PreviewUserEnrichmentRunInput,
+  EnrichmentRunRecord, EnrichmentRunStatus, EnrichmentRunOperation,
+} from "./shared/interfaces/enrichment-run.interface.js";
+export type { NegotiationTimeoutQueue } from "./shared/interfaces/negotiation-events.interface.js";
 export type { AgentDispatcher, AgentDispatchResult, NegotiationTurnPayload } from "./shared/interfaces/agent-dispatcher.interface.js";
 export type { AgentRecord, AgentTransportRecord, AgentPermissionRecord, AgentWithRelations, CreateAgentInput, CreateTransportInput, GrantPermissionInput, AgentDatabase } from './shared/interfaces/agent.interface.js';
 export { SYSTEM_AGENT_IDS } from './shared/interfaces/agent.interface.js';
@@ -143,6 +183,7 @@ export { dispatchElicitations } from "./mcp/elicitation.dispatcher.js";
 export type { ElicitResultLike, ElicitInputFn, DispatchElicitationsParams } from "./mcp/elicitation.dispatcher.js";
 
 // ─── States (for advanced graph consumers) ────────────────────────────────────
+// @experimental — internal graph-state shapes; may change in a minor release.
 
 export type { UserNegotiationContext, NegotiationTurn, NegotiationOutcome, SeedAssessment } from "./shared/schemas/negotiation-state.schema.js";
 export type { NegotiationGraphLike } from "./negotiation/negotiation.state.js";

--- a/packages/protocol/src/shared/interfaces/chat-session.interface.ts
+++ b/packages/protocol/src/shared/interfaces/chat-session.interface.ts
@@ -1,3 +1,17 @@
+// ═══════════════════════════════════════════════════════════════════════════════
+// Chat session reads
+//
+// Port contract (host application implements):
+//   • Reads only — no method here mutates state.
+//   • `getSession` returns `null` when the session does not exist OR is not owned
+//     by `userId` (ownership is enforced at this boundary, not by the caller).
+//   • `getSessionMessages` / `listSessions` return an empty array (never null) when
+//     there is nothing to return.
+//   • `limit` / `messageLimit`, when provided, cap the most-recent N rows; when
+//     omitted the adapter applies its own sane default.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/** One conversation, summarized (no message bodies). */
 export interface ChatSessionSummary {
   sessionId: string;
   title: string | null;

--- a/packages/protocol/src/shared/interfaces/discovery-run.interface.ts
+++ b/packages/protocol/src/shared/interfaces/discovery-run.interface.ts
@@ -1,5 +1,23 @@
 import type { ResolvedToolContext } from "../agent/tool.helpers.js";
 
+// ═══════════════════════════════════════════════════════════════════════════════
+// Discovery run persistence + queue
+//
+// Models an async `discover_opportunities` job as a durable, owner-scoped record.
+//
+// Port contract (host application implements `DiscoveryRunStore` + `DiscoveryRunQueue`):
+//   • Status is a one-way lifecycle: queued → running → (succeeded | failed | cancelled).
+//     The `mark*` transitions must be idempotent — re-applying a terminal state is a no-op.
+//   • Every read is owner-scoped: `get` and `requestCancel` take `userId` and MUST
+//     return `null` when the run is missing or owned by another user (no cross-user reads).
+//   • `isCancelRequested` is polled cooperatively by the running graph; the store sets
+//     the flag via `requestCancel`, the worker observes it and calls `markCancelled`.
+//   • `listActive` returns queued/running runs only (used to coalesce duplicate
+//     discovery requests) — empty array, never null.
+//   • `DiscoveryRunQueue.cancel` returns `true` if a pending job was removed, `false`
+//     if nothing was queued (already running/finished).
+// ═══════════════════════════════════════════════════════════════════════════════
+
 export type DiscoveryRunStatus = "queued" | "running" | "succeeded" | "failed" | "cancelled";
 
 export interface DiscoveryRunInput {

--- a/packages/protocol/src/shared/interfaces/embedder.interface.ts
+++ b/packages/protocol/src/shared/interfaces/embedder.interface.ts
@@ -49,6 +49,19 @@ export interface EmbeddingGenerateOptions {
   signal?: AbortSignal;
 }
 
+// ═══════════════════════════════════════════════════════════════════════════════
+// Embedding generation + vector / HyDE search
+//
+// Port contract (host application implements):
+//   • `generate` is shape-preserving: a `string` input yields one `number[]`; a
+//     `string[]` input yields `number[][]` in the same order. Vectors are
+//     `dimensions`-long (default per the adapter; the schema assumes 2000).
+//   • `search` returns matches sorted by descending `score` (cosine similarity in
+//     [0,1]); it returns an empty array — never null — when nothing clears `minScore`.
+//   • Implementations should be deterministic for a fixed input/model and must not
+//     throw for an empty corpus (return []). Network/model failures may throw.
+// ═══════════════════════════════════════════════════════════════════════════════
+
 export interface EmbeddingGenerator {
   generate(text: string | string[], dimensions?: number, options?: EmbeddingGenerateOptions): Promise<number[] | number[][]>;
 }

--- a/packages/protocol/src/shared/interfaces/enrichment-run.interface.ts
+++ b/packages/protocol/src/shared/interfaces/enrichment-run.interface.ts
@@ -1,5 +1,20 @@
 import type { ResolvedToolContext } from "../agent/tool.helpers.js";
 
+// ═══════════════════════════════════════════════════════════════════════════════
+// Enrichment run persistence + queue
+//
+// Mirrors the discovery-run contract for the enrichment pipeline (profile/context
+// preview + update). See discovery-run.interface.ts for the shared lifecycle rules.
+//
+// Port contract (host application implements `EnrichmentRunStore` + `EnrichmentRunQueue`):
+//   • Status lifecycle queued → running → (succeeded | failed | cancelled); `mark*`
+//     transitions are idempotent.
+//   • `get` / `requestCancel` are owner-scoped and return `null` for missing or
+//     non-owned runs.
+//   • `listActive` returns queued/running runs (empty array, never null).
+//   • Legacy `*_user_profile` operations are read-compat only — never written by new code.
+// ═══════════════════════════════════════════════════════════════════════════════
+
 export type EnrichmentRunStatus = "queued" | "running" | "succeeded" | "failed" | "cancelled";
 // Canonical run operations are the *_user_context names (IND-371). The legacy
 // *_user_profile values are retained so historical run rows persisted before the


### PR DESCRIPTION
Brings `@indexnetwork/protocol` up to published-package quality across documentation, the public contract, and interface specs. **No runtime behavior changes — the exported surface is unchanged** (verified by backend typecheck against the rebuilt barrel).

## Documentation
- **`STABILITY.md`** (new) — defines the public contract (root entry point only, no deep imports), Stable vs `@experimental` tiers mapped to barrel sections, the SemVer policy (including that port-contract semantics like ownership scoping and null-vs-throw are part of the contract), and the deprecation path.
- **`CHANGELOG.md`** (new) — Keep a Changelog format, reconstructed from git history (4.0.0 breaking profile→enrichment rename, 3.6.0, 2.0.0, etc.), with `4.3.0` finalized.
- **`README.md`** — fixed stale post-4.0.0 references that would have caused broken imports (`ProfileGraphFactory`→`EnrichmentGraphFactory`, `ProfileRunStore/Queue`→`EnrichmentRunStore/Queue`, `profileRuns`→`enrichmentRuns`); added a Stability & versioning section.

## Public surface
- **`src/index.ts`** — replaced all 16 `export type *` wildcards (which auto-leaked every type in those interface files) with explicit named exports, so the surface is enumerated and additions are intentional. Added an entry-point header and stability-tier annotations; marked the advanced `States` section `@experimental`.

## Interface contracts
- Added port-contract doc-comments to `ChatSessionReader`, `DiscoveryRunStore/Queue`, `EnrichmentRunStore/Queue`, and `Embedder` — documenting ownership scoping, null-vs-empty-array conventions, and lifecycle idempotency that adapters must honor.

## Verification
- protocol `bun run build` ✓
- backend `tsc --noEmit` against the restructured barrel ✓ (surface unchanged)
- 648 protocol tests pass ✓

## Release
- Bumps `package.json` 4.2.0 → **4.3.0** (minor: additive docs + `@experimental` tagging, no breaking changes).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1039"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784666352&installation_id=140549914&pr_number=1039&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1039&signature=76965cb650508e9931ac86dabbfdee3f837215e9d960e94a51744fa1f2bc1763"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->