### PR TITLE
fix(api): import drizzle helpers from sql subpath

### DIFF
--- a/services/api/src/adapters/agent-token.adapter.ts
+++ b/services/api/src/adapters/agent-token.adapter.ts
@@ -1,4 +1,4 @@
-import { and, eq, sql } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm/sql';
 
 import db from '../lib/drizzle/drizzle';
 import * as schema from '../schemas/database.schema';

--- a/services/api/src/adapters/agent.database.adapter.ts
+++ b/services/api/src/adapters/agent.database.adapter.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray, isNull, or, sql } from 'drizzle-orm';
+import { and, desc, eq, inArray, isNull, or, sql } from 'drizzle-orm/sql';
 
 
 import db from '../lib/drizzle/drizzle';

--- a/services/api/src/adapters/auth.adapter.ts
+++ b/services/api/src/adapters/auth.adapter.ts
@@ -1,5 +1,5 @@
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
-import { and, eq, sql } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm/sql';
 
 import db from '../lib/drizzle/drizzle';
 import * as schema from '../schemas/database.schema';

--- a/services/api/src/adapters/chat-summary.database.adapter.ts
+++ b/services/api/src/adapters/chat-summary.database.adapter.ts
@@ -2,7 +2,7 @@
  * Drizzle-backed I/O for the chat_session_summaries table. Pure persistence;
  * no business logic. Wrapped by ChatSummaryService.
  */
-import { and, asc, desc, eq, gt, ne, or } from 'drizzle-orm';
+import { and, asc, desc, eq, gt, ne, or } from 'drizzle-orm/sql';
 
 import db from '../lib/drizzle/drizzle';
 import * as schema from '../schemas/database.schema';

--- a/services/api/src/adapters/contact.database.adapter.ts
+++ b/services/api/src/adapters/contact.database.adapter.ts
@@ -5,7 +5,7 @@
  * ChatDatabaseAdapter do not interfere with ContactService integration tests.
  */
 
-import { asc, eq, and, inArray, isNull, isNotNull, or, ilike, sql } from 'drizzle-orm';
+import { asc, eq, and, inArray, isNull, isNotNull, or, ilike, sql } from 'drizzle-orm/sql';
 import * as schema from '../schemas/database.schema';
 import db from '../lib/drizzle/drizzle';
 

--- a/services/api/src/adapters/database.shared.ts
+++ b/services/api/src/adapters/database.shared.ts
@@ -3,7 +3,7 @@
  * tables, operators, DTO types, and cross-adapter helper functions.
  * No dependency on lib/protocol. Imported by every database/*.adapter.ts file.
  */
-import { eq, and, or, isNull, isNotNull, sql, count, desc, gt, lt, lte, ne, inArray, ilike, notInArray, asc, not } from 'drizzle-orm';
+import { eq, and, or, isNull, isNotNull, sql, count, desc, gt, lt, lte, ne, inArray, ilike, notInArray, asc, not } from 'drizzle-orm/sql';
 import * as schema from '../schemas/database.schema';
 import db from '../lib/drizzle/drizzle';
 import { traceAppOperation } from '../lib/sentry-performance';

--- a/services/api/src/adapters/discovery-run.adapter.ts
+++ b/services/api/src/adapters/discovery-run.adapter.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray } from 'drizzle-orm';
+import { and, desc, eq, inArray } from 'drizzle-orm/sql';
 
 import db from '../lib/drizzle/drizzle';
 import { opportunityDiscoveryRuns } from '../schemas/database.schema';

--- a/services/api/src/adapters/embedder.adapter.ts
+++ b/services/api/src/adapters/embedder.adapter.ts
@@ -4,7 +4,7 @@
  */
 
 import OpenAI from 'openai';
-import { and, eq, inArray, isNotNull, isNull, ne, sql } from 'drizzle-orm';
+import { and, eq, inArray, isNotNull, isNull, ne, sql } from 'drizzle-orm/sql';
 import { OPENROUTER_EMBEDDING_BASE_URL, OPENROUTER_EMBEDDING_DIMENSIONS, OPENROUTER_EMBEDDING_MODEL } from '../lib/embedding/embedding.config';
 import db from '../lib/drizzle/drizzle';
 import { traceAppOperation } from '../lib/sentry-performance';

