### PR TITLE
chore(hermes-plugin): add subtree sync

### DIFF
--- a/.github/workflows/sync-subtrees.yml
+++ b/.github/workflows/sync-subtrees.yml
@@ -47,6 +47,13 @@ jobs:
             target_branch: ''
             ignore_joins: 'false'
             rebase_onto_main: 'false'
+          - prefix: packages/hermes-plugin
+            repo: indexnetwork/hermes-plugin
+            source_branch: ''
+            upstream_repo: ''
+            target_branch: ''
+            ignore_joins: 'false'
+            rebase_onto_main: 'false'
           - prefix: apps/mac
             repo: indexnetwork/mac-client
             source_branch: ''

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,18 @@ git subtree push --prefix=packages/claude-plugin https://github.com/indexnetwork
 git subtree pull --squash --prefix=packages/claude-plugin https://github.com/indexnetwork/claude-plugin.git <branch>
 ```
 
+#### packages/hermes-plugin/ → indexnetwork/hermes-plugin
+
+The `@indexnetwork/hermes-plugin` Hermes-native plugin package — ships the Index Network Hermes plugin manifest, Python registration surface, MCP-backed tool handlers, bundled skills placeholder, and dashboard placeholder. Edit via this monorepo; the standalone `indexnetwork/hermes-plugin` repo is a public subtree mirror synced on `dev`/`main` pushes.
+
+```bash
+# Manual push if the workflow failed (use dev or main)
+git subtree push --prefix=packages/hermes-plugin https://github.com/indexnetwork/hermes-plugin.git <branch>
+
+# Pull if the external repo was edited directly (avoid — always edit via this repo)
+git subtree pull --squash --prefix=packages/hermes-plugin https://github.com/indexnetwork/hermes-plugin.git <branch>
+```
+
 #### apps/mac/ → indexnetwork/mac-client
 
 The native Apple client prototype (macOS + iOS WKWebView shells around self-contained React/HTML bundles). The monorepo path is synced to the standalone `indexnetwork/mac-client` repo on `dev`/`main` pushes.
@@ -205,6 +217,7 @@ index/
 │   ├── protocol/        # @indexnetwork/protocol NPM package — subtree → indexnetwork/protocol
 │   ├── cli/             # @indexnetwork/cli — Bun, TypeScript — subtree → indexnetwork/cli
 │   ├── claude-plugin/   # @indexnetwork/claude-plugin — index-orchestrator and index-negotiator skills, subtree → indexnetwork/claude-plugin
+│   ├── hermes-plugin/   # @indexnetwork/hermes-plugin — Hermes-native plugin, subtree → indexnetwork/hermes-plugin
 │   └── edge-city/       # Edge-City submodules: agentvillage, landing, controlplane
 ├── docs/                # Project documentation (design/, domain/, guides/, specs/)
 └── scripts/             # Worktree helpers, hooks, dev launcher

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ index/
 │   └── mac/           # Native Apple client subtree → indexnetwork/mac-client
 ├── services/
 │   └── api/           # Backend API and agent engine (Bun, TypeScript)
-├── packages/          # Shared protocol, CLI, and plugin packages
+├── packages/          # Shared protocol, CLI, Claude plugin, and Hermes plugin packages
 ├── docs/              # Project documentation (see Documentation section)
 └── scripts/           # Worktree helpers, hooks, dev launcher
 ```

--- a/docs/design/architecture-overview.md
+++ b/docs/design/architecture-overview.md
@@ -28,6 +28,8 @@ index/
   packages/
     protocol/        @indexnetwork/protocol NPM package (agent graphs, interfaces, tools)
     cli/             CLI client (@indexnetwork/cli, Bun, TypeScript)
+    claude-plugin/   Claude/Codex plugin distribution, subtree-synced publicly
+    hermes-plugin/   Hermes-native plugin distribution, subtree-synced publicly
 ```
 
 **API service** is a native Bun HTTP server (`Bun.serve`) running on port 3001. It hosts the API, LangGraph-based agent system, database layer, job queues, and event infrastructure.


### PR DESCRIPTION
## Summary
- add packages/hermes-plugin to the Sync subtrees GitHub Actions matrix
- document the public indexnetwork/hermes-plugin subtree mirror in project guidance
- note the Hermes plugin package in root architecture docs

## Verification
- git diff --check
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/sync-subtrees.yml'); puts 'yaml ok'"

## Notes
- Created public repo: https://github.com/indexnetwork/hermes-plugin
- Subtree split/push is intentionally handled by the Sync subtrees GitHub Action on dev/main pushes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784802912&installation_id=140549914&pr_number=1050&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1050&signature=8b55709d2ed931de813c5e92ef911949652292c19b34e76bb0d419bae798b11e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->