### PR TITLE
feat(hermes-plugin): forward Index MCP tools

### DIFF
--- a/packages/hermes-plugin/README.md
+++ b/packages/hermes-plugin/README.md
@@ -13,7 +13,8 @@ tools.py      # JSON-string-returning tool handlers
 
 The plugin provides these native Hermes tools:
 
-- `index_read_intents` — calls the canonical Index MCP `read_intents` tool using `INDEX_API_KEY`.
+- `index_read_intents` — calls the canonical Index MCP `read_intents` tool using `INDEX_API_KEY` with argument validation.
+- `index_<mcp_tool_name>` — generated pass-through wrappers for the rest of the Index MCP surface, including `index_read_docs`, `index_create_intent`, `index_read_networks`, `index_discover_opportunities`, `index_get_discovery_run`, and `index_list_opportunities`.
 - `index_agent_me` — calls `GET /api/agents/me` to return the authenticated personal Index agent for the configured key.
 - `index_pickup_negotiation` — calls the personal-agent pickup endpoint to poll and claim one pending negotiation turn.
 - `index_respond_negotiation` — submits an autonomous personal-agent negotiation response with action, message, reasoning, and suggested roles.
@@ -28,7 +29,15 @@ It also bundles generated, namespaced Hermes plugin skills, an orchestrator hint
 
 ## Install / enable in Hermes
 
-A Hermes plugin directory must be installed under `~/.hermes/plugins/<plugin-name>/` or a one-level category path. For local testing, copy or symlink this directory:
+Install the public plugin with Hermes:
+
+```bash
+hermes plugins install indexnetwork/hermes-plugin
+```
+
+The manifest declares `requires_env: INDEX_API_KEY`, so `hermes plugins install` prompts for it and saves it to Hermes' `.env`. Use an Index agent-bound API key when running autonomous negotiation tools.
+
+For local development, a Hermes plugin directory must be installed under `~/.hermes/plugins/<plugin-name>/` or a one-level category path. Copy or symlink this directory:
 
 ```bash
 mkdir -p ~/.hermes/plugins
@@ -36,7 +45,7 @@ ln -s /path/to/index/packages/hermes-plugin ~/.hermes/plugins/index-network
 hermes plugins enable index-network
 ```
 
-The manifest declares `requires_env: INDEX_API_KEY`, so `hermes plugins install` can prompt for it and save it to Hermes' `.env`. Use an Index agent-bound API key when running autonomous negotiation tools. You can also set it manually:
+You can also set the key manually:
 
 ```bash
 export INDEX_API_KEY="..."
@@ -72,6 +81,19 @@ Accepts:
 ```
 
 With no arguments, it returns the authenticated caller's own active intents as seen through the scoped Index MCP server.
+
+### `index_<mcp_tool_name>` forwarded wrappers
+
+The plugin registers Hermes wrappers for each canonical Index MCP tool that does not already have a dedicated wrapper. Examples:
+
+- `index_read_docs({"topic":"mcp_agent_guide"})`
+- `index_create_intent({"description":"...","autoApprove":true})`
+- `index_read_networks({})`
+- `index_discover_opportunities({"searchQuery":"..."})`
+- `index_get_discovery_run({"discoveryRunId":"..."})`
+- `index_list_opportunities({})`
+
+Wrapper names are formed by prefixing the MCP tool name with `index_`; arguments are passed through unchanged to the underlying MCP tool. Tool responses are decoded from the MCP envelope and returned as JSON strings to Hermes.
 
 ### `index_agent_me`
 

--- a/packages/hermes-plugin/__init__.py
+++ b/packages/hermes-plugin/__init__.py
@@ -87,6 +87,13 @@ def register(ctx):
         schema=schemas.INDEX_READ_INTENTS,
         handler=tools.index_read_intents,
     )
