### PR TITLE
test(mac): verify API client endpoints

### DIFF
--- a/apps/mac/api/README.md
+++ b/apps/mac/api/README.md
@@ -7,6 +7,7 @@ It is intentionally **not imported** by `HaloApp` or `HaloApp-iOS` yet. The curr
 ## Intended role
 
 - Own calls to `services/api` (`/api/auth/me`, `/api/intents/list`, `/api/opportunities/home`, `/api/questions`, conversations, etc.).
+- Keep endpoint paths aligned with the decorated controllers in `services/api/src/controllers` and the `/api` global prefix in `services/api/src/main.ts`.
 - Convert backend DTOs into the existing prototype shapes (`INTENTS`, people/opportunity cards, clarifiers).
 - Keep auth/token handling isolated from UI components.
 - Preserve fake-data fallback in the app until an explicit integration step.
@@ -16,6 +17,17 @@ It is intentionally **not imported** by `HaloApp` or `HaloApp-iOS` yet. The curr
 - `client.mjs` — dependency-free fetch wrapper and resource methods for the Index API.
 - `mappers.mjs` — pure mappers from API responses to the current mac prototype view models.
 - `index.mjs` — barrel exports for future consumers.
+
+## Endpoint coverage checked against controllers
+
+The client base URL includes `/api`, matching the global prefix applied in `services/api/src/main.ts`. Resource methods currently cover these controller routes:
+
+- `auth.controller.ts`: `GET /auth/me`
+- `network.controller.ts`: `GET /networks`, `GET /networks/:id/overview`, `GET /networks/:id/my-intents`
+- `intent.controller.ts`: `POST /intents/list`, `GET /intents/:id`, `PATCH /intents/:id/archive`
+- `opportunity.controller.ts`: `GET /opportunities`, `GET /opportunities/home`, `GET /opportunities/chat-context`, `GET /opportunities/:id`, `GET /opportunities/:id/invite-message`, `PATCH /opportunities/:id/status`, `POST /opportunities/:id/start-chat`
+- `question.controller.ts`: `GET /questions`, `POST /questions/:id/answer`, `POST /questions/:id/dismiss`
+- `conversation.controller.ts`: `GET /conversations`, `GET /conversations/negotiations`, `GET /conversations/:id/messages`, `POST /conversations/:id/messages`, `POST /conversations/dm`, `PATCH /conversations/:id/metadata`, `DELETE /conversations/:id`
 
 ## Non-goals for this first step
 

