### PR TITLE
feat(hermes-plugin): add live dashboard summary

### DIFF
--- a/packages/hermes-plugin/README.md
+++ b/packages/hermes-plugin/README.md
@@ -19,13 +19,13 @@ The plugin provides these native Hermes tools:
 - `index_pickup_negotiation` — calls the personal-agent pickup endpoint to poll and claim one pending negotiation turn.
 - `index_respond_negotiation` — submits an autonomous personal-agent negotiation response with action, message, reasoning, and suggested roles.
 
-It also bundles generated, namespaced Hermes plugin skills, an orchestrator hint hook, a slash command, and a static read-only dashboard tab:
+It also bundles generated, namespaced Hermes plugin skills, an orchestrator hint hook, a slash command, and a live read-only dashboard tab:
 
 - `skills/index-orchestrator/SKILL.md` — signal/intent review and discovery preparation guidance for Hermes.
 - `skills/index-negotiator/SKILL.md` — autonomous personal-agent negotiation guidance for scheduled Hermes runs.
 - `pre_llm_call` hook — nudges Hermes to load `skill_view("index-network:index-orchestrator")` for clear Index/signal/intent/opportunity prompts.
 - `/index` command — returns the same skill-loading hint explicitly.
-- `dashboard/` — Hermes dashboard tab with static read-only guidance for Index signals, protocol usage, and autonomous negotiator setup.
+- `dashboard/` — Hermes dashboard tab showing scoped intents, opportunities, negotiation activity, and joined networks.
 
 ## Install / enable in Hermes
 
@@ -206,11 +206,12 @@ The plugin ships a plugin-local Hermes dashboard tab under `dashboard/`:
 dashboard/manifest.json
 dashboard/dist/index.js
 dashboard/dist/style.css
+dashboard/plugin_api.py
 ```
 
-The tab appears as **Index Network** in Hermes and is read-only. It summarizes protocol guidance for signals and communities, explains autonomous negotiator setup, and never calls live Index APIs or the pickup/respond negotiation tools from dashboard UI.
+The tab appears as **Index Network** in Hermes and is live read-only. It shows the authenticated user's own intents, actionable opportunities, negotiation activity summary, and joined networks. The dashboard backend reuses `tools.py` for Index authentication, scoped MCP forwarding, timeouts, and response decoding instead of creating a second Index client.
 
-This slice intentionally ships the dashboard as static-only. Python dashboard backend routes are deferred until Hermes route authentication is documented for this plugin source; any future live route design should reuse `tools.py` for Index authentication, scoped MCP forwarding, timeouts, and response decoding instead of creating a second client.
+The dashboard never claims pending negotiation turns or submits negotiation responses. Those actions remain explicit Hermes tool/skill flows.
 
 ## Verify
 
@@ -222,7 +223,7 @@ bun test scripts/tests/build-skills.spec.ts
 cd packages/hermes-plugin && bun run test
 ```
 
-For manual dashboard checks, run `curl http://127.0.0.1:9119/api/dashboard/plugins/rescan` or restart `hermes dashboard`, then open the **Index Network** tab. The tab should render static guidance without requiring `/api/plugins/index-network/*` backend routes.
+For manual dashboard checks, restart `hermes dashboard` after changing `plugin_api.py` (or run `curl http://127.0.0.1:9119/api/dashboard/plugins/rescan` after asset-only changes), then open the **Index Network** tab. The tab should load `/api/plugins/index-network/summary` through `SDK.fetchJSON` and render scoped Index data.
 
 For Hermes discovery debugging:
 

--- a/packages/hermes-plugin/dashboard/README.md
+++ b/packages/hermes-plugin/dashboard/README.md
@@ -6,26 +6,31 @@ This directory contains the plugin-local Hermes dashboard tab for the Index Netw
 dashboard/manifest.json   # Hermes dashboard plugin manifest
 dashboard/dist/index.js   # no-build IIFE bundle registered with the Hermes Plugin SDK
 dashboard/dist/style.css  # theme-aware styles scoped to .index-dashboard*
+dashboard/plugin_api.py   # read-only FastAPI routes mounted by Hermes dashboard
 ```
 
 ## Scope
 
-The dashboard is intentionally static and read-only. It gives Hermes users protocol-aligned guidance for Index Network signals, communities, and autonomous negotiator setup without exposing Python dashboard routes or creating a second Index data contract.
+The dashboard is live and read-only. It shows the authenticated Index user's:
+
+- intents;
+- opportunities;
+- negotiation activity summary;
+- joined networks.
+
+The backend route reuses `../tools.py` rather than creating a second Index client. That keeps `INDEX_API_KEY`, `INDEX_MCP_URL`, timeout handling, Telegram forwarding, MCP response decoding, and network-scoped agent visibility in one place.
 
 It does **not**:
 
-- mount Python backend routes;
-- call live Index MCP or REST APIs;
 - claim pending negotiation turns;
 - submit negotiation responses;
 - run discovery;
-- expose raw tool output, internal identifiers, tokens, raw messages, or assistant reasoning.
+- create, update, or delete Index records;
+- expose raw tool envelopes, tokens, raw messages, or assistant reasoning.
 
 ## Runtime behavior
 
-The tab always registers as `index-network` and renders static protocol-aligned guidance through `dist/index.js` and `dist/style.css`.
-
-Live dashboard routes are deliberately deferred until Hermes exposes a documented route-auth mechanism for this plugin source. When that work is reintroduced, route handlers should live behind explicit authentication and continue reusing the native handlers in `../tools.py`; do not add direct Index MCP or REST client code in the dashboard.
+The tab registers as `index-network` and fetches `/api/plugins/index-network/summary` through `SDK.fetchJSON`, so Hermes dashboard session authentication is handled by the host. The summary endpoint calls the existing read-only Index tools for intents, intent-network assignments, opportunities, negotiation activity counts, and networks, then returns dashboard-safe data. Negotiations are intentionally aggregated instead of listed because this dashboard does not render conversation threads.
 
 ## Verify
 
@@ -35,10 +40,10 @@ From the monorepo root:
 cd packages/hermes-plugin && bun run test
 ```
 
-For manual Hermes dashboard testing, refresh plugin discovery after installing or changing dashboard files:
+For manual Hermes dashboard testing, restart `hermes dashboard` after changing `plugin_api.py` (backend routes are mounted at dashboard startup). For asset-only changes, refresh plugin discovery:
 
 ```bash
 curl http://127.0.0.1:9119/api/dashboard/plugins/rescan
 ```
 
-Then open `hermes dashboard` and visit the **Index Network** tab. The tab should render static guidance without requiring Python dashboard routes.
+Then open `hermes dashboard` and visit the **Index Network** tab.

--- a/packages/hermes-plugin/dashboard/dist/index.js
+++ b/packages/hermes-plugin/dashboard/dist/index.js
@@ -1,9 +1,9 @@
 /**
  * Index Network Hermes dashboard.
  *
- * Registers a static, read-only dashboard tab. Live Python dashboard routes are
- * deliberately deferred until route authentication is explicit for this plugin
- * source, so this bundle performs no network fetches.
+ * Registers a read-only dashboard tab that loads user-scoped Index data through
+ * the plugin backend. The backend reuses the native Hermes tool handlers so
+ * INDEX_API_KEY scoping and protocol visibility rules stay centralized.
  */
 (function () {
   "use strict";
@@ -21,99 +21,208 @@
   const CardTitle = components.CardTitle || "h2";
   const CardContent = components.CardContent || "div";
   const Badge = components.Badge || "span";
+  const Button = components.Button || "button";
+  const API = "/api/plugins/index-network";
 
   function BadgeText(props) {
-    return React.createElement(Badge, { variant: "outline", className: "index-dashboard__badge" }, props.children);
+    return React.createElement(Badge, { variant: props.variant || "outline", className: "index-dashboard__badge" }, props.children);
   }
 
-  function GuidanceCard(props) {
-    return React.createElement(Card, { className: "index-dashboard__card" },
+  function formatCount(count) {
+    return Number.isFinite(count) ? String(count) : "0";
+  }
+
+  function getSection(summary, key) {
+    return (summary && summary.sections && summary.sections[key]) || { items: [], count: 0, summary: {} };
+  }
+
+  function EmptyState(props) {
+    return React.createElement("div", { className: "index-dashboard__empty" }, props.children || "Nothing to show yet.");
+  }
+
+  function ItemList(props) {
+    const items = Array.isArray(props.items) ? props.items : [];
+    if (props.error) {
+      return React.createElement("div", { className: "index-dashboard__error" }, props.error);
+    }
+    if (items.length === 0) {
+      return React.createElement(EmptyState, null, props.emptyMessage || props.empty || "Nothing to show yet.");
+    }
+    return React.createElement("div", { className: props.compact ? "index-dashboard__items index-dashboard__items--compact" : "index-dashboard__items" },
+      items.map(function (item, index) {
+        return React.createElement("article", { className: "index-dashboard__item", key: String(index) + (item.title || "") },
+          React.createElement("div", { className: "index-dashboard__item-head" },
+            React.createElement("h3", { className: "index-dashboard__item-title" }, item.title || "Untitled"),
+            item.status ? React.createElement(BadgeText, { variant: item.status === "waiting_for_agent" ? "default" : "outline" }, String(item.status).replace(/_/g, " ")) : null,
+          ),
+          item.detail ? React.createElement("p", { className: "index-dashboard__item-detail" }, item.detail) : null,
+          Array.isArray(item.networks) && item.networks.length > 0
+            ? React.createElement("div", { className: "index-dashboard__item-networks" },
+              React.createElement("span", null, "Assigned to"),
+              item.networks.map(function (network) {
+                return React.createElement(BadgeText, { key: String(network), variant: "outline" }, network);
+              }),
+            )
+            : null,
+          item.meta ? React.createElement("p", { className: "index-dashboard__item-meta" }, item.meta) : null,
+        );
+      }),
+    );
+  }
+
+  function Panel(props) {
+    return React.createElement(Card, { className: props.primary ? "index-dashboard__card index-dashboard__card--primary" : "index-dashboard__card" },
       React.createElement(CardHeader, { className: "index-dashboard__card-header" },
         React.createElement("div", { className: "index-dashboard__card-title-row" },
-          React.createElement(CardTitle, { className: "index-dashboard__card-title" }, props.title),
-          props.badge ? React.createElement(BadgeText, null, props.badge) : null,
+          React.createElement("div", null,
+            React.createElement(CardTitle, { className: "index-dashboard__card-title" }, props.title),
+            props.description ? React.createElement("p", { className: "index-dashboard__card-description" }, props.description) : null,
+          ),
+          props.count !== undefined ? React.createElement(BadgeText, null, formatCount(props.count)) : null,
         ),
       ),
       React.createElement(CardContent, { className: "index-dashboard__card-content" }, props.children),
     );
   }
 
-  function BulletList(props) {
-    return React.createElement("ul", { className: "index-dashboard__list" },
-      props.items.map(function (item) {
-        return React.createElement("li", { key: item }, item);
-      }),
+  function StatPill(props) {
+    return React.createElement("div", { className: "index-dashboard__stat" },
+      React.createElement("strong", null, formatCount(props.value)),
+      React.createElement("span", null, props.label),
     );
   }
 
-  function StatusPanel() {
+  function StatusPanel(props) {
     return React.createElement("div", { className: "index-dashboard__status-card" },
-      React.createElement(BadgeText, null, "Static read-only"),
-      React.createElement("p", null,
-        "This dashboard version does not mount Python routes or call live Index APIs. Use the bundled Hermes tools and skills for authenticated work.",
+      React.createElement("div", null,
+        React.createElement(BadgeText, { variant: props.error ? "destructive" : "outline" }, props.error ? "Needs attention" : "Live read-only"),
+        React.createElement("p", null,
+          props.error
+            ? props.error
+            : "Loaded through the Hermes dashboard backend with the configured Index agent key.",
+        ),
       ),
+      React.createElement(Button, { type: "button", onClick: props.onRefresh, disabled: props.loading, className: "index-dashboard__refresh" },
+        props.loading ? "Refreshing…" : "Refresh",
+      ),
+    );
+  }
+
+  function NegotiationActivity(props) {
+    const section = props.section || {};
+    const summary = section.summary || {};
+    const total = section.count || 0;
+    const active = summary.active || 0;
+    const waiting = summary.waitingForAgent || 0;
+    const completed = summary.completed || 0;
+    const needsAttention = summary.needsAttention || waiting;
+    if (section.error) {
+      return React.createElement("div", { className: "index-dashboard__error" }, section.error);
+    }
+    return React.createElement("div", { className: "index-dashboard__activity" },
+      React.createElement("div", { className: "index-dashboard__activity-main" },
+        React.createElement("span", null, formatCount(needsAttention)),
+        React.createElement("p", null, "need attention"),
+      ),
+      React.createElement("p", { className: "index-dashboard__activity-summary" },
+        "Index summarizes this automatically from negotiation statuses: ",
+        formatCount(total), " total, ",
+        formatCount(active), " active, ",
+        formatCount(waiting), " waiting for an agent, and ",
+        formatCount(completed), " completed.",
+      ),
+      React.createElement("div", { className: "index-dashboard__activity-grid" },
+        React.createElement(StatPill, { value: active, label: "active" }),
+        React.createElement(StatPill, { value: waiting, label: "waiting" }),
+        React.createElement(StatPill, { value: completed, label: "completed" }),
+        React.createElement(StatPill, { value: total, label: "total" }),
+      ),
+      React.createElement("p", { className: "index-dashboard__activity-note" }, section.note || "No negotiation conversations are rendered in this read-only dashboard."),
     );
   }
 
   function IndexNetworkDashboard() {
+    const useState = React.useState;
+    const useEffect = React.useEffect;
+    const state = useState(null);
+    const summary = state[0];
+    const setSummary = state[1];
+    const loadingState = useState(true);
+    const loading = loadingState[0];
+    const setLoading = loadingState[1];
+    const errorState = useState(null);
+    const error = errorState[0];
+    const setError = errorState[1];
+
+    function load() {
+      setLoading(true);
+      setError(null);
+      if (!SDK.fetchJSON) {
+        setError("This Hermes dashboard host does not expose authenticated plugin fetches.");
+        setLoading(false);
+        return;
+      }
+      SDK.fetchJSON(API + "/summary")
+        .then(function (payload) {
+          if (!payload || payload.success === false) {
+            throw new Error((payload && payload.error) || "Index dashboard data could not be loaded.");
+          }
+          setSummary(payload);
+        })
+        .catch(function (err) {
+          setError(err && err.message ? err.message : String(err));
+        })
+        .finally(function () {
+          setLoading(false);
+        });
+    }
+
+    useEffect(function () {
+      load();
+    }, []);
+
+    const intents = getSection(summary, "intents");
+    const opportunities = getSection(summary, "opportunities");
+    const negotiations = getSection(summary, "negotiations");
+    const networks = getSection(summary, "networks");
+
     return React.createElement("div", { className: "index-dashboard" },
       React.createElement("section", { className: "index-dashboard__hero" },
         React.createElement("div", null,
           React.createElement("p", { className: "index-dashboard__eyebrow" }, "Index Network"),
-          React.createElement("h1", { className: "index-dashboard__title" }, "Signals and autonomous negotiation"),
+          React.createElement("h1", { className: "index-dashboard__title" }, "Your network radar"),
           React.createElement("p", { className: "index-dashboard__subtitle" },
-            "A static read-only overview for the Index Network Hermes plugin. It keeps protocol guidance close to the native Hermes tools while avoiding unauthenticated dashboard backend routes.",
+            "A live, read-only brief of what you are looking for, who the network has surfaced, and which communities shape the search.",
           ),
-          React.createElement("p", { className: "index-dashboard__agent" },
-            "Load index-network:index-orchestrator in Hermes chat for authenticated signal review and discovery preparation.",
+          React.createElement("div", { className: "index-dashboard__stats" },
+            React.createElement(StatPill, { value: intents.count, label: "intents" }),
+            React.createElement(StatPill, { value: opportunities.count, label: "opportunities" }),
+            React.createElement(StatPill, { value: networks.count, label: "networks" }),
           ),
         ),
-        React.createElement(StatusPanel, null),
+        React.createElement(StatusPanel, { loading: loading, error: error, onRefresh: load }),
       ),
 
-      React.createElement("div", { className: "index-dashboard__grid" },
-        React.createElement(GuidanceCard, { title: "Signals", badge: "Guidance" },
-          React.createElement("p", null,
-            "Use signal language in user-facing copy and keep communities' visibility bounded by the configured Index agent key.",
+      loading && !summary
+        ? React.createElement("div", { className: "index-dashboard__loading" }, "Loading Index Network data…")
+        : React.createElement("div", { className: "index-dashboard__shell" },
+          React.createElement("main", { className: "index-dashboard__main" },
+            React.createElement(Panel, { primary: true, title: "Opportunities", count: opportunities.count, description: "Actionable matches currently visible to you." },
+              React.createElement(ItemList, { items: opportunities.items, error: opportunities.error, emptyMessage: opportunities.emptyMessage, empty: "No actionable opportunities yet." }),
+            ),
+            React.createElement(Panel, { title: "Negotiation activity", count: negotiations.count, description: "Counts only — conversation threads are not rendered in this dashboard." },
+              React.createElement(NegotiationActivity, { section: negotiations }),
+            ),
           ),
-          React.createElement(BulletList, { items: [
-            "Summarize the top few relevant points instead of displaying raw records.",
-            "Prefer community names and concise descriptions over internal identifiers.",
-            "Use the native Hermes tools when authenticated live data is needed.",
-          ] }),
+          React.createElement("aside", { className: "index-dashboard__sidebar" },
+            React.createElement(Panel, { title: "Intents", count: intents.count, description: "Your active signals." },
+              React.createElement(ItemList, { compact: true, items: intents.items, error: intents.error, empty: "No active intents yet." }),
+            ),
+            React.createElement(Panel, { title: "Networks", count: networks.count, description: "Joined communities and personal networks." },
+              React.createElement(ItemList, { compact: true, items: networks.items, error: networks.error, empty: "You are not joined to any networks yet." }),
+            ),
+          ),
         ),
-
-        React.createElement(GuidanceCard, { title: "Protocol guide", badge: "Static" },
-          React.createElement("p", null,
-            "Explain Index results as short prose or bullets. Do not surface internal identifiers unless the user can act on them, and never expose tokens, raw messages, or assistant reasoning.",
-          ),
-          React.createElement("p", { className: "index-dashboard__muted" },
-            "For interactive work, load the bundled skill index-network:index-orchestrator in Hermes.",
-          ),
-        ),
-
-        React.createElement(GuidanceCard, { title: "Autonomous negotiator", badge: "Scheduled" },
-          React.createElement("p", null,
-            "Autonomous negotiation is handled by the bundled index-network:index-negotiator skill on a schedule. A frequent scheduled run keeps the personal-agent heartbeat fresh.",
-          ),
-          React.createElement(BulletList, { items: [
-            "No claim button is shown here; claiming a pending turn is an authenticated tool action.",
-            "No response controls are shown here; submitted negotiation actions must remain tool-confirmed.",
-            "Use the schedule/gateway configuration in Hermes for autonomous operation.",
-          ] }),
-        ),
-
-        React.createElement(GuidanceCard, { title: "Dashboard status", badge: "Static-only" },
-          React.createElement("p", null,
-            "Live dashboard routes are deferred until route authentication is documented for this plugin source. The tab remains useful without backend route mounting.",
-          ),
-          React.createElement(BulletList, { items: [
-            "Static assets load through the Hermes dashboard plugin registry.",
-            "Authenticated Index access stays in the native Hermes tools and bundled skills.",
-            "Future live routes should reuse tools.py instead of adding a second Index client.",
-          ] }),
-        ),
-      ),
     );
   }
 

--- a/packages/hermes-plugin/dashboard/dist/style.css
+++ b/packages/hermes-plugin/dashboard/dist/style.css
@@ -13,7 +13,8 @@
   border: 1px solid var(--color-border, rgba(148, 163, 184, 0.24));
   border-radius: var(--radius, 0.75rem);
   background:
-    radial-gradient(circle at top left, rgba(79, 209, 197, 0.16), transparent 36rem),
+    radial-gradient(circle at 12% 18%, rgba(79, 209, 197, 0.18), transparent 26rem),
+    radial-gradient(circle at 88% 0%, rgba(129, 140, 248, 0.14), transparent 22rem),
     var(--color-card, rgba(15, 23, 42, 0.72));
   color: var(--color-card-foreground, inherit);
 }
@@ -42,6 +43,37 @@
   line-height: 1.6;
 }
 
+.index-dashboard__stats,
+.index-dashboard__activity-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  margin-top: 1rem;
+}
+
+.index-dashboard__stat {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.45rem;
+  padding: 0.45rem 0.65rem;
+  border: 1px solid color-mix(in srgb, var(--color-border, rgba(148, 163, 184, 0.24)) 78%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-background, #020617) 34%, transparent);
+}
+
+.index-dashboard__stat strong {
+  color: var(--color-card-foreground, inherit);
+  font-size: 0.95rem;
+  line-height: 1;
+}
+
+.index-dashboard__stat span {
+  color: var(--color-muted-foreground, rgba(148, 163, 184, 0.92));
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
 .index-dashboard__status-card,
 .index-dashboard__card {
   border: 1px solid var(--color-border, rgba(148, 163, 184, 0.24));
@@ -64,16 +96,41 @@
   line-height: 1.55;
 }
 
-.index-dashboard__agent {
-  margin: 0.75rem 0 0;
-  color: var(--color-muted-foreground, rgba(148, 163, 184, 0.92));
-  font-size: 0.875rem;
+.index-dashboard__refresh {
+  align-self: flex-start;
 }
 
-.index-dashboard__grid {
+.index-dashboard__loading,
+.index-dashboard__empty,
+.index-dashboard__error {
+  padding: 0.85rem;
+  border: 1px dashed var(--color-border, rgba(148, 163, 184, 0.24));
+  border-radius: calc(var(--radius, 0.75rem) * 0.75);
+  color: var(--color-muted-foreground, rgba(148, 163, 184, 0.92));
+  font-size: 0.9rem;
+}
+
+.index-dashboard__error {
+  border-color: color-mix(in srgb, var(--color-destructive, #ef4444) 50%, transparent);
+  color: var(--color-destructive, #ef4444);
+}
+
+.index-dashboard__shell {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: minmax(0, 1.55fr) minmax(280px, 0.85fr);
   gap: 1rem;
+  align-items: start;
+}
+
+.index-dashboard__main,
+.index-dashboard__sidebar {
+  display: grid;
+  gap: 1rem;
+}
+
+.index-dashboard__card--primary {
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--color-card, #0f172a) 96%, rgba(79, 209, 197, 0.12)), var(--color-card, #0f172a));
 }
 
 .index-dashboard__card-header {
@@ -82,13 +139,18 @@
 
 .index-dashboard__card-title-row {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 0.75rem;
 }
 
 .index-dashboard__card-title {
   font-size: 1rem;
+}
+
+.index-dashboard__card-description {
+  margin-top: 0.25rem !important;
+  font-size: 0.82rem;
 }
 
 .index-dashboard__card-content {
@@ -99,27 +161,124 @@
 
 .index-dashboard__badge {
   white-space: nowrap;
+  text-transform: capitalize;
 }
 
-.index-dashboard__list {
+.index-dashboard__items {
   display: grid;
-  gap: 0.45rem;
+  gap: 0.65rem;
+}
+
+.index-dashboard__items--compact {
+  gap: 0.5rem;
+}
+
+.index-dashboard__item {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.85rem;
+  border: 1px solid color-mix(in srgb, var(--color-border, rgba(148, 163, 184, 0.24)) 72%, transparent);
+  border-radius: calc(var(--radius, 0.75rem) * 0.75);
+  background: color-mix(in srgb, var(--color-background, #020617) 36%, transparent);
+}
+
+.index-dashboard__card--primary .index-dashboard__item:first-child {
+  border-color: color-mix(in srgb, var(--color-primary, #4fd1c5) 48%, var(--color-border, rgba(148, 163, 184, 0.24)));
+  background: color-mix(in srgb, var(--color-primary, #4fd1c5) 8%, transparent);
+}
+
+.index-dashboard__items--compact .index-dashboard__item {
+  padding: 0.7rem;
+}
+
+.index-dashboard__item-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.index-dashboard__item-title {
   margin: 0;
-  padding-left: 1.1rem;
+  color: var(--color-card-foreground, inherit);
+  font-size: 0.95rem;
+  line-height: 1.35;
+}
+
+.index-dashboard__items--compact .index-dashboard__item-title {
+  font-size: 0.88rem;
+}
+
+.index-dashboard__item-detail {
+  font-size: 0.88rem;
+}
+
+.index-dashboard__items--compact .index-dashboard__item-detail {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  font-size: 0.8rem;
+}
+
+.index-dashboard__item-meta {
   color: var(--color-muted-foreground, rgba(148, 163, 184, 0.92));
+  font-size: 0.78rem;
 }
 
-.index-dashboard__list li::marker {
-  color: var(--color-primary, currentColor);
+.index-dashboard__item-networks {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--color-muted-foreground, rgba(148, 163, 184, 0.92));
+  font-size: 0.76rem;
 }
 
-.index-dashboard__muted {
-  font-size: 0.875rem;
+.index-dashboard__item-networks > span:first-child {
+  margin-right: 0.1rem;
 }
 
-@media (max-width: 900px) {
+.index-dashboard__activity {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.index-dashboard__activity-main {
+  display: flex;
+  align-items: baseline;
+  gap: 0.65rem;
+}
+
+.index-dashboard__activity-main span {
+  color: var(--color-card-foreground, inherit);
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  font-weight: 800;
+  line-height: 1;
+  letter-spacing: -0.06em;
+}
+
+.index-dashboard__activity-main p {
+  font-size: 0.92rem;
+}
+
+.index-dashboard__activity-summary {
+  color: var(--color-card-foreground, inherit) !important;
+  font-size: 0.95rem;
+}
+
+.index-dashboard__activity-grid {
+  margin-top: 0;
+}
+
+.index-dashboard__activity-note {
+  padding-top: 0.15rem;
+  font-size: 0.82rem;
+}
+
+@media (max-width: 980px) {
   .index-dashboard__hero,
-  .index-dashboard__grid {
+  .index-dashboard__shell {
     grid-template-columns: 1fr;
   }
 }

--- a/packages/hermes-plugin/dashboard/manifest.json
+++ b/packages/hermes-plugin/dashboard/manifest.json
@@ -1,13 +1,14 @@
 {
   "name": "index-network",
   "label": "Index Network",
-  "description": "Read-only Index Network overview for signals, protocol guidance, and autonomous negotiator setup.",
+  "description": "Live read-only Index Network overview for intents, opportunities, negotiations, and joined networks.",
   "icon": "Sparkles",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "tab": {
     "path": "/index-network",
     "position": "after:skills"
   },
   "entry": "dist/index.js",
-  "css": "dist/style.css"
+  "css": "dist/style.css",
+  "api": "plugin_api.py"
 }

--- a/packages/hermes-plugin/dashboard/plugin_api.py
+++ b/packages/hermes-plugin/dashboard/plugin_api.py
@@ -1,0 +1,349 @@
+"""Index Network Hermes dashboard plugin backend.
+
+Mounted at /api/plugins/index-network/ by Hermes dashboard. The routes are
+read-only and reuse the plugin's native Index MCP tool handlers so dashboard
+visibility stays scoped to the configured INDEX_API_KEY principal.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+try:
+    from fastapi import APIRouter
+except Exception:  # Allows local smoke tests without dashboard dependencies.
+    class APIRouter:  # type: ignore
+        def get(self, *_args, **_kwargs):
+            return lambda fn: fn
+
+router = APIRouter()
+
+_DASHBOARD_DIR = Path(__file__).resolve().parent
+_PLUGIN_ROOT = _DASHBOARD_DIR.parent
+_TOOLS_PATH = _PLUGIN_ROOT / "tools.py"
+_SUMMARY_LIMIT = 12
+_PREVIEW_CHARS = 240
+
+
+def _load_tools_module():
+    spec = importlib.util.spec_from_file_location("index_network_hermes_dashboard_tools", _TOOLS_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Could not load Index Network tools module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+tools = _load_tools_module()
+
+
+def _parse_tool_json(raw: str) -> dict[str, Any]:
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return {"success": False, "error": f"Index tool returned invalid JSON: {exc}"}
+    if isinstance(parsed, dict):
+        return parsed
+    return {"success": True, "data": parsed}
+
+
+def _call_read_intents() -> dict[str, Any]:
+    return _parse_tool_json(tools.index_read_intents({"limit": _SUMMARY_LIMIT, "page": 1}))
+
+
+def _call_mcp(tool_name: str, args: dict[str, Any] | None = None) -> dict[str, Any]:
+    return _parse_tool_json(tools.index_forwarded_mcp_tool(tool_name, args or {}))
+
+
+def _data(payload: dict[str, Any]) -> Any:
+    if payload.get("success") is False:
+        return None
+    return payload.get("data") if "data" in payload else payload
+
+
+def _text(value: Any, fallback: str = "") -> str:
+    if value is None:
+        return fallback
+    if isinstance(value, str):
+        return value.strip() or fallback
+    if isinstance(value, (int, float, bool)):
+        return str(value)
+    if isinstance(value, dict):
+        for key in ("summary", "description", "title", "name", "text", "value"):
+            result = _text(value.get(key))
+            if result:
+                return result
+    return fallback
+
+
+def _truncate(value: Any, limit: int = _PREVIEW_CHARS) -> str:
+    clean = re.sub(r"\s+", " ", _text(value)).strip()
+    if len(clean) <= limit:
+        return clean
+    return clean[: limit - 1].rstrip() + "…"
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _section_error(payload: dict[str, Any]) -> str | None:
+    if payload.get("success") is not False:
+        return None
+    return _text(payload.get("error"), "Index request failed.")
+
+
+def _same_preview(left: str, right: str) -> bool:
+    lhs = re.sub(r"\s+", " ", left).strip().rstrip("…")
+    rhs = re.sub(r"\s+", " ", right).strip().rstrip("…")
+    if not lhs or not rhs:
+        return False
+    return lhs == rhs or lhs.startswith(rhs) or rhs.startswith(lhs)
+
+
+def _normalize_intents(payload: dict[str, Any], intent_networks: dict[str, list[str]] | None = None) -> dict[str, Any]:
+    data = _data(payload)
+    intents = _list(data.get("intents") if isinstance(data, dict) else None)
+    networks_by_intent = intent_networks or {}
+    items = []
+    for intent in intents[:_SUMMARY_LIMIT]:
+        if not isinstance(intent, dict):
+            continue
+        intent_id = _text(intent.get("id"))
+        summary = _text(intent.get("summary"))
+        description = _text(intent.get("description") or intent.get("payload") or intent.get("context"))
+        title = (
+            _truncate(summary, 140)
+            or _truncate(description, 140)
+            or "Untitled intent"
+        )
+        detail = _truncate(description)
+        item: dict[str, Any] = {"title": title}
+        if detail and not _same_preview(title, detail):
+            item["detail"] = detail
+        status = _text(intent.get("status"))
+        if status:
+            item["status"] = status
+        assigned_networks = networks_by_intent.get(intent_id, []) if intent_id else []
+        if assigned_networks:
+            item["networks"] = assigned_networks[:4]
+        confidence = intent.get("confidence")
+        if isinstance(confidence, (int, float)):
+            item["meta"] = f"{round(confidence * 100)}% confidence"
+        items.append(item)
+    total = data.get("totalCount", data.get("count", len(items))) if isinstance(data, dict) else len(items)
+    return {"items": items, "count": total if isinstance(total, int) else len(items), "error": _section_error(payload)}
+
+
+def _parse_opportunity_message(message: str) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    current: dict[str, Any] | None = None
+    body_lines: list[str] = []
+
+    def flush() -> None:
+        nonlocal current, body_lines
+        if current is None:
+            return
+        detail_lines = []
+        status = None
+        for line in body_lines:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if stripped.lower().startswith("status:"):
+                status = stripped.split(":", 1)[1].strip()
+                continue
+            if re.match(r"^(profileUrl|acceptUrl|opportunityId|feedCategory|negotiationUrl|confidence):", stripped):
+                continue
+            if stripped.startswith("<!--"):
+                continue
+            detail_lines.append(stripped)
+        if detail_lines:
+            current["detail"] = _truncate(" ".join(detail_lines))
+        if status:
+            current["status"] = status
+        items.append(current)
+        current = None
+        body_lines = []
+
+    for raw_line in message.splitlines():
+        match = re.match(r"^\s*\d+\.\s+(.+?)\s*$", raw_line)
+        if match:
+            flush()
+            current = {"title": _truncate(match.group(1), 120) or "Opportunity"}
+            continue
+        if current is not None:
+            body_lines.append(raw_line)
+    flush()
+    return items
+
+
+def _normalize_opportunities(payload: dict[str, Any]) -> dict[str, Any]:
+    data = _data(payload)
+    if not isinstance(data, dict):
+        return {"items": [], "count": 0, "error": _section_error(payload)}
+    message = _text(data.get("message"))
+    items = _parse_opportunity_message(message)[:_SUMMARY_LIMIT] if message else []
+    count = data.get("count", len(items))
+    if not items and data.get("summary") and (not isinstance(count, int) or count > 0):
+        items = [{"title": _text(data.get("summary")), "detail": _truncate(data.get("message"))}]
+    return {
+        "items": items,
+        "count": count if isinstance(count, int) else len(items),
+        "emptyMessage": _text(data.get("message")) if not items else "",
+        "error": _section_error(payload),
+    }
+
+
+def _count_from_negotiation_payload(payload: dict[str, Any]) -> int:
+    data = _data(payload)
+    if not isinstance(data, dict):
+        return 0
+    count = data.get("totalCount", data.get("count", 0))
+    return count if isinstance(count, int) else 0
+
+
+def _normalize_negotiation_activity(payloads: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    errors = [_section_error(payload) for payload in payloads.values()]
+    first_error = next((err for err in errors if err), None)
+    total = _count_from_negotiation_payload(payloads.get("all", {}))
+    waiting = _count_from_negotiation_payload(payloads.get("waiting_for_agent", {}))
+    active = _count_from_negotiation_payload(payloads.get("active", {}))
+    completed = _count_from_negotiation_payload(payloads.get("completed", {}))
+    return {
+        "count": total,
+        "summary": {
+            "active": active,
+            "waitingForAgent": waiting,
+            "completed": completed,
+            "needsAttention": waiting,
+        },
+        "note": "No negotiation conversations are rendered in this read-only dashboard.",
+        "error": first_error,
+    }
+
+
+def _network_key(network: dict[str, Any]) -> str:
+    for key in ("networkId", "id", "title", "name"):
+        value = _text(network.get(key))
+        if value:
+            return value
+    return json.dumps(network, sort_keys=True, default=str)
+
+
+def _joined_network_refs(payload: dict[str, Any]) -> list[dict[str, str]]:
+    data = _data(payload)
+    joined: list[Any] = []
+    if isinstance(data, dict):
+        joined.extend(_list(data.get("memberOf")))
+        joined.extend(_list(data.get("owns")))
+    refs: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for membership in _list(data.get("memberships") if isinstance(data, dict) else None):
+        if not isinstance(membership, dict):
+            continue
+        network_id = _text(membership.get("networkId") or membership.get("id"))
+        if not network_id or network_id in seen:
+            continue
+        seen.add(network_id)
+        refs.append({"id": network_id, "title": _text(membership.get("networkTitle") or membership.get("title") or membership.get("name"), "Untitled network")})
+    for network in joined:
+        if not isinstance(network, dict):
+            continue
+        network_id = _text(network.get("networkId") or network.get("id"))
+        if not network_id or network_id in seen:
+            continue
+        seen.add(network_id)
+        refs.append({"id": network_id, "title": _text(network.get("title") or network.get("name"), "Untitled network")})
+    return refs
+
+
+def _intent_ids(payload: dict[str, Any]) -> list[str]:
+    data = _data(payload)
+    intents = _list(data.get("intents") if isinstance(data, dict) else None)
+    ids: list[str] = []
+    for intent in intents[:_SUMMARY_LIMIT]:
+        if not isinstance(intent, dict):
+            continue
+        intent_id = _text(intent.get("id"))
+        if intent_id:
+            ids.append(intent_id)
+    return ids
+
+
+def _intent_network_titles(networks_payload: dict[str, Any], intent_ids: list[str]) -> dict[str, list[str]]:
+    titles_by_network = {ref["id"]: ref["title"] for ref in _joined_network_refs(networks_payload)}
+    titles_by_intent: dict[str, list[str]] = {}
+    for intent_id in intent_ids[:_SUMMARY_LIMIT]:
+        for network_id, network_title in list(titles_by_network.items())[:_SUMMARY_LIMIT]:
+            link_payload = _call_mcp("read_intent_indexes", {"intentId": intent_id, "networkId": network_id})
+            data = _data(link_payload)
+            links = _list(data.get("links") if isinstance(data, dict) else None)
+            if not links:
+                continue
+            titles = titles_by_intent.setdefault(intent_id, [])
+            if network_title not in titles:
+                titles.append(network_title)
+    return titles_by_intent
+
+
+def _normalize_networks(payload: dict[str, Any]) -> dict[str, Any]:
+    data = _data(payload)
+    joined: list[Any] = []
+    if isinstance(data, dict):
+        joined.extend(_list(data.get("memberOf")))
+        joined.extend(_list(data.get("owns")))
+    seen: set[str] = set()
+    items = []
+    for network in joined:
+        if not isinstance(network, dict):
+            continue
+        key = _network_key(network)
+        if key in seen:
+            continue
+        seen.add(key)
+        title = _text(network.get("title") or network.get("name"), "Untitled network")
+        detail = _truncate(network.get("renderedContext") or network.get("prompt") or network.get("description"))
+        permissions = _list(network.get("permissions"))
+        meta_parts = []
+        if network.get("isPersonal") is True:
+            meta_parts.append("personal")
+        if permissions:
+            meta_parts.append(", ".join(_text(p) for p in permissions if _text(p)))
+        item: dict[str, Any] = {"title": title}
+        if detail:
+            item["detail"] = detail
+        if meta_parts:
+            item["meta"] = " · ".join(meta_parts)
+        items.append(item)
+    return {"items": items[:_SUMMARY_LIMIT], "count": len(items), "error": _section_error(payload)}
+
+
+@router.get("/summary")
+def summary() -> dict[str, Any]:
+    """Return a read-only, user-scoped dashboard summary."""
+    intents_payload = _call_read_intents()
+    opportunities_payload = _call_mcp("list_opportunities")
+    networks_payload = _call_mcp("read_networks")
+    memberships_payload = _call_mcp("read_network_memberships")
+    intent_networks = _intent_network_titles(memberships_payload, _intent_ids(intents_payload))
+    negotiation_payloads = {
+        "all": _call_mcp("list_negotiations", {"status": "all", "limit": 1, "page": 1}),
+        "active": _call_mcp("list_negotiations", {"status": "active", "limit": 1, "page": 1}),
+        "waiting_for_agent": _call_mcp("list_negotiations", {"status": "waiting_for_agent", "limit": 1, "page": 1}),
+        "completed": _call_mcp("list_negotiations", {"status": "completed", "limit": 1, "page": 1}),
+    }
+
+    return {
+        "success": True,
+        "sections": {
+            "intents": _normalize_intents(intents_payload, intent_networks),
+            "opportunities": _normalize_opportunities(opportunities_payload),
+            "negotiations": _normalize_negotiation_activity(negotiation_payloads),
+            "networks": _normalize_networks(networks_payload),
+        },
+    }

--- a/packages/hermes-plugin/package.json
+++ b/packages/hermes-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/hermes-plugin",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Hermes-native Index Network plugin with MCP and personal-agent tools",
   "license": "MIT",
   "type": "module",

--- a/packages/hermes-plugin/plugin.yaml
+++ b/packages/hermes-plugin/plugin.yaml
@@ -1,5 +1,5 @@
 name: index-network
-version: 0.4.0
+version: 0.5.0
 description: Index Network Hermes plugin with native tools backed by Index MCP and personal-agent APIs.
 provides_tools:
   - index_read_intents

--- a/packages/hermes-plugin/tests/smoke.py
+++ b/packages/hermes-plugin/tests/smoke.py
@@ -12,11 +12,12 @@ import sys
 import urllib.request
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
-PYTHON_FILES = ["__init__.py", "schemas.py", "tools.py"]
+PYTHON_FILES = ["__init__.py", "schemas.py", "tools.py", "dashboard/plugin_api.py"]
 DASHBOARD_FILES = [
     "dashboard/manifest.json",
     "dashboard/dist/index.js",
     "dashboard/dist/style.css",
+    "dashboard/plugin_api.py",
 ]
 
 
@@ -54,6 +55,19 @@ def load_plugin():
     return module
 
 
+def load_dashboard_api():
+    spec = importlib.util.spec_from_file_location(
+        "index_network_dashboard_api",
+        ROOT / "dashboard" / "plugin_api.py",
+    )
+    if spec is None or spec.loader is None:
+        raise AssertionError("Could not create import spec for dashboard API")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
 class FakeResponse:
     def __init__(self, payload=None, *, status=200, headers=None):
         self.payload = payload
@@ -73,6 +87,16 @@ class FakeResponse:
         if isinstance(self.payload, bytes):
             return self.payload
         return json.dumps(self.payload).encode()
+
+
+def mcp_text_response(payload, *, response_id=1):
+    return FakeResponse(
+        {
+            "jsonrpc": "2.0",
+            "id": response_id,
+            "result": {"content": [{"type": "text", "text": json.dumps(payload)}]},
+        }
+    )
 
 
 def install_fake_urlopen(responses, captured):
@@ -148,46 +172,34 @@ def main() -> None:
     assert dashboard_manifest["label"] == "Index Network"
     assert dashboard_manifest["entry"] == "dist/index.js"
     assert dashboard_manifest["css"] == "dist/style.css"
-    assert "api" not in dashboard_manifest
+    assert dashboard_manifest["api"] == "plugin_api.py"
     assert dashboard_manifest["tab"]["path"] == "/index-network"
-    for key in ("entry", "css"):
+    for key in ("entry", "css", "api"):
         assert (ROOT / "dashboard" / dashboard_manifest[key]).exists(), dashboard_manifest[key]
-    assert not (ROOT / "dashboard" / "plugin_api.py").exists()
 
     dashboard_js_path = ROOT / "dashboard" / "dist" / "index.js"
     subprocess.run(["node", "--check", str(dashboard_js_path)], check=True)
     dashboard_js = dashboard_js_path.read_text()
     assert 'register("index-network"' in dashboard_js
-    assert "Static read-only" in dashboard_js
-    assert "Static-only" in dashboard_js
-    assert "Signals" in dashboard_js
-    assert "communities" in dashboard_js
-    assert "internal identifiers" in dashboard_js
-    assert "raw records" in dashboard_js
-    assert "/api/" + "plugins/" not in dashboard_js
-    assert "SDK.fetchJSON" not in dashboard_js
-    assert "Live read-only" not in dashboard_js
-    assert "raw JSON" not in dashboard_js
-    assert "tool_call" not in dashboard_js
-    assert "intentId" not in dashboard_js
-    assert "networkId" not in dashboard_js
-    assert "opportunityId" not in dashboard_js
+    assert "Live read-only" in dashboard_js
+    assert "Intents" in dashboard_js
+    assert "Opportunities" in dashboard_js
+    assert "Negotiation activity" in dashboard_js
+    assert "Networks" in dashboard_js
+    assert "/api/" + "plugins/index-network" in dashboard_js
+    assert "SDK.fetchJSON" in dashboard_js
     assert "index_pickup_negotiation" not in dashboard_js
     assert "index_respond_negotiation" not in dashboard_js
 
-
-
     dashboard_readme = (ROOT / "dashboard" / "README.md").read_text()
     package_readme = (ROOT / "README.md").read_text()
-    assert "static and read-only" in dashboard_readme
-    assert "mount Python backend routes" in dashboard_readme
-    assert "Live dashboard routes are deliberately deferred" in dashboard_readme
+    assert "live and read-only" in dashboard_readme
+    assert "dashboard/plugin_api.py" in dashboard_readme
     assert "../tools.py" in dashboard_readme
-    assert "static-only" in package_readme
-    assert "never calls live Index APIs" in package_readme
+    assert "claim pending negotiation turns" in dashboard_readme
+    assert "live read-only" in package_readme
+    assert "dashboard/plugin_api.py" in package_readme
     assert "tools.py" in package_readme
-    forbidden_api_path = "dashboard/" + "plugin_api.py"
-    assert forbidden_api_path not in package_readme
 
     assert [name for name, _path in ctx.skills] == ["index-negotiator", "index-orchestrator"]
     for _name, skill_md in ctx.skills:
@@ -358,6 +370,138 @@ def main() -> None:
                 }
             )
         ) == {"success": False, "error": "message is required for counter and question actions."}
+
+        dashboard_api = load_dashboard_api()
+        captured = []
+        install_fake_urlopen(
+            [
+                mcp_text_response(
+                    {
+                        "success": True,
+                        "data": {
+                            "intents": [
+                                {
+                                    "id": "intent-hidden",
+                                    "summary": "Find robotics mentors",
+                                    "description": "Looking for mentors in applied robotics.",
+                                    "status": "active",
+                                    "confidence": 0.91,
+                                }
+                            ],
+                            "count": 1,
+                        },
+                    },
+                    response_id=10,
+                ),
+                mcp_text_response(
+                    {
+                        "success": True,
+                        "data": {
+                            "found": True,
+                            "count": 1,
+                            "message": "You have 1 opportunity.\n\n1. Ada\n   Can advise on robotics hiring.\n   status: draft\n   opportunityId: hidden\n\nDo NOT print raw JSON.",
+                        },
+                    },
+                    response_id=11,
+                ),
+                mcp_text_response(
+                    {
+                        "success": True,
+                        "data": {
+                            "memberOf": [
+                                {
+                                    "networkId": "network-hidden",
+                                    "title": "Robotics Guild",
+                                    "prompt": "People building robotics companies.",
+                                    "permissions": ["member"],
+                                }
+                            ],
+                            "owns": [],
+                            "publicNetworks": [{"title": "Not joined"}],
+                        },
+                    },
+                    response_id=12,
+                ),
+                mcp_text_response(
+                    {
+                        "success": True,
+                        "data": {
+                            "userId": "user-hidden",
+                            "count": 1,
+                            "memberships": [
+                                {
+                                    "networkId": "network-hidden",
+                                    "networkTitle": "Robotics Guild",
+                                    "permissions": ["member"],
+                                }
+                            ],
+                        },
+                    },
+                    response_id=13,
+                ),
+                mcp_text_response(
+                    {
+                        "success": True,
+                        "data": {
+                            "links": [
+                                {
+                                    "intentId": "intent-hidden",
+                                    "networkId": "network-hidden",
+                                    "intentTitle": "Looking for mentors in applied robotics.",
+                                    "relevancyScore": 0.94,
+                                }
+                            ],
+                            "count": 1,
+                        },
+                    },
+                    response_id=14,
+                ),
+                mcp_text_response(
+                    {"success": True, "data": {"count": 1, "totalCount": 7, "negotiations": [{"status": "completed"}]}},
+                    response_id=15,
+                ),
+                mcp_text_response(
+                    {"success": True, "data": {"count": 1, "totalCount": 2, "negotiations": [{"status": "active"}]}},
+                    response_id=16,
+                ),
+                mcp_text_response(
+                    {"success": True, "data": {"count": 1, "totalCount": 1, "negotiations": [{"status": "waiting_for_agent"}]}},
+                    response_id=17,
+                ),
+                mcp_text_response(
+                    {"success": True, "data": {"count": 1, "totalCount": 4, "negotiations": [{"status": "completed"}]}},
+                    response_id=18,
+                ),
+            ],
+            captured,
+        )
+        summary = dashboard_api.summary()
+        assert summary["success"] is True
+        sections = summary["sections"]
+        assert sections["intents"]["items"][0]["title"] == "Find robotics mentors"
+        assert sections["intents"]["items"][0]["detail"] == "Looking for mentors in applied robotics."
+        assert sections["intents"]["items"][0]["networks"] == ["Robotics Guild"]
+        assert sections["opportunities"]["items"][0]["title"] == "Ada"
+        assert sections["negotiations"]["count"] == 7
+        assert sections["negotiations"]["summary"] == {
+            "active": 2,
+            "waitingForAgent": 1,
+            "completed": 4,
+            "needsAttention": 1,
+        }
+        assert sections["networks"]["items"][0]["title"] == "Robotics Guild"
+        assert sections["networks"]["count"] == 1
+        assert [entry["body"]["params"]["name"] for entry in captured] == [
+            "read_intents",
+            "list_opportunities",
+            "read_networks",
+            "read_network_memberships",
+            "read_intent_indexes",
+            "list_negotiations",
+            "list_negotiations",
+            "list_negotiations",
+            "list_negotiations",
+        ]
     finally:
         urllib.request.urlopen = old_urlopen
         if old_api_key is not None:


### PR DESCRIPTION
## Summary
- add a read-only Hermes dashboard backend route that reuses existing Index tool handlers
- render live intents, opportunities, negotiation activity counts, and joined networks
- show intent network assignments and keep negotiations aggregated instead of conversation-like rows

## Tests
- python3 -m py_compile packages/hermes-plugin/dashboard/plugin_api.py
- node --check packages/hermes-plugin/dashboard/dist/index.js
- cd packages/hermes-plugin && bun run test
- live local Hermes dashboard API smoke test at http://127.0.0.1:9120/index-network

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784920319&installation_id=140549914&pr_number=1058&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1058&signature=36d207beba9167610b24ec2ef66b28bf40b42a2ab56a3ecb2ecde273c00d45f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->