+    for tool_name in schemas.FORWARDED_MCP_TOOLS:
+        ctx.register_tool(
+            name=f"index_{tool_name}",
+            toolset="index-network",
+            schema=schemas.forwarded_mcp_schema(tool_name),
+            handler=tools.make_mcp_tool_handler(tool_name),
+        )
     ctx.register_tool(
         name="index_agent_me",
         toolset="index-network",

--- a/packages/hermes-plugin/package.json
+++ b/packages/hermes-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/hermes-plugin",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Hermes-native Index Network plugin with MCP and personal-agent tools",
   "license": "MIT",
   "type": "module",

--- a/packages/hermes-plugin/plugin.yaml
+++ b/packages/hermes-plugin/plugin.yaml
@@ -1,8 +1,61 @@
 name: index-network
-version: 0.3.0
+version: 0.4.0
 description: Index Network Hermes plugin with native tools backed by Index MCP and personal-agent APIs.
 provides_tools:
   - index_read_intents
+  - index_register_agent
+  - index_list_agents
+  - index_update_agent
+  - index_delete_agent
+  - index_grant_agent_permission
+  - index_revoke_agent_permission
+  - index_list_conversations
+  - index_get_conversation
+  - index_import_contacts
+  - index_list_contacts
+  - index_add_contact
+  - index_remove_contact
+  - index_search_contacts
+  - index_read_user_contexts
+  - index_record_onboarding_privacy_consent
+  - index_preview_user_context
+  - index_confirm_user_context
+  - index_create_user_context
+  - index_update_user_context
+  - index_get_enrichment_run
+  - index_cancel_enrichment_run
+  - index_complete_onboarding
+  - index_import_gmail_contacts
+  - index_create_intent
+  - index_update_intent
+  - index_delete_intent
+  - index_create_intent_index
+  - index_read_intent_indexes
+  - index_delete_intent_index
+  - index_search_intents
+  - index_list_negotiations
+  - index_get_negotiation
+  - index_respond_to_negotiation
+  - index_read_networks
+  - index_read_network_memberships
+  - index_update_network
+  - index_create_network
+  - index_delete_network
+  - index_create_network_membership
+  - index_delete_network_membership
+  - index_discover_opportunities
+  - index_get_discovery_run
+  - index_cancel_discovery_run
+  - index_list_opportunities
+  - index_update_opportunity
+  - index_confirm_opportunity_delivery
+  - index_create_premise
+  - index_read_premises
+  - index_update_premise
+  - index_retract_premise
+  - index_read_pending_questions
+  - index_scrape_url
+  - index_read_docs
   - index_agent_me
   - index_pickup_negotiation
   - index_respond_negotiation

--- a/packages/hermes-plugin/schemas.py
+++ b/packages/hermes-plugin/schemas.py
@@ -47,6 +47,81 @@ INDEX_READ_INTENTS = {
     },
 }
 
