### PR TITLE
feat(hermes-plugin): add MCP-backed read intents tool

### DIFF
--- a/packages/hermes-plugin/README.md
+++ b/packages/hermes-plugin/README.md
@@ -1,42 +1,84 @@
 # Index Network Hermes Plugin
 
-An empty Hermes plugin starter for future Index Network integrations.
+Hermes-native plugin for Index Network. It follows the official Hermes plugin layout from [Build a Hermes Plugin](https://hermes-agent.nousresearch.com/docs/guides/build-a-hermes-plugin):
 
-This package is intentionally a fill-in-later Hermes plugin, not a generator. It keeps the official Hermes plugin file shape in place so future work can add Index Network MCP-backed tools and a dashboard view without redoing the package scaffold.
+```text
+plugin.yaml   # manifest: tools, hooks, env requirements
+__init__.py   # register(ctx): schemas -> handlers, plugin skills
+schemas.py    # LLM-facing tool schemas
+tools.py      # JSON-string-returning tool handlers
+```
 
 ## Current status
 
-- `plugin.yaml` declares the plugin.
-- `__init__.py` exposes `register(ctx)` and currently registers bundled skills only when they are added.
-- `schemas.py` is reserved for future LLM-facing tool schemas.
-- `tools.py` is reserved for future JSON-string-returning tool handlers.
-- `skills/` is reserved for bundled Hermes skills.
-- `dashboard/` is reserved for a future Hermes dashboard extension.
+The plugin now provides one native Hermes tool:
 
-No tools, MCP servers, API keys, cron jobs, hooks, commands, or dashboard tabs are wired yet.
+- `index_read_intents` — calls the canonical Index MCP `read_intents` tool using `INDEX_API_KEY`.
 
-## Fill in later
+It also keeps placeholders for future bundled skills and dashboard work:
 
-### MCP-backed tools
+- `skills/` — optional namespaced, read-only Hermes plugin skills registered with `ctx.register_skill()`.
+- `dashboard/` — reserved for a future dashboard extension.
 
-1. Add schemas to `schemas.py`.
-2. Add handlers to `tools.py`.
-3. Import `schemas` and `tools` in `__init__.py`.
-4. Register each handler from `register(ctx)` with `ctx.register_tool()`.
+No hooks, slash commands, CLI commands, cron jobs, or dashboard tabs are wired yet.
 
-### Bundled skills
+## Install / enable in Hermes
 
-Add skill files under:
+A Hermes plugin directory must be installed under `~/.hermes/plugins/<plugin-name>/` or a one-level category path. For local testing, copy or symlink this directory:
+
+```bash
+mkdir -p ~/.hermes/plugins
+ln -s /path/to/index/packages/hermes-plugin ~/.hermes/plugins/index-network
+hermes plugins enable index-network
+```
+
+The manifest declares `requires_env: INDEX_API_KEY`, so `hermes plugins install` can prompt for it and save it to Hermes' `.env`. You can also set it manually:
+
+```bash
+export INDEX_API_KEY="..."
+```
+
+Optional environment variables:
+
+- `INDEX_MCP_URL` — defaults to `https://protocol.index.network/mcp`.
+- `INDEX_MCP_TIMEOUT_SECONDS` — defaults to `30`.
+- `INDEX_TELEGRAM_USERNAME` — forwarded as `x-index-telegram-username` when present.
+
+## Tool contract
+
+Handlers intentionally follow Hermes' plugin rules:
+
+- signature: `def handler(args: dict, **kwargs) -> str`
+- always return a JSON string
+- catch exceptions and return JSON error payloads
+- accept `**kwargs` for forward compatibility
+
+`index_read_intents` accepts:
+
+```json
+{
+  "networkId": "optional Index/network UUID",
+  "userId": "optional user UUID",
+  "limit": 20,
+  "page": 1
+}
+```
+
+With no arguments, it returns the authenticated caller's own active intents as seen through the scoped Index MCP server.
+
+## Bundled skills
+
+Add future plugin skills as:
 
 ```text
 skills/<skill-name>/SKILL.md
 ```
 
-The existing `_register_skills(ctx)` helper registers them with `ctx.register_skill()`.
+`__init__.py` registers each skill directory with `ctx.register_skill()`, so Hermes can load them as `index-network:<skill-name>`. Do not copy plugin skills into `~/.hermes/skills`; Hermes plugin skills are namespaced and read-only.
 
-### Dashboard view
+## Dashboard view
 
-When the dashboard is implemented, add the Hermes dashboard extension files under `dashboard/`:
+When dashboard work starts, add the Hermes dashboard files under `dashboard/`:
 
 ```text
 dashboard/manifest.json
@@ -50,4 +92,11 @@ dashboard/plugin_api.py
 ```bash
 cd packages/hermes-plugin
 bun run test
+```
+
+For Hermes discovery debugging:
+
+```bash
+HERMES_PLUGINS_DEBUG=1 hermes plugins list
+hermes logs --level WARNING | grep -i plugin
 ```

--- a/packages/hermes-plugin/__init__.py
+++ b/packages/hermes-plugin/__init__.py
@@ -1,18 +1,21 @@
-"""Index Network Hermes plugin starter.
+"""Index Network Hermes plugin.
 
-This file is intentionally minimal. Fill it in as the Index Network Hermes
-plugin grows: MCP-backed tools, dashboard support, hooks, commands, and bundled
-skills should be registered from register(ctx).
+This plugin follows the official Hermes plugin guide: plugin.yaml declares the
+capabilities, schemas.py defines what the LLM sees, tools.py implements handlers
+that always return JSON strings, and register(ctx) wires everything into Hermes.
 """
 
 from pathlib import Path
+
+from . import schemas, tools
 
 
 def _register_skills(ctx):
     """Register bundled plugin skills when skills are added.
 
-    TODO: Add SKILL.md files under skills/<skill-name>/, then keep this helper
-    enabled so Hermes can load them as index-network:<skill-name>.
+    Plugin skills are namespaced and read-only in Hermes; they are not copied
+    into ~/.hermes/skills. Add SKILL.md files under skills/<skill-name>/ and
+    they will load as index-network:<skill-name>.
     """
     skills_dir = Path(__file__).parent / "skills"
     if not skills_dir.exists():
@@ -25,18 +28,11 @@ def _register_skills(ctx):
 
 
 def register(ctx):
-    """Register Index Network plugin capabilities with Hermes.
-
-    TODO: Register future MCP-backed tools here, for example:
-        ctx.register_tool(
-            name="read_index_context",
-            toolset="index-network",
-            schema=schemas.READ_INDEX_CONTEXT,
-            handler=tools.read_index_context,
-            description="Read Index Network context.",
-        )
-
-    TODO: Register hooks, slash commands, or CLI commands here if the plugin
-    needs them later.
-    """
+    """Register Index Network plugin capabilities with Hermes."""
+    ctx.register_tool(
+        name="index_read_intents",
+        toolset="index-network",
+        schema=schemas.INDEX_READ_INTENTS,
+        handler=tools.index_read_intents,
+    )
     _register_skills(ctx)

--- a/packages/hermes-plugin/package.json
+++ b/packages/hermes-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@indexnetwork/hermes-plugin",
-  "version": "0.1.0",
-  "description": "Empty Hermes plugin starter for future Index Network MCP and dashboard integrations",
+  "version": "0.2.0",
+  "description": "Hermes-native Index Network plugin with MCP-backed tools",
   "license": "MIT",
   "type": "module",
   "homepage": "https://index.network",
@@ -17,10 +17,11 @@
     "tools.py",
     "skills/",
     "dashboard/",
+    "tests/",
     "README.md",
     "LICENSE"
   ],
   "scripts": {
-    "test": "python3 -c \"import ast, pathlib; [ast.parse(pathlib.Path(p).read_text(), filename=p) for p in ['__init__.py', 'schemas.py', 'tools.py']]\""
+    "test": "python3 tests/smoke.py"
   }
 }

--- a/packages/hermes-plugin/plugin.yaml
+++ b/packages/hermes-plugin/plugin.yaml
@@ -1,5 +1,11 @@
 name: index-network
-version: 0.1.0
-description: Empty Index Network Hermes plugin starter. Fill in MCP tools and dashboard extensions later.
-provides_tools: []
+version: 0.2.0
+description: Index Network Hermes plugin with native tools backed by the Index MCP server.
+provides_tools:
+  - index_read_intents
 provides_hooks: []
+requires_env:
+  - name: INDEX_API_KEY
+    description: Index Network agent API key used to authenticate MCP tool calls.
+    url: https://index.network/agents
+    secret: true

--- a/packages/hermes-plugin/schemas.py
+++ b/packages/hermes-plugin/schemas.py
@@ -1,17 +1,48 @@
-"""Schemas for future Index Network Hermes tools.
+"""Hermes tool schemas for the Index Network plugin.
 
-Keep LLM-facing JSON schemas here. The plugin intentionally registers no tools
-right now; add schemas as MCP-backed tools are implemented.
+Schemas are the LLM-facing contract. Keep them specific about when to call each
+native Hermes tool and what arguments are accepted.
+"""
 
-Example shape to fill in later:
-
-READ_INDEX_CONTEXT = {
-    "name": "read_index_context",
-    "description": "Read Index Network context for the current user.",
+INDEX_READ_INTENTS = {
+    "name": "index_read_intents",
+    "description": (
+        "Read Index Network intents/signals through the authenticated Index MCP "
+        "server. Use this when the user asks what they are looking for, what "
+        "signals they have, or what members of a specific Index/community are "
+        "seeking. With no parameters, returns the caller's own active intents. "
+        "Pass networkId to browse intents in an Index the caller can access; "
+        "pass userId to filter to one user where the Index scope allows it."
+    ),
     "parameters": {
         "type": "object",
-        "properties": {},
+        "properties": {
+            "networkId": {
+                "type": "string",
+                "description": (
+                    "Optional Index/network UUID. When provided, reads intents "
+                    "in that Index/community."
+                ),
+            },
+            "userId": {
+                "type": "string",
+                "description": (
+                    "Optional user UUID. Filters to one user's intents when the "
+                    "authenticated Index agent is allowed to read them."
+                ),
+            },
+            "limit": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 100,
+                "description": "Optional page size from 1 to 100.",
+            },
+            "page": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Optional 1-based page number. Used with limit.",
+            },
+        },
         "required": [],
     },
 }
-"""

--- a/packages/hermes-plugin/tests/smoke.py
+++ b/packages/hermes-plugin/tests/smoke.py
@@ -1,0 +1,116 @@
+"""Smoke tests for the Index Network Hermes plugin."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import json
+import os
+import pathlib
+import sys
+import urllib.request
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+PYTHON_FILES = ["__init__.py", "schemas.py", "tools.py"]
+
+
+class FakeContext:
+    def __init__(self) -> None:
+        self.tools = []
+        self.skills = []
+
+    def register_tool(self, **kwargs):
+        self.tools.append(kwargs)
+
+    def register_skill(self, name, skill_md):
+        self.skills.append((name, skill_md))
+
+
+def load_plugin():
+    spec = importlib.util.spec_from_file_location(
+        "index_network_hermes_plugin",
+        ROOT / "__init__.py",
+        submodule_search_locations=[str(ROOT)],
+    )
+    if spec is None or spec.loader is None:
+        raise AssertionError("Could not create import spec for plugin")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> None:
+    for relative_path in PYTHON_FILES:
+        source = (ROOT / relative_path).read_text()
+        ast.parse(source, filename=relative_path)
+
+    plugin = load_plugin()
+    ctx = FakeContext()
+    plugin.register(ctx)
+
+    tool_names = [entry["name"] for entry in ctx.tools]
+    assert tool_names == ["index_read_intents"], tool_names
+    assert ctx.tools[0]["schema"]["name"] == "index_read_intents"
+    assert callable(ctx.tools[0]["handler"])
+
+    old_api_key = os.environ.pop("INDEX_API_KEY", None)
+    old_urlopen = urllib.request.urlopen
+    try:
+        missing_key = json.loads(plugin.tools.index_read_intents({}))
+        assert missing_key["success"] is False
+        assert "INDEX_API_KEY" in missing_key["error"]
+
+        invalid_limit = json.loads(plugin.tools.index_read_intents({"limit": 101}))
+        assert invalid_limit == {"success": False, "error": "limit must be at most 100."}
+
+        class FakeResponse:
+            headers = {"Content-Type": "application/json"}
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, traceback):
+                return False
+
+            def read(self):
+                return json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "result": {
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": json.dumps({"success": True, "data": {"intents": [], "count": 0}}),
+                                }
+                            ]
+                        },
+                    }
+                ).encode()
+
+        captured = {}
+
+        def fake_urlopen(request, timeout):
+            captured["timeout"] = timeout
+            captured["headers"] = dict(request.header_items())
+            captured["body"] = json.loads(request.data.decode())
+            return FakeResponse()
+
+        urllib.request.urlopen = fake_urlopen
+        os.environ["INDEX_API_KEY"] = "test-key"
+        ok = json.loads(plugin.tools.index_read_intents({"limit": 10, "page": 1}))
+        assert ok == {"success": True, "data": {"intents": [], "count": 0}}
+        assert captured["body"]["method"] == "tools/call"
+        assert captured["body"]["params"] == {"name": "read_intents", "arguments": {"limit": 10, "page": 1}}
+        assert captured["headers"]["X-api-key"] == "test-key"
+    finally:
+        urllib.request.urlopen = old_urlopen
+        if old_api_key is not None:
+            os.environ["INDEX_API_KEY"] = old_api_key
+        else:
+            os.environ.pop("INDEX_API_KEY", None)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/hermes-plugin/tools.py
+++ b/packages/hermes-plugin/tools.py
@@ -1,14 +1,222 @@
-"""Handlers for future Index Network Hermes tools.
+"""Hermes tool handlers for the Index Network plugin.
 
-The plugin intentionally exposes no handlers right now. Add JSON-string-returning
-handlers here when Index Network MCP-backed tools are wired in.
+Handlers follow the official Hermes plugin contract:
+- signature: handler(args: dict, **kwargs) -> str
+- always return a JSON string
+- catch errors and return JSON error payloads instead of raising
+"""
 
-Example shape to fill in later:
+from __future__ import annotations
 
 import json
+import os
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+
+_DEFAULT_INDEX_MCP_URL = "https://protocol.index.network/mcp"
+_MAX_ERROR_BODY_CHARS = 2_000
 
 
-def read_index_context(args: dict, **kwargs) -> str:
-    del args, kwargs
-    return json.dumps({"success": True, "context": None})
-"""
+def _json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, separators=(",", ":"))
+
+
+def _error(message: str, **extra: Any) -> str:
+    payload: dict[str, Any] = {"success": False, "error": message}
+    payload.update(extra)
+    return _json(payload)
+
+
+def _clean_string(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _positive_int(value: Any, name: str, *, maximum: int | None = None) -> tuple[int | None, str | None]:
+    if value is None:
+        return None, None
+    if isinstance(value, bool):
+        return None, f"{name} must be an integer."
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None, f"{name} must be an integer."
+    if parsed < 1:
+        return None, f"{name} must be at least 1."
+    if maximum is not None and parsed > maximum:
+        return None, f"{name} must be at most {maximum}."
+    return parsed, None
+
+
+def _timeout_seconds() -> float:
+    raw = os.environ.get("INDEX_MCP_TIMEOUT_SECONDS", "30").strip()
+    try:
+        parsed = float(raw)
+    except ValueError:
+        return 30.0
+    return parsed if parsed > 0 else 30.0
+
+
+def _mcp_url() -> str:
+    return os.environ.get("INDEX_MCP_URL", _DEFAULT_INDEX_MCP_URL).strip() or _DEFAULT_INDEX_MCP_URL
+
+
+def _headers(api_key: str) -> dict[str, str]:
+    headers = {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "x-api-key": api_key,
+        "x-index-surface": "hermes-plugin",
+    }
+    telegram_handle = os.environ.get("INDEX_TELEGRAM_USERNAME", "").strip()
+    if telegram_handle:
+        headers["x-index-telegram-username"] = telegram_handle
+    return headers
+
+
+def _parse_json(data: str) -> Any:
+    return json.loads(data)
+
+
+def _parse_sse(data: str) -> Any:
+    """Return the last JSON data payload from an SSE response."""
+    last_payload: Any = None
+    data_lines: list[str] = []
+
+    def flush() -> None:
+        nonlocal last_payload, data_lines
+        if not data_lines:
+            return
+        raw = "\n".join(data_lines).strip()
+        data_lines = []
+        if not raw or raw == "[DONE]":
+            return
+        last_payload = _parse_json(raw)
+
+    for line in data.splitlines():
+        if not line.strip():
+            flush()
+            continue
+        if line.startswith("data:"):
+            data_lines.append(line[5:].lstrip())
+    flush()
+
+    if last_payload is None:
+        raise ValueError("SSE response did not include a JSON data payload")
+    return last_payload
+
+
+def _parse_mcp_response(body: bytes, content_type: str) -> Any:
+    text = body.decode("utf-8", errors="replace")
+    if "text/event-stream" in content_type.lower():
+        return _parse_sse(text)
+    return _parse_json(text)
+
+
+def _decode_tool_result(message: dict[str, Any]) -> dict[str, Any]:
+    if "error" in message:
+        err = message.get("error") or {}
+        if isinstance(err, dict):
+            return {
+                "success": False,
+                "error": str(err.get("message") or "Index MCP request failed."),
+                "code": err.get("code"),
+            }
+        return {"success": False, "error": str(err)}
+
+    result = message.get("result")
+    if not isinstance(result, dict):
+        return {"success": True, "data": result}
+
+    content = result.get("content")
+    if isinstance(content, list):
+        texts = [item.get("text") for item in content if isinstance(item, dict) and item.get("type") == "text"]
+        text = "\n".join(str(item) for item in texts if item is not None).strip()
+        if text:
+            try:
+                parsed_text = _parse_json(text)
+            except json.JSONDecodeError:
+                parsed_text = None
+            if isinstance(parsed_text, dict):
+                return parsed_text
+            return {"success": not bool(result.get("isError")), "text": text}
+
+    return {"success": not bool(result.get("isError")), "data": result}
+
+
+def _call_index_mcp(tool_name: str, arguments: dict[str, Any]) -> str:
+    api_key = os.environ.get("INDEX_API_KEY", "").strip()
+    if not api_key:
+        return _error(
+            "INDEX_API_KEY is required. Install the plugin with Hermes or set INDEX_API_KEY in the Hermes environment."
+        )
+
+    request_body = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": int(time.time() * 1000),
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": arguments},
+        }
+    ).encode("utf-8")
+
+    request = urllib.request.Request(
+        _mcp_url(),
+        data=request_body,
+        headers=_headers(api_key),
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=_timeout_seconds()) as response:
+            body = response.read()
+            parsed = _parse_mcp_response(body, response.headers.get("Content-Type", ""))
+            if not isinstance(parsed, dict):
+                return _json({"success": True, "data": parsed})
+            return _json(_decode_tool_result(parsed))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")[:_MAX_ERROR_BODY_CHARS]
+        return _error(
+            f"Index MCP HTTP request failed with status {exc.code}.",
+            status=exc.code,
+            body=body,
+        )
+    except urllib.error.URLError as exc:
+        return _error(f"Index MCP request failed: {exc.reason}")
+    except Exception as exc:  # noqa: BLE001 - Hermes handlers must not raise.
+        return _error(f"Index MCP response could not be processed: {exc}")
+
+
+def index_read_intents(args: dict, **kwargs) -> str:
+    """Read Index Network intents through the canonical MCP read_intents tool."""
+    del kwargs
+    if not isinstance(args, dict):
+        return _error("Arguments must be an object.")
+
+    arguments: dict[str, Any] = {}
+
+    network_id = _clean_string(args.get("networkId"))
+    if network_id:
+        arguments["networkId"] = network_id
+
+    user_id = _clean_string(args.get("userId"))
+    if user_id:
+        arguments["userId"] = user_id
+
+    limit, limit_error = _positive_int(args.get("limit"), "limit", maximum=100)
+    if limit_error:
+        return _error(limit_error)
+    if limit is not None:
+        arguments["limit"] = limit
+
+    page, page_error = _positive_int(args.get("page"), "page")
+    if page_error:
+        return _error(page_error)
+    if page is not None:
+        arguments["page"] = page
+
+    return _call_index_mcp("read_intents", arguments)


### PR DESCRIPTION
## Summary
- add the native Hermes index_read_intents tool backed by Index MCP read_intents
- declare INDEX_API_KEY as a Hermes requires_env secret and register the tool via register(ctx)
- document install/debug workflow and add smoke coverage for registration, validation, and MCP request decoding

## Tests
- cd packages/hermes-plugin && bun run test
- python3 -m py_compile packages/hermes-plugin/__init__.py packages/hermes-plugin/schemas.py packages/hermes-plugin/tools.py packages/hermes-plugin/tests/smoke.py
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1048"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784802134&installation_id=140549914&pr_number=1048&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1048&signature=f2a1f585549aa1c490939f54bcfa0d1d48ebfc0717b5505263e85d61988f21f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->