--- a/apps/mac/api/client.mjs
+++ b/apps/mac/api/client.mjs
@@ -120,7 +120,15 @@ export function createIndexApiClient(options = {}) {
     opportunities: {
       list: (query = {}, options = {}) => request(`/opportunities${toQueryString(query)}`, options),
       home: (query = {}, options = {}) => request(`/opportunities/home${toQueryString(query)}`, options),
+      chatContext: (peerUserId, options = {}) => request(
+        `/opportunities/chat-context${toQueryString({ peerUserId })}`,
+        options,
+      ),
       get: (opportunityId, options = {}) => request(`/opportunities/${encodeURIComponent(opportunityId)}`, options),
+      inviteMessage: (opportunityId, options = {}) => request(
+        `/opportunities/${encodeURIComponent(opportunityId)}/invite-message`,
+        options,
+      ),
       updateStatus: (opportunityId, status, options = {}) => request(
         `/opportunities/${encodeURIComponent(opportunityId)}/status`,
         { ...options, method: 'PATCH', body: { status } },
@@ -148,6 +156,7 @@ export function createIndexApiClient(options = {}) {
 
     conversations: {
       list: (options = {}) => request('/conversations', options),
+      negotiations: (options = {}) => request('/conversations/negotiations', options),
       messages: (conversationId, query = {}, options = {}) => request(
         `/conversations/${encodeURIComponent(conversationId)}/messages${toQueryString(query)}`,
         options,
@@ -159,6 +168,14 @@ export function createIndexApiClient(options = {}) {
       getOrCreateDm: (peerUserId, options = {}) => request(
         '/conversations/dm',
         { ...options, method: 'POST', body: { peerUserId } },
+      ),
+      updateMetadata: (conversationId, metadata, options = {}) => request(
+        `/conversations/${encodeURIComponent(conversationId)}/metadata`,
+        { ...options, method: 'PATCH', body: { metadata } },
+      ),
+      delete: (conversationId, options = {}) => request(
+        `/conversations/${encodeURIComponent(conversationId)}`,
+        { ...options, method: 'DELETE' },
       ),
     },
   };

--- a/apps/mac/api/client.spec.mjs
+++ b/apps/mac/api/client.spec.mjs
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'bun:test';
+
+import { createIndexApiClient, normalizeApiBaseUrl, toQueryString } from './client.mjs';
+
+function createRecordingFetch() {
+  const calls = [];
+  const fetchImpl = async (url, init = {}) => {
+    calls.push({ url, init });
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  };
+  return { calls, fetchImpl };
+}
+
+async function expectCall(label, invoke, expected) {
+  const { calls, fetchImpl } = createRecordingFetch();
+  const client = createIndexApiClient({
+    apiBaseUrl: 'https://protocol.example/api/',
+    getToken: () => 'token-1',
+    fetchImpl,
+  });
+
+  await invoke(client);
+
+  expect(calls, label).toHaveLength(1);
+  const call = calls[0];
+  expect(call.url, label).toBe(`https://protocol.example/api${expected.path}`);
+  expect(call.init.method, label).toBe(expected.method || 'GET');
+  expect(call.init.headers.Authorization, label).toBe('Bearer token-1');
+  if ('body' in expected) {
+    expect(call.init.body, label).toBe(JSON.stringify(expected.body));
+  } else {
+    expect(call.init.body, label).toBeUndefined();
+  }
+}
+
+describe('mac Index API client endpoint contract', () => {
+  it('normalizes base URLs and query strings', () => {
+    expect(normalizeApiBaseUrl('https://protocol.example/api///')).toBe('https://protocol.example/api');
+    expect(toQueryString({ status: 'pending', empty: '', nil: null, missing: undefined, limit: 20 })).toBe('?status=pending&limit=20');
+  });
+
+  it('uses controller-backed auth/network/intent endpoints', async () => {
+    await expectCall('auth.me', (client) => client.auth.me(), { path: '/auth/me' });
+    await expectCall('networks.list', (client) => client.networks.list(), { path: '/networks' });
+    await expectCall('networks.overview', (client) => client.networks.overview('net/1'), { path: '/networks/net%2F1/overview' });
+    await expectCall('networks.myIntents', (client) => client.networks.myIntents('net/1'), { path: '/networks/net%2F1/my-intents' });
+    await expectCall('intents.list', (client) => client.intents.list({ page: 1 }), { path: '/intents/list', method: 'POST', body: { page: 1 } });
+    await expectCall('intents.get', (client) => client.intents.get('intent/1'), { path: '/intents/intent%2F1' });
+    await expectCall('intents.archive', (client) => client.intents.archive('intent/1'), { path: '/intents/intent%2F1/archive', method: 'PATCH' });
+  });
+
+  it('uses controller-backed opportunity endpoints', async () => {
+    await expectCall('opportunities.list', (client) => client.opportunities.list({ status: 'pending', limit: 10 }), { path: '/opportunities?status=pending&limit=10' });
+    await expectCall('opportunities.home', (client) => client.opportunities.home({ noCache: true }), { path: '/opportunities/home?noCache=true' });
+    await expectCall('opportunities.chatContext', (client) => client.opportunities.chatContext('user/1'), { path: '/opportunities/chat-context?peerUserId=user%2F1' });
+    await expectCall('opportunities.get', (client) => client.opportunities.get('opp/1'), { path: '/opportunities/opp%2F1' });
+    await expectCall('opportunities.inviteMessage', (client) => client.opportunities.inviteMessage('opp/1'), { path: '/opportunities/opp%2F1/invite-message' });
+    await expectCall('opportunities.updateStatus', (client) => client.opportunities.updateStatus('opp/1', 'accepted'), { path: '/opportunities/opp%2F1/status', method: 'PATCH', body: { status: 'accepted' } });
+    await expectCall('opportunities.startChat', (client) => client.opportunities.startChat('opp/1'), { path: '/opportunities/opp%2F1/start-chat', method: 'POST', body: {} });
+  });
+
+  it('uses controller-backed question and conversation endpoints', async () => {
+    await expectCall('questions.pending', (client) => client.questions.pending({ sourceId: 'intent/1' }), { path: '/questions?status=pending&sourceId=intent%2F1' });
+    await expectCall('questions.answer', (client) => client.questions.answer('question/1', { selectedOptions: ['yes'] }), { path: '/questions/question%2F1/answer', method: 'POST', body: { selectedOptions: ['yes'] } });
+    await expectCall('questions.dismiss', (client) => client.questions.dismiss('question/1'), { path: '/questions/question%2F1/dismiss', method: 'POST', body: {} });
+
+    await expectCall('conversations.list', (client) => client.conversations.list(), { path: '/conversations' });
+    await expectCall('conversations.negotiations', (client) => client.conversations.negotiations(), { path: '/conversations/negotiations' });
+    await expectCall('conversations.messages', (client) => client.conversations.messages('conv/1', { limit: 50 }), { path: '/conversations/conv%2F1/messages?limit=50' });
+    await expectCall('conversations.sendMessage', (client) => client.conversations.sendMessage('conv/1', { parts: [{ text: 'hi' }] }), { path: '/conversations/conv%2F1/messages', method: 'POST', body: { parts: [{ text: 'hi' }] } });
+    await expectCall('conversations.getOrCreateDm', (client) => client.conversations.getOrCreateDm('user/1'), { path: '/conversations/dm', method: 'POST', body: { peerUserId: 'user/1' } });
+    await expectCall('conversations.updateMetadata', (client) => client.conversations.updateMetadata('conv/1', { title: 'hello' }), { path: '/conversations/conv%2F1/metadata', method: 'PATCH', body: { metadata: { title: 'hello' } } });
+    await expectCall('conversations.delete', (client) => client.conversations.delete('conv/1'), { path: '/conversations/conv%2F1', method: 'DELETE' });
+  });
+});


### PR DESCRIPTION
## Summary
- align the standalone mac API client with controller-backed opportunity and conversation endpoints
- document endpoint coverage against services/api controllers
- add a Bun test that locks request paths, methods, auth header, and bodies

## Tests
- bun test apps/mac/api/client.spec.mjs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784802258&installation_id=140549914&pr_number=1049&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1049&signature=123248af9135ea1ef97c70e43d92b17c00a26e849cc2f614bf673ee9b4ead039"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->