+FORWARDED_MCP_TOOLS = (
+    "register_agent",
+    "list_agents",
+    "update_agent",
+    "delete_agent",
+    "grant_agent_permission",
+    "revoke_agent_permission",
+    "list_conversations",
+    "get_conversation",
+    "import_contacts",
+    "list_contacts",
+    "add_contact",
+    "remove_contact",
+    "search_contacts",
+    "read_user_contexts",
+    "record_onboarding_privacy_consent",
+    "preview_user_context",
+    "confirm_user_context",
+    "create_user_context",
+    "update_user_context",
+    "get_enrichment_run",
+    "cancel_enrichment_run",
+    "complete_onboarding",
+    "import_gmail_contacts",
+    "create_intent",
+    "update_intent",
+    "delete_intent",
+    "create_intent_index",
+    "read_intent_indexes",
+    "delete_intent_index",
+    "search_intents",
+    "list_negotiations",
+    "get_negotiation",
+    "respond_to_negotiation",
+    "read_networks",
+    "read_network_memberships",
+    "update_network",
+    "create_network",
+    "delete_network",
+    "create_network_membership",
+    "delete_network_membership",
+    "discover_opportunities",
+    "get_discovery_run",
+    "cancel_discovery_run",
+    "list_opportunities",
+    "update_opportunity",
+    "confirm_opportunity_delivery",
+    "create_premise",
+    "read_premises",
+    "update_premise",
+    "retract_premise",
+    "read_pending_questions",
+    "scrape_url",
+    "read_docs",
+)
+
+
+def forwarded_mcp_schema(tool_name: str) -> dict:
+    """Build a Hermes schema for a pass-through Index MCP tool wrapper."""
+    return {
+        "name": f"index_{tool_name}",
+        "description": (
+            f"Call the Index MCP `{tool_name}` tool with the provided JSON arguments. "
+            "Use this for Index capabilities that do not have a dedicated Hermes-native wrapper. "
+            "If unsure about arguments or workflow, call index_read_docs with topic='mcp_agent_guide' first."
+        ),
+        "parameters": {
+            "type": "object",
+            "description": f"Arguments passed directly to the Index MCP `{tool_name}` tool.",
+            "additionalProperties": True,
+            "required": [],
+        },
+    }
+
+
 INDEX_AGENT_ME = {
     "name": "index_agent_me",
     "description": (

--- a/packages/hermes-plugin/skills/index-orchestrator/SKILL.md
+++ b/packages/hermes-plugin/skills/index-orchestrator/SKILL.md
@@ -50,13 +50,14 @@ Other banned words: leverage, unlock, optimize, scale, disrupt, revolutionary, A
 
 ## Hermes tool availability
 
-This bundled Hermes skill is loaded from the `index-network` plugin namespace. The plugin's native tool surface is intentionally focused:
+This bundled Hermes skill is loaded from the `index-network` plugin namespace. The plugin provides:
 
-- `index_read_intents` — reads Index Network intents through the authenticated Index MCP server using `INDEX_API_KEY`.
+- `index_read_intents` — a dedicated, validated wrapper for the Index MCP `read_intents` tool.
+- `index_<mcp_tool_name>` wrappers for the rest of the Index MCP surface, such as `index_create_intent`, `index_read_networks`, `index_discover_opportunities`, `index_get_discovery_run`, `index_list_opportunities`, and `index_read_docs`.
 - `index_agent_me` — reads the authenticated personal agent identity.
 - `index_pickup_negotiation` and `index_respond_negotiation` — available when the task is specifically to run the user's autonomous Index negotiator.
 
-If additional Index MCP tools are configured separately in Hermes, you may use them when they are actually available. Do not claim you can create, update, delete, discover, notify, or negotiate unless the corresponding tool is present and its response confirms the action.
+Do not claim you created, updated, deleted, discovered, notified, or negotiated anything unless the corresponding tool response confirms the action. If unsure about arguments or workflow for a forwarded MCP wrapper, call `index_read_docs(topic="mcp_agent_guide")` first.
 
 ## Setup
 
@@ -89,23 +90,24 @@ index_read_intents(networkId=..., userId=..., limit=20, page=1)
 
 Only use IDs the user provided or that a prior tool call returned. Do not invent IDs.
 
-## Pattern 3: Prepare a new signal draft
+## Pattern 3: Prepare or save a signal
 
-When the user wants to add or improve a signal but no create/update tool is available:
+When the user wants to add or improve a signal:
 
 1. Draft a concise signal description in plain text.
-2. Say that this Hermes plugin version can draft it but cannot save it unless an Index create/update tool is available.
-3. If a create/update tool is available separately, ask for confirmation before calling it.
+2. Ask for confirmation before creating, updating, or deleting a signal.
+3. After confirmation, use `index_create_intent`, `index_update_intent`, or `index_delete_intent` as appropriate.
+4. Report only what the tool response confirms.
 
-Specificity test: a good signal names a domain, desired counterpart, concrete action, constraint, or timing.
+Specificity test: a good signal names a domain, desired counterpart, concrete action, constraint, or timing. MCP agents should pass `autoApprove=true` when creating a confirmed signal because Hermes has no Index web-card UI.
 
 ## Pattern 4: Broader discovery requests
 
 For requests like "find people who can help with X" or "who should I meet":
 
-- First inspect existing signals with `index_read_intents`.
-- If no discovery tool is available, explain that this Hermes plugin version can review signals but cannot run discovery yet.
-- If an Index discovery tool is available separately, use it only after you understand the user's goal.
+- First inspect existing signals with `index_read_intents` unless the user supplied a fresh search query directly.
+- Use `index_discover_opportunities` for discovery and `index_get_discovery_run` when the response returns an async run id.
+- Use `index_list_opportunities` to review existing actionable opportunities.
 
 ## Presentation rules
 

--- a/packages/hermes-plugin/tests/smoke.py
+++ b/packages/hermes-plugin/tests/smoke.py
@@ -101,21 +101,38 @@ def main() -> None:
     plugin = load_plugin()
     ctx = FakeContext()
     plugin.register(ctx)
+    assert set(plugin.schemas.FORWARDED_MCP_TOOLS) == plugin.tools._FORWARDED_MCP_TOOLS
 
     tool_names = [entry["name"] for entry in ctx.tools]
-    assert tool_names == [
-        "index_read_intents",
-        "index_agent_me",
-        "index_pickup_negotiation",
-        "index_respond_negotiation",
-    ], tool_names
+    expected_tool_names = (
+        ["index_read_intents"]
+        + [f"index_{name}" for name in plugin.schemas.FORWARDED_MCP_TOOLS]
+        + ["index_agent_me", "index_pickup_negotiation", "index_respond_negotiation"]
+    )
+    assert tool_names == expected_tool_names, tool_names
+    assert len(tool_names) == len(set(tool_names))
+    assert "index_create_intent" in tool_names
+    assert "index_discover_opportunities" in tool_names
+    assert "index_read_docs" in tool_names
     assert [entry["schema"]["name"] for entry in ctx.tools] == tool_names
-    assert [entry["handler"] for entry in ctx.tools] == [
-        plugin.tools.index_read_intents,
-        plugin.tools.index_agent_me,
-        plugin.tools.index_pickup_negotiation,
-        plugin.tools.index_respond_negotiation,
-    ]
+    handlers_by_name = {entry["name"]: entry["handler"] for entry in ctx.tools}
+    assert handlers_by_name["index_read_intents"] == plugin.tools.index_read_intents
+    assert handlers_by_name["index_agent_me"] == plugin.tools.index_agent_me
+    assert handlers_by_name["index_pickup_negotiation"] == plugin.tools.index_pickup_negotiation
+    assert handlers_by_name["index_respond_negotiation"] == plugin.tools.index_respond_negotiation
+    assert handlers_by_name["index_create_intent"].__name__ == "index_create_intent"
+
+    manifest_tools = []
+    in_tools = False
+    for line in (ROOT / "plugin.yaml").read_text().splitlines():
+        if line == "provides_tools:":
+            in_tools = True
+            continue
+        if in_tools and line and not line.startswith("  - "):
+            break
+        if in_tools and line.startswith("  - "):
+            manifest_tools.append(line.removeprefix("  - "))
+    assert manifest_tools == tool_names
     assert [name for name, _path in ctx.skills] == ["index-negotiator", "index-orchestrator"]
     for _name, skill_md in ctx.skills:
         assert pathlib.Path(skill_md).name == "SKILL.md"
@@ -173,6 +190,35 @@ def main() -> None:
         assert captured[-1]["body"]["method"] == "tools/call"
         assert captured[-1]["body"]["params"] == {"name": "read_intents", "arguments": {"limit": 10, "page": 1}}
         assert captured[-1]["headers"]["X-api-key"] == "test-key"
+
+        captured = []
+        install_fake_urlopen(
+            [
+                FakeResponse(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "result": {
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": json.dumps({"success": True, "intentId": "intent-1"}),
+                                }
+                            ]
+                        },
+                    }
+                )
+            ],
+            captured,
+        )
+        create_intent = handlers_by_name["index_create_intent"]
+        created = json.loads(create_intent({"description": "Find robotics mentors", "autoApprove": True}))
+        assert created == {"success": True, "intentId": "intent-1"}
+        assert captured[-1]["body"]["params"] == {
+            "name": "create_intent",
+            "arguments": {"description": "Find robotics mentors", "autoApprove": True},
+        }
+        assert json.loads(create_intent([])) == {"success": False, "error": "Arguments must be an object."}
 
         os.environ["INDEX_API_URL"] = "https://api.example.test/api"
         captured = []