--- a/services/api/src/adapters/enrichment-run.adapter.ts
+++ b/services/api/src/adapters/enrichment-run.adapter.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray } from 'drizzle-orm';
+import { and, desc, eq, inArray } from 'drizzle-orm/sql';
 
 import db from '../lib/drizzle/drizzle';
 import { enrichmentToolRuns } from '../schemas/database.schema';

--- a/services/api/src/adapters/questioner.adapter.ts
+++ b/services/api/src/adapters/questioner.adapter.ts
@@ -11,7 +11,7 @@
  * alignment spec.
  */
 
-import { eq, and, sql, or, isNull } from 'drizzle-orm';
+import { eq, and, sql, or, isNull } from 'drizzle-orm/sql';
 
 import { questions } from '../schemas/database.schema';
 import type { QuestionDetection, QuestionActor } from '../schemas/database.schema';

--- a/services/api/src/adapters/tests/agent.database.spec.ts
+++ b/services/api/src/adapters/tests/agent.database.spec.ts
@@ -12,7 +12,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
 import { AgentDatabaseAdapter } from '../agent.database.adapter';
 import db from '../../lib/drizzle/drizzle';
 import * as schema from '../../schemas/database.schema';
-import { eq } from 'drizzle-orm';
+import { eq } from 'drizzle-orm/sql';
 
 describe('AgentDatabaseAdapter.touchLastSeen', () => {
   const adapter = new AgentDatabaseAdapter();

--- a/services/api/src/adapters/tests/auth.adapter.spec.ts
+++ b/services/api/src/adapters/tests/auth.adapter.spec.ts
@@ -8,7 +8,7 @@ import { config } from "dotenv";
 config({ path: '.env.test', override: true });
 
 import { describe, it, expect, afterAll } from 'bun:test';
-import { eq } from 'drizzle-orm';
+import { eq } from 'drizzle-orm/sql';
 
 import db from '../../lib/drizzle/drizzle';
 import * as schema from '../../schemas/database.schema';

--- a/services/api/src/adapters/tests/chat-summary.database.adapter.spec.ts
+++ b/services/api/src/adapters/tests/chat-summary.database.adapter.spec.ts
@@ -2,7 +2,7 @@ import { config } from "dotenv";
 config({ path: ".env.test", override: true });
 
 import { describe, it, expect, afterAll } from "bun:test";
-import { eq } from "drizzle-orm";
+import { eq } from "drizzle-orm/sql";
 
 import db from "../../lib/drizzle/drizzle.js";
 import * as schema from "../../schemas/database.schema.js";

--- a/services/api/src/adapters/tests/database.adapter.spec.ts
+++ b/services/api/src/adapters/tests/database.adapter.spec.ts
@@ -7,7 +7,7 @@ import { config } from "dotenv";
 config({ path: '.env.test', override: true });
 
 import { describe, expect, it, beforeAll, afterAll } from 'bun:test';
-import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
+import { and, eq, inArray, isNull, sql } from 'drizzle-orm/sql';
 import { v4 as uuidv4 } from 'uuid';
 import db from '../../lib/drizzle/drizzle';
 import { users, userSocials, networks, networkMembers, intents, intentNetworks, premises, premiseNetworks, opportunities } from '../../schemas/database.schema';

--- a/services/api/src/adapters/tests/embedder.adapter.spec.ts
+++ b/services/api/src/adapters/tests/embedder.adapter.spec.ts
@@ -8,7 +8,7 @@ import { config } from "dotenv";
 config({ path: '.env.test', override: true });
 
 import { describe, expect, it, beforeAll, afterAll } from 'bun:test';
-import { eq, inArray } from 'drizzle-orm';
+import { eq, inArray } from 'drizzle-orm/sql';
 import { v4 as uuidv4 } from 'uuid';
 import db from '../../lib/drizzle/drizzle';
 import { users, networks, networkMembers, intents, intentNetworks } from '../../schemas/database.schema';

--- a/services/api/src/adapters/tests/ghost-dedup.spec.ts
+++ b/services/api/src/adapters/tests/ghost-dedup.spec.ts
@@ -3,7 +3,7 @@ import { config } from "dotenv";
 config({ path: '.env.test', override: true });
 
 import { describe, expect, it, beforeAll, afterAll } from 'bun:test';
-import { eq, and, inArray } from 'drizzle-orm';
+import { eq, and, inArray } from 'drizzle-orm/sql';
 import { v4 as uuidv4 } from 'uuid';
 import db from '../../lib/drizzle/drizzle';
 import { users, userSocials, networks, networkMembers, intents, opportunities } from '../../schemas/database.schema';

--- a/services/api/src/adapters/tests/personal-network.adapter.spec.ts
+++ b/services/api/src/adapters/tests/personal-network.adapter.spec.ts
@@ -12,7 +12,7 @@ import { config } from 'dotenv';
 config({ path: '.env.test', override: true });
 
 import { describe, expect, it, beforeAll, afterAll } from 'bun:test';
-import { eq, and, inArray } from 'drizzle-orm';
+import { eq, and, inArray } from 'drizzle-orm/sql';
 
 import db from '../../lib/drizzle/drizzle';
 import { users, networks, networkMembers, intents, intentNetworks, personalNetworks } from '../../schemas/database.schema';

--- a/services/api/src/cli/audit-agentvillage-onboarding.ts
+++ b/services/api/src/cli/audit-agentvillage-onboarding.ts
@@ -5,7 +5,7 @@ import path from 'path';
 const envFile = `.env.development`;
 dotenv.config({ path: path.resolve(process.cwd(), envFile) });
 
-import { sql } from 'drizzle-orm';
+import { sql } from 'drizzle-orm/sql';
 
 import db, { closeDb } from '../lib/drizzle/drizzle';
 import type { OnboardingState } from '../types/users.types';

--- a/services/api/src/cli/audit-experiment-email-collisions.ts
+++ b/services/api/src/cli/audit-experiment-email-collisions.ts
@@ -5,7 +5,7 @@ import path from 'path';
 const envFile = `.env.development`;
 dotenv.config({ path: path.resolve(process.cwd(), envFile) });
 
-import { sql } from 'drizzle-orm';
+import { sql } from 'drizzle-orm/sql';
 
 import db, { closeDb } from '../lib/drizzle/drizzle';
 

--- a/services/api/src/cli/backfill-context-hyde.ts
+++ b/services/api/src/cli/backfill-context-hyde.ts
@@ -12,7 +12,7 @@ import path from 'path';
 const envFile = process.env.NODE_ENV === 'development' ? '.env.development' : '.env.production';
 dotenv.config({ path: path.resolve(process.cwd(), envFile) });
 
-import { and, eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm/sql';
 
 import db, { closeDb } from '../lib/drizzle/drizzle';
 import * as schema from '../schemas/database.schema';

--- a/services/api/src/cli/backfill-intent-networks.ts
+++ b/services/api/src/cli/backfill-intent-networks.ts
@@ -28,7 +28,7 @@ import path from 'path';
 const envFile = process.env.NODE_ENV === 'development' ? '.env.development' : '.env.production';
 dotenv.config({ path: path.resolve(process.cwd(), envFile) });
 
-import { and, isNull, sql } from 'drizzle-orm';
+import { and, isNull, sql } from 'drizzle-orm/sql';
 
 import db, { closeDb } from '../lib/drizzle/drizzle';
 import * as schema from '../schemas/database.schema';

--- a/services/api/src/cli/backfill-intent-questions.ts
+++ b/services/api/src/cli/backfill-intent-questions.ts
@@ -27,7 +27,7 @@ import path from 'path';
 const envFile = process.env.NODE_ENV === 'development' ? '.env.development' : '.env.production';
 dotenv.config({ path: path.resolve(process.cwd(), envFile) });
 
-import { and, desc, eq, isNull, sql } from 'drizzle-orm';
+import { and, desc, eq, isNull, sql } from 'drizzle-orm/sql';
 
 import db, { closeDb } from '../lib/drizzle/drizzle';
 import { intents, networkMembers, questions, users } from '../schemas/database.schema';

--- a/services/api/src/cli/backfill-personal-index-prompts.ts
+++ b/services/api/src/cli/backfill-personal-index-prompts.ts
@@ -22,7 +22,7 @@ import path from 'path';
 const envFile = process.env.NODE_ENV === 'production' ? '.env.production' : '.env.development';
 dotenv.config({ path: path.resolve(process.cwd(), envFile) });
 
-import { sql } from 'drizzle-orm';
+import { sql } from 'drizzle-orm/sql';
 
 import db, { closeDb } from '../lib/drizzle/drizzle';
 

--- a/services/api/src/cli/backfill-premises.ts
+++ b/services/api/src/cli/backfill-premises.ts
@@ -11,7 +11,7 @@ import path from 'path';
 const envFile = process.env.NODE_ENV === 'development' ? '.env.development' : '.env.production';
 dotenv.config({ path: path.resolve(process.cwd(), envFile) });
 
-import { and, eq, isNull } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm/sql';
 
 import db, { closeDb } from '../lib/drizzle/drizzle';
 import { networkMembers, users } from '../schemas/database.schema';

--- a/services/api/src/cli/db-flush.ts
+++ b/services/api/src/cli/db-flush.ts
@@ -5,7 +5,7 @@ import path from 'path';
 const envFile = `.env.development`;
 dotenv.config({ path: path.resolve(process.cwd(), envFile) });
 
-import { sql } from 'drizzle-orm';
+import { sql } from 'drizzle-orm/sql';
 import db, { closeDb } from '../lib/drizzle/drizzle';
 import { setLevel } from '../lib/log';
 

--- a/services/api/src/cli/db-seed.ts
+++ b/services/api/src/cli/db-seed.ts
@@ -2,7 +2,7 @@
 import dotenv from 'dotenv';
 import path from 'path';
 import { writeFile } from 'node:fs/promises';
-import { and, eq, sql } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm/sql';
 
 const envFile = `.env.development`;
 dotenv.config({ path: path.resolve(process.cwd(), envFile) });

--- a/services/api/src/cli/opportunity-three-user-test.ts
+++ b/services/api/src/cli/opportunity-three-user-test.ts
@@ -17,7 +17,7 @@
  */
 import dotenv from 'dotenv';
 import path from 'path';
-import { inArray } from 'drizzle-orm';
+import { inArray } from 'drizzle-orm/sql';
 
 dotenv.config({ path: path.resolve(process.cwd(), '.env.development') });
 

--- a/services/api/src/cli/rediscover-user-opportunities.ts
+++ b/services/api/src/cli/rediscover-user-opportunities.ts
@@ -21,7 +21,7 @@ import path from 'path';
 const envFile = process.env.NODE_ENV === 'development' ? '.env.development' : '.env.production';
 dotenv.config({ path: path.resolve(process.cwd(), envFile) });
 
-import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
+import { and, eq, inArray, isNull, sql } from 'drizzle-orm/sql';
 
 import db, { closeDb } from '../lib/drizzle/drizzle';
 import { intents, opportunities, users } from '../schemas/database.schema';

--- a/services/api/src/cli/seed-experiment-network.ts
+++ b/services/api/src/cli/seed-experiment-network.ts
@@ -24,7 +24,7 @@
  */
 import dotenv from 'dotenv';
 import path from 'path';
-import { and, eq, isNull, sql } from 'drizzle-orm';
+import { and, eq, isNull, sql } from 'drizzle-orm/sql';
 
 const envFile = `.env.development`;
 dotenv.config({ path: path.resolve(process.cwd(), envFile) });

--- a/services/api/src/controllers/debug.controller.ts
+++ b/services/api/src/controllers/debug.controller.ts
@@ -1,4 +1,4 @@
-import { eq, and, sql, desc, asc, min, max, count, inArray, gte, lte } from 'drizzle-orm';
+import { eq, and, sql, desc, asc, min, max, count, inArray, gte, lte } from 'drizzle-orm/sql';
 
 import db from '../lib/drizzle/drizzle';
 import { log } from '../lib/log';

--- a/services/api/src/controllers/tests/auth.controller.spec.ts
+++ b/services/api/src/controllers/tests/auth.controller.spec.ts
@@ -3,7 +3,7 @@ import { config } from "dotenv";
 config({ path: '.env.test', override: true });
 
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
-import { eq } from "drizzle-orm";
+import { eq } from "drizzle-orm/sql";
 import { AuthController } from "../auth.controller";
 import { UserDatabaseAdapter } from "../../adapters/database.adapter";
 import db from "../../lib/drizzle/drizzle";

--- a/services/api/src/controllers/tests/chat.controller.spec.ts
+++ b/services/api/src/controllers/tests/chat.controller.spec.ts
@@ -3,7 +3,7 @@ import { config } from "dotenv";
 config({ path: '.env.test', override: true });
 
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
-import { eq } from "drizzle-orm";
+import { eq } from "drizzle-orm/sql";
 import { ChatController } from "../chat.controller";
 import { ChatDatabaseAdapter, UserDatabaseAdapter, EnrichmentDatabaseAdapter, IntentDatabaseAdapter, NetworkGraphDatabaseAdapter } from "../../adapters/database.adapter";
 import { chatSessionService } from "../../services/chat.service";

--- a/services/api/src/controllers/tests/network.controller.spec.ts
+++ b/services/api/src/controllers/tests/network.controller.spec.ts
@@ -9,7 +9,7 @@ mock.module('../../lib/email/transport.helper', () => ({
   executeSendEmail: sendEmailSpy,
 }));
 
-import { inArray } from "drizzle-orm";
+import { inArray } from "drizzle-orm/sql";
 
 // ---------------------------------------------------------------------------
 // Restore mocks after all tests

--- a/services/api/src/guards/agent-scope.guard.ts
+++ b/services/api/src/guards/agent-scope.guard.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm';
+import { eq } from 'drizzle-orm/sql';
 
 import db from '../lib/drizzle/drizzle';
 import { agentPermissions } from '../schemas/database.schema';

--- a/services/api/src/guards/auth.guard.ts
+++ b/services/api/src/guards/auth.guard.ts
@@ -1,5 +1,5 @@
 import { jwtVerify, createRemoteJWKSet } from 'jose';
-import { eq } from 'drizzle-orm';
+import { eq } from 'drizzle-orm/sql';
 
 import db from '../lib/drizzle/drizzle';
 import { resolveApiKeyUserId } from '../lib/apikey/principal';

--- a/services/api/src/guards/experiment.guard.ts
+++ b/services/api/src/guards/experiment.guard.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm/sql';
 
 import db from '../lib/drizzle/drizzle';
 import { hashMasterKey } from '../lib/experiment/master-key';

--- a/services/api/src/guards/tests/agent-scope.guard.spec.ts
+++ b/services/api/src/guards/tests/agent-scope.guard.spec.ts
@@ -2,7 +2,7 @@ import { config } from 'dotenv';
 config({ path: '.env.test', override: true });
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { eq, inArray } from 'drizzle-orm';
+import { eq, inArray } from 'drizzle-orm/sql';
 
 import db from '../../lib/drizzle/drizzle';
 import * as schema from '../../schemas/database.schema';

--- a/services/api/src/guards/tests/experiment.guard.spec.ts
+++ b/services/api/src/guards/tests/experiment.guard.spec.ts
@@ -2,7 +2,7 @@ import { config } from 'dotenv';
 config({ path: '.env.test', override: true });
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { inArray } from 'drizzle-orm';
+import { inArray } from 'drizzle-orm/sql';
 
 import db from '../../lib/drizzle/drizzle';
 import * as schema from '../../schemas/database.schema';

--- a/services/api/src/lib/email/notification.sender.ts
+++ b/services/api/src/lib/email/notification.sender.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm';
+import { eq } from 'drizzle-orm/sql';
 
 import db from '../drizzle/drizzle';
 import { userNotificationSettings, users } from '../../schemas/database.schema';

--- a/services/api/src/queues/negotiations/claim-timeout.queue.ts
+++ b/services/api/src/queues/negotiations/claim-timeout.queue.ts
@@ -1,5 +1,5 @@
 import { Job } from 'bullmq';
-import { and, eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm/sql';
 
 import db from '../../lib/drizzle/drizzle';
 import * as convSchema from '../../schemas/conversation.schema';

--- a/services/api/src/services/agent-test-message.service.ts
+++ b/services/api/src/services/agent-test-message.service.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull, lt, or, sql } from 'drizzle-orm';
+import { and, eq, isNull, lt, or, sql } from 'drizzle-orm/sql';
 import { randomUUID } from 'node:crypto';
 
 import db from '../lib/drizzle/drizzle';

--- a/services/api/src/services/connect-link.service.ts
+++ b/services/api/src/services/connect-link.service.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gt, sql } from 'drizzle-orm';
+import { and, desc, eq, gt, sql } from 'drizzle-orm/sql';
 
 import db from '../lib/drizzle/drizzle';
 import { connectLinks, opportunities } from '../schemas/database.schema';

--- a/services/api/src/services/debug.service.ts
+++ b/services/api/src/services/debug.service.ts
@@ -1,4 +1,4 @@
-import { eq, and, sql, ne, isNull, isNotNull, count, inArray } from 'drizzle-orm';
+import { eq, and, sql, ne, isNull, isNotNull, count, inArray } from 'drizzle-orm/sql';
 
 import db from '../lib/drizzle/drizzle';
 import { intents, intentNetworks, networks, networkMembers, userContexts } from '../schemas/database.schema';

--- a/services/api/src/services/experiment.service.ts
+++ b/services/api/src/services/experiment.service.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull, sql } from 'drizzle-orm';
+import { and, eq, isNull, sql } from 'drizzle-orm/sql';
 
 import db from '../lib/drizzle/drizzle';
 import { log } from '../lib/log';

--- a/services/api/src/services/negotiation-polling.service.ts
+++ b/services/api/src/services/negotiation-polling.service.ts
@@ -1,4 +1,4 @@
-import { eq, and, sql, asc, isNull } from 'drizzle-orm';
+import { eq, and, sql, asc, isNull } from 'drizzle-orm/sql';
 
 import db from '../lib/drizzle/drizzle';
 import * as convSchema from '../schemas/conversation.schema';

--- a/services/api/src/services/network-invitation.service.ts
+++ b/services/api/src/services/network-invitation.service.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm/sql';
 
 import db from '../lib/drizzle/drizzle';
 import { log } from '../lib/log';

--- a/services/api/src/services/network.service.ts
+++ b/services/api/src/services/network.service.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull, sql } from 'drizzle-orm';
+import { and, eq, isNull, sql } from 'drizzle-orm/sql';
 
 import db from '../lib/drizzle/drizzle';
 import { log } from '../lib/log';

