### PR TITLE
chore(review): address release #1038 review findings

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,11 @@
-# Run type checks, architectural boundary checks, and adapter naming checks
-# on PRs to dev and on direct pushes to dev.
+# Run type checks, architectural boundary checks, adapter naming checks, and
+# hermetic pinning tests on PRs to dev/main and on direct pushes to dev/main.
 #
 # Enforces protocol layering rules (eslint-plugin-boundaries),
 # adapter naming conventions, and TypeScript compilation.
+#
+# `main` is included so release PRs (dev -> main) get an independent gate of
+# their own rather than riding solely on the per-PR checks that ran into dev.
 #
 # NOTE: Only boundary violations fail the lint check. Pre-existing lint
 # errors (no-explicit-any, no-unused-vars) are not gated here yet.
@@ -11,9 +14,9 @@ name: Lint and typecheck
 
 on:
   pull_request:
-    branches: [dev]
+    branches: [dev, main]
   push:
-    branches: [dev]
+    branches: [dev, main]
 
 concurrency:
   group: lint-${{ github.head_ref || github.ref }}
@@ -78,3 +81,29 @@ jobs:
 
       - name: Type check backend
         run: cd backend && bun run build
+
+  test:
+    # Runs the hermetic pinning/characterization specs that mock all external
+    # systems (Redis/LLM/DB), so they need no services, secrets, or built
+    # protocol dist. Keeps these regression pins gated in CI rather than
+    # depending on local-only manual runs.
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.2.20"
+
+      - name: Install dependencies
+        run: |
+          bun install
+          cd backend && bun install
+
+      - name: Run hermetic pinning tests
+        run: |
+          cd backend
+          bun test \
+            src/adapters/tests/can-actor-see-opportunity.spec.ts \
+            src/queues/tests/timeout.queue.spec.ts \
+            src/queues/tests/claim-timeout.queue.spec.ts

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -87,13 +87,21 @@ jobs:
     # systems (Redis/LLM/DB), so they need no services, secrets, or built
     # protocol dist. Keeps these regression pins gated in CI rather than
     # depending on local-only manual runs.
+    #
+    # NOTE: pinned to a newer Bun than the lint/typecheck jobs (1.2.20). The
+    # specs use a deferred `await import()` of the queue (so a fallback
+    # OPENROUTER_API_KEY is set before the protocol barrel's eager createModel
+    # evaluates); under `bun test` 1.2.20 that dynamic import mis-resolves
+    # drizzle-orm's `export * from "./relations.js"` re-export and fails to find
+    # the `relations` named export. Newer Bun resolves it correctly. The app
+    # runtime is unaffected (it imports the same schema fine).
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.2.20"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: |

--- a/backend/src/queues/opportunity/discovery.shared.ts
+++ b/backend/src/queues/opportunity/discovery.shared.ts
@@ -62,14 +62,20 @@ export async function runOpportunityDiscovery<TOpts extends OpportunityInvokeOpt
   deps?: OpportunityDiscoveryDeps & { invokeOpportunityGraph?: (opts: TOpts) => Promise<void> };
   invokeOpts: TOpts;
   logger: DiscoveryLogger;
-  /** Human label for log lines + the thrown error, e.g. `'FromIntent'` / `'from-intent'`. */
+  /** Human label for log-line prefixes, e.g. `'FromIntent'`. */
   label: string;
+  /**
+   * Label for the thrown fallback error message, e.g. `'from-intent'`. Kept
+   * distinct from `label` so the thrown message stays lowercase-dashed (matching
+   * the pre-split queues) while log prefixes stay PascalCase. Defaults to `label`.
+   */
+  errorLabel?: string;
   /** Identifier fields merged into every log line (e.g. `{ intentId, userId }`). */
   logContext: Record<string, unknown>;
   /** Whether to emit the verbose graph-trace line (from-enrichment opts out). Defaults to true. */
   logTrace?: boolean;
 }): Promise<void> {
-  const { graphDb, deps, invokeOpts, logger, label, logContext, logTrace = true } = params;
+  const { graphDb, deps, invokeOpts, logger, label, errorLabel = label, logContext, logTrace = true } = params;
 
   if (deps?.invokeOpportunityGraph) {
     await deps.invokeOpportunityGraph(invokeOpts);
@@ -80,7 +86,7 @@ export async function runOpportunityDiscovery<TOpts extends OpportunityInvokeOpt
   const result = await opportunityGraph.invoke(invokeOpts);
   if (result.error) {
     logger.error(`[${label}] Graph failed`, { ...logContext, error: result.error });
-    throw new Error(typeof result.error === 'string' ? result.error : `${label} graph failed`);
+    throw new Error(typeof result.error === 'string' ? result.error : `${errorLabel} graph failed`);
   }
 
   const candidates = Array.isArray(result.candidates) ? result.candidates : [];

--- a/backend/src/queues/opportunity/from-enrichment.queue.ts
+++ b/backend/src/queues/opportunity/from-enrichment.queue.ts
@@ -98,6 +98,7 @@ export class FromEnrichmentQueue {
       invokeOpts,
       logger: this.logger,
       label: 'FromEnrichment',
+      errorLabel: 'from-enrichment',
       logContext: { userId, networkId },
       logTrace: false,
     });

--- a/backend/src/queues/opportunity/from-intent.queue.ts
+++ b/backend/src/queues/opportunity/from-intent.queue.ts
@@ -110,6 +110,7 @@ export class FromIntentQueue {
       invokeOpts,
       logger: this.logger,
       label: 'FromIntent',
+      errorLabel: 'from-intent',
       logContext: { intentId, userId },
     });
   }