--- a/packages/hermes-plugin/tools.py
+++ b/packages/hermes-plugin/tools.py
@@ -20,6 +20,63 @@ _DEFAULT_INDEX_API_URL = "https://protocol.index.network/api"
 _MAX_ERROR_BODY_CHARS = 2_000
 _NEGOTIATION_ACTIONS = {"propose", "accept", "reject", "counter", "question"}
 _NEGOTIATION_ROLES = {"agent", "patient", "peer"}
+_FORWARDED_MCP_TOOLS = frozenset(
+    {
+        "register_agent",
+        "list_agents",
+        "update_agent",
+        "delete_agent",
+        "grant_agent_permission",
+        "revoke_agent_permission",
+        "list_conversations",
+        "get_conversation",
+        "import_contacts",
+        "list_contacts",
+        "add_contact",
+        "remove_contact",
+        "search_contacts",
+        "read_user_contexts",
+        "record_onboarding_privacy_consent",
+        "preview_user_context",
+        "confirm_user_context",
+        "create_user_context",
+        "update_user_context",
+        "get_enrichment_run",
+        "cancel_enrichment_run",
+        "complete_onboarding",
+        "import_gmail_contacts",
+        "create_intent",
+        "update_intent",
+        "delete_intent",
+        "create_intent_index",
+        "read_intent_indexes",
+        "delete_intent_index",
+        "search_intents",
+        "list_negotiations",
+        "get_negotiation",
+        "respond_to_negotiation",
+        "read_networks",
+        "read_network_memberships",
+        "update_network",
+        "create_network",
+        "delete_network",
+        "create_network_membership",
+        "delete_network_membership",
+        "discover_opportunities",
+        "get_discovery_run",
+        "cancel_discovery_run",
+        "list_opportunities",
+        "update_opportunity",
+        "confirm_opportunity_delivery",
+        "create_premise",
+        "read_premises",
+        "update_premise",
+        "retract_premise",
+        "read_pending_questions",
+        "scrape_url",
+        "read_docs",
+    }
+)
 
 
 def _json(payload: dict[str, Any]) -> str:
@@ -298,6 +355,29 @@ def _validate_suggested_roles(value: Any) -> tuple[dict[str, str] | None, str | 
     if other_user not in _NEGOTIATION_ROLES:
         return None, "suggestedRoles.otherUser must be one of: agent, patient, peer."
     return {"ownUser": own_user, "otherUser": other_user}, None
+
+
+def index_forwarded_mcp_tool(tool_name: str, args: dict, **kwargs) -> str:
+    """Forward a Hermes tool call to an allowlisted Index MCP tool."""
+    del kwargs
+    if tool_name not in _FORWARDED_MCP_TOOLS:
+        return _error(f"Unsupported Index MCP tool: {tool_name}")
+    if not isinstance(args, dict):
+        return _error("Arguments must be an object.")
+    return _call_index_mcp(tool_name, args)
+
+
+def make_mcp_tool_handler(tool_name: str):
+    """Create a Hermes handler for an allowlisted pass-through Index MCP tool."""
+    if tool_name not in _FORWARDED_MCP_TOOLS:
+        raise ValueError(f"Unsupported Index MCP tool: {tool_name}")
+
+    def handler(args: dict, **kwargs) -> str:
+        return index_forwarded_mcp_tool(tool_name, args, **kwargs)
+
+    handler.__name__ = f"index_{tool_name}"
+    handler.__doc__ = f"Forward to the Index MCP {tool_name} tool."
+    return handler
 
 
 def index_read_intents(args: dict, **kwargs) -> str:

--- a/packages/protocol/skills/hermes-plugin/index-orchestrator.template.md
+++ b/packages/protocol/skills/hermes-plugin/index-orchestrator.template.md
@@ -9,13 +9,14 @@ description: Use in Hermes when the user asks to inspect Index Network signals/i
 
 ## Hermes tool availability
 
-This bundled Hermes skill is loaded from the `index-network` plugin namespace. The plugin's native tool surface is intentionally focused:
+This bundled Hermes skill is loaded from the `index-network` plugin namespace. The plugin provides:
 
-- `index_read_intents` — reads Index Network intents through the authenticated Index MCP server using `INDEX_API_KEY`.
+- `index_read_intents` — a dedicated, validated wrapper for the Index MCP `read_intents` tool.
+- `index_<mcp_tool_name>` wrappers for the rest of the Index MCP surface, such as `index_create_intent`, `index_read_networks`, `index_discover_opportunities`, `index_get_discovery_run`, `index_list_opportunities`, and `index_read_docs`.
 - `index_agent_me` — reads the authenticated personal agent identity.
 - `index_pickup_negotiation` and `index_respond_negotiation` — available when the task is specifically to run the user's autonomous Index negotiator.
 
-If additional Index MCP tools are configured separately in Hermes, you may use them when they are actually available. Do not claim you can create, update, delete, discover, notify, or negotiate unless the corresponding tool is present and its response confirms the action.
+Do not claim you created, updated, deleted, discovered, notified, or negotiated anything unless the corresponding tool response confirms the action. If unsure about arguments or workflow for a forwarded MCP wrapper, call `index_read_docs(topic="mcp_agent_guide")` first.
 
 ## Setup
 
@@ -48,23 +49,24 @@ index_read_intents(networkId=..., userId=..., limit=20, page=1)
 
 Only use IDs the user provided or that a prior tool call returned. Do not invent IDs.
 
-## Pattern 3: Prepare a new signal draft
+## Pattern 3: Prepare or save a signal
 
-When the user wants to add or improve a signal but no create/update tool is available:
+When the user wants to add or improve a signal:
 
 1. Draft a concise signal description in plain text.
-2. Say that this Hermes plugin version can draft it but cannot save it unless an Index create/update tool is available.
-3. If a create/update tool is available separately, ask for confirmation before calling it.
+2. Ask for confirmation before creating, updating, or deleting a signal.
+3. After confirmation, use `index_create_intent`, `index_update_intent`, or `index_delete_intent` as appropriate.
+4. Report only what the tool response confirms.
 
-Specificity test: a good signal names a domain, desired counterpart, concrete action, constraint, or timing.
+Specificity test: a good signal names a domain, desired counterpart, concrete action, constraint, or timing. MCP agents should pass `autoApprove=true` when creating a confirmed signal because Hermes has no Index web-card UI.
 
 ## Pattern 4: Broader discovery requests
 
 For requests like "find people who can help with X" or "who should I meet":
 
-- First inspect existing signals with `index_read_intents`.
-- If no discovery tool is available, explain that this Hermes plugin version can review signals but cannot run discovery yet.
-- If an Index discovery tool is available separately, use it only after you understand the user's goal.
+- First inspect existing signals with `index_read_intents` unless the user supplied a fresh search query directly.
+- Use `index_discover_opportunities` for discovery and `index_get_discovery_run` when the response returns an async run id.
+- Use `index_list_opportunities` to review existing actionable opportunities.
 
 ## Presentation rules
 


### PR DESCRIPTION
## Summary
- add Hermes-native forwarded wrappers for the canonical Index MCP tool surface
- register forwarded schemas/handlers and keep plugin manifest in sync
- update Hermes orchestrator guidance, README docs, and smoke coverage
- bump hermes plugin package/manifest version to 0.4.0

## Tests
- bun run build:skills
- cd packages/hermes-plugin && bun run test
- bun test scripts/tests/build-skills.spec.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784820652&installation_id=140549914&pr_number=1054&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1054&signature=b8bf09b5f6e0a284cf0abfe8324e566eb7c3d05f47c36a5811eb43b34dce34cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->