### PR TITLE
fix(api): import drizzle schema helpers from subpaths

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -103,9 +103,12 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.14"
+          no-cache: true
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: |
+          bun pm cache rm || true
+          bun install --frozen-lockfile
 
       - name: Run hermetic pinning tests
         run: |

--- a/services/api/src/schemas/conversation.schema.ts
+++ b/services/api/src/schemas/conversation.schema.ts
@@ -1,5 +1,6 @@
 import { pgTable, pgEnum, text, timestamp, jsonb, index, primaryKey, uniqueIndex } from 'drizzle-orm/pg-core';
-import { relations, sql } from 'drizzle-orm';
+import { relations } from 'drizzle-orm/relations';
+import { sql } from 'drizzle-orm/sql';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Enums

--- a/services/api/src/schemas/database.schema.ts
+++ b/services/api/src/schemas/database.schema.ts
@@ -1,6 +1,7 @@
 import { pgTable, pgEnum, text, timestamp, bigint, boolean, json, jsonb, integer, uniqueIndex, index, doublePrecision, numeric, primaryKey } from 'drizzle-orm/pg-core';
 import { vector } from 'drizzle-orm/pg-core';
-import { relations, sql } from 'drizzle-orm';
+import { relations } from 'drizzle-orm/relations';
+import { sql } from 'drizzle-orm/sql';
 import type { Id } from '../types/common.types';
 
 // Enums


### PR DESCRIPTION
## Summary
- import schema-only Drizzle helpers from explicit `drizzle-orm/relations` and `drizzle-orm/sql` subpaths
- avoid Bun/Linux resolving Drizzle root barrel `export *` incorrectly in hermetic tests

## Tests
- cd services/api && bun test src/adapters/tests/can-actor-see-opportunity.spec.ts src/queues/tests/timeout.queue.spec.ts src/queues/tests/claim-timeout.queue.spec.ts
- cd services/api && bun run build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1060"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784921139&installation_id=140549914&pr_number=1060&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1060&signature=16a7943dee769889327c07bfbbf1138437094e42e85f374b84cb578691d694fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->