--- a/services/api/src/services/opportunity-delivery.service.ts
+++ b/services/api/src/services/opportunity-delivery.service.ts
@@ -12,7 +12,7 @@
  *      committed row for the same (user, opportunity, channel, deliveredAtStatus) tuple.
  */
 
-import { and, eq, inArray, isNotNull, isNull, sql } from 'drizzle-orm';
+import { and, eq, inArray, isNotNull, isNull, sql } from 'drizzle-orm/sql';
 import { randomUUID } from 'node:crypto';
 
 import { OpportunityPresenter, canUserSeeOpportunity, classifyOpportunity, gatherPresenterContext, getOrCreateDeliveryCardBatch, isActionableForViewer, type PresenterDatabase } from '@indexnetwork/protocol';

--- a/services/api/src/services/opportunity.service.ts
+++ b/services/api/src/services/opportunity.service.ts
@@ -3,7 +3,7 @@ import { log } from '../lib/log';
 import type { Id } from '../types/common.types';
 import { OpportunityGraphFactory, HydeGraphFactory, HomeGraphFactory, MaintenanceGraphFactory, type MaintenanceGraphDatabase, type MaintenanceGraphCache, type MaintenanceGraphQueue, HydeGenerator, LensInferrer, presentOpportunity, type UserInfo, canUserSeeOpportunity, validateOpportunityActors, persistOpportunities, getPrimaryActionLabel, OpportunityPresenter, gatherPresenterContext, getOrCreateDeliveryCardBatch, type PresenterDatabase, stripUuids, stripIntroducerMentions } from '@indexnetwork/protocol';
 import type { OpportunityControllerDatabase, OpportunityGraphDatabase, HydeGraphDatabase, HomeGraphDatabase, CreateOpportunityData, Opportunity, OpportunityActor, OpportunityStatus, Embedder, HydeCache, OpportunityCache } from '@indexnetwork/protocol';
