### PR TITLE
chore: align index terminology with networks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,7 +241,7 @@ index/
 - `src/schemas/` - Drizzle table definitions; primary schema is `schemas/database.schema.ts`
 - `src/guards/` - Auth/validation guards
 - `src/queues/` - BullMQ job queue definitions
-- `src/events/` - Event emitters (intent events, index membership events, premise lifecycle events)
+- `src/events/` - Event emitters (intent events, network membership events, premise lifecycle events)
 - `src/cli/` - CLI and maintenance scripts
 - `packages/protocol/` - `@indexnetwork/protocol` NPM package — the agent graphs, interfaces, and tools layer. Published independently; `services/api/` imports it as a versioned NPM dependency.
 
@@ -288,17 +288,17 @@ Intents track their origin via `sourceType` (`file|integration|link|discovery_fo
 
 Intents have `confidence` (0-1) and `inferenceType` (`explicit|implicit`).
 
-### Personal Indexes
+### Personal Networks
 
-Each user has a personal index (`isPersonal=true`) created on registration, tracked via the `personal_networks` mapping table. Ownership via `network_members` with `permissions: ['owner']`, not a denormalized column. Contacts are stored as `network_members` rows with `'contact'` permission on the owner's personal index -- no separate contacts table. `ContactService.addContact(email)` handles finding/creating users (including ghost users) and upserting membership. Personal indexes cannot be deleted, renamed, or listed publicly.
+Each user has a personal network (`isPersonal=true`) created on registration, tracked via the `personal_networks` mapping table. Ownership via `network_members` with `permissions: ['owner']`, not a denormalized column. Contacts are stored as `network_members` rows with `'contact'` permission on the owner's personal network -- no separate contacts table. `ContactService.addContact(email)` handles finding/creating users (including ghost users) and upserting membership. Personal networks cannot be deleted, renamed, or listed publicly.
 
-### Index Prompts & Auto-Assignment
+### Network Prompts & Auto-Assignment
 
-Indexes and members have `prompt` fields used by LLM agents to evaluate intent membership. Members have `autoAssign: boolean` for auto-tagging new intents.
+Networks and members have `prompt` fields used by LLM agents to evaluate intent membership. Members have `autoAssign: boolean` for auto-tagging new intents.
 
 ### Relevancy Scoring
 
-`IntentIndexer` agent scores intent-network fit as `relevancyScore` (0.0-1.0) in `intent_networks`. Used during opportunity discovery to break ties across shared networks. Indexes without prompts default to 1.0.
+`IntentIndexer` agent scores intent-network fit as `relevancyScore` (0.0-1.0) in `intent_networks`. Used during opportunity discovery to break ties across shared networks. Networks without prompts default to 1.0.
 
 ### Queue-Based Processing
 
@@ -312,7 +312,7 @@ Each user has network-scoped **user contexts** (`user_contexts` table) — synth
 
 ### Event-Driven Broker System
 
-Events in `src/events/`: `IntentEvents.onCreated/onUpdated/onArchived` (with `intentId`, `userId`, optional `payload`, `previousStatus`). Index membership events in `network_membership.event.ts`. Premise lifecycle events in `premise.event.ts`: `PremiseEvents.onCreated/onUpdated/onRetracted/onExpired` — each enqueues cascade and profile regeneration jobs via `EnrichmentQueue`. Question lifecycle events in `question.event.ts`: `QuestionEvents.onCreated/onAnswered` — `onAnswered` dispatches to mode-specific handlers (`question.answer.handler.ts`): enrichment→premise creation, intent→description refinement + HyDE regen, negotiation→opportunity metadata enrichment (read back during continuation via `NegotiationQueries.getOpportunityUserAnswers`), discovery→no-op. Questions have an optional `conversationId` column linking them to the chat session that triggered them, and `detection.messageId` for anchoring to a specific assistant message. `tool.factory.ts` wraps `questionerEnqueue` in `sessionAwareEnqueue` to default `conversationId` from the active session context. The frontend renders conversation-linked questions inline via `InjectedQuestions`; sidebar badge uses `noConversation=true` to exclude them. Services emit events after DB transactions; other services/graphs react independently.
+Events in `src/events/`: `IntentEvents.onCreated/onUpdated/onArchived` (with `intentId`, `userId`, optional `payload`, `previousStatus`). Network membership events in `network_membership.event.ts`. Premise lifecycle events in `premise.event.ts`: `PremiseEvents.onCreated/onUpdated/onRetracted/onExpired` — each enqueues cascade and profile regeneration jobs via `EnrichmentQueue`. Question lifecycle events in `question.event.ts`: `QuestionEvents.onCreated/onAnswered` — `onAnswered` dispatches to mode-specific handlers (`question.answer.handler.ts`): enrichment→premise creation, intent→description refinement + HyDE regen, negotiation→opportunity metadata enrichment (read back during continuation via `NegotiationQueries.getOpportunityUserAnswers`), discovery→no-op. Questions have an optional `conversationId` column linking them to the chat session that triggered them, and `detection.messageId` for anchoring to a specific assistant message. `tool.factory.ts` wraps `questionerEnqueue` in `sessionAwareEnqueue` to default `conversationId` from the active session context. The frontend renders conversation-linked questions inline via `InjectedQuestions`; sidebar badge uses `noConversation=true` to exclude them. Services emit events after DB transactions; other services/graphs react independently.
 
 ### Agent Registry
 

--- a/apps/web/src/app/index/[indexId]/page.tsx
+++ b/apps/web/src/app/index/[indexId]/page.tsx
@@ -41,16 +41,16 @@ export default function PublicJoinPage() {
   useEffect(() => {
     const loadIndexAndCheckAuth = async () => {
       try {
-        // Load public index by ID
+        // Load public network by ID
         const index = await publicIndexesService.getPublicIndexById(indexId!);
         setState(prev => ({ ...prev, index }));
 
-        // Double-check that this is a public index
+        // Double-check that this is a public network
         if (index.permissions?.joinPolicy !== 'anyone') {
-          setState(prev => ({ 
-            ...prev, 
-            step: 'error', 
-            error: 'This index is private. You need an invitation to join.' 
+          setState(prev => ({
+            ...prev,
+            step: 'error',
+            error: 'This network is private. You need an invitation to join.'
           }));
           return;
         }
@@ -71,23 +71,23 @@ export default function PublicJoinPage() {
           if (response.user) {
             setState(prev => ({ ...prev, user: response.user || null }));
 
-            // Join the public index immediately
+            // Join the public network immediately
             try {
               const joinResult = await indexesService.joinIndex(index.id);
-              
+
               // Check if user is already a member
               if (joinResult?.alreadyMember) {
                 setState(prev => ({ ...prev, step: 'already-member' }));
                 return;
               }
-              
+
               await refreshIndexes();
             } catch (err) {
-              console.error('Failed to join index:', err);
-              setState(prev => ({ 
-                ...prev, 
-                step: 'error', 
-                error: 'Failed to join index' 
+              console.error('Failed to join network:', err);
+              setState(prev => ({
+                ...prev,
+                step: 'error',
+                error: 'Failed to join network'
               }));
               return;
             }
@@ -97,18 +97,18 @@ export default function PublicJoinPage() {
           }
         } catch (err) {
           console.error('Failed to fetch user:', err);
-          setState(prev => ({ 
-            ...prev, 
-            step: 'error', 
-            error: 'Failed to load user data' 
+          setState(prev => ({
+            ...prev,
+            step: 'error',
+            error: 'Failed to load user data'
           }));
         }
       } catch (err) {
-        console.error('Failed to load index:', err);
-        setState(prev => ({ 
-          ...prev, 
-          step: 'error', 
-          error: (err as Error)?.message || 'Index not found or is private' 
+        console.error('Failed to load network:', err);
+        setState(prev => ({
+          ...prev,
+          step: 'error',
+          error: (err as Error)?.message || 'Network not found or is private'
         }));
       }
     };
@@ -119,7 +119,7 @@ export default function PublicJoinPage() {
   // Trigger reload when user authenticates
   useEffect(() => {
     if (isAuthenticated && isReady && state.step === 'auth-required') {
-      // Trigger reload to join the index
+      // Trigger reload to join the network
       setState(prev => ({ ...prev, step: 'loading' }));
     }
   }, [isAuthenticated, isReady, state.step]);
@@ -129,11 +129,11 @@ export default function PublicJoinPage() {
 
     try {
       setState(prev => ({ ...prev, step: 'joining' }));
-      
+
       const result = await indexesService.joinIndex(state.index.id);
-      
+
       if (result?.alreadyMember) {
-        success('You are already a member of this index');
+        success('You are already a member of this network');
         setState(prev => ({ ...prev, step: 'already-member' }));
       } else {
         success(`Successfully joined ${result?.network?.title || state.index.title}!`);
@@ -143,18 +143,18 @@ export default function PublicJoinPage() {
         navigate(`/`);
       }
     } catch (err) {
-      console.error('Failed to join index:', err);
-      notifyError((err as Error)?.message || 'Failed to join index');
-      setState(prev => ({ 
-        ...prev, 
-        step: 'error', 
-        error: (err as Error)?.message || 'Failed to join index' 
+      console.error('Failed to join network:', err);
+      notifyError((err as Error)?.message || 'Failed to join network');
+      setState(prev => ({
+        ...prev,
+        step: 'error',
+        error: (err as Error)?.message || 'Failed to join network'
       }));
     }
   };
 
   const handleLogin = () => {
-    // Store index ID to auto-join after authentication
+    // Store network ID to auto-join after authentication
     if (typeof window !== 'undefined' && state.index?.id) {
       localStorage.setItem('pending_network_join', state.index.id);
     }
@@ -177,7 +177,7 @@ export default function PublicJoinPage() {
           <div className="flex items-center gap-3 mb-4">
             <Globe className="h-5 w-5 text-black" />
             <h2 className="text-sm font-medium text-gray-600 font-ibm-plex-mono">
-              Public Index
+              Public Network
             </h2>
           </div>
 
@@ -207,7 +207,7 @@ export default function PublicJoinPage() {
           <ContentContainer>
             <div className="flex flex-col items-center justify-center py-12">
               <Loader2 className="h-8 w-8 animate-spin text-gray-400 mb-4" />
-              <p className="text-gray-600 font-ibm-plex-mono">Loading index...</p>
+              <p className="text-gray-600 font-ibm-plex-mono">Loading network...</p>
             </div>
           </ContentContainer>
         );
@@ -223,7 +223,7 @@ export default function PublicJoinPage() {
               </div>
               <h1 className="text-2xl font-bold text-black mb-2 font-ibm-plex-mono">Not Found</h1>
               <p className="text-gray-600 font-ibm-plex-mono">
-                {state.error || 'This index was not found or is private.'}
+                {state.error || 'This network was not found or is private.'}
               </p>
             </div>
             <Button
@@ -260,7 +260,7 @@ export default function PublicJoinPage() {
           <ContentContainer>
             <div className="flex flex-col items-center justify-center py-12">
               <Loader2 className="h-8 w-8 animate-spin text-blue-600 mb-4" />
-              <p className="text-gray-600 font-ibm-plex-mono">Joining index...</p>
+              <p className="text-gray-600 font-ibm-plex-mono">Joining network...</p>
             </div>
           </ContentContainer>
         );

--- a/apps/web/src/app/l/[code]/page.tsx
+++ b/apps/web/src/app/l/[code]/page.tsx
@@ -47,16 +47,16 @@ export default function InvitationPage() {
   useEffect(() => {
     const loadIndexAndCheckAuth = async () => {
       try {
-        // Load index by share code (works for both invitation codes and index IDs)
+        // Load index by share code (works for both invitation codes and network IDs)
         const index = await publicIndexesService.getIndexByShareCode(code!);
         setState(prev => ({ ...prev, index }));
 
         // Reject public networks - they should use /index/[networkId] instead
         if (index.permissions?.joinPolicy === 'anyone') {
-          setState(prev => ({ 
-            ...prev, 
-            step: 'error', 
-            error: 'No invitation found' 
+          setState(prev => ({
+            ...prev,
+            step: 'error',
+            error: 'No invitation found'
           }));
           return;
         }
@@ -89,18 +89,18 @@ export default function InvitationPage() {
           }
         } catch (err) {
           console.error('Failed to fetch user:', err);
-          setState(prev => ({ 
-            ...prev, 
-            step: 'error', 
-            error: 'Failed to load user data' 
+          setState(prev => ({
+            ...prev,
+            step: 'error',
+            error: 'Failed to load user data'
           }));
         }
       } catch (err) {
-        console.error('Failed to load index:', err);
-        setState(prev => ({ 
-          ...prev, 
-          step: 'error', 
-          error: (err as Error)?.message || 'Invalid or expired invitation link' 
+        console.error('Failed to load network:', err);
+        setState(prev => ({
+          ...prev,
+          step: 'error',
+          error: (err as Error)?.message || 'Invalid or expired invitation link'
         }));
       }
     };
@@ -121,12 +121,12 @@ export default function InvitationPage() {
 
     try {
       setState(prev => ({ ...prev, step: 'joining' }));
-      
+
       // Accept private invitation
       const result = await indexesService.acceptInvitation(code!);
-      
+
       if (result?.alreadyMember) {
-        success('You are already a member of this index');
+        success('You are already a member of this network');
         setState(prev => ({ ...prev, step: 'already-member' }));
       } else {
         success(`Successfully joined ${result?.network?.title || state.index.title}!`);
@@ -138,10 +138,10 @@ export default function InvitationPage() {
     } catch (err) {
       console.error('Failed to accept invitation:', err);
       notifyError((err as Error)?.message || 'Failed to accept invitation');
-      setState(prev => ({ 
-        ...prev, 
-        step: 'error', 
-        error: (err as Error)?.message || 'Failed to accept invitation' 
+      setState(prev => ({
+        ...prev,
+        step: 'error',
+        error: (err as Error)?.message || 'Failed to accept invitation'
       }));
     }
   };
@@ -252,7 +252,7 @@ export default function InvitationPage() {
           <ContentContainer>
             <div className="flex flex-col items-center justify-center py-12">
               <Loader2 className="h-8 w-8 animate-spin text-blue-600 mb-4" />
-              <p className="text-gray-600 font-ibm-plex-mono">Joining index...</p>
+              <p className="text-gray-600 font-ibm-plex-mono">Joining network...</p>
             </div>
           </ContentContainer>
         );

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -39,7 +39,7 @@ export default function Sidebar() {
   const opportunitiesService = useOpportunities();
   const { indexes, addIndex } = useNetworksState();
   const { success, error } = useNotifications();
-  
+
   const [chatSessions, setChatSessions] = useState<ChatSession[]>([]);
   const [loadingSessions, setLoadingSessions] = useState(false);
   const [navigatingToChat, setNavigatingToChat] = useState(false);
@@ -85,7 +85,7 @@ export default function Sidebar() {
       }
     } catch (err) {
       console.error('Error creating index:', err);
-      error('Failed to create index');
+      error('Failed to create network');
     }
   }, [indexesService, addIndex, success, error]);
 
@@ -292,7 +292,7 @@ export default function Sidebar() {
       {/* Spacer */}
       <div className="flex-1" />
 
-      
+
 
       {/* Networks & Agent - above user dropdown */}
       <nav className="flex-shrink-0 px-2 space-y-1 pb-2">

--- a/apps/web/src/components/SynthesisMarkdown.tsx
+++ b/apps/web/src/components/SynthesisMarkdown.tsx
@@ -40,7 +40,7 @@ export default function SynthesisMarkdown({ content, className = '', onArchive, 
       if (target.tagName === 'A' && target.closest('.synthesis-markdown-content')) {
         return;
       }
-      
+
       if (popoverRef.current && !popoverRef.current.contains(target)) {
         closePopover();
       }
@@ -79,13 +79,13 @@ export default function SynthesisMarkdown({ content, className = '', onArchive, 
 
     const rect = (event.target as HTMLElement).getBoundingClientRect();
     const popoverWidth = 90;
-    
+
     // Use click position for horizontal alignment, keep within viewport
     let x = event.clientX;
     if (x + popoverWidth > window.innerWidth) {
       x = window.innerWidth - popoverWidth - 10;
     }
-    
+
     // Calculate which line was clicked and align below that line
     const clickY = event.clientY;
     const element = event.target as HTMLElement;
@@ -185,4 +185,3 @@ export default function SynthesisMarkdown({ content, className = '', onArchive, 
   );
 }
 
-    

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -278,8 +278,8 @@ export default function ChatView({ userId, userName, userAvatar, isGhost = false
               <div className="flex flex-col items-center justify-center py-20 text-[#3D3D3D]">
                 {isGhost ? (
                   <>
-                    <p className="text-sm font-medium">{userName} hasn&apos;t joined Index yet.</p>
-                    <p className="text-xs text-gray-400 mt-1">Send a message and we&apos;ll let you know when they join.</p>
+                    <p className="text-sm font-medium">{userName} hasn&apos;t joined yet.</p>
+                    <p className="text-xs text-gray-400 mt-1">Send a message and we&apos;ll let you know when they do.</p>
                   </>
                 ) : (
                   <p className="text-sm">Start a conversation with {userName}</p>
@@ -290,7 +290,7 @@ export default function ChatView({ userId, userName, userAvatar, isGhost = false
             {isGhost && messages.length > 0 && (
               <div className="text-center py-3">
                 <p className="text-xs text-gray-400 bg-gray-50 border border-gray-100 rounded-xl px-4 py-2.5 inline-block">
-                  <span className="font-medium text-gray-500">{userName}</span> is invited by you &mdash; we&apos;ll let you know when they join Index.
+                  <span className="font-medium text-gray-500">{userName}</span> is invited by you &mdash; we&apos;ll let you know when they join.
                 </p>
               </div>
             )}

--- a/apps/web/src/components/chat/ToolCallsDisplay.tsx
+++ b/apps/web/src/components/chat/ToolCallsDisplay.tsx
@@ -152,8 +152,8 @@ const GRAPH_DISPLAY_NAMES: Record<string, string> = {
   "home": "Home graph",
   "network": "Network graph",
   "network_membership": "Network membership",
-  "index": "Index graph",
-  "index_membership": "Index membership",
+  "index": "Network graph",
+  "index_membership": "Network membership",
 };
 
 const AGENT_DISPLAY_NAMES: Record<string, string> = {
@@ -169,7 +169,7 @@ const AGENT_DISPLAY_NAMES: Record<string, string> = {
   "intent-inferrer": "Inferring intents",
   "intent-verifier": "Verifying intents",
   "intent-reconciler": "Reconciling intents",
-  "intent-indexer": "Indexing intents",
+  "intent-networker": "Indexing intents",
   "profile-generator": "Generating profile",
   "hyde-generator": "Generating HyDE",
   "lens-inferrer": "Inferring lenses",

--- a/apps/web/src/components/settings/IntegrationsTab.tsx
+++ b/apps/web/src/components/settings/IntegrationsTab.tsx
@@ -125,7 +125,7 @@ export default function IntegrationsTab({
       await loadConnections();
       autoImportContacts(toolkit);
     } catch {
-      error(`Failed to link ${toolkitLabel(toolkit)} to this index`);
+      error(`Failed to link ${toolkitLabel(toolkit)} to this network`);
     }
   };
 
@@ -138,7 +138,7 @@ export default function IntegrationsTab({
       const allConns = await integrationsService.getConnections();
       const existingConn = allConns.connections.find(c => c.toolkit === toolkit);
       if (existingConn) {
-        // Already OAuth'd -- just link to this index
+        // Already OAuth'd -- just link to this network
         success(`${toolkitLabel(toolkit)} connected`);
         await linkAndImport(toolkit);
         setPendingToolkit(null);
@@ -209,7 +209,7 @@ export default function IntegrationsTab({
     setPendingToolkit(toolkit);
     try {
       await integrationsService.unlinkIntegration(toolkit, networkId);
-      success(`${toolkitLabel(toolkit)} removed from this index`);
+      success(`${toolkitLabel(toolkit)} removed from this network`);
       await loadConnections();
     } catch {
       error(`Failed to remove ${toolkitLabel(toolkit)}`);

--- a/apps/web/src/components/settings/SettingsTab.tsx
+++ b/apps/web/src/components/settings/SettingsTab.tsx
@@ -145,7 +145,7 @@ export default function SettingsTab({
       } else if (removeImageRequested) {
         finalImageUrl = null;
       }
-      // Personal indexes accept only a prompt edit (rename/avatar are blocked
+      // Personal networks accept only a prompt edit (rename/avatar are blocked
       // server-side); send prompt alone to avoid a rejected update.
       const updatedIndex = await updateNetwork(
         networkId,
@@ -298,7 +298,7 @@ export default function SettingsTab({
           </label>
           <Input id="title" value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Network title" disabled={network.isPersonal} />
           {network.isPersonal && (
-            <p className="text-xs text-gray-400 mt-1.5">Your personal index can&apos;t be renamed.</p>
+            <p className="text-xs text-gray-400 mt-1.5">Your personal network can&apos;t be renamed.</p>
           )}
         </div>
         <div>

--- a/apps/web/src/hooks/useMentionableUsers.ts
+++ b/apps/web/src/hooks/useMentionableUsers.ts
@@ -69,7 +69,7 @@ export function useMentionableUsers({
     }
   }, [enabled, indexService, indexesLoading]);
 
-  // Stable signature of index IDs so joins/leaves trigger refetch even when length is unchanged
+  // Stable signature of network IDs so joins/leaves trigger refetch even when length is unchanged
   const indexesSignature =
     indexes.length === 0
       ? ''

--- a/apps/web/src/hooks/useSuggestions.ts
+++ b/apps/web/src/hooks/useSuggestions.ts
@@ -23,7 +23,7 @@ interface UseSuggestionsOptions {
   hasMessages?: boolean;
   /** Intent ID for dynamic refinement suggestions (e.g. intent detail view) */
   intentId?: string;
-  /** Selected index ID to filter/contextualize suggestions */
+  /** Selected network ID to filter/contextualize suggestions */
   networkId?: string | null;
   /** Whether to fetch suggestions (e.g., on focus) */
   enabled?: boolean;

--- a/apps/web/src/services/admin.ts
+++ b/apps/web/src/services/admin.ts
@@ -22,7 +22,7 @@ export interface OpportunityDiscoveryResponse {
 
 // Service functions for admin operations
 export const createAdminService = (api: ReturnType<typeof import('../lib/api').useAuthenticatedAPI>) => ({
-  // Discover opportunities for index members
+  // Discover opportunities for network members
   discoverOpportunities: async (networkId: string, request: OpportunityDiscoveryRequest) => {
     return await api.post<OpportunityDiscoveryResponse>(`/admin/${networkId}/opportunities`, request);
   }

--- a/docs/design/architecture-overview.md
+++ b/docs/design/architecture-overview.md
@@ -205,8 +205,8 @@ Graphs are LangGraph state machines. Each graph is created by a factory class th
 | Enrichment | Enrich users and decompose identity into premises, with optional scraping |
 | Opportunity | HyDE-based discovery: search, evaluate, rank, persist |
 | HyDE | Generate hypothetical document embeddings (cache-aware) |
-| Network | Manage index (network) CRUD |
-| NetworkMembership | Manage index member join/leave |
+| Network | Manage network (network) CRUD |
+| NetworkMembership | Manage network member join/leave |
 | IntentNetwork | Evaluate and assign/unassign intents to indexes |
 | Home | Categorize and curate home feed content |
 | Maintenance | Periodic maintenance tasks |
@@ -224,7 +224,7 @@ Agents are pure LLM reasoning units. They accept structured input (Zod schemas),
 | Intent Inferrer | Extracts intents from uploaded content |
 | Intent Reconciler | Decides create/update/expire actions for intents |
 | Intent Verifier | Validates felicity conditions on intents |
-| Intent Indexer | Scores intent-to-index fit (relevancy 0.0-1.0) |
+| Intent Indexer | Scores intent-to-network fit (relevancy 0.0-1.0) |
 | Opportunity Evaluator | Scores and synthesizes opportunity matches |
 | Enrichment Generator | Generates identity drafts from identity signals (onboarding draft tools) |
 | HyDE Generator | Creates hypothetical document embeddings |
@@ -236,8 +236,8 @@ Tools are the capabilities exposed to the chat agent. They bridge the agent loop
 | Tool File | Capabilities |
 |-----------|-------------|
 | `enrichment.tools.ts` | read/create/update user profiles |
-| `intent.tools.ts` | CRUD intents, manage intent-index assignments |
-| `network.tools.ts` | CRUD indexes (networks), manage memberships |
+| `intent.tools.ts` | CRUD intents, manage intent-network assignments |
+| `network.tools.ts` | CRUD networks (networks), manage memberships |
 | `contact.tools.ts` | import, add, remove, and list contacts |
 | `opportunity.tools.ts` | Discover and send opportunities |
 | `agent.tools.ts` | register, list, update, delete agents and manage agent permissions |
@@ -356,7 +356,7 @@ The chat system is the primary entry point for user interaction. When a user sen
 
 1. **HTTP layer**: The request hits `ChatController`, which validates input and delegates to the chat service.
 
-2. **Graph initialization**: The chat graph loads session context (conversation history, user profile, index memberships) and truncates to fit the context window.
+2. **Graph initialization**: The chat graph loads session context (conversation history, user profile, network memberships) and truncates to fit the context window.
 
 3. **ReAct loop**: The `ChatAgent` enters a loop (up to 12 iterations). Each iteration, the LLM sees the full conversation and decides to either call tools or produce a final response.
 
@@ -514,7 +514,7 @@ The canonical schema lives in `services/api/src/schemas/database.schema.ts`. All
 
 **Soft deletes**: Records use `deletedAt` timestamps rather than hard deletes, preserving audit trails and enabling recovery.
 
-**Vector similarity search**: Intents and premises have vector embeddings. Queries use pgvector's cosine similarity with HNSW indexes for sub-millisecond approximate nearest-neighbor lookups. This powers opportunity discovery, finding similar intents and premises across index members.
+**Vector similarity search**: Intents and premises have vector embeddings. Queries use pgvector's cosine similarity with HNSW indexes for sub-millisecond approximate nearest-neighbor lookups. This powers opportunity discovery, finding similar intents and premises across network members.
 
 ### Migration Workflow
 

--- a/docs/design/protocol-deep-dive.md
+++ b/docs/design/protocol-deep-dive.md
@@ -169,7 +169,7 @@ The propose mode is a dry-run that extracts and verifies intents without persist
 **Nodes:** `prep`, `scope`, `resolve`, `discovery`, `evaluation`, `ranking`, `intro_validation`, `intro_evaluation`, `persist`, `negotiate`, `read`, `update`, `delete_opp`, `send`
 **State:** `OpportunityGraphState` (userId, searchQuery, indexId, triggerIntentId, targetUserId, candidates, evaluatedOpportunities, trigger, dedupAlreadyAccepted, etc.)
 **Conditional edges:**
-- After `prep`: routes to `scope` or `END` (no index memberships)
+- After `prep`: routes to `scope` or `END` (no network memberships)
 - After `discovery`: routes to `evaluation` or `END` (no candidates)
 - After `evaluation`: routes to `ranking` or `END` (no evaluated opportunities)
 
@@ -179,7 +179,7 @@ The graph supports multiple discovery paths, searching across intents and premis
 - **Intent-based (Path A):** Trigger intent is assigned to an index — use its HyDE documents for search
 - **Query-based (Path B):** Query-generated HyDE documents for search
 - **Context-to-intent (Path C):** User contexts (network-scoped paragraph representations from the premise graph) are embedded and used to search for matching intents via `searchIntentsByContextEmbedding()`. Candidates carry `discoverySource: 'context-to-intent'`.
-- **Direct connection:** When `targetUserId` is set (user @-mentioned someone), bypass vector search and construct candidates from shared indexes
+- **Direct connection:** When `targetUserId` is set (user @-mentioned someone), bypass vector search and construct candidates from shared networks
 
 All discovery strategies are merged via `mergeStrategyCandidates()`, which deduplicates by `userId:networkId:entityId` and applies a multi-strategy boost (+0.05 per additional strategy, capped at 0.15).
 
@@ -235,7 +235,7 @@ All operations are database-only -- no LLM calls. Create sets the caller as owne
 
 **Flow:** `START -> {add_member | list_members | remove_member} -> END`
 
-Self-join is only allowed for public indexes (`joinPolicy: 'anyone'`). Inviting others requires membership; for invite-only indexes, only the owner can add members.
+Self-join is only allowed for public networks (`joinPolicy: 'anyone'`). Inviting others requires membership; for invite-only indexes, only the owner can add members.
 
 **Dependencies:** `NetworkMembershipGraphDatabase`
 
@@ -355,9 +355,9 @@ Intents must pass verification to be persisted. Invalid types (ASSERTIVE, EXPRES
 ### 4.5 Intent Indexer
 
 **File:** `intent.indexer.ts`
-**Role:** Scores how well an intent fits within an index based on the index prompt and member prompt.
+**Role:** Scores how well an intent fits within an index based on the network prompt and member prompt.
 **Model:** `google/gemini-2.5-flash`
-**Input:** Intent payload, index prompt, member prompt, source name
+**Input:** Intent payload, network prompt, member prompt, source name
 **Output:** Index score, member score (0-1 each)
 **Used by:** Intent Index Graph (assign node), Opportunity Graph (scope node for query-based scoring)
 
@@ -473,7 +473,7 @@ Replaces the old hardcoded strategy enum (mirror, reciprocal, mentor, etc.) with
 ### 4.19 Premise Indexer
 
 **File:** `premise/premise.indexer.ts`
-**Role:** Scores a premise's relevancy to a network based on the index prompt and member preferences.
+**Role:** Scores a premise's relevancy to a network based on the network prompt and member preferences.
 **Model:** `google/gemini-2.5-flash`
 **Input:** premiseText, indexPrompt, optional memberPrompt and networkContext
 **Output:** indexScore (0.0-1.0), memberScore (0.0-1.0), reasoning
@@ -502,7 +502,7 @@ Tools bridge the ChatAgent to subgraphs. Each tool file defines LangChain tool f
 |-----------|-------|---------------------|
 | `enrichment.tools.ts` | read_user_profiles, create_user_profile, update_user_profile | Enrichment Graph |
 | `intent.tools.ts` | read_intents, create_intent, update_intent, delete_intent, search_intents, create_intent_index, read_intent_indexes, delete_intent_index | Intent Graph, Intent Index Graph, Opportunity Graph (auto-discovery on create) |
-| `network.tools.ts` | read_indexes, read_users, create_index, update_index, delete_index, create_index_membership | Index Graph, Index Membership Graph |
+| `network.tools.ts` | read_indexes, read_users, create_index, update_index, delete_index, create_index_membership | Network Graph, Network Membership Graph |
 | `opportunity.tools.ts` | discover_opportunities, list_opportunities, update_opportunity | Opportunity Graph |
 | `contact.tools.ts` | add_contact, list_contacts, search_contacts | (direct service calls) |
 | `chat.tools.ts` | list_conversations, get_conversation | (direct `ChatSessionReader` calls) |
@@ -566,7 +566,7 @@ createMcpServer(
 
 - `deps` — the same shared tool dependencies used by the chat agent (database, embedder, scraper, graphs, …).
 - `authResolver` — reads the HTTP request and returns `{ userId, agentId }`. Callers pass an `x-api-key` header; the resolver looks up the key via Better Auth and reads `metadata.agentId` off the stored token. Requests without an `agentId` are rejected at the gate below.
-- `scopedDepsFactory` — creates per-request `userDb` and `systemDb` scoped to the caller's index memberships, so every tool call runs against the caller's actual data perimeter.
+- `scopedDepsFactory` — creates per-request `userDb` and `systemDb` scoped to the caller's network memberships, so every tool call runs against the caller's actual data perimeter.
 
 ### Tool loop
 
@@ -694,7 +694,7 @@ The opportunity discovery pipeline is the most complex workflow in the system. I
 User intent/query
     |
     v
-[Prep] Load user's index memberships, active intents, profile
+[Prep] Load user's network memberships, active intents, profile
     |
     v
 [Scope] Determine which indexes to search; score query relevancy per index
@@ -728,7 +728,7 @@ User intent/query
 3. Searches both the profiles and intents vector indexes per lens
 4. Merges candidates from all lenses with deduplication
 
-**Direct connection:** When a `targetUserId` is specified (user @-mentioned someone), vector search is bypassed entirely. The system constructs candidates directly from shared index memberships and the target user's active intents.
+**Direct connection:** When a `targetUserId` is specified (user @-mentioned someone), vector search is bypassed entirely. The system constructs candidates directly from shared network memberships and the target user's active intents.
 
 ### Evaluation
 
@@ -741,7 +741,7 @@ Each match gets a score (0-100), reasoning (written from a third-party analytica
 
 ### Deduplication and ranking
 
-Candidates are deduplicated by `(sourceUserId, candidateUserId, indexId)` with the highest-scoring entry winning. When a candidate appears across multiple shared indexes, the index with the highest relevancy score (from `intent_networks.relevancyScore`) is preferred as the tiebreaker.
+Candidates are deduplicated by `(sourceUserId, candidateUserId, indexId)` with the highest-scoring entry winning. When a candidate appears across multiple shared networks, the index with the highest relevancy score (from `intent_networks.relevancyScore`) is preferred as the tiebreaker.
 
 ### Negotiation (optional)
 
@@ -805,9 +805,9 @@ Intents with high semantic entropy (>0.75) or low clarity (<40) are considered v
 
 **Delete:** Skips inference and verification entirely. The reconciler generates `expire` actions for the target intent IDs, and the executor archives them (soft delete). Associated HyDE documents are cleaned up via a queued job.
 
-### Intent-index assignment
+### Intent-network assignment
 
-Intent-to-index assignment is handled separately by the Intent Index Graph. When an intent is created and the user is in an index-scoped chat, the `create_intent_index` tool assigns the intent with either:
+Intent-to-network assignment is handled separately by the Intent Index Graph. When an intent is created and the user is in a network-scoped chat, the `create_intent_index` tool assigns the intent with either:
 - Direct assignment (score 1.0) when `skipEvaluation` is true
 - Evaluated assignment via `IntentIndexer` agent when the index has prompts defining its purpose
 
@@ -860,7 +860,7 @@ The protocol layer emits real-time trace events during graph and agent execution
 
 ### Naming convention
 
-Agent names in trace events use kebab-case: `intent-inferrer`, `profile-generator`, `hyde-generator`, `opportunity-evaluator`, `lens-inferrer`, `home-categorizer`, `intent-verifier`, `intent-reconciler`, `intent-indexer`.
+Agent names in trace events use kebab-case: `intent-inferrer`, `profile-generator`, `hyde-generator`, `opportunity-evaluator`, `lens-inferrer`, `home-categorizer`, `intent-verifier`, `intent-reconciler`, `intent-networker`.
 
 ### Agent timing tracking
 

--- a/docs/domain/intents.md
+++ b/docs/domain/intents.md
@@ -156,7 +156,7 @@ The `sourceId` field references the originating record in the corresponding tabl
 
 ---
 
-## Intent-Index Assignment and Relevancy Scoring
+## Intent-Network Assignment and Relevancy Scoring
 
 Intents do not exist in isolation -- they are assigned to one or more indexes (communities). The many-to-many relationship between intents and indexes is tracked in the `intent_networks` junction table, which carries an optional `relevancyScore` (0.0-1.0).
 
@@ -164,7 +164,7 @@ Intents do not exist in isolation -- they are assigned to one or more indexes (c
 
 When an intent is created or updated, the Intent Indexer agent evaluates how well it fits each candidate index. The agent considers:
 
-1. **Index prompt** -- the purpose/scope of the community
+1. **Network prompt** -- the purpose/scope of the community
 2. **Member prompt** -- the user's specific sharing preferences in that community
 3. **Intent content** -- what the intent actually says
 4. **Source context** -- where the intent came from
@@ -184,7 +184,7 @@ An intent qualifies for an index when its `indexScore` reaches 0.7 or above. Bel
 
 ### Relevancy in discovery
 
-The `relevancyScore` stored on the junction table is used during opportunity discovery to break ties. When a candidate appears across multiple shared indexes, the index with the highest relevancy to the trigger intent wins. Indexes without prompts default to a score of 1.0.
+The `relevancyScore` stored on the junction table is used during opportunity discovery to break ties. When a candidate appears across multiple shared networks, the index with the highest relevancy to the trigger intent wins. Networks without prompts default to a score of 1.0.
 
 ---
 

--- a/docs/domain/opportunities.md
+++ b/docs/domain/opportunities.md
@@ -169,7 +169,7 @@ Each opportunity carries interpretations written from a third-party analytical p
 
 Key properties of interpretations:
 - **Non-leaking**: Neither description reveals the other party's raw intent text. If an intent is incognito, the interpretation describes relevant attributes instead.
-- **Contextually grounded**: Uses publicly shareable signals (profile data, shared index membership)
+- **Contextually grounded**: Uses publicly shareable signals (profile data, shared network membership)
 - **Specific**: Explains what each side brings to the connection and why it is mutually valuable
 
 The interpretation `reasoning` field is sanitized to strip UUIDs, preventing internal identifiers from leaking into user-facing text.
@@ -218,7 +218,7 @@ The evaluator's analysis:
 ### Context
 
 Additional metadata:
-- `indexId`: The index scope (if index-scoped discovery)
+- `indexId`: The network scope (if network-scoped discovery)
 - `conversationId`: The conversation where this opportunity was discussed (if chat-driven)
 
 ---

--- a/docs/specs/api-reference.md
+++ b/docs/specs/api-reference.md
@@ -1343,7 +1343,7 @@ Returns a full diagnostic snapshot for a single intent, including the intent rec
 
 ### GET /api/debug/home
 
-Returns a home-level diagnostic snapshot for the authenticated user, including intent stats, index memberships, opportunity aggregates, simulated home-view filtering, and a pipeline-health diagnosis.
+Returns a home-level diagnostic snapshot for the authenticated user, including intent stats, network memberships, opportunity aggregates, simulated home-view filtering, and a pipeline-health diagnosis.
 
 **Auth**: DebugGuard + AuthGuard
 
@@ -1459,7 +1459,7 @@ Returns a debug-friendly view of a chat session, including messages and per-turn
 
 ### GET /api/networks
 
-List indexes the authenticated user is a member of, including their personal index.
+List networks the authenticated user is a member of, including their personal network.
 
 **Auth**: AuthGuard
 
@@ -1513,7 +1513,7 @@ Search users by name/email, optionally excluding existing members of an index.
 
 ### GET /api/networks/my-members
 
-Get all members of every index the signed-in user is a member of (deduplicated). Used for @mentions in chat.
+Get all members of every network the signed-in user is a member of (deduplicated). Used for @mentions in chat.
 
 **Auth**: AuthGuard
 
@@ -1526,7 +1526,7 @@ Get all members of every index the signed-in user is a member of (deduplicated).
 
 ### GET /api/networks/discovery/public
 
-Get public indexes the user has not joined.
+Get public networks the user has not joined.
 
 **Auth**: AuthGuard
 
@@ -1555,7 +1555,7 @@ Get an index by its invitation share code. Used for invitation page preview.
 
 ### GET /api/networks/public/:id
 
-Get a public index by ID. Only works for indexes with `joinPolicy: 'anyone'`.
+Get a public network by ID. Only works for indexes with `joinPolicy: 'anyone'`.
 
 **Auth**: None (public)
 
@@ -1571,7 +1571,7 @@ Get a public index by ID. Only works for indexes with `joinPolicy: 'anyone'`.
 
 ### GET /api/networks/shared/:userId
 
-Get non-personal indexes shared between the authenticated user and a target user.
+Get non-personal networks shared between the authenticated user and a target user.
 
 **Auth**: AuthGuard
 
@@ -1618,7 +1618,7 @@ Key must match `/^[a-z0-9][a-z0-9-]*[a-z0-9]$/`, be 3–64 characters, and not c
 
 ### GET /api/networks/:id
 
-Get a single index by ID with owner info and member count. Members only.
+Get a single network by ID with owner info and member count. Members only.
 
 **Auth**: AuthGuard
 
@@ -1661,7 +1661,7 @@ Update an index (title, prompt, image, join policy). Owner only.
 
 ### DELETE /api/networks/:id
 
-Soft-delete an index. Owner only.
+Soft-delete a network. Owner only.
 
 **Auth**: AuthGuard
 
@@ -1834,7 +1834,7 @@ Get current user's intents in an index. Members only.
 
 ### POST /api/networks/:id/join
 
-Join a public index.
+Join a public network.
 
 **Auth**: AuthGuard
 
@@ -2201,7 +2201,7 @@ Import contacts from a connected toolkit into an index.
 **Request body**:
 ```json
 {
-  "indexId": "string (optional — defaults to personal index)"
+  "indexId": "string (optional — defaults to personal network)"
 }
 ```
 
@@ -3146,7 +3146,7 @@ Tools are organized by domain. Each tool has its own input schema (see `GET /api
 | `update_intent` | Intent | Update an intent (runs full graph pipeline) |
 | `delete_intent` | Intent | Archive/delete an intent |
 | `create_intent_index` | Intent | Link an intent to an index |
-| `read_intent_indexes` | Intent | List indexes linked to an intent |
+| `read_intent_indexes` | Intent | List networks linked to an intent |
 | `delete_intent_index` | Intent | Unlink an intent from an index |
 | `read_networks` | Network | List user's networks |
 | `read_network_memberships` | Network | List members of a network |

--- a/docs/specs/cli-reference.md
+++ b/docs/specs/cli-reference.md
@@ -268,7 +268,7 @@ The `index network` command manages networks (the user-facing term for indexes) 
 
 ### `index network list`
 
-Lists networks the authenticated user is a member of. Calls `GET /api/networks`. Renders a table with columns: title, member count, role (owner/admin/member), join policy, created date. Personal indexes (`isPersonal: true`) are filtered from the display.
+Lists networks the authenticated user is a member of. Calls `GET /api/networks`. Renders a table with columns: title, member count, role (owner/admin/member), join policy, created date. Personal networks (`isPersonal: true`) are filtered from the display.
 
 ### `index network create <name>`
 

--- a/docs/specs/introducer-discovery.md
+++ b/docs/specs/introducer-discovery.md
@@ -12,7 +12,7 @@ Build a background pipeline that proactively discovers introducer opportunities 
 
 ### Contact-scoped discovery
 
-For each of a user's top-N contacts (sorted by intent freshness), run a scoped HyDE discovery against other contacts within the user's personal index. Reuse the existing `OpportunityGraphFactory` with `onBehalfOfUserId` set to the contact being evaluated, scoped to the user's personal index.
+For each of a user's top-N contacts (sorted by intent freshness), run a scoped HyDE discovery against other contacts within the user's personal network. Reuse the existing `OpportunityGraphFactory` with `onBehalfOfUserId` set to the contact being evaluated, scoped to the user's personal network.
 
 - Cap at 5 contacts per maintenance cycle
 - Cap at 3 candidate opportunities per contact
@@ -37,7 +37,7 @@ Introducer opportunities naturally fill connector-flow slots via the existing `c
 
 - Maintenance graph invocation remains fire-and-forget; introducer discovery must not block the home view response
 - Must reuse existing `OpportunityGraphFactory` -- no parallel discovery implementation
-- Discovery scoped to user's personal index contacts only (Phase 1)
+- Discovery scoped to user's personal network contacts only (Phase 1)
 - Opportunities created with introducer as the `userId` (state.userId) and contact as `onBehalfOfUserId`
 - Services do not import other services; cross-service communication via events/queues
 - Graph factories receive dependencies via constructor injection
@@ -47,7 +47,7 @@ Introducer opportunities naturally fill connector-flow slots via the existing `c
 
 1. `MaintenanceGraphFactory` has an `introducerDiscovery` node that discovers introducer opportunities
 2. The introducer discovery node activates when connector-flow count is below soft target
-3. Contacts are selected from the user's personal index (up to 5 per cycle)
+3. Contacts are selected from the user's personal network (up to 5 per cycle)
 4. Each contact's intents are used to discover opportunities against other contacts (up to 3 per contact)
 5. Created opportunities have `detection.source = 'introducer_discovery'` and status `latent`
 6. Created opportunities have the user as introducer actor and both contacts as parties

--- a/docs/specs/user-index-keys.md
+++ b/docs/specs/user-index-keys.md
@@ -46,7 +46,7 @@ All existing endpoints that accept a UUID in path params now also accept a key (
 
 ### CLI display changes
 
-**Network list:** Show key column (instead of UUID). Personal indexes remain filtered.
+**Network list:** Show key column (instead of UUID). Personal networks remain filtered.
 
 **Intent list:** Show first 8 characters of UUID as short ID.
 
@@ -59,7 +59,7 @@ All existing endpoints that accept a UUID in path params now also accept a key (
 ## Constraints
 
 - Keys are unique per table but not globally unique across tables
-- Personal indexes can have keys (auto-generated from user's name + "-personal" or similar), but personal indexes remain hidden from public listings
+- Personal networks can have keys (auto-generated from user's name + "-personal" or similar), but personal networks remain hidden from public listings
 - Key column is nullable to support existing records without keys
 - Prefix matching uses SQL LIKE, not full-text search
 - Prefix matching minimum length is not enforced server-side (the CLI displays 8 chars, but the API accepts any prefix length)

--- a/packages/claude-plugin/skills/index-negotiator/SKILL.md
+++ b/packages/claude-plugin/skills/index-negotiator/SKILL.md
@@ -34,7 +34,7 @@ Other banned words: leverage, unlock, optimize, scale, disrupt, revolutionary, A
 - **User** — has one Profile, many Memberships, many Intents
 - **Profile** — identity (name, bio, location) plus a synthesized `context` paragraph
 - **Index** — community with title, prompt (purpose), join policy. Has many Members
-- **Membership** — User ↔ Index junction. `isPersonal: true` marks the user's personal index (contacts)
+- **Membership** — User ↔ Index junction. `isPersonal: true` marks the user's personal network (contacts)
 - **Intent** — what a user is looking for (signal). Description, summary, embedding
 - **IntentIndex** — Intent ↔ Index junction (auto-assigned by system)
 - **Opportunity** — discovered connection between users. Roles, status, reasoning

--- a/packages/claude-plugin/skills/index-orchestrator/SKILL.md
+++ b/packages/claude-plugin/skills/index-orchestrator/SKILL.md
@@ -34,7 +34,7 @@ Other banned words: leverage, unlock, optimize, scale, disrupt, revolutionary, A
 - **User** — has one Profile, many Memberships, many Intents
 - **Profile** — identity (name, bio, location) plus a synthesized `context` paragraph
 - **Index** — community with title, prompt (purpose), join policy. Has many Members
-- **Membership** — User ↔ Index junction. `isPersonal: true` marks the user's personal index (contacts)
+- **Membership** — User ↔ Index junction. `isPersonal: true` marks the user's personal network (contacts)
 - **Intent** — what a user is looking for (signal). Description, summary, embedding
 - **IntentIndex** — Intent ↔ Index junction (auto-assigned by system)
 - **Opportunity** — discovered connection between users. Roles, status, reasoning
@@ -53,7 +53,7 @@ Other banned words: leverage, unlock, optimize, scale, disrupt, revolutionary, A
 On activation, silently call (do not show raw output):
 1. `read_user_contexts` — load the current user's profile
 2. `read_intents` — load their active signals
-3. `read_network_memberships` — load their index memberships (note which has `isPersonal: true`)
+3. `read_network_memberships` — load their network memberships (note which has `isPersonal: true`)
 
 If MCP tools are unavailable:
 - **OAuth (default):** call any Index tool — it challenges with OAuth on first use. Complete the browser flow.
@@ -80,7 +80,7 @@ For "find me a mentor", "who needs a React dev", "looking for investors":
 
 **Call `discover_opportunities(searchQuery=user's request)` FIRST. Do NOT call `create_intent` unless the user explicitly says "save", "create", "add", or "remember" a signal.**
 
-- For "in my network" / "from my contacts" / "people I know": pass the personal index ID (`isPersonal: true`) as `networkId`
+- For "in my network" / "from my contacts" / "people I know": pass the personal network ID (`isPersonal: true`) as `networkId`
 - If the tool returns `suggestIntentCreationForVisibility: true` and `suggestedIntentDescription`: after presenting results, ask once: "Would you also like to create a signal for this so others can find you?" If yes, call `create_intent(description=suggestedIntentDescription)` and include the returned ` ```intent_proposal ` block verbatim
 - When all candidates are exhausted, suggest the user create a signal — do NOT offer "show more"
 
@@ -115,8 +115,8 @@ When the user mentions a specific person AND wants to connect:
 
 ```
 1. read_user_contexts(userId=X) + read_network_memberships(userId=X)
-2. Intersect their indexes with the current user's preloaded memberships → find shared indexes
-3. If no shared indexes: tell the user there is no connection path
+2. Intersect their indexes with the current user's preloaded memberships → find shared networks
+3. If no shared networks: tell the user there is no connection path
 4. discover_opportunities(targetUserId=X, searchQuery="<synthesized reason>")
 5. Present the opportunity card
 ```
@@ -167,16 +167,16 @@ Exception: for profile creation, pass URLs directly to `create_user_context` —
 **Always gather context before calling `discover_opportunities`. The tool does NOT fetch data internally for introductions.**
 
 ```
-1. read_network_memberships(userId=A) + read_network_memberships(userId=B) → shared indexes
-2. If no shared indexes: tell user there is no shared community
+1. read_network_memberships(userId=A) + read_network_memberships(userId=B) → shared networks
+2. If no shared networks: tell user there is no shared community
 3. read_user_contexts(userId=A) + read_user_contexts(userId=B)
-4. For each shared index: read_intents(networkId=X, userId=A) + read_intents(networkId=X, userId=B)
+4. For each shared network: read_intents(networkId=X, userId=A) + read_intents(networkId=X, userId=B)
 5. Summarize: "Here's what I found about A and B..."
 6. discover_opportunities(partyUserIds=[A,B], entities=[{userId:A, profile:{...}, intents:[...], networkId:sharedId}, {userId:B, ...}], hint="user's reason")
 7. Present the draft introduction
 ```
 
-The `entities` array must include each party's userId, full profile, intents from the shared index, and the shared networkId. Never include the current user in `entities`.
+The `entities` array must include each party's userId, full profile, intents from the shared network, and the shared networkId. Never include the current user in `entities`.
 
 ## Pattern 5a: Discover connections for someone else
 
@@ -204,7 +204,7 @@ Do NOT use Pattern 5 here. Do NOT ask for a second person. Do NOT suggest creati
 2. read_intents(networkId=X) → what members are looking for
 3. read_network_memberships(networkId=X) → who's in it
 
-# Create an index
+# Create a network
 create_intent_index(title=..., prompt=...)
 
 # Join an index

--- a/packages/cli/cli-output-reference.html
+++ b/packages/cli/cli-output-reference.html
@@ -544,7 +544,7 @@ body {
   <span class="bold">Index Assignments</span>
   <span class="c-cyan">*</span> AI Research Collaborations<span class="c-gray"> (0.92)</span>
   <span class="c-cyan">*</span> Crypto & Identity<span class="c-gray"> (0.78)</span>
-  <span class="c-cyan">*</span> Personal Index<span class="c-gray"> (1.00)</span>
+  <span class="c-cyan">*</span> Personal Network<span class="c-gray"> (1.00)</span>
   <span class="c-gray">──────────────────────────────────────────────────</span></div>
     </div>
 
@@ -1103,7 +1103,7 @@ This domain is for use in illustrative examples in documents...
 <span class="c-red"><span class="bold">error</span>: Missing signal ID. Usage: index intent show &lt;id&gt;</span>
 <span class="c-red"><span class="bold">error</span>: Usage: index profile update &lt;action&gt; [--details &lt;text&gt;]</span>
 <span class="c-red"><span class="bold">error</span>: Negotiation not found: abc123</span>
-<span class="c-red"><span class="bold">error</span>: No shared indexes found between these users.</span>
+<span class="c-red"><span class="bold">error</span>: No shared networks found between these users.</span>
 <span class="c-red"><span class="bold">error</span>: `--json` requires an explicit conversation subcommand.</span></div>
     </div>
 
@@ -1227,7 +1227,7 @@ This domain is for use in illustrative examples in documents...
 <span class="c-orange">&gt; Updating index...</span>                   <span class="dim">update_index</span>
 <span class="c-orange">&gt; Deleting index...</span>                   <span class="dim">delete_index</span>
 <span class="c-orange">&gt; Adding member to index...</span>           <span class="dim">create_index_membership</span>
-<span class="c-orange">&gt; Fetching index memberships...</span>      <span class="dim">read_index_memberships</span>
+<span class="c-orange">&gt; Fetching network memberships...</span>      <span class="dim">read_index_memberships</span>
 <span class="c-orange">&gt; Searching for relevant connections...</span> <span class="dim">create_opportunities</span>
 <span class="c-orange">&gt; Listing your opportunities...</span>      <span class="dim">list_my_opportunities</span>
 <span class="c-orange">&gt; Updating opportunity status...</span>     <span class="dim">update_opportunity</span>

--- a/packages/cli/src/network.command.ts
+++ b/packages/cli/src/network.command.ts
@@ -72,7 +72,7 @@ export async function handleNetwork(
 }
 
 /**
- * List networks the user is a member of, excluding personal indexes.
+ * List networks the user is a member of, excluding personal networks.
  */
 async function networkList(client: ApiClient, json?: boolean): Promise<void> {
   const networks = await client.listNetworks();

--- a/packages/cli/src/opportunity.command.ts
+++ b/packages/cli/src/opportunity.command.ts
@@ -163,7 +163,7 @@ async function opportunityStatusUpdate(
 }
 
 /**
- * Gather profiles and intents for two users, find a shared index,
+ * Gather profiles and intents for two users, find a shared network,
  * then call discover_opportunities in introduction mode.
  */
 async function discoverIntroduction(
@@ -175,7 +175,7 @@ async function discoverIntroduction(
 ): Promise<void> {
   if (!json) output.info("Gathering data for introduction...");
 
-  // Step 1: Find shared indexes between the two users
+  // Step 1: Find shared networks between the two users
   const [membershipsA, membershipsB] = await Promise.all([
     client.callTool("read_network_memberships", { userId: userA }),
     client.callTool("read_network_memberships", { userId: userB }),
@@ -194,7 +194,7 @@ async function discoverIntroduction(
   const shared = indexesB.filter((m) => idsA.has(m.networkId));
 
   if (shared.length === 0) {
-    const err = "No shared indexes found between these users. They must be members of at least one common network.";
+    const err = "No shared networks found between these users. They must be members of at least one common network.";
     if (json) { console.log(JSON.stringify({ success: false, error: err })); return; }
     output.error(err, 1);
     return;

--- a/packages/cli/tests/network.command.spec.ts
+++ b/packages/cli/tests/network.command.spec.ts
@@ -84,7 +84,7 @@ describe("handleNetwork", () => {
     await mock.stop();
   });
 
-  it("lists networks, filtering out personal indexes", async () => {
+  it("lists networks, filtering out personal networks", async () => {
     mock.on("GET", "/api/networks", () =>
       Response.json({
         networks: [
@@ -94,7 +94,7 @@ describe("handleNetwork", () => {
       }),
     );
 
-    // Should not throw; personal index filtered in handler
+    // Should not throw; personal network filtered in handler
     await handleNetwork(client, "list", [], {});
   });
 

--- a/packages/cli/tests/tool-calls.spec.ts
+++ b/packages/cli/tests/tool-calls.spec.ts
@@ -368,7 +368,7 @@ describe("CLI tool call contracts", () => {
       expect(createCall.query.hint).toBeUndefined();
     });
 
-    it("discover --introduce fails gracefully when no shared indexes", async () => {
+    it("discover --introduce fails gracefully when no shared networks", async () => {
       mock.setToolResponse("read_network_memberships", {
         success: true,
         data: { memberships: [] },

--- a/packages/hermes-plugin/schemas.py
+++ b/packages/hermes-plugin/schemas.py
@@ -9,10 +9,10 @@ INDEX_READ_INTENTS = {
     "description": (
         "Read Index Network intents/signals through the authenticated Index MCP "
         "server. Use this when the user asks what they are looking for, what "
-        "signals they have, or what members of a specific Index/community are "
+        "signals they have, or what members of a specific network/community are "
         "seeking. With no parameters, returns the caller's own active intents. "
         "Pass networkId to browse intents in an Index the caller can access; "
-        "pass userId to filter to one user where the Index scope allows it."
+        "pass userId to filter to one user where the network scope allows it."
     ),
     "parameters": {
         "type": "object",
@@ -20,8 +20,8 @@ INDEX_READ_INTENTS = {
             "networkId": {
                 "type": "string",
                 "description": (
-                    "Optional Index/network UUID. When provided, reads intents "
-                    "in that Index/community."
+                    "Optional network UUID. When provided, reads intents "
+                    "in that network/community."
                 ),
             },
             "userId": {

--- a/packages/hermes-plugin/skills/index-negotiator/SKILL.md
+++ b/packages/hermes-plugin/skills/index-negotiator/SKILL.md
@@ -34,7 +34,7 @@ Other banned words: leverage, unlock, optimize, scale, disrupt, revolutionary, A
 - **User** — has one Profile, many Memberships, many Intents
 - **Profile** — identity (name, bio, location) plus a synthesized `context` paragraph
 - **Index** — community with title, prompt (purpose), join policy. Has many Members
-- **Membership** — User ↔ Index junction. `isPersonal: true` marks the user's personal index (contacts)
+- **Membership** — User ↔ Index junction. `isPersonal: true` marks the user's personal network (contacts)
 - **Intent** — what a user is looking for (signal). Description, summary, embedding
 - **IntentIndex** — Intent ↔ Index junction (auto-assigned by system)
 - **Opportunity** — discovered connection between users. Roles, status, reasoning

--- a/packages/hermes-plugin/skills/index-orchestrator/SKILL.md
+++ b/packages/hermes-plugin/skills/index-orchestrator/SKILL.md
@@ -34,7 +34,7 @@ Other banned words: leverage, unlock, optimize, scale, disrupt, revolutionary, A
 - **User** — has one Profile, many Memberships, many Intents
 - **Profile** — identity (name, bio, location) plus a synthesized `context` paragraph
 - **Index** — community with title, prompt (purpose), join policy. Has many Members
-- **Membership** — User ↔ Index junction. `isPersonal: true` marks the user's personal index (contacts)
+- **Membership** — User ↔ Index junction. `isPersonal: true` marks the user's personal network (contacts)
 - **Intent** — what a user is looking for (signal). Description, summary, embedding
 - **IntentIndex** — Intent ↔ Index junction (auto-assigned by system)
 - **Opportunity** — discovered connection between users. Roles, status, reasoning

--- a/packages/protocol/IMPLEMENTATION.md
+++ b/packages/protocol/IMPLEMENTATION.md
@@ -167,8 +167,8 @@ Each factory takes its typed dependencies in the constructor and exposes a
 | `PremiseGraphFactory` | Decompose and index a user's premises |
 | `NegotiationGraphFactory` | Multi-turn bilateral negotiation flows |
 | `HydeGraphFactory` | Generate hypothetical documents and embed them (cache-aware) |
-| `NetworkGraphFactory` | Manage index/network CRUD |
-| `NetworkMembershipGraphFactory` | Manage index/network member join/leave |
+| `NetworkGraphFactory` | Manage network/network CRUD |
+| `NetworkMembershipGraphFactory` | Manage network/network member join/leave |
 | `IntentNetworkGraphFactory` | Evaluate and assign/unassign intents to indexes |
 | `HomeGraphFactory` | Categorize and curate home-feed content |
 | `MaintenanceGraphFactory` | Periodic maintenance (feed health, opportunity expiration) |

--- a/packages/protocol/eval/matching/README.md
+++ b/packages/protocol/eval/matching/README.md
@@ -111,7 +111,7 @@ use Tier 1 when introducing a new surgical behavior or minimal-pair rule.
 co-researchers on a landmark paper, a songwriting duo, a first-check investor + founder,
 a cross-disciplinary biomedical research pair), recreated as the people looked *before* they
 connected. Each case places the discoverer, the eventual partner, and three plausible
-contemporary distractors in one shared index, and asserts the evaluator surfaces the partner
+contemporary distractors in one shared network, and asserts the evaluator surfaces the partner
 (band `[60, 100]`) while the distractors do not (`[0, 29]`). Evaluator input names stay
 anonymized so the model judges on fit, not fame, but `reportNames` exposes the real-world
 referents in HTML/reports. Run with `bun run eval:matching -- --rule historical`.

--- a/packages/protocol/eval/matching/tests/matching.historical.spec.ts
+++ b/packages/protocol/eval/matching/tests/matching.historical.spec.ts
@@ -60,7 +60,7 @@ describe("tier-3 historical corpus", () => {
     }
   });
 
-  it("uses at most two indexes per case, and every index used has a context entry", () => {
+  it("uses at most two indexes per case, and every network used has a context entry", () => {
     for (const c of HISTORICAL_CASES) {
       const nets = new Set(c.input.entities.map((e) => e.networkId));
       expect(nets.size).toBeLessThanOrEqual(2);

--- a/packages/protocol/skills/claude-plugin/index-orchestrator.template.md
+++ b/packages/protocol/skills/claude-plugin/index-orchestrator.template.md
@@ -12,7 +12,7 @@ description: Use when the user asks about finding people, connections, opportuni
 On activation, silently call (do not show raw output):
 1. `read_user_contexts` — load the current user's profile
 2. `read_intents` — load their active signals
-3. `read_network_memberships` — load their index memberships (note which has `isPersonal: true`)
+3. `read_network_memberships` — load their network memberships (note which has `isPersonal: true`)
 
 If MCP tools are unavailable:
 - **OAuth (default):** call any Index tool — it challenges with OAuth on first use. Complete the browser flow.
@@ -39,7 +39,7 @@ For "find me a mentor", "who needs a React dev", "looking for investors":
 
 **Call `discover_opportunities(searchQuery=user's request)` FIRST. Do NOT call `create_intent` unless the user explicitly says "save", "create", "add", or "remember" a signal.**
 
-- For "in my network" / "from my contacts" / "people I know": pass the personal index ID (`isPersonal: true`) as `networkId`
+- For "in my network" / "from my contacts" / "people I know": pass the personal network ID (`isPersonal: true`) as `networkId`
 - If the tool returns `suggestIntentCreationForVisibility: true` and `suggestedIntentDescription`: after presenting results, ask once: "Would you also like to create a signal for this so others can find you?" If yes, call `create_intent(description=suggestedIntentDescription)` and include the returned ` ```intent_proposal ` block verbatim
 - When all candidates are exhausted, suggest the user create a signal — do NOT offer "show more"
 
@@ -74,8 +74,8 @@ When the user mentions a specific person AND wants to connect:
 
 ```
 1. read_user_contexts(userId=X) + read_network_memberships(userId=X)
-2. Intersect their indexes with the current user's preloaded memberships → find shared indexes
-3. If no shared indexes: tell the user there is no connection path
+2. Intersect their indexes with the current user's preloaded memberships → find shared networks
+3. If no shared networks: tell the user there is no connection path
 4. discover_opportunities(targetUserId=X, searchQuery="<synthesized reason>")
 5. Present the opportunity card
 ```
@@ -126,16 +126,16 @@ Exception: for profile creation, pass URLs directly to `create_user_context` —
 **Always gather context before calling `discover_opportunities`. The tool does NOT fetch data internally for introductions.**
 
 ```
-1. read_network_memberships(userId=A) + read_network_memberships(userId=B) → shared indexes
-2. If no shared indexes: tell user there is no shared community
+1. read_network_memberships(userId=A) + read_network_memberships(userId=B) → shared networks
+2. If no shared networks: tell user there is no shared community
 3. read_user_contexts(userId=A) + read_user_contexts(userId=B)
-4. For each shared index: read_intents(networkId=X, userId=A) + read_intents(networkId=X, userId=B)
+4. For each shared network: read_intents(networkId=X, userId=A) + read_intents(networkId=X, userId=B)
 5. Summarize: "Here's what I found about A and B..."
 6. discover_opportunities(partyUserIds=[A,B], entities=[{userId:A, profile:{...}, intents:[...], networkId:sharedId}, {userId:B, ...}], hint="user's reason")
 7. Present the draft introduction
 ```
 
-The `entities` array must include each party's userId, full profile, intents from the shared index, and the shared networkId. Never include the current user in `entities`.
+The `entities` array must include each party's userId, full profile, intents from the shared network, and the shared networkId. Never include the current user in `entities`.
 
 ## Pattern 5a: Discover connections for someone else
 
@@ -163,7 +163,7 @@ Do NOT use Pattern 5 here. Do NOT ask for a second person. Do NOT suggest creati
 2. read_intents(networkId=X) → what members are looking for
 3. read_network_memberships(networkId=X) → who's in it
 
-# Create an index
+# Create a network
 create_intent_index(title=..., prompt=...)
 
 # Join an index

--- a/packages/protocol/skills/core-guidance.partial.md
+++ b/packages/protocol/skills/core-guidance.partial.md
@@ -27,7 +27,7 @@ Other banned words: leverage, unlock, optimize, scale, disrupt, revolutionary, A
 - **User** — has one Profile, many Memberships, many Intents
 - **Profile** — identity (name, bio, location) plus a synthesized `context` paragraph
 - **Index** — community with title, prompt (purpose), join policy. Has many Members
-- **Membership** — User ↔ Index junction. `isPersonal: true` marks the user's personal index (contacts)
+- **Membership** — User ↔ Index junction. `isPersonal: true` marks the user's personal network (contacts)
 - **Intent** — what a user is looking for (signal). Description, summary, embedding
 - **IntentIndex** — Intent ↔ Index junction (auto-assigned by system)
 - **Opportunity** — discovered connection between users. Roles, status, reasoning

--- a/packages/protocol/src/README.md
+++ b/packages/protocol/src/README.md
@@ -15,7 +15,7 @@ packages/protocol/src/
   maintenance/      Maintenance graph (feed health, opportunity expiration)
   mcp/              MCP server + elicitation builder/dispatcher
   negotiation/      Negotiation graph, agent (IndexNegotiator), insight + summarizer, tools
-  network/          Network (index) graph, membership graph, intent-index (indexer) graph, recommender, tools
+  network/          Network (index) graph, membership graph, intent-network (indexer) graph, recommender, tools
   opportunity/      Opportunity graph, evaluator, presenter, enricher, discover, evidence, introducer, delivery card, utils
     feed/           Home feed graph, feed categorizer, feed health
   premise/          Premise graph, decomposer, analyzer, indexer, tools
@@ -44,8 +44,8 @@ packages/protocol/src/
 | Premise | `premise/premise.graph.ts` | Decompose self-descriptive input into atomic premises, classify/score felicity, index + assign to networks |
 | Opportunity | `opportunity/opportunity.graph.ts` | HyDE-based discovery: search, evaluate (valency), rank, persist |
 | HyDE | `shared/hyde/hyde.graph.ts` | Generate hypothetical documents (Mirror, Reciprocal, Neighborhood) and embed them (cache-aware) |
-| Network | `network/network.graph.ts` | Manage index CRUD |
-| Network Membership | `network/membership/membership.graph.ts` | Manage index member join/leave |
+| Network | `network/network.graph.ts` | Manage network CRUD |
+| Network Membership | `network/membership/membership.graph.ts` | Manage network member join/leave |
 | Intent Indexer | `network/indexer/indexer.graph.ts` | Evaluate and assign/unassign intents to indexes |
 | Feed | `opportunity/feed/feed.graph.ts` | Categorize and curate home feed content |
 | Maintenance | `maintenance/maintenance.graph.ts` | Periodic maintenance tasks (feed health, opportunity expiration) |
@@ -66,7 +66,7 @@ packages/protocol/src/
 | Intent Inferrer | `intent/intent.inferrer.ts` | Intent graph — extracts structured intents from free text |
 | Intent Reconciler | `intent/intent.reconciler.ts` | Intent graph — determines create/update/expire action (Donnellan's distinction) |
 | Intent Verifier | `intent/intent.verifier.ts` | Intent graph — classifies speech act type; scores felicity conditions and semantic entropy |
-| Intent Indexer | `intent/intent.indexer.ts` | Intent Index graph — scores intent-index fit as relevancy score |
+| Intent Indexer | `intent/intent.indexer.ts` | Intent Network graph — scores intent-network fit as relevancy score |
 | Enrichment Generator | `enrichment/enrichment.generator.ts` | Enrichment graph — generates structured identity from raw data |
 | Enrichment Enricher | `enrichment/enrichment.enricher.ts` | Identity enrichment — display name and metadata enrichment |
 | Premise Decomposer | `premise/premise.decomposer.ts` | Premise graph — decomposes free text into atomic, first-person self-descriptive premises |
@@ -120,7 +120,7 @@ The system models human collaboration through a linguistic and information-theor
 | **Premise** | A **declarative or assertive speech act** about the self — an atomic, first-person proposition a user asserts about who they are ("I am a climate-tech founder", "I hold a PhD in computational biology"). Premises are *conditions of possibility*: facts that ground discovery, as opposed to intents, which are desires/requests. They are decomposed from profile/free-text input, classified and felicity-scored by the Premise Analyzer, embedded, and assigned to networks. The premise graph (`premise/premise.graph.ts`) owns their create/update/query lifecycle, and premise changes cascade into profile and user-context regeneration. |
 | **User Context** | A network-scoped synthetic paragraph synthesized from a user's premises by the `UserContextGenerator`, stored with its embedding. The opportunity graph uses contexts for **context-to-intent discovery** — it loads a user's contexts and searches for matching intents, running alongside premise-to-premise discovery as a complementary strategy. Regenerated whenever the user's premises change. |
 | **Intent** | A **commissive** or **directive speech act** — what the user is seeking or offering. Modelled as a Specific Indefinite: a future state uniquely satisfiable by a matching candidate. Each intent carries a **semantic entropy** score (constraint density), a **referential anchor** (Donnellan referential/attributive mode), and **felicity condition** scores (preparatory/authority and sincerity). |
-| **Index** | A community scoped to a purpose. Has members with roles, an optional prompt for LLM-based evaluation, and a join policy. Discovery is index-scoped — opportunities only arise between intents that share an index. |
+| **Index** | A community scoped to a purpose. Has members with roles, an optional prompt for LLM-based evaluation, and a join policy. Discovery is network-scoped — opportunities only arise between intents that share an index. |
 | **Opportunity** | A **semantic intersection**: the point where a candidate's constitutive facts (profile/intent) satisfy the propositional content of a source intent. Scored by the Opportunity Evaluator using **valency** (argument-role fit) and **constraint satisfaction**. Presented with dual descriptions per **Grice's Maxim of Relation** — one framed for the source, one for the candidate. |
 | **HyDE** | Hypothetical Document Embeddings. Three strategy types: **Mirror** (hallucinates the ideal candidate's biography — direct satisfaction of the intent's conditions), **Reciprocal** (hallucinates a complementary intent via meaning postulates — "if A wants to buy, infer B wants to sell"), and **Neighborhood** (hallucinates the discourse frame/community context). The encoder acts as a dense bottleneck filtering hallucinated specifics and retaining the semantic signal. |
 | **Felicity Conditions** | Scores evaluating whether an intent is valid: **preparatory condition** (does the user have the authority/skills for this act?) and **sincerity condition** (is the commitment genuine?). Intents that fail these are classified as *misfired* or *void*. |
@@ -273,7 +273,7 @@ sequenceDiagram
     Note over HG: Reciprocal: "intent to join as co-founder on React project"
     HG-->>OG: HyDE embeddings (dense bottleneck applied)
 
-    Note over OG: Vector search within index scope
+    Note over OG: Vector search within network scope
     Note over OG: OpportunityEvaluator: scores via valency + constraint satisfaction
     Note over OG: Assigns Patient (user) / Agent (candidate) roles
     Note over OG: OpportunityPresenter: dual descriptions (Grice's Maxim of Relation)
@@ -351,7 +351,7 @@ Handled by the **HyDE Graph** and **Enrichment Graph**:
 Handled by the **Opportunity Graph**:
 1. **Prep**: Load user's indexed intents and HyDE documents.
 2. **Scope**: Determine target indexes (single or all).
-3. **Discovery**: Vector similarity search within index scope. Two complementary strategies run and merge: **premise-to-premise** matching (the user's premise embeddings are searched against candidate premises) and **context-to-intent** matching (a user's network-scoped context embeddings are searched against candidate intents). (Profile-HyDE discovery was retired in WS10.)
+3. **Discovery**: Vector similarity search within network scope. Two complementary strategies run and merge: **premise-to-premise** matching (the user's premise embeddings are searched against candidate premises) and **context-to-intent** matching (a user's network-scoped context embeddings are searched against candidate intents). (Profile-HyDE discovery was retired in WS10.)
 4. **Evaluation**: `OpportunityEvaluator` scores each candidate pair via **valency** (does the candidate fill the argument slot of the source's goal verb?) and **constraint satisfaction** (does the candidate's constitutive context match all extracted constraints?). Assigns role: Agent, Patient, or Peer.
 5. **Presentation**: `OpportunityPresenter` generates two descriptions per Grice's Maxim of Relation — one from the source's frame, one from the candidate's frame.
 6. **Persist**: Opportunities created as `latent` with actor roles. Role determines tier-0 visibility (see Opportunity Lifecycle above).
@@ -362,7 +362,7 @@ The **Chat Graph** is a ReAct loop: one `agent_loop` node where the LLM decides 
 
 ## Key Invariants
 
-- **Index-scoped discovery**: Opportunities only arise between intents sharing an index
+- **Network-scoped discovery**: Opportunities only arise between intents sharing an index
 - **Specific Indefinites only**: Underspecified (high-entropy) intents do not enter the graph — they trigger elaboration
 - **Felicity-gated persistence**: Only intents classified as `felicitous` are persisted as active
 - **Dual synthesis**: Each opportunity has descriptions framed for both actors (Grice's Maxim of Relation)

--- a/packages/protocol/src/chat/chat.agent.ts
+++ b/packages/protocol/src/chat/chat.agent.ts
@@ -247,7 +247,7 @@ export class ChatAgent {
 
   /**
    * Async factory: creates a ChatAgent with resolved user/index context.
-   * Resolves user/index identity from DB during tool initialization.
+   * Resolves user/network identity from DB during tool initialization.
    */
   static async create(context: ToolContext): Promise<ChatAgent> {
     const { networkId: legacyNetworkId } = context;

--- a/packages/protocol/src/chat/chat.prompt.modules.ts
+++ b/packages/protocol/src/chat/chat.prompt.modules.ts
@@ -114,7 +114,7 @@ For open-ended connection-seeking ("find me a mentor", "who needs a React dev", 
 
 **CRITICAL: DO NOT create an intent first. Discovery comes FIRST.**
 
-**Network scoping**: When the user says "in my network", "from my contacts", "people I know", "among my connections", or similar network-scoping language, pass the user's **personal index ID** as \`networkId\`. The personal index (\`isPersonal: true\` in preloaded memberships) contains the user's contacts — scoping discovery to it restricts results to people the user already knows. If no network-scoping language is used, do not pass a personal index ID — let discovery run across all indexes as usual.
+**Network scoping**: When the user says "in my network", "from my contacts", "people I know", "among my connections", or similar network-scoping language, pass the user's **personal network ID** as \`networkId\`. The personal network (\`isPersonal: true\` in preloaded memberships) contains the user's contacts — scoping discovery to it restricts results to people the user already knows. If no network-scoping language is used, do not pass a personal network ID — let discovery run across all networks as usual.
 
 - Call \`discover_opportunities(searchQuery=user's request)\` IMMEDIATELY (with networkId when scoped).
 - Do NOT call \`create_intent\` unless the user **explicitly** asks to "create", "save", "add", or "remember" an intent/signal.
@@ -132,8 +132,8 @@ When the user mentions a specific person via @mention or name AND expresses inte
 
 \`\`\`
 1. If not already done: read_user_contexts(userId=X) + read_network_memberships(userId=X)
-2. Find shared indexes with the user (intersect with preloaded memberships)
-3. If no shared indexes: tell the user you can't find a connection path
+2. Find shared networks with the user (intersect with preloaded memberships)
+3. If no shared networks: tell the user you can't find a connection path
 4. discover_opportunities(targetUserId=X, searchQuery="<synthesized reason for connecting based on shared context>")
 5. Present the opportunity card
 \`\`\`
@@ -181,15 +181,15 @@ const introductionModule: PromptModule = {
 
 \`\`\`
 1. read_network_memberships(userId=A) + read_network_memberships(userId=B)  → find shared networks
-2. If no shared indexes: tell user they're not in any shared community
+2. If no shared networks: tell user they're not in any shared community
 3. read_user_contexts(userId=A) + read_user_contexts(userId=B)
-4. For each shared index: read_intents(networkId=X, userId=A) + read_intents(networkId=X, userId=B)
+4. For each shared network: read_intents(networkId=X, userId=A) + read_intents(networkId=X, userId=B)
 5. Summarize to user: "Here's what I found about A and B..."
 6. discover_opportunities(partyUserIds=[A,B], entities=[{userId:A, profile:{...}, intents:[...], networkId:shared}, {userId:B, ...}], hint="user's reason")
 7. Present the draft introduction
 \`\`\`
 
-The entities array must include each party's userId, profile data, intents from shared indexes, and the shared networkId. The hint is the user's stated reason (e.g. "both AI devs"). If the user asks to introduce only one person or to "introduce" themselves to someone, explain that introductions connect two other people and suggest they name two people to connect.
+The entities array must include each party's userId, profile data, intents from shared networks, and the shared networkId. The hint is the user's stated reason (e.g. "both AI devs"). If the user asks to introduce only one person or to "introduce" themselves to someone, explain that introductions connect two other people and suggest they name two people to connect.
 
 ### 6a. Discover who to introduce to someone
 
@@ -303,7 +303,7 @@ const communityModule: PromptModule = {
 \`\`\`
 
 ### When to mention community/index
-Index and community membership is background: handle it without talking about indexes unless the user asks or it's sign-up, leave, or owner settings. Do not proactively mention "your indexes", "your communities", "which index", "in your current communities", or similar. Only mention indexes (or communities, lists) when: (i) post-onboarding sign-up to a community, (ii) user explicitly asked about their indexes/communities, (iii) user wants to leave one, (iv) owner is changing index/community settings. Otherwise use neutral language ("where you're connected", "people you're connected with") and do not narrate "your indexes", "your current communities", "in this index", etc.
+Index and community membership is background: handle it without talking about indexes unless the user asks or it's sign-up, leave, or owner settings. Do not proactively mention "your indexes", "your communities", "which index", "in your current communities", or similar. Only mention indexes (or communities, lists) when: (i) post-onboarding sign-up to a community, (ii) user explicitly asked about their indexes/communities, (iii) user wants to leave one, (iv) owner is changing index/community settings. Otherwise use neutral language ("where you're connected", "people you're connected with") and do not narrate "your indexes", "your current communities", "in this network", etc.
 `,
 };
 
@@ -353,7 +353,7 @@ const sharedContextModule: PromptModule = {
 1. read_network_memberships(userId=me)     → my networks
 2. read_network_memberships(userId=other)  → their networks
 3. Intersect networkIds
-4. For each shared index: read_intents(networkId=shared)
+4. For each shared network: read_intents(networkId=shared)
 5. read_user_contexts(userId=other)
 6. Synthesize: what overlaps, where they could collaborate
 \`\`\`

--- a/packages/protocol/src/chat/chat.prompt.ts
+++ b/packages/protocol/src/chat/chat.prompt.ts
@@ -31,11 +31,11 @@ function buildCoreHead(ctx: ResolvedToolContext): string {
     ? deriveAllowedNetworkIds({ memberships: ctx.userNetworks, scopeType: 'network', scopeId: scopedNetworkId })
     : [];
   const reachable = scopedNetworkId
-    ? `, reach: ${reachableIds.length} index(es) including your personal index`
+    ? `, reach: ${reachableIds.length} network(s) including your personal network`
     : "";
   const indexScope = scopedNetworkId
-    ? `index "${ctx.indexName ?? "Unknown"}" (id: ${scopedNetworkId}), role: ${roleLabel}${reachable}`
-    : "no index scope (general chat)";
+    ? `network "${ctx.indexName ?? "Unknown"}" (id: ${scopedNetworkId}), role: ${roleLabel}${reachable}`
+    : "no network scope (general chat)";
 
   return `You are Index. You help the right people find the user and help the user find them.
 Here's what you can do:
@@ -155,8 +155,8 @@ ${focusedNetworkId(ctx) ? `6. **Community discovery (skipped — already in scop
      \`\`\`networks_panel
      {}
      \`\`\`
-   - When presenting, avoid being vocal about 'indexes' unless the user asks.
-   - For each index the user wants to join → call \`create_network_membership(networkId=X)\` (omit userId to self-join)
+   - When presenting, avoid being vocal about internal terminology unless the user asks.
+   - For each network the user wants to join → call \`create_network_membership(networkId=X)\` (omit userId to self-join)
    - After handling the user's response (joins processed, question answered, or user skips) → ALWAYS proceed to step 7 (intent capture). Do NOT end the conversation at communities.`}
 
 7. **Capture intent**
@@ -185,7 +185,7 @@ When the user says "yes", "looks good", "that's right", "correct", or any affirm
 }
 
 /**
- * Preloaded context (user, profile, memberships, scoped index), preloaded context
+ * Preloaded context (user, profile, memberships, scoped network), preloaded context
  * policy, architecture philosophy, entity model, and tools reference table.
  */
 function buildCoreBody(ctx: ResolvedToolContext): string {
@@ -194,8 +194,8 @@ function buildCoreBody(ctx: ResolvedToolContext): string {
     ? JSON.stringify(ctx.userProfile, null, 2)
     : "null";
 
-  // When scoped to an index, only include that index in memberships context
-  // When not scoped (general chat), include all indexes
+  // When scoped to a network, only include that network in memberships context
+  // When not scoped (general chat), include all networks
   const scopedNetworkId = focusedNetworkId(ctx);
   const relevantIndexes = scopedNetworkId
     ? ctx.userNetworks.filter((m) => m.networkId === scopedNetworkId)
@@ -234,18 +234,18 @@ ${userContext}
 ${profileContext}
 \`\`\`
 
-### Current User Index Memberships (preloaded context${scopedNetworkId ? " — scoped to current index" : ""})
+### Current User Index Memberships (preloaded context${scopedNetworkId ? " — scoped to current network" : ""})
 \`\`\`json
 ${indexesContext}
 \`\`\`
 
 ### Scoped Index (preloaded context)
-${scopedIndexContext ?? 'No scoped index — general chat.'}
+${scopedIndexContext ?? 'No scoped network — general chat.'}
 
 ### Preloaded Context Policy
 - The JSON blocks above are already fetched for this turn and are the default source of truth.
-- **Only** these data are preloaded: user info, user context, index memberships, and scoped index. **Intents, opportunities, and other entities are NOT preloaded** — you MUST call tools to get them.
-- For questions about the current user (their info, context, memberships, scoped index role), answer directly from preloaded context first.
+- **Only** these data are preloaded: user info, user context, network memberships, and scoped network. **Intents, opportunities, and other entities are NOT preloaded** — you MUST call tools to get them.
+- For questions about the current user (their info, context, memberships, scoped network role), answer directly from preloaded context first.
 - For "show my profile", "what's my profile", or "how am I showing up", answer from **Current User Context** in preloaded context when it is non-null; only call read_user_contexts when the user asks to refresh or when context is null.
 - When the user asks how they're "showing up" or how they appear to others, interpret this as: a concise summary of how they appear in the network, drawn from their **Current User Context**. Lead with that summary. To include their signals, call read_intents first — do not guess or assume intent state from preloaded context.
 - Do **not** call tools for data that is already present in preloaded context.
@@ -280,23 +280,23 @@ All tools are simple read/write operations. No hidden logic.
 
 | Tool | Params | What it does |
 |------|--------|-------------|
-| **read_user_contexts** | userId?, networkId?, query? | Read profile(s). No args = self. With \`query\`: find members by name across user's indexes |
+| **read_user_contexts** | userId?, networkId?, query? | Read profile(s). No args = self. With \`query\`: find members by name across user's networks |
 | **create_user_context** | linkedinUrl?, githubUrl?, etc. | Generate profile from URLs/data |
 | **update_user_context** | profileId?, action, details | Patch profile (omit profileId for current user) |
 | **complete_onboarding** | (none) | Mark onboarding complete (call once at step 8 wrap-up, after intent capture) |
-| **read_networks** | showAll? | List user's indexes |
+| **read_networks** | showAll? | List user's networks |
 | **create_network** | title, prompt?, joinPolicy? | Create community |
-| **update_network** | networkId?, settings | Update index (owner only) |
-| **delete_network** | networkId | Delete index (owner, sole member) |
-| **read_network_memberships** | networkId?, userId? | List members or list user's indexes |
-| **create_network_membership** | userId, networkId | Add user to index |
-| **read_intents** | networkId?, userId?, limit?, page? | Read intents by index/user |
+| **update_network** | networkId?, settings | Update network (owner only) |
+| **delete_network** | networkId | Delete network (owner, sole member) |
+| **read_network_memberships** | networkId?, userId? | List members or list user's networks |
+| **create_network_membership** | userId, networkId | Add user to network |
+| **read_intents** | networkId?, userId?, limit?, page? | Read intents by network/user |
 | **create_intent** | description, networkId? | Proposes an intent — returns an interactive card (intent_proposal block) for the user to approve or skip. Does NOT persist until the user clicks "Create Intent". |
 | **update_intent** | intentId, description | Update intent text |
 | **delete_intent** | intentId | Archive intent |
-| **create_intent_index** | intentId, networkId | Link intent to index |
-| **read_intent_indexes** | intentId?, networkId?, userId? | Read intent↔index links |
-| **delete_intent_index** | intentId, networkId | Unlink intent from index |
+| **create_intent_index** | intentId, networkId | Link intent to network |
+| **read_intent_indexes** | intentId?, networkId?, userId? | Read intent↔network links |
+| **delete_intent_index** | intentId, networkId | Unlink intent from network |
 | **discover_opportunities** | searchQuery?, networkId?, targetUserId?, partyUserIds?, entities?, hint? | Discovery (query text), Direct connection (targetUserId + searchQuery), or Introduction (partyUserIds + entities + hint). |
 | **list_opportunities** | networkId? | List draft and pending opportunities the user can act on. Use when user wants to review existing opportunities. |
 | **update_opportunity** | opportunityId, status | Change status: pending (send draft or latent), accepted, rejected, expired |
@@ -311,24 +311,24 @@ ${ctx.contactsEnabled ? `| **add_contact** | email, name? | Manually add single 
 }
 
 /**
- * Index scope block. Returns scoped variant when a network scope envelope is set,
+ * Network scope block. Returns scoped variant when a network scope envelope is set,
  * scopeless variant otherwise. Includes owner line.
  */
 function buildScoping(ctx: ResolvedToolContext): string {
   const scopedNetworkId = focusedNetworkId(ctx);
   return `
-### Index Scope
+### Network Scope
 ${
   scopedNetworkId
-    ? `- This chat is scoped to index "${ctx.indexName ?? "Unknown"}" (id: ${scopedNetworkId}). Default networkId for create_intent is ${scopedNetworkId}. read_intents (no params) returns the caller's own intents across their reachable indexes (the bound community plus their personal index) — there is no implicit "default networkId" for read_intents; pass ${scopedNetworkId} explicitly to browse all members' intents in this community.
-- **Scope enforcement**: read_intents with no args returns caller-owned intents across the reachable indexes (bound + personal). read_intents(networkId) browses all members' intents in that community. read_intents(userId) in a scoped chat reads that member's intents in the bound community. discover_opportunities with no networkId arg is limited to this focused community only; the personal index is still used for self-owned writes/assignments, not for scoped opportunity visibility. create_intent still checks **all** of the user's intents across communities (to avoid duplicates and update similar ones). Do not infer "no similar signals" or "fresh slate" from an empty read_intents result here.
+    ? `- This chat is scoped to network "${ctx.indexName ?? "Unknown"}" (id: ${scopedNetworkId}). Default networkId for create_intent is ${scopedNetworkId}. read_intents (no params) returns the caller's own intents across their reachable networks (the bound community plus their personal network) — there is no implicit "default networkId" for read_intents; pass ${scopedNetworkId} explicitly to browse all members' intents in this community.
+- **Scope enforcement**: read_intents with no args returns caller-owned intents across the reachable networks (bound + personal). read_intents(networkId) browses all members' intents in that community. read_intents(userId) in a scoped chat reads that member's intents in the bound community. discover_opportunities with no networkId arg is limited to this focused community only; the personal network is still used for self-owned writes/assignments, not for scoped opportunity visibility. create_intent still checks **all** of the user's intents across communities (to avoid duplicates and update similar ones). Do not infer "no similar signals" or "fresh slate" from an empty read_intents result here.
 - **Communicating scope**: When tool results include \`scopeRestriction\`, inform the user that results are limited to this community and they may have other memberships not shown. Never imply the scoped results represent all their data.
 - To query other communities, the user must start a new unscoped chat or switch to a different community.
-- When presenting, you may use the index title; avoid being vocal about 'indexes' unless the user asks.`
-    : `- No index scope. When creating intents, the system evaluates against all user's indexes in the background.
+- When presenting, you may use the network title; avoid being vocal about internal terminology unless the user asks.`
+    : `- No network scope. When creating intents, the system evaluates against all user's networks in the background.
 - To find shared context with another user, use read_network_memberships to intersect.`
 }
-${ctx.isOwner ? `- You are the **owner** of this index. You can update settings, add members, delete it.` : ""}
+${ctx.isOwner ? `- You are the **owner** of this network. You can update settings, add members, delete it.` : ""}
 `;
 }
 
@@ -373,7 +373,7 @@ Found them both. Alice is building developer tools, Bob is focused on AI infrast
 
 > Checking mutual interests
 \`\`\`
-(Internally: reading intents from shared indexes)
+(Internally: reading intents from shared networkes)
 → (tools run) →
 \`\`\`
 Here's what I found…

--- a/packages/protocol/src/chat/chat.state.ts
+++ b/packages/protocol/src/chat/chat.state.ts
@@ -23,7 +23,7 @@ export interface IntentSubgraphResult {
   intents?: unknown[];
   count?: number;
   error?: string;
-  /** When the intent graph exits early (e.g. index-scoped without intents); surface to user. */
+  /** When the intent graph exits early (e.g. network-scoped without intents); surface to user. */
   requiredMessage?: string;
 }
 

--- a/packages/protocol/src/chat/tests/__snapshots__/chat.prompt.modules.spec.ts.snap
+++ b/packages/protocol/src/chat/tests/__snapshots__/chat.prompt.modules.spec.ts.snap
@@ -1,6 +1,6 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
-exports[`buildSystemContent snapshot identity general chat (no index scope, no onboarding) — patterns are NOT in base prompt 1`] = `
+exports[`buildSystemContent snapshot identity general chat (no network scope, no onboarding) — patterns are NOT in base prompt 1`] = `
 "You are Index. You help the right people find the user and help the user find them.
 Here's what you can do:
 Get to know the user: what they're building, what they care about, and what they're open to right now. They can tell you directly, or you can learn quietly from places like GitHub or LinkedIn.
@@ -36,7 +36,7 @@ Other banned words: leverage, unlock, optimize, scale, disrupt, revolutionary, A
 
 ## Session
 - User: Alice Test (alice@example.com), id: user-1
-- Scope: no index scope (general chat)
+- Scope: no network scope (general chat)
 
 ### Current User (preloaded context)
 \`\`\`json
@@ -60,7 +60,7 @@ Other banned words: leverage, unlock, optimize, scale, disrupt, revolutionary, A
 }
 \`\`\`
 
-### Current User Index Memberships (preloaded context)
+### Current User Network Memberships (preloaded context)
 \`\`\`json
 [
   {
@@ -95,7 +95,7 @@ No scoped index — general chat.
 
 ### Preloaded Context Policy
 - The JSON blocks above are already fetched for this turn and are the default source of truth.
-- **Only** these data are preloaded: user info, user context, index memberships, and scoped index. **Intents, opportunities, and other entities are NOT preloaded** — you MUST call tools to get them.
+- **Only** these data are preloaded: user info, user context, network memberships, and scoped index. **Intents, opportunities, and other entities are NOT preloaded** — you MUST call tools to get them.
 - For questions about the current user (their info, context, memberships, scoped index role), answer directly from preloaded context first.
 - For "show my profile", "what's my profile", or "how am I showing up", answer from **Current User Context** in preloaded context when it is non-null; only call read_user_contexts when the user asks to refresh or when context is null.
 - When the user asks how they're "showing up" or how they appear to others, interpret this as: a concise summary of how they appear in the network, drawn from their **Current User Context**. Lead with that summary. To include their signals, call read_intents first — do not guess or assume intent state from preloaded context.
@@ -138,7 +138,7 @@ All tools are simple read/write operations. No hidden logic.
 | **read_networks** | showAll? | List user's indexes |
 | **create_network** | title, prompt?, joinPolicy? | Create community |
 | **update_network** | networkId?, settings | Update index (owner only) |
-| **delete_network** | networkId | Delete index (owner, sole member) |
+| **delete_network** | networkId | Delete network (owner, sole member) |
 | **read_network_memberships** | networkId?, userId? | List members or list user's indexes |
 | **create_network_membership** | userId, networkId | Add user to index |
 | **read_intents** | networkId?, userId?, limit?, page? | Read intents by index/user |
@@ -159,8 +159,8 @@ All tools are simple read/write operations. No hidden logic.
 | **add_contact** | email, name? | Manually add single contact to network |
 | **remove_contact** | contactId | Remove contact from network |
 
-### Index Scope
-- No index scope. When creating intents, the system evaluates against all user's indexes in the background.
+### Network Scope
+- No network scope. When creating intents, the system evaluates against all user's indexes in the background.
 - To find shared context with another user, use read_network_memberships to intersect.
 
 
@@ -199,7 +199,7 @@ Found them both. Alice is building developer tools, Bob is focused on AI infrast
 
 > Checking mutual interests
 \`\`\`
-(Internally: reading intents from shared indexes)
+(Internally: reading intents from shared networks)
 → (tools run) →
 \`\`\`
 Here's what I found…
@@ -245,7 +245,7 @@ What NOT to narrate (group silently with the main action):
 - Keep iterating until you have a good answer. Don't give up after one call."
 `;
 
-exports[`buildSystemContent snapshot identity scoped chat (index scope, owner) produces stable output 1`] = `
+exports[`buildSystemContent snapshot identity scoped chat (network scope, owner) produces stable output 1`] = `
 "You are Index. You help the right people find the user and help the user find them.
 Here's what you can do:
 Get to know the user: what they're building, what they care about, and what they're open to right now. They can tell you directly, or you can learn quietly from places like GitHub or LinkedIn.
@@ -281,7 +281,7 @@ Other banned words: leverage, unlock, optimize, scale, disrupt, revolutionary, A
 
 ## Session
 - User: Alice Test (alice@example.com), id: user-1
-- Scope: index "AI Builders" (id: idx-community), role: owner, reach: 2 index(es) including your personal index
+- Scope: index "AI Builders" (id: idx-community), role: owner, reach: 2 index(es) including your personal network
 
 ### Current User (preloaded context)
 \`\`\`json
@@ -305,7 +305,7 @@ Other banned words: leverage, unlock, optimize, scale, disrupt, revolutionary, A
 }
 \`\`\`
 
-### Current User Index Memberships (preloaded context — scoped to current index)
+### Current User Network Memberships (preloaded context — scoped to current index)
 \`\`\`json
 [
   {
@@ -331,7 +331,7 @@ AI enthusiasts
 
 ### Preloaded Context Policy
 - The JSON blocks above are already fetched for this turn and are the default source of truth.
-- **Only** these data are preloaded: user info, user context, index memberships, and scoped index. **Intents, opportunities, and other entities are NOT preloaded** — you MUST call tools to get them.
+- **Only** these data are preloaded: user info, user context, network memberships, and scoped index. **Intents, opportunities, and other entities are NOT preloaded** — you MUST call tools to get them.
 - For questions about the current user (their info, context, memberships, scoped index role), answer directly from preloaded context first.
 - For "show my profile", "what's my profile", or "how am I showing up", answer from **Current User Context** in preloaded context when it is non-null; only call read_user_contexts when the user asks to refresh or when context is null.
 - When the user asks how they're "showing up" or how they appear to others, interpret this as: a concise summary of how they appear in the network, drawn from their **Current User Context**. Lead with that summary. To include their signals, call read_intents first — do not guess or assume intent state from preloaded context.
@@ -374,7 +374,7 @@ All tools are simple read/write operations. No hidden logic.
 | **read_networks** | showAll? | List user's indexes |
 | **create_network** | title, prompt?, joinPolicy? | Create community |
 | **update_network** | networkId?, settings | Update index (owner only) |
-| **delete_network** | networkId | Delete index (owner, sole member) |
+| **delete_network** | networkId | Delete network (owner, sole member) |
 | **read_network_memberships** | networkId?, userId? | List members or list user's indexes |
 | **create_network_membership** | userId, networkId | Add user to index |
 | **read_intents** | networkId?, userId?, limit?, page? | Read intents by index/user |
@@ -395,13 +395,13 @@ All tools are simple read/write operations. No hidden logic.
 | **add_contact** | email, name? | Manually add single contact to network |
 | **remove_contact** | contactId | Remove contact from network |
 
-### Index Scope
-- This chat is scoped to index "AI Builders" (id: idx-community). Default networkId for create_intent is idx-community. read_intents (no params) returns the caller's own intents across their reachable indexes (the bound community plus their personal index) — there is no implicit "default networkId" for read_intents; pass idx-community explicitly to browse all members' intents in this community.
-- **Scope enforcement**: read_intents with no args returns caller-owned intents across the reachable indexes (bound + personal). read_intents(networkId) browses all members' intents in that community. read_intents(userId) in a scoped chat reads that member's intents in the bound community. discover_opportunities with no networkId arg is limited to this focused community only; the personal index is still used for self-owned writes/assignments, not for scoped opportunity visibility. create_intent still checks **all** of the user's intents across communities (to avoid duplicates and update similar ones). Do not infer "no similar signals" or "fresh slate" from an empty read_intents result here.
+### Network Scope
+- This chat is scoped to index "AI Builders" (id: idx-community). Default networkId for create_intent is idx-community. read_intents (no params) returns the caller's own intents across their reachable networks (the bound community plus their personal network) — there is no implicit "default networkId" for read_intents; pass idx-community explicitly to browse all members' intents in this community.
+- **Scope enforcement**: read_intents with no args returns caller-owned intents across the reachable networks (bound + personal). read_intents(networkId) browses all members' intents in that community. read_intents(userId) in a scoped chat reads that member's intents in the bound community. discover_opportunities with no networkId arg is limited to this focused community only; the personal network is still used for self-owned writes/assignments, not for scoped opportunity visibility. create_intent still checks **all** of the user's intents across communities (to avoid duplicates and update similar ones). Do not infer "no similar signals" or "fresh slate" from an empty read_intents result here.
 - **Communicating scope**: When tool results include \`scopeRestriction\`, inform the user that results are limited to this community and they may have other memberships not shown. Never imply the scoped results represent all their data.
 - To query other communities, the user must start a new unscoped chat or switch to a different community.
 - When presenting, you may use the index title; avoid being vocal about 'indexes' unless the user asks.
-- You are the **owner** of this index. You can update settings, add members, delete it.
+- You are the **owner** of this network. You can update settings, add members, delete it.
 
 ### CRITICAL: Action Integrity
 - **NEVER claim you performed a write action without calling the corresponding tool.** Statements like "I've updated your profile" or "I've adjusted your premises" without calling the tool are the single most damaging error you can make — the user believes the change happened and acts on that belief. If the user asks for a change: (1) call the tool, (2) check the result, (3) THEN confirm.
@@ -438,7 +438,7 @@ Found them both. Alice is building developer tools, Bob is focused on AI infrast
 
 > Checking mutual interests
 \`\`\`
-(Internally: reading intents from shared indexes)
+(Internally: reading intents from shared networks)
 → (tools run) →
 \`\`\`
 Here's what I found…
@@ -520,7 +520,7 @@ Other banned words: leverage, unlock, optimize, scale, disrupt, revolutionary, A
 
 ## Session
 - User: Alice Test (alice@example.com), id: user-1
-- Scope: no index scope (general chat)
+- Scope: no network scope (general chat)
 
 ## ONBOARDING MODE (ACTIVE)
 
@@ -636,7 +636,7 @@ When the user says "yes", "looks good", "that's right", "correct", or any affirm
 }
 \`\`\`
 
-### Current User Index Memberships (preloaded context)
+### Current User Network Memberships (preloaded context)
 \`\`\`json
 [
   {
@@ -671,7 +671,7 @@ No scoped index — general chat.
 
 ### Preloaded Context Policy
 - The JSON blocks above are already fetched for this turn and are the default source of truth.
-- **Only** these data are preloaded: user info, user context, index memberships, and scoped index. **Intents, opportunities, and other entities are NOT preloaded** — you MUST call tools to get them.
+- **Only** these data are preloaded: user info, user context, network memberships, and scoped index. **Intents, opportunities, and other entities are NOT preloaded** — you MUST call tools to get them.
 - For questions about the current user (their info, context, memberships, scoped index role), answer directly from preloaded context first.
 - For "show my profile", "what's my profile", or "how am I showing up", answer from **Current User Context** in preloaded context when it is non-null; only call read_user_contexts when the user asks to refresh or when context is null.
 - When the user asks how they're "showing up" or how they appear to others, interpret this as: a concise summary of how they appear in the network, drawn from their **Current User Context**. Lead with that summary. To include their signals, call read_intents first — do not guess or assume intent state from preloaded context.
@@ -714,7 +714,7 @@ All tools are simple read/write operations. No hidden logic.
 | **read_networks** | showAll? | List user's indexes |
 | **create_network** | title, prompt?, joinPolicy? | Create community |
 | **update_network** | networkId?, settings | Update index (owner only) |
-| **delete_network** | networkId | Delete index (owner, sole member) |
+| **delete_network** | networkId | Delete network (owner, sole member) |
 | **read_network_memberships** | networkId?, userId? | List members or list user's indexes |
 | **create_network_membership** | userId, networkId | Add user to index |
 | **read_intents** | networkId?, userId?, limit?, page? | Read intents by index/user |
@@ -735,8 +735,8 @@ All tools are simple read/write operations. No hidden logic.
 | **add_contact** | email, name? | Manually add single contact to network |
 | **remove_contact** | contactId | Remove contact from network |
 
-### Index Scope
-- No index scope. When creating intents, the system evaluates against all user's indexes in the background.
+### Network Scope
+- No network scope. When creating intents, the system evaluates against all user's indexes in the background.
 - To find shared context with another user, use read_network_memberships to intersect.
 
 
@@ -775,7 +775,7 @@ Found them both. Alice is building developer tools, Bob is focused on AI infrast
 
 > Checking mutual interests
 \`\`\`
-(Internally: reading intents from shared indexes)
+(Internally: reading intents from shared networks)
 → (tools run) →
 \`\`\`
 Here's what I found…
@@ -857,7 +857,7 @@ Other banned words: leverage, unlock, optimize, scale, disrupt, revolutionary, A
 
 ## Session
 - User: Alice Test (alice@example.com), id: user-1
-- Scope: no index scope (general chat)
+- Scope: no network scope (general chat)
 
 ## ONBOARDING MODE (ACTIVE)
 
@@ -975,7 +975,7 @@ When the user says "yes", "looks good", "that's right", "correct", or any affirm
 }
 \`\`\`
 
-### Current User Index Memberships (preloaded context)
+### Current User Network Memberships (preloaded context)
 \`\`\`json
 [
   {
@@ -1010,7 +1010,7 @@ No scoped index — general chat.
 
 ### Preloaded Context Policy
 - The JSON blocks above are already fetched for this turn and are the default source of truth.
-- **Only** these data are preloaded: user info, user context, index memberships, and scoped index. **Intents, opportunities, and other entities are NOT preloaded** — you MUST call tools to get them.
+- **Only** these data are preloaded: user info, user context, network memberships, and scoped index. **Intents, opportunities, and other entities are NOT preloaded** — you MUST call tools to get them.
 - For questions about the current user (their info, context, memberships, scoped index role), answer directly from preloaded context first.
 - For "show my profile", "what's my profile", or "how am I showing up", answer from **Current User Context** in preloaded context when it is non-null; only call read_user_contexts when the user asks to refresh or when context is null.
 - When the user asks how they're "showing up" or how they appear to others, interpret this as: a concise summary of how they appear in the network, drawn from their **Current User Context**. Lead with that summary. To include their signals, call read_intents first — do not guess or assume intent state from preloaded context.
@@ -1053,7 +1053,7 @@ All tools are simple read/write operations. No hidden logic.
 | **read_networks** | showAll? | List user's indexes |
 | **create_network** | title, prompt?, joinPolicy? | Create community |
 | **update_network** | networkId?, settings | Update index (owner only) |
-| **delete_network** | networkId | Delete index (owner, sole member) |
+| **delete_network** | networkId | Delete network (owner, sole member) |
 | **read_network_memberships** | networkId?, userId? | List members or list user's indexes |
 | **create_network_membership** | userId, networkId | Add user to index |
 | **read_intents** | networkId?, userId?, limit?, page? | Read intents by index/user |
@@ -1074,8 +1074,8 @@ All tools are simple read/write operations. No hidden logic.
 | **add_contact** | email, name? | Manually add single contact to network |
 | **remove_contact** | contactId | Remove contact from network |
 
-### Index Scope
-- No index scope. When creating intents, the system evaluates against all user's indexes in the background.
+### Network Scope
+- No network scope. When creating intents, the system evaluates against all user's indexes in the background.
 - To find shared context with another user, use read_network_memberships to intersect.
 
 
@@ -1114,7 +1114,7 @@ Found them both. Alice is building developer tools, Bob is focused on AI infrast
 
 > Checking mutual interests
 \`\`\`
-(Internally: reading intents from shared indexes)
+(Internally: reading intents from shared networks)
 → (tools run) →
 \`\`\`
 Here's what I found…
@@ -1196,7 +1196,7 @@ Other banned words: leverage, unlock, optimize, scale, disrupt, revolutionary, A
 
 ## Session
 - User: Alice Test (alice@example.com), id: user-1
-- Scope: no index scope (general chat)
+- Scope: no network scope (general chat)
 
 ### Current User (preloaded context)
 \`\`\`json
@@ -1220,7 +1220,7 @@ Other banned words: leverage, unlock, optimize, scale, disrupt, revolutionary, A
 }
 \`\`\`
 
-### Current User Index Memberships (preloaded context)
+### Current User Network Memberships (preloaded context)
 \`\`\`json
 [
   {
@@ -1255,7 +1255,7 @@ No scoped index — general chat.
 
 ### Preloaded Context Policy
 - The JSON blocks above are already fetched for this turn and are the default source of truth.
-- **Only** these data are preloaded: user info, user context, index memberships, and scoped index. **Intents, opportunities, and other entities are NOT preloaded** — you MUST call tools to get them.
+- **Only** these data are preloaded: user info, user context, network memberships, and scoped index. **Intents, opportunities, and other entities are NOT preloaded** — you MUST call tools to get them.
 - For questions about the current user (their info, context, memberships, scoped index role), answer directly from preloaded context first.
 - For "show my profile", "what's my profile", or "how am I showing up", answer from **Current User Context** in preloaded context when it is non-null; only call read_user_contexts when the user asks to refresh or when context is null.
 - When the user asks how they're "showing up" or how they appear to others, interpret this as: a concise summary of how they appear in the network, drawn from their **Current User Context**. Lead with that summary. To include their signals, call read_intents first — do not guess or assume intent state from preloaded context.
@@ -1298,7 +1298,7 @@ All tools are simple read/write operations. No hidden logic.
 | **read_networks** | showAll? | List user's indexes |
 | **create_network** | title, prompt?, joinPolicy? | Create community |
 | **update_network** | networkId?, settings | Update index (owner only) |
-| **delete_network** | networkId | Delete index (owner, sole member) |
+| **delete_network** | networkId | Delete network (owner, sole member) |
 | **read_network_memberships** | networkId?, userId? | List members or list user's indexes |
 | **create_network_membership** | userId, networkId | Add user to index |
 | **read_intents** | networkId?, userId?, limit?, page? | Read intents by index/user |
@@ -1325,7 +1325,7 @@ For open-ended connection-seeking ("find me a mentor", "who needs a React dev", 
 
 **CRITICAL: DO NOT create an intent first. Discovery comes FIRST.**
 
-**Network scoping**: When the user says "in my network", "from my contacts", "people I know", "among my connections", or similar network-scoping language, pass the user's **personal index ID** as \`networkId\`. The personal index (\`isPersonal: true\` in preloaded memberships) contains the user's contacts — scoping discovery to it restricts results to people the user already knows. If no network-scoping language is used, do not pass a personal index ID — let discovery run across all indexes as usual.
+**Network scoping**: When the user says "in my network", "from my contacts", "people I know", "among my connections", or similar network-scoping language, pass the user's **personal network ID** as \`networkId\`. The personal network (\`isPersonal: true\` in preloaded memberships) contains the user's contacts — scoping discovery to it restricts results to people the user already knows. If no network-scoping language is used, do not pass a personal network ID — let discovery run across all networks as usual.
 
 - Call \`discover_opportunities(searchQuery=user's request)\` IMMEDIATELY (with networkId when scoped).
 - Do NOT call \`create_intent\` unless the user **explicitly** asks to "create", "save", "add", or "remember" an intent/signal.
@@ -1343,8 +1343,8 @@ When the user mentions a specific person via @mention or name AND expresses inte
 
 \`\`\`
 1. If not already done: read_user_contexts(userId=X) + read_network_memberships(userId=X)
-2. Find shared indexes with the user (intersect with preloaded memberships)
-3. If no shared indexes: tell the user you can't find a connection path
+2. Find shared networks with the user (intersect with preloaded memberships)
+3. If no shared networks: tell the user you can't find a connection path
 4. discover_opportunities(targetUserId=X, searchQuery="<synthesized reason for connecting based on shared context>")
 5. Present the opportunity card
 \`\`\`
@@ -1448,7 +1448,7 @@ If the user pastes or types a profile URL (e.g. linkedin.com/..., github.com/...
 \`\`\`
 
 ### When to mention community/index
-Index and community membership is background: handle it without talking about indexes unless the user asks or it's sign-up, leave, or owner settings. Do not proactively mention "your indexes", "your communities", "which index", "in your current communities", or similar. Only mention indexes (or communities, lists) when: (i) post-onboarding sign-up to a community, (ii) user explicitly asked about their indexes/communities, (iii) user wants to leave one, (iv) owner is changing index/community settings. Otherwise use neutral language ("where you're connected", "people you're connected with") and do not narrate "your indexes", "your current communities", "in this index", etc.
+Index and community membership is background: handle it without talking about indexes unless the user asks or it's sign-up, leave, or owner settings. Do not proactively mention "your indexes", "your communities", "which index", "in your current communities", or similar. Only mention indexes (or communities, lists) when: (i) post-onboarding sign-up to a community, (ii) user explicitly asked about their indexes/communities, (iii) user wants to leave one, (iv) owner is changing index/community settings. Otherwise use neutral language ("where you're connected", "people you're connected with") and do not narrate "your indexes", "your current communities", "in this network", etc.
 
 
 ### 9. Import contacts from Gmail
@@ -1483,15 +1483,15 @@ remove_contact(contactId=X)
 1. read_network_memberships(userId=me)     → my networks
 2. read_network_memberships(userId=other)  → their networks
 3. Intersect networkIds
-4. For each shared index: read_intents(networkId=shared)
+4. For each shared network: read_intents(networkId=shared)
 5. read_user_contexts(userId=other)
 6. Synthesize: what overlaps, where they could collaborate
 \`\`\`
 
 - Messages may contain \`@[Display Name](userId)\` markup. The value in parentheses is the userId.
 
-### Index Scope
-- No index scope. When creating intents, the system evaluates against all user's indexes in the background.
+### Network Scope
+- No network scope. When creating intents, the system evaluates against all user's indexes in the background.
 - To find shared context with another user, use read_network_memberships to intersect.
 
 
@@ -1530,7 +1530,7 @@ Found them both. Alice is building developer tools, Bob is focused on AI infrast
 
 > Checking mutual interests
 \`\`\`
-(Internally: reading intents from shared indexes)
+(Internally: reading intents from shared networks)
 → (tools run) →
 \`\`\`
 Here's what I found…

--- a/packages/protocol/src/chat/tests/__snapshots__/chat.prompt.modules.spec.ts.snap
+++ b/packages/protocol/src/chat/tests/__snapshots__/chat.prompt.modules.spec.ts.snap
@@ -60,7 +60,7 @@ Other banned words: leverage, unlock, optimize, scale, disrupt, revolutionary, A
 }
 \`\`\`
 
-### Current User Network Memberships (preloaded context)
+### Current User Index Memberships (preloaded context)
 \`\`\`json
 [
   {
@@ -91,12 +91,12 @@ Other banned words: leverage, unlock, optimize, scale, disrupt, revolutionary, A
 \`\`\`
 
 ### Scoped Index (preloaded context)
-No scoped index — general chat.
+No scoped network — general chat.
 
 ### Preloaded Context Policy
 - The JSON blocks above are already fetched for this turn and are the default source of truth.
-- **Only** these data are preloaded: user info, user context, network memberships, and scoped index. **Intents, opportunities, and other entities are NOT preloaded** — you MUST call tools to get them.
-- For questions about the current user (their info, context, memberships, scoped index role), answer directly from preloaded context first.
+- **Only** these data are preloaded: user info, user context, network memberships, and scoped network. **Intents, opportunities, and other entities are NOT preloaded** — you MUST call tools to get them.
+- For questions about the current user (their info, context, memberships, scoped network role), answer directly from preloaded context first.
 - For "show my profile", "what's my profile", or "how am I showing up", answer from **Current User Context** in preloaded context when it is non-null; only call read_user_contexts when the user asks to refresh or when context is null.
 - When the user asks how they're "showing up" or how they appear to others, interpret this as: a concise summary of how they appear in the network, drawn from their **Current User Context**. Lead with that summary. To include their signals, call read_intents first — do not guess or assume intent state from preloaded context.
 - Do **not** call tools for data that is already present in preloaded context.
@@ -131,23 +131,23 @@ All tools are simple read/write operations. No hidden logic.
 
 | Tool | Params | What it does |
 |------|--------|-------------|
-| **read_user_contexts** | userId?, networkId?, query? | Read profile(s). No args = self. With \`query\`: find members by name across user's indexes |
+| **read_user_contexts** | userId?, networkId?, query? | Read profile(s). No args = self. With \`query\`: find members by name across user's networks |
 | **create_user_context** | linkedinUrl?, githubUrl?, etc. | Generate profile from URLs/data |
 | **update_user_context** | profileId?, action, details | Patch profile (omit profileId for current user) |
 | **complete_onboarding** | (none) | Mark onboarding complete (call once at step 8 wrap-up, after intent capture) |
-| **read_networks** | showAll? | List user's indexes |
+| **read_networks** | showAll? | List user's networks |
 | **create_network** | title, prompt?, joinPolicy? | Create community |
-| **update_network** | networkId?, settings | Update index (owner only) |
+| **update_network** | networkId?, settings | Update network (owner only) |
 | **delete_network** | networkId | Delete network (owner, sole member) |
-| **read_network_memberships** | networkId?, userId? | List members or list user's indexes |
-| **create_network_membership** | userId, networkId | Add user to index |
-| **read_intents** | networkId?, userId?, limit?, page? | Read intents by index/user |
+| **read_network_memberships** | networkId?, userId? | List members or list user's networks |
+| **create_network_membership** | userId, networkId | Add user to network |
+| **read_intents** | networkId?, userId?, limit?, page? | Read intents by network/user |
 | **create_intent** | description, networkId? | Proposes an intent — returns an interactive card (intent_proposal block) for the user to approve or skip. Does NOT persist until the user clicks "Create Intent". |
 | **update_intent** | intentId, description | Update intent text |
 | **delete_intent** | intentId | Archive intent |
-| **create_intent_index** | intentId, networkId | Link intent to index |
-| **read_intent_indexes** | intentId?, networkId?, userId? | Read intent↔index links |
-| **delete_intent_index** | intentId, networkId | Unlink intent from index |
+| **create_intent_index** | intentId, networkId | Link intent to network |
+| **read_intent_indexes** | intentId?, networkId?, userId? | Read intent↔network links |
+| **delete_intent_index** | intentId, networkId | Unlink intent from network |
 | **discover_opportunities** | searchQuery?, networkId?, targetUserId?, partyUserIds?, entities?, hint? | Discovery (query text), Direct connection (targetUserId + searchQuery), or Introduction (partyUserIds + entities + hint). |
 | **list_opportunities** | networkId? | List draft and pending opportunities the user can act on. Use when user wants to review existing opportunities. |
 | **update_opportunity** | opportunityId, status | Change status: pending (send draft or latent), accepted, rejected, expired |
@@ -160,7 +160,7 @@ All tools are simple read/write operations. No hidden logic.
 | **remove_contact** | contactId | Remove contact from network |
 
 ### Network Scope
-- No network scope. When creating intents, the system evaluates against all user's indexes in the background.
+- No network scope. When creating intents, the system evaluates against all user's networks in the background.
 - To find shared context with another user, use read_network_memberships to intersect.
 
 
@@ -199,7 +199,7 @@ Found them both. Alice is building developer tools, Bob is focused on AI infrast
 
 > Checking mutual interests
 \`\`\`
-(Internally: reading intents from shared networks)
+(Internally: reading intents from shared networkes)
 → (tools run) →
 \`\`\`
 Here's what I found…
@@ -281,7 +281,7 @@ Other banned words: leverage, unlock, optimize, scale, disrupt, revolutionary, A
 
 ## Session
 - User: Alice Test (alice@example.com), id: user-1
-- Scope: index "AI Builders" (id: idx-community), role: owner, reach: 2 index(es) including your personal network
+- Scope: network "AI Builders" (id: idx-community), role: owner, reach: 2 network(s) including your personal network
 
 ### Current User (preloaded context)
 \`\`\`json
@@ -305,7 +305,7 @@ Other banned words: leverage, unlock, optimize, scale, disrupt, revolutionary, A
 }
 \`\`\`
 
-### Current User Network Memberships (preloaded context — scoped to current index)
+### Current User Index Memberships (preloaded context — scoped to current network)
 \`\`\`json
 [
   {
@@ -331,8 +331,8 @@ AI enthusiasts
 
 ### Preloaded Context Policy
 - The JSON blocks above are already fetched for this turn and are the default source of truth.
-- **Only** these data are preloaded: user info, user context, network memberships, and scoped index. **Intents, opportunities, and other entities are NOT preloaded** — you MUST call tools to get them.
-- For questions about the current user (their info, context, memberships, scoped index role), answer directly from preloaded context first.
+- **Only** these data are preloaded: user info, user context, network memberships, and scoped network. **Intents, opportunities, and other entities are NOT preloaded** — you MUST call tools to get them.
+- For questions about the current user (their info, context, memberships, scoped network role), answer directly from preloaded context first.
 - For "show my profile", "what's my profile", or "how am I showing up", answer from **Current User Context** in preloaded context when it is non-null; only call read_user_contexts when the user asks to refresh or when context is null.
 - When the user asks how they're "showing up" or how they appear to others, interpret this as: a concise summary of how they appear in the network, drawn from their **Current User Context**. Lead with that summary. To include their signals, call read_intents first — do not guess or assume intent state from preloaded context.
 - Do **not** call tools for data that is already present in preloaded context.
@@ -367,23 +367,23 @@ All tools are simple read/write operations. No hidden logic.
 
 | Tool | Params | What it does |
 |------|--------|-------------|
-| **read_user_contexts** | userId?, networkId?, query? | Read profile(s). No args = self. With \`query\`: find members by name across user's indexes |
+| **read_user_contexts** | userId?, networkId?, query? | Read profile(s). No args = self. With \`query\`: find members by name across user's networks |
 | **create_user_context** | linkedinUrl?, githubUrl?, etc. | Generate profile from URLs/data |
 | **update_user_context** | profileId?, action, details | Patch profile (omit profileId for current user) |
 | **complete_onboarding** | (none) | Mark onboarding complete (call once at step 8 wrap-up, after intent capture) |
-| **read_networks** | showAll? | List user's indexes |
+| **read_networks** | showAll? | List user's networks |
 | **create_network** | title, prompt?, joinPolicy? | Create community |
-| **update_network** | networkId?, settings | Update index (owner only) |
+| **update_network** | networkId?, settings | Update network (owner only) |
 | **delete_network** | networkId | Delete network (owner, sole member) |
-| **read_network_memberships** | networkId?, userId? | List members or list user's indexes |
-| **create_network_membership** | userId, networkId | Add user to index |
-| **read_intents** | networkId?, userId?, limit?, page? | Read intents by index/user |
+| **read_network_memberships** | networkId?, userId? | List members or list user's networks |
+| **create_network_membership** | userId, networkId | Add user to network |
+| **read_intents** | networkId?, userId?, limit?, page? | Read intents by network/user |
 | **create_intent** | description, networkId? | Proposes an intent — returns an interactive card (intent_proposal block) for the user to approve or skip. Does NOT persist until the user clicks "Create Intent". |
 | **update_intent** | intentId, description | Update intent text |
 | **delete_intent** | intentId | Archive intent |
-| **create_intent_index** | intentId, networkId | Link intent to index |
-| **read_intent_indexes** | intentId?, networkId?, userId? | Read intent↔index links |
-| **delete_intent_index** | intentId, networkId | Unlink intent from index |
+| **create_intent_index** | intentId, networkId | Link intent to network |
+| **read_intent_indexes** | intentId?, networkId?, userId? | Read intent↔network links |
+| **delete_intent_index** | intentId, networkId | Unlink intent from network |
 | **discover_opportunities** | searchQuery?, networkId?, targetUserId?, partyUserIds?, entities?, hint? | Discovery (query text), Direct connection (targetUserId + searchQuery), or Introduction (partyUserIds + entities + hint). |
 | **list_opportunities** | networkId? | List draft and pending opportunities the user can act on. Use when user wants to review existing opportunities. |
 | **update_opportunity** | opportunityId, status | Change status: pending (send draft or latent), accepted, rejected, expired |
@@ -396,11 +396,11 @@ All tools are simple read/write operations. No hidden logic.
 | **remove_contact** | contactId | Remove contact from network |
 
 ### Network Scope
-- This chat is scoped to index "AI Builders" (id: idx-community). Default networkId for create_intent is idx-community. read_intents (no params) returns the caller's own intents across their reachable networks (the bound community plus their personal network) — there is no implicit "default networkId" for read_intents; pass idx-community explicitly to browse all members' intents in this community.
+- This chat is scoped to network "AI Builders" (id: idx-community). Default networkId for create_intent is idx-community. read_intents (no params) returns the caller's own intents across their reachable networks (the bound community plus their personal network) — there is no implicit "default networkId" for read_intents; pass idx-community explicitly to browse all members' intents in this community.
 - **Scope enforcement**: read_intents with no args returns caller-owned intents across the reachable networks (bound + personal). read_intents(networkId) browses all members' intents in that community. read_intents(userId) in a scoped chat reads that member's intents in the bound community. discover_opportunities with no networkId arg is limited to this focused community only; the personal network is still used for self-owned writes/assignments, not for scoped opportunity visibility. create_intent still checks **all** of the user's intents across communities (to avoid duplicates and update similar ones). Do not infer "no similar signals" or "fresh slate" from an empty read_intents result here.
 - **Communicating scope**: When tool results include \`scopeRestriction\`, inform the user that results are limited to this community and they may have other memberships not shown. Never imply the scoped results represent all their data.
 - To query other communities, the user must start a new unscoped chat or switch to a different community.
-- When presenting, you may use the index title; avoid being vocal about 'indexes' unless the user asks.
+- When presenting, you may use the network title; avoid being vocal about internal terminology unless the user asks.
 - You are the **owner** of this network. You can update settings, add members, delete it.
 
 ### CRITICAL: Action Integrity
@@ -438,7 +438,7 @@ Found them both. Alice is building developer tools, Bob is focused on AI infrast
 
 > Checking mutual interests
 \`\`\`
-(Internally: reading intents from shared networks)
+(Internally: reading intents from shared networkes)
 → (tools run) →
 \`\`\`
 Here's what I found…
@@ -587,8 +587,8 @@ This is the user's first conversation. They just signed up. Guide them through s
      \`\`\`networks_panel
      {}
      \`\`\`
-   - When presenting, avoid being vocal about 'indexes' unless the user asks.
-   - For each index the user wants to join → call \`create_network_membership(networkId=X)\` (omit userId to self-join)
+   - When presenting, avoid being vocal about internal terminology unless the user asks.
+   - For each network the user wants to join → call \`create_network_membership(networkId=X)\` (omit userId to self-join)
    - After handling the user's response (joins processed, question answered, or user skips) → ALWAYS proceed to step 7 (intent capture). Do NOT end the conversation at communities.
 
 7. **Capture intent**
@@ -636,7 +636,7 @@ When the user says "yes", "looks good", "that's right", "correct", or any affirm
 }
 \`\`\`
 
-### Current User Network Memberships (preloaded context)
+### Current User Index Memberships (preloaded context)
 \`\`\`json
 [
   {
@@ -667,12 +667,12 @@ When the user says "yes", "looks good", "that's right", "correct", or any affirm
 \`\`\`
 
 ### Scoped Index (preloaded context)
-No scoped index — general chat.
+No scoped network — general chat.
 
 ### Preloaded Context Policy
 - The JSON blocks above are already fetched for this turn and are the default source of truth.
-- **Only** these data are preloaded: user info, user context, network memberships, and scoped index. **Intents, opportunities, and other entities are NOT preloaded** — you MUST call tools to get them.
-- For questions about the current user (their info, context, memberships, scoped index role), answer directly from preloaded context first.
+- **Only** these data are preloaded: user info, user context, network memberships, and scoped network. **Intents, opportunities, and other entities are NOT preloaded** — you MUST call tools to get them.
+- For questions about the current user (their info, context, memberships, scoped network role), answer directly from preloaded context first.
 - For "show my profile", "what's my profile", or "how am I showing up", answer from **Current User Context** in preloaded context when it is non-null; only call read_user_contexts when the user asks to refresh or when context is null.
 - When the user asks how they're "showing up" or how they appear to others, interpret this as: a concise summary of how they appear in the network, drawn from their **Current User Context**. Lead with that summary. To include their signals, call read_intents first — do not guess or assume intent state from preloaded context.
 - Do **not** call tools for data that is already present in preloaded context.
@@ -707,23 +707,23 @@ All tools are simple read/write operations. No hidden logic.
 
 | Tool | Params | What it does |
 |------|--------|-------------|
-| **read_user_contexts** | userId?, networkId?, query? | Read profile(s). No args = self. With \`query\`: find members by name across user's indexes |
+| **read_user_contexts** | userId?, networkId?, query? | Read profile(s). No args = self. With \`query\`: find members by name across user's networks |
 | **create_user_context** | linkedinUrl?, githubUrl?, etc. | Generate profile from URLs/data |
 | **update_user_context** | profileId?, action, details | Patch profile (omit profileId for current user) |
 | **complete_onboarding** | (none) | Mark onboarding complete (call once at step 8 wrap-up, after intent capture) |
-| **read_networks** | showAll? | List user's indexes |
+| **read_networks** | showAll? | List user's networks |
 | **create_network** | title, prompt?, joinPolicy? | Create community |
-| **update_network** | networkId?, settings | Update index (owner only) |
+| **update_network** | networkId?, settings | Update network (owner only) |
 | **delete_network** | networkId | Delete network (owner, sole member) |
-| **read_network_memberships** | networkId?, userId? | List members or list user's indexes |
-| **create_network_membership** | userId, networkId | Add user to index |
-| **read_intents** | networkId?, userId?, limit?, page? | Read intents by index/user |
+| **read_network_memberships** | networkId?, userId? | List members or list user's networks |
+| **create_network_membership** | userId, networkId | Add user to network |
+| **read_intents** | networkId?, userId?, limit?, page? | Read intents by network/user |
 | **create_intent** | description, networkId? | Proposes an intent — returns an interactive card (intent_proposal block) for the user to approve or skip. Does NOT persist until the user clicks "Create Intent". |
 | **update_intent** | intentId, description | Update intent text |
 | **delete_intent** | intentId | Archive intent |
-| **create_intent_index** | intentId, networkId | Link intent to index |
-| **read_intent_indexes** | intentId?, networkId?, userId? | Read intent↔index links |
-| **delete_intent_index** | intentId, networkId | Unlink intent from index |
+| **create_intent_index** | intentId, networkId | Link intent to network |
+| **read_intent_indexes** | intentId?, networkId?, userId? | Read intent↔network links |
+| **delete_intent_index** | intentId, networkId | Unlink intent from network |
 | **discover_opportunities** | searchQuery?, networkId?, targetUserId?, partyUserIds?, entities?, hint? | Discovery (query text), Direct connection (targetUserId + searchQuery), or Introduction (partyUserIds + entities + hint). |
 | **list_opportunities** | networkId? | List draft and pending opportunities the user can act on. Use when user wants to review existing opportunities. |
 | **update_opportunity** | opportunityId, status | Change status: pending (send draft or latent), accepted, rejected, expired |
@@ -736,7 +736,7 @@ All tools are simple read/write operations. No hidden logic.
 | **remove_contact** | contactId | Remove contact from network |
 
 ### Network Scope
-- No network scope. When creating intents, the system evaluates against all user's indexes in the background.
+- No network scope. When creating intents, the system evaluates against all user's networks in the background.
 - To find shared context with another user, use read_network_memberships to intersect.
 
 
@@ -775,7 +775,7 @@ Found them both. Alice is building developer tools, Bob is focused on AI infrast
 
 > Checking mutual interests
 \`\`\`
-(Internally: reading intents from shared networks)
+(Internally: reading intents from shared networkes)
 → (tools run) →
 \`\`\`
 Here's what I found…
@@ -926,8 +926,8 @@ This is the user's first conversation. They just signed up. Guide them through s
      \`\`\`networks_panel
      {}
      \`\`\`
-   - When presenting, avoid being vocal about 'indexes' unless the user asks.
-   - For each index the user wants to join → call \`create_network_membership(networkId=X)\` (omit userId to self-join)
+   - When presenting, avoid being vocal about internal terminology unless the user asks.
+   - For each network the user wants to join → call \`create_network_membership(networkId=X)\` (omit userId to self-join)
    - After handling the user's response (joins processed, question answered, or user skips) → ALWAYS proceed to step 7 (intent capture). Do NOT end the conversation at communities.
 
 7. **Capture intent**
@@ -975,7 +975,7 @@ When the user says "yes", "looks good", "that's right", "correct", or any affirm
 }
 \`\`\`
 
-### Current User Network Memberships (preloaded context)
+### Current User Index Memberships (preloaded context)
 \`\`\`json
 [
   {
@@ -1006,12 +1006,12 @@ When the user says "yes", "looks good", "that's right", "correct", or any affirm
 \`\`\`
 
 ### Scoped Index (preloaded context)
-No scoped index — general chat.
+No scoped network — general chat.
 
 ### Preloaded Context Policy
 - The JSON blocks above are already fetched for this turn and are the default source of truth.
-- **Only** these data are preloaded: user info, user context, network memberships, and scoped index. **Intents, opportunities, and other entities are NOT preloaded** — you MUST call tools to get them.
-- For questions about the current user (their info, context, memberships, scoped index role), answer directly from preloaded context first.
+- **Only** these data are preloaded: user info, user context, network memberships, and scoped network. **Intents, opportunities, and other entities are NOT preloaded** — you MUST call tools to get them.
+- For questions about the current user (their info, context, memberships, scoped network role), answer directly from preloaded context first.
 - For "show my profile", "what's my profile", or "how am I showing up", answer from **Current User Context** in preloaded context when it is non-null; only call read_user_contexts when the user asks to refresh or when context is null.
 - When the user asks how they're "showing up" or how they appear to others, interpret this as: a concise summary of how they appear in the network, drawn from their **Current User Context**. Lead with that summary. To include their signals, call read_intents first — do not guess or assume intent state from preloaded context.
 - Do **not** call tools for data that is already present in preloaded context.
@@ -1046,23 +1046,23 @@ All tools are simple read/write operations. No hidden logic.
 
 | Tool | Params | What it does |
 |------|--------|-------------|
-| **read_user_contexts** | userId?, networkId?, query? | Read profile(s). No args = self. With \`query\`: find members by name across user's indexes |
+| **read_user_contexts** | userId?, networkId?, query? | Read profile(s). No args = self. With \`query\`: find members by name across user's networks |
 | **create_user_context** | linkedinUrl?, githubUrl?, etc. | Generate profile from URLs/data |
 | **update_user_context** | profileId?, action, details | Patch profile (omit profileId for current user) |
 | **complete_onboarding** | (none) | Mark onboarding complete (call once at step 8 wrap-up, after intent capture) |
-| **read_networks** | showAll? | List user's indexes |
+| **read_networks** | showAll? | List user's networks |
 | **create_network** | title, prompt?, joinPolicy? | Create community |
-| **update_network** | networkId?, settings | Update index (owner only) |
+| **update_network** | networkId?, settings | Update network (owner only) |
 | **delete_network** | networkId | Delete network (owner, sole member) |
-| **read_network_memberships** | networkId?, userId? | List members or list user's indexes |
-| **create_network_membership** | userId, networkId | Add user to index |
-| **read_intents** | networkId?, userId?, limit?, page? | Read intents by index/user |
+| **read_network_memberships** | networkId?, userId? | List members or list user's networks |
+| **create_network_membership** | userId, networkId | Add user to network |
+| **read_intents** | networkId?, userId?, limit?, page? | Read intents by network/user |
 | **create_intent** | description, networkId? | Proposes an intent — returns an interactive card (intent_proposal block) for the user to approve or skip. Does NOT persist until the user clicks "Create Intent". |
 | **update_intent** | intentId, description | Update intent text |
 | **delete_intent** | intentId | Archive intent |
-| **create_intent_index** | intentId, networkId | Link intent to index |
-| **read_intent_indexes** | intentId?, networkId?, userId? | Read intent↔index links |
-| **delete_intent_index** | intentId, networkId | Unlink intent from index |
+| **create_intent_index** | intentId, networkId | Link intent to network |
+| **read_intent_indexes** | intentId?, networkId?, userId? | Read intent↔network links |
+| **delete_intent_index** | intentId, networkId | Unlink intent from network |
 | **discover_opportunities** | searchQuery?, networkId?, targetUserId?, partyUserIds?, entities?, hint? | Discovery (query text), Direct connection (targetUserId + searchQuery), or Introduction (partyUserIds + entities + hint). |
 | **list_opportunities** | networkId? | List draft and pending opportunities the user can act on. Use when user wants to review existing opportunities. |
 | **update_opportunity** | opportunityId, status | Change status: pending (send draft or latent), accepted, rejected, expired |
@@ -1075,7 +1075,7 @@ All tools are simple read/write operations. No hidden logic.
 | **remove_contact** | contactId | Remove contact from network |
 
 ### Network Scope
-- No network scope. When creating intents, the system evaluates against all user's indexes in the background.
+- No network scope. When creating intents, the system evaluates against all user's networks in the background.
 - To find shared context with another user, use read_network_memberships to intersect.
 
 
@@ -1114,7 +1114,7 @@ Found them both. Alice is building developer tools, Bob is focused on AI infrast
 
 > Checking mutual interests
 \`\`\`
-(Internally: reading intents from shared networks)
+(Internally: reading intents from shared networkes)
 → (tools run) →
 \`\`\`
 Here's what I found…
@@ -1220,7 +1220,7 @@ Other banned words: leverage, unlock, optimize, scale, disrupt, revolutionary, A
 }
 \`\`\`
 
-### Current User Network Memberships (preloaded context)
+### Current User Index Memberships (preloaded context)
 \`\`\`json
 [
   {
@@ -1251,12 +1251,12 @@ Other banned words: leverage, unlock, optimize, scale, disrupt, revolutionary, A
 \`\`\`
 
 ### Scoped Index (preloaded context)
-No scoped index — general chat.
+No scoped network — general chat.
 
 ### Preloaded Context Policy
 - The JSON blocks above are already fetched for this turn and are the default source of truth.
-- **Only** these data are preloaded: user info, user context, network memberships, and scoped index. **Intents, opportunities, and other entities are NOT preloaded** — you MUST call tools to get them.
-- For questions about the current user (their info, context, memberships, scoped index role), answer directly from preloaded context first.
+- **Only** these data are preloaded: user info, user context, network memberships, and scoped network. **Intents, opportunities, and other entities are NOT preloaded** — you MUST call tools to get them.
+- For questions about the current user (their info, context, memberships, scoped network role), answer directly from preloaded context first.
 - For "show my profile", "what's my profile", or "how am I showing up", answer from **Current User Context** in preloaded context when it is non-null; only call read_user_contexts when the user asks to refresh or when context is null.
 - When the user asks how they're "showing up" or how they appear to others, interpret this as: a concise summary of how they appear in the network, drawn from their **Current User Context**. Lead with that summary. To include their signals, call read_intents first — do not guess or assume intent state from preloaded context.
 - Do **not** call tools for data that is already present in preloaded context.
@@ -1291,23 +1291,23 @@ All tools are simple read/write operations. No hidden logic.
 
 | Tool | Params | What it does |
 |------|--------|-------------|
-| **read_user_contexts** | userId?, networkId?, query? | Read profile(s). No args = self. With \`query\`: find members by name across user's indexes |
+| **read_user_contexts** | userId?, networkId?, query? | Read profile(s). No args = self. With \`query\`: find members by name across user's networks |
 | **create_user_context** | linkedinUrl?, githubUrl?, etc. | Generate profile from URLs/data |
 | **update_user_context** | profileId?, action, details | Patch profile (omit profileId for current user) |
 | **complete_onboarding** | (none) | Mark onboarding complete (call once at step 8 wrap-up, after intent capture) |
-| **read_networks** | showAll? | List user's indexes |
+| **read_networks** | showAll? | List user's networks |
 | **create_network** | title, prompt?, joinPolicy? | Create community |
-| **update_network** | networkId?, settings | Update index (owner only) |
+| **update_network** | networkId?, settings | Update network (owner only) |
 | **delete_network** | networkId | Delete network (owner, sole member) |
-| **read_network_memberships** | networkId?, userId? | List members or list user's indexes |
-| **create_network_membership** | userId, networkId | Add user to index |
-| **read_intents** | networkId?, userId?, limit?, page? | Read intents by index/user |
+| **read_network_memberships** | networkId?, userId? | List members or list user's networks |
+| **create_network_membership** | userId, networkId | Add user to network |
+| **read_intents** | networkId?, userId?, limit?, page? | Read intents by network/user |
 | **create_intent** | description, networkId? | Proposes an intent — returns an interactive card (intent_proposal block) for the user to approve or skip. Does NOT persist until the user clicks "Create Intent". |
 | **update_intent** | intentId, description | Update intent text |
 | **delete_intent** | intentId | Archive intent |
-| **create_intent_index** | intentId, networkId | Link intent to index |
-| **read_intent_indexes** | intentId?, networkId?, userId? | Read intent↔index links |
-| **delete_intent_index** | intentId, networkId | Unlink intent from index |
+| **create_intent_index** | intentId, networkId | Link intent to network |
+| **read_intent_indexes** | intentId?, networkId?, userId? | Read intent↔network links |
+| **delete_intent_index** | intentId, networkId | Unlink intent from network |
 | **discover_opportunities** | searchQuery?, networkId?, targetUserId?, partyUserIds?, entities?, hint? | Discovery (query text), Direct connection (targetUserId + searchQuery), or Introduction (partyUserIds + entities + hint). |
 | **list_opportunities** | networkId? | List draft and pending opportunities the user can act on. Use when user wants to review existing opportunities. |
 | **update_opportunity** | opportunityId, status | Change status: pending (send draft or latent), accepted, rejected, expired |
@@ -1491,7 +1491,7 @@ remove_contact(contactId=X)
 - Messages may contain \`@[Display Name](userId)\` markup. The value in parentheses is the userId.
 
 ### Network Scope
-- No network scope. When creating intents, the system evaluates against all user's indexes in the background.
+- No network scope. When creating intents, the system evaluates against all user's networks in the background.
 - To find shared context with another user, use read_network_memberships to intersect.
 
 
@@ -1530,7 +1530,7 @@ Found them both. Alice is building developer tools, Bob is focused on AI infrast
 
 > Checking mutual interests
 \`\`\`
-(Internally: reading intents from shared networks)
+(Internally: reading intents from shared networkes)
 → (tools run) →
 \`\`\`
 Here's what I found…

--- a/packages/protocol/src/chat/tests/chat.graph.mocks.ts
+++ b/packages/protocol/src/chat/tests/chat.graph.mocks.ts
@@ -1,7 +1,7 @@
 /**
  * Configurable mock database and fixture data for chat graph workflow tests.
  * Use createChatGraphMockDb(config) to get a full ChatGraphCompositeDatabase
- * with controllable profile, intents, index membership, and opportunities.
+ * with controllable profile, intents, network membership, and opportunities.
  */
 
 import type { ChatGraphCompositeDatabase, CreateIntentData, ActiveIntent, IndexedIntentDetails, NetworkMembership, OwnedIndex, UserRecord, Opportunity, OpportunityStatus } from "../../shared/interfaces/database.interface.js";
@@ -283,7 +283,7 @@ export function createMockProtocolDeps(overrides?: Partial<ProtocolDeps>): Proto
   return {
     cache: { get: async () => null, set: async () => {}, delete: async () => false, exists: async () => false, mget: async () => [], deleteByPattern: async () => 0 },
     hydeCache: { get: async () => null, set: async () => {}, delete: async () => false, exists: async () => false },
-     
+
     integration: { createSession: async () => ({ toolkits: async () => ({ items: [] }), authorize: async () => ({ redirectUrl: "" }) }), executeToolAction: async () => ({ successful: true }), listConnections: async () => [], getAuthUrl: async () => ({ redirectUrl: "" }), disconnect: async () => ({ success: true }) } as unknown as ProtocolDeps["integration"],
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     intentQueue: { addGenerateHydeJob: async () => ({}), addDeleteHydeJob: async () => ({}) } as any,

--- a/packages/protocol/src/chat/tests/chat.prompt.modules.spec.ts
+++ b/packages/protocol/src/chat/tests/chat.prompt.modules.spec.ts
@@ -384,7 +384,7 @@ function makeCtx(overrides: Partial<ResolvedToolContext> = {}): ResolvedToolCont
 }
 
 describe("buildSystemContent snapshot identity", () => {
-  test("general chat (no index scope, no onboarding) — patterns are NOT in base prompt", () => {
+  test("general chat (no network scope, no onboarding) — patterns are NOT in base prompt", () => {
     const ctx = makeCtx();
     const output = buildSystemContent(ctx);
 
@@ -395,7 +395,7 @@ describe("buildSystemContent snapshot identity", () => {
     const preloadedIdx = output.indexOf("### Current User (preloaded context)");
     const architectureIdx = output.indexOf("## Architecture Philosophy");
     const toolsIdx = output.indexOf("## Tools Reference");
-    const scopingIdx = output.indexOf("### Index Scope");
+    const scopingIdx = output.indexOf("### Network Scope");
     const urlsIdx = output.indexOf("### URLs");
     const narrationIdx = output.indexOf("### Narration Style");
     const outputFmtIdx = output.indexOf("### Output Format");
@@ -425,7 +425,7 @@ describe("buildSystemContent snapshot identity", () => {
     expect(output).toMatchSnapshot();
   });
 
-  test("scoped chat (index scope, owner) produces stable output", () => {
+  test("scoped chat (network scope, owner) produces stable output", () => {
     const ctx = makeCtx({
       networkId: "idx-community",
       indexName: "AI Builders",
@@ -436,7 +436,7 @@ describe("buildSystemContent snapshot identity", () => {
     const output = buildSystemContent(ctx);
 
     expect(output).toContain('This chat is scoped to index "AI Builders"');
-    expect(output).toContain("You are the **owner** of this index");
+    expect(output).toContain("You are the **owner** of this network");
     expect(output).toContain("scoped to current index");
 
     expect(output).toMatchSnapshot();
@@ -548,7 +548,7 @@ describe("buildSystemContent snapshot identity", () => {
 
     // The base prompt sections should still be present
     expect(output).toContain("You are Index.");
-    expect(output).toContain("### Index Scope");
+    expect(output).toContain("### Network Scope");
     expect(output).toContain("### Output Format");
   });
 });

--- a/packages/protocol/src/chat/tests/chat.prompt.modules.spec.ts
+++ b/packages/protocol/src/chat/tests/chat.prompt.modules.spec.ts
@@ -343,6 +343,10 @@ describe("PROMPT_MODULES registry", () => {
 // ═══════════════════════════════════════════════════════════════════════════════
 
 function makeCtx(overrides: Partial<ResolvedToolContext> = {}): ResolvedToolContext {
+  const scopeOverrides = overrides.networkId && !overrides.scopeType
+    ? { scopeType: 'network' as const, scopeId: overrides.networkId }
+    : {};
+
   return {
     userId: "user-1",
     userName: "Alice Test",
@@ -379,6 +383,7 @@ function makeCtx(overrides: Partial<ResolvedToolContext> = {}): ResolvedToolCont
     isOnboarding: false,
     hasName: true,
     contactsEnabled: true,
+    ...scopeOverrides,
     ...overrides,
   };
 }
@@ -435,9 +440,9 @@ describe("buildSystemContent snapshot identity", () => {
     });
     const output = buildSystemContent(ctx);
 
-    expect(output).toContain('This chat is scoped to index "AI Builders"');
+    expect(output).toContain('This chat is scoped to network "AI Builders"');
     expect(output).toContain("You are the **owner** of this network");
-    expect(output).toContain("scoped to current index");
+    expect(output).toContain("scoped to current network");
 
     expect(output).toMatchSnapshot();
   });

--- a/packages/protocol/src/chat/tests/chat.prompt.spec.ts
+++ b/packages/protocol/src/chat/tests/chat.prompt.spec.ts
@@ -475,11 +475,11 @@ function completedUser(userId: string, nameOverride?: string) {
   };
 }
 
-/** Shared index that multiple test users belong to. */
+/** Shared network that multiple test users belong to. */
 const SHARED_INDEX_ID = "idx-shared-ai-builders";
 const SHARED_INDEX = { id: SHARED_INDEX_ID, title: "AI Builders" };
 
-/** Build a NetworkMembership for a user in the shared index. */
+/** Build a NetworkMembership for a user in the shared network. */
 function sharedMembership(extra?: Partial<NetworkMembership>): NetworkMembership {
   return {
     networkId: SHARED_INDEX_ID,

--- a/packages/protocol/src/chat/tests/chat.prompt.spec.ts
+++ b/packages/protocol/src/chat/tests/chat.prompt.spec.ts
@@ -25,6 +25,10 @@ import { extractRecentToolCalls, resolveModules, type IterationContext } from ".
 function makeCtx(
   overrides: Partial<ResolvedToolContext> = {},
 ): ResolvedToolContext {
+  const scopeOverrides = overrides.networkId && !overrides.scopeType
+    ? { scopeType: 'network' as const, scopeId: overrides.networkId }
+    : {};
+
   return {
     userId: "user-1",
     userName: "Alice Test",
@@ -55,6 +59,7 @@ function makeCtx(
     ],
     isOnboarding: false,
     hasName: true,
+    ...scopeOverrides,
     ...overrides,
   } as unknown as ResolvedToolContext;
 }

--- a/packages/protocol/src/chat/tests/chat.suggester.spec.ts
+++ b/packages/protocol/src/chat/tests/chat.suggester.spec.ts
@@ -51,7 +51,7 @@ describe("SuggestionGenerator", () => {
     const result = await generator.generate({
       messages: [
         { role: "user", content: "Who here is looking for a co-founder?" },
-        { role: "assistant", content: "In this index, 3 members have intents about co-founders. I can list them or narrow by skills." },
+        { role: "assistant", content: "In this network, 3 members have intents about co-founders. I can list them or narrow by skills." },
       ],
       indexContext: "AI founders and technical co-founders",
     });

--- a/packages/protocol/src/contact/contact.tools.ts
+++ b/packages/protocol/src/contact/contact.tools.ts
@@ -21,8 +21,8 @@ export function createContactTools(defineTool: DefineTool, deps: ToolDeps) {
   const import_contacts = contactsEnabled ? defineTool({
     name: 'import_contacts',
     description:
-      "Bulk-imports contacts into the authenticated user's personal network (personal index). Contacts become members of the user's " +
-      "personal index with 'contact' permission, making them available for opportunity discovery.\n\n" +
+      "Bulk-imports contacts into the authenticated user's personal network (personal network). Contacts become members of the user's " +
+      "personal network with 'contact' permission, making them available for opportunity discovery.\n\n" +
       "**What happens:** Each contact is matched by email. If the email belongs to an existing user, they're linked directly. " +
       "If not, a 'ghost user' is created — a placeholder account enriched with public profile data (from LinkedIn, GitHub, etc.) " +
       "that participates in opportunity matching even before the person joins the platform.\n\n" +
@@ -60,7 +60,7 @@ export function createContactTools(defineTool: DefineTool, deps: ToolDeps) {
     name: 'list_contacts',
     description:
       "Lists all contacts in the authenticated user's personal network. Contacts are people the user has added " +
-      "(via import_contacts, add_contact, or import_gmail_contacts) stored as members of their personal index.\n\n" +
+      "(via import_contacts, add_contact, or import_gmail_contacts) stored as members of their personal network.\n\n" +
       "**When to use:** To see who's in the user's network, find a contact's userId for other operations, " +
       "or check if a specific person is already a contact.\n\n" +
       "**Returns:** Array of contacts, each with: userId (use with read_user_contexts or discover_opportunities), " +
@@ -101,7 +101,7 @@ export function createContactTools(defineTool: DefineTool, deps: ToolDeps) {
       "For bulk imports, use import_contacts instead.\n\n" +
       "**What happens:** Looks up the email. If an account exists, links that user as a contact. " +
       "If not, creates a ghost user (placeholder enriched with public profile data) and adds them. " +
-      "The contact can then appear in opportunity discovery within the user's personal index.\n\n" +
+      "The contact can then appear in opportunity discovery within the user's personal network.\n\n" +
       "**When to use:** When the user wants to add a specific person (e.g. 'add john@example.com to my network').\n\n" +
       "**Returns:** Confirmation with the contact's userId and whether a new ghost user was created (isNewGhost). " +
       "Use the userId with discover_opportunities(targetUserId) to find connection opportunities.",
@@ -132,10 +132,10 @@ export function createContactTools(defineTool: DefineTool, deps: ToolDeps) {
     name: 'remove_contact',
     description:
       "Removes a contact from the authenticated user's personal network. The contact relationship is deleted — " +
-      "the person is no longer a member of the user's personal index and won't appear in personal-index-scoped discovery.\n\n" +
+      "the person is no longer a member of the user's personal network and won't appear in personal-network-scoped discovery.\n\n" +
       "**When to use:** When the user wants to remove someone from their network (e.g. 'remove John from my contacts').\n\n" +
       "**Note:** This only removes the contact relationship. If the contact is a real user (not a ghost), " +
-      "they still exist on the platform and may appear in shared index discovery.\n\n" +
+      "they still exist on the platform and may appear in shared network discovery.\n\n" +
       "**Returns:** Confirmation that the contact was removed.",
     querySchema: z.object({
       contactUserId: z.string().describe('The userId of the contact to remove. Get this from list_contacts results.'),

--- a/packages/protocol/src/docs/Latent Opportunity Lifecycle.md
+++ b/packages/protocol/src/docs/Latent Opportunity Lifecycle.md
@@ -1,6 +1,6 @@
 # Latent Opportunity Lifecycle
 
-> **Status**: Design  
+> **Status**: Design
 > **Related**: Opportunity Graph (`../graphs/opportunity.graph.ts`), Chat Graph, Intent Graph
 
 ## Motivation
@@ -138,13 +138,13 @@ When an opportunity transitions to `pending`, **only the role that becomes newly
 
 No schema changes are required; targeting is derived from `actors[].role`.
 
-## Key Constraint: Index-Scoped Discovery
+## Key Constraint: Network-Scoped Discovery
 
 **Opportunities only exist between intents that share the same index.** Non-indexed intents cannot participate in opportunity discovery. This ensures:
 
 - Privacy: Users control which indexes they join and what they share
-- Relevance: Index prompts guide matching
-- Scalability: Search space is bounded by index membership
+- Relevance: Network prompts guide matching
+- Scalability: Search space is bounded by network membership
 
 ## Lifecycle State Diagram
 
@@ -185,7 +185,7 @@ graph LR
 
 1. **Prep Node**: Fetches user's active indexed intents with hyde documents; validates at least one indexed intent.
 2. **Scope Node**: Determines target indexes (single or all user indexes).
-3. **Discovery Node**: Vector similarity search on hyde embeddings within index scope; returns candidate pairs.
+3. **Discovery Node**: Vector similarity search on hyde embeddings within network scope; returns candidate pairs.
 4. **Evaluation Node**: OpportunityEvaluator (LLM) scores each candidate and assigns **valency role** (Agent / Patient / Peer). This role drives visibility and notifications.
 5. **Ranking Node**: Sorts by score, applies limit, deduplicates.
 6. **Persist Node**: Creates opportunities with `status: 'latent'` and assigns actor roles from valency.
@@ -218,7 +218,7 @@ Discovery flow is unchanged: user or agent calls `discover_opportunities` → gr
 
 ## Hyde Documents and Semantic Search
 
-Discovery uses hyde embeddings for vector similarity within index scope. Both source and candidate must have hyde documents. The evaluator assigns valency (and thus actor roles) from profile and intent context; that assignment is persisted and used for visibility and notifications only — no extra schema fields.
+Discovery uses hyde embeddings for vector similarity within network scope. Both source and candidate must have hyde documents. The evaluator assigns valency (and thus actor roles) from profile and intent context; that assignment is persisted and used for visibility and notifications only — no extra schema fields.
 
 ## Future Extensions
 

--- a/packages/protocol/src/enrichment/enrichment.tools.ts
+++ b/packages/protocol/src/enrichment/enrichment.tools.ts
@@ -308,7 +308,7 @@ export function createEnrichmentTools(defineTool: DefineTool, deps: ToolDeps) {
       "use these as the source of truth for whether the user still needs onboarding (do not rely on local file state).",
     querySchema: z.object({
       userId: z.string().optional().describe("Fetch a specific user's profile by their user ID. Get user IDs from read_network_memberships or list_contacts."),
-      networkId: z.string().optional().describe("Index UUID — fetch profiles of all members in this index, or narrow a name search to this index. Get from read_networks."),
+      networkId: z.string().optional().describe("Network UUID — fetch profiles of all members in this network, or narrow a name search to this network. Get from read_networks."),
       query: z.string().optional().describe("Name to search for (case-insensitive substring match). Searches across all the user's indexes unless networkId is also provided. Use this when the user asks to 'find' or 'look up' someone."),
     }),
     handler: async ({ context, query }) => {
@@ -326,7 +326,7 @@ export function createEnrichmentTools(defineTool: DefineTool, deps: ToolDeps) {
       if (nameQuery) {
         const pattern = nameQuery.toLowerCase();
         const MAX_RESULTS = 20;
-        // When chat is index-scoped, restrict name search to that index
+        // When chat is network-scoped, restrict name search to that index
         const searchIndexId = effectiveIndexId || scopedNetworkId || undefined;
 
         let candidates: Array<{ userId: string; name: string; avatar: string | null }>;
@@ -395,12 +395,12 @@ export function createEnrichmentTools(defineTool: DefineTool, deps: ToolDeps) {
 
       // --- Mode 3: networkId provided → fetch all member profiles ---
       if (effectiveIndexId) {
-        // Strict scope enforcement: when chat is index-scoped, only allow querying that index
+        // Strict scope enforcement: when chat is network-scoped, only allow querying that index
         if (scopedNetworkId && effectiveIndexId !== scopedNetworkId) {
           return error(`This chat is scoped to ${scopedIndexLabel}. You can only read profiles from this community.`);
         }
 
-        // Verify the caller is a member of the index they're querying
+        // Verify the caller is a member of the network they're querying
         const callerIsMember = await systemDb.isNetworkMember(effectiveIndexId, context.userId);
         if (!callerIsMember) {
           return error(
@@ -408,7 +408,7 @@ export function createEnrichmentTools(defineTool: DefineTool, deps: ToolDeps) {
           );
         }
 
-        // Use systemDb for cross-user access within shared indexes
+        // Use systemDb for cross-user access within shared networkes
         const members = await systemDb.getNetworkMembers(effectiveIndexId);
         const profiles = await Promise.all(
           members.map(async (member) => {
@@ -430,7 +430,7 @@ export function createEnrichmentTools(defineTool: DefineTool, deps: ToolDeps) {
 
       // --- Mode 2: userId provided (different user) → fetch single profile directly ---
       if (targetUserId && targetUserId !== context.userId) {
-        // Strict scope enforcement: when chat is index-scoped, verify user is in that index
+        // Strict scope enforcement: when chat is network-scoped, verify user is in that index
         if (scopedNetworkId) {
           const isInScopedIndex = await systemDb.isNetworkMember(scopedNetworkId, targetUserId);
           if (!isInScopedIndex) {
@@ -438,7 +438,7 @@ export function createEnrichmentTools(defineTool: DefineTool, deps: ToolDeps) {
           }
         }
 
-        // Use systemDb for cross-user profile access (requires shared index)
+        // Use systemDb for cross-user profile access (requires shared network)
         const profile = await systemDb.getProfile(targetUserId);
         if (profile) {
           // Thin identity + the user's global user_context text (profile-replacing

--- a/packages/protocol/src/enrichment/tests/read-user-profiles-query.spec.ts
+++ b/packages/protocol/src/enrichment/tests/read-user-profiles-query.spec.ts
@@ -33,7 +33,7 @@ describe("read_user_contexts — query mode resilience", () => {
         ],
         // Throws for bad-user (e.g. fragmented identity), succeeds for good-user
         getProfile: async (userId: string) => {
-          if (userId === "bad-user") throw new Error("Access denied: no shared index with user");
+          if (userId === "bad-user") throw new Error("Access denied: no shared network with user");
           return {
             identity: { name: "Alice Smith", bio: "Engineer", location: "NYC" },
             attributes: { skills: ["TypeScript"], interests: ["AI"] },

--- a/packages/protocol/src/integration/integration.tools.ts
+++ b/packages/protocol/src/integration/integration.tools.ts
@@ -35,7 +35,7 @@ export function createIntegrationTools(defineTool: DefineTool, deps: ToolDeps) {
       "After they complete OAuth, call this tool again to perform the actual import.\n\n" +
       "**What happens on import:** All Gmail contacts with valid name+email are imported. " +
       "Contacts without existing platform accounts become ghost users (enriched with public profile data from LinkedIn, GitHub, etc.). " +
-      "All imported contacts are added to the user's personal index for opportunity discovery.\n\n" +
+      "All imported contacts are added to the user's personal network for opportunity discovery.\n\n" +
       "**When to use:** When the user asks to import or sync their Gmail/Google contacts. No parameters needed.\n\n" +
       "**Returns:** Either `{ requiresAuth: true, authUrl }` (user needs to authenticate) or import statistics: " +
       "imported (total), newContacts (ghost users created), existingContacts (already in network), skipped (invalid entries).",

--- a/packages/protocol/src/intent/intent.graph.ts
+++ b/packages/protocol/src/intent/intent.graph.ts
@@ -102,7 +102,7 @@ export class IntentGraphFactory {
      * Node 0: Prep
      * Always fetches ALL of the user's active intents from the DB via getActiveIntents(userId).
      * This ensures reconciliation can detect duplicates and modifications globally,
-     * regardless of index scope.
+     * regardless of network scope.
      */
     const prepNode = async (state: typeof IntentGraphState.State) => {
       return timed("IntentGraph.prep", async () => {
@@ -675,7 +675,7 @@ export class IntentGraphFactory {
     /**
      * Node: Query
      * Fast-path read node — fetches intents from DB based on scope.
-     * Handles: global user intents, index-scoped (all or filtered by user).
+     * Handles: global user intents, network-scoped (all or filtered by user).
      * No LLM calls; no inference/verification/reconciliation.
      */
     const queryNode = async (state: typeof IntentGraphState.State) => {
@@ -688,7 +688,7 @@ export class IntentGraphFactory {
         });
 
         try {
-          // Scope-aware default: caller's intents across all reachable indexes.
+          // Scope-aware default: caller's intents across all reachable networks.
           // Triggered when the tool layer passed indexScope and did not pick a
           // specific networkId or queryUserId — i.e. "my intents" in a chat
           // where the agent's reach is more than one index.
@@ -724,7 +724,7 @@ export class IntentGraphFactory {
             };
           }
 
-          // When allUserIntents is true, ignore index scope and return all
+          // When allUserIntents is true, ignore network scope and return all
           const effectiveIndexId = state.allUserIntents ? undefined : state.networkId;
 
           if (effectiveIndexId) {
@@ -740,7 +740,7 @@ export class IntentGraphFactory {
               };
             }
 
-            // Index-scoped read
+            // Network-scoped read
             if (!state.queryUserId) {
               // All intents in the index (any member can see)
               const intents = await this.database.getNetworkIntentsForMember(
@@ -753,7 +753,7 @@ export class IntentGraphFactory {
                   readResult: {
                     count: 0,
                     intents: [],
-                    message: "No intents in this index yet.",
+                    message: "No intents in this network yet.",
                     networkId: effectiveIndexId,
                   },
                 };
@@ -787,8 +787,8 @@ export class IntentGraphFactory {
                   intents: [],
                   message:
                     effectiveUserId === state.userId
-                      ? "You don't have any intents in this index yet."
-                      : "No intents for that user in this index.",
+                      ? "You don't have any intents in this network yet."
+                      : "No intents for that user in this network.",
                   networkId: effectiveIndexId,
                 },
               };
@@ -811,7 +811,7 @@ export class IntentGraphFactory {
             };
           }
 
-          // Global (no index scope): return user's own active intents
+          // Global (no network scope): return user's own active intents
           const intents = await this.database.getActiveIntents(state.userId);
           if (intents.length === 0) {
             return {
@@ -863,7 +863,7 @@ export class IntentGraphFactory {
       }
       return shouldRunInference(state);
     };
-    
+
     /**
      * Determines if inference should run based on operation mode.
      * Delete operations skip inference entirely and go straight to reconciliation.
@@ -873,13 +873,13 @@ export class IntentGraphFactory {
         logger.verbose('Delete mode - skipping inference, routing to reconciliation');
         return 'reconciler';
       }
-      
+
       logger.verbose('Running inference', {
         operationMode: state.operationMode
       });
       return 'inference';
     };
-    
+
     /**
      * Determines if verification should run based on operation mode and inferred intents.
      * Skips verification for:
@@ -895,17 +895,17 @@ export class IntentGraphFactory {
         logger.verbose('No intents to verify - skipping verification, routing to reconciliation');
         return 'reconciler';
       }
-      
+
       if (state.operationMode === 'update') {
         logger.verbose('Update mode with new intents - running verification');
         return 'verification';
       }
-      
+
       if (state.operationMode === 'create') {
         logger.verbose('Create mode - running verification');
         return 'verification';
       }
-      
+
       // Default to verification for safety
       logger.verbose('Default routing to verification');
       return 'verification';
@@ -928,7 +928,7 @@ export class IntentGraphFactory {
       // - DELETE:  prep → reconciliation → executor → END (skips inference and verification)
       // - PROPOSE: prep → inference → verification → END (no reconciliation/execution, no DB writes)
       .addEdge(START, "prep")
-      
+
       // After prep: read mode → query; else inference or reconciler
       .addConditionalEdges("prep", afterPrepRoute, {
         query: "query",
@@ -939,14 +939,14 @@ export class IntentGraphFactory {
 
       // Query (read mode) always ends
       .addEdge("query", END)
-      
+
       // After inference: decide if we need verification (skip if no intents)
       .addConditionalEdges("inference", shouldRunVerification, {
         verification: "verification",
         reconciler: "reconciler",
         __end__: END,
       })
-      
+
       // After verification: propose mode exits early; others continue to reconciliation
       .addConditionalEdges("verification", (state: typeof IntentGraphState.State) => {
         if (state.operationMode === 'propose') {
@@ -958,10 +958,10 @@ export class IntentGraphFactory {
         reconciler: "reconciler",
         __end__: END,
       })
-      
+
       // Reconciliation always goes to executor
       .addEdge("reconciler", "executor")
-      
+
       // Executor is always the end
       .addEdge("executor", END);
 

--- a/packages/protocol/src/intent/intent.indexer.ts
+++ b/packages/protocol/src/intent/intent.indexer.ts
@@ -38,7 +38,7 @@ Determine if a User Intent is appropriate for a specific Index (community) and m
 
 INPUTS:
 1. Intent: The content/action the user wants to perform.
-2. Index Prompt: The purpose/scope of the target community (Index).
+2. Network Prompt: The purpose/scope of the target community (Index).
 3. Member Prompt: The specific sharing preferences of the user in that community (optional).
 4. Source: Origin of the intent (file, link, etc.) (optional).
 5. Network Context: Rendered context about the network including type, dates, location, and events (optional).
@@ -46,7 +46,7 @@ INPUTS:
 NETWORK TYPE AWARENESS:
 - When Network Context is provided, use it to inform your scoring.
 - For EVENT networks: consider temporal relevance. An intent about "meeting at the venue" is highly relevant to an upcoming event but irrelevant after it ends. Intents about topics aligned with the event's themes should score higher.
-- For COMMUNITY networks: score based on the index prompt and member preferences as usual.
+- For COMMUNITY networks: score based on the network prompt and member preferences as usual.
 - If the network context includes dates and the intent is time-sensitive, factor temporal proximity into the score.
 
 SCORING RUBRIC:
@@ -57,7 +57,7 @@ SCORING RUBRIC:
 - 0.0-0.2: Not appropriate.
 
 OUTPUT RULES:
-- Provide \`indexScore\` based on how well the Intent fits the Index Prompt.
+- Provide \`indexScore\` based on how well the Intent fits the Network Prompt.
 - Provide \`memberScore\` based on how well the Intent fits the Member Prompt (if provided). If Member Prompt is missing/empty, return 0.0 for memberScore.
 - Provide concise \`reasoning\`.
 `;

--- a/packages/protocol/src/intent/intent.indexer.ts
+++ b/packages/protocol/src/intent/intent.indexer.ts
@@ -157,7 +157,7 @@ export class IntentIndexer {
 
   /**
    * Alias for invoke. Evaluates the appropriateness of an intent for a given index and member context.
-   * Kept for compatibility with callers (e.g. Index Graph) that use evaluate().
+   * Kept for compatibility with callers (e.g. Network Graph) that use evaluate().
    */
   @Timed()
   public async evaluate(

--- a/packages/protocol/src/intent/intent.state.ts
+++ b/packages/protocol/src/intent/intent.state.ts
@@ -92,9 +92,9 @@ export const IntentGraphState = Annotation.Root({
   }),
 
   /**
-   * Optional index scope (index ID). Used for linking created intents to an index
+   * Optional network scope (network ID). Used for linking created intents to a network
    * and for scoping read operations. Prep always fetches ALL user intents via
-   * getActiveIntents(userId) regardless of index scope (for global dedup/reconciliation).
+   * getActiveIntents(userId) regardless of network scope (for global dedup/reconciliation).
    */
   networkId: Annotation<string | undefined>({
     reducer: (curr, next) => next ?? curr,
@@ -194,9 +194,9 @@ export const IntentGraphState = Annotation.Root({
   // --- Read Mode Fields ---
 
   /**
-   * For read mode: the set of index IDs the caller's agent can reach.
+   * For read mode: the set of network IDs the caller's agent can reach.
    * When set and neither networkId nor queryUserId is provided, the graph
-   * returns the caller's own intents across all indexes in this set (scope-aware
+   * returns the caller's own intents across all networks in this set (scope-aware
    * default path). Derived by the tool layer from the scope envelope plus memberships.
    */
   indexScope: Annotation<string[] | undefined>({
@@ -205,8 +205,8 @@ export const IntentGraphState = Annotation.Root({
   }),
 
   /**
-   * For read mode: filter intents by a specific user when reading in an index.
-   * When omitted and index-scoped, returns all intents in the index.
+   * For read mode: filter intents by a specific user when reading in a network.
+   * When omitted and network-scoped, returns all intents in the network.
    */
   queryUserId: Annotation<string | undefined>({
     reducer: (curr, next) => next ?? curr,
@@ -215,7 +215,7 @@ export const IntentGraphState = Annotation.Root({
 
   /**
    * For read mode: when true, return all of the current user's intents
-   * ignoring index scope. Used before create_intent to detect duplicates.
+   * ignoring network scope. Used before create_intent to detect duplicates.
    */
   allUserIntents: Annotation<boolean>({
     reducer: (curr, next) => next ?? curr,

--- a/packages/protocol/src/intent/intent.tools.ts
+++ b/packages/protocol/src/intent/intent.tools.ts
@@ -21,7 +21,7 @@ function sanitizeJsonForCodeFence(json: string): string {
   return json.replace(/`/g, "\\u0060");
 }
 
-/** When context is index-scoped, verifies the caller is still a member of that index. Returns error message or null. */
+/** When context is network-scoped, verifies the caller is still a member of that index. Returns error message or null. */
 async function ensureScopedMembership(
   context: ToolScopeEnvelope & { indexName?: string; userId: string },
   systemDb: ToolDeps['systemDb']
@@ -80,17 +80,17 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       "Retrieves intents (signals of interest/need, e.g. 'Looking for a React developer in Berlin'). " +
       "Intents are the core unit of discovery — they represent what users are seeking and drive semantic matching for opportunities.\n\n" +
       "**Usage modes:**\n" +
-      "- No parameters: returns the **caller's own** active intents. In an index-scoped chat the result is clamped to the reachable indexes (the bound index plus the user's personal index). In an unscoped chat the result spans all of the user's active intents. There is no implicit default to the scoped index — to browse the bound community's intents, pass `networkId` explicitly.\n" +
+      "- No parameters: returns the **caller's own** active intents. In an network-scoped chat the result is clamped to the reachable networks (the bound network plus the user's personal network). In an unscoped chat the result spans all of the user's active intents. There is no implicit default to the scoped network — to browse the bound community's intents, pass `networkId` explicitly.\n" +
       "- With networkId: returns **all members'** intents in that index (community browse path). Add userId to filter to one member.\n" +
-      "- With userId in an index-scoped chat: reads that member's intents in the bound index. The target user must be a member of that index.\n" +
-      "- With userId in an unscoped chat: only works for the current user (cannot read another user's global intents without an index scope).\n\n" +
-      "**Workflow:** To explore what members of an index are looking for, first call read_network_memberships(networkId) to list members, " +
+      "- With userId in an network-scoped chat: reads that member's intents in the bound network. The target user must be a member of that index.\n" +
+      "- With userId in an unscoped chat: only works for the current user (cannot read another user's global intents without an network scope).\n\n" +
+      "**Workflow:** To explore what members of a network are looking for, first call read_network_memberships(networkId) to list members, " +
       "then read_intents(networkId) to see all intents in that community. " +
       "Each intent includes: id, description (payload), summary, confidence (0-1), inferenceType (explicit/implicit), status, and linked indexes.\n\n" +
       "**Returns:** Paginated list of intents with count. Use the intent IDs in subsequent calls to update_intent, delete_intent, or create_intent_index.",
     querySchema: z.object({
-      networkId: z.string().optional().describe("Index UUID — filters intents to this index (community browse path: returns all members' intents). There is no implicit default in index-scoped chats; omit to get caller-owned intents across the reachable indexes, or pass the scoped index UUID to browse community members. Get index IDs from read_networks."),
-      userId: z.string().optional().describe("User ID — filters to this user's intents. In an index-scoped chat, this reads that member's intents in the bound index (no networkId required). In an unscoped chat, only the current user is allowed without networkId; cross-user reads require an index scope. Omit for caller-owned intents."),
+      networkId: z.string().optional().describe("Network UUID — filters intents to this network (community browse path: returns all members' intents). There is no implicit default in network-scoped chats; omit to get caller-owned intents across the reachable networks, or pass the scoped network UUID to browse community members. Get network IDs from read_networks."),
+      userId: z.string().optional().describe("User ID — filters to this user's intents. In an network-scoped chat, this reads that member's intents in the bound network (no networkId required). In an unscoped chat, only the current user is allowed without networkId; cross-user reads require an network scope. Omit for caller-owned intents."),
       limit: z.number().int().min(1).max(100).optional().describe("Page size (1-100). Defaults to returning all results if omitted."),
       page: z.number().int().min(1).optional().describe("Page number (1-based). Only used when limit is also provided."),
     }),
@@ -118,7 +118,7 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
         );
       }
 
-      // Cross-user read in scoped chat: target user must be a member of the scoped index
+      // Cross-user read in scoped chat: target user must be a member of the scoped network
       if (scopedNetworkId && explicitUserId && explicitUserId !== context.userId) {
         const isInScopedIndex = await deps.systemDb.isNetworkMember(scopedNetworkId, explicitUserId);
         if (!isInScopedIndex) {
@@ -128,7 +128,7 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
         }
       }
 
-      // Cross-user global read is disallowed without an index scope
+      // Cross-user global read is disallowed without an network scope
       if (!explicitNetworkId && !scopedNetworkId && explicitUserId && explicitUserId !== context.userId) {
         return error("Cannot read another user's global intents. Use networkId to scope to a shared network.");
       }
@@ -166,7 +166,7 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
         graphInput.queryUserId = explicitUserId;
         graphInput.allUserIntents = true;
       } else if (scopedNetworkId) {
-        // Scoped chat, implicit read: caller-only across reachable indexes.
+        // Scoped chat, implicit read: caller-only across reachable networks.
         graphInput.indexScope = deriveAllowedNetworkIds({
           memberships: context.userNetworks,
           scopeType: 'network',
@@ -236,7 +236,7 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       "to create_user_context are handled by that tool directly — do not scrape first.",
     querySchema: z.object({
       description: z.string().describe("A clear, specific description of what the user is looking for. Should be concept-based, not a raw URL. If the user shared a URL, scrape it first with scrape_url and pass the synthesized content here. Vague descriptions will be rejected — include what kind, what for, and/or timeframe."),
-      networkId: z.string().optional().describe("Index UUID to link the intent to upon creation. Defaults to the scoped index in index-scoped chats. Get index IDs from read_networks. If omitted, the system auto-assigns to relevant indexes based on their prompts."),
+      networkId: z.string().optional().describe("Network UUID to link the intent to upon creation. Defaults to the scoped network in network-scoped chats. Get network IDs from read_networks. If omitted, the system auto-assigns to relevant networks based on their prompts."),
       autoApprove: z.boolean().optional().describe("When true, automatically persists all verified intents without returning proposal cards for manual approval. MCP agents SHOULD set this to true since there is no UI for card-based approval. Web chat agents should omit or set to false to get interactive proposal cards."),
     }),
     handler: async ({ context, query }) => {
@@ -454,7 +454,7 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       const scopedNetworkId = focusedNetworkId(context);
       const scopedIndexLabel = focusedNetworkLabel(context);
 
-      // Strict scope enforcement: when chat is index-scoped, verify intent is linked to that index
+      // Strict scope enforcement: when chat is network-scoped, verify intent is linked to that index
       if (scopedNetworkId) {
         const db = deps.userDb;
         const intentNetworks = await db.getNetworkIdsForIntent(intentId);
@@ -531,7 +531,7 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       const scopedNetworkId = focusedNetworkId(context);
       const scopedIndexLabel = focusedNetworkLabel(context);
 
-      // Strict scope enforcement: when chat is index-scoped, verify intent is linked to that index
+      // Strict scope enforcement: when chat is network-scoped, verify intent is linked to that index
       if (scopedNetworkId) {
         const db = deps.userDb;
         const intentNetworks = await db.getNetworkIdsForIntent(intentId);
@@ -569,14 +569,14 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
   const createIntentIndex = defineTool({
     name: "create_intent_index",
     description:
-      "Manually links an intent to an index (community), making it visible to other members and eligible for opportunity discovery within that index. " +
+      "Manually links an intent to a network (community), making it visible to other members and eligible for opportunity discovery within that index. " +
       "Normally intents are auto-assigned to relevant indexes on creation, but use this to explicitly add an intent to an additional index.\n\n" +
       "**When to use:** When the user wants to share an existing intent with a specific community they belong to, " +
-      "or when auto-assignment missed an index the user considers relevant.\n\n" +
+      "or when auto-assignment missed a network the user considers relevant.\n\n" +
       "**Returns:** Confirmation that the link was created. The intent will now appear in that index's intent list and participate in discovery within that community.",
     querySchema: z.object({
       intentId: z.string().describe("The UUID of the intent to link. Get this from read_intents results."),
-      networkId: z.string().optional().describe("The UUID of the index to link the intent to. Get this from read_networks. Defaults to the scoped index in index-scoped chats."),
+      networkId: z.string().optional().describe("The UUID of the network to link the intent to. Get this from read_networks. Defaults to the scoped network in network-scoped chats."),
     }),
     handler: async ({ context, query }) => {
       const scopeErr = await ensureScopedMembership(context, deps.systemDb);
@@ -589,7 +589,7 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
         return error("Invalid ID format. Both must be UUIDs.");
       }
 
-      // Strict scope enforcement: when chat is index-scoped, only allow linking to that index
+      // Strict scope enforcement: when chat is network-scoped, only allow linking to that index
       if (scopedNetworkId && networkId !== scopedNetworkId) {
         return error(
           `This chat is scoped to ${scopedIndexLabel}. You can only link intents to this community.`
@@ -629,13 +629,13 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       "**Usage modes:**\n" +
       "- With networkId: lists all intents linked to that index. Add userId to filter to one member's intents in that index.\n" +
       "- With intentId + networkId: checks whether a specific intent is linked to a specific index.\n" +
-      "- intentId alone requires a networkId (the system won't reveal all indexes an intent is in).\n\n" +
+      "- intentId alone requires a networkId (the system won't reveal all networks an intent is in).\n\n" +
       "**When to use:** To audit which intents are active in a community, verify an intent's index assignment before unlinking, " +
       "or check if a newly created intent was auto-assigned to the expected index.\n\n" +
-      "**Returns:** List of intent-index links with relevancy scores (0-1, how well the intent fits the index's purpose).",
+      "**Returns:** List of intent-network links with relevancy scores (0-1, how well the intent fits the network's purpose).",
     querySchema: z.object({
       intentId: z.string().optional().describe("Intent UUID — check if this specific intent is linked to the specified index. Must be combined with networkId."),
-      networkId: z.string().optional().describe("Index UUID — list all intents linked to this index. Get this from read_networks. Defaults to scoped index in index-scoped chats."),
+      networkId: z.string().optional().describe("Network UUID — list all intents linked to this network. Get this from read_networks. Defaults to scoped network in network-scoped chats."),
       userId: z.string().optional().describe("Filter results to this user's intents within the specified index. Omit to see all members' intents."),
     }),
     handler: async ({ context, query }) => {
@@ -657,7 +657,7 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
         return error("Provide networkId or intentId.");
       }
 
-      // Strict scope enforcement: when chat is index-scoped, only allow querying that index
+      // Strict scope enforcement: when chat is network-scoped, only allow querying that index
       if (scopedNetworkId && networkId && networkId !== scopedNetworkId) {
         return error(
           `This chat is scoped to ${scopedIndexLabel}. You can only read intent links from this community.`
@@ -667,10 +667,10 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       // When only intentId is provided, enforce scope - don't reveal all linked indexes
       if (intentId && !networkId) {
         if (scopedNetworkId) {
-          // When scoped, only check if intent is linked to the scoped index
+          // When scoped, only check if intent is linked to the scoped network
           networkId = scopedNetworkId;
         } else {
-          // When unscoped, still don't reveal all indexes - require explicit networkId
+          // When unscoped, still don't reveal all networks - require explicit networkId
           return error(
             "Please provide a networkId to check if the intent is linked to a specific network. Listing all linked networks is not supported."
           );
@@ -700,14 +700,14 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
   const deleteIntentIndex = defineTool({
     name: "delete_intent_index",
     description:
-      "Removes the link between an intent and an index. The intent itself is NOT deleted — it just stops being visible in that community " +
+      "Removes the link between an intent and a network. The intent itself is NOT deleted — it just stops being visible in that community " +
       "and no longer participates in opportunity discovery within that index. The intent may still be linked to other indexes.\n\n" +
       "**When to use:** When the user wants to withdraw an intent from a specific community without archiving it entirely. " +
       "Use read_intent_indexes first to verify the link exists.\n\n" +
       "**Returns:** Confirmation that the link was removed. To fully remove an intent, use delete_intent instead.",
     querySchema: z.object({
       intentId: z.string().describe("The UUID of the intent to unlink. Get this from read_intents or read_intent_indexes."),
-      networkId: z.string().optional().describe("The UUID of the index to unlink from. Get this from read_networks. Defaults to the scoped index in index-scoped chats."),
+      networkId: z.string().optional().describe("The UUID of the network to unlink from. Get this from read_networks. Defaults to the scoped network in network-scoped chats."),
     }),
     handler: async ({ context, query }) => {
       const scopeErr = await ensureScopedMembership(context, deps.systemDb);
@@ -720,7 +720,7 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
         return error("Invalid ID format. Both must be UUIDs.");
       }
 
-      // Strict scope enforcement: when chat is index-scoped, only allow unlinking from that index
+      // Strict scope enforcement: when chat is network-scoped, only allow unlinking from that index
       if (scopedNetworkId && networkId !== scopedNetworkId) {
         return error(
           `This chat is scoped to ${scopedIndexLabel}. You can only unlink intents from this community.`

--- a/packages/protocol/src/intent/tests/intent.graph.spec.ts
+++ b/packages/protocol/src/intent/tests/intent.graph.spec.ts
@@ -191,7 +191,7 @@ describe('IntentGraph - Conditional Flow (Operation Modes)', () => {
     expect(result.verifiedIntents).toBeDefined();
     expect(result.actions).toBeDefined();
     expect(result.executionResults).toBeDefined();
-    
+
     // CREATE should go through full pipeline
     expect(result.inferredIntents!.length).toBeGreaterThan(0);
   }, 60000);
@@ -208,7 +208,7 @@ describe('IntentGraph - Conditional Flow (Operation Modes)', () => {
     expect(result.inferredIntents).toBeDefined();
     expect(result.actions).toBeDefined();
     expect(result.executionResults).toBeDefined();
-    
+
     // UPDATE may skip verification if no new intents are inferred
   }, 60000);
 
@@ -224,7 +224,7 @@ describe('IntentGraph - Conditional Flow (Operation Modes)', () => {
     // DELETE should skip inference and verification
     expect(!result.inferredIntents || result.inferredIntents.length === 0).toBe(true);
     expect(!result.verifiedIntents || result.verifiedIntents.length === 0).toBe(true);
-    
+
     // But should have actions
     expect(result.actions).toBeDefined();
     expect(result.actions!.length).toBeGreaterThan(0);
@@ -277,7 +277,7 @@ describe('IntentGraph - Prep always fetches from DB', () => {
       networkId: 'idx-yc-founders'
     });
 
-    // Prep should always fetch from DB, regardless of index scope
+    // Prep should always fetch from DB, regardless of network scope
     expect(getActiveIntentsCalls).toContain('test-user-1');
     expect(result.activeIntents).toBeDefined();
     expect(result.inferredIntents).toBeDefined();

--- a/packages/protocol/src/maintenance/maintenance.graph.ts
+++ b/packages/protocol/src/maintenance/maintenance.graph.ts
@@ -22,9 +22,9 @@ const FRESHNESS_WINDOW_MS = 12 * 60 * 60 * 1000; // 12 hours
 export interface MaintenanceGraphDatabase {
   getOpportunitiesForUser(userId: string, options?: { limit?: number }): Promise<Array<{ id: string; actors: Array<{ userId: string; role: string }>; status: string; [key: string]: unknown }>>;
   getActiveIntents(userId: string): Promise<Array<{ id: string; payload: string }>>;
-  /** Get the user's personal index ID (for introducer discovery). */
+  /** Get the user's personal network ID (for introducer discovery). */
   getPersonalIndexId(userId: string): Promise<string | null>;
-  /** Get contacts with intent freshness data from a personal index (for introducer discovery). */
+  /** Get contacts with intent freshness data from a personal network (for introducer discovery). */
   getContactsWithIntentFreshness(
     personalIndexId: string,
     ownerId: string,

--- a/packages/protocol/src/mcp/mcp.server.ts
+++ b/packages/protocol/src/mcp/mcp.server.ts
@@ -276,7 +276,7 @@ export interface ScopedDepsFactory {
 /**
  * Computes the concrete network IDs passed to the per-request scoped DB factory.
  * When a network scope is present, the agent reaches that network plus the
- * user's personal index. Otherwise the full membership set is returned.
+ * user's personal network. Otherwise the full membership set is returned.
  */
 export const computeAgentAllowedNetworkIds = (
   userNetworks: { networkId: string; isPersonal?: boolean | null }[],
@@ -294,7 +294,7 @@ export const computeAgentAllowedNetworkIds = (
  * calls would still resolve an unscoped/global view.
  *
  * No-op when there is no scope, or when an explicit scope is already set
- * (a user-driven index-scoped chat must keep precedence over the agent
+ * (a user-driven network-scoped chat must keep precedence over the agent
  * binding — which would be a strict subset anyway, since the API key cannot
  * reach beyond its bound network).
  */
@@ -438,7 +438,7 @@ NEVER use "search" in any form. Use "looking up" for indexed data, "find" / "loo
 - User — has one Profile, many Memberships, many Intents.
 - Profile — identity (bio, skills, interests, location).
 - Index — community with title, prompt (purpose), join policy. Has Members.
-- Membership — User↔Index junction. \`isPersonal: true\` marks the user's personal index (contacts).
+- Membership — User↔Index junction. \`isPersonal: true\` marks the user's personal network (contacts).
 - Intent — what a user is looking for (signal). Description, summary, embedding.
 - IntentIndex — Intent↔Index junction (auto-assigned).
 - Opportunity — discovered connection between users. Roles, status, reasoning.
@@ -658,7 +658,7 @@ export function createMcpServer(
 
           // Build per-request scoped databases via injected factory.
           // Network-scoped agents are clamped to their bound network plus the user's
-          // personal index — they cannot reach other networks even when the user is
+          // personal network — they cannot reach other networks even when the user is
           // a member of them. The personal-index reachability is preserved so the
           // agent can still manage its owner's profile and contacts.
           const allowedNetworkIds = deriveAllowedNetworkIds({

--- a/packages/protocol/src/mcp/tests/compute-agent-index-scope.spec.ts
+++ b/packages/protocol/src/mcp/tests/compute-agent-index-scope.spec.ts
@@ -20,17 +20,17 @@ describe('computeAgentAllowedNetworkIds', () => {
     expect(scope).toEqual(['personal-1', 'community-A', 'community-B', 'community-C']);
   });
 
-  test('clamps to scope + personal index when scope is set', () => {
+  test('clamps to scope + personal network when scope is set', () => {
     const scope = computeAgentAllowedNetworkIds(memberships, 'network', 'community-B');
     expect(scope.sort()).toEqual(['community-B', 'personal-1'].sort());
   });
 
-  test('returns only the personal index when scope is set but not in memberships', () => {
+  test('returns only the personal network when scope is set but not in memberships', () => {
     const scope = computeAgentAllowedNetworkIds(memberships, 'network', 'community-XYZ');
     expect(scope).toEqual(['personal-1']);
   });
 
-  test('returns empty array when scope is set, no match, and no personal index', () => {
+  test('returns empty array when scope is set, no match, and no personal network', () => {
     const scope = computeAgentAllowedNetworkIds(
       [{ networkId: 'community-A', isPersonal: false }],
       'network',

--- a/packages/protocol/src/network/indexer/indexer.graph.ts
+++ b/packages/protocol/src/network/indexer/indexer.graph.ts
@@ -18,10 +18,10 @@ const logger = protocolLogger("IntentNetworkGraphFactory");
  *
  * Handles CRUD for the intent_indexes junction table:
  * - create: Assign an intent to an index (direct or evaluated via IntentIndexer agent)
- * - read: List intent-index links (by intentId or by networkId)
+ * - read: List intent-network links (by intentId or by networkId)
  * - delete: Unassign an intent from an index
  *
- * The evaluate-based assignment flow is migrated from the old Index Graph.
+ * The evaluate-based assignment flow is migrated from the old Network Graph.
  */
 export class IntentNetworkGraphFactory {
   constructor(
@@ -93,7 +93,7 @@ export class IntentNetworkGraphFactory {
             };
           }
 
-          // Evaluated assignment (migrated from old Index Graph)
+          // Evaluated assignment (migrated from old Network Graph)
           const intentForIndexing = await this.database.getIntentForIndexing(intentId);
           if (!intentForIndexing) {
             return { agentTimings: agentTimingsAccum, mutationResult: { success: false, error: "Intent not found for networking." } };
@@ -117,7 +117,7 @@ export class IntentNetworkGraphFactory {
               scope: "network",
               indexPrompt,
               memberPrompt,
-              evaluator: "intent-indexer",
+              evaluator: "intent-networker",
               source: "intent-network-graph",
               createdAt: new Date().toISOString(),
             });
@@ -147,7 +147,7 @@ export class IntentNetworkGraphFactory {
 
           const _traceEmitterIndexer = requestContext.getStore()?.traceEmitter;
           const _indexerStart = Date.now();
-          _traceEmitterIndexer?.({ type: "agent_start", name: "intent-indexer" });
+          _traceEmitterIndexer?.({ type: "agent_start", name: "intent-networker" });
           let result: Awaited<ReturnType<typeof indexer.evaluate>> | null = null;
           try {
             result = await indexer.evaluate(
@@ -160,7 +160,7 @@ export class IntentNetworkGraphFactory {
           } finally {
             const _indexerMs = Date.now() - _indexerStart;
             agentTimingsAccum.push({ name: 'intent.indexer', durationMs: _indexerMs });
-            _traceEmitterIndexer?.({ type: "agent_end", name: "intent-indexer", durationMs: _indexerMs, summary: result ? `Scored: index=${result.indexScore.toFixed(2)}, member=${result.memberScore.toFixed(2)}` : "intent-indexer failed" });
+            _traceEmitterIndexer?.({ type: "agent_end", name: "intent-networker", durationMs: _indexerMs, summary: result ? `Scored: index=${result.indexScore.toFixed(2)}, member=${result.memberScore.toFixed(2)}` : "intent-networker failed" });
           }
 
           if (!result) {
@@ -180,7 +180,7 @@ export class IntentNetworkGraphFactory {
             indexPrompt,
             memberPrompt,
             rawScores: { indexScore: result.indexScore, memberScore: result.memberScore },
-            evaluator: "intent-indexer",
+            evaluator: "intent-networker",
             source: "intent-network-graph",
             reason: result.reasoning,
             createdAt: new Date().toISOString(),
@@ -214,8 +214,8 @@ export class IntentNetworkGraphFactory {
     };
 
     /**
-     * Read Node: Query intent-index relationships.
-     * - By intentId only: list all indexes the intent is in (owner only)
+     * Read Node: Query intent-network relationships.
+     * - By intentId only: list all networks the intent is in (owner only)
      * - By networkId only: list intents in the index (member only)
      * - By both intentId and networkId: check if specific link exists (owner only)
      */
@@ -223,10 +223,10 @@ export class IntentNetworkGraphFactory {
       return timed("IntentNetworkGraph.read", async () => {
         const intentId = state.intentId;
         const networkId = state.networkId;
-        logger.verbose("Read intent-index links", { userId: state.userId, intentId, networkId, queryUserId: state.queryUserId });
+        logger.verbose("Read intent-network links", { userId: state.userId, intentId, networkId, queryUserId: state.queryUserId });
 
         try {
-          // By both: check if specific intent-index link exists
+          // By both: check if specific intent-network link exists
           if (intentId && networkId) {
             const intent = await this.database.getIntent(intentId);
             if (!intent) {
@@ -246,7 +246,7 @@ export class IntentNetworkGraphFactory {
             };
           }
 
-          // By intent only: list all indexes for this intent
+          // By intent only: list all networks for this intent
           if (intentId) {
             const intent = await this.database.getIntent(intentId);
             if (!intent) {
@@ -323,7 +323,7 @@ export class IntentNetworkGraphFactory {
             },
           };
         } catch (err) {
-          logger.error("Read intent-index failed", { error: err });
+          logger.error("Read intent-network failed", { error: err });
           return { error: "Failed to fetch intent-network links." };
         }
       });

--- a/packages/protocol/src/network/indexer/indexer.state.ts
+++ b/packages/protocol/src/network/indexer/indexer.state.ts
@@ -38,7 +38,7 @@ export interface AssignmentResult {
 /**
  * Intent Index Graph State.
  * Handles CRUD for the intent_indexes junction table (linking intents to indexes).
- * Absorbs the old Index Graph's evaluate-based assignment flow.
+ * Absorbs the old Network Graph's evaluate-based assignment flow.
  *
  * Flow:
  * START → router → {
@@ -75,14 +75,14 @@ export const IntentNetworkGraphState = Annotation.Root({
 
   /**
    * When true, skip LLM evaluation and assign directly.
-   * (Migrated from old Index Graph.)
+   * (Migrated from old Network Graph.)
    */
   skipEvaluation: Annotation<boolean>({
     reducer: (_, next) => next,
     default: () => true,
   }),
 
-  // --- Intermediate State (populated by nodes, migrated from old Index Graph) ---
+  // --- Intermediate State (populated by nodes, migrated from old Network Graph) ---
 
   /** Intent payload and metadata. Null if intent not found. */
   intent: Annotation<IntentForIndexing | null>({
@@ -102,7 +102,7 @@ export const IntentNetworkGraphState = Annotation.Root({
     default: () => null,
   }),
 
-  /** Final decision: should intent be in this index? */
+  /** Final decision: should intent be in this network? */
   shouldAssign: Annotation<boolean | undefined>({
     reducer: (_, next) => next,
     default: () => undefined,

--- a/packages/protocol/src/network/membership/membership.graph.ts
+++ b/packages/protocol/src/network/membership/membership.graph.ts
@@ -7,7 +7,7 @@ import { NetworkMembershipGraphState } from "./membership.state.js";
 const logger = protocolLogger("NetworkMembershipGraphFactory");
 
 /**
- * Factory class to build and compile the Index Membership Graph.
+ * Factory class to build and compile the Network Membership Graph.
  *
  * Handles CRUD operations for the index_members table:
  * - create: Add a member to an index (validates join policy and ownership)
@@ -23,7 +23,7 @@ export class NetworkMembershipGraphFactory {
     /**
      * Add Member Node: Add a user as a member of an index.
      * Handles two cases:
-     * 1. Self-join (targetUserId === userId): Only allowed for public indexes (joinPolicy 'anyone')
+     * 1. Self-join (targetUserId === userId): Only allowed for public networks (joinPolicy 'anyone')
      * 2. Invite others (targetUserId !== userId): Requires caller to be member; owner-only for invite_only
      */
     const addMemberNode = async (state: typeof NetworkMembershipGraphState.State) => {
@@ -48,19 +48,19 @@ export class NetworkMembershipGraphFactory {
           const isSelfJoin = state.targetUserId === state.userId;
 
           if (isSelfJoin) {
-            // Self-join: only allowed for public indexes
+            // Self-join: only allowed for public networks
             if (joinPolicy !== 'anyone') {
               return {
                 mutationResult: {
                   success: false,
-                  error: "This index is invite-only. You cannot join without an invitation from an existing member.",
+                  error: "This network is invite-only. You cannot join without an invitation from an existing member.",
                 },
               };
             }
 
             const result = await this.database.addMemberToNetwork(state.networkId, state.targetUserId, 'member');
             if (result.alreadyMember) {
-              return { mutationResult: { success: true, message: "You are already a member of this index." } };
+              return { mutationResult: { success: true, message: "You are already a member of this network." } };
             }
 
             return { mutationResult: { success: true, message: `You have joined "${indexRecord.title}".` } };
@@ -81,7 +81,7 @@ export class NetworkMembershipGraphFactory {
 
           const result = await this.database.addMemberToNetwork(state.networkId, state.targetUserId, 'member');
           if (result.alreadyMember) {
-            return { mutationResult: { success: true, message: "That user is already a member of this index." } };
+            return { mutationResult: { success: true, message: "That user is already a member of this network." } };
           }
 
           return { mutationResult: { success: true, message: "Member added to the index." } };
@@ -103,7 +103,7 @@ export class NetworkMembershipGraphFactory {
      */
     const listMembersNode = async (state: typeof NetworkMembershipGraphState.State) => {
       return timed("NetworkMembershipGraph.listMembers", async () => {
-        logger.verbose("List index members", {
+        logger.verbose("List network members", {
           userId: state.userId,
           networkId: state.networkId,
         });
@@ -138,10 +138,10 @@ export class NetworkMembershipGraphFactory {
           };
         } catch (err) {
           logger.error("List members failed", { error: err });
-          if (err instanceof Error && err.message === "Access denied: Not a member of this index") {
+          if (err instanceof Error && err.message === "Access denied: Not a member of this network") {
             return { error: "You must be a member of that index." };
           }
-          return { error: "Failed to fetch index members." };
+          return { error: "Failed to fetch network members." };
         }
       });
     };
@@ -178,7 +178,7 @@ export class NetworkMembershipGraphFactory {
             return { mutationResult: { success: false, error: "Cannot remove the index owner." } };
           }
           if (result.notMember) {
-            return { mutationResult: { success: false, error: "User is not a member of this index." } };
+            return { mutationResult: { success: false, error: "User is not a member of this network." } };
           }
           if (!result.success) {
             return { mutationResult: { success: false, error: "Failed to remove member." } };

--- a/packages/protocol/src/network/membership/membership.graph.ts
+++ b/packages/protocol/src/network/membership/membership.graph.ts
@@ -69,13 +69,13 @@ export class NetworkMembershipGraphFactory {
           // Inviting others: must be a member first
           const isMember = await this.database.isNetworkMember(state.networkId, state.userId);
           if (!isMember) {
-            return { mutationResult: { success: false, error: "You must be a member of that index to add others." } };
+            return { mutationResult: { success: false, error: "You must be a member of that network to add others." } };
           }
 
           if (joinPolicy === 'invite_only') {
             const isOwner = await this.database.isIndexOwner(state.networkId, state.userId);
             if (!isOwner) {
-              return { mutationResult: { success: false, error: "Only the index owner can add members when the index is invite-only." } };
+              return { mutationResult: { success: false, error: "Only the network owner can add members when the network is invite-only." } };
             }
           }
 
@@ -84,7 +84,7 @@ export class NetworkMembershipGraphFactory {
             return { mutationResult: { success: true, message: "That user is already a member of this network." } };
           }
 
-          return { mutationResult: { success: true, message: "Member added to the index." } };
+          return { mutationResult: { success: true, message: "Member added to the network." } };
         } catch (err) {
           logger.error("Add member failed", { error: err });
           return {
@@ -98,7 +98,7 @@ export class NetworkMembershipGraphFactory {
     };
 
     /**
-     * List Members Node: List all members of an index.
+     * List Members Node: List all members of a network.
      * Validates caller is a member.
      */
     const listMembersNode = async (state: typeof NetworkMembershipGraphState.State) => {
@@ -117,7 +117,7 @@ export class NetworkMembershipGraphFactory {
                 count: 0,
                 members: [],
               },
-              error: "Index not found or you are not a member.",
+              error: "Network not found or you are not a member.",
             };
           }
 
@@ -139,7 +139,7 @@ export class NetworkMembershipGraphFactory {
         } catch (err) {
           logger.error("List members failed", { error: err });
           if (err instanceof Error && err.message === "Access denied: Not a member of this network") {
-            return { error: "You must be a member of that index." };
+            return { error: "You must be a member of that network." };
           }
           return { error: "Failed to fetch network members." };
         }
@@ -147,11 +147,11 @@ export class NetworkMembershipGraphFactory {
     };
 
     /**
-     * Remove Member Node: Remove a member from an index (owner only).
+     * Remove Member Node: Remove a member from a network (owner only).
      */
     const removeMemberNode = async (state: typeof NetworkMembershipGraphState.State) => {
       return timed("NetworkMembershipGraph.removeMember", async () => {
-        logger.verbose("Remove member from index", {
+        logger.verbose("Remove member from network", {
           userId: state.userId,
           networkId: state.networkId,
           targetUserId: state.targetUserId,
@@ -163,19 +163,19 @@ export class NetworkMembershipGraphFactory {
 
         // Cannot remove yourself via this flow
         if (state.targetUserId === state.userId) {
-          return { mutationResult: { success: false, error: "You cannot remove yourself. Use 'leave index' instead." } };
+          return { mutationResult: { success: false, error: "You cannot remove yourself. Use 'leave network' instead." } };
         }
 
         try {
           const isOwner = await this.database.isIndexOwner(state.networkId, state.userId);
           if (!isOwner) {
-            return { mutationResult: { success: false, error: "Only the index owner can remove members." } };
+            return { mutationResult: { success: false, error: "Only the network owner can remove members." } };
           }
 
           const result = await this.database.removeMemberFromIndex(state.networkId, state.targetUserId);
 
           if (result.wasOwner) {
-            return { mutationResult: { success: false, error: "Cannot remove the index owner." } };
+            return { mutationResult: { success: false, error: "Cannot remove the network owner." } };
           }
           if (result.notMember) {
             return { mutationResult: { success: false, error: "User is not a member of this network." } };

--- a/packages/protocol/src/network/membership/membership.state.ts
+++ b/packages/protocol/src/network/membership/membership.state.ts
@@ -1,8 +1,8 @@
 import { Annotation } from "@langchain/langgraph";
 
 /**
- * Index Membership Graph State.
- * Handles CRUD operations for index memberships (index_members table).
+ * Network Membership Graph State.
+ * Handles CRUD operations for network memberships (index_members table).
  *
  * Flow:
  * START → routerNode → {addMemberNode | listMembersNode | removeMemberNode} → END

--- a/packages/protocol/src/network/network.graph.ts
+++ b/packages/protocol/src/network/network.graph.ts
@@ -100,7 +100,7 @@ export class NetworkGraphFactory {
                 stats: {
                   memberOfCount: memberOf.length,
                   ownsCount: owns.length,
-                  scopeNote: "Showing current index and your personal network. Use showAll: true for all networks.",
+                  scopeNote: "Showing current network and your personal network. Use showAll: true for all networks.",
                 },
               },
             };

--- a/packages/protocol/src/network/network.graph.ts
+++ b/packages/protocol/src/network/network.graph.ts
@@ -12,7 +12,7 @@ const logger = protocolLogger("NetworkGraphFactory");
  * Factory class to build and compile the Index (CRUD) Graph.
  *
  * Handles create, read, update, and delete operations for indexes.
- * Membership and intent-index assignment operations are handled by
+ * Membership and intent-network assignment operations are handled by
  * separate graphs (NetworkMembershipGraph and IntentNetworkGraph).
  *
  * Flow:
@@ -25,11 +25,11 @@ export class NetworkGraphFactory {
     // --- NODE DEFINITIONS ---
 
     /**
-     * Read Node: List indexes the user belongs to and owns.
+     * Read Node: List networks the user belongs to and owns.
      */
     const readNode = async (state: typeof NetworkGraphState.State) => {
       return timed("NetworkGraph.read", async () => {
-        logger.verbose("Read indexes", { userId: state.userId, networkId: state.networkId, showAll: state.showAll });
+        logger.verbose("Read networks", { userId: state.userId, networkId: state.networkId, showAll: state.showAll });
 
         // Shared projections for both the scoped and unscoped read paths.
         const projectMembership = (m: Awaited<ReturnType<typeof this.database.getNetworkMemberships>>[number]) => ({
@@ -56,12 +56,12 @@ export class NetworkGraphFactory {
             this.database.getPublicIndexesNotJoined(state.userId),
           ]);
 
-          // If index-scoped and not showAll, return just that index plus the
-          // user's personal index (their contacts). The personal index is part
+          // If network-scoped and not showAll, return just that index plus the
+          // user's personal network (their contacts). The personal network is part
           // of every allowed-network reach calculation for network-bound agents,
           // and a user clicked into a community-scoped
           // chat still owns their contact list — so surfacing it here keeps
-          // tools that operate on the personal index (add_contact, list_contacts,
+          // tools that operate on the personal network (add_contact, list_contacts,
           // import_*_contacts) discoverable. Other community memberships are
           // still hidden, and `publicNetworks` is omitted.
           const scopeToCurrentIndex = state.networkId && !state.showAll;
@@ -100,7 +100,7 @@ export class NetworkGraphFactory {
                 stats: {
                   memberOfCount: memberOf.length,
                   ownsCount: owns.length,
-                  scopeNote: "Showing current index and your personal index. Use showAll: true for all indexes.",
+                  scopeNote: "Showing current index and your personal network. Use showAll: true for all networks.",
                 },
               },
             };
@@ -124,7 +124,7 @@ export class NetworkGraphFactory {
             },
           };
         } catch (err) {
-          logger.error("Read indexes failed", { error: err });
+          logger.error("Read networks failed", { error: err });
           return { error: "Failed to fetch network information." };
         }
       });
@@ -135,7 +135,7 @@ export class NetworkGraphFactory {
      */
     const createNode = async (state: typeof NetworkGraphState.State) => {
       return timed("NetworkGraph.create", async () => {
-        logger.verbose("Create index", { userId: state.userId, createInput: state.createInput });
+        logger.verbose("Create network", { userId: state.userId, createInput: state.createInput });
 
         if (!state.createInput?.title?.trim()) {
           return { mutationResult: { success: false, error: "Title is required." } };
@@ -167,7 +167,7 @@ export class NetworkGraphFactory {
             },
           };
         } catch (err) {
-          logger.error("Create index failed", { error: err });
+          logger.error("Create network failed", { error: err });
           if (createdIndexId) {
             try { await this.database.softDeleteNetwork(createdIndexId); } catch {}
           }
@@ -216,12 +216,12 @@ export class NetworkGraphFactory {
     };
 
     /**
-     * Delete Node: Soft-delete an index (owner only, sole member).
+     * Delete Node: Soft-delete a network (owner only, sole member).
      */
     const deleteNode = async (state: typeof NetworkGraphState.State) => {
       return timed("NetworkGraph.delete", async () => {
         const networkId = state.networkId;
-        logger.verbose("Delete index", { userId: state.userId, networkId });
+        logger.verbose("Delete network", { userId: state.userId, networkId });
 
         if (!networkId) {
           return { mutationResult: { success: false, error: "networkId is required for delete." } };
@@ -248,7 +248,7 @@ export class NetworkGraphFactory {
             },
           };
         } catch (err) {
-          logger.error("Delete index failed", { error: err });
+          logger.error("Delete network failed", { error: err });
           return { mutationResult: { success: false, error: "Failed to delete network." } };
         }
       });

--- a/packages/protocol/src/network/network.state.ts
+++ b/packages/protocol/src/network/network.state.ts
@@ -1,7 +1,7 @@
 import { Annotation } from "@langchain/langgraph";
 
 /**
- * Index Graph State.
+ * Network Graph State.
  * Handles CRUD operations for indexes (communities).
  *
  * Flow:
@@ -13,7 +13,7 @@ export const NetworkGraphState = Annotation.Root({
   /** User performing the action. Always required. */
   userId: Annotation<string>,
 
-  /** Target index ID. Required for read/update/delete. From ChatGraph or tool arg. */
+  /** Target network ID. Required for read/update/delete. From ChatGraph or tool arg. */
   networkId: Annotation<string | undefined>({
     reducer: (_, next) => next,
     default: () => undefined,
@@ -50,7 +50,7 @@ export const NetworkGraphState = Annotation.Root({
     default: () => undefined,
   }),
 
-  /** When true and index-scoped, read returns all user indexes (not just scoped one). */
+  /** When true and network-scoped, read returns all user indexes (not just scoped one). */
   showAll: Annotation<boolean>({
     reducer: (_, next) => next,
     default: () => false,

--- a/packages/protocol/src/network/network.tools.ts
+++ b/packages/protocol/src/network/network.tools.ts
@@ -5,7 +5,6 @@ import { renderNetworkContext } from '../shared/network/metadata.renderer.js';
 
 import type { DefineTool, ToolDeps } from "../shared/agent/tool.helpers.js";
 import { success, error, UUID_REGEX } from "../shared/agent/tool.helpers.js";
-import { focusedNetworkId, focusedNetworkLabel } from "../shared/agent/tool.scope.js";
 import { NetworkRecommender } from "./network.recommender.js";
 
 // Lazy singleton — only instantiated on first onboarding ranking call so that
@@ -35,7 +34,7 @@ export function createNetworkTools(defineTool: DefineTool, deps: ToolDeps) {
       "**Returns:** Up to three lists — `memberOf` (networks the user joined), `owns` (networks the user created), and `publicNetworks` " +
       "(publicly joinable communities the user is not yet a member of). Entries in `memberOf` include `isPersonal` set to `true` for the user's " +
       "personal network.\n\n" +
-      "**Note:** In index-scoped chats, only the scoped network is returned. During onboarding, `orderedNetworkIds` " +
+      "**Note:** In network-scoped chats, only the scoped network is returned. During onboarding, `orderedNetworkIds` " +
       "may be returned alongside `publicNetworks` \u2014 a ranked array of network IDs ordered by relevance to the user's profile (omitted when ranking is unavailable or fails).",
     querySchema: z.object({
       userId: z.string().optional().describe("Must be the current user's ID or omitted. Cannot list another user's indexes."),
@@ -45,15 +44,12 @@ export function createNetworkTools(defineTool: DefineTool, deps: ToolDeps) {
         return error("You can only list your own indexes. Omit userId to see the current user's indexes.");
       }
 
-      const scopedNetworkId = focusedNetworkId(context);
-      const scopedIndexLabel = focusedNetworkLabel(context);
-
       const _readIndexGraphStart = Date.now();
       const _readIndexTraceEmitter = requestContext.getStore()?.traceEmitter;
       _readIndexTraceEmitter?.({ type: "graph_start", name: "index" });
       const result = await graphs.index.invoke({
         userId: context.userId,
-        networkId: scopedNetworkId,
+        networkId: context.networkId || undefined,
         operationMode: 'read' as const,
         showAll: false, // Never allow bypass - strict scope enforcement
       });
@@ -73,13 +69,13 @@ export function createNetworkTools(defineTool: DefineTool, deps: ToolDeps) {
         };
 
         // When scoped, add clear metadata so model knows results are limited
-        if (scopedNetworkId) {
+        if (context.networkId) {
           return success({
             ...enriched,
             scopeRestriction: {
               isScoped: true,
-              scopedToIndex: scopedIndexLabel,
-              message: `Results are limited to "${scopedIndexLabel}" because this chat is scoped to that community. The user may belong to other communities not shown here.`,
+              scopedToIndex: context.indexName ?? context.networkId,
+              message: `Results are limited to "${context.indexName ?? 'this network'}" because this chat is scoped to that community. The user may belong to other communities not shown here.`,
             },
             _graphTimings: [{ name: 'index', durationMs: _readIndexGraphMs, agents: result.agentTimings ?? [] }],
           });
@@ -159,44 +155,42 @@ export function createNetworkTools(defineTool: DefineTool, deps: ToolDeps) {
   const readIndexMemberships = defineTool({
     name: "read_network_memberships",
     description:
-      "Reads index membership information — who is in which community. Essential for understanding the social graph before " +
+      "Reads network membership information — who is in which community. Essential for understanding the social graph before " +
       "creating introductions or exploring intents.\n\n" +
       "**Usage modes:**\n" +
       "- With `networkId` only: lists ALL members of that index — returns userId, name, avatar, permissions (owner/member), intentCount, and joinedAt. " +
       "Use this to see who's in a community before browsing their intents or creating introductions.\n" +
-      "- With `userId` only (or omit for self): lists all indexes that user belongs to — returns networkId, networkTitle, permissions, joinedAt.\n" +
+      "- With `userId` only (or omit for self): lists all networks that user belongs to — returns networkId, networkTitle, permissions, joinedAt.\n" +
       "- With both `networkId` and `userId`: checks whether that specific user is a member of that specific index (returns isMember boolean).\n\n" +
-      "**When to use:** Before creating introductions (need to verify shared index membership), to explore community members, " +
+      "**When to use:** Before creating introductions (need to verify shared network membership), to explore community members, " +
       "or to check if a user belongs to a specific index.\n\n" +
       "**Returns:** Member list with user details, or membership list with index details, or a membership check result.\n\n" +
-      "**Personal index semantics.** The personal index (`isPersonal: true` on the membership) is the user's " +
+      "**Personal network semantics.** The personal network (`isPersonal: true` on the membership) is the user's " +
       "contact list — members of that index are the user's contacts. For another user, this tool only reveals the " +
       "indexes you already share with them.\n\n" +
       "**Shared-context pattern.** To find overlap with another user: (1) omit `userId` to read your own " +
-      "memberships, (2) call this tool with the other person's actual `userId` to get the shared indexes, " +
+      "memberships, (2) call this tool with the other person's actual `userId` to get the shared networks, " +
       "(3) call read_intents for each shared network to see what each is looking for there, (4) call " +
       "read_user_contexts for the other party. That sequence gives you enough to decide whether to propose a " +
       "direct connection or an introduction.",
     querySchema: z.object({
-      networkId: z.string().optional().describe("Index UUID — lists all members of this index. Get from read_networks. In index-scoped chats, only the scoped index can be queried."),
-      userId: z.string().optional().describe("User ID — lists that user's index memberships. Omit to get the current user's memberships. When combined with networkId, checks if this user is in that specific index."),
+      networkId: z.string().optional().describe("Network UUID — lists all members of this network. Get from read_networks. In network-scoped chats, only the scoped index can be queried."),
+      userId: z.string().optional().describe("User ID — lists that user's network memberships. Omit to get the current user's memberships. When combined with networkId, checks if this user is in that specific index."),
     }),
     handler: async ({ context, query }) => {
-      const scopedNetworkId = focusedNetworkId(context);
-      const scopedIndexLabel = focusedNetworkLabel(context);
       const networkId = query.networkId?.trim() || undefined;
       const userId = query.userId?.trim() || undefined;
 
       if (networkId && !UUID_REGEX.test(networkId)) {
-        return error("Invalid index ID format. Use the exact UUID from read_networks.");
+        return error("Invalid network ID format. Use the exact UUID from read_networks.");
       }
 
       // Mode 1: list members of an index
       if (networkId && !userId) {
-        // Enforce strict scope: when chat is index-scoped, only allow querying that index
-        if (scopedNetworkId && networkId !== scopedNetworkId) {
+        // Enforce strict scope: when chat is network-scoped, only allow querying that index
+        if (context.networkId && networkId !== context.networkId) {
           return error(
-            `This chat is scoped to ${scopedIndexLabel}. You can only query members of this index.`
+            `This chat is scoped to ${context.indexName ?? 'this network'}. You can only query members of this network.`
           );
         }
 
@@ -217,22 +211,22 @@ export function createNetworkTools(defineTool: DefineTool, deps: ToolDeps) {
         if (result.readResult) {
           return success({ ...result.readResult, _graphTimings: [{ name: 'network_membership', durationMs: _readMembersGraphMs, agents: result.agentTimings ?? [] }] });
         }
-        return error("Failed to fetch index members.");
+        return error("Failed to fetch network members.");
       }
 
       // Mode 2: list a user's memberships (indexes they belong to)
       const targetUserId = userId || context.userId;
 
-      // Use userDb for own memberships, but systemDb access is implicit through shared index scope
+      // Use userDb for own memberships, but systemDb access is implicit through shared network scope
       let memberships: Awaited<ReturnType<typeof userDb.getNetworkMemberships>>;
       if (targetUserId !== context.userId) {
-        // Cross-user access: systemDb will validate shared index membership
+        // Cross-user access: systemDb will validate shared network membership
         const callerMemberships = await userDb.getNetworkMemberships();
         if (networkId) {
-          // Strict scope enforcement: when chat is index-scoped, only allow querying that index
-          if (scopedNetworkId && networkId !== scopedNetworkId) {
+          // Strict scope enforcement: when chat is network-scoped, only allow querying that index
+          if (context.networkId && networkId !== context.networkId) {
             return error(
-              `This chat is scoped to ${scopedIndexLabel}. You can only query membership in this community.`
+              `This chat is scoped to ${context.indexName ?? 'this network'}. You can only query membership in this community.`
             );
           }
 
@@ -247,37 +241,37 @@ export function createNetworkTools(defineTool: DefineTool, deps: ToolDeps) {
           if (isMember) {
             return success({ isMember: true, userId: targetUserId, networkId });
           }
-          return success({ isMember: false, userId: targetUserId, networkId, message: "User is not a member of this index." });
+          return success({ isMember: false, userId: targetUserId, networkId, message: "User is not a member of this network." });
         } else {
-          // Strict scope enforcement: when chat is index-scoped, only check the scoped index
-          if (scopedNetworkId) {
-            const isMember = await systemDb.isNetworkMember(scopedNetworkId, targetUserId);
+          // Strict scope enforcement: when chat is network-scoped, only check the scoped index
+          if (context.networkId) {
+            const isMember = await systemDb.isNetworkMember(context.networkId, targetUserId);
             if (isMember) {
               return success({
                 isMember: true,
                 userId: targetUserId,
-                networkId: scopedNetworkId,
+                networkId: context.networkId,
                 scopeRestriction: {
                   isScoped: true,
-                  scopedToIndex: scopedIndexLabel,
-                  message: `This chat is scoped to "${scopedIndexLabel}". Only membership in this community is shown.`,
+                  scopedToIndex: context.indexName ?? context.networkId,
+                  message: `This chat is scoped to "${context.indexName ?? 'this network'}". Only membership in this community is shown.`,
                 },
               });
             }
             return success({
               isMember: false,
               userId: targetUserId,
-              networkId: scopedNetworkId,
+              networkId: context.networkId,
               message: "User is not a member of this community.",
               scopeRestriction: {
                 isScoped: true,
-                scopedToIndex: scopedIndexLabel,
-                message: `This chat is scoped to "${scopedIndexLabel}". Only membership in this community was checked.`,
+                scopedToIndex: context.indexName ?? context.networkId,
+                message: `This chat is scoped to "${context.indexName ?? 'this network'}". Only membership in this community was checked.`,
               },
             });
           }
 
-          // Unscoped chat: show overlap with shared indexes (intersection of caller and target memberships)
+          // Unscoped chat: show overlap with shared networks (intersection of caller and target memberships)
           const sharedIndexes: typeof callerMemberships = [];
           for (const m of callerMemberships) {
             if (await systemDb.isNetworkMember(m.networkId, targetUserId)) {
@@ -297,27 +291,28 @@ export function createNetworkTools(defineTool: DefineTool, deps: ToolDeps) {
               networkId: m.networkId,
               networkTitle: m.networkTitle,
             })),
-            note: "Only showing shared indexes.",
+            note: "Only showing shared networks.",
           });
         }
       } else {
         // Own memberships - use userDb
         memberships = await userDb.getNetworkMemberships();
 
-        // The scope envelope's network id is the focus of the scoped chat — it filters
-        // what we show, not what we can reach. Concrete reach is derived separately.
-        // Strict scope enforcement: when chat is index-scoped, only return the scoped index membership
-        if (scopedNetworkId && !networkId) {
-          memberships = memberships.filter((m) => m.networkId === scopedNetworkId);
+        // NOTE: context.networkId here is the *focus* of the scoped chat — it filters
+        // what we show, not what we can reach. indexScope is the reach; the bound
+        // network is one element of it. See IND-306 for the equivalent in read_intents.
+        // Strict scope enforcement: when chat is network-scoped, only return the scoped network membership
+        if (context.networkId && !networkId) {
+          memberships = memberships.filter((m) => m.networkId === context.networkId);
         }
       }
 
       // If both networkId and userId: filter to that specific membership
       if (networkId) {
-        // Strict scope enforcement: when chat is index-scoped, only allow querying that index
-        if (scopedNetworkId && networkId !== scopedNetworkId) {
+        // Strict scope enforcement: when chat is network-scoped, only allow querying that index
+        if (context.networkId && networkId !== context.networkId) {
           return error(
-            `This chat is scoped to ${scopedIndexLabel}. You can only query membership in this community.`
+            `This chat is scoped to ${context.indexName ?? 'this network'}. You can only query membership in this community.`
           );
         }
 
@@ -332,7 +327,7 @@ export function createNetworkTools(defineTool: DefineTool, deps: ToolDeps) {
         }
         const match = memberships.find((m) => m.networkId === networkId);
         if (!match) {
-          return success({ isMember: false, userId: targetUserId, networkId, message: "User is not a member of this index." });
+          return success({ isMember: false, userId: targetUserId, networkId, message: "User is not a member of this network." });
         }
         return success({
           isMember: true,
@@ -345,7 +340,7 @@ export function createNetworkTools(defineTool: DefineTool, deps: ToolDeps) {
       }
 
       // When scoped, add clear metadata so model knows results are limited
-      if (scopedNetworkId && targetUserId === context.userId) {
+      if (context.networkId && targetUserId === context.userId) {
         return success({
           userId: targetUserId,
           count: memberships.length,
@@ -357,8 +352,8 @@ export function createNetworkTools(defineTool: DefineTool, deps: ToolDeps) {
           })),
           scopeRestriction: {
             isScoped: true,
-            scopedToIndex: scopedIndexLabel,
-            message: `Results are limited to "${scopedIndexLabel}" because this chat is scoped to that community. The user may belong to other communities not shown here.`,
+            scopedToIndex: context.indexName ?? context.networkId,
+            message: `Results are limited to "${context.indexName ?? 'this network'}" because this chat is scoped to that community. The user may belong to other communities not shown here.`,
           },
         });
       }
@@ -387,30 +382,28 @@ export function createNetworkTools(defineTool: DefineTool, deps: ToolDeps) {
   const updateNetwork = defineTool({
     name: "update_network",
     description:
-      "Updates settings of an existing index (community). Only the index owner can perform updates.\n\n" +
+      "Updates settings of an existing network (community). Only the network owner can perform updates.\n\n" +
       "**Updatable fields:** title (display name), prompt (purpose description used for intent auto-assignment), " +
       "imageUrl (community avatar), joinPolicy ('anyone' for open or 'invite_only'), allowGuestVibeCheck (allow non-members to preview).\n\n" +
-      "**When to use:** When an index owner wants to change their community's settings — e.g. update the purpose description, " +
+      "**When to use:** When a network owner wants to change their community's settings — e.g. update the purpose description, " +
       "change from invite-only to open, or update the community image.\n\n" +
-      "**Important:** Changing the prompt affects how future intents are evaluated for auto-assignment to this index. " +
-      "Existing intent-index links are not re-evaluated automatically.\n\n" +
+      "**Important:** Changing the prompt affects how future intents are evaluated for auto-assignment to this network. " +
+      "Existing intent-network links are not re-evaluated automatically.\n\n" +
       "**Returns:** Confirmation with the list of settings that were updated.",
     querySchema: z.object({
-      networkId: z.string().optional().describe("Index UUID to update. Get from read_networks. Defaults to the scoped index in index-scoped chats."),
+      networkId: z.string().optional().describe("Network UUID to update. Get from read_networks. Defaults to the scoped index in network-scoped chats."),
       settings: updateNetworkSettingsSchema.describe("Object with fields to update. All fields are optional — only include the ones to change. title: display name. prompt: purpose description (used for intent auto-assignment). imageUrl: community image URL (null to remove). joinPolicy: 'anyone' or 'invite_only'. allowGuestVibeCheck: boolean."),
     }),
     handler: async ({ context, query }) => {
-      const scopedNetworkId = focusedNetworkId(context);
-      const scopedIndexLabel = focusedNetworkLabel(context);
-      const effectiveIndexId = (query.networkId?.trim() || scopedNetworkId) ?? null;
+      const effectiveIndexId = (query.networkId?.trim() || context.networkId) ?? null;
       if (!effectiveIndexId || !UUID_REGEX.test(effectiveIndexId)) {
         return error("Valid networkId required.");
       }
 
-      // Strict scope enforcement: when chat is index-scoped, only allow updating that index
-      if (scopedNetworkId && effectiveIndexId !== scopedNetworkId) {
+      // Strict scope enforcement: when chat is network-scoped, only allow updating that index
+      if (context.networkId && effectiveIndexId !== context.networkId) {
         return error(
-          `This chat is scoped to ${scopedIndexLabel}. You can only update this community's settings.`
+          `This chat is scoped to ${context.indexName ?? 'this network'}. You can only update this community's settings.`
         );
       }
 
@@ -436,15 +429,15 @@ export function createNetworkTools(defineTool: DefineTool, deps: ToolDeps) {
   const createNetwork = defineTool({
     name: "create_network",
     description:
-      "Creates a new index (community/group). The authenticated user becomes the owner with full control over settings and membership.\n\n" +
-      "**What is an index?** A shared space where members post intents (what they're looking for) and the system discovers opportunities " +
-      "(complementary matches) between members. The index's prompt guides what kinds of intents belong.\n\n" +
+      "Creates a new network (community/group). The authenticated user becomes the owner with full control over settings and membership.\n\n" +
+      "**What is a network?** A shared space where members post intents (what they're looking for) and the system discovers opportunities " +
+      "(complementary matches) between members. The network's prompt guides what kinds of intents belong.\n\n" +
       "**When to use:** When the user wants to create a new community — e.g. a professional network, interest group, or project team.\n\n" +
-      "**Returns:** The new index's networkId (UUID) and title. Use the networkId to add members (create_network_membership), " +
+      "**Returns:** The new network's networkId (UUID) and title. Use the networkId to add members (create_network_membership), " +
       "link intents (create_intent_index), or run discovery (discover_opportunities with networkId).",
     querySchema: z.object({
-      title: z.string().describe("Display name of the index (e.g. 'AI Founders Berlin', 'Design Co-op'). Required."),
-      prompt: z.string().optional().describe("Description of what this community is about (e.g. 'Early-stage AI/ML founders in Berlin looking for co-founders, advisors, and investors'). Used by the system to evaluate which intents belong in this index. Highly recommended for better auto-assignment."),
+      title: z.string().describe("Display name of the network (e.g. 'AI Founders Berlin', 'Design Co-op'). Required."),
+      prompt: z.string().optional().describe("Description of what this community is about (e.g. 'Early-stage AI/ML founders in Berlin looking for co-founders, advisors, and investors'). Used by the system to evaluate which intents belong in this network. Highly recommended for better auto-assignment."),
       imageUrl: z.string().url().optional().describe("URL for the community's avatar/image. Optional."),
       joinPolicy: z.enum(['anyone', 'invite_only']).optional().describe("'anyone' = open (any user can self-join), 'invite_only' = only the owner can add members. Defaults to 'invite_only'."),
     }),
@@ -479,35 +472,33 @@ export function createNetworkTools(defineTool: DefineTool, deps: ToolDeps) {
             _graphTimings: [{ name: 'index', durationMs: _createNetworkGraphMs, agents: result.agentTimings ?? [] }],
           });
         }
-        return error(result.mutationResult.error || "Failed to create index.");
+        return error(result.mutationResult.error || "Failed to create network.");
       }
-      return error("Failed to create index.");
+      return error("Failed to create network.");
     },
   });
 
   const deleteNetwork = defineTool({
     name: "delete_network",
     description:
-      "Permanently deletes an index (community). Only the owner can delete, and the index must have no other members " +
-      "(remove all members first with delete_network_membership). Personal indexes cannot be deleted.\n\n" +
-      "**When to use:** When the owner wants to disband a community. This is irreversible — all intent-index links to this index are removed.\n\n" +
+      "Permanently deletes a network (community). Only the owner can delete, and the network must have no other members " +
+      "(remove all members first with delete_network_membership). Personal networks cannot be deleted.\n\n" +
+      "**When to use:** When the owner wants to disband a community. This is irreversible — all intent-network links to this network are removed.\n\n" +
       "**Prerequisites:** Must be the owner. Must be the sole remaining member (remove others first).\n\n" +
-      "**Returns:** Confirmation that the index was deleted.",
+      "**Returns:** Confirmation that the network was deleted.",
     querySchema: z.object({
-      networkId: z.string().optional().describe("Index UUID to delete. Get from read_networks. Defaults to the scoped index in index-scoped chats. Cannot be a personal index."),
+      networkId: z.string().optional().describe("Network UUID to delete. Get from read_networks. Defaults to the scoped index in network-scoped chats. Cannot be a personal network."),
     }),
     handler: async ({ context, query }) => {
-      const scopedNetworkId = focusedNetworkId(context);
-      const scopedIndexLabel = focusedNetworkLabel(context);
-      const networkId = query.networkId?.trim() || scopedNetworkId;
+      const networkId = query.networkId?.trim() || context.networkId;
       if (!networkId || !UUID_REGEX.test(networkId)) {
         return error("Valid networkId required.");
       }
 
-      // Strict scope enforcement: when chat is index-scoped, only allow deleting that index
-      if (scopedNetworkId && networkId !== scopedNetworkId) {
+      // Strict scope enforcement: when chat is network-scoped, only allow deleting that index
+      if (context.networkId && networkId !== context.networkId) {
         return error(
-          `This chat is scoped to ${scopedIndexLabel}. You can only delete this community.`
+          `This chat is scoped to ${context.indexName ?? 'this network'}. You can only delete this community.`
         );
       }
 
@@ -523,7 +514,7 @@ export function createNetworkTools(defineTool: DefineTool, deps: ToolDeps) {
       _deleteNetworkTraceEmitter?.({ type: "graph_end", name: "index", durationMs: _deleteNetworkGraphMs });
 
       if (result.mutationResult && !result.mutationResult.success) {
-        return error(result.mutationResult.error || "Failed to delete index.");
+        return error(result.mutationResult.error || "Failed to delete network.");
       }
       return success({ message: "Network deleted.", _graphTimings: [{ name: 'index', durationMs: _deleteNetworkGraphMs, agents: result.agentTimings ?? [] }] });
     },
@@ -532,31 +523,29 @@ export function createNetworkTools(defineTool: DefineTool, deps: ToolDeps) {
   const createNetworkMembership = defineTool({
     name: "create_network_membership",
     description:
-      "Adds a user as a member of an index (community). Membership enables the user to post intents in the index and be discovered " +
+      "Adds a user as a member of a network (community). Membership enables the user to post intents in the network and be discovered " +
       "by other members through opportunity matching.\n\n" +
       "**Usage modes:**\n" +
-      "- Omit userId: self-join (only works for indexes with joinPolicy 'anyone').\n" +
-      "- With userId: add another user (only the index owner can do this for 'invite_only' indexes).\n\n" +
-      "**When to use:** When the user wants to join an open community, or when an index owner wants to invite someone.\n\n" +
+      "- Omit userId: self-join (only works for networks with joinPolicy 'anyone').\n" +
+      "- With userId: add another user (only the network owner can do this for 'invite_only' indexes).\n\n" +
+      "**When to use:** When the user wants to join an open community, or when a network owner wants to invite someone.\n\n" +
       "**Returns:** Confirmation that the member was added (or a note that they were already a member). " +
-      "After joining, the user's existing intents with autoAssign=true may be evaluated against the new index.",
+      "After joining, the user's existing intents with autoAssign=true may be evaluated against the new network.",
     querySchema: z.object({
-      userId: z.string().optional().describe("User ID to add as a member. Omit to join the index yourself. Get user IDs from read_user_contexts(query=name) or read_network_memberships."),
-      networkId: z.string().optional().describe("Index UUID to add the member to. Get from read_networks. Defaults to the scoped index in index-scoped chats."),
+      userId: z.string().optional().describe("User ID to add as a member. Omit to join the network yourself. Get user IDs from read_user_contexts(query=name) or read_network_memberships."),
+      networkId: z.string().optional().describe("Network UUID to add the member to. Get from read_networks. Defaults to the scoped index in network-scoped chats."),
     }),
     handler: async ({ context, query }) => {
-      const scopedNetworkId = focusedNetworkId(context);
-      const scopedIndexLabel = focusedNetworkLabel(context);
-      const networkId = query.networkId?.trim() || scopedNetworkId;
+      const networkId = query.networkId?.trim() || context.networkId;
       const targetUserId = query.userId?.trim() || context.userId;
       if (!networkId || !UUID_REGEX.test(networkId)) {
-        return error("Invalid index ID format. Use the exact UUID from read_networks.");
+        return error("Invalid network ID format. Use the exact UUID from read_networks.");
       }
 
-      // Strict scope enforcement: when chat is index-scoped, only allow adding to that index
-      if (scopedNetworkId && networkId !== scopedNetworkId) {
+      // Strict scope enforcement: when chat is network-scoped, only allow adding to that index
+      if (context.networkId && networkId !== context.networkId) {
         return error(
-          `This chat is scoped to ${scopedIndexLabel}. You can only add members to this community.`
+          `This chat is scoped to ${context.indexName ?? 'this network'}. You can only add members to this community.`
         );
       }
 
@@ -590,20 +579,18 @@ export function createNetworkTools(defineTool: DefineTool, deps: ToolDeps) {
   const deleteNetworkMembership = defineTool({
     name: "delete_network_membership",
     description:
-      "Removes a user from an index (community). After removal, the user's intents are unlinked from this index " +
+      "Removes a user from a network (community). After removal, the user's intents are unlinked from this network " +
       "and they can no longer participate in opportunity discovery within it.\n\n" +
-      "**Permissions:** Only the index owner can remove members. The owner themselves cannot be removed (delete the index instead).\n\n" +
-      "**When to use:** When an index owner wants to remove a member from the community. " +
+      "**Permissions:** Only the network owner can remove members. The owner themselves cannot be removed (delete the network instead).\n\n" +
+      "**When to use:** When a network owner wants to remove a member from the community. " +
       "Use read_network_memberships(networkId) first to get the userId of the member to remove.\n\n" +
       "**Returns:** Confirmation that the member was removed.",
     querySchema: z.object({
-      userId: z.string().describe("User ID of the member to remove. Get from read_network_memberships(networkId). Cannot be the index owner."),
-      networkId: z.string().optional().describe("Index UUID to remove the member from. Get from read_networks. Defaults to the scoped index in index-scoped chats."),
+      userId: z.string().describe("User ID of the member to remove. Get from read_network_memberships(networkId). Cannot be the network owner."),
+      networkId: z.string().optional().describe("Network UUID to remove the member from. Get from read_networks. Defaults to the scoped index in network-scoped chats."),
     }),
     handler: async ({ context, query }) => {
-      const scopedNetworkId = focusedNetworkId(context);
-      const scopedIndexLabel = focusedNetworkLabel(context);
-      const networkId = query.networkId?.trim() || scopedNetworkId;
+      const networkId = query.networkId?.trim() || context.networkId;
       const targetUserId = query.userId?.trim();
 
       if (!networkId || !UUID_REGEX.test(networkId)) {
@@ -613,10 +600,10 @@ export function createNetworkTools(defineTool: DefineTool, deps: ToolDeps) {
         return error("userId is required.");
       }
 
-      // Strict scope enforcement: when chat is index-scoped, only allow that index
-      if (scopedNetworkId && networkId !== scopedNetworkId) {
+      // Strict scope enforcement: when chat is network-scoped, only allow that index
+      if (context.networkId && networkId !== context.networkId) {
         return error(
-          `This chat is scoped to ${scopedIndexLabel}. You can only manage members of this community.`
+          `This chat is scoped to ${context.indexName ?? 'this network'}. You can only manage members of this community.`
         );
       }
 

--- a/packages/protocol/src/network/tests/mcp-batch1-network.graph.spec.ts
+++ b/packages/protocol/src/network/tests/mcp-batch1-network.graph.spec.ts
@@ -3,11 +3,11 @@ import { describe, expect, test } from "bun:test";
 import { NetworkGraphFactory } from "../network.graph.js";
 
 describe("NetworkGraphFactory MCP Batch 1 read serialization", () => {
-  test("scoped read includes the personal index alongside the bound network", async () => {
+  test("scoped read includes the personal network alongside the bound network", async () => {
     // Scenario: a network-scoped agent (or a user-driven community-scoped chat)
     // calls read_networks with state.networkId set to the bound community.
     // The response must include BOTH that community AND the user's personal
-    // index — the personal index is reachable in every allowed-network scope
+    // index — the personal network is reachable in every allowed-network scope
     // so add_contact / list_contacts work, and dropping
     // it from the read_networks payload made those tools undiscoverable.
     const personalNetworkId = "11111111-1111-4111-8111-111111111111";
@@ -18,7 +18,7 @@ describe("NetworkGraphFactory MCP Batch 1 read serialization", () => {
         {
           networkId: personalNetworkId,
           networkTitle: "My Network",
-          indexPrompt: "Personal index",
+          indexPrompt: "Personal network",
           permissions: ["owner"],
           memberPrompt: null,
           autoAssign: true,
@@ -50,7 +50,7 @@ describe("NetworkGraphFactory MCP Batch 1 read serialization", () => {
         {
           id: personalNetworkId,
           title: "My Network",
-          prompt: "Personal index",
+          prompt: "Personal network",
           memberCount: 0,
           intentCount: 2,
           permissions: { joinPolicy: "invite_only" },
@@ -76,7 +76,7 @@ describe("NetworkGraphFactory MCP Batch 1 read serialization", () => {
     expect(result.readResult.stats.scopeNote).toContain("personal");
   });
 
-  test("scoped read does not duplicate the personal index when the bound network IS personal", async () => {
+  test("scoped read does not duplicate the personal network when the bound network IS personal", async () => {
     const personalNetworkId = "11111111-1111-4111-8111-111111111111";
 
     const graph = new NetworkGraphFactory({
@@ -111,7 +111,7 @@ describe("NetworkGraphFactory MCP Batch 1 read serialization", () => {
     const graph = new NetworkGraphFactory({
       getNetworkMemberships: async () => [{
         networkId: "11111111-1111-4111-8111-111111111111",
-        networkTitle: "Personal Index",
+        networkTitle: "Personal Network",
         indexPrompt: "Private network",
         permissions: ["owner"],
         memberPrompt: null,

--- a/packages/protocol/src/opportunity/opportunity.discover.ts
+++ b/packages/protocol/src/opportunity/opportunity.discover.ts
@@ -706,7 +706,7 @@ export async function runDiscoverFromQuery(
         searchQuery: queryOrEmpty || undefined,
         // A single index resolves to the strict networkId override (membership-
         // validated in the scope node). Multiple indexes (e.g. a network-scoped
-        // agent's bound network + personal index) pass through as indexScope so
+        // agent's bound network + personal network) pass through as indexScope so
         // the graph stays bounded instead of falling back to all networks.
         networkId: indexScope.length === 1 ? indexScope[0] : undefined,
         ...(indexScope.length > 1 ? { indexScope } : {}),
@@ -1215,7 +1215,7 @@ export async function continueDiscovery(input: {
   cache: Cache;
   userId: string;
   discoveryId: string;
-  /** If provided, validates the cached session's indexScope contains this index. */
+  /** If provided, validates the cached session's indexScope contains this network. */
   expectedIndexId?: string;
   limit?: number;
   chatSessionId?: string;

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -240,8 +240,8 @@ export class OpportunityGraphFactory {
 
     /**
      * Node 0: Prep
-     * Fetches user's index memberships and validates requirements.
-     * Returns empty if user has no index memberships (requirement).
+     * Fetches user's network memberships and validates requirements.
+     * Returns empty if user has no network memberships (requirement).
      */
     const prepNode = withNodeTrace(
       "opportunity-prep",
@@ -371,7 +371,7 @@ export class OpportunityGraphFactory {
             }
             targetIndexIds = [state.networkId];
           } else if (state.indexScope && state.indexScope.length > 0) {
-            // Bounded scope (e.g. a network-scoped agent's reachable indexes):
+            // Bounded scope (e.g. a network-scoped agent's reachable networks):
             // intersect with the user's actual memberships so discovery never
             // reaches networks outside the agent's bound scope.
             const allowed = new Set(state.indexScope);
@@ -432,7 +432,7 @@ export class OpportunityGraphFactory {
                 }
                 const _indexerStart = Date.now();
                 const traceEmitter = requestContext.getStore()?.traceEmitter;
-                traceEmitter?.({ type: "agent_start", name: "intent-indexer" });
+                traceEmitter?.({ type: "agent_start", name: "intent-networker" });
                 let result: Awaited<ReturnType<typeof indexer.invoke>> | null = null;
                 try {
                   result = await indexer.invoke(
@@ -444,7 +444,7 @@ export class OpportunityGraphFactory {
                   return { networkId: ti.networkId, score: 1.0 };
                 } finally {
                   const _indexerDuration = Date.now() - _indexerStart;
-                  traceEmitter?.({ type: "agent_end", name: "intent-indexer", durationMs: _indexerDuration, summary: `Scored index ${ti.networkId}` });
+                  traceEmitter?.({ type: "agent_end", name: "intent-networker", durationMs: _indexerDuration, summary: `Scored index ${ti.networkId}` });
                   scopeAgentTimings.push({ name: 'intent.indexer', durationMs: _indexerDuration });
                 }
                 if (!result) return { networkId: ti.networkId, score: 1.0 };
@@ -517,7 +517,7 @@ export class OpportunityGraphFactory {
       "opportunity-resolve",
       async (state: typeof OpportunityGraphState.State) => {
       return timed("OpportunityGraph.resolve", async () => {
-        logger.verbose('[Graph:Resolve] Resolving intent and index membership', {
+        logger.verbose('[Graph:Resolve] Resolving intent and network membership', {
           triggerIntentId: state.triggerIntentId,
           hasSearchQuery: !!state.searchQuery,
           indexedIntentsCount: state.indexedIntents.length,
@@ -636,7 +636,7 @@ export class OpportunityGraphFactory {
 
           // ── Direct-connection fast path ──
           // When targetUserId is set (user @-mentioned someone), bypass vector search
-          // and construct candidates directly from shared indexes.
+          // and construct candidates directly from shared networks.
           if (state.targetUserId) {
             if (state.targetUserId === discoveryUserId) {
               logger.warn('[Graph:Discovery] Direct-connection target matches discoverer; skipping self-match', {
@@ -680,7 +680,7 @@ export class OpportunityGraphFactory {
             const directCandidates: CandidateMatch[] = [];
 
             if (targetIntents.length > 0) {
-              // Build one candidate per intent per shared index it belongs to
+              // Build one candidate per intent per shared network it belongs to
               for (const intent of targetIntents) {
                 const intentNetworkIds = await this.database.getNetworkIdsForIntent(intent.id);
                 const overlapping = sharedIndexIds.filter(id => intentNetworkIds.includes(id));
@@ -722,7 +722,7 @@ export class OpportunityGraphFactory {
               candidates: directCandidates,
               trace: [{
                 node: "discovery",
-                detail: `Direct connection → ${directCandidates.length} candidate(s) from ${sharedIndexIds.length} shared index(es)`,
+                detail: `Direct connection → ${directCandidates.length} candidate(s) from ${sharedIndexIds.length} shared network(es)`,
                 data: {
                   targetUserId: state.targetUserId,
                   candidateCount: directCandidates.length,
@@ -1780,10 +1780,10 @@ export class OpportunityGraphFactory {
             const score = evaluated?.score;
             const reasoning = evaluated?.reasoning;
             const didPass = score !== undefined && score >= minScore;
-            const status = score !== undefined 
-              ? (didPass ? '✓ passed' : `✗ score ${score}`) 
+            const status = score !== undefined
+              ? (didPass ? '✓ passed' : `✗ score ${score}`)
               : '✗ not scored';
-            
+
             traceEntries.push({
               node: "candidate",
               detail: `${candidateName}: ${status}`,
@@ -2310,7 +2310,7 @@ export class OpportunityGraphFactory {
 
     /**
      * Node: intro_validation (create_introduction path)
-     * Validates index scope, membership for introducer and all party users, and no existing opportunity.
+     * Validates network scope, membership for introducer and all party users, and no existing opportunity.
      */
     const introValidationNode = async (state: typeof OpportunityGraphState.State) => {
       return timed("OpportunityGraph.introValidation", async () => {

--- a/packages/protocol/src/opportunity/opportunity.introducer.ts
+++ b/packages/protocol/src/opportunity/opportunity.introducer.ts
@@ -2,7 +2,7 @@
  * Introducer Discovery: proactive discovery of connector-flow opportunities
  * between a user's contacts.
  *
- * Selects top-N contacts from the user's personal index and runs scoped
+ * Selects top-N contacts from the user's personal network and runs scoped
  * HyDE discovery for each, creating latent introducer opportunities that
  * the user (as introducer) must approve before parties see them.
  */
@@ -31,9 +31,9 @@ export interface ContactWithIntents {
 
 /** Database methods needed for introducer discovery contact selection. */
 export interface IntroducerDiscoveryDatabase {
-  /** Get the user's personal index ID. */
+  /** Get the user's personal network ID. */
   getPersonalIndexId(userId: string): Promise<string | null>;
-  /** Get contacts from a personal index with their intent freshness data. */
+  /** Get contacts from a personal network with their intent freshness data. */
   getContactsWithIntentFreshness(
     personalIndexId: string,
     ownerId: string,
@@ -72,7 +72,7 @@ export async function selectContactsForDiscovery(
 ): Promise<ContactWithIntents[]> {
   const personalIndexId = await database.getPersonalIndexId(userId);
   if (!personalIndexId) {
-    logger.verbose(`[IntroducerDiscovery] No personal index found — userId=${userId}`);
+    logger.verbose(`[IntroducerDiscovery] No personal network found — userId=${userId}`);
     return [];
   }
 

--- a/packages/protocol/src/opportunity/opportunity.state.ts
+++ b/packages/protocol/src/opportunity/opportunity.state.ts
@@ -9,9 +9,9 @@ import type { DiscoveryNegotiation, DiscoverySummary } from "./question.prompt.j
 
 /**
  * Opportunity Graph State (Linear Multi-Step Workflow)
- * 
+ *
  * Flow: Prep → Scope → Discovery → Evaluation → Ranking → Persist → END
- * 
+ *
  * Following the intent graph pattern with Annotation-based state management.
  */
 
@@ -186,12 +186,12 @@ export const OpportunityGraphState = Annotation.Root({
     reducer: (curr, next) => next ?? curr,
     default: () => '' as Id<'users'>,
   }),
-  
+
   searchQuery: Annotation<string | undefined>({
     reducer: (curr, next) => next ?? curr,
     default: () => undefined,
   }),
-  
+
   networkId: Annotation<Id<'networks'> | undefined>({
     reducer: (curr, next) => next ?? curr,
     default: () => undefined,
@@ -199,7 +199,7 @@ export const OpportunityGraphState = Annotation.Root({
 
   /**
    * Optional set of indexes discovery may search within (e.g. a network-scoped
-   * agent's reachable indexes: the bound network plus the user's personal index).
+   * agent's reachable networks: the bound network plus the user's personal network).
    * The scope node intersects this with the user's actual memberships. Ignored
    * when `networkId` is set (single-network override). When unset, discovery
    * spans all of the user's networks.
@@ -321,21 +321,21 @@ export const OpportunityGraphState = Annotation.Root({
     reducer: (curr, next) => next ?? curr,
     default: () => undefined,
   }),
-  
+
   // ─── Intermediate Fields (Accumulated) ───
-  
+
   /** User's indexed intents with hyde documents (from prep) */
   indexedIntents: Annotation<IndexedIntent[]>({
     reducer: (curr, next) => next ?? curr,
     default: () => [],
   }),
-  
+
   /** User's network memberships (from prep) */
   userNetworks: Annotation<Id<'networks'>[]>({
     reducer: (curr, next) => next ?? curr,
     default: () => [],
   }),
-  
+
   /** Target indexes to search within (from scope) */
   targetNetworks: Annotation<TargetNetwork[]>({
     reducer: (curr, next) => next ?? curr,
@@ -401,7 +401,7 @@ export const OpportunityGraphState = Annotation.Root({
     reducer: (curr, next) => next ?? curr,
     default: () => ({}),
   }),
-  
+
   /** Candidate matches from semantic search (from discovery) */
   candidates: Annotation<CandidateMatch[]>({
     reducer: (curr, next) => next ?? curr,
@@ -431,9 +431,9 @@ export const OpportunityGraphState = Annotation.Root({
     reducer: (curr, next) => next ?? curr,
     default: () => [],
   }),
-  
+
   // ─── Output Fields (Overwrite per turn) ───
-  
+
   /** Final ranked and persisted opportunities */
   opportunities: Annotation<Opportunity[]>({
     reducer: (curr, next) => next,
@@ -450,7 +450,7 @@ export const OpportunityGraphState = Annotation.Root({
     reducer: (curr, next) => next ?? curr,
     default: () => [],
   }),
-  
+
   /** Error message if any step fails */
   error: Annotation<string | undefined>({
     reducer: (curr, next) => next,

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -466,7 +466,7 @@ export function buildOpportunityPresentation(
  * Encoded as JSON of a normalized object — NOT a delimiter join — so a
  * user-supplied string containing the delimiter can never make two distinct
  * requests collide. `hint` and each entity's `networkId` are included because
- * they change the discovery result (different reason / different shared index),
+ * they change the discovery result (different reason / different shared network),
  * so requests that differ only in those must NOT coalesce. Natural-language
  * fields (`searchQuery`, `hint`) are lowercased; identifiers and the opaque
  * `continueFrom` pagination token are only trimmed (case-sensitive) so distinct
@@ -557,9 +557,9 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
       "Opportunities are the core output of the discovery engine, representing potential valuable connections between people.\n\n" +
       "**NOT for person lookup** — use read_user_contexts(query=name) to find people by name.\n\n" +
       "**Four modes:**\n" +
-      "1. **Discovery** (most common): pass `searchQuery` and/or `networkId`. The system finds other users in shared indexes " +
+      "1. **Discovery** (most common): pass `searchQuery` and/or `networkId`. The system finds other users in shared networkes " +
       "whose intents semantically complement the query. Uses HyDE embeddings and LLM evaluation for scoring.\n" +
-      "2. **Introduction**: pass `partyUserIds` (2+ user IDs) + `entities` (pre-gathered profiles and intents from shared indexes). " +
+      "2. **Introduction**: pass `partyUserIds` (2+ user IDs) + `entities` (pre-gathered profiles and intents from shared networkes). " +
       "You MUST call read_user_contexts and read_intents for each party BEFORE calling this. " +
       "Optionally pass `hint` with the user's reason for the introduction.\n" +
       "3. **Direct connection**: pass `targetUserId` + `searchQuery`. Creates an opportunity between the current user and one specific person.\n" +
@@ -577,13 +577,13 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
       "Do NOT call create_intent for these phrasings — create_intent is only for when the user explicitly " +
       "asks to \"create\", \"save\", \"add\", or \"remember\" a signal.\n\n" +
       "**Personal-index scoping.** When the user says \"in my network\", \"from my contacts\", \"people I know\", " +
-      "or similar scoping language, pass the user's personal index ID (from memberships where `isPersonal: true`) " +
-      "as `networkId`. The personal index contains the user's contacts — scoping discovery to it restricts " +
+      "or similar scoping language, pass the user's personal network ID (from memberships where `isPersonal: true`) " +
+      "as `networkId`. The personal network contains the user's contacts — scoping discovery to it restricts " +
       "results to people the user already knows. Without this scoping language, omit networkId to let discovery " +
-      "run across all indexes.\n\n" +
+      "run across all networks.\n\n" +
       "**Introduction mode prerequisites.** When using `partyUserIds` + `entities`, YOU must pre-fetch each party's " +
       "profile and intents before calling this tool. The entities array must include each party's userId, profile, " +
-      "intents from shared indexes, and the shared networkId. Call read_user_contexts, read_network_memberships, " +
+      "intents from shared networkes, and the shared networkId. Call read_user_contexts, read_network_memberships, " +
       "and read_intents for both parties first. The introducer (current user) must NOT appear in entities.\n\n" +
       "**Signal-visibility follow-up.** If the response includes `suggestIntentCreationForVisibility: true` and " +
       "`suggestedIntentDescription`, after presenting opportunity cards ask the user ONCE whether they'd also like " +
@@ -602,7 +602,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
       networkId: z
         .string()
         .optional()
-        .describe("Index UUID to scope discovery to a specific community. Get from read_networks. In an index-scoped chat, omitting this runs discovery only in the scoped community; pass the personal index ID (from read_networks, isPersonal=true) only when the user explicitly asks to discover among contacts."),
+        .describe("Network UUID to scope discovery to a specific community. Get from read_networks. In an network-scoped chat, omitting this runs discovery only in the scoped community; pass the personal network ID (from read_networks, isPersonal=true) only when the user explicitly asks to discover among contacts."),
       intentId: z
         .string()
         .optional()
@@ -649,15 +649,15 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
               .optional(),
             networkId: z
               .string()
-              .describe("Shared index this entity's data comes from (required for intro mode)"),
+              .describe("Shared network this entity's data comes from (required for intro mode)"),
           }),
         )
         .optional()
         .describe(
           "Introduction mode: pre-gathered profile and intent data for each party being introduced. " +
-          "Each entry needs userId, networkId (the shared index), and optionally profile (name, bio, skills, interests) and intents (intentId, payload). " +
+          "Each entry needs userId, networkId (the shared network), and optionally profile (name, bio, skills, interests) and intents (intentId, payload). " +
           "Gather this data by calling read_user_contexts and read_intents for each party BEFORE calling discover_opportunities. " +
-          "All entities must share the same networkId (the shared index where both parties are members).",
+          "All entities must share the same networkId (the shared network where both parties are members).",
         ),
       hint: z
         .string()
@@ -671,7 +671,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
       const scopedNetworkId = focusedNetworkId(context);
       const scopedIndexLabel = focusedNetworkLabel(context);
 
-      // Strict scope enforcement: when chat is index-scoped, only allow that index
+      // Strict scope enforcement: when chat is network-scoped, only allow that index
       if (
         scopedNetworkId &&
         query.networkId?.trim() &&
@@ -1083,7 +1083,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         indexScope = [effectiveIndexId];
       } else if (context.scopeType === 'network' && context.scopeId) {
         // Scoped chat: discovery is focused-network only. Self-owned writes may
-        // include personal indexes, but opportunity visibility must not.
+        // include personal networkes, but opportunity visibility must not.
         const scopedDiscoveryIds = deriveDiscoveryNetworkIds({
           memberships: context.userNetworks,
           scopeType: context.scopeType,
@@ -1094,7 +1094,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         // Scoped context: preserve focused-only discovery using the scope envelope.
         indexScope = [scopedNetworkId];
       } else {
-        // No scope - use all indexes (only in unscoped chat)
+        // No scope - use all networks (only in unscoped chat)
         const _scopeGraphStart = Date.now();
         const _scopeIndexTraceEmitter = requestContext.getStore()?.traceEmitter;
         _scopeIndexTraceEmitter?.({ type: "graph_start", name: "index" });
@@ -1543,7 +1543,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
     name: "list_opportunities",
     description:
       "Lists the authenticated user's actionable opportunities (discovered connections). Returns opportunity cards ready for display.\n\n" +
-      "**What are opportunities?** Matches between users whose intents complement each other within shared indexes. " +
+      "**What are opportunities?** Matches between users whose intents complement each other within shared networkes. " +
       "Each opportunity has a status: draft (not yet sent), pending (sent, awaiting response), accepted, rejected, or expired.\n\n" +
       "**What this returns:** Only draft and pending opportunities — the ones the user can still act on. " +
       "Accepted, rejected, and expired ones are not surfaced through this tool.\n\n" +
@@ -1554,7 +1554,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
       networkId: z
         .string()
         .optional()
-        .describe("Index UUID to filter opportunities to a specific community. Get from read_networks. Defaults to the scoped index in index-scoped chats. Omit to see opportunities across all indexes."),
+        .describe("Network UUID to filter opportunities to a specific community. Get from read_networks. Defaults to the scoped network in network-scoped chats. Omit to see opportunities across all networks."),
       includeDigestMarkers: z
         .boolean()
         .optional()
@@ -1564,7 +1564,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
       const scopedNetworkId = focusedNetworkId(context);
       const scopedIndexLabel = focusedNetworkLabel(context);
 
-      // Strict scope enforcement: when chat is index-scoped, only allow that index
+      // Strict scope enforcement: when chat is network-scoped, only allow that index
       if (
         scopedNetworkId &&
         query.networkId?.trim() &&
@@ -2166,7 +2166,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         return error(`This opportunity is already ${opportunity.status} and cannot be updated.`);
       }
 
-      // Strict scope enforcement: when chat is index-scoped, the caller's own
+      // Strict scope enforcement: when chat is network-scoped, the caller's own
       // actor entry on this opportunity must be anchored on the bound network.
       // Mirrors the per-actor filter in getOpportunitiesForUser — relying on
       // a focus-scope id or any-actor matches would let a counterpart's network

--- a/packages/protocol/src/opportunity/tests/opportunity.graph.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.graph.spec.ts
@@ -236,7 +236,7 @@ function createMockGraphWithFnOverrides(deps?: {
 
 describe('Opportunity Graph', () => {
   describe('Prep node', () => {
-    test('when user has no index memberships, returns error and no opportunities', async () => {
+    test('when user has no network memberships, returns error and no opportunities', async () => {
       const { compiledGraph, mockHydeGenerator, mockEmbedder } = createMockGraph({
         getUserIndexIds: () => Promise.resolve([]),
       });
@@ -317,7 +317,7 @@ describe('Opportunity Graph', () => {
       await compiledGraph.invoke({
         userId: 'a0000000-0000-4000-8000-000000000001' as Id<'users'>,
         searchQuery: 'co-founder',
-        // A network-scoped agent reaches only its bound network + personal index;
+        // A network-scoped agent reaches only its bound network + personal network;
         // idx-3 is another network the user belongs to and must not be searched.
         indexScope: ['idx-1', 'idx-2'] as Id<'networks'>[],
         options: { limit: 5 },
@@ -333,7 +333,7 @@ describe('Opportunity Graph', () => {
   });
 
   describe('Discovery node', () => {
-    test('performs vector search with index scope and excludeUserId', async () => {
+    test('performs vector search with network scope and excludeUserId', async () => {
       const { compiledGraph, mockEmbedder } = createMockGraph();
       const searchSpy = spyOn(mockEmbedder, 'searchWithHydeEmbeddings').mockResolvedValue([
         {
@@ -1290,7 +1290,7 @@ describe('Opportunity Graph', () => {
   });
 
   describe('Conditional routing: early exit', () => {
-    test('when no index memberships, full invoke does not call HyDE or search or createOpportunity', async () => {
+    test('when no network memberships, full invoke does not call HyDE or search or createOpportunity', async () => {
       const { compiledGraph, mockDb, mockHydeGenerator, mockEmbedder } = createMockGraph({
         getUserIndexIds: () => Promise.resolve([]),
       });
@@ -1476,7 +1476,7 @@ describe('Opportunity Graph', () => {
       expect(result.opportunities?.length ?? 0).toBe(0);
     });
 
-    test('when introducer is not index member returns error', async () => {
+    test('when introducer is not network member returns error', async () => {
       const { compiledGraph, mockDb } = createMockGraph();
       spyOn(mockDb, 'isNetworkMember').mockImplementation(async (networkId: string, userId: string) => {
         if (userId === 'a0000000-0000-4000-8000-000000000001') return false;
@@ -1992,7 +1992,7 @@ describe('Opportunity Graph', () => {
       expect(targetCandidate!.candidateIntentId).toBeUndefined();
     });
 
-    test('no shared indexes returns empty candidates with per-userId memberships', async () => {
+    test('no shared networks returns empty candidates with per-userId memberships', async () => {
       const mockDb: OpportunityGraphDatabase = {
         getProfile: () => Promise.resolve(null),
         createOpportunity: (data) => Promise.resolve({
@@ -2051,7 +2051,7 @@ describe('Opportunity Graph', () => {
         options: {},
       } as OpportunityGraphInvokeInput)) as OpportunityGraphInvokeResult;
 
-      // No shared indexes → 0 candidates
+      // No shared networks → 0 candidates
       expect(result.candidates.length).toBe(0);
     });
 

--- a/packages/protocol/src/premise/premise.indexer.ts
+++ b/packages/protocol/src/premise/premise.indexer.ts
@@ -15,7 +15,7 @@ Determine if a User Premise (a self-descriptive proposition about who someone is
 
 INPUTS:
 1. Premise: A self-description the user asserts about themselves.
-2. Index Prompt: The purpose/scope of the target community (Index).
+2. Network Prompt: The purpose/scope of the target community (Index).
 3. Member Prompt: The specific sharing preferences of the user in that community (optional).
 
 SCORING RUBRIC:
@@ -26,7 +26,7 @@ SCORING RUBRIC:
 - 0.0-0.2: Not relevant. The premise has no connection to this community.
 
 OUTPUT RULES:
-- Provide indexScore based on how well the Premise fits the Index Prompt.
+- Provide indexScore based on how well the Premise fits the Network Prompt.
 - Provide memberScore based on how well the Premise fits the Member Prompt (if provided). If Member Prompt is missing/empty, return 0.0.
 - Provide concise reasoning.
 `;
@@ -55,7 +55,7 @@ export class PremiseIndexer {
   /**
    * Scores the relevancy of a premise to a network index and member preferences.
    *
-   * @param input - The premise text, index prompt, member prompt, and optional network context.
+   * @param input - The premise text, network prompt, member prompt, and optional network context.
    * @returns Structured output with indexScore, memberScore, and reasoning.
    */
   @Timed()
@@ -71,8 +71,8 @@ export class PremiseIndexer {
       "# Premise",
       input.premiseText,
       "",
-      "# Index Prompt",
-      input.indexPrompt || "(No index prompt provided)",
+      "# Network Prompt",
+      input.indexPrompt || "(No network prompt provided)",
       "",
       "# Member Prompt",
       input.memberPrompt || "(No member prompt provided)",

--- a/packages/protocol/src/questioner/questioner.tools.ts
+++ b/packages/protocol/src/questioner/questioner.tools.ts
@@ -95,7 +95,7 @@ export function createQuestionerTools(defineTool: DefineTool, deps: ToolDeps) {
               isScoped: true,
               scopedToIndex: focusedNetworkLabel(context),
               message:
-                `Results are restricted to "${context.indexName ?? "this index"}" and ` +
+                `Results are restricted to "${context.indexName ?? "this network"}" and ` +
                 `exclude negotiation questions because this agent is scoped to that index.`,
             },
           });

--- a/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
+++ b/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
@@ -30,7 +30,7 @@ mock.module("../../../intent/intent.graph.js", () => ({
         }) => {
           // For read operations, replicate the real queryNode logic using the database
           if (input.operationMode === "read") {
-            // Scope-aware default: caller's intents across all reachable indexes.
+            // Scope-aware default: caller's intents across all reachable networks.
             // Triggered when the tool layer passed indexScope and did not pick a
             // specific networkId or queryUserId.
             if (
@@ -85,7 +85,7 @@ mock.module("../../../intent/intent.graph.js", () => ({
                       userId: i.userId,
                       userName: i.userName,
                     })),
-                    ...(intents.length === 0 && { message: "No intents in this index yet." }),
+                    ...(intents.length === 0 && { message: "No intents in this network yet." }),
                   },
                 };
               }
@@ -109,7 +109,7 @@ mock.module("../../../intent/intent.graph.js", () => ({
               };
             }
 
-            // No index scope: return user's own active intents
+            // No network scope: return user's own active intents
             const intents = await db.getActiveIntents(input.userId);
             return {
               readResult: {
@@ -124,7 +124,7 @@ mock.module("../../../intent/intent.graph.js", () => ({
             };
           }
 
-          // For update/delete with index scope: enforce index scoping (intent must be in index)
+          // For update/delete with network scope: enforce index scoping (intent must be in index)
           if (
             (input.operationMode === "update" || input.operationMode === "delete") &&
             input.networkId &&
@@ -153,7 +153,7 @@ mock.module("../../../intent/intent.graph.js", () => ({
             };
           }
 
-          // For non-read operations without index scope, return default empty results
+          // For non-read operations without network scope, return default empty results
           return {
             executionResults: [],
             actions: [],
@@ -524,7 +524,7 @@ describe("read_intents tool", () => {
   });
 });
 
-describe("read_intents tool (index-scoped: owner vs member)", () => {
+describe("read_intents tool (network-scoped: owner vs member)", () => {
   const networkId = testIndexId;
   const allIndexIntents: IndexedIntentDetails[] = [
     { id: "ix-1", payload: "Intent from Alice", summary: "Alice", userId: "user-alice", userName: "Alice", createdAt: new Date("2025-01-01") },
@@ -888,7 +888,7 @@ describe("read_network_memberships tool (list members)", () => {
       isNetworkMember: async () => true,
       getNetworkMembersForMember: async (networkId, uid) => {
         if (networkId === memberIndexId && uid === testUserId) return mockMembers;
-        throw new Error("Access denied: Not a member of this index");
+        throw new Error("Access denied: Not a member of this network");
       },
     });
     const context: ToolContext = { userId: testUserId, database: mockDb, embedder: mockEmbedder, scraper: mockScraper, ...mockProtocolDeps };
@@ -926,11 +926,11 @@ describe("read_network_memberships tool (list members)", () => {
     const result = await tool.invoke({ networkId: "not-a-uuid" });
     const parsed = JSON.parse(result);
     expect(parsed.success).toBe(false);
-    expect(parsed.error).toMatch(/Invalid index ID/i);
+    expect(parsed.error).toMatch(/Invalid network ID/i);
   });
 });
 
-describe("create_intent tool (Phase 2 index scope)", () => {
+describe("create_intent tool (Phase 2 network scope)", () => {
   test("create_intent tool schema includes optional networkId", async () => {
     const mockDb = createMockDatabase(async () => []);
     const context: ToolContext = { userId: testUserId, database: mockDb, embedder: mockEmbedder, scraper: mockScraper, ...mockProtocolDeps };
@@ -1029,7 +1029,7 @@ describe("scrape_url tool", () => {
 describe("read_networks (Phase 3 network-scoped)", () => {
   const scopedIndexId = "a1b2c3d4-0000-4000-8000-000000000010";
 
-  test("when scope envelope is set and showAll not true, returns only current index membership with scopeNote", async () => {
+  test("when scope envelope is set and showAll not true, returns only current network membership with scopeNote", async () => {
     const oneMembership = [{ networkId: scopedIndexId, networkTitle: "Current Index", indexPrompt: null, permissions: [], memberPrompt: null, autoAssign: true, isPersonal: false, joinedAt: new Date() }];
     const mockDb = createMockDatabase(async () => [], {
       getNetworkMemberships: async (uid) => (uid === testUserId ? oneMembership : []),
@@ -1044,7 +1044,7 @@ describe("read_networks (Phase 3 network-scoped)", () => {
     expect(parsed.success).toBe(true);
     expect(parsed.data.memberOf).toHaveLength(1);
     expect(parsed.data.memberOf[0].networkId).toBe(scopedIndexId);
-    expect(parsed.data.stats.scopeNote).toContain("Showing current index");
+    expect(parsed.data.stats.scopeNote).toContain("Showing current network");
   });
 
   test("when scope envelope is set, showAll parameter is ignored (strict scope enforcement)", async () => {
@@ -1064,10 +1064,10 @@ describe("read_networks (Phase 3 network-scoped)", () => {
     const result = await tool.invoke({});
     const parsed = JSON.parse(result);
     expect(parsed.success).toBe(true);
-    // Only returns scoped index, not all 2 memberships - strict scope enforcement
+    // Only returns scoped network, not all 2 memberships - strict scope enforcement
     expect(parsed.data.memberOf).toHaveLength(1);
     expect(parsed.data.memberOf[0].networkId).toBe(scopedIndexId);
-    expect(parsed.data.stats.scopeNote).toContain("Showing current index");
+    expect(parsed.data.stats.scopeNote).toContain("Showing current network");
   });
 
 });
@@ -1166,7 +1166,7 @@ describe("discover_opportunities tool", () => {
     expect(shape?.intentId).toBeDefined();
   });
 
-  test("when user has no index memberships (getNetworkMemberships returns []), returns found false with message about joining an index", async () => {
+  test("when user has no network memberships (getNetworkMemberships returns []), returns found false with message about joining a network", async () => {
     const mockDb = createMockDatabase(async () => [], {
       getNetworkMemberships: async () => [],
     });
@@ -1203,7 +1203,7 @@ describe("discover_opportunities tool", () => {
     const tool = tools.find((t: { name: string }) => t.name === "discover_opportunities") as {
       invoke: (args: { partyUserIds?: string[]; entities?: Array<{ userId: string; networkId?: string }> }) => Promise<string>;
     };
-    const errorMessageRe = /networkId|shared index|required/i;
+    const errorMessageRe = /networkId|shared network|required/i;
     try {
       const result = await tool.invoke({
         partyUserIds: [testUserId, "other-user-id"],
@@ -1885,7 +1885,7 @@ describe("read_user_contexts tool (query parameter — name search)", () => {
     } as unknown as SystemDatabase;
   }
 
-  test("query finds a member by name across all indexes", async () => {
+  test("query finds a member by name across all networks", async () => {
     const mockDb = createMockDatabase(async () => []);
     const mockSystemDb = createMockSystemDb();
     const context: ToolContext = { userId: testUserId, database: mockDb, embedder: mockEmbedder, scraper: mockScraper, systemDb: mockSystemDb, ...mockProtocolDeps };

--- a/packages/protocol/src/shared/agent/tool.factory.ts
+++ b/packages/protocol/src/shared/agent/tool.factory.ts
@@ -43,7 +43,7 @@ const logger = protocolLogger("ChatTools");
 
 /**
  * Creates all chat tools bound to a specific user context.
- * Resolves user/index identity from DB at init time.
+ * Resolves user/network identity from DB at init time.
  * Tools are created fresh for each user session to ensure proper isolation.
  *
  * All external dependencies (cache, integration, queue, etc.) are provided

--- a/packages/protocol/src/shared/agent/tool.helpers.ts
+++ b/packages/protocol/src/shared/agent/tool.helpers.ts
@@ -54,7 +54,7 @@ export type CompiledGraph = { invoke: (input: any) => Promise<any> };
 
 /**
  * Resolved context available to every tool handler.
- * Contains the current user and optional index identity, resolved from DB at init.
+ * Contains the current user and optional network identity, resolved from DB at init.
  * The LLM can see this context (via system prompt) but cannot change it.
  */
 export interface ResolvedToolContext {
@@ -69,7 +69,7 @@ export interface ResolvedToolContext {
   /** Focused request scope id. When `scopeType === 'network'`, this is the focused network id. */
   scopeId?: string;
   indexName?: string;
-  /** True when chat is index-scoped and the user owns the index. */
+  /** True when chat is network-scoped and the user owns the index. */
   isOwner?: boolean;
   // Rich identity context for prompt/tool orchestration.
   user: UserRecord;
@@ -131,11 +131,11 @@ export interface ToolContext {
   database: ChatGraphCompositeDatabase;
   /** Context-bound database for accessing the authenticated user's own resources. Created internally if not provided. */
   userDb?: UserDatabase;
-  /** Context-bound database for LLM/system operations on cross-user resources within shared indexes. Created internally if not provided. */
+  /** Context-bound database for LLM/system operations on cross-user resources within shared networks. Created internally if not provided. */
   systemDb?: SystemDatabase;
   embedder: Embedder;
   scraper: Scraper;
-  /** When set, chat is scoped to this index; tools use it as the default focused network. */
+  /** When set, chat is scoped to this network; tools use it as the default focused network. */
   networkId?: string;
   /** Focused request scope type. Currently only `network` is supported. */
   scopeType?: ToolScopeType;
@@ -278,7 +278,7 @@ export class ChatContextAccessError extends Error {
 
 /**
  * Resolve the canonical context used by chat tools and system prompt.
- * This preloads user identity, profile, index memberships, and scoped index role.
+ * This preloads user identity, profile, network memberships, and scoped index role.
  */
 export async function resolveChatContext(params: {
   database: Pick<
@@ -332,7 +332,7 @@ export async function resolveChatContext(params: {
 
     if (!isMember) {
       throw new ChatContextAccessError(
-        "You are not a member of this index",
+        "You are not a member of this network",
         403,
         "INDEX_MEMBERSHIP_REQUIRED"
       );
@@ -434,7 +434,7 @@ export interface ToolDeps {
   database: ChatGraphCompositeDatabase;
   /** Context-bound database for accessing the authenticated user's own resources. */
   userDb: UserDatabase;
-  /** Context-bound database for LLM/system operations on cross-user resources within shared indexes. */
+  /** Context-bound database for LLM/system operations on cross-user resources within shared networks. */
   systemDb: SystemDatabase;
   scraper: Scraper;
   embedder: import('../interfaces/embedder.interface.js').Embedder;

--- a/packages/protocol/src/shared/agent/tool.scope.ts
+++ b/packages/protocol/src/shared/agent/tool.scope.ts
@@ -47,7 +47,7 @@ export function focusedNetworkId(scope: ToolScopeEnvelope): string | undefined {
 
 /** Human-readable label for a focused scope, used in scope-restriction notes. */
 export function focusedNetworkLabel(scope: ToolScopeEnvelope & { indexName?: string }): string {
-  return scope.indexName ?? focusedNetworkId(scope) ?? 'this index';
+  return scope.indexName ?? focusedNetworkId(scope) ?? 'this network';
 }
 
 export function deriveAllowedNetworkIds(input: DeriveNetworkScopeInput): string[] {

--- a/packages/protocol/src/shared/agent/utility.tools.ts
+++ b/packages/protocol/src/shared/agent/utility.tools.ts
@@ -75,22 +75,22 @@ export function createUtilityTools(defineTool: DefineTool, deps: ToolDeps) {
 
 - **Users**: People on the platform. Authenticated via API key (X-API-Key header) for MCP/external agents, or session-based (Better Auth) for the web app.
 - **Profiles**: A user's identity — name, bio, skills, interests, location, social links. Generated from account data or social URLs via enrichment. One profile per user.
-- **Indexes** (also called "networks"): Communities or groups where members share intents and discover opportunities. Each has a title, optional prompt (purpose description), join policy (anyone or invite_only), and an owner. The user's **personal index** (isPersonal=true) stores their contacts.
-- **Index Members**: Junction between Users and Indexes. Tracks permissions (owner, member, contact), join date, auto-assign setting, and optional member prompt.
+- **Indexes** (also called "networks"): Communities or groups where members share intents and discover opportunities. Each has a title, optional prompt (purpose description), join policy (anyone or invite_only), and an owner. The user's **personal network** (isPersonal=true) stores their contacts.
+- **Network Members**: Junction between Users and Indexes. Tracks permissions (owner, member, contact), join date, auto-assign setting, and optional member prompt.
 - **Intents**: Signals of interest/need — what a user is looking for (e.g. "Looking for a React developer in Berlin"). Each has a description (payload), summary, confidence score (0-1), inferenceType (explicit/implicit), source tracking, and vector embedding.
 - **IntentNetworks**: Many-to-many junction between Intents and Indexes. An intent can be in multiple indexes. Has a relevancyScore (0-1) indicating how well the intent fits the index's purpose.
-- **Opportunities**: Discovered connections between users based on complementary intents within shared indexes. Have actors with roles (introducer, party), status lifecycle, match reasoning, confidence score, and presentation data.
-- **Contacts**: People in a user's personal network, stored as index members with 'contact' permission on the personal index. Can be real users or ghost users (placeholder accounts enriched from public data).
+- **Opportunities**: Discovered connections between users based on complementary intents within shared networks. Have actors with roles (introducer, party), status lifecycle, match reasoning, confidence score, and presentation data.
+- **Contacts**: People in a user's personal network, stored as network members with 'contact' permission on the personal network. Can be real users or ghost users (placeholder accounts enriched from public data).
 - **Ghost Users**: Placeholder accounts created for contacts who aren't on the platform yet. Enriched with public profile data (LinkedIn, GitHub) and participate in opportunity matching.
 
 ### Key Relationships
 - Users → Profiles (1:1)
-- Users → Indexes (many:many via Index Members)
+- Users → Indexes (many:many via Network Members)
 - Users → Intents (1:many, user owns intents)
 - Intents → Indexes (many:many via IntentNetworks with relevancyScore)
 - Opportunities → Users (many:many via actors with roles)
-- Opportunities → Indexes (scoped to shared index context)
-- Contacts → Personal Index (stored as members with 'contact' permission)`,
+- Opportunities → Indexes (scoped to shared network context)
+- Contacts → Personal Network (stored as members with 'contact' permission)`,
 
         intents: `## Intent Lifecycle
 
@@ -98,8 +98,8 @@ Intents are the core unit of discovery — they represent what users are seeking
 
 1. **Creation** (create_intent): User describes what they're looking for. The system runs inference (extracting structured intents from free text) and verification (checking specificity, speech-act type). Returns a proposal for user approval.
 2. **Confidence & Classification**: Each intent gets a confidence score (0-1), inferenceType (explicit = user stated directly, implicit = system inferred), and speech act classification (commissive, directive, assertive).
-3. **Index Assignment**: After creation, the intent is automatically evaluated against all indexes the user belongs to. The index's prompt is used as criteria. Matching indexes get linked via IntentNetworks with a relevancyScore (0-1).
-4. **Discovery Trigger**: Creating an intent triggers background opportunity detection — the system searches for other users in shared indexes whose intents complement this one.
+3. **Index Assignment**: After creation, the intent is automatically evaluated against all networks the user belongs to. The index's prompt is used as criteria. Matching indexes get linked via IntentNetworks with a relevancyScore (0-1).
+4. **Discovery Trigger**: Creating an intent triggers background opportunity detection — the system searches for other users in shared networks whose intents complement this one.
 5. **Source Tracking**: Intents track their origin via sourceType (file, integration, link, discovery_form, enrichment) and sourceId.
 6. **Update** (update_intent): Re-processes through inference/verification, recalculates embeddings and index assignments.
 7. **Archive** (delete_intent): Soft-deletes the intent. It stops participating in discovery but is not permanently removed.
@@ -113,7 +113,7 @@ Intents are the core unit of discovery — they represent what users are seeking
 
 Opportunities represent discovered connections between users — potential matches worth pursuing.
 
-1. **Detection** (discover_opportunities): The opportunity graph finds users whose intents semantically complement each other within shared indexes. Uses HyDE embeddings for retrieval and an LLM evaluator for scoring.
+1. **Detection** (discover_opportunities): The opportunity graph finds users whose intents semantically complement each other within shared networks. Uses HyDE embeddings for retrieval and an LLM evaluator for scoring.
 2. **Roles**: Each opportunity assigns roles to actors:
    - **introducer**: The person who triggered the introduction (may be the system or another user)
    - **party**: The people being connected (typically 2)
@@ -138,11 +138,11 @@ Opportunities represent discovered connections between users — potential match
 
 Indexes (also called "networks") are communities where members share what they're looking for and the system discovers connections between them.
 
-- **Purpose prompt**: Each index has an optional prompt describing its purpose (e.g. "AI/ML co-founders in Berlin"). This prompt is used by the intent indexer to evaluate whether an intent belongs in this community. Indexes without prompts accept all intents (relevancyScore defaults to 1.0).
+- **Purpose prompt**: Each index has an optional prompt describing its purpose (e.g. "AI/ML co-founders in Berlin"). This prompt is used by the intent indexer to evaluate whether an intent belongs in this community. Networks without prompts accept all intents (relevancyScore defaults to 1.0).
 - **Join policy**: "anyone" (open — any user can self-join) or "invite_only" (only the owner can add members).
-- **Personal index**: Each user has exactly one personal index (isPersonal=true) created on registration. It stores their contacts. Cannot be deleted, renamed, or listed publicly.
+- **Personal network**: Each user has exactly one personal network (isPersonal=true) created on registration. It stores their contacts. Cannot be deleted, renamed, or listed publicly.
 - **Membership**: Members can see all intents in the index. The **auto-assign** setting on a membership means new intents by that user are automatically evaluated against the index.
-- **Owner permissions**: Index owners can update settings (title, prompt, joinPolicy), add/remove members, and delete the index (if sole member).
+- **Owner permissions**: Network owners can update settings (title, prompt, joinPolicy), add/remove members, and delete the network (if sole member).
 - **Discovery scope**: Opportunities are discovered within index boundaries — the system matches intents of members who share at least one index.
 
 ### Index Workflow
@@ -172,11 +172,11 @@ Profiles are the user's identity on the platform, used for semantic matching in 
 
         contacts: `## Contact Management
 
-Contacts are people in a user's personal network, stored as members of their personal index with 'contact' permission.
+Contacts are people in a user's personal network, stored as members of their personal network with 'contact' permission.
 
 - **Adding contacts**: Via import_contacts (bulk), add_contact (single email), or import_gmail_contacts (Google integration).
 - **Ghost users**: When a contact email doesn't match an existing account, a ghost user is created. Ghost users are enriched with public profile data and participate in opportunity matching — they can be discovered even before joining the platform.
-- **Personal index scope**: Pass the personal index networkId to discover_opportunities to scope discovery to just the user's contacts.
+- **Personal network scope**: Pass the personal network networkId to discover_opportunities to scope discovery to just the user's contacts.
 - **Contact data**: Each contact has userId, name, email, avatar, and isGhost flag.
 
 ### Contact Workflow
@@ -232,7 +232,7 @@ Discovery is the process of finding meaningful connections between users based o
 3. discover_opportunities(networkId=personalIndexId) → find matches among contacts
 
 ### Creating a Community
-1. create_network(title, prompt) → create index
+1. create_network(title, prompt) → create network
 2. create_network_membership(networkId, userId) → invite members
 3. Members create intents → auto-indexed
 4. discover_opportunities(networkId) → discover connections within community`,
@@ -247,9 +247,9 @@ Discovery is the process of finding meaningful connections between users based o
 
 ### Key Constraints
 - Users can only read their own intents globally, or intents in indexes they belong to
-- Users can only read profiles of people in shared indexes
-- Index-scoped operations are restricted to that index
-- Personal indexes cannot be deleted or renamed
+- Users can only read profiles of people in shared networks
+- Network-scoped operations are restricted to that index
+- Personal networks cannot be deleted or renamed
 - Only index owners can update settings, add/remove members (for invite_only indexes)
 
 ### Rate Limits & Best Practices

--- a/packages/protocol/src/shared/agent/utility.tools.ts
+++ b/packages/protocol/src/shared/agent/utility.tools.ts
@@ -250,7 +250,7 @@ Discovery is the process of finding meaningful connections between users based o
 - Users can only read profiles of people in shared networks
 - Network-scoped operations are restricted to that index
 - Personal networks cannot be deleted or renamed
-- Only index owners can update settings, add/remove members (for invite_only indexes)
+- Only network owners can update settings, add/remove members (for invite_only networks)
 
 ### Rate Limits & Best Practices
 - Avoid unnecessary read_intents/read_networks calls — cache results within a conversation

--- a/packages/protocol/src/shared/interfaces/database.interface.ts
+++ b/packages/protocol/src/shared/interfaces/database.interface.ts
@@ -388,7 +388,7 @@ export interface OwnedIndex {
 }
 
 /**
- * Member details visible to index owners (and optionally to members with privacy rules).
+ * Member details visible to network owners (and optionally to members with privacy rules).
  */
 export interface IndexMemberDetails {
   /** User ID */
@@ -414,7 +414,7 @@ export interface IndexMemberDetails {
 }
 
 /**
- * Intent details visible to index owners.
+ * Intent details visible to network owners.
  */
 export interface IndexedIntentDetails {
   /** Intent ID */
@@ -1139,7 +1139,7 @@ export interface Database {
 
   /**
    * Removes a user from an index.
-   * Only the index owner can remove members. Cannot remove the owner.
+   * Only the network owner can remove members. Cannot remove the owner.
    *
    * @param networkId - The index to remove from
    * @param userId - The user to remove

--- a/packages/protocol/src/shared/interfaces/database.interface.ts
+++ b/packages/protocol/src/shared/interfaces/database.interface.ts
@@ -161,7 +161,7 @@ export interface CreateIntentData {
   embedding?: number[];
   /** Whether the intent should be hidden from public views */
   isIncognito?: boolean;
-  /** Index IDs to associate with (optional, uses dynamic scoping if empty) */
+  /** Network IDs to associate with (optional, uses dynamic scoping if empty) */
   networkIds?: string[];
   /** Source type for provenance tracking */
   sourceType?: 'file' | 'integration' | 'link' | 'discovery_form' | 'enrichment';
@@ -283,7 +283,7 @@ export interface SimilarIntentSearchOptions {
 
 /**
  * Represents a user's membership in an index with full details.
- * Used for displaying index memberships in chat (index_query).
+ * Used for displaying network memberships in chat (index_query).
  */
 export interface NetworkMembership {
   /** Unique identifier of the index */
@@ -292,15 +292,15 @@ export interface NetworkMembership {
   networkTitle: string;
   /** Index description/prompt (what the community is about) */
   indexPrompt: string | null;
-  /** Member's permissions in this index */
+  /** Member's permissions in this network */
   permissions: string[];
-  /** Member's custom prompt (overrides index prompt for their intents) */
+  /** Member's custom prompt (overrides network prompt for their intents) */
   memberPrompt: string | null;
-  /** Whether new intents are auto-assigned to this index */
+  /** Whether new intents are auto-assigned to this network */
   autoAssign: boolean;
-  /** Whether this is the user's personal index ("My Network") */
+  /** Whether this is the user's personal network ("My Network") */
   isPersonal: boolean;
-  /** When the user joined the index */
+  /** When the user joined the network */
   joinedAt: Date;
 }
 
@@ -357,7 +357,7 @@ export interface PremiseRecord {
  * Represents an index owned by the user with full details.
  */
 export interface OwnedIndex {
-  /** Index ID */
+  /** Network ID */
   id: string;
   /** Display title */
   title: string;
@@ -371,7 +371,7 @@ export interface OwnedIndex {
     allowGuestVibeCheck: boolean;
     invitationLink: { code: string } | null;
   };
-  /** Whether this is a personal index */
+  /** Whether this is a personal network */
   isPersonal: boolean;
   /** When the index was created */
   createdAt: Date;
@@ -399,7 +399,7 @@ export interface IndexMemberDetails {
   avatar: string | null;
   /** User's email; only present when viewer is owner/admin or the member themselves (privacy-safe) */
   email?: string | null;
-  /** Member's permissions in this index */
+  /** Member's permissions in this network */
   permissions: string[];
   /** Member's custom prompt */
   memberPrompt: string | null;
@@ -407,7 +407,7 @@ export interface IndexMemberDetails {
   autoAssign: boolean;
   /** When they joined */
   joinedAt: Date;
-  /** Count of their intents in this index */
+  /** Count of their intents in this network */
   intentCount: number;
   /** Whether this user is a ghost (not yet onboarded) */
   isGhost?: boolean;
@@ -629,7 +629,7 @@ export interface Database {
    * Caller must be a member of that index; only the user's own intents are returned.
    *
    * @param userId - The user requesting (must be a member of the index)
-   * @param indexNameOrId - Index UUID or display name (e.g. "Commons")
+   * @param indexNameOrId - Network UUID or display name (e.g. "Commons")
    * @returns Array of active intents in that index for the user, or empty if not a member / no match
    */
   getIntentsInIndexForMember(userId: string, indexNameOrId: string): Promise<ActiveIntent[]>;
@@ -746,11 +746,11 @@ export interface Database {
   // ─────────────────────────────────────────────────────────────────────────────
 
   /**
-   * Gets Index IDs where the user has auto-assign membership enabled.
+   * Gets Network IDs where the user has auto-assign membership enabled.
    * Used for determining which indexes to associate new intents with.
    *
    * @param userId - The unique identifier of the user
-   * @returns Array of index IDs
+   * @returns Array of network IDs
    *
    * @example
    * ```typescript
@@ -763,19 +763,19 @@ export interface Database {
   getUserIndexIds(userId: string): Promise<string[]>;
 
   /**
-   * Retrieves all indexes the user is a member of with full details.
-   * Used for displaying index memberships in chat (index_query).
+   * Retrieves all networks the user is a member of with full details.
+   * Used for displaying network memberships in chat (index_query).
    *
    * @param userId - The unique identifier of the user
-   * @returns Array of index memberships with details
+   * @returns Array of network memberships with details
    */
   getNetworkMemberships(userId: string): Promise<NetworkMembership[]>;
 
   /**
-   * Get a single index membership by index and user.
-   * Used when the preloaded memberships list may not contain this index (e.g. after isNetworkMember check).
+   * Get a single network membership by index and user.
+   * Used when the preloaded memberships list may not contain this network (e.g. after isNetworkMember check).
    *
-   * @param networkId - The index ID
+   * @param networkId - The network ID
    * @param userId - The user ID
    * @returns The membership or null if not found
    */
@@ -848,7 +848,7 @@ export interface Database {
   ): Promise<SimilarIntent[]>;
 
   // ─────────────────────────────────────────────────────────────────────────────
-  // Index Graph Operations (Intent–Index Assignment)
+  // Network Graph Operations (Intent–Network Assignment)
   // ─────────────────────────────────────────────────────────────────────────────
 
   /**
@@ -874,7 +874,7 @@ export interface Database {
   /**
    * Network memberships that should be considered for assignment policy. Unlike
    * getUserIndexIds, this is not gated by network_members.autoAssign and carries
-   * personal-index metadata so scoped writes can include the user's personal index.
+   * personal-index metadata so scoped writes can include the user's personal network.
    */
   getAssignmentNetworkMembershipsForUser(userId: string): Promise<AssignmentNetworkMembership[]>;
 
@@ -939,11 +939,11 @@ export interface Database {
   getOwnedIndexes(userId: string): Promise<OwnedIndex[]>;
 
   /**
-   * Get public indexes (joinPolicy 'anyone') that the user has not joined.
+   * Get public networks (joinPolicy 'anyone') that the user has not joined.
    * Used for discovering communities available to join.
    *
    * @param userId - The user ID to check memberships against
-   * @returns Object containing array of public indexes with owner info
+   * @returns Object containing array of public networks with owner info
    */
   getPublicIndexesNotJoined(userId: string): Promise<{
     networks: Array<{
@@ -1003,7 +1003,7 @@ export interface Database {
   ): Promise<IndexMemberDetails[]>;
 
   /**
-   * Get all members from every index the user is a member of (deduplicated).
+   * Get all members from every network the user is a member of (deduplicated).
    * Used for mentionable-users: anyone who shares at least one index with the requesting user.
    *
    * @param userId - The signed-in user
@@ -1051,7 +1051,7 @@ export interface Database {
    * include intents in indexes outside scope).
    *
    * @param userId - The intent owner (always the caller).
-   * @param indexIds - The set of index IDs to filter on. Empty → empty result.
+   * @param indexIds - The set of network IDs to filter on. Empty → empty result.
    * @returns Active intents owned by userId in any of indexIds, deduped by intent id.
    */
   getActiveIntentsAcrossIndexes(userId: string, indexIds: string[]): Promise<ActiveIntent[]>;
@@ -1100,7 +1100,7 @@ export interface Database {
    * Create a new index and return its record.
    *
    * @param data - Title, optional prompt, optional imageUrl, optional joinPolicy
-   * @returns The created index with id, title, prompt, imageUrl, permissions
+   * @returns The created network with id, title, prompt, imageUrl, permissions
    */
   createNetwork(data: {
     title: string;
@@ -1280,7 +1280,7 @@ export interface Database {
   /**
    * Get opportunities in an index (for index admins).
    *
-   * @param networkId - Index ID
+   * @param networkId - Network ID
    * @param options - Optional filters and pagination
    * @returns Array of opportunities
    */
@@ -1353,8 +1353,8 @@ export interface Database {
    * Check if an opportunity already exists between the given actors in the index (deduplication).
    *
    * @param actorIds - Array of user IDs that would be actors
-   * @param networkId - Index ID
-   * @returns True if a non-expired opportunity exists with exactly these actors in this index
+   * @param networkId - Network ID
+   * @returns True if a non-expired opportunity exists with exactly these actors in this network
    */
   opportunityExistsBetweenActors(
     actorIds: string[],
@@ -1393,7 +1393,7 @@ export interface Database {
   /**
    * Expire opportunities for a user removed from an index.
    *
-   * @param networkId - Index ID
+   * @param networkId - Network ID
    * @param userId - User ID that was removed
    * @returns Number of opportunities updated to expired
    */
@@ -1433,7 +1433,7 @@ export interface Database {
   /** Create a ghost user (unregistered contact) with empty profile. */
   createGhostUser(data: { name: string; email: string }): Promise<{ id: string }>;
 
-  /** Upsert a contact membership in the owner's personal index (index_members with permissions=['contact']). */
+  /** Upsert a contact membership in the owner's personal network (index_members with permissions=['contact']). */
   upsertContactMembership(ownerId: string, contactUserId: string, options?: { restore?: boolean }): Promise<void>;
 
   /**
@@ -1452,24 +1452,24 @@ export interface Database {
    */
   unhideConversation(userId: string, conversationId: string): Promise<void>;
 
-  /** Hard-delete a contact membership from the owner's personal index. */
+  /** Hard-delete a contact membership from the owner's personal network. */
   hardDeleteContactMembership(ownerId: string, contactUserId: string): Promise<void>;
 
-  /** Get all contact members from the owner's personal index with user details. */
+  /** Get all contact members from the owner's personal network with user details. */
   getContactMembers(ownerId: string): Promise<Array<{
     userId: string;
     user: { id: string; name: string; email: string; avatar: string | null; isGhost: boolean };
   }>>;
 
-  /** Clear a reverse opt-out (reactivate soft-deleted contact membership in another user's personal index). */
+  /** Clear a reverse opt-out (reactivate soft-deleted contact membership in another user's personal network). */
   clearReverseOptOut(ownerId: string, otherUserId: string): Promise<void>;
 
   /**
-   * Returns the IDs of personal indexes where the given user is a contact member.
-   * Used for auto-assigning new intents to personal indexes of contacts who imported this user.
+   * Returns the IDs of personal networks where the given user is a contact member.
+   * Used for auto-assigning new intents to personal networks of contacts who imported this user.
    *
    * @param userId - The user whose contact memberships to look up
-   * @returns Array of personal index IDs
+   * @returns Array of personal network IDs
    */
   getPersonalIndexesForContact(userId: string): Promise<{ networkId: string }[]>;
 
@@ -1639,7 +1639,7 @@ export interface Database {
  * Context-bound database for accessing the authenticated user's own resources.
  * Created with authUserId bound at construction; no userId parameter needed on methods.
  *
- * **NOT index-scoped**: Returns ALL of the user's own resources regardless of index.
+ * **NOT network-scoped**: Returns ALL of the user's own resources regardless of index.
  * This is critical for the IntentReconciler which needs the full picture for deduplication.
  *
  * Use via `createUserDatabase(db, authUserId)` factory function.
@@ -1674,7 +1674,7 @@ export interface UserDatabase {
   setUserSocials(socials: { label: string; value: string }[]): Promise<void>;
 
   // ─────────────────────────────────────────────────────────────────────────────
-  // Intent Operations (own only, ALL intents - not index-scoped)
+  // Intent Operations (own only, ALL intents - not network-scoped)
   // ─────────────────────────────────────────────────────────────────────────────
 
   /** Get ALL active intents for the authenticated user (not index-filtered). */
@@ -1734,19 +1734,19 @@ export interface UserDatabase {
   isIntentAssignedToIndex(intentId: string, networkId: string): Promise<boolean>;
 
   // ─────────────────────────────────────────────────────────────────────────────
-  // Index Membership Operations (own memberships only)
+  // Network Membership Operations (own memberships only)
   // ─────────────────────────────────────────────────────────────────────────────
 
-  /** Get all index memberships for the authenticated user. */
+  /** Get all network memberships for the authenticated user. */
   getNetworkMemberships(): Promise<NetworkMembership[]>;
 
-  /** Get index IDs with auto-assign enabled for the authenticated user. */
+  /** Get network IDs with auto-assign enabled for the authenticated user. */
   getUserIndexIds(): Promise<string[]>;
 
   /** Get indexes owned by the authenticated user. */
   getOwnedIndexes(): Promise<OwnedIndex[]>;
 
-  /** Get a specific index membership for the authenticated user. */
+  /** Get a specific network membership for the authenticated user. */
   getNetworkMembership(networkId: string): Promise<NetworkMembership | null>;
 
   /** Get index + member context for the authenticated user (for auto-assign). */
@@ -1780,10 +1780,10 @@ export interface UserDatabase {
   softDeleteNetwork(networkId: string): Promise<void>;
 
   // ─────────────────────────────────────────────────────────────────────────────
-  // Public Index Discovery (joinable indexes the user is not a member of)
+  // Public Network Discovery (joinable indexes the user is not a member of)
   // ─────────────────────────────────────────────────────────────────────────────
 
-  /** Get public indexes (joinPolicy 'anyone') that the user has not joined. */
+  /** Get public networks (joinPolicy 'anyone') that the user has not joined. */
   getPublicIndexesNotJoined(): Promise<{
     networks: Array<{
       id: string;
@@ -1794,7 +1794,7 @@ export interface UserDatabase {
     }>;
   }>;
 
-  /** Join a public index (validates joinPolicy === 'anyone'). */
+  /** Join a public network (validates joinPolicy === 'anyone'). */
   joinPublicNetwork(networkId: string): Promise<{ success: boolean; alreadyMember?: boolean }>;
 
   // ─────────────────────────────────────────────────────────────────────────────
@@ -1831,14 +1831,14 @@ export interface UserDatabase {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// SYSTEM DATABASE INTERFACE (Cross-User Within Shared Indexes)
+// SYSTEM DATABASE INTERFACE (Cross-User Within Shared Networks)
 // ═══════════════════════════════════════════════════════════════════════════════
 
 /**
  * Context-bound database for LLM/system operations that access cross-user resources.
  * Created with authUserId + indexScope[]; validates membership before access.
  *
- * **Index-scoped**: All cross-user operations are restricted to users/resources
+ * **Network-scoped**: All cross-user operations are restricted to users/resources
  * within the bound indexScope[]. This prevents the LLM from accessing arbitrary users' data.
  *
  * Use via `createSystemDatabase(db, authUserId, indexScope)` factory function.
@@ -1854,14 +1854,14 @@ export interface SystemDatabase {
   // Profile Operations (any user in scope)
   // ─────────────────────────────────────────────────────────────────────────────
 
-  /** Get a user's profile (requires shared index membership). */
+  /** Get a user's profile (requires shared network membership). */
   getProfile(userId: string): Promise<UserIdentity | null>;
 
-  /** Get a user's basic record (requires shared index membership). */
+  /** Get a user's basic record (requires shared network membership). */
   getUser(userId: string): Promise<UserRecord | null>;
 
   // ─────────────────────────────────────────────────────────────────────────────
-  // Intent Operations (cross-user within shared indexes)
+  // Intent Operations (cross-user within shared networks)
   // ─────────────────────────────────────────────────────────────────────────────
 
   /** Get all intents in an index (cross-user, requires membership). */
@@ -1878,7 +1878,7 @@ export interface SystemDatabase {
    * include intents in indexes outside scope).
    *
    * @param userId - The intent owner (always the caller).
-   * @param indexIds - The set of index IDs to filter on. Empty → empty result.
+   * @param indexIds - The set of network IDs to filter on. Empty → empty result.
    * @returns Active intents owned by userId in any of indexIds, deduped by intent id.
    */
   getActiveIntentsAcrossIndexes(userId: string, indexIds: string[]): Promise<ActiveIntent[]>;
@@ -1886,11 +1886,11 @@ export interface SystemDatabase {
   /** Get a single intent by ID (if in scope). */
   getIntent(intentId: string): Promise<IntentRecord | null>;
 
-  /** Find similar intents across users within the index scope. */
+  /** Find similar intents across users within the network scope. */
   findSimilarIntentsInScope(embedding: number[], options?: SimilarIntentSearchOptions): Promise<SimilarIntent[]>;
 
   // ─────────────────────────────────────────────────────────────────────────────
-  // Index Membership Operations (any index in scope)
+  // Network Membership Operations (any index in scope)
   // ─────────────────────────────────────────────────────────────────────────────
 
   /** Check if a user is a member of an index. */
@@ -1902,7 +1902,7 @@ export interface SystemDatabase {
   /** Get all members of an index (requires membership). */
   getNetworkMembers(networkId: string): Promise<IndexMemberDetails[]>;
 
-  /** Get all members across all indexes in scope (deduplicated). */
+  /** Get all members across all networks in scope (deduplicated). */
   getMembersFromScope(): Promise<{ userId: Id<'users'>; name: string; avatar: string | null }[]>;
 
   /** Add a user to an index (requires ownership or 'anyone' policy). */
@@ -2008,7 +2008,7 @@ export interface SystemDatabase {
 // - IntentGraphDatabase → maps to UserDatabase (mutations) + SystemDatabase (reads)
 // - OpportunityGraphDatabase → maps to SystemDatabase (cross-user operations)
 // - NetworkGraphDatabase → maps to UserDatabase (own indexes)
-// - IntentNetworkGraphDatabase → maps to both (own intent ↔ shared index)
+// - IntentNetworkGraphDatabase → maps to both (own intent ↔ shared network)
 // - NetworkMembershipGraphDatabase → maps to SystemDatabase (cross-user)
 // - HydeGraphDatabase → maps to both (own HyDE vs cross-user matching)
 //
@@ -2100,7 +2100,7 @@ export type ChatGraphCompositeDatabase = Pick<
   | 'unassignIntentFromIndex'
   | 'getNetworkIdsForIntent'
   | 'getIntentIndexScores'
-  // Personal index auto-assignment (used by intent graph executor)
+  // Personal network auto-assignment (used by intent graph executor)
   | 'getPersonalIndexesForContact'
   // Index Ownership Operations (owner-only)
   | 'getOwnedIndexes'
@@ -2146,7 +2146,7 @@ export type ChatGraphCompositeDatabase = Pick<
 
 /**
  * Database interface for Opportunity Graph operations.
- * Includes prep/scope (index membership, intents, index details), persist (create, dedupe),
+ * Includes prep/scope (network membership, intents, index details), persist (create, dedupe),
  * and CRUD operations (read, update status, send).
  *
  * Access layer: SystemDatabase (cross-user opportunity operations)
@@ -2361,9 +2361,9 @@ export type OpportunityControllerDatabase = Pick<
 /**
  * Database interface narrowed for Intent Graph operations.
  * Provides state population (getActiveIntents), action execution (create/update/archive),
- * and read operations (query intents; getIntentsInIndexForMember for index-scoped reads).
+ * and read operations (query intents; getIntentsInIndexForMember for network-scoped reads).
  *
- * Access layer: UserDatabase (mutations on own intents) + SystemDatabase (index-scoped reads)
+ * Access layer: UserDatabase (mutations on own intents) + SystemDatabase (network-scoped reads)
  */
 export type IntentGraphDatabase = Pick<
   Database,
@@ -2381,16 +2381,16 @@ export type IntentGraphDatabase = Pick<
   | 'getProfile'
   // Global user_context paragraph for questioner intent prompts
   | 'getUserContext'
-  // Personal index auto-assignment
+  // Personal network auto-assignment
   | 'getPersonalIndexesForContact'
   | 'assignIntentToNetwork'
 >;
 
 /**
- * Database interface narrowed for Index Graph CRUD operations.
+ * Database interface narrowed for Network Graph CRUD operations.
  * Handles create, read, update, delete of indexes (communities).
  *
- * Access layer: UserDatabase (CRUD on own indexes and memberships)
+ * Access layer: UserDatabase (CRUD on own networks and memberships)
  */
 export type NetworkGraphDatabase = Pick<
   Database,
@@ -2432,8 +2432,8 @@ export type IntentNetworkGraphDatabase = Pick<
 >;
 
 /**
- * Database interface narrowed for Index Membership Graph operations.
- * Handles CRUD for index memberships (add, list, remove members).
+ * Database interface narrowed for Network Membership Graph operations.
+ * Handles CRUD for network memberships (add, list, remove members).
  *
  * Access layer: SystemDatabase (cross-user membership operations)
  */

--- a/packages/protocol/src/shared/interfaces/embedder.interface.ts
+++ b/packages/protocol/src/shared/interfaces/embedder.interface.ts
@@ -14,9 +14,9 @@ export interface LensEmbedding {
   embedding: number[];
 }
 
-/** Options for searchWithHydeEmbeddings (index scope, limits, min score). */
+/** Options for searchWithHydeEmbeddings (network scope, limits, min score). */
 export interface HydeSearchOptions {
-  /** Index IDs to scope the search (members / assigned intents only). */
+  /** Network IDs to scope the search (members / assigned intents only). */
   indexScope: string[];
   /** Exclude this user ID from results (e.g. source intent owner). */
   excludeUserId?: string;

--- a/services/api/src/adapters/auth.adapter.ts
+++ b/services/api/src/adapters/auth.adapter.ts
@@ -90,10 +90,10 @@ export class AuthDatabaseAdapter {
   }
 
   /**
-   * Creates a personal index for the user if one doesn't exist.
+   * Creates a personal network for the user if one doesn't exist.
    * Idempotent — safe to call on every sign-in.
    * @param userId - The authenticated user
-   * @returns The personal index ID
+   * @returns The personal network ID
    */
   async ensurePersonalNetwork(userId: string): Promise<string> {
     return ensurePersonalNetwork(userId);

--- a/services/api/src/adapters/chat.database.adapter.ts
+++ b/services/api/src/adapters/chat.database.adapter.ts
@@ -384,7 +384,7 @@ export class ChatDatabaseAdapter {
 
   /**
    * IDs of all non-personal (community) networks the user is an active member of.
-   * Excludes soft-deleted memberships, soft-deleted networks, and personal indexes.
+   * Excludes soft-deleted memberships, soft-deleted networks, and personal networks.
    * @param userId - The user whose community memberships to resolve
    * @returns Array of network IDs (possibly empty)
    */
@@ -403,7 +403,7 @@ export class ChatDatabaseAdapter {
   }
 
   /**
-   * Check whether an index is a personal index.
+   * Check whether an index is a personal network.
    * @param networkId - The index to check
    * @returns true if the index has isPersonal = true
    */
@@ -487,8 +487,8 @@ export class ChatDatabaseAdapter {
         and(
           isNull(schema.networks.deletedAt),
           inArray(schema.networks.id, ids),
-          // Only include personal indexes owned by the requesting user;
-          // contacts in someone else's personal index must not see it.
+          // Only include personal networks owned by the requesting user;
+          // contacts in someone else's personal network must not see it.
           or(
             eq(schema.networks.isPersonal, false),
             eq(ownerMembers.userId, userId)
@@ -585,16 +585,16 @@ export class ChatDatabaseAdapter {
   }
 
   /**
-   * Get public indexes that the user has not joined (for discovery).
+   * Get public networks that the user has not joined (for discovery).
    */
   async getPublicIndexesNotJoined(userId: string) {
     const userIndexIds = await db
       .select({ networkId: schema.networkMembers.networkId })
       .from(schema.networkMembers)
       .where(eq(schema.networkMembers.userId, userId));
-    
+
     const excludeIds = userIndexIds.map(r => r.networkId);
-    
+
     const whereConditions = [
       isNull(schema.networks.deletedAt),
       eq(schema.networks.isPersonal, false),
@@ -694,7 +694,7 @@ export class ChatDatabaseAdapter {
   /**
    * Returns the user's own personal network ID(s). Sourced from `personal_networks`
    * (PK on userId) rather than joining `network_members` × `isPersonal=true`, so
-   * contact memberships on other users' personal indexes are excluded by
+   * contact memberships on other users' personal networks are excluded by
    * construction. Fail-soft (returns []) to match {@link getUserIndexIds} since
    * this runs in the HyDE worker path.
    */
@@ -1013,7 +1013,7 @@ export class ChatDatabaseAdapter {
   async getNetworkMembersForMember(networkId: string, requestingUserId: string) {
     const isMember = await this.isNetworkMember(networkId, requestingUserId);
     if (!isMember) {
-      throw new Error('Access denied: Not a member of this index');
+      throw new Error('Access denied: Not a member of this network');
     }
 
     const members = await db
@@ -1078,7 +1078,7 @@ export class ChatDatabaseAdapter {
   async getNetworkMembersForOwner(networkId: string, requestingUserId: string) {
     const isOwner = await this.isIndexOwner(networkId, requestingUserId);
     if (!isOwner) {
-      throw new Error('Access denied: Not an owner of this index');
+      throw new Error('Access denied: Not an owner of this network');
     }
 
     const members = await db
@@ -1169,7 +1169,7 @@ export class ChatDatabaseAdapter {
   ) {
     const isOwner = await this.isIndexOwner(networkId, requestingUserId);
     if (!isOwner) {
-      throw new Error('Access denied: Not an owner of this index');
+      throw new Error('Access denied: Not an owner of this network');
     }
 
     const limit = options?.limit ?? 50;
@@ -1249,7 +1249,7 @@ export class ChatDatabaseAdapter {
   ) {
     const isMember = await this.isNetworkMember(networkId, requestingUserId);
     if (!isMember) {
-      throw new Error('Access denied: Not a member of this index');
+      throw new Error('Access denied: Not a member of this network');
     }
 
     const limit = options?.limit ?? 50;
@@ -1402,7 +1402,7 @@ export class ChatDatabaseAdapter {
   ) {
     const isOwner = await this.isIndexOwner(networkId, requestingUserId);
     if (!isOwner) {
-      throw new Error('Access denied: Not an owner of this index');
+      throw new Error('Access denied: Not an owner of this network');
     }
 
     const [existing] = await db.select().from(networks).where(eq(networks.id, networkId)).limit(1);
@@ -1530,7 +1530,7 @@ export class ChatDatabaseAdapter {
   async regenerateInvitationLink(networkId: string, requestingUserId: string) {
     const isOwner = await this.isIndexOwner(networkId, requestingUserId);
     if (!isOwner) {
-      throw new Error('Access denied: Not an owner of this index');
+      throw new Error('Access denied: Not an owner of this network');
     }
 
     const [existing] = await db.select().from(networks).where(eq(networks.id, networkId)).limit(1);
@@ -1750,7 +1750,7 @@ export class ChatDatabaseAdapter {
         type: networks.type,
         metadata: networks.metadata,
       });
-    if (!row) throw new Error('Failed to create index');
+    if (!row) throw new Error('Failed to create network');
     const perms = (row.permissions as schema.NetworkPermissionsState | null) ?? {
       joinPolicy: 'invite_only',
       invitationLink: null,
@@ -1842,9 +1842,9 @@ export class ChatDatabaseAdapter {
   }
 
   /**
-   * Resolve an index identifier (UUID or key) to a UUID.
+   * Resolve an network identifier (UUID or key) to a UUID.
    * @param idOrKey - UUID or human-readable key
-   * @returns The index UUID, or null if not found
+   * @returns The network UUID, or null if not found
    */
   async resolveIndexId(idOrKey: string): Promise<string | null> {
     const isFullUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(idOrKey);
@@ -1871,7 +1871,7 @@ export class ChatDatabaseAdapter {
   // ─────────────────────────────────────────────────────────────────────────────
 
   /**
-   * Get a single index with owner info and member count.
+   * Get a single network with owner info and member count.
    * Checks that the requesting user is a member; throws "Access denied" if not.
    */
   async getPublicIndexDetail(networkId: string) {
@@ -2059,7 +2059,7 @@ export class ChatDatabaseAdapter {
 
     const isMember = await this.isNetworkMember(networkId, requestingUserId);
     if (!isMember) {
-      throw new Error('Access denied: Not a member of this index');
+      throw new Error('Access denied: Not a member of this network');
     }
 
     const memberCount = await this.getNetworkMemberCount(networkId);
@@ -2083,13 +2083,13 @@ export class ChatDatabaseAdapter {
   }
 
   /**
-   * Search users within the caller's personal index members by name or email,
+   * Search users within the caller's personal network members by name or email,
    * optionally excluding existing members of a target index.
    */
   async searchPersonalNetworkMembers(userId: string, query: string, excludeIndexId?: string) {
     if (!query || query.trim().length === 0) return [];
 
-    // Find user's contacts from personal index (index_members with permissions=['contact'])
+    // Find user's contacts from personal network (index_members with permissions=['contact'])
     const personalIndexId = await getPersonalIndexId(userId);
     if (!personalIndexId) return [];
 
@@ -2255,7 +2255,7 @@ export class ChatDatabaseAdapter {
   async removeMemberForOwner(networkId: string, memberUserId: string, requestingUserId: string) {
     const isOwner = await this.isIndexOwner(networkId, requestingUserId);
     if (!isOwner) {
-      throw new Error('Access denied: Not an owner of this index');
+      throw new Error('Access denied: Not an owner of this network');
     }
 
     if (memberUserId === requestingUserId) {
@@ -2273,7 +2273,7 @@ export class ChatDatabaseAdapter {
   }
 
   /**
-   * Join a public index (anyone can join if joinPolicy is 'anyone').
+   * Join a public network (anyone can join if joinPolicy is 'anyone').
    */
   async joinPublicNetwork(networkId: string, userId: string) {
     const [index] = await db
@@ -2288,7 +2288,7 @@ export class ChatDatabaseAdapter {
 
     const perms = (index.permissions as { joinPolicy?: string } | null);
     if (perms?.joinPolicy !== 'anyone') {
-      throw new Error('This index is not public');
+      throw new Error('This network is not public');
     }
 
     return await this.addMemberToNetwork(networkId, userId, 'member');
@@ -2301,7 +2301,7 @@ export class ChatDatabaseAdapter {
   async leaveNetwork(networkId: string, userId: string) {
     const isOwner = await this.isIndexOwner(networkId, userId);
     if (isOwner) {
-      throw new Error('Cannot leave an index you own. Delete the index instead.');
+      throw new Error('Cannot leave a network you own. Delete the network instead.');
     }
 
     const deleted = await db
@@ -2310,18 +2310,18 @@ export class ChatDatabaseAdapter {
       .returning({ userId: networkMembers.userId });
 
     if (deleted.length === 0) {
-      throw new Error('You are not a member of this index');
+      throw new Error('You are not a member of this network');
     }
   }
 
   /**
-   * Soft-delete an index. Owner-only.
+   * Soft-delete a network. Owner-only.
    * Checks isIndexOwner internally; throws "Access denied" if not owner.
    */
   async deleteIndexForOwner(networkId: string, requestingUserId: string) {
     const isOwner = await this.isIndexOwner(networkId, requestingUserId);
     if (!isOwner) {
-      throw new Error('Access denied: Not an owner of this index');
+      throw new Error('Access denied: Not an owner of this network');
     }
 
     await this.softDeleteNetwork(networkId);
@@ -2567,9 +2567,9 @@ export class ChatDatabaseAdapter {
 
 
   /**
-   * Returns personal index IDs where the given user is a contact member.
+   * Returns personal network IDs where the given user is a contact member.
    * @param userId - The user whose contact memberships to look up
-   * @returns Array of personal index IDs
+   * @returns Array of personal network IDs
    */
   async getPersonalIndexesForContact(userId: string): Promise<{ networkId: string }[]> {
     return db
@@ -2674,9 +2674,9 @@ export class ChatDatabaseAdapter {
 
 
   /**
-   * Upsert a contact membership in the owner's personal index.
+   * Upsert a contact membership in the owner's personal network.
    * Inserts an index_members row with permissions=['contact'].
-   * @param ownerId - The owner of the personal index
+   * @param ownerId - The owner of the personal network
    * @param contactUserId - The user to add as a contact member
    * @param options - If restore=true, reactivates soft-deleted rows via onConflictDoUpdate(deletedAt=null).
    *                  If restore=false (default), skips soft-deleted rows and uses onConflictDoNothing for active ones.
@@ -2730,9 +2730,9 @@ export class ChatDatabaseAdapter {
   }
 
   /**
-   * Bulk upsert contact memberships in the owner's personal index.
+   * Bulk upsert contact memberships in the owner's personal network.
    * Respects opt-outs: skips contacts that have a soft-deleted membership row.
-   * @param ownerId - The owner of the personal index
+   * @param ownerId - The owner of the personal network
    * @param contactUserIds - User IDs to add as contacts
    * @returns Resolves when all non-opted-out memberships are upserted
    */
@@ -2964,8 +2964,8 @@ export class ChatDatabaseAdapter {
   }
 
   /**
-   * Hard-delete a contact membership from the owner's personal index.
-   * @param ownerId - The owner of the personal index
+   * Hard-delete a contact membership from the owner's personal network.
+   * @param ownerId - The owner of the personal network
    * @param contactUserId - The contact user to remove
    */
   async hardDeleteContactMembership(ownerId: string, contactUserId: string): Promise<void> {
@@ -2984,9 +2984,9 @@ export class ChatDatabaseAdapter {
 
   /**
    * Clear a soft-deleted contact membership that the other user has for this owner.
-   * This removes the "reverse opt-out" so the other user's personal index no longer blocks the owner.
+   * This removes the "reverse opt-out" so the other user's personal network no longer blocks the owner.
    * @param ownerId - The user being added as a contact
-   * @param otherUserId - The other user whose personal index may have a soft-deleted row for ownerId
+   * @param otherUserId - The other user whose personal network may have a soft-deleted row for ownerId
    */
   async clearReverseOptOut(ownerId: string, otherUserId: string): Promise<void> {
     const otherPersonalIndexId = await getPersonalIndexId(otherUserId);
@@ -3005,14 +3005,14 @@ export class ChatDatabaseAdapter {
 
   /**
    * Bulk clear soft-deleted contact memberships (reverse opt-outs) for multiple users.
-   * Removes rows where `ownerId` appears as a soft-deleted contact in each user's personal index.
+   * Removes rows where `ownerId` appears as a soft-deleted contact in each user's personal network.
    * @param ownerId - The user being added as a contact
-   * @param otherUserIds - The users whose personal indexes may have soft-deleted rows for ownerId
+   * @param otherUserIds - The users whose personal networks may have soft-deleted rows for ownerId
    */
   async clearReverseOptOutBulk(ownerId: string, otherUserIds: string[]): Promise<void> {
     if (otherUserIds.length === 0) return;
 
-    // Batch lookup personal indexes for all other users
+    // Batch lookup personal networks for all other users
     const personalIndexRows = await db
       .select({ userId: schema.personalNetworks.userId, networkId: schema.personalNetworks.networkId })
       .from(schema.personalNetworks)
@@ -3021,7 +3021,7 @@ export class ChatDatabaseAdapter {
     const personalIndexIds = personalIndexRows.map(r => r.networkId);
     if (personalIndexIds.length === 0) return;
 
-    // Single DELETE across all matching personal indexes
+    // Single DELETE across all matching personal networks
     await db.delete(schema.networkMembers)
       .where(
         and(
@@ -3034,8 +3034,8 @@ export class ChatDatabaseAdapter {
   }
 
   /**
-   * Get all contact members from the owner's personal index.
-   * @param ownerId - The owner of the personal index
+   * Get all contact members from the owner's personal network.
+   * @param ownerId - The owner of the personal network
    * @returns Array of contact members with user details
    */
   async getContactMembers(ownerId: string): Promise<Array<{
@@ -3077,19 +3077,19 @@ export class ChatDatabaseAdapter {
   }
 
   /**
-   * Get the user's personal index ID.
-   * @param userId - The user whose personal index to find
-   * @returns The personal index ID, or null if none exists
+   * Get the user's personal network ID.
+   * @param userId - The user whose personal network to find
+   * @returns The personal network ID, or null if none exists
    */
   async getPersonalIndexId(userId: string): Promise<string | null> {
     return getPersonalIndexId(userId);
   }
 
   /**
-   * Get contacts from a personal index with their latest intent timestamp and intent count.
+   * Get contacts from a personal network with their latest intent timestamp and intent count.
    * Contacts are sorted by most recent intent (freshest first) for introducer discovery.
    *
-   * @param personalIndexId - The personal index to query
+   * @param personalIndexId - The personal network to query
    * @param ownerId - The index owner (excluded from results)
    * @param limit - Maximum contacts to return
    * @returns Contacts with intent freshness data

--- a/services/api/src/adapters/chat.database.adapter.ts
+++ b/services/api/src/adapters/chat.database.adapter.ts
@@ -3090,7 +3090,7 @@ export class ChatDatabaseAdapter {
    * Contacts are sorted by most recent intent (freshest first) for introducer discovery.
    *
    * @param personalIndexId - The personal network to query
-   * @param ownerId - The index owner (excluded from results)
+   * @param ownerId - The network owner (excluded from results)
    * @param limit - Maximum contacts to return
    * @returns Contacts with intent freshness data
    */

--- a/services/api/src/adapters/contact.database.adapter.ts
+++ b/services/api/src/adapters/contact.database.adapter.ts
@@ -20,9 +20,9 @@ async function ensurePersonalNetwork(userId: string): Promise<string> {
 
   const networkId = crypto.randomUUID();
 
-  // Personal indexes are prompt-less by default so the assignment policy treats
+  // Personal networks are prompt-less by default so the assignment policy treats
   // them as "no filtration" (score 1.0) — every one of the owner's intents lands
-  // in their own personal index. The owner may later set a prompt to curate it.
+  // in their own personal network. The owner may later set a prompt to curate it.
   await db.insert(schema.networks).values({
     id: networkId,
     title: 'My Network',

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -1402,7 +1402,7 @@ export class ConversationDatabaseAdapter {
   }
 
   /**
-   * Update chat session index scope.
+   * Update chat session network scope.
    */
   async updateChatSessionIndex(sessionId: string, networkId: string | null): Promise<void> {
     await this._upsertConvMeta(sessionId, { networkId });

--- a/services/api/src/adapters/database.adapter.ts
+++ b/services/api/src/adapters/database.adapter.ts
@@ -154,7 +154,7 @@ export function createUserDatabase(db: ChatDatabaseAdapter, authUserId: string) 
     updateIndexSettings: (networkId: string, data: Parameters<ChatDatabaseAdapter['updateIndexSettings']>[2]) => db.updateIndexSettings(networkId, authUserId, data),
     softDeleteNetwork: async (networkId: string) => {
       const isOwner = await db.isIndexOwner(networkId, authUserId);
-      if (!isOwner) throw new Error('Access denied: not index owner');
+      if (!isOwner) throw new Error('Access denied: not network owner');
       const isPersonal = await db.isPersonalNetwork(networkId);
       if (isPersonal) throw new Error('Cannot delete personal network');
       return db.softDeleteNetwork(networkId);

--- a/services/api/src/adapters/database.adapter.ts
+++ b/services/api/src/adapters/database.adapter.ts
@@ -138,7 +138,7 @@ export function createUserDatabase(db: ChatDatabaseAdapter, authUserId: string) 
     },
 
     // ─────────────────────────────────────────────────────────────────────────────
-    // Index Membership Operations
+    // Network Membership Operations
     // ─────────────────────────────────────────────────────────────────────────────
     getNetworkMemberships: () => db.getNetworkMemberships(authUserId),
     getUserIndexIds: () => db.getUserIndexIds(authUserId),
@@ -156,12 +156,12 @@ export function createUserDatabase(db: ChatDatabaseAdapter, authUserId: string) 
       const isOwner = await db.isIndexOwner(networkId, authUserId);
       if (!isOwner) throw new Error('Access denied: not index owner');
       const isPersonal = await db.isPersonalNetwork(networkId);
-      if (isPersonal) throw new Error('Cannot delete personal index');
+      if (isPersonal) throw new Error('Cannot delete personal network');
       return db.softDeleteNetwork(networkId);
     },
 
     // ─────────────────────────────────────────────────────────────────────────────
-    // Public Index Discovery
+    // Public Network Discovery
     // ─────────────────────────────────────────────────────────────────────────────
     getPublicIndexesNotJoined: () => db.getPublicIndexesNotJoined(authUserId),
     joinPublicNetwork: (networkId: string) => db.joinPublicNetwork(networkId, authUserId),
@@ -198,12 +198,12 @@ export function createUserDatabase(db: ChatDatabaseAdapter, authUserId: string) 
 }
 
 /**
- * Creates a SystemDatabase bound to the authenticated user and index scope.
- * Cross-user operations are restricted to users within the shared indexes.
+ * Creates a SystemDatabase bound to the authenticated user and network scope.
+ * Cross-user operations are restricted to users within the shared networks.
  *
  * @param db - The raw ChatDatabaseAdapter
  * @param authUserId - The authenticated user's ID
- * @param indexScope - Array of index IDs the user has access to
+ * @param indexScope - Array of network IDs the user has access to
  * @param embedder - Optional vector store for findSimilarIntentsInScope (pgvector search). When omitted, findSimilarIntentsInScope returns [].
  * @returns A SystemDatabase bound to authUserId and indexScope
  */
@@ -232,7 +232,7 @@ export function createSystemDatabase(
     const theirMemberships = await db.getNetworkMemberships(userId);
     if (theirMemberships.some((m) => indexScope.includes(m.networkId))) return true;
 
-    // Check if either user's personal index contains the other as a contact
+    // Check if either user's personal network contains the other as a contact
     const myPersonalId = await getPersonalIndexId(authUserId);
     const theirPersonalId = await getPersonalIndexId(userId);
 
@@ -256,13 +256,13 @@ export function createSystemDatabase(
     // ─────────────────────────────────────────────────────────────────────────────
     getProfile: async (userId: string) => {
       if (!(await verifySharedIndex(userId))) {
-        throw new Error('Access denied: no shared index with user');
+        throw new Error('Access denied: no shared network with user');
       }
       return db.getProfile(userId);
     },
     getUser: async (userId: string) => {
       if (!(await verifySharedIndex(userId))) {
-        throw new Error('Access denied: no shared index with user');
+        throw new Error('Access denied: no shared network with user');
       }
       return db.getUser(userId);
     },
@@ -324,7 +324,7 @@ export function createSystemDatabase(
     },
 
     // ─────────────────────────────────────────────────────────────────────────────
-    // Index Membership Operations (cross-user within scope)
+    // Network Membership Operations (cross-user within scope)
     // ─────────────────────────────────────────────────────────────────────────────
     /**
      * Checks network membership without scope check.
@@ -346,7 +346,7 @@ export function createSystemDatabase(
     /**
      * Adds a member to an index without scope check.
      * @remarks Intentionally unscoped -- used by join flows, invitation acceptance, and
-     * contact addition that operate outside the caller's current index scope.
+     * contact addition that operate outside the caller's current network scope.
      */
     addMemberToNetwork: (networkId: string, userId: string, role: 'owner' | 'member') => db.addMemberToNetwork(networkId, userId, role),
     /**
@@ -427,7 +427,7 @@ export function createSystemDatabase(
     expireOpportunitiesByIntent: (intentId: string) => db.expireOpportunitiesByIntent(intentId),
     /**
      * Expires opportunities for a removed member without scope check.
-     * @remarks Intentionally unscoped -- called by index membership removal event handlers
+     * @remarks Intentionally unscoped -- called by network membership removal event handlers
      * that clean up opportunities when a member leaves or is kicked from an index.
      */
     expireOpportunitiesForRemovedMember: (networkId: string, userId: string) => db.expireOpportunitiesForRemovedMember(networkId, userId),

--- a/services/api/src/adapters/database.shared.ts
+++ b/services/api/src/adapters/database.shared.ts
@@ -34,10 +34,10 @@ export function detectSocialLabel(value: string): string {
 export const SYSTEM_AGENT_ID = 'system-agent';
 
 /**
- * Creates a personal index for the user if one doesn't exist.
+ * Creates a personal network for the user if one doesn't exist.
  * Adds the user as the owner member.
- * @param userId - The user to create a personal index for
- * @returns The personal index ID
+ * @param userId - The user to create a personal network for
+ * @returns The personal network ID
  */
 export async function ensurePersonalNetwork(userId: string): Promise<string> {
   // Fast path: check mapping table
@@ -51,9 +51,9 @@ export async function ensurePersonalNetwork(userId: string): Promise<string> {
 
   const networkId = crypto.randomUUID();
 
-  // Personal indexes are prompt-less by default so the assignment policy treats
+  // Personal networks are prompt-less by default so the assignment policy treats
   // them as "no filtration" (score 1.0) — every one of the owner's intents lands
-  // in their own personal index. The owner may later set a prompt to curate it.
+  // in their own personal network. The owner may later set a prompt to curate it.
   await db.insert(schema.networks).values({
     id: networkId,
     title: 'My Network',
@@ -83,9 +83,9 @@ export async function ensurePersonalNetwork(userId: string): Promise<string> {
 }
 
 /**
- * Returns the personal index ID for a user.
+ * Returns the personal network ID for a user.
  * @param userId - The user to look up
- * @returns The personal index ID, or null if not found
+ * @returns The personal network ID, or null if not found
  */
 export async function getPersonalIndexId(userId: string): Promise<string | null> {
   const result = await db
@@ -512,7 +512,7 @@ export interface BasicUserInfo {
 
 /**
  * UserDatabaseAdapter
- * 
+ *
  * Wraps all database operations for users table and related tables.
  */
 export interface FileRow {
@@ -546,7 +546,7 @@ export interface FileListResult {
 
 /**
  * FileDatabaseAdapter
- * 
+ *
  * Wraps all database operations for files table.
  */
 export interface LinkRow {

--- a/services/api/src/adapters/intent.database.adapter.ts
+++ b/services/api/src/adapters/intent.database.adapter.ts
@@ -351,7 +351,7 @@ export class IntentDatabaseAdapter {
   /**
    * Associates an intent with an index (inserts intent_indexes row).
    * @param intentId - The intent identifier.
-   * @param networkId - The index identifier.
+   * @param networkId - The network identifier.
    * @returns Promise that resolves when the row is inserted.
    * @throws May throw on database insertion errors (db.insert/schema.intentNetworks).
    */
@@ -378,9 +378,9 @@ export class IntentDatabaseAdapter {
   }
 
   /**
-   * Returns personal index IDs where the given user is a contact member.
+   * Returns personal network IDs where the given user is a contact member.
    * @param userId - The user whose contact memberships to look up
-   * @returns Array of personal index IDs
+   * @returns Array of personal network IDs
    */
   async getPersonalIndexesForContact(userId: string): Promise<{ networkId: string }[]> {
     return db
@@ -463,7 +463,7 @@ export class IntentDatabaseAdapter {
     options?: { limit?: number; offset?: number }
   ) {
     const isMember = await this.isNetworkMember(networkId, requestingUserId);
-    if (!isMember) throw new Error('Access denied: Not a member of this index');
+    if (!isMember) throw new Error('Access denied: Not a member of this network');
 
     const limit = options?.limit ?? 50;
     const offset = options?.offset ?? 0;

--- a/services/api/src/adapters/network-graph.database.adapter.ts
+++ b/services/api/src/adapters/network-graph.database.adapter.ts
@@ -108,7 +108,7 @@ export class NetworkGraphDatabaseAdapter {
   }
 
   /**
-   * Delete an index and its members/intent-index links (for test teardown).
+   * Delete a network and its members/intent-network links (for test teardown).
    */
   async deleteNetworkAndMembers(networkId: string): Promise<void> {
     await db.delete(intentNetworks).where(eq(intentNetworks.networkId, networkId));

--- a/services/api/src/adapters/opportunity.database.adapter.ts
+++ b/services/api/src/adapters/opportunity.database.adapter.ts
@@ -744,9 +744,9 @@ export class OpportunityDatabaseAdapter {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// Index Graph Database Adapter
+// Network Graph Database Adapter
 // ═══════════════════════════════════════════════════════════════════════════════
 
 /**
- * Database adapter for Index Graph (intent/index context and assignment).
+ * Database adapter for Network Graph (intent/network context and assignment).
  */

--- a/services/api/src/adapters/tests/auth.adapter.spec.ts
+++ b/services/api/src/adapters/tests/auth.adapter.spec.ts
@@ -20,7 +20,7 @@ describe('AuthDatabaseAdapter', () => {
   const cleanupIndexIds: string[] = [];
 
   afterAll(async () => {
-    // Clean up index members and indexes first (FK constraints)
+    // Clean up network members and indexes first (FK constraints)
     for (const networkId of cleanupIndexIds) {
       await db.delete(schema.networkMembers).where(eq(schema.networkMembers.networkId, networkId)).catch(() => {});
       await db.delete(schema.networks).where(eq(schema.networks.id, networkId)).catch(() => {});
@@ -224,7 +224,7 @@ describe('AuthDatabaseAdapter', () => {
         updatedAt: new Date(),
       });
 
-      // Create some related data for the ghost (index membership)
+      // Create some related data for the ghost (network membership)
       const networkId = crypto.randomUUID();
       cleanupIndexIds.push(networkId);
       await db.insert(schema.networks).values({
@@ -258,7 +258,7 @@ describe('AuthDatabaseAdapter', () => {
 
       expect(result.id).toBe(ghostId);
 
-      // Verify index membership still references ghost's original ID
+      // Verify network membership still references ghost's original ID
       const [member] = await db.select()
         .from(schema.networkMembers)
         .where(eq(schema.networkMembers.userId, ghostId));

--- a/services/api/src/adapters/tests/database.adapter.spec.ts
+++ b/services/api/src/adapters/tests/database.adapter.spec.ts
@@ -417,7 +417,7 @@ describe('ChatDatabaseAdapter', () => {
     expect(o!.intentCount).toBeGreaterThanOrEqual(1);
   });
 
-  it('should report index owner', async () => {
+  it('should report network owner', async () => {
     expect(await adapter.isIndexOwner(fixture.networkId, fixture.userAId)).toBe(true);
     expect(await adapter.isIndexOwner(fixture.networkId, fixture.userBId)).toBe(false);
   });

--- a/services/api/src/adapters/tests/database.adapter.spec.ts
+++ b/services/api/src/adapters/tests/database.adapter.spec.ts
@@ -51,7 +51,7 @@ beforeAll(async () => {
   await db.insert(networks).values({
     id: networkId,
     title: TEST_PREFIX + 'Test Index',
-    prompt: 'Test index prompt',
+    prompt: 'Test network prompt',
   });
   await db.insert(networkMembers).values([
     { networkId, userId: userAId, permissions: ['owner'], autoAssign: false },
@@ -181,7 +181,7 @@ describe('ChatDatabaseAdapter', () => {
     await adapter.archiveIntent(created.id);
   });
 
-  it('should get intents in index for member by index id', async () => {
+  it('should get intents in index for member by network id', async () => {
     const list = await adapter.getIntentsInIndexForMember(fixture.userAId, fixture.networkId);
     expect(list.length).toBeGreaterThanOrEqual(1);
     expect(list.some((i) => i.id === fixture.intent1Id)).toBe(true);
@@ -225,7 +225,7 @@ describe('ChatDatabaseAdapter', () => {
     expect(doc!.hydeText).toBe(desc);
   });
 
-  it('should get index memberships for user', async () => {
+  it('should get network memberships for user', async () => {
     const memberships = await adapter.getNetworkMemberships(fixture.userAId);
     expect(memberships.length).toBeGreaterThanOrEqual(1);
     const m = memberships.find((x) => x.networkId === fixture.networkId);
@@ -258,7 +258,7 @@ describe('ChatDatabaseAdapter', () => {
     }
   });
 
-  it('should get user index ids for auto-assign member', async () => {
+  it('should get user network ids for auto-assign member', async () => {
     const indexIds = await adapter.getUserIndexIds(fixture.userBId);
     expect(indexIds).toContain(fixture.networkId);
   });
@@ -270,7 +270,7 @@ describe('ChatDatabaseAdapter', () => {
     expect(row!.userId).toBe(fixture.userAId);
   });
 
-  it('should get index member context for member with autoAssign', async () => {
+  it('should get network member context for member with autoAssign', async () => {
     const ctx = await adapter.getNetworkMemberContext(fixture.networkId, fixture.userBId);
     expect(ctx).not.toBeNull();
     expect(ctx!.networkId).toBe(fixture.networkId);
@@ -282,7 +282,7 @@ describe('ChatDatabaseAdapter', () => {
     expect(assigned).toBe(true);
   });
 
-  it('should get index ids for intent', async () => {
+  it('should get network ids for intent', async () => {
     const indexIds = await adapter.getNetworkIdsForIntent(fixture.intent1Id);
     expect(indexIds).toEqual([fixture.networkId]);
     const empty = await adapter.getNetworkIdsForIntent(uuidv4());
@@ -319,7 +319,7 @@ describe('ChatDatabaseAdapter', () => {
       finalScore: 0.76,
       assigned: true,
       reason: 'Matched network and member prompts.',
-      evaluator: 'intent-indexer',
+      evaluator: 'intent-networker',
       source: 'test',
       createdAt: '2026-06-09T00:00:00.000Z',
     };
@@ -422,13 +422,13 @@ describe('ChatDatabaseAdapter', () => {
     expect(await adapter.isIndexOwner(fixture.networkId, fixture.userBId)).toBe(false);
   });
 
-  it('should get index members for member', async () => {
+  it('should get network members for member', async () => {
     const members = await adapter.getNetworkMembersForMember(fixture.networkId, fixture.userBId);
     expect(members.length).toBeGreaterThanOrEqual(1);
     expect(members.some((m) => m.userId === fixture.userAId || m.userId === fixture.userBId)).toBe(true);
   });
 
-  it('should get index members for owner', async () => {
+  it('should get network members for owner', async () => {
     const members = await adapter.getNetworkMembersForOwner(fixture.networkId, fixture.userAId);
     expect(members.length).toBeGreaterThanOrEqual(1);
   });
@@ -448,7 +448,7 @@ describe('ChatDatabaseAdapter', () => {
     expect(list.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('should report index membership', async () => {
+  it('should report network membership', async () => {
     expect(await adapter.isNetworkMember(fixture.networkId, fixture.userAId)).toBe(true);
     expect(await adapter.isNetworkMember(fixture.networkId, fixture.userBId)).toBe(true);
     expect(await adapter.isNetworkMember(fixture.networkId, uuidv4())).toBe(false);
@@ -1400,7 +1400,7 @@ describe('NetworkGraphDatabaseAdapter', () => {
     expect(row).toBeNull();
   });
 
-  it('should get index member context', async () => {
+  it('should get network member context', async () => {
     const ctx = await adapter.getNetworkMemberContext(fixture.networkId, fixture.userBId);
     expect(ctx).not.toBeNull();
     expect(ctx!.networkId).toBe(fixture.networkId);
@@ -1416,7 +1416,7 @@ describe('NetworkGraphDatabaseAdapter', () => {
     expect(await adapter.isIntentAssignedToIndex(fixture.intent1Id, fixture.networkId)).toBe(true);
   });
 
-  it('should get index ids for intent', async () => {
+  it('should get network ids for intent', async () => {
     const indexIds = await adapter.getNetworkIdsForIntent(fixture.intent1Id);
     expect(indexIds).toEqual([fixture.networkId]);
     const empty = await adapter.getNetworkIdsForIntent(uuidv4());
@@ -1428,7 +1428,7 @@ describe('NetworkGraphDatabaseAdapter', () => {
     await db.insert(intents).values({
       id: newIntentId,
       userId: fixture.userBId,
-      payload: TEST_PREFIX + 'Index graph assign test',
+      payload: TEST_PREFIX + 'Network graph assign test',
       sourceType: 'discovery_form',
       sourceId: fixture.userBId,
     });

--- a/services/api/src/adapters/tests/embedder.adapter.spec.ts
+++ b/services/api/src/adapters/tests/embedder.adapter.spec.ts
@@ -130,7 +130,7 @@ describe('EmbedderAdapter', () => {
   });
 
   describe('search (single-vector)', () => {
-    it('should return intent match when searching with same embedding and index scope', async () => {
+    it('should return intent match when searching with same embedding and network scope', async () => {
       const queryVector = makeTestVector(42);
       await db.insert(intents).values({
         id: fixture.intentId,
@@ -153,7 +153,7 @@ describe('EmbedderAdapter', () => {
       expect(match!.score).toBeGreaterThanOrEqual(0.99);
     });
 
-    it('should apply index scope filtering (only members of index)', async () => {
+    it('should apply network scope filtering (only members of index)', async () => {
       const queryVector = makeTestVector(100);
       const results = await adapter.search<{ id: string; userId: string }>(
         queryVector,
@@ -164,7 +164,7 @@ describe('EmbedderAdapter', () => {
       for (const r of results) {
         expect(r.item).toBeDefined();
       }
-      // All results should be from intents in this index (enforced by join in adapter)
+      // All results should be from intents in this network (enforced by join in adapter)
       expect(results.length).toBeLessThanOrEqual(5);
     });
   });

--- a/services/api/src/adapters/tests/personal-network.adapter.spec.ts
+++ b/services/api/src/adapters/tests/personal-network.adapter.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Integration tests for Personal Index lifecycle.
+ * Integration tests for Personal Network lifecycle.
  * Verifies ensurePersonalNetwork, getPersonalIndexId, contact sync,
  * contact removal cleanup, getNetworkMemberships filtering, and isPersonalNetwork.
  *
@@ -71,7 +71,7 @@ beforeAll(async () => {
     status: 'ACTIVE',
   });
 
-  // Use ensurePersonalNetwork to create the owner's personal index
+  // Use ensurePersonalNetwork to create the owner's personal network
   const personalIndexId = await ensurePersonalNetwork(ownerUserId);
 
   fixture = {
@@ -116,7 +116,7 @@ afterAll(async () => {
 // ─── ensurePersonalNetwork ────────────────────────────────────────────────────────
 
 describe('ensurePersonalNetwork', () => {
-  it('creates a personal index with correct title and personal_indexes entry', async () => {
+  it('creates a personal network with correct title and personal_indexes entry', async () => {
     const [row] = await db
       .select()
       .from(networks)
@@ -166,11 +166,11 @@ describe('ensurePersonalNetwork', () => {
     expect(membership.autoAssign).toBe(true);
   });
 
-  it('is idempotent — calling twice returns the same index ID', async () => {
+  it('is idempotent — calling twice returns the same network ID', async () => {
     const secondCall = await ensurePersonalNetwork(fixture.ownerUserId);
     expect(secondCall).toBe(fixture.personalIndexId);
 
-    // Verify only one personal index exists for this user
+    // Verify only one personal network exists for this user
     const rows = await db
       .select({ networkId: personalNetworks.networkId })
       .from(personalNetworks)
@@ -182,12 +182,12 @@ describe('ensurePersonalNetwork', () => {
 // ─── getPersonalIndexId ─────────────────────────────────────────────────────────
 
 describe('getPersonalIndexId', () => {
-  it('returns the correct index ID for a user with a personal index', async () => {
+  it('returns the correct network ID for a user with a personal network', async () => {
     const result = await getPersonalIndexId(fixture.ownerUserId);
     expect(result).toBe(fixture.personalIndexId);
   });
 
-  it('returns null for a user without a personal index', async () => {
+  it('returns null for a user without a personal network', async () => {
     const result = await getPersonalIndexId(fixture.otherUserId);
     expect(result).toBeNull();
   });
@@ -198,12 +198,12 @@ describe('getPersonalIndexId', () => {
 describe('getPersonalIndexesForContact', () => {
   const chatDb = new ChatDatabaseAdapter();
 
-  it('returns empty array when user is not a contact in any personal index', async () => {
+  it('returns empty array when user is not a contact in any personal network', async () => {
     const result = await chatDb.getPersonalIndexesForContact(fixture.otherUserId);
     expect(result).toEqual([]);
   });
 
-  it('returns personal indexes where user is a contact member', async () => {
+  it('returns personal networks where user is a contact member', async () => {
     // Manually add the contact user as a contact member
     await db.insert(networkMembers).values({
       networkId: fixture.personalIndexId,
@@ -218,9 +218,9 @@ describe('getPersonalIndexesForContact', () => {
   });
 });
 
-// ─── upsertContactMembership → personal index sync ─────────────────────────────
+// ─── upsertContactMembership → personal network sync ─────────────────────────────
 
-describe('upsertContactMembership → personal index sync', () => {
+describe('upsertContactMembership → personal network sync', () => {
   const chatDb = new ChatDatabaseAdapter();
 
   it('creates index_members entry with contact permissions for new contacts', async () => {
@@ -251,10 +251,10 @@ describe('upsertContactMembership → personal index sync', () => {
 
 // ─── Contact removal → cleanup ──────────────────────────────────────────────────
 
-describe('hardDeleteContactMembership → personal index cleanup', () => {
+describe('hardDeleteContactMembership → personal network cleanup', () => {
   const chatDb = new ChatDatabaseAdapter();
 
-  it('removes contact membership from personal index', async () => {
+  it('removes contact membership from personal network', async () => {
     await chatDb.hardDeleteContactMembership(fixture.ownerUserId, fixture.contactUserId);
 
     // Contact's membership should be removed
@@ -276,7 +276,7 @@ describe('hardDeleteContactMembership → personal index cleanup', () => {
 describe('getNetworkMemberships', () => {
   const chatDb = new ChatDatabaseAdapter();
 
-  it('returns the user\'s own personal index', async () => {
+  it('returns the user\'s own personal network', async () => {
     const memberships = await chatDb.getNetworkMemberships(fixture.ownerUserId);
 
     const personalMembership = memberships.find(m => m.networkId === fixture.personalIndexId);
@@ -291,8 +291,8 @@ describe('getNetworkMemberships', () => {
     expect(regularMembership).toBeDefined();
   });
 
-  it('does NOT return other users\' personal indexes the user is a contact in', async () => {
-    // Re-add contact as member of owner's personal index
+  it('does NOT return other users\' personal networks the user is a contact in', async () => {
+    // Re-add contact as member of owner's personal network
     await db.insert(networkMembers).values({
       networkId: fixture.personalIndexId,
       userId: fixture.contactUserId,
@@ -300,7 +300,7 @@ describe('getNetworkMemberships', () => {
       autoAssign: false,
     }).onConflictDoNothing();
 
-    // Contact's memberships should NOT include the owner's personal index
+    // Contact's memberships should NOT include the owner's personal network
     const memberships = await chatDb.getNetworkMemberships(fixture.contactUserId);
     const ownerPersonalIndex = memberships.find(m => m.networkId === fixture.personalIndexId);
     expect(ownerPersonalIndex).toBeUndefined();
@@ -312,7 +312,7 @@ describe('getNetworkMemberships', () => {
 describe('isPersonalNetwork', () => {
   const chatDb = new ChatDatabaseAdapter();
 
-  it('returns true for a personal index', async () => {
+  it('returns true for a personal network', async () => {
     const result = await chatDb.isPersonalNetwork(fixture.personalIndexId);
     expect(result).toBe(true);
   });
@@ -330,19 +330,19 @@ describe('isPersonalNetwork', () => {
 
 // ─── NetworkService assertNotPersonal guard ───────────────────────────────────────
 
-describe('NetworkService personal index guards', () => {
+describe('NetworkService personal network guards', () => {
   const service = new NetworkService();
 
-  it('rejects updateNetwork on a personal index', async () => {
+  it('rejects updateNetwork on a personal network', async () => {
     await expect(
       service.updateNetwork(fixture.personalIndexId, fixture.ownerUserId, { title: 'New Title' }),
-    ).rejects.toThrow('personal indexes cannot be modified directly');
+    ).rejects.toThrow('personal networks cannot be modified directly');
   });
 
-  it('rejects deleteNetwork on a personal index', async () => {
+  it('rejects deleteNetwork on a personal network', async () => {
     await expect(
       service.deleteNetwork(fixture.personalIndexId, fixture.ownerUserId),
-    ).rejects.toThrow('personal indexes cannot be modified directly');
+    ).rejects.toThrow('personal networks cannot be modified directly');
   });
 
   it('allows updateNetwork on a regular index', async () => {
@@ -350,8 +350,8 @@ describe('NetworkService personal index guards', () => {
     try {
       await service.updateNetwork(fixture.regularIndexId, fixture.ownerUserId, { title: TEST_PREFIX + 'Updated' });
     } catch (error: unknown) {
-      // Only fail if the error is about personal indexes
-      if (error instanceof Error && error.message.includes('personal indexes')) {
+      // Only fail if the error is about personal networks
+      if (error instanceof Error && error.message.includes('personal networks')) {
         throw error;
       }
       // Other errors (e.g. missing permissions check) are acceptable here

--- a/services/api/src/adapters/tests/system-database.spec.ts
+++ b/services/api/src/adapters/tests/system-database.spec.ts
@@ -36,8 +36,8 @@ import type { ChatDatabaseAdapter } from '../database.adapter';
 
 const AUTH_USER = 'user-auth-123';
 const OTHER_USER = 'user-other-456';
-const SCOPED_INDEX = 'index-scoped-1';
-const SCOPED_INDEX_2 = 'index-scoped-2';
+const SCOPED_INDEX = 'network-scoped-1';
+const SCOPED_INDEX_2 = 'network-scoped-2';
 const OUT_OF_SCOPE_INDEX = 'index-out-of-scope';
 
 function createMockDb(): ChatDatabaseAdapter {
@@ -468,12 +468,12 @@ describe('createSystemDatabase', () => {
       (mockDb.getNetworkMemberships as ReturnType<typeof mock>).mockResolvedValueOnce([
         { networkId: 'some-unrelated-network' },
       ]);
-      await expect(sysDb.getProfile(OTHER_USER)).rejects.toThrow('no shared index');
+      await expect(sysDb.getProfile(OTHER_USER)).rejects.toThrow('no shared network');
     });
 
     it('getUser throws when other user shares no scoped network and no personal network contact', async () => {
       (mockDb.getNetworkMemberships as ReturnType<typeof mock>).mockResolvedValueOnce([]);
-      await expect(sysDb.getUser(OTHER_USER)).rejects.toThrow('no shared index');
+      await expect(sysDb.getUser(OTHER_USER)).rejects.toThrow('no shared network');
     });
   });
 });

--- a/services/api/src/adapters/tests/user-database.spec.ts
+++ b/services/api/src/adapters/tests/user-database.spec.ts
@@ -380,7 +380,7 @@ describe('createUserDatabase', () => {
   });
 
   // ─────────────────────────────────────────────────────────────────────────────
-  // Index Membership Operations — authUserId binding
+  // Network Membership Operations — authUserId binding
   // ─────────────────────────────────────────────────────────────────────────────
 
   describe('network membership operations bind authUserId', () => {
@@ -443,12 +443,12 @@ describe('createUserDatabase', () => {
     it('softDeleteNetwork throws when index is personal even if user is owner', async () => {
       (mockDb.isIndexOwner as ReturnType<typeof mock>).mockResolvedValueOnce(true);
       (mockDb.isPersonalNetwork as ReturnType<typeof mock>).mockResolvedValueOnce(true);
-      await expect(userDb.softDeleteNetwork('idx-personal')).rejects.toThrow('Cannot delete personal index');
+      await expect(userDb.softDeleteNetwork('idx-personal')).rejects.toThrow('Cannot delete personal network');
     });
   });
 
   // ─────────────────────────────────────────────────────────────────────────────
-  // Public Index Discovery
+  // Public Network Discovery
   // ─────────────────────────────────────────────────────────────────────────────
 
   describe('public network discovery binds authUserId', () => {

--- a/services/api/src/cli/backfill-intent-networks.ts
+++ b/services/api/src/cli/backfill-intent-networks.ts
@@ -123,7 +123,7 @@ async function main(): Promise<void> {
         indexPrompt,
         memberPrompt,
         rawScores: raw,
-        evaluator: 'intent-indexer',
+        evaluator: 'intent-networker',
         source: 'backfill-intent-networks',
         createdAt: new Date().toISOString(),
       });

--- a/services/api/src/cli/backfill-personal-index-prompts.ts
+++ b/services/api/src/cli/backfill-personal-index-prompts.ts
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
 /**
- * Backfill CLI: heal personal indexes after removing the hidden boilerplate prompt.
+ * Backfill CLI: heal personal networks after removing the hidden boilerplate prompt.
  *
  * Two idempotent steps:
- *   1. Clear the system boilerplate prompt from personal indexes (only the exact
+ *   1. Clear the system boilerplate prompt from personal networks (only the exact
  *      boilerplate string — any user-authored prompt is preserved).
- *   2. Assign every active intent to its owner's personal index (relevancy 1.0)
- *      when that personal index is now prompt-less and the intent isn't already
- *      a member. Prompt-less personal index == "no filtration" == holds everything.
+ *   2. Assign every active intent to its owner's personal network (relevancy 1.0)
+ *      when that personal network is now prompt-less and the intent isn't already
+ *      a member. Prompt-less personal network == "no filtration" == holds everything.
  *
  * Dry-run by default: pass --apply to write. Defaults to .env.development unless
  * NODE_ENV=production (mirrors the other maintenance scripts).
@@ -26,7 +26,7 @@ import { sql } from 'drizzle-orm/sql';
 
 import db, { closeDb } from '../lib/drizzle/drizzle';
 
-const BOILERPLATE = "Personal index containing the owner's imported contacts for network-scoped discovery.";
+const BOILERPLATE = "Personal network containing the owner's imported contacts for network-scoped discovery.";
 
 async function main() {
   const apply = process.argv.slice(2).includes('--apply');
@@ -56,8 +56,8 @@ async function main() {
   `);
   const orphanCount = Number((orphanRows[0] as { count: number | string })?.count ?? 0);
 
-  console.log(`Personal indexes with boilerplate prompt to clear: ${boilerplateCount}`);
-  console.log(`Active intents missing from their personal index to heal: ${orphanCount}`);
+  console.log(`Personal networks with boilerplate prompt to clear: ${boilerplateCount}`);
+  console.log(`Active intents missing from their personal network to heal: ${orphanCount}`);
 
   if (!apply) {
     console.log('\nDry-run only — re-run with --apply to write changes.\n');
@@ -70,9 +70,9 @@ async function main() {
     where is_personal = true and deleted_at is null and prompt = ${BOILERPLATE}
     returning id
   `);
-  console.log(`Step 1: cleared boilerplate prompt on ${(cleared as unknown[]).length} personal indexes.`);
+  console.log(`Step 1: cleared boilerplate prompt on ${(cleared as unknown[]).length} personal networks.`);
 
-  // --- Step 2: assign missing active intents to their personal index ---------
+  // --- Step 2: assign missing active intents to their personal network ---------
   // Runs AFTER step 1 so n.prompt is null for indexes we just cleared; any
   // user-authored prompt remains non-null and is intentionally skipped.
   const healed = await db.execute(sql`
@@ -90,7 +90,7 @@ async function main() {
     on conflict (intent_id, network_id) do nothing
     returning intent_id
   `);
-  console.log(`Step 2: assigned ${(healed as unknown[]).length} intents to their personal index.\n`);
+  console.log(`Step 2: assigned ${(healed as unknown[]).length} intents to their personal network.\n`);
 }
 
 main()

--- a/services/api/src/cli/db-seed.ts
+++ b/services/api/src/cli/db-seed.ts
@@ -236,7 +236,7 @@ async function createUser(account: SeedAccount): Promise<{ id: string }> {
 /**
  * Create or get users for the given accounts and ensure they are members of all seed indexes.
  * @param accounts - List of accounts (real or synthetic).
- * @param options.ownerIndex - Index in this array that receives 'owner' on all indexes; others get 'member'. Omit for all 'member'.
+ * @param options.ownerIndex - Index in this array that receives 'owner' on all networks; others get 'member'. Omit for all 'member'.
  */
 async function ensureUsersAndMemberships(
   accounts: SeedAccount[],
@@ -305,7 +305,7 @@ async function seedDatabase(): Promise<{ ok: boolean; error?: string }> {
     if (!silent && DB_SEED_TESTER_PERSONAS.length > 0) console.log(`  Personas to seed: ${personasToSeed.length} (--personas=${personasLimit}, max ${TESTER_PERSONAS_MAX})`);
     if (!silent) console.log('Creating indexes...');
 
-    // Create all indexes
+    // Create all networks
     for (let i = 0; i < SEED_INDEXES.length; i++) {
       const idx = SEED_INDEXES[i];
       try {
@@ -333,7 +333,7 @@ async function seedDatabase(): Promise<{ ok: boolean; error?: string }> {
     if (!silent) console.log(`  System admin users: ${adminUsers.length} ready`);
 
     if (!silent) console.log(`Creating synthetic persona users (1..${personasToSeed.length})...`);
-    // Synthetic tester personas (first is owner of all indexes); count controlled by --personas
+    // Synthetic tester personas (first is owner of all networks); count controlled by --personas
     const personaAccounts: SeedAccount[] = personasToSeed.map((p) => ({
       email: p.email,
       name: p.name,
@@ -345,7 +345,7 @@ async function seedDatabase(): Promise<{ ok: boolean; error?: string }> {
     const personaUsers = await ensureUsersAndMemberships(personaAccounts, { ownerIndex: 0 });
     if (!silent) console.log(`  Persona users: ${personaUsers.length} ready`);
 
-    if (!silent) console.log('Enqueueing profile HyDE jobs for index members...');
+    if (!silent) console.log('Enqueueing profile HyDE jobs for network members...');
     let successfulEnqueues = 0;
     for (const user of personaUsers) {
       try {

--- a/services/api/src/controllers/debug.controller.ts
+++ b/services/api/src/controllers/debug.controller.ts
@@ -204,7 +204,7 @@ export class DebugController {
 
   /**
    * Returns a home-level diagnostic snapshot for the authenticated user.
-   * Gathers intent stats, index memberships, opportunity aggregates,
+   * Gathers intent stats, network memberships, opportunity aggregates,
    * simulated home-view filtering, and a pipeline-health diagnosis.
    * @param _req - Incoming request (unused beyond guard processing)
    * @param user - Authenticated user from AuthGuard
@@ -464,7 +464,7 @@ export class DebugController {
         exportedAt: new Date().toISOString(),
         preflight,
         result: null,
-        diagnosis: 'User has no index memberships — cannot discover opportunities.',
+        diagnosis: 'User has no network memberships — cannot discover opportunities.',
       });
     }
     if (preflight.candidatePool.otherMembersInIndexes === 0) {

--- a/services/api/src/controllers/integration.controller.ts
+++ b/services/api/src/controllers/integration.controller.ts
@@ -15,7 +15,7 @@ function isAllowedToolkit(t: string): t is AllowedToolkit {
 }
 
 /**
- * Manages external integration connections (OAuth), index-scoped linking, and contact import.
+ * Manages external integration connections (OAuth), network-scoped linking, and contact import.
  * OAuth connections are user-level (Composio); the index_integrations table tracks
  * which connections are linked to which indexes.
  */
@@ -124,8 +124,8 @@ export class IntegrationController {
 
   /**
    * Import contacts from a connected toolkit into an index.
-   * Personal indexes receive contacts with 'contact' permission;
-   * non-personal indexes receive members with 'member' permission.
+   * Personal networks receive contacts with 'contact' permission;
+   * non-personal networks receive members with 'member' permission.
    * POST /api/integrations/:toolkit/import
    */
   @Post('/:toolkit/import')

--- a/services/api/src/controllers/tests/chat.controller.spec.ts
+++ b/services/api/src/controllers/tests/chat.controller.spec.ts
@@ -29,7 +29,7 @@ describe("ChatController Integration", () => {
   const intentAdapter = new IntentDatabaseAdapter();
   const indexAdapter = new NetworkGraphDatabaseAdapter();
   let testUserId: string;
-  /** Index IDs created for getIntentsInIndexForMember tests; cleaned in afterAll */
+  /** Network IDs created for getIntentsInIndexForMember tests; cleaned in afterAll */
   let testIndexId: string | null = null;
   let testIndexIdOther: string | null = null;
   let unauthorizedStreamIndexId: string | null = null;
@@ -137,7 +137,7 @@ describe("ChatController Integration", () => {
       };
 
       const created = await adapter.createIntent(intentData);
-      
+
       expect(created).not.toBeNull();
       expect(created.id).toBeDefined();
       expect(created.payload).toBe(intentData.payload);
@@ -156,7 +156,7 @@ describe("ChatController Integration", () => {
       // Get the intent we created
       const intents = await adapter.getActiveIntents(testUserId);
       expect(intents.length).toBeGreaterThan(0);
-      
+
       const intentId = intents[0].id;
       const updated = await adapter.updateIntent(intentId, {
         payload: "Looking for collaborators on a machine learning project",
@@ -172,7 +172,7 @@ describe("ChatController Integration", () => {
       // Get the intent we created
       const intents = await adapter.getActiveIntents(testUserId);
       expect(intents.length).toBeGreaterThan(0);
-      
+
       const intentId = intents[0].id;
       const result = await adapter.archiveIntent(intentId);
 
@@ -223,7 +223,7 @@ describe("ChatController Integration", () => {
       expect(intents[0].payload).toBe("Looking for collaborators on a machine learning project");
     });
 
-    test("getIntentsInIndexForMember should return intents when queried by index ID", async () => {
+    test("getIntentsInIndexForMember should return intents when queried by network ID", async () => {
       expect(testIndexId).not.toBeNull();
       const intents = await adapter.getIntentsInIndexForMember(testUserId!, testIndexId!);
       expect(intents).toBeArray();
@@ -252,7 +252,7 @@ describe("ChatController Integration", () => {
       const mockRequest = {
         json: async () => ({})
       } as unknown as Request;
-      
+
       const mockUser: AuthenticatedUser = {
         id: testUserId,
         email: "test-chat-controller@example.com",
@@ -270,7 +270,7 @@ describe("ChatController Integration", () => {
       const mockRequest = {
         json: async () => { throw new Error('Invalid JSON'); }
       } as unknown as Request;
-      
+
       const mockUser: AuthenticatedUser = {
         id: testUserId,
         email: "test-chat-controller@example.com",
@@ -279,7 +279,7 @@ describe("ChatController Integration", () => {
 
       const response = await controller.message(mockRequest, mockUser);
       const data = await response.json() as ChatResponse;
-      
+
       expect(response.status).toBe(400);
       expect(data.error).toBe('Invalid request body. Expected { message: string }');
     });
@@ -288,7 +288,7 @@ describe("ChatController Integration", () => {
       const mockRequest = {
         json: async () => ({ message: "Hello, how are you?" })
       } as unknown as Request;
-      
+
       const mockUser: AuthenticatedUser = {
         id: testUserId,
         email: "test-chat-controller@example.com",
@@ -311,7 +311,7 @@ describe("ChatController Integration", () => {
       const mockRequest = {
         json: async () => ({ message: "I'm looking for people who are interested in building AI agents" })
       } as unknown as Request;
-      
+
       const mockUser: AuthenticatedUser = {
         id: testUserId,
         email: "test-chat-controller@example.com",
@@ -333,7 +333,7 @@ describe("ChatController Integration", () => {
       const mockRequest = {
         json: async () => ({ message: "Update my profile to include that I'm now focused on LLM applications" })
       } as unknown as Request;
-      
+
       const mockUser: AuthenticatedUser = {
         id: testUserId,
         email: "test-chat-controller@example.com",

--- a/services/api/src/controllers/tests/integration.controller.spec.ts
+++ b/services/api/src/controllers/tests/integration.controller.spec.ts
@@ -1,7 +1,7 @@
 /**
  * Unit tests for IntegrationController.
  * Tests ownership verification on disconnect, basic list/connect flows,
- * and index-scoped link/unlink/import operations.
+ * and network-scoped link/unlink/import operations.
  */
 import { config } from "dotenv";
 config({ path: '.env.test', override: true });
@@ -253,7 +253,7 @@ describe("IntegrationController", () => {
       expect(res.status).toBe(400);
     });
 
-    test("should import contacts for an owned non-personal index", async () => {
+    test("should import contacts for an owned non-personal network", async () => {
       const req = new Request("http://test/api/integrations/gmail/import", {
         method: "POST",
         body: JSON.stringify({ networkId: INDEX_OWNED }),

--- a/services/api/src/controllers/tests/integration.controller.spec.ts
+++ b/services/api/src/controllers/tests/integration.controller.spec.ts
@@ -154,7 +154,7 @@ describe("IntegrationController", () => {
       expect(linkedIntegrations[0].toolkit).toBe("gmail");
     });
 
-    test("should return 400 when user is not index owner", async () => {
+    test("should return 400 when user is not network owner", async () => {
       const req = new Request("http://test/api/integrations/gmail/link", {
         method: "POST",
         body: JSON.stringify({ networkId: INDEX_NOT_OWNED }),
@@ -212,7 +212,7 @@ describe("IntegrationController", () => {
       expect(linkedIntegrations).toHaveLength(0);
     });
 
-    test("should return 400 when user is not index owner", async () => {
+    test("should return 400 when user is not network owner", async () => {
       const req = new Request(`http://test/api/integrations/gmail/link?networkId=${INDEX_NOT_OWNED}`, {
         method: "DELETE",
       });

--- a/services/api/src/controllers/tests/network.controller.spec.ts
+++ b/services/api/src/controllers/tests/network.controller.spec.ts
@@ -85,7 +85,7 @@ describe("NetworkController Integration", () => {
       expect(data.error).toBe("title is required");
     });
 
-    test("should return 200 and create index when title provided", async () => {
+    test("should return 200 and create network when title provided", async () => {
       const req = new Request("http://localhost/networks", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -169,7 +169,7 @@ describe("NetworkController Integration", () => {
       expect(data.network!.title).toBe("Test Index");
     });
 
-    test("should return 404 when index id does not exist", async () => {
+    test("should return 404 when network id does not exist", async () => {
       const fakeId = "00000000-0000-0000-0000-000000000000";
       const req = new Request("http://localhost/networks/" + fakeId);
       const res = await controller.get(req, mockUser(), { id: fakeId });

--- a/services/api/src/lib/betterauth/betterauth.ts
+++ b/services/api/src/lib/betterauth/betterauth.ts
@@ -85,7 +85,7 @@ export function createAuth(deps: AuthDeps) {
             try {
               await authDb.ensurePersonalNetwork(session.userId);
             } catch (err) {
-              logger.error('Failed to ensure personal index on sign-in', { userId: session.userId, error: err });
+              logger.error('Failed to ensure personal network on sign-in', { userId: session.userId, error: err });
             }
           },
         },
@@ -96,7 +96,7 @@ export function createAuth(deps: AuthDeps) {
             try {
               await authDb.ensurePersonalNetwork(user.id);
             } catch (err) {
-              logger.error('Failed to create personal index on registration', { userId: user.id, error: err });
+              logger.error('Failed to create personal network on registration', { userId: user.id, error: err });
             }
           },
         },

--- a/services/api/src/queues/enrichment.queue.ts
+++ b/services/api/src/queues/enrichment.queue.ts
@@ -52,7 +52,7 @@ export interface EnrichmentQueueDeps {
  * Enrichment queue: BullMQ queue plus worker and job handlers.
  *
  * Handles `ensure_profile_hyde`: invokes the profile graph in write mode so the user has
- * a profile and HyDE documents for discovery (index members can be found).
+ * a profile and HyDE documents for discovery (network members can be found).
  *
  * Handles `enrich.user`: enriches users (ghost or real) via Chat API enrichment
  * inside the profile graph, then generates profile + HyDE documents.

--- a/services/api/src/queues/intent.queue.ts
+++ b/services/api/src/queues/intent.queue.ts
@@ -337,7 +337,7 @@ export class IntentQueue implements IntentGraphQueue {
       this.deps?.addOpportunityJob ??
       ((d: { intentId: string; userId: string; networkIds?: string[] }) => fromIntentQueue.addJob(d));
     // Carry only the focused network scope into discovery. Assignment writes may
-    // include the user's personal index, but scoped opportunity discovery must not.
+    // include the user's personal network, but scoped opportunity discovery must not.
     const discoveryScope: { networkIds?: string[] } = await (async () => {
       try {
         const assignmentMemberships = await this.getAssignmentMemberships(userId);
@@ -437,7 +437,7 @@ export class IntentQueue implements IntentGraphQueue {
             indexPrompt,
             memberPrompt,
             rawScores: result ? { indexScore: result.indexScore, memberScore: result.memberScore } : undefined,
-            evaluator: 'intent-indexer',
+            evaluator: 'intent-networker',
             source,
             reason: result?.reasoning,
             createdAt: new Date().toISOString(),

--- a/services/api/src/queues/tests/intent.queue.spec.ts
+++ b/services/api/src/queues/tests/intent.queue.spec.ts
@@ -346,7 +346,7 @@ describe('IntentQueue', () => {
         const getAssignmentNetworkIdsForUser = mock(async () => ['net-a', 'net-b']);
         const getNetworkAssignmentContext = mock(async (networkId: string) => ({
           networkId,
-          indexPrompt: `Index prompt for ${networkId}`,
+          indexPrompt: `Network prompt for ${networkId}`,
           memberPrompt: `Member prompt for ${networkId}`,
         }));
         const db = {

--- a/services/api/src/services/chat.service.ts
+++ b/services/api/src/services/chat.service.ts
@@ -73,11 +73,11 @@ export class ChatSessionService {
   }
 
   /**
-   * Update the index scope for a session. Validates ownership.
+   * Update the network scope for a session. Validates ownership.
    *
    * @param sessionId - The session ID
    * @param userId - The user ID to validate ownership
-   * @param networkId - The index ID to set, or undefined to clear
+   * @param networkId - The network ID to set, or undefined to clear
    * @returns True if updated, false if not found or unauthorized
    */
   async updateSessionIndex(sessionId: string, userId: string, networkId: string | undefined): Promise<boolean> {
@@ -108,7 +108,7 @@ export class ChatSessionService {
 
     const isMember = await this.graphDb.isNetworkMember(normalizedIndexId, userId);
     if (!isMember) {
-      return { ok: false, status: 403, error: 'You are not a member of this index' };
+      return { ok: false, status: 403, error: 'You are not a member of this network' };
     }
 
     return { ok: true };
@@ -116,40 +116,40 @@ export class ChatSessionService {
 
   /**
    * Get a session by ID, validating ownership.
-   * 
+   *
    * @param sessionId - The session ID
    * @param userId - The user ID to validate ownership
    * @returns The session if found and owned by user, null otherwise
    */
   async getSession(sessionId: string, userId: string) {
     logger.verbose('Getting session', { sessionId, userId });
-    
+
     const session = await this.db.getChatSession(sessionId);
-    
+
     if (!session || session.userId !== userId) {
       logger.warn('Session not found or unauthorized', { sessionId, userId });
       return null;
     }
-    
+
     return session;
   }
 
   /**
    * Get all sessions for a user, ordered by most recent.
-   * 
+   *
    * @param userId - The user's UUID
    * @param limit - Maximum number of sessions to return (default: 10)
    * @returns List of sessions
    */
   async getUserSessions(userId: string, limit = 10) {
     logger.verbose('Getting user sessions', { userId, limit });
-    
+
     return this.db.getUserChatSessions(userId, limit);
   }
 
   /**
    * Add a message to a session.
-   * 
+   *
    * @param params - Message parameters
    * @returns The created message ID (snowflake format)
    */
@@ -189,42 +189,42 @@ export class ChatSessionService {
 
   /**
    * Get messages for a session in chronological order.
-   * 
+   *
    * @param sessionId - The session ID
    * @param limit - Maximum number of messages to return (all if omitted)
    * @returns List of messages
    */
   async getSessionMessages(sessionId: string, limit?: number) {
     logger.verbose('Getting session messages', { sessionId, limit });
-    
+
     return this.db.getChatSessionMessages(sessionId, limit);
   }
 
   /**
    * Delete a session and all its messages (cascade).
-   * 
+   *
    * @param sessionId - The session ID to delete
    * @param userId - The user ID to validate ownership
    * @returns True if deleted, false if not found or unauthorized
    */
   async deleteSession(sessionId: string, userId: string): Promise<boolean> {
     logger.verbose('Deleting session', { sessionId, userId });
-    
+
     const session = await this.getSession(sessionId, userId);
     if (!session) {
       logger.warn('Cannot delete: session not found or unauthorized', { sessionId, userId });
       return false;
     }
-    
+
     await this.db.deleteChatSession(sessionId);
-    
+
     logger.verbose('Session deleted', { sessionId });
     return true;
   }
 
   /**
    * Update session title.
-   * 
+   *
    * @param sessionId - The session ID
    * @param userId - The user ID to validate ownership
    * @param title - The new title
@@ -232,14 +232,14 @@ export class ChatSessionService {
    */
   async updateSessionTitle(sessionId: string, userId: string, title: string): Promise<boolean> {
     logger.verbose('Updating session title', { sessionId, userId, titleLength: title.length });
-    
+
     const session = await this.getSession(sessionId, userId);
     if (!session) {
       return false;
     }
-    
+
     await this.db.updateChatSessionTitle(sessionId, title);
-    
+
     return true;
   }
 
@@ -274,7 +274,7 @@ export class ChatSessionService {
 
   /**
    * Process a message through the chat graph (non-streaming).
-   * 
+   *
    * @param userId - The user ID
    * @param messageContent - The message content
    * @returns Graph execution result with response text
@@ -299,7 +299,7 @@ export class ChatSessionService {
 
   /**
    * Get checkpointer for streaming (if needed).
-   * 
+   *
    * @returns PostgresSaver checkpointer or undefined
    */
   async getCheckpointer(): Promise<PostgresSaver | undefined> {
@@ -316,7 +316,7 @@ export class ChatSessionService {
   /**
    * Get the chat graph factory for streaming operations.
    * This is used by controllers that need to stream chat events.
-   * 
+   *
    * @returns The ChatGraphFactory instance
    */
   getGraphFactory(): ChatGraphFactory {
@@ -399,7 +399,7 @@ export class ChatSessionService {
 
   /**
    * Auto-generate a session title based on conversation history.
-   * 
+   *
    * @param sessionId - The session ID
    * @param userId - The user ID
    * @returns The generated title or undefined if generation fails

--- a/services/api/src/services/contact.service.ts
+++ b/services/api/src/services/contact.service.ts
@@ -94,7 +94,7 @@ export interface ResolveResult {
  * ContactService
  *
  * Manages user contacts ("My Network") using index_members with 'contact' permission
- * on the owner's personal index.
+ * on the owner's personal network.
  *
  * RESPONSIBILITIES:
  * - Add/remove contacts via index_members rows
@@ -234,7 +234,7 @@ export class ContactService {
 
   /**
    * Import contacts in bulk using batched DB operations.
-   * Resolves users, upserts contact memberships on the owner's personal index,
+   * Resolves users, upserts contact memberships on the owner's personal network,
    * and clears reverse opt-outs.
    *
    * @param ownerId - The user importing contacts

--- a/services/api/src/services/integration.service.ts
+++ b/services/api/src/services/integration.service.ts
@@ -197,7 +197,7 @@ export class IntegrationService {
   /**
    * List all linked integrations for an index.
    *
-   * @param userId - Authenticated user ID (must be index owner)
+   * @param userId - Authenticated user ID (must be network owner)
    * @param networkId - The index to query
    * @returns Array of toolkit/connectedAccountId pairs
    */
@@ -254,7 +254,7 @@ export class IntegrationService {
    * Configure sync settings (interval, calendarId, status) for an integration on an index.
    * The integration must already be linked via linkToIndex.
    *
-   * @param userId - Authenticated user (must be index owner)
+   * @param userId - Authenticated user (must be network owner)
    * @param networkId - Target index
    * @param toolkit - Toolkit slug (e.g. 'google_calendar')
    * @param config - Partial sync configuration to merge

--- a/services/api/src/services/integration.service.ts
+++ b/services/api/src/services/integration.service.ts
@@ -80,18 +80,18 @@ export class IntegrationService {
   private async assertNetworkOwner(networkId: string, userId: string): Promise<void> {
     const isOwner = await this.db.isIndexOwner(networkId, userId);
     if (!isOwner) {
-      throw new Error('Access denied: you must be an owner of this index');
+      throw new Error('Access denied: you must be an owner of this network');
     }
   }
 
   /**
    * Fetch contacts from the given toolkit and import them into an index.
-   * Personal indexes get contacts with 'contact' permission; non-personal
+   * Personal networks get contacts with 'contact' permission; non-personal
    * indexes get members with 'member' permission.
    *
    * @param userId - Authenticated user ID
    * @param toolkit - Which provider to import from
-   * @param networkId - Target index (uses personal index when omitted)
+   * @param networkId - Target index (uses personal network when omitted)
    * @returns Bulk import statistics
    */
   async importContacts(userId: string, toolkit: Toolkit, networkId?: string): Promise<ImportResult> {

--- a/services/api/src/services/intent.service.ts
+++ b/services/api/src/services/intent.service.ts
@@ -10,11 +10,11 @@ const logger = log.service.from("IntentService");
 
 /**
  * IntentService
- * 
+ *
  * Manages intent processing through the Intent Graph and CRUD operations.
  * Uses IntentDatabaseAdapter for database operations.
  * Uses IntentGraphFactory for graph-based intent processing.
- * 
+ *
  * RESPONSIBILITIES:
  * - Process intents through Intent Graph
  * - Extract, verify, reconcile, and execute intent actions
@@ -55,7 +55,7 @@ export class IntentService {
   /**
    * Process user input through the Intent Graph.
    * Extracts, verifies, reconciles, and executes intent actions.
-   * 
+   *
    * @param userId - The user ID
    * @param userProfile - The user profile as JSON string
    * @param content - Optional input content to process
@@ -83,7 +83,7 @@ export class IntentService {
 
   /**
    * List intents for a user with pagination and filters.
-   * 
+   *
    * @param userId - The user ID
    * @param options - Pagination and filter options
    * @returns Intents and pagination metadata
@@ -302,7 +302,7 @@ export class IntentService {
     try {
       await this.adapter.deleteIntentIndexAssociations(intentId);
     } catch (err) {
-      logger.error('[IntentService] Failed to delete intent-index associations', { intentId, error: err });
+      logger.error('[IntentService] Failed to delete intent-network associations', { intentId, error: err });
     }
 
     try {

--- a/services/api/src/services/network.service.ts
+++ b/services/api/src/services/network.service.ts
@@ -14,20 +14,20 @@ const logger = log.service.from("NetworkService");
 
 /**
  * NetworkService
- * 
+ *
  * Manages index/community operations.
  * Uses ChatDatabaseAdapter for database operations.
- * 
+ *
  * RESPONSIBILITIES:
- * - List indexes for users
+ * - List networks for users
  * - Get single index details
- * - Manage index memberships
+ * - Manage network memberships
  */
 export class NetworkService {
   constructor(private adapter = new ChatDatabaseAdapter()) {}
 
   /**
-   * Get all indexes that a user is a member of, including their personal index.
+   * Get all networks that a user is a member of, including their personal network.
    */
   async getNetworksForUser(userId: string) {
     logger.verbose('[NetworkService] Getting networks for user', { userId });
@@ -55,7 +55,7 @@ export class NetworkService {
     // Fetch the full index details with user and member count
     const fullIndex = await this.adapter.getNetworkDetail(index.id, userId);
     if (!fullIndex) {
-      throw new Error('Failed to create index');
+      throw new Error('Failed to create network');
     }
     return fullIndex;
   }
@@ -102,15 +102,15 @@ export class NetworkService {
   }
 
   /**
-   * Get a public index by ID (no auth required). Returns null if not public.
+   * Get a public network by ID (no auth required). Returns null if not public.
    */
   async getPublicNetworkById(networkId: string) {
-    logger.verbose('[NetworkService] Getting public index by id', { networkId });
+    logger.verbose('[NetworkService] Getting public network by id', { networkId });
     return this.adapter.getPublicIndexDetail(networkId);
   }
 
   /**
-   * Get a single index by ID with owner info and member count.
+   * Get a single network by ID with owner info and member count.
    * Only members of the index can view it.
    */
   async getNetworkById(networkId: string, userId: string) {
@@ -120,13 +120,13 @@ export class NetworkService {
 
   /**
    * Update index settings (title, prompt, permissions). Owner-only.
-   * @throws Error if the index is a personal index.
+   * @throws Error if the index is a personal network.
    * @throws Error if attempting to change join policy on an experiment network.
    */
   async updateNetwork(networkId: string, userId: string, data: { title?: string; prompt?: string | null; imageUrl?: string | null; joinPolicy?: 'anyone' | 'invite_only'; allowGuestVibeCheck?: boolean; profileEnrichment?: schema.ProfileEnrichmentPolicy; type?: 'community' | 'event'; metadata?: Record<string, unknown>; contextInjection?: { discovery: boolean } }) {
     logger.verbose('[NetworkService] Updating index', { networkId, userId });
     if (await this.adapter.isPersonalNetwork(networkId)) {
-      // Personal indexes can't be renamed/deleted/repurposed (see assertNotPersonal),
+      // Personal networks can't be renamed/deleted/repurposed (see assertNotPersonal),
       // but the owner may set or clear a discovery prompt to curate what auto-assigns
       // into My Network. Restrict edits to the prompt field only; ownership is
       // enforced inside updateIndexSettings.
@@ -135,7 +135,7 @@ export class NetworkService {
         (k) => (data as Record<string, unknown>)[k] !== undefined && !editableForPersonal.has(k),
       );
       if (rejected.length > 0) {
-        throw new Error(`Access denied: personal indexes only allow editing the prompt (rejected: ${rejected.join(', ')}).`);
+        throw new Error(`Access denied: personal networks only allow editing the prompt (rejected: ${rejected.join(', ')}).`);
       }
       return this.adapter.updateIndexSettings(networkId, userId, { prompt: data.prompt });
     }
@@ -196,7 +196,7 @@ export class NetworkService {
   }
 
   /**
-   * Search users within the caller's personal index members,
+   * Search users within the caller's personal network members,
    * optionally excluding existing members of a target index.
    */
   async searchPersonalNetworkMembers(userId: string, q: string, excludeIndexId?: string) {
@@ -205,7 +205,7 @@ export class NetworkService {
 
   /**
    * Add a member to an index. Owner-only.
-   * @throws Error if the index is a personal index.
+   * @throws Error if the index is a personal network.
    */
   async addMember(networkId: string, userId: string, requestingUserId: string, role: 'owner' | 'member' = 'member') {
     logger.verbose('[NetworkService] Adding member', { networkId, userId, role });
@@ -225,7 +225,7 @@ export class NetworkService {
 
   /**
    * Remove a member from an index. Owner-only.
-   * @throws Error if the index is a personal index.
+   * @throws Error if the index is a personal network.
    */
   async removeMember(networkId: string, memberId: string, userId: string) {
     logger.verbose('[NetworkService] Removing member', { networkId, memberId, userId });
@@ -234,8 +234,8 @@ export class NetworkService {
   }
 
   /**
-   * Soft-delete an index. Owner-only.
-   * @throws Error if the index is a personal index.
+   * Soft-delete a network. Owner-only.
+   * @throws Error if the index is a personal network.
    */
   async deleteNetwork(networkId: string, userId: string) {
     logger.verbose('[NetworkService] Deleting index', { networkId, userId });
@@ -251,7 +251,7 @@ export class NetworkService {
     if (network?.isExperiment) {
       // Verify ownership first
       const isOwner = await this.adapter.isIndexOwner(networkId, userId);
-      if (!isOwner) throw new Error('Access denied: Not an owner of this index');
+      if (!isOwner) throw new Error('Access denied: Not an owner of this network');
       await this.adapter.softDeleteExperimentNetwork(networkId);
     } else {
       await this.adapter.deleteIndexForOwner(networkId, userId);
@@ -277,7 +277,7 @@ export class NetworkService {
   }
 
   /**
-   * Get all members from every index the signed-in user is a member of (deduplicated).
+   * Get all members from every network the signed-in user is a member of (deduplicated).
    * Used for mentionable users / @mentions.
    */
   async getMembersFromMyNetworks(userId: string) {
@@ -302,10 +302,10 @@ export class NetworkService {
   }
 
   /**
-   * Get public indexes that the user has not joined (for discovery).
+   * Get public networks that the user has not joined (for discovery).
    */
   async getPublicNetworks(userId: string) {
-    logger.verbose('[NetworkService] Getting public indexes for user', { userId });
+    logger.verbose('[NetworkService] Getting public networks for user', { userId });
     return this.adapter.getPublicIndexesNotJoined(userId);
   }
 
@@ -332,17 +332,17 @@ export class NetworkService {
   }
 
   /**
-   * Join a public index.
+   * Join a public network.
    */
   async joinPublicNetwork(networkId: string, userId: string) {
-    logger.verbose('[NetworkService] Joining public index', { networkId, userId });
+    logger.verbose('[NetworkService] Joining public network', { networkId, userId });
     await this.adapter.joinPublicNetwork(networkId, userId);
     return this.adapter.getNetworkDetail(networkId, userId);
   }
 
   /**
    * Leave an index. Members (non-owners) can leave.
-   * @throws Error if the index is a personal index.
+   * @throws Error if the index is a personal network.
    */
   async leaveNetwork(networkId: string, userId: string) {
     logger.verbose('[NetworkService] Leaving index', { networkId, userId });
@@ -357,7 +357,7 @@ export class NetworkService {
     logger.verbose('[NetworkService] Getting member settings', { networkId, userId });
     const settings = await this.adapter.getMemberSettings(networkId, userId);
     if (!settings) {
-      throw new Error('Not a member of this index');
+      throw new Error('Not a member of this network');
     }
     return settings;
   }
@@ -383,7 +383,7 @@ export class NetworkService {
     logger.verbose('[NetworkService] Getting network overview', { networkId, userId });
     const isMember = await this.adapter.isNetworkMember(networkId, userId);
     if (!isMember) {
-      throw new Error('Access denied: Not a member of this index');
+      throw new Error('Access denied: Not a member of this network');
     }
     const [intents, premises, userContext] = await Promise.all([
       this.adapter.getNetworkIntentsForMemberOwn(networkId, userId),
@@ -398,9 +398,9 @@ export class NetworkService {
   }
 
   /**
-   * Resolve an index identifier (UUID or key) to a UUID.
+   * Resolve an network identifier (UUID or key) to a UUID.
    * @param idOrKey - UUID or human-readable key
-   * @returns The index UUID, or null if not found
+   * @returns The network UUID, or null if not found
    */
   async resolveIndexId(idOrKey: string): Promise<string | null> {
     logger.verbose('[NetworkService] Resolving network ID or key', { idOrKey });
@@ -460,13 +460,13 @@ export class NetworkService {
   }
 
   /**
-   * Assert that an index is not a personal index.
+   * Assert that an index is not a personal network.
    * @throws Error if the index is personal.
    */
   private async assertNotPersonal(networkId: string): Promise<void> {
     const isPersonal = await this.adapter.isPersonalNetwork(networkId);
     if (isPersonal) {
-      throw new Error('Access denied: personal indexes cannot be modified directly.');
+      throw new Error('Access denied: personal networks cannot be modified directly.');
     }
   }
 

--- a/services/api/src/services/opportunity.service.ts
+++ b/services/api/src/services/opportunity.service.ts
@@ -60,12 +60,12 @@ export class OpportunityServiceEvents extends EventEmitter {
 
 /**
  * OpportunityService
- * 
+ *
  * Manages opportunity operations including discovery, listing, and creation.
  * Uses OpportunityControllerDatabase adapter for database operations.
  * Uses OpportunityGraph for AI-powered opportunity discovery.
  * Emits opportunity events (created, expired) after transactional writes so subscribers see consistent state.
- * 
+ *
  * RESPONSIBILITIES:
  * - List opportunities for users and indexes
  * - Get and present individual opportunities
@@ -381,7 +381,7 @@ export class OpportunityService {
 
   /**
    * Get a single opportunity with full presentation details.
-   * 
+   *
    * @param opportunityId - The opportunity ID
    * @param viewerId - The user viewing the opportunity
    * @returns Opportunity with presentation data or null
@@ -463,7 +463,7 @@ export class OpportunityService {
 
   /**
    * Update opportunity status.
-   * 
+   *
    * @param opportunityId - The opportunity ID
    * @param status - New status
    * @param userId - User making the update (for authorization)
@@ -776,7 +776,7 @@ export class OpportunityService {
 
   /**
    * Discover opportunities via HyDE graph.
-   * 
+   *
    * @param userId - The user ID
    * @param query - Search query
    * @param limit - Number of results
@@ -812,8 +812,8 @@ export class OpportunityService {
 
   /**
    * Get opportunities for a specific index.
-   * 
-   * @param networkId - The index ID
+   *
+   * @param networkId - The network ID
    * @param userId - User requesting (for authorization)
    * @param options - Filter options
    * @returns List of opportunities or error
@@ -850,8 +850,8 @@ export class OpportunityService {
 
   /**
    * Create a manual opportunity (curator feature).
-   * 
-   * @param networkId - The index ID
+   *
+   * @param networkId - The network ID
    * @param creatorId - User creating the opportunity
    * @param data - Opportunity creation data
    * @returns Created opportunity or error
@@ -1120,7 +1120,7 @@ export class OpportunityService {
    *
    * @param creatorId - User creating the opportunity
    * @param parties - Parties involved
-   * @param networkId - The index ID
+   * @param networkId - The network ID
    * @returns Permission result
    */
   private async checkCreatePermission(
@@ -1130,13 +1130,13 @@ export class OpportunityService {
   ): Promise<{ allowed: boolean }> {
     const isOwner = await this.db.isIndexOwner(networkId, creatorId);
     const isSelfIncluded = parties.some((p) => p.userId === creatorId);
-    
+
     if (isOwner) return { allowed: true };
-    
+
     const isMember = await this.db.isNetworkMember(networkId, creatorId);
     if (!isMember) return { allowed: false };
     if (isSelfIncluded) return { allowed: true };
-    
+
     return { allowed: true };
   }
 

--- a/services/api/src/services/tests/contact.service.spec.ts
+++ b/services/api/src/services/tests/contact.service.spec.ts
@@ -31,7 +31,7 @@ let svc: ContactService;
 
 /**
  * Helper: build the WHERE predicate matching a user's contact-permission
- * membership row in the owner's personal index.
+ * membership row in the owner's personal network.
  */
 function contactMembershipQuery(userId: string) {
   return and(
@@ -42,17 +42,17 @@ function contactMembershipQuery(userId: string) {
 }
 
 /**
- * Helper: create a user and personal index for testing.
+ * Helper: create a user and personal network for testing.
  */
 async function createTestUser(id: string, email: string, name: string): Promise<string> {
   await db.insert(users).values({ id, name, email });
   createdUserIds.push(id);
 
-  // Create personal index
+  // Create personal network
   const networkId = crypto.randomUUID();
   await db.insert(networks).values({
     id: networkId,
-    title: `${name}'s Personal Index`,
+    title: `${name}'s Personal Network`,
     isPersonal: true,
   });
   await db.insert(personalNetworks).values({ userId: id, networkId });
@@ -71,10 +71,10 @@ beforeAll(async () => {
   ownerId = crypto.randomUUID();
   existingUserId = crypto.randomUUID();
 
-  // Create owner with personal index
+  // Create owner with personal network
   personalIndexId = await createTestUser(ownerId, ownerEmail, TEST_PREFIX + 'Owner');
 
-  // Create an existing (non-ghost) user (no personal index needed for them)
+  // Create an existing (non-ghost) user (no personal network needed for them)
   await db.insert(users).values({
     id: existingUserId,
     name: TEST_PREFIX + 'ExistingContact',
@@ -89,7 +89,7 @@ afterAll(async () => {
   if (allUserIds.length > 0) {
     await db.delete(networkMembers).where(inArray(networkMembers.userId, allUserIds));
   }
-  // Remove all members from personal index before deleting it (avoids FK constraint)
+  // Remove all members from personal network before deleting it (avoids FK constraint)
   await db.delete(networkMembers).where(eq(networkMembers.networkId, personalIndexId));
   // Clean personal_indexes for owner
   await db.delete(personalNetworks).where(eq(personalNetworks.userId, ownerId));
@@ -196,10 +196,10 @@ describe('addContact', () => {
     const otherEmail = `${TEST_PREFIX}other@example.com`;
     const otherId = crypto.randomUUID();
 
-    // Create "other" user with personal index
+    // Create "other" user with personal network
     const otherIndexId = await createTestUser(otherId, otherEmail, TEST_PREFIX + 'Other');
 
-    // Simulate: other user has owner as a soft-deleted contact in their personal index
+    // Simulate: other user has owner as a soft-deleted contact in their personal network
     await db.insert(networkMembers).values({
       networkId: otherIndexId,
       userId: ownerId,
@@ -211,7 +211,7 @@ describe('addContact', () => {
     // Owner adds other as contact — should clear reverse opt-out
     await svc.addContact(ownerId, otherEmail);
 
-    // The soft-deleted row in other's personal index for owner should be gone
+    // The soft-deleted row in other's personal network for owner should be gone
     const rows = await db
       .select()
       .from(networkMembers)
@@ -224,7 +224,7 @@ describe('addContact', () => {
       );
     expect(rows.length).toBe(0);
 
-    // Cleanup: remove the other personal index
+    // Cleanup: remove the other personal network
     await db.delete(networkMembers).where(eq(networkMembers.networkId, otherIndexId));
     await db.delete(personalNetworks).where(eq(personalNetworks.userId, otherId));
     await db.delete(networks).where(eq(networks.id, otherIndexId));

--- a/services/api/src/services/tests/network.service.personal-prompt.spec.ts
+++ b/services/api/src/services/tests/network.service.personal-prompt.spec.ts
@@ -25,7 +25,7 @@ function makeService() {
   return { service: new NetworkService(adapter), updateIndexSettings };
 }
 
-describe('networkService.updateNetwork on a personal index', () => {
+describe('networkService.updateNetwork on a personal network', () => {
   test('allows a prompt-only edit', async () => {
     const { service, updateIndexSettings } = makeService();
     await service.updateNetwork(PERSONAL_ID, USER_ID, { prompt: 'AI founders only' });
@@ -38,7 +38,7 @@ describe('networkService.updateNetwork on a personal index', () => {
     expect(updateIndexSettings).toHaveBeenCalledWith(PERSONAL_ID, USER_ID, { prompt: null });
   });
 
-  test('rejects a rename (title) on a personal index', async () => {
+  test('rejects a rename (title) on a personal network', async () => {
     const { service, updateIndexSettings } = makeService();
     await expect(
       service.updateNetwork(PERSONAL_ID, USER_ID, { title: 'Renamed' }),

--- a/services/api/tests/introducer-discovery.spec.ts
+++ b/services/api/tests/introducer-discovery.spec.ts
@@ -54,7 +54,7 @@ describe('IntroducerDiscovery', () => {
   });
 
   describe('selectContactsForDiscovery', () => {
-    it('returns empty when user has no personal index', async () => {
+    it('returns empty when user has no personal network', async () => {
       const db = createMockDatabase({ personalIndexId: null });
       const result = await selectContactsForDiscovery(db, userId);
       expect(result).toEqual([]);
@@ -108,7 +108,7 @@ describe('IntroducerDiscovery', () => {
       expect(queue.addJob).not.toHaveBeenCalled();
     });
 
-    it('returns early when user has no personal index', async () => {
+    it('returns early when user has no personal network', async () => {
       const db = createMockDatabase({ personalIndexId: null });
       const queue = createMockQueue();
       const result = await runIntroducerDiscovery(db, queue, userId);
@@ -130,7 +130,7 @@ describe('IntroducerDiscovery', () => {
       expect(result.jobsEnqueued).toBe(2);
       expect(queue.addJob).toHaveBeenCalledTimes(2);
 
-      // Verify job data includes introducer prefix and personal index
+      // Verify job data includes introducer prefix and personal network
       const firstCall = (queue.addJob as ReturnType<typeof mock>).mock.calls[0];
       expect(firstCall[0].intentId).toStartWith('introducer:');
       expect(firstCall[0].userId).toBe(userId);

--- a/services/api/tests/maintenance-introducer-discovery.spec.ts
+++ b/services/api/tests/maintenance-introducer-discovery.spec.ts
@@ -129,7 +129,7 @@ describe('MaintenanceGraph — Introducer Discovery', () => {
     expect(introducerJobs.length).toBe(0);
   }, 30_000);
 
-  it('skips introducer discovery when user has no personal index', async () => {
+  it('skips introducer discovery when user has no personal network', async () => {
     const deps = createMockDeps({
       opportunities: Array.from({ length: 3 }, (_, i) => ({
         id: `opp-${i}`,
@@ -151,7 +151,7 @@ describe('MaintenanceGraph — Introducer Discovery', () => {
     const graph = factory.createGraph();
     const result = await graph.invoke({ userId });
 
-    // No introducer discovery jobs (no personal index)
+    // No introducer discovery jobs (no personal network)
     const addJobCalls = (deps.queue.addJob as ReturnType<typeof mock>).mock.calls;
     const introducerJobs = addJobCalls.filter(
       (call: unknown[]) => typeof call[0] === 'object' && call[0]?.contactUserId != null,


### PR DESCRIPTION
## Summary
- Replace high-confidence domain “index” wording with “network” across UI copy, docs, prompts, tests, and generated plugin skill outputs
- Preserve brand, API, CLI, and compatibility terminology such as Index Network, index.network, indexId, indexScope, and read_indexes
- Update deterministic prompt snapshots after terminology changes

## Verification
- bun run build:skills
- git diff --exit-code -- packages/claude-plugin/skills packages/hermes-plugin/skills
- python3 -m py_compile packages/hermes-plugin/schemas.py
- cd packages/protocol && bun run build
- cd apps/web && bun run build
- cd packages/cli && bun test tests/network.command.spec.ts tests/tool-calls.spec.ts
- cd packages/protocol && bun test src/chat/tests/chat.prompt.modules.spec.ts
- High-confidence terminology rescan: 0 flags

## Notes
Broader changed-test batches surfaced failures in existing/adjacent protocol and API tests; see PR discussion before merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1067"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784997533&installation_id=140549914&pr_number=1067&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1067&signature=85b0b04545176a1230afa4967e4ef51dae9dc2f58ebfd0a751cb5d2ba7aad52f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->