--- a/backend/src/queues/opportunity/from-introducer.queue.ts
+++ b/backend/src/queues/opportunity/from-introducer.queue.ts
@@ -110,6 +110,7 @@ export class FromIntroducerQueue {
       invokeOpts,
       logger: this.logger,
       label: 'FromIntroducer',
+      errorLabel: 'from-introducer',
       logContext: { userId, contactUserId },
     });
   }

--- a/backend/src/queues/tests/claim-timeout.queue.spec.ts
+++ b/backend/src/queues/tests/claim-timeout.queue.spec.ts
@@ -7,6 +7,9 @@
  */
 import { config } from 'dotenv';
 config({ path: '.env.test', override: true });
+// Fallback so the eager protocol barrel (createModel) can evaluate without a real
+// key when .env.test is absent (e.g. CI). Keeps the spec hermetic.
+process.env.OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY || 'test-key';
 
 import { describe, expect, it, mock, afterAll, beforeEach } from 'bun:test';
 
@@ -62,7 +65,9 @@ afterAll(() => {
   mock.restore();
 });
 
-import { NegotiationClaimTimeoutQueue } from '../negotiations/claim-timeout.queue';
+// Deferred import: ensures the mock.module(...) registrations above apply before
+// the real ../negotiations/claim-timeout.queue (and its protocol barrel) are evaluated.
+const { NegotiationClaimTimeoutQueue } = await import('../negotiations/claim-timeout.queue');
 
 function makeDb(messages: unknown[]) {
   const db = {

--- a/backend/src/queues/tests/timeout.queue.spec.ts
+++ b/backend/src/queues/tests/timeout.queue.spec.ts
@@ -6,6 +6,9 @@
  */
 import { config } from 'dotenv';
 config({ path: '.env.test', override: true });
+// Fallback so the eager protocol barrel (createModel) can evaluate without a real
+// key when .env.test is absent (e.g. CI). Keeps the spec hermetic.
+process.env.OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY || 'test-key';
 
 import { describe, expect, it, mock, afterAll, beforeEach } from 'bun:test';
 
@@ -39,7 +42,9 @@ afterAll(() => {
   mock.restore();
 });
 
-import { NegotiationTimeoutQueue } from '../negotiations/timeout.queue';
+// Deferred import: ensures the mock.module(...) registrations above apply before
+// the real ../negotiations/timeout.queue (and its protocol barrel) are evaluated.
+const { NegotiationTimeoutQueue } = await import('../negotiations/timeout.queue');
 
 type Calls = Record<string, unknown[][]>;
 


### PR DESCRIPTION
## Summary

Follow-up addressing the low-severity, non-blocking findings from the **Release 2026-06-21 (#1038)** review. Lands on `dev`; once merged, the release branch is forward-updated so PR #1038 picks these up.

The reviewer found no blocking correctness/security issues — these are quality/gating fixes.

## Changes

### Tests
- **Make timeout/claim-timeout specs hermetic (finding #2)** — `timeout.queue.spec.ts` and `claim-timeout.queue.spec.ts` statically imported the queue (evaluating the real `@indexnetwork/protocol` barrel's eager `createModel` before the in-body `mock.module(...)` applied) and relied on `.env.test` carrying a real `OPENROUTER_API_KEY`. Added a fallback key and switched to a deferred `await import()`, matching the hermetic `enrichment.queue.spec.ts` pattern. They now pass with **no key set and no built protocol dist**.

### CI
- **Gate release PRs + run pinning tests (finding #1)** — `lint.yml` only triggered on PRs/pushes to `dev`, so the `dev→main` release PR had no independent gate and the new `bun test` pins never ran in CI. Added `main` to the triggers and a `test` job running the three hermetic pinning specs (`can-actor-see-opportunity`, `timeout`, `claim-timeout`).

### Refactor
- **Restore lowercase-dashed discovery error message (finding #4)** — the adapter/queue split collapsed the thrown fallback message and the log-line prefix into one `label`, changing `'from-intent graph failed'` → `'FromIntent graph failed'`. Added an optional `errorLabel` (defaults to `label`) so the thrown message stays lowercase-dashed (matching the pre-split queues) while log prefixes stay PascalCase.

> Finding #3 (delete orphaned `PendingQuestions.tsx`) was intentionally **not** included per maintainer decision.

## Verification
- `cd backend && bun run build` — typecheck clean.
- `env -u OPENROUTER_API_KEY bun test src/adapters/tests/can-actor-see-opportunity.spec.ts src/queues/tests/timeout.queue.spec.ts src/queues/tests/claim-timeout.queue.spec.ts` — **26 pass / 0 fail** with no key and no protocol dist.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1040"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784666598&installation_id=140549914&pr_number=1040&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1040&signature=93d01ddfd16ba3dcb303c008a42cfdac57983c03009c04d7fb37fa12e85a013c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->