-import { and, eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm/sql';
 
 import { ChatDatabaseAdapter, chatDatabaseAdapter } from '../adapters/database.adapter';
 import { EmbedderAdapter } from '../adapters/embedder.adapter';

--- a/services/api/src/services/service.template.md
+++ b/services/api/src/services/service.template.md
@@ -312,7 +312,7 @@ export class EnrichmentService {
 - **Example**:
   \`\`\`typescript
   // In adapters/embedder.adapter.ts — a new corpus search method on EmbedderAdapter
-  import { sql, isNotNull } from 'drizzle-orm';
+  import { sql, isNotNull } from 'drizzle-orm/sql';
 
   async searchMyEntities<T>(vector: number[], limit = 10): Promise<{ item: T; score: number }[]> {
     const vectorString = JSON.stringify(vector);

--- a/services/api/src/services/tests/chat-summary.service.spec.ts
+++ b/services/api/src/services/tests/chat-summary.service.spec.ts
@@ -2,7 +2,7 @@ import { config } from "dotenv";
 config({ path: ".env.test", override: true });
 
 import { describe, it, expect, afterAll, mock } from "bun:test";
-import { eq } from "drizzle-orm";
+import { eq } from "drizzle-orm/sql";
 import db from "../../lib/drizzle/drizzle";
 import * as schema from "../../schemas/database.schema";
 import { ChatSummaryDatabaseAdapter } from "../../adapters/chat-summary.database.adapter";

--- a/services/api/src/services/tests/connect-link.service.spec.ts
+++ b/services/api/src/services/tests/connect-link.service.spec.ts
@@ -3,7 +3,7 @@ import { config } from 'dotenv';
 config({ path: '.env.test', override: true });
 
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
-import { eq } from 'drizzle-orm';
+import { eq } from 'drizzle-orm/sql';
 
 import db from '../../lib/drizzle/drizzle';
 import { connectLinks, opportunities, users } from '../../schemas/database.schema';

--- a/services/api/src/services/tests/contact.service.spec.ts
+++ b/services/api/src/services/tests/contact.service.spec.ts
@@ -8,7 +8,7 @@ import { config } from 'dotenv';
 config({ path: '.env.test', override: true });
 
 import { describe, expect, it, beforeAll, afterAll } from 'bun:test';
-import { eq, and, inArray, sql } from 'drizzle-orm';
+import { eq, and, inArray, sql } from 'drizzle-orm/sql';
 import db from '../../lib/drizzle/drizzle';
 import { users, networks, networkMembers, personalNetworks } from '../../schemas/database.schema';
 import { ContactService } from '../contact.service';

--- a/services/api/src/services/tests/network-invitation.service.spec.ts
+++ b/services/api/src/services/tests/network-invitation.service.spec.ts
@@ -2,7 +2,7 @@ import { config } from 'dotenv';
 config({ path: '.env.test', override: true });
 
 import { afterAll, beforeAll, describe, expect, mock, test } from 'bun:test';
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm/sql';
 
 const sendSpy = mock(async (_args: { to: string; subject: string; html: string; text: string }) => ({ data: null, skipped: false }));
 mock.module('../../lib/email/transport.helper', () => ({

--- a/services/api/src/services/tests/network.service.master-key-rotation.spec.ts
+++ b/services/api/src/services/tests/network.service.master-key-rotation.spec.ts
@@ -2,7 +2,7 @@ import { config } from 'dotenv';
 config({ path: '.env.test', override: true });
 
 import { afterAll, beforeAll, describe, expect, mock, test } from 'bun:test';
-import { eq, inArray } from 'drizzle-orm';
+import { eq, inArray } from 'drizzle-orm/sql';
 
 const sendSpy = mock(async (_args: { to: string; subject: string; html: string; text: string }) => ({ data: null, skipped: false }));
 mock.module('../../lib/email/transport.helper', () => ({

--- a/services/api/src/services/tests/opportunity-delivery.spec.ts
+++ b/services/api/src/services/tests/opportunity-delivery.spec.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeEach, describe, expect, it } from 'bun:test';
 import { randomUUID } from 'node:crypto';
 
-import { eq, sql } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm/sql';
 
 import db from '../../lib/drizzle/drizzle';
 import { agents, opportunities, opportunityDeliveries, users } from '../../schemas/database.schema';


### PR DESCRIPTION
## Summary
- switch remaining API Drizzle helper imports from the fragile root barrel to the explicit `drizzle-orm/sql` subpath
- update the service template example to match

## Verification
- `cd services/api && bun test src/adapters/tests/can-actor-see-opportunity.spec.ts src/queues/tests/timeout.queue.spec.ts src/queues/tests/claim-timeout.queue.spec.ts`
- `cd services/api && bun run build`

Follow-up for failed post-merge release check on #1062: `SyntaxError: export 'ne' not found in 'drizzle-orm'`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1063"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784930132&installation_id=140549914&pr_number=1063&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1063&signature=5a610e0af5c524c89fef2fa84fd63d4d508e0bb0552c3211eb384b0938903957"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->