### PR TITLE
fix(ci): isolate hermetic test install from cache

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -103,9 +103,12 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.14"
+          no-cache: true
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: |
+          bun pm cache rm || true
+          bun install --frozen-lockfile
 
       - name: Run hermetic pinning tests
         run: |


### PR DESCRIPTION
## Summary
- disable setup-bun package caching for the hermetic pinning test job
- clear Bun package cache before the frozen install so CI does not reuse a stale/corrupt drizzle-orm package cache

## Tests
- bun pm cache rm || true
- bun install --frozen-lockfile
- cd services/api && bun test src/adapters/tests/can-actor-see-opportunity.spec.ts src/queues/tests/timeout.queue.spec.ts src/queues/tests/claim-timeout.queue.spec.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784920943&installation_id=140549914&pr_number=1059&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1059&signature=244b8584ccfa22f4b32313699f6b4baec6e76be3b0924df3de1895a61d406ae3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->