### PR TITLE
feat(chat): add intent-scoped orchestrator sessions

### DIFF
--- a/apps/web/src/app/library/page.tsx
+++ b/apps/web/src/app/library/page.tsx
@@ -6,6 +6,8 @@ import { useAuthContext } from "@/contexts/AuthContext";
 import { useAPI } from "@/contexts/APIContext";
 import { useAuthenticatedAPI } from "@/lib/api";
 import { useNotifications } from "@/contexts/NotificationContext";
+import { useAIChat } from "@/contexts/AIChatContext";
+import { useNetworkFilter } from "@/contexts/IndexFilterContext";
 import { formatDate } from "@/lib/utils";
 import { formatFileSize, getFileCategoryBadge } from "@/lib/file-validation";
 import IntentList from "@/components/IntentList";
@@ -57,6 +59,8 @@ export default function LibraryPage() {
   const { filesService, linksService, intentsService } = useAPI();
   const api = useAuthenticatedAPI();
   const { success, error } = useNotifications();
+  const { clearChat, resolveIntentSession } = useAIChat();
+  const { setSelectedNetworkIds } = useNetworkFilter();
 
   const activeTab: TabValue = VALID_TABS.includes(tab as TabValue) ? (tab as TabValue) : 'intents';
   const setActiveTab = (v: string) => navigate(`/library/${v}`, { replace: true });
@@ -198,6 +202,18 @@ export default function LibraryPage() {
     }
   }, [intentsService, success, error, loadIntents]);
 
+  const handleOpenIntentChat = useCallback(async (intent: LibrarySourceIntent) => {
+    try {
+      clearChat({ abortStream: false });
+      setSelectedNetworkIds([]);
+      const label = (intent.summary && intent.summary.trim().length > 0 ? intent.summary : intent.payload).trim();
+      const sessionId = await resolveIntentSession({ id: intent.id, label });
+      navigate(`/d/${sessionId}`);
+    } catch {
+      error('Failed to open intent chat');
+    }
+  }, [clearChat, setSelectedNetworkIds, resolveIntentSession, navigate, error]);
+
   // Delete file handler
   const handleDeleteFile = useCallback(async (fileId: string) => {
     setFiles(prev => prev.filter(f => f.id !== fileId));
@@ -290,6 +306,7 @@ export default function LibraryPage() {
                 isLoading={loadingIntents}
                 emptyMessage="No intents yet"
                 onArchiveIntent={handleArchiveIntent}
+                onIntentClick={handleOpenIntentChat}
                 className="w-full"
               />
             )}

--- a/apps/web/src/components/ChatContent.tsx
+++ b/apps/web/src/components/ChatContent.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useGmailConnect } from "@/hooks/useGmailConnect";
 import { useNavigate } from "react-router";
-import { ArrowUp, Pencil, Paperclip, Square, X, Globe, ChevronDown, Lock, ChevronLeft, Share2, Check, Users } from "lucide-react";
+import { ArrowUp, Pencil, Paperclip, Square, X, Globe, ChevronDown, Lock, ChevronLeft, Share2, Check, Users, MessageSquare } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { MentionsTextInput } from "@/components/MentionsInput";
 import { useAIChat } from "@/contexts/AIChatContext";
@@ -62,6 +62,8 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
     sessionId,
     sessionTitle,
     suggestions: contextSuggestions,
+    chatScope,
+    setChatScope,
     setScopeNetworkId,
     sessionNetworkId,
     updateSessionTitle,
@@ -188,18 +190,31 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
   const questionsService = useQuestionsService();
   const [injectedQuestions, setInjectedQuestions] = useState<PendingQuestion[]>([]);
 
-  // Fetch conversation-linked questions on session load
+  // Fetch conversation-linked questions on session load. In intent-scoped
+  // sessions, also include pending questions derived from that selected intent,
+  // its opportunities, and their negotiations.
   useEffect(() => {
     if (!sessionId) {
       setInjectedQuestions([]);
       return;
     }
     let active = true;
-    questionsService.getByConversation(sessionId).then((qs) => {
-      if (active) setInjectedQuestions(qs);
+    const scopeQuestionPromise = chatScope?.type === "intent"
+      ? questionsService.getPending({ scopeType: "intent", scopeId: chatScope.id })
+      : Promise.resolve([] as PendingQuestion[]);
+    Promise.all([
+      questionsService.getByConversation(sessionId),
+      scopeQuestionPromise,
+    ]).then(([conversationQuestions, scopeQuestions]) => {
+      if (!active) return;
+      const deduped = new Map<string, PendingQuestion>();
+      for (const question of [...conversationQuestions, ...scopeQuestions]) {
+        deduped.set(question.id, question);
+      }
+      setInjectedQuestions([...deduped.values()]);
     }).catch(() => {});
     return () => { active = false; };
-  }, [sessionId, questionsService]);
+  }, [sessionId, questionsService, chatScope]);
 
   // Group injected questions by messageId
   const injectedByMessageId = useMemo(() => {
@@ -299,12 +314,18 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
   const { selectedNetworkIds, setSelectedNetworkIds } = useNetworkFilter();
   const selectedIndexId =
     selectedNetworkIds.length === 1 ? selectedNetworkIds[0] : null;
+  const intentOpportunityScope = useMemo(
+    () => chatScope?.type === "intent"
+      ? { scopeType: "intent" as const, scopeId: chatScope.id }
+      : undefined,
+    [chatScope],
+  );
 
   // Suggestions: from context (done event) when we have messages, else static starters
   const { suggestions } = useSuggestions({
     contextSuggestions: contextSuggestions ?? null,
     hasMessages: messages.length > 0,
-    networkId: selectedIndexId,
+    networkId: chatScope?.type === "network" ? selectedIndexId : undefined,
     enabled: messages.length > 0,
   });
 
@@ -321,12 +342,14 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
 
   // Sync network filter selection to chat scope so backend receives networkId when user has selected a network
   useEffect(() => {
+    if (chatScope?.type === "intent") return;
     setScopeNetworkId(selectedIndexId);
-  }, [selectedIndexId, setScopeNetworkId]);
+  }, [selectedIndexId, setScopeNetworkId, chatScope?.type]);
 
-  // Fetch home view when on home (no messages) and USE_HOME_API
+  // Fetch home view only on the root/home composer. Empty /d/:sessionId
+  // conversations should render the chat shell, not the discovery home feed.
   useEffect(() => {
-    if (!USE_HOME_API || messages.length > 0) {
+    if (!USE_HOME_API || messages.length > 0 || sessionIdFromUrl) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setHomeViewData(null);
       return;
@@ -336,7 +359,12 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
     const urlParams = new URLSearchParams(window.location.search);
     const noCache = urlParams.get('noCache') === '1' || urlParams.get('noCache') === 'true';
     opportunitiesService
-      .getHomeView({ networkId: selectedIndexId ?? undefined, limit: 5, noCache })
+      .getHomeView({
+        ...(chatScope?.type === "network" ? { networkId: selectedIndexId ?? undefined } : {}),
+        ...(intentOpportunityScope ?? {}),
+        limit: 5,
+        noCache,
+      })
       .then((res) => {
         setHomeViewData(res);
         setHomeViewLoading(false);
@@ -346,7 +374,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
         setHomeViewData(null);
         setHomeViewLoading(false);
       });
-  }, [messages.length, selectedIndexId, opportunitiesService]);
+  }, [messages.length, sessionIdFromUrl, selectedIndexId, opportunitiesService, chatScope?.type, intentOpportunityScope]);
 
   const handleSuggestionClick = useCallback(
     (suggestion: {
@@ -381,11 +409,12 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
       navigatingToHomeRef.current = true;
       // Don't abort in-flight stream so the new session can finish and appear in the sidebar
       clearChat({ abortStream: false });
+      setChatScope(null);
       setSelectedNetworkIds([]);
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setSessionLoaded(true);
     }
-  }, [sessionIdFromUrl, loadSession, clearChat]);
+  }, [sessionIdFromUrl, loadSession, clearChat, setChatScope, setSelectedNetworkIds]);
 
 
   useEffect(() => {
@@ -462,7 +491,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
 
         setOpportunityActionLoading((prev) => ({ ...prev, [opportunityId]: true }));
         try {
-          const result = await opportunitiesService.updateStatus(opportunityId, "accepted");
+          const result = await opportunitiesService.updateStatus(opportunityId, "accepted", intentOpportunityScope);
           setOpportunityStatusMap((prev) => ({ ...prev, [opportunityId]: "accepted" }));
           removeOpportunityFromHomeView(opportunityId);
           const counterpartUserId = result.counterpartUserId ?? fallbackUserId;
@@ -482,7 +511,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
       if (action === "accepted" && !isIntroducer && !isGhost) {
         setOpportunityActionLoading((prev) => ({ ...prev, [opportunityId]: true }));
         try {
-          const result = await opportunitiesService.startChat(opportunityId);
+          const result = await opportunitiesService.startChat(opportunityId, intentOpportunityScope);
           setOpportunityStatusMap((prev) => ({ ...prev, [opportunityId]: "accepted" }));
           removeOpportunityFromHomeView(opportunityId);
           refreshConversations();
@@ -502,7 +531,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
       setOpportunityActionLoading((prev) => ({ ...prev, [opportunityId]: true }));
       try {
         const effectiveStatus = isIntroducer && action === "accepted" ? "pending" : action;
-        const result = await opportunitiesService.updateStatus(opportunityId, effectiveStatus);
+        const result = await opportunitiesService.updateStatus(opportunityId, effectiveStatus, intentOpportunityScope);
         setOpportunityStatusMap((prev) => ({ ...prev, [opportunityId]: effectiveStatus }));
 
         if (action === "accepted" && isIntroducer) {
@@ -525,7 +554,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
         setOpportunityActionLoading((prev) => ({ ...prev, [opportunityId]: false }));
       }
     },
-    [opportunitiesService, navigate, showError, showSuccess, refreshConversations, removeOpportunityFromHomeView],
+    [opportunitiesService, navigate, showError, showSuccess, refreshConversations, removeOpportunityFromHomeView, intentOpportunityScope],
   );
 
   /**
@@ -539,7 +568,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
     async (opportunityId: string, counterpartUserId: string) => {
       setOpportunityActionLoading((prev) => ({ ...prev, [opportunityId]: true }));
       try {
-        const result = await opportunitiesService.startChat(opportunityId);
+        const result = await opportunitiesService.startChat(opportunityId, intentOpportunityScope);
         setOpportunityStatusMap((prev) => ({ ...prev, [opportunityId]: "accepted" }));
         refreshConversations();
         // Always route to the h2h chat page (`/u/:peer/chat`). `/chat/:id`
@@ -552,7 +581,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
         setOpportunityActionLoading((prev) => ({ ...prev, [opportunityId]: false }));
       }
     },
-    [opportunitiesService, navigate, showError, refreshConversations],
+    [opportunitiesService, navigate, showError, refreshConversations, intentOpportunityScope],
   );
 
   const archiveProposalIntent = useCallback(
@@ -857,12 +886,34 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
     </>
   );
 
-  // HOME STATE - No messages yet
-  if (messages.length === 0) {
+  // HOME STATE - No messages yet. A resolved /d/:sessionId may legitimately
+  // have no messages yet; keep that in conversation mode so intent-scoped
+  // sessions open directly into the chat shell with their scope chip visible.
+  if (messages.length === 0 && !sessionIdFromUrl) {
     const personalIndex = indexes.find((i) => i.isPersonal);
     const selectedIndex = indexes.find((i) => selectedNetworkIds.includes(i.id));
 
     const renderScopeDropdown = () => {
+      if (chatScope?.type === "intent") {
+        return (
+          <div className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium text-black bg-gray-100 border border-gray-200">
+            <MessageSquare className="w-4 h-4" />
+            {!isInputMultiline && (
+              <span className="max-w-48 truncate">
+                {chatScope.label || "Selected intent"}
+              </span>
+            )}
+            <button
+              type="button"
+              onClick={() => setChatScope(null)}
+              className="p-0.5 rounded-full text-gray-500 hover:text-black hover:bg-gray-200"
+              aria-label="Clear intent scope"
+            >
+              <X className="w-3.5 h-3.5" />
+            </button>
+          </div>
+        );
+      }
       if (indexes.length === 0) return null;
       return (
         <div className="relative shrink-0">
@@ -1273,7 +1324,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
   }
 
   // CONVERSATION MODE - Has messages
-  const boundIndexId = sessionNetworkId ?? selectedIndexId;
+  const boundIndexId = chatScope?.type === "network" ? (sessionNetworkId ?? selectedIndexId) : null;
   const boundIndex = indexes.find((i) => i.id === boundIndexId) ?? null;
 
   return (
@@ -1285,6 +1336,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
           type="button"
           onClick={() => {
             clearChat({ abortStream: false });
+            setChatScope(null);
             setSelectedNetworkIds([]);
             navigate("/");
           }}
@@ -1350,6 +1402,14 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
                   <DebugCopyButton fetchPath={`/debug/chat/${sessionId}`} title="Copy chat debug JSON" />
                 )}
               </>
+            )}
+            {chatScope?.type === "intent" && (
+              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-600 ml-2">
+                <MessageSquare className="w-3 h-3" />
+                <span className="truncate max-w-40">
+                  {chatScope.label || "Selected intent"}
+                </span>
+              </span>
             )}
             {boundIndex && (
               <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-600 ml-2">

--- a/apps/web/src/components/IntentList.tsx
+++ b/apps/web/src/components/IntentList.tsx
@@ -124,6 +124,7 @@ interface IntentListProps<T extends BaseIntent> {
   onArchiveIntent?: (intent: T) => void;
   onRemoveIntent?: (intent: T) => void;
   onOpenIntentSource?: (intent: T) => void;
+  onIntentClick?: (intent: T) => void;
   newIntentIds?: Set<string>;
   selectedIntentIds?: Set<string>;
   removingIntentIds?: Set<string>;
@@ -137,6 +138,7 @@ export default function IntentList<T extends BaseIntent>({
   onArchiveIntent,
   onRemoveIntent,
   onOpenIntentSource,
+  onIntentClick,
   newIntentIds = new Set(),
   selectedIntentIds = new Set(),
   removingIntentIds = new Set(),
@@ -190,9 +192,19 @@ export default function IntentList<T extends BaseIntent>({
         
         return (
           <div 
-            key={intent.id} 
+            key={intent.id}
+            role={onIntentClick ? "button" : undefined}
+            tabIndex={onIntentClick ? 0 : undefined}
+            onClick={onIntentClick ? () => onIntentClick(intent) : undefined}
+            onKeyDown={onIntentClick ? (e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onIntentClick(intent);
+              }
+            } : undefined}
             className={cn(
               "group relative p-4 rounded-lg border transition-all duration-200",
+              onIntentClick && "cursor-pointer focus:outline-none focus:ring-2 focus:ring-[#4091BB]/30",
               isSelectedSource 
                 ? "border-blue-200 bg-blue-50/50" 
                 : isFresh
@@ -238,7 +250,9 @@ export default function IntentList<T extends BaseIntent>({
 
               {/* Actions */}
               <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                <DebugCopyButton fetchPath={`/debug/intents/${intent.id}`} />
+                <div onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
+                  <DebugCopyButton fetchPath={`/debug/intents/${intent.id}`} />
+                </div>
                 {onOpenIntentSource && canOpenSource && (
                   <button
                     onClick={(e) => {

--- a/apps/web/src/components/NetworkOverviewPanel.tsx
+++ b/apps/web/src/components/NetworkOverviewPanel.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router';
 import * as AlertDialog from '@radix-ui/react-alert-dialog';
 import { LogOut } from 'lucide-react';
 import { Network } from '@/lib/types';
@@ -6,6 +7,8 @@ import { Button } from '@/components/ui/button';
 import IntentList from '@/components/IntentList';
 import { useNetworksState } from '@/contexts/IndexesContext';
 import { useNotifications } from '@/contexts/NotificationContext';
+import { useAIChat } from '@/contexts/AIChatContext';
+import { useNetworkFilter } from '@/contexts/IndexFilterContext';
 import { useAuthenticatedAPI } from '@/lib/api';
 import { useNetworks } from '@/contexts/APIContext';
 
@@ -18,8 +21,11 @@ interface NetworkOverviewPanelProps {
 }
 
 export default function NetworkOverviewPanel({ index, isOwner, onLeft, onLeaveRequest, onLeaveRequestHandled }: NetworkOverviewPanelProps) {
+  const navigate = useNavigate();
   const { removeIndex } = useNetworksState();
   const { success, error } = useNotifications();
+  const { clearChat, resolveIntentSession } = useAIChat();
+  const { setSelectedNetworkIds } = useNetworkFilter();
   const api = useAuthenticatedAPI();
   const indexesService = useNetworks();
 
@@ -63,6 +69,18 @@ export default function NetworkOverviewPanel({ index, isOwner, onLeft, onLeaveRe
     loadOverview();
   }, [index.id, indexesService]);
 
+  const handleOpenIntentChat = useCallback(async (intent: { id: string; payload: string; summary?: string | null }) => {
+    try {
+      clearChat({ abortStream: false });
+      setSelectedNetworkIds([]);
+      const label = (intent.summary && intent.summary.trim().length > 0 ? intent.summary : intent.payload).trim();
+      const sessionId = await resolveIntentSession({ id: intent.id, label });
+      navigate(`/d/${sessionId}`);
+    } catch {
+      error('Failed to open intent chat');
+    }
+  }, [clearChat, setSelectedNetworkIds, resolveIntentSession, navigate, error]);
+
   const handleLeaveNetwork = async () => {
     try {
       setIsLeaving(true);
@@ -99,6 +117,7 @@ export default function NetworkOverviewPanel({ index, isOwner, onLeft, onLeaveRe
             intents={intents}
             isLoading={intentsLoading}
             emptyMessage="You haven't shared any intents in this network yet"
+            onIntentClick={handleOpenIntentChat}
           />
         </div>
 

--- a/apps/web/src/contexts/AIChatContext.tsx
+++ b/apps/web/src/contexts/AIChatContext.tsx
@@ -136,6 +136,11 @@ interface ChatMessage {
   wasInterrupted?: boolean;
 }
 
+export type ChatScope =
+  | { type: "network"; id: string; label?: string }
+  | { type: "intent"; id: string; label?: string }
+  | null;
+
 interface AIChatContextType {
   isOpen: boolean;
   setIsOpen: (open: boolean) => void;
@@ -145,10 +150,16 @@ interface AIChatContextType {
   setSessionId: (id: string | null) => void;
   /** The network bound to the current session (persisted). Null if no network scope. */
   sessionNetworkId: string | null;
+  /** Effective mutually-exclusive chat scope. Intent scope and network scope are never active together. */
+  chatScope: ChatScope;
+  /** Set the active chat scope. Call with null for "Everywhere". */
+  setChatScope: (scope: ChatScope) => void;
   /** When the user has selected a single network (e.g. in chat dropdown), chat and create_intent are scoped to that network. */
   scopeNetworkId: string | null;
   /** Set the current network scope (e.g. from the network filter dropdown in ChatContent). Call with null for "Everywhere". */
   setScopeNetworkId: (networkId: string | null) => void;
+  /** Resolve or create the stable orchestrator session for an intent scope. */
+  resolveIntentSession: (intent: { id: string; label?: string }) => Promise<string>;
   /** Context-aware suggestions from the last done event; empty when no messages or after clear/load. */
   suggestions: Suggestion[];
   isLoading: boolean;
@@ -255,14 +266,18 @@ function mergeDebugMetaIntoTraceEvents(
 
 export function AIChatProvider({ children }: { children: React.ReactNode }) {
   const { pathname } = useLocation();
-  const [scopeNetworkIdOverride, setScopeNetworkIdOverride] = useState<
-    string | null
-  >(null);
-  const scopeFromPath = getScopeNetworkIdFromPathname(pathname);
-  // For new chats, use the UI selection; for existing sessions, the session's bound network takes precedence
+  const [scopeOverride, setScopeOverride] = useState<ChatScope>(null);
+  const pathNetworkScopeId = getScopeNetworkIdFromPathname(pathname);
+  const scopeFromPath: ChatScope = pathNetworkScopeId
+    ? { type: "network", id: pathNetworkScopeId }
+    : null;
+  // For existing sessions, the session's bound scope takes precedence over UI/path selection.
+  const [sessionScope, setSessionScope] = useState<ChatScope>(null);
+  // Backward-compatible network alias for existing consumers.
   const [sessionNetworkId, setSessionNetworkId] = useState<string | null>(null);
-  // Effective scope: session's bound network takes precedence, then UI override, then path
-  const scopeNetworkId = sessionNetworkId ?? scopeNetworkIdOverride ?? scopeFromPath;
+  // Effective scope: session-bound scope takes precedence, then UI override, then path.
+  const chatScope = sessionScope ?? scopeOverride ?? scopeFromPath;
+  const scopeNetworkId = chatScope?.type === "network" ? chatScope.id : null;
 
   const [isOpen, setIsOpen] = useState(false);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -279,6 +294,22 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
   const [pendingQueue, setPendingQueue] = useState<QueuedMessage[]>([]);
   /** When true, sendMessage will only refetch sessions on X-Session-Id and not set sessionId (used when user navigated away during stream). */
   const skipSessionUpdateForRequestRef = useRef(false);
+
+  const setChatScope = useCallback((scope: ChatScope) => {
+    setScopeOverride(scope);
+  }, []);
+
+  const setScopeNetworkId = useCallback((networkId: string | null) => {
+    setScopeOverride(networkId ? { type: "network", id: networkId } : null);
+  }, []);
+
+  const resolveIntentSession = useCallback(async (intent: { id: string; label?: string }) => {
+    const response = await apiClient.post<{
+      session: { id: string; scopeType?: "intent" | "network" | null; scopeId?: string | null };
+    }>("/chat/session/resolve", { scopeType: "intent", scopeId: intent.id });
+    setScopeOverride({ type: "intent", id: intent.id, ...(intent.label ? { label: intent.label } : {}) });
+    return response.session.id;
+  }, []);
 
   const cancelQueuedMessage = useCallback((id: string) => {
     const t = interruptTimeoutsRef.current.get(id);
@@ -404,7 +435,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
             message.trim() || (fileIds?.length ? "Attached file(s)." : ""),
           sessionId,
           ...(fileIds?.length ? { fileIds } : {}),
-          ...(scopeNetworkId ? { networkId: scopeNetworkId } : {}),
+          ...(chatScope ? { scopeType: chatScope.type, scopeId: chatScope.id } : {}),
           ...(options?.prefillMessages?.length ? { prefillMessages: options.prefillMessages } : {}),
         };
 
@@ -420,10 +451,10 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
             refetchSessions();
           } else {
             setSessionId(newSessionId);
-            // The network selected at session creation becomes the session's bound network
-            // (scopeNetworkId at this point is the UI selection since sessionNetworkId is null for new chats)
-            if (scopeNetworkId) {
-              setSessionNetworkId(scopeNetworkId);
+            // The scope selected at session creation becomes the session's bound scope.
+            if (chatScope) {
+              setSessionScope(chatScope);
+              setSessionNetworkId(chatScope.type === "network" ? chatScope.id : null);
             }
             refetchSessions();
           }
@@ -894,7 +925,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
         );
       }
     },
-    [sessionId, scopeNetworkId, refetchSessions],
+    [sessionId, chatScope, refetchSessions],
   );
 
   const stopStream = useCallback(() => {
@@ -929,7 +960,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
       // Use hidden:true — the placeholder is the canonical user bubble.
       void sendMessage(nextMsg.message, nextMsg.fileIds, nextMsg.attachmentNames, { hidden: true });
     }
-  // sendMessage is stable when sessionId/scopeNetworkId/refetchSessions don't change;
+  // sendMessage is stable when sessionId/chatScope/refetchSessions don't change;
   // including it would loop. Drain only fires on isLoading transitions.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoading]);
@@ -951,6 +982,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
     setSuggestions([]);
     setSessionId(null);
     setSessionTitle(null);
+    setSessionScope(null); // Clear session-bound scope so new chat can use UI selection
     setSessionNetworkId(null); // Clear session-bound network so new chat can use UI selection
     if (abortStream && abortControllerRef.current) {
       abortControllerRef.current.abort();
@@ -971,6 +1003,8 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
           id: string;
           title?: string | null;
           networkId?: string | null;
+          scopeType?: "network" | "intent" | null;
+          scopeId?: string | null;
         };
         messages: Array<{
           id: string;
@@ -998,8 +1032,20 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
       setSessionId(data.session.id);
       setSessionTitle(data.session.title?.trim() ?? null);
       setSuggestions([]); // Session load does not return suggestions; next response will
-      // Load the session's bound network - this is the persisted scope for this conversation
-      setSessionNetworkId(data.session.networkId ?? null);
+      // Load the session's bound scope - this is the persisted scope for this conversation.
+      const loadedScope: ChatScope = data.session.scopeType && data.session.scopeId
+        ? {
+            type: data.session.scopeType,
+            id: data.session.scopeId,
+            ...(data.session.scopeType === "intent" && data.session.title?.trim()
+              ? { label: data.session.title.trim() }
+              : {}),
+          }
+        : data.session.networkId
+          ? { type: "network", id: data.session.networkId }
+          : null;
+      setSessionScope(loadedScope);
+      setSessionNetworkId(loadedScope?.type === "network" ? loadedScope.id : null);
       setMessages(
         data.messages.map((m) => ({
           id: m.id,
@@ -1055,8 +1101,11 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
         sessionTitle,
         setSessionId,
         sessionNetworkId,
+        chatScope,
+        setChatScope,
         scopeNetworkId,
-        setScopeNetworkId: setScopeNetworkIdOverride,
+        setScopeNetworkId,
+        resolveIntentSession,
         suggestions,
         isLoading,
         stopStream,

--- a/apps/web/src/services/opportunities.ts
+++ b/apps/web/src/services/opportunities.ts
@@ -80,6 +80,8 @@ export interface HomeViewResponse {
 
 export interface GetHomeViewOptions {
   networkId?: string;
+  scopeType?: 'intent';
+  scopeId?: string;
   limit?: number;
   noCache?: boolean;
 }
@@ -148,6 +150,8 @@ export const createOpportunitiesService = (
   ): Promise<HomeViewResponse> => {
     const params = new URLSearchParams();
     if (options?.networkId) params.set('networkId', options.networkId);
+    if (options?.scopeType) params.set('scopeType', options.scopeType);
+    if (options?.scopeId) params.set('scopeId', options.scopeId);
     if (options?.limit != null) params.set('limit', String(options.limit));
     if (options?.noCache) params.set('noCache', '1');
     const qs = params.toString();
@@ -186,11 +190,12 @@ export const createOpportunitiesService = (
 
   updateStatus: async (
     opportunityId: string,
-    status: OpportunityStatus
+    status: OpportunityStatus,
+    scope?: { scopeType: 'intent'; scopeId: string },
   ): Promise<OpportunityStatusUpdateResponse> => {
     return api.patch<OpportunityStatusUpdateResponse>(
       `/opportunities/${opportunityId}/status`,
-      { status }
+      { status, ...(scope ?? {}) }
     );
   },
 
@@ -213,6 +218,7 @@ export const createOpportunitiesService = (
    */
   startChat: async (
     opportunityId: string,
+    scope?: { scopeType: 'intent'; scopeId: string },
   ): Promise<{
     conversationId: string;
     counterpartUserId: string;
@@ -222,7 +228,7 @@ export const createOpportunitiesService = (
       conversationId: string;
       counterpartUserId: string;
       opportunity: { id: string; status: OpportunityStatus };
-    }>(`/opportunities/${opportunityId}/start-chat`, {});
+    }>(`/opportunities/${opportunityId}/start-chat`, scope ?? {});
   },
 
   /**

--- a/apps/web/src/services/questions.ts
+++ b/apps/web/src/services/questions.ts
@@ -63,18 +63,22 @@ export const createQuestionsService = (
 ) => ({
   /**
    * Fetch pending questions for the authenticated user.
-   * Optionally filter by mode, sourceType, sourceId, or noConversation.
+   * Optionally filter by mode, sourceType, sourceId, selected intent scope, or noConversation.
    */
   getPending: async (filters?: {
     mode?: QuestionDetection['mode'];
     sourceType?: string;
     sourceId?: string;
+    scopeType?: 'intent';
+    scopeId?: string;
     noConversation?: boolean;
   }): Promise<PendingQuestion[]> => {
     const params = new URLSearchParams({ status: 'pending' });
     if (filters?.mode) params.set('mode', filters.mode);
     if (filters?.sourceType) params.set('sourceType', filters.sourceType);
     if (filters?.sourceId) params.set('sourceId', filters.sourceId);
+    if (filters?.scopeType) params.set('scopeType', filters.scopeType);
+    if (filters?.scopeId) params.set('scopeId', filters.scopeId);
     if (filters?.noConversation) params.set('noConversation', 'true');
     const res = await api.get<QuestionsListResponse>(`/questions?${params}`);
     return res.questions ?? [];

--- a/docs/specs/api-reference.md
+++ b/docs/specs/api-reference.md
@@ -349,7 +349,9 @@ SSE streaming endpoint for chat messages with context support. Streams graph eve
   "sessionId": "string | null (optional — creates new session if omitted)",
   "useCheckpointer": "boolean (optional, default: true)",
   "fileIds": ["string (optional — file IDs to attach)"],
-  "indexId": "string | null (optional — scope to a specific index)",
+  "scopeType": "network | intent | null (optional — mutually-exclusive focused scope)",
+  "scopeId": "string | null (required when scopeType is provided)",
+  "networkId": "string | null (deprecated alias for scopeType=network)",
   "recipientUserId": "string | null (optional — DM recipient for ghost invites)",
   "prefillMessages": [
     { "role": "assistant | user", "content": "string (max 10000 chars)" }
@@ -383,6 +385,33 @@ List all chat sessions for the authenticated user.
 }
 ```
 
+### POST /api/chat/session/resolve
+
+Resolve or create the stable orchestrator chat session for a selected intent. Repeated calls by the same user for the same intent return the same session.
+
+**Auth**: AuthGuard
+
+**Request body**:
+```json
+{
+  "scopeType": "intent",
+  "scopeId": "intent UUID"
+}
+```
+
+**Response**:
+```json
+{
+  "session": {
+    "id": "...",
+    "scopeType": "intent",
+    "scopeId": "...",
+    "title": "..."
+  },
+  "created": false
+}
+```
+
 ### POST /api/chat/session
 
 Get a specific session with its messages (including assistant metadata).
@@ -399,7 +428,13 @@ Get a specific session with its messages (including assistant metadata).
 **Response**:
 ```json
 {
-  "session": { ... },
+  "session": {
+    "id": "...",
+    "title": "...",
+    "networkId": "... (legacy network alias, nullable)",
+    "scopeType": "network | intent | null",
+    "scopeId": "... (nullable)"
+  },
   "messages": [
     {
       "id": "...",

--- a/packages/protocol/src/chat/chat.prompt.ts
+++ b/packages/protocol/src/chat/chat.prompt.ts
@@ -1,6 +1,6 @@
 import type { ResolvedToolContext } from "../shared/agent/tool.factory.js";
 
-import { deriveAllowedNetworkIds, focusedNetworkId } from "../shared/agent/tool.scope.js";
+import { deriveAllowedNetworkIds, focusedIntentId, focusedNetworkId } from "../shared/agent/tool.scope.js";
 import { renderNetworkContext } from '../shared/network/metadata.renderer.js';
 import { resolveModules } from "./chat.prompt.modules.js";
 import type { IterationContext } from "./chat.prompt.modules.js";
@@ -24,6 +24,7 @@ export const ITERATION_NUDGE = `[System Note: You've made several tool calls. Pl
  */
 function buildCoreHead(ctx: ResolvedToolContext): string {
   const scopedNetworkId = focusedNetworkId(ctx);
+  const scopedIntentId = focusedIntentId(ctx);
   const roleLabel = !scopedNetworkId
     ? "general"
     : (ctx.scopedMembershipRole ?? (ctx.isOwner ? "owner" : "member"));
@@ -33,9 +34,11 @@ function buildCoreHead(ctx: ResolvedToolContext): string {
   const reachable = scopedNetworkId
     ? `, reach: ${reachableIds.length} network(s) including your personal network`
     : "";
-  const indexScope = scopedNetworkId
-    ? `network "${ctx.indexName ?? "Unknown"}" (id: ${scopedNetworkId}), role: ${roleLabel}${reachable}`
-    : "no network scope (general chat)";
+  const indexScope = scopedIntentId
+    ? `selected intent (id: ${scopedIntentId}) — only this intent is available; use list_opportunities and read_pending_questions to inspect its related opportunities, negotiation context, and questions`
+    : scopedNetworkId
+      ? `network "${ctx.indexName ?? "Unknown"}" (id: ${scopedNetworkId}), role: ${roleLabel}${reachable}`
+      : "no network scope (general chat)";
 
   return `You are Index. You help the right people find the user and help the user find them.
 Here's what you can do:
@@ -316,11 +319,18 @@ ${ctx.contactsEnabled ? `| **add_contact** | email, name? | Manually add single 
  */
 function buildScoping(ctx: ResolvedToolContext): string {
   const scopedNetworkId = focusedNetworkId(ctx);
+  const scopedIntentId = focusedIntentId(ctx);
   return `
-### Network Scope
+### Scope
 ${
-  scopedNetworkId
-    ? `- This chat is scoped to network "${ctx.indexName ?? "Unknown"}" (id: ${scopedNetworkId}). Default networkId for create_intent is ${scopedNetworkId}. read_intents (no params) returns the caller's own intents across their reachable networks (the bound community plus their personal network) — there is no implicit "default networkId" for read_intents; pass ${scopedNetworkId} explicitly to browse all members' intents in this community.
+  scopedIntentId
+    ? `- This chat is scoped to one selected intent (id: ${scopedIntentId}). Only that intent is available here.
+- **Scope enforcement**: read_intents returns exactly the selected intent. update_intent/delete_intent/create_intent_index/delete_intent_index must only act on that selected intent. Do not create a different intent from this chat.
+- **Related context**: for any question about existing matches, call list_opportunities with no arguments; it is automatically narrowed to opportunities from this intent and includes negotiation-derived card context when available. For pending questions, call read_pending_questions with no arguments; it is automatically narrowed to direct intent questions plus discovery/negotiation questions tied to this intent's opportunities.
+- **Discovery**: discover_opportunities with no intentId uses this selected intent as the discovery source. If an intentId is supplied it must match ${scopedIntentId}.
+- Never imply results represent the user's other intents.`
+    : scopedNetworkId
+      ? `- This chat is scoped to network "${ctx.indexName ?? "Unknown"}" (id: ${scopedNetworkId}). Default networkId for create_intent is ${scopedNetworkId}. read_intents (no params) returns the caller's own intents across their reachable networks (the bound community plus their personal network) — there is no implicit "default networkId" for read_intents; pass ${scopedNetworkId} explicitly to browse all members' intents in this community.
 - **Scope enforcement**: read_intents with no args returns caller-owned intents across the reachable networks (bound + personal). read_intents(networkId) browses all members' intents in that community. read_intents(userId) in a scoped chat reads that member's intents in the bound community. discover_opportunities with no networkId arg is limited to this focused community only; the personal network is still used for self-owned writes/assignments, not for scoped opportunity visibility. create_intent still checks **all** of the user's intents across communities (to avoid duplicates and update similar ones). Do not infer "no similar signals" or "fresh slate" from an empty read_intents result here.
 - **Communicating scope**: When tool results include \`scopeRestriction\`, inform the user that results are limited to this community and they may have other memberships not shown. Never imply the scoped results represent all their data.
 - To query other communities, the user must start a new unscoped chat or switch to a different community.

--- a/packages/protocol/src/intent/intent.tools.ts
+++ b/packages/protocol/src/intent/intent.tools.ts
@@ -9,7 +9,7 @@ import type { DefineTool, ToolDeps } from "../shared/agent/tool.helpers.js";
 import { success, error, UUID_REGEX } from "../shared/agent/tool.helpers.js";
 import type { UserRecord } from "../shared/interfaces/database.interface.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
-import { deriveAllowedNetworkIds, focusedNetworkId, focusedNetworkLabel, type ToolScopeEnvelope } from "../shared/agent/tool.scope.js";
+import { deriveAllowedNetworkIds, focusedIntentId, focusedNetworkId, focusedNetworkLabel, type ToolScopeEnvelope } from "../shared/agent/tool.scope.js";
 
 const logger = protocolLogger("ChatTools:Intent");
 
@@ -100,9 +100,14 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
 
       // Distinguish "explicit network browse" from "implicit scope-aware read"
       const scopedNetworkId = focusedNetworkId(context);
+      const scopedIntentId = focusedIntentId(context);
       const scopedIndexLabel = focusedNetworkLabel(context);
       const explicitNetworkId = query.networkId?.trim();
       const explicitUserId = query.userId?.trim();
+
+      if (scopedIntentId && (explicitNetworkId || (explicitUserId && explicitUserId !== context.userId))) {
+        return error("This chat is scoped to one selected intent. Only that intent is available here.");
+      }
 
       // Validate explicit networkId format
       if (explicitNetworkId && !UUID_REGEX.test(explicitNetworkId)) {
@@ -152,6 +157,28 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
         userProfile: "",
         operationMode: 'read' as const,
       };
+
+      if (scopedIntentId) {
+        const intent = await deps.systemDb.getIntent(scopedIntentId);
+        if (!intent || intent.userId !== context.userId || intent.archivedAt) {
+          return error("This selected intent is no longer available.");
+        }
+        return success({
+          count: 1,
+          totalCount: 1,
+          intents: [{
+            id: intent.id,
+            description: intent.payload,
+            summary: intent.summary,
+            createdAt: intent.createdAt,
+          }],
+          scopeRestriction: {
+            isScoped: true,
+            scopedToIntent: scopedIntentId,
+            message: "Results are restricted to the selected intent.",
+          },
+        });
+      }
 
       if (explicitNetworkId) {
         graphInput.networkId = explicitNetworkId;
@@ -247,7 +274,12 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       }
 
       const scopedNetworkId = focusedNetworkId(context);
+      const scopedIntentId = focusedIntentId(context);
       const scopedIndexLabel = focusedNetworkLabel(context);
+
+      if (scopedIntentId) {
+        return error("This chat is scoped to an existing selected intent. Update that intent instead of creating a different one here.");
+      }
 
       // Strict scope enforcement
       if (scopedNetworkId && query.networkId?.trim() && query.networkId.trim() !== scopedNetworkId) {
@@ -452,7 +484,12 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       }
 
       const scopedNetworkId = focusedNetworkId(context);
+      const scopedIntentId = focusedIntentId(context);
       const scopedIndexLabel = focusedNetworkLabel(context);
+
+      if (scopedIntentId && scopedIntentId !== intentId) {
+        return error("This chat is scoped to one selected intent. You can only update that intent here.");
+      }
 
       // Strict scope enforcement: when chat is network-scoped, verify intent is linked to that index
       if (scopedNetworkId) {
@@ -529,7 +566,12 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       }
 
       const scopedNetworkId = focusedNetworkId(context);
+      const scopedIntentId = focusedIntentId(context);
       const scopedIndexLabel = focusedNetworkLabel(context);
+
+      if (scopedIntentId && scopedIntentId !== intentId) {
+        return error("This chat is scoped to one selected intent. You can only delete that intent here.");
+      }
 
       // Strict scope enforcement: when chat is network-scoped, verify intent is linked to that index
       if (scopedNetworkId) {
@@ -582,9 +624,13 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       const scopeErr = await ensureScopedMembership(context, deps.systemDb);
       if (scopeErr) return error(scopeErr);
       const scopedNetworkId = focusedNetworkId(context);
+      const scopedIntentId = focusedIntentId(context);
       const scopedIndexLabel = focusedNetworkLabel(context);
       const intentId = query.intentId?.trim() ?? "";
       const networkId = query.networkId?.trim() || scopedNetworkId || "";
+      if (scopedIntentId && intentId !== scopedIntentId) {
+        return error("This chat is scoped to one selected intent. You can only link that intent here.");
+      }
       if (!UUID_REGEX.test(intentId) || !UUID_REGEX.test(networkId)) {
         return error("Invalid ID format. Both must be UUIDs.");
       }
@@ -642,10 +688,18 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       const scopeErr = await ensureScopedMembership(context, deps.systemDb);
       if (scopeErr) return error(scopeErr);
       const scopedNetworkId = focusedNetworkId(context);
+      const scopedIntentId = focusedIntentId(context);
       const scopedIndexLabel = focusedNetworkLabel(context);
-      const intentId = query.intentId?.trim() || undefined;
+      const intentId = query.intentId?.trim() || scopedIntentId || undefined;
       let networkId = query.networkId?.trim() || scopedNetworkId || undefined;
       const queryUserId = query.userId?.trim() || undefined;
+
+      if (scopedIntentId && query.intentId?.trim() && query.intentId.trim() !== scopedIntentId) {
+        return error("This chat is scoped to one selected intent. You can only read links for that intent here.");
+      }
+      if (scopedIntentId && queryUserId && queryUserId !== context.userId) {
+        return error("This chat is scoped to one selected intent. Other users' intent links are not available here.");
+      }
 
       if (intentId && !UUID_REGEX.test(intentId)) {
         return error("Invalid intent ID format.");
@@ -713,9 +767,13 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       const scopeErr = await ensureScopedMembership(context, deps.systemDb);
       if (scopeErr) return error(scopeErr);
       const scopedNetworkId = focusedNetworkId(context);
+      const scopedIntentId = focusedIntentId(context);
       const scopedIndexLabel = focusedNetworkLabel(context);
       const intentId = query.intentId?.trim() ?? "";
       const networkId = query.networkId?.trim() || scopedNetworkId || "";
+      if (scopedIntentId && intentId !== scopedIntentId) {
+        return error("This chat is scoped to one selected intent. You can only unlink that intent here.");
+      }
       if (!UUID_REGEX.test(intentId) || !UUID_REGEX.test(networkId)) {
         return error("Invalid ID format. Both must be UUIDs.");
       }

--- a/packages/protocol/src/opportunity/opportunity.pending-questions.ts
+++ b/packages/protocol/src/opportunity/opportunity.pending-questions.ts
@@ -13,13 +13,16 @@ export const MAX_PENDING_QUESTIONS = 3;
 export interface MergePendingQuestionsInput {
   findPendingQuestions?: (
     userId: string,
-    filters?: { sourceType?: string; sourceId?: string; networkId?: string },
+    filters?: { sourceType?: string; sourceId?: string; networkId?: string; scopeType?: 'intent'; scopeId?: string },
   ) => Promise<PendingQuestionSummary[]>;
   userId: string;
   sourceType?: string;
   sourceId?: string;
   /** Restrict to questions whose actor carries this network id. */
   networkId?: string;
+  /** Optional selected-intent scope. */
+  scopeType?: 'intent';
+  scopeId?: string;
   /** IDs already shown in this chat session — skip them. */
   surfacedQuestionIds: Set<string>;
 }
@@ -42,12 +45,13 @@ export async function mergePendingQuestions(
     return { questions: [], surfacedIds: [] };
   }
 
-  const hasFilters = Boolean(input.sourceType || input.networkId);
+  const hasFilters = Boolean(input.sourceType || input.networkId || input.scopeType);
   const filters = hasFilters
     ? {
         ...(input.sourceType ? { sourceType: input.sourceType } : {}),
         ...(input.sourceId ? { sourceId: input.sourceId } : {}),
         ...(input.networkId ? { networkId: input.networkId } : {}),
+        ...(input.scopeType && input.scopeId ? { scopeType: input.scopeType, scopeId: input.scopeId } : {}),
       }
     : undefined;
 

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -742,7 +742,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
             userId: context.userId,
             userName: context.userName,
             userEmail: context.userEmail,
-            ...(scopedNetworkId ? { scopeType: 'network' as const, scopeId: scopedNetworkId } : {}),
+            ...(context.scopeType && context.scopeId ? { scopeType: context.scopeType, scopeId: context.scopeId } : scopedNetworkId ? { scopeType: 'network' as const, scopeId: scopedNetworkId } : {}),
             ...(context.indexName ? { indexName: context.indexName } : {}),
             ...(context.sessionId ? { sessionId: context.sessionId } : {}),
             ...(context.agentId ? { agentId: context.agentId } : {}),
@@ -1125,10 +1125,15 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         { step: "resolve_index_scope", detail: `${indexScope.length} index(es)` },
       ];
 
-      const triggerIntentId = query.intentId?.trim() || undefined;
-      if (triggerIntentId != null && !UUID_REGEX.test(triggerIntentId)) {
+      const contextIntentId = focusedIntentId(context);
+      const requestedIntentId = query.intentId?.trim() || undefined;
+      if (requestedIntentId != null && !UUID_REGEX.test(requestedIntentId)) {
         return error("Invalid intent ID format.");
       }
+      if (contextIntentId && requestedIntentId && requestedIntentId !== contextIntentId) {
+        return error("This chat is scoped to a different intent.");
+      }
+      const triggerIntentId = contextIntentId ?? requestedIntentId;
 
       if (query.introTargetUserId?.trim() && query.introTargetUserId.trim() === context.userId) {
         return error("You cannot discover introductions for yourself. Try regular discovery instead.");
@@ -1199,6 +1204,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         userId: context.userId,
         sourceType: 'discovery',
         ...(context.scopeType === 'network' && context.scopeId ? { networkId: context.scopeId } : {}),
+        ...(contextIntentId ? { scopeType: 'intent' as const, scopeId: contextIntentId } : {}),
         surfacedQuestionIds: new Set(), // Dedup handled at chat.agent level
       });
       const pendingQuestions = pendingQuestionResult.questions;

--- a/packages/protocol/src/opportunity/tests/discover.pendingQuestions.test.ts
+++ b/packages/protocol/src/opportunity/tests/discover.pendingQuestions.test.ts
@@ -53,8 +53,8 @@ describe("mergePendingQuestions", () => {
     expect(result.surfacedIds).toEqual([]);
   });
 
-  it("filters by sourceType, sourceId, and networkId when provided", async () => {
-    const fn = mock(async (_uid: string, filters?: { sourceType?: string; sourceId?: string; networkId?: string }) => {
+  it("filters by sourceType, sourceId, networkId, and intent scope when provided", async () => {
+    const fn = mock(async (_uid: string, filters?: { sourceType?: string; sourceId?: string; networkId?: string; scopeType?: 'intent'; scopeId?: string }) => {
       if (filters?.sourceType === "opportunity") return [{ ...baseSummary, id: "pq-2", sourceType: "opportunity" }];
       return [baseSummary];
     });
@@ -64,9 +64,11 @@ describe("mergePendingQuestions", () => {
       sourceType: "opportunity",
       sourceId: "opp-1",
       networkId: "net-1",
+      scopeType: "intent",
+      scopeId: "intent-1",
       surfacedQuestionIds: new Set(),
     });
-    expect(fn).toHaveBeenCalledWith("u1", { sourceType: "opportunity", sourceId: "opp-1", networkId: "net-1" });
+    expect(fn).toHaveBeenCalledWith("u1", { sourceType: "opportunity", sourceId: "opp-1", networkId: "net-1", scopeType: "intent", scopeId: "intent-1" });
     expect(result.questions).toHaveLength(1);
     expect(result.questions[0].id).toBe("pq-2");
   });

--- a/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
+++ b/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
@@ -381,7 +381,7 @@ const mockProtocolDeps: Omit<ToolContext, 'userId' | 'database' | 'embedder' | '
 };
 
 describe("createChatTools", () => {
-  test("returns an array that includes read_intents, read_networks, read_network_memberships", async () => {
+  test("returns an array that includes read_intents, read_networks, read_network_memberships, read_pending_questions", async () => {
     const mockDb = createMockDatabase(async () => []);
     const context: ToolContext = { userId: testUserId, database: mockDb, embedder: mockEmbedder, scraper: mockScraper, ...mockProtocolDeps };
     const tools = await createChatTools(context);
@@ -389,6 +389,7 @@ describe("createChatTools", () => {
     expect(tools.find((t: { name: string }) => t.name === "read_intents")).toBeDefined();
     expect(tools.find((t: { name: string }) => t.name === "read_networks")).toBeDefined();
     expect(tools.find((t: { name: string }) => t.name === "read_network_memberships")).toBeDefined();
+    expect(tools.find((t: { name: string }) => t.name === "read_pending_questions")).toBeDefined();
   });
 
   test("includes list_opportunities alongside discover_opportunities and update_opportunity", async () => {

--- a/packages/protocol/src/shared/agent/tool.factory.ts
+++ b/packages/protocol/src/shared/agent/tool.factory.ts
@@ -30,6 +30,7 @@ import { createContactTools } from "../../contact/contact.tools.js";
 import { createAgentTools } from "../../agent/agent.tools.js";
 import { createNegotiationTools } from "../../negotiation/negotiation.tools.js";
 import { createPremiseTools } from "../../premise/premise.tools.js";
+import { createQuestionerTools } from "../../questioner/questioner.tools.js";
 
 // Re-export types for consumers
 export type { ToolContext, ResolvedToolContext, ProtocolDeps } from "./tool.helpers.js";
@@ -214,6 +215,7 @@ export async function createChatTools(
     ...(deps.chatSummary && { chatSummary: deps.chatSummary }),
     ...(deps.questionGenerator && { questionGenerator: deps.questionGenerator }),
     ...(sessionAwareEnqueue && { questionerEnqueue: sessionAwareEnqueue }),
+    ...(deps.findPendingQuestions && { findPendingQuestions: deps.findPendingQuestions }),
     ...(deps.negotiationSummary && { negotiationSummary: deps.negotiationSummary }),
     graphs: {
       profile: profileGraph,
@@ -239,6 +241,7 @@ export async function createChatTools(
     ? createNegotiationTools(defineTool, toolDeps)
     : [];
   const premiseTools = createPremiseTools(defineTool, toolDeps);
+  const questionerTools = createQuestionerTools(defineTool, toolDeps);
 
   // confirm_opportunity_delivery is an OpenClaw-delivery ledger write and must not be
   // callable from regular chat sessions.
@@ -260,6 +263,7 @@ export async function createChatTools(
     ...agentTools,
     ...negotiationTools,
     ...premiseTools,
+    ...questionerTools,
   ];
 }
 

--- a/packages/protocol/src/shared/agent/tool.helpers.ts
+++ b/packages/protocol/src/shared/agent/tool.helpers.ts
@@ -178,6 +178,22 @@ export interface ToolContext {
    * Injected by the composition root when QUESTIONER_ENABLED=true.
    */
   questionerEnqueue?: QuestionerEnqueueFn;
+  /**
+   * Lookup pending questions for a user, optionally filtered by source,
+   * detection mode, selected intent scope, or capped by count.
+   */
+  findPendingQuestions?: (
+    userId: string,
+    filters?: {
+      sourceType?: string;
+      sourceId?: string;
+      scopeType?: 'intent';
+      scopeId?: string;
+      networkId?: string;
+      modes?: QuestionMode[];
+      limit?: number;
+    },
+  ) => Promise<PendingQuestionSummary[]>;
   /** Negotiation-digest summarizer. Optional; consumers fall back to deterministic digests. */
   negotiationSummary?: NegotiationSummaryReader;
   /** Profile enrichment from external data sources. */

--- a/services/api/drizzle/0087_add_chat_session_scopes.sql
+++ b/services/api/drizzle/0087_add_chat_session_scopes.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "chat_session_scopes" (
+	"conversation_id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"scope_type" text NOT NULL,
+	"scope_id" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "chat_session_scopes" ADD CONSTRAINT "chat_session_scopes_conversation_id_conversations_id_fk" FOREIGN KEY ("conversation_id") REFERENCES "public"."conversations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "chat_session_scopes_user_scope_unique" ON "chat_session_scopes" USING btree ("user_id","scope_type","scope_id");--> statement-breakpoint
+CREATE INDEX "chat_session_scopes_user_id_idx" ON "chat_session_scopes" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "chat_session_scopes_scope_idx" ON "chat_session_scopes" USING btree ("scope_type","scope_id");

--- a/services/api/drizzle/meta/0087_snapshot.json
+++ b/services/api/drizzle/meta/0087_snapshot.json
@@ -1,0 +1,5038 @@
+{
+  "id": "011a0f0d-99d5-490a-8470-7cde8c65e2fe",
+  "prevId": "e12c7da3-d9fe-4797-aebb-293562c94222",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_permissions": {
+      "name": "agent_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "permission_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actions": {
+          "name": "actions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_permissions_agent_id_idx": {
+          "name": "agent_permissions_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_permissions_user_id_idx": {
+          "name": "agent_permissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_permissions_agent_user_idx": {
+          "name": "agent_permissions_agent_user_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_agent_permissions_global": {
+          "name": "uniq_agent_permissions_global",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_permissions\".\"scope\" = 'global'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_permissions_agent_id_agents_id_fk": {
+          "name": "agent_permissions_agent_id_agents_id_fk",
+          "tableFrom": "agent_permissions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_permissions_user_id_users_id_fk": {
+          "name": "agent_permissions_user_id_users_id_fk",
+          "tableFrom": "agent_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_messages": {
+      "name": "agent_test_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_token": {
+          "name": "reservation_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reserved_at": {
+          "name": "reserved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_test_messages_agent_pending": {
+          "name": "idx_agent_test_messages_agent_pending",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reserved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_messages_agent_id_agents_id_fk": {
+          "name": "agent_test_messages_agent_id_agents_id_fk",
+          "tableFrom": "agent_test_messages",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_messages_requested_by_user_id_users_id_fk": {
+          "name": "agent_test_messages_requested_by_user_id_users_id_fk",
+          "tableFrom": "agent_test_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_transports": {
+      "name": "agent_transports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "transport_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_transports_agent_id_idx": {
+          "name": "agent_transports_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_transports_agent_id_agents_id_fk": {
+          "name": "agent_transports_agent_id_agents_id_fk",
+          "tableFrom": "agent_transports",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "agent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_on_opportunity": {
+          "name": "notify_on_opportunity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "daily_summary_enabled": {
+          "name": "daily_summary_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "handle_negotiations": {
+          "name": "handle_negotiations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_daily_summary_at": {
+          "name": "last_daily_summary_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agents_owner_id_idx": {
+          "name": "agents_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_type_idx": {
+          "name": "agents_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_last_seen_at_idx": {
+          "name": "agents_last_seen_at_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_users_id_fk": {
+          "name": "agents_owner_id_users_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apikey_user_id_users_id_fk": {
+          "name": "apikey_user_id_users_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connect_links": {
+      "name": "connect_links",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "greeting": {
+          "name": "greeting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_surface": {
+          "name": "preferred_surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connect_links_kind_recipient_uq": {
+          "name": "connect_links_kind_recipient_uq",
+          "columns": [
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connect_links_expires_at_idx": {
+          "name": "connect_links_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connect_links_user_id_users_id_fk": {
+          "name": "connect_links_user_id_users_id_fk",
+          "tableFrom": "connect_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connect_links_opportunity_id_opportunities_id_fk": {
+          "name": "connect_links_opportunity_id_opportunities_id_fk",
+          "tableFrom": "connect_links",
+          "tableTo": "opportunities",
+          "columnsFrom": [
+            "opportunity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrichment_tool_runs": {
+      "name": "enrichment_tool_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "discovery_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "enrichment_tool_runs_user_created_idx": {
+          "name": "enrichment_tool_runs_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "enrichment_tool_runs_status_created_idx": {
+          "name": "enrichment_tool_runs_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "enrichment_tool_runs_operation_created_idx": {
+          "name": "enrichment_tool_runs_operation_created_idx",
+          "columns": [
+            {
+              "expression": "operation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "enrichment_tool_runs_expires_at_idx": {
+          "name": "enrichment_tool_runs_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "enrichment_tool_runs_user_id_users_id_fk": {
+          "name": "enrichment_tool_runs_user_id_users_id_fk",
+          "tableFrom": "enrichment_tool_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "enrichment_tool_runs_agent_id_agents_id_fk": {
+          "name": "enrichment_tool_runs_agent_id_agents_id_fk",
+          "tableFrom": "enrichment_tool_runs",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "files_user_id_users_id_fk": {
+          "name": "files_user_id_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hyde_documents": {
+      "name": "hyde_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_text": {
+          "name": "source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_corpus": {
+          "name": "target_corpus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hyde_text": {
+          "name": "hyde_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hyde_embedding": {
+          "name": "hyde_embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "hyde_source_idx": {
+          "name": "hyde_source_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_strategy_idx": {
+          "name": "hyde_strategy_idx",
+          "columns": [
+            {
+              "expression": "strategy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_embedding_idx": {
+          "name": "hyde_embedding_idx",
+          "columns": [
+            {
+              "expression": "hyde_embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "hyde_expires_idx": {
+          "name": "hyde_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_source_strategy_unique": {
+          "name": "hyde_source_strategy_unique",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "strategy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_corpus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.intent_networks": {
+      "name": "intent_networks",
+      "schema": "",
+      "columns": {
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relevancy_score": {
+          "name": "relevancy_score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignment_metadata": {
+          "name": "assignment_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "intent_networks_network_id_idx": {
+          "name": "intent_networks_network_id_idx",
+          "columns": [
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intent_networks_intent_id_intents_id_fk": {
+          "name": "intent_networks_intent_id_intents_id_fk",
+          "tableFrom": "intent_networks",
+          "tableTo": "intents",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "intent_networks_network_id_networks_id_fk": {
+          "name": "intent_networks_network_id_networks_id_fk",
+          "tableFrom": "intent_networks",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "intent_networks_intent_id_network_id_pk": {
+          "name": "intent_networks_intent_id_network_id_pk",
+          "columns": [
+            "intent_id",
+            "network_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.intents": {
+      "name": "intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_incognito": {
+          "name": "is_incognito",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "semantic_entropy": {
+          "name": "semantic_entropy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "referential_anchor": {
+          "name": "referential_anchor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intent_mode": {
+          "name": "intent_mode",
+          "type": "intent_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ATTRIBUTIVE'"
+        },
+        "speech_act_type": {
+          "name": "speech_act_type",
+          "type": "speech_act_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "felicity_authority": {
+          "name": "felicity_authority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "felicity_sincerity": {
+          "name": "felicity_sincerity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "felicity_clarity": {
+          "name": "felicity_clarity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "intent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {
+        "embeddingIndex": {
+          "name": "embeddingIndex",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intents_user_id_users_id_fk": {
+          "name": "intents_user_id_users_id_fk",
+          "tableFrom": "intents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.links": {
+      "name": "links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "links_user_id_users_id_fk": {
+          "name": "links_user_id_users_id_fk",
+          "tableFrom": "links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.network_integrations": {
+      "name": "network_integrations",
+      "schema": "",
+      "columns": {
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolkit": {
+          "name": "toolkit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_config": {
+          "name": "sync_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "network_integrations_network_id_networks_id_fk": {
+          "name": "network_integrations_network_id_networks_id_fk",
+          "tableFrom": "network_integrations",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "network_integrations_network_id_toolkit_pk": {
+          "name": "network_integrations_network_id_toolkit_pk",
+          "columns": [
+            "network_id",
+            "toolkit"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.network_members": {
+      "name": "network_members",
+      "schema": "",
+      "columns": {
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_assign": {
+          "name": "auto_assign",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "network_members_network_id_networks_id_fk": {
+          "name": "network_members_network_id_networks_id_fk",
+          "tableFrom": "network_members",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "network_members_user_id_users_id_fk": {
+          "name": "network_members_user_id_users_id_fk",
+          "tableFrom": "network_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "network_members_network_id_user_id_pk": {
+          "name": "network_members_network_id_user_id_pk",
+          "columns": [
+            "network_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.networks": {
+      "name": "networks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_experiment": {
+          "name": "is_experiment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "experiment_master_key_hash": {
+          "name": "experiment_master_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "network_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'community'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"joinPolicy\":\"invite_only\",\"invitationLink\":null,\"allowGuestVibeCheck\":false}'::json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "indexes_key_unique": {
+          "name": "indexes_key_unique",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_access_token_client_id_idx": {
+          "name": "oauth_access_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_user_id_idx": {
+          "name": "oauth_access_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_users_id_fk": {
+          "name": "oauth_access_token_user_id_users_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_access_token_unique": {
+          "name": "oauth_access_token_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        },
+        "oauth_access_token_refresh_token_unique": {
+          "name": "oauth_access_token_refresh_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_application": {
+      "name": "oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_application_user_id_idx": {
+          "name": "oauth_application_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_application_user_id_users_id_fk": {
+          "name": "oauth_application_user_id_users_id_fk",
+          "tableFrom": "oauth_application",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_application_client_id_unique": {
+          "name": "oauth_application_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_id_idx": {
+          "name": "oauth_consent_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_user_id_idx": {
+          "name": "oauth_consent_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_users_id_fk": {
+          "name": "oauth_consent_user_id_users_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunities": {
+      "name": "opportunities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "detection": {
+          "name": "detection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actors": {
+          "name": "actors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interpretation": {
+          "name": "interpretation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "opportunity_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "opportunities_status_idx": {
+          "name": "opportunities_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunities_accepted_by_users_id_fk": {
+          "name": "opportunities_accepted_by_users_id_fk",
+          "tableFrom": "opportunities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "accepted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunity_deliveries": {
+      "name": "opportunity_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivered_at_status": {
+          "name": "delivered_at_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_token": {
+          "name": "reservation_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reserved_at": {
+          "name": "reserved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_opp_deliveries_committed": {
+          "name": "uniq_opp_deliveries_committed",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "delivered_at_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"opportunity_deliveries\".\"delivered_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_opp_deliveries_open_reservations": {
+          "name": "idx_opp_deliveries_open_reservations",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reserved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"opportunity_deliveries\".\"delivered_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunity_deliveries_opportunity_id_opportunities_id_fk": {
+          "name": "opportunity_deliveries_opportunity_id_opportunities_id_fk",
+          "tableFrom": "opportunity_deliveries",
+          "tableTo": "opportunities",
+          "columnsFrom": [
+            "opportunity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "opportunity_deliveries_user_id_users_id_fk": {
+          "name": "opportunity_deliveries_user_id_users_id_fk",
+          "tableFrom": "opportunity_deliveries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "opportunity_deliveries_agent_id_agents_id_fk": {
+          "name": "opportunity_deliveries_agent_id_agents_id_fk",
+          "tableFrom": "opportunity_deliveries",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunity_discovery_runs": {
+      "name": "opportunity_discovery_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "discovery_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "opportunity_discovery_runs_user_created_idx": {
+          "name": "opportunity_discovery_runs_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opportunity_discovery_runs_status_created_idx": {
+          "name": "opportunity_discovery_runs_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opportunity_discovery_runs_expires_at_idx": {
+          "name": "opportunity_discovery_runs_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunity_discovery_runs_user_id_users_id_fk": {
+          "name": "opportunity_discovery_runs_user_id_users_id_fk",
+          "tableFrom": "opportunity_discovery_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "opportunity_discovery_runs_agent_id_agents_id_fk": {
+          "name": "opportunity_discovery_runs_agent_id_agents_id_fk",
+          "tableFrom": "opportunity_discovery_runs",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_networks": {
+      "name": "personal_networks",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "personal_networks_network_id_unique": {
+          "name": "personal_networks_network_id_unique",
+          "columns": [
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_networks_user_id_users_id_fk": {
+          "name": "personal_networks_user_id_users_id_fk",
+          "tableFrom": "personal_networks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "personal_networks_network_id_networks_id_fk": {
+          "name": "personal_networks_network_id_networks_id_fk",
+          "tableFrom": "personal_networks",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "personal_networks_user_id_pk": {
+          "name": "personal_networks_user_id_pk",
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.premise_networks": {
+      "name": "premise_networks",
+      "schema": "",
+      "columns": {
+        "premise_id": {
+          "name": "premise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relevancy_score": {
+          "name": "relevancy_score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignment_metadata": {
+          "name": "assignment_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "premise_networks_network_id_idx": {
+          "name": "premise_networks_network_id_idx",
+          "columns": [
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "premise_networks_premise_id_premises_id_fk": {
+          "name": "premise_networks_premise_id_premises_id_fk",
+          "tableFrom": "premise_networks",
+          "tableTo": "premises",
+          "columnsFrom": [
+            "premise_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "premise_networks_network_id_networks_id_fk": {
+          "name": "premise_networks_network_id_networks_id_fk",
+          "tableFrom": "premise_networks",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "premise_networks_premise_id_network_id_pk": {
+          "name": "premise_networks_premise_id_network_id_pk",
+          "columns": [
+            "premise_id",
+            "network_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.premises": {
+      "name": "premises",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assertion": {
+          "name": "assertion",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis": {
+          "name": "analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validity": {
+          "name": "validity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "premise_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retracted_at": {
+          "name": "retracted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "premises_embedding_idx": {
+          "name": "premises_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "premises_user_id_idx": {
+          "name": "premises_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "premises_status_idx": {
+          "name": "premises_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "premises_user_id_users_id_fk": {
+          "name": "premises_user_id_users_id_fk",
+          "tableFrom": "premises",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "detection": {
+          "name": "detection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actors": {
+          "name": "actors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "question_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "answer": {
+          "name": "answer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "questions_status_idx": {
+          "name": "questions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "questions_conversation_id_idx": {
+          "name": "questions_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_contexts": {
+      "name": "user_contexts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "premise_hash": {
+          "name": "premise_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_contexts_user_network_uniq": {
+          "name": "user_contexts_user_network_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_contexts\".\"network_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_contexts_user_global_uniq": {
+          "name": "user_contexts_user_global_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_contexts\".\"network_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_contexts_embedding_idx": {
+          "name": "user_contexts_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "user_contexts_user_id_idx": {
+          "name": "user_contexts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_contexts_network_id_idx": {
+          "name": "user_contexts_network_id_idx",
+          "columns": [
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_contexts_user_id_users_id_fk": {
+          "name": "user_contexts_user_id_users_id_fk",
+          "tableFrom": "user_contexts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_contexts_network_id_networks_id_fk": {
+          "name": "user_contexts_network_id_networks_id_fk",
+          "tableFrom": "user_contexts",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_settings": {
+      "name": "user_notification_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"connectionUpdates\":true,\"weeklyNewsletter\":true}'::json"
+        },
+        "unsubscribe_token": {
+          "name": "unsubscribe_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_settings_user_id_users_id_fk": {
+          "name": "user_notification_settings_user_id_users_id_fk",
+          "tableFrom": "user_notification_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_notification_settings_user_id_unique": {
+          "name": "user_notification_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_notification_settings_unsubscribe_token_unique": {
+          "name": "user_notification_settings_unsubscribe_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "unsubscribe_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_socials": {
+      "name": "user_socials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_socials_user_id": {
+          "name": "idx_user_socials_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_user_socials_user_label": {
+          "name": "uniq_user_socials_user_label",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_socials\".\"label\" <> 'custom'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_socials_user_id_users_id_fk": {
+          "name": "user_socials_user_id_users_id_fk",
+          "tableFrom": "user_socials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro": {
+          "name": "intro",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding": {
+          "name": "onboarding",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::json"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UTC'"
+        },
+        "last_weekly_email_sent_at": {
+          "name": "last_weekly_email_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_ghost": {
+          "name": "is_ghost",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_key_unique": {
+          "name": "users_key_unique",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artifacts": {
+      "name": "artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "artifacts_task_id_idx": {
+          "name": "artifacts_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifacts_task_id_tasks_id_fk": {
+          "name": "artifacts_task_id_tasks_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session_scopes": {
+      "name": "chat_session_scopes",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chat_session_scopes_user_scope_unique": {
+          "name": "chat_session_scopes_user_scope_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_session_scopes_user_id_idx": {
+          "name": "chat_session_scopes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_session_scopes_scope_idx": {
+          "name": "chat_session_scopes_scope_idx",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_session_scopes_conversation_id_conversations_id_fk": {
+          "name": "chat_session_scopes_conversation_id_conversations_id_fk",
+          "tableFrom": "chat_session_scopes",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session_summaries": {
+      "name": "chat_session_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_message_id": {
+          "name": "from_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_message_id": {
+          "name": "to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "digest": {
+          "name": "digest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chat_session_summaries_session_latest_idx": {
+          "name": "chat_session_summaries_session_latest_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_session_summaries_conversation_id_conversations_id_fk": {
+          "name": "chat_session_summaries_conversation_id_conversations_id_fk",
+          "tableFrom": "chat_session_summaries",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_session_summaries_from_message_id_messages_id_fk": {
+          "name": "chat_session_summaries_from_message_id_messages_id_fk",
+          "tableFrom": "chat_session_summaries",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "from_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "chat_session_summaries_to_message_id_messages_id_fk": {
+          "name": "chat_session_summaries_to_message_id_messages_id_fk",
+          "tableFrom": "chat_session_summaries",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "to_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_metadata": {
+      "name": "conversation_metadata",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_metadata_conversation_id_conversations_id_fk": {
+          "name": "conversation_metadata_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_metadata",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_participants": {
+      "name": "conversation_participants",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_type": {
+          "name": "participant_type",
+          "type": "participant_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "hidden_at": {
+          "name": "hidden_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversation_participants_participant_id_idx": {
+          "name": "conversation_participants_participant_id_idx",
+          "columns": [
+            {
+              "expression": "participant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_participants_conversation_id_idx": {
+          "name": "conversation_participants_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_participants_conversation_id_conversations_id_fk": {
+          "name": "conversation_participants_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_participants",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_participants_conversation_id_participant_id_pk": {
+          "name": "conversation_participants_conversation_id_participant_id_pk",
+          "columns": [
+            "conversation_id",
+            "participant_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dm_pair": {
+          "name": "dm_pair",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversations_dm_pair_idx": {
+          "name": "conversations_dm_pair_idx",
+          "columns": [
+            {
+              "expression": "dm_pair",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "message_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_task_ids": {
+          "name": "reference_task_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_conversation_id_created_at_idx": {
+          "name": "messages_conversation_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_sender_id_idx": {
+          "name": "messages_sender_id_idx",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_task_id_idx": {
+          "name": "messages_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_task_id_tasks_id_fk": {
+          "name": "messages_task_id_tasks_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "task_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "status_message": {
+          "name": "status_message",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_timestamp": {
+          "name": "status_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_agent_id": {
+          "name": "claimed_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tasks_conversation_id_idx": {
+          "name": "tasks_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_state_idx": {
+          "name": "tasks_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_metadata_opportunity_id_idx": {
+          "name": "tasks_metadata_opportunity_id_idx",
+          "columns": [
+            {
+              "expression": "(\"metadata\"->>'opportunityId')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"tasks\".\"metadata\"->>'type' = 'negotiation'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_conversation_id_conversations_id_fk": {
+          "name": "tasks_conversation_id_conversations_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_status": {
+      "name": "agent_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive"
+      ]
+    },
+    "public.agent_type": {
+      "name": "agent_type",
+      "schema": "public",
+      "values": [
+        "personal",
+        "system"
+      ]
+    },
+    "public.discovery_run_status": {
+      "name": "discovery_run_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "succeeded",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.intent_mode": {
+      "name": "intent_mode",
+      "schema": "public",
+      "values": [
+        "REFERENTIAL",
+        "ATTRIBUTIVE"
+      ]
+    },
+    "public.intent_status": {
+      "name": "intent_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "PAUSED",
+        "FULFILLED",
+        "EXPIRED"
+      ]
+    },
+    "public.network_type": {
+      "name": "network_type",
+      "schema": "public",
+      "values": [
+        "community",
+        "event"
+      ]
+    },
+    "public.opportunity_status": {
+      "name": "opportunity_status",
+      "schema": "public",
+      "values": [
+        "latent",
+        "draft",
+        "negotiating",
+        "pending",
+        "stalled",
+        "accepted",
+        "rejected",
+        "expired"
+      ]
+    },
+    "public.permission_scope": {
+      "name": "permission_scope",
+      "schema": "public",
+      "values": [
+        "global",
+        "node",
+        "network"
+      ]
+    },
+    "public.premise_status": {
+      "name": "premise_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "RETRACTED",
+        "EXPIRED"
+      ]
+    },
+    "public.question_status": {
+      "name": "question_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "answered",
+        "dismissed"
+      ]
+    },
+    "public.source_type": {
+      "name": "source_type",
+      "schema": "public",
+      "values": [
+        "file",
+        "integration",
+        "link",
+        "discovery_form",
+        "enrichment"
+      ]
+    },
+    "public.speech_act_type": {
+      "name": "speech_act_type",
+      "schema": "public",
+      "values": [
+        "COMMISSIVE",
+        "DIRECTIVE"
+      ]
+    },
+    "public.transport_channel": {
+      "name": "transport_channel",
+      "schema": "public",
+      "values": [
+        "mcp"
+      ]
+    },
+    "public.message_role": {
+      "name": "message_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "agent"
+      ]
+    },
+    "public.participant_type": {
+      "name": "participant_type",
+      "schema": "public",
+      "values": [
+        "user",
+        "agent"
+      ]
+    },
+    "public.task_state": {
+      "name": "task_state",
+      "schema": "public",
+      "values": [
+        "submitted",
+        "working",
+        "input_required",
+        "completed",
+        "failed",
+        "canceled",
+        "rejected",
+        "auth_required",
+        "waiting_for_agent",
+        "claimed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/services/api/drizzle/meta/_journal.json
+++ b/services/api/drizzle/meta/_journal.json
@@ -610,6 +610,13 @@
       "when": 1781778982776,
       "tag": "0086_rename_question_mode_profile",
       "breakpoints": true
+    },
+    {
+      "idx": 87,
+      "version": "7",
+      "when": 1782566344414,
+      "tag": "0087_add_chat_session_scopes",
+      "breakpoints": true
     }
   ]
 }

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -1,4 +1,4 @@
-import { readUserContext, schema, Artifact, ChatConversationMeta, ChatMessage, ChatMessageMeta, ChatSession, Conversation, ConversationParticipant, ConversationSummary, CreateMessageInput, CreateSessionInput, Message, ResolvedParticipant, SYSTEM_AGENT_ID, Task, and, asc, count, db, desc, eq, gt, inArray, isNull, lt, opportunities, or, sql } from './database.shared';
+import { readUserContext, schema, Artifact, ChatConversationMeta, ChatMessage, ChatMessageMeta, ChatScopeType, ChatSession, Conversation, ConversationParticipant, ConversationSummary, CreateMessageInput, CreateSessionInput, Message, ResolvedParticipant, SYSTEM_AGENT_ID, Task, and, asc, count, db, desc, eq, gt, inArray, isNull, lt, opportunities, or, sql } from './database.shared';
 
 
 export class ConversationDatabaseAdapter {
@@ -1093,15 +1093,26 @@ export class ConversationDatabaseAdapter {
     userId: string,
     meta: ChatConversationMeta | null,
   ): ChatSession {
+    const legacyNetworkId = meta?.networkId ?? null;
+    const scopeType = this._normalizeScopeType(meta?.scopeType) ?? (legacyNetworkId ? 'network' : null);
+    const scopeId = typeof meta?.scopeId === 'string' && meta.scopeId.trim()
+      ? meta.scopeId.trim()
+      : legacyNetworkId;
     return {
       id: conv.id,
       userId,
       title: meta?.title ?? null,
-      networkId: meta?.networkId ?? null,
+      networkId: legacyNetworkId,
+      scopeType,
+      scopeId: scopeType ? scopeId : null,
       shareToken: meta?.shareToken ?? null,
       createdAt: conv.createdAt,
       updatedAt: conv.updatedAt,
     };
+  }
+
+  private _normalizeScopeType(value: unknown): ChatScopeType | null {
+    return value === 'network' || value === 'intent' ? value : null;
   }
 
   /**
@@ -1123,14 +1134,37 @@ export class ConversationDatabaseAdapter {
         { conversationId: data.id, participantId: SYSTEM_AGENT_ID, participantType: 'agent' as const },
       ]);
 
-      // Store title and networkId in conversation_metadata
+      // Store title and canonical scope in conversation_metadata.
+      const normalizedScopeType = this._normalizeScopeType(data.scopeType);
+      const normalizedScopeId = data.scopeId?.trim() || undefined;
+      const networkId = normalizedScopeType === 'network'
+        ? normalizedScopeId
+        : data.networkId?.trim() || undefined;
       const meta: ChatConversationMeta = {};
       if (data.title) meta.title = data.title;
-      if (data.networkId?.trim()) meta.networkId = data.networkId.trim();
+      if (networkId) meta.networkId = networkId;
+      if (normalizedScopeType && normalizedScopeId) {
+        meta.scopeType = normalizedScopeType;
+        meta.scopeId = normalizedScopeId;
+      } else if (networkId) {
+        meta.scopeType = 'network';
+        meta.scopeId = networkId;
+      }
       if (Object.keys(meta).length > 0) {
         await tx.insert(schema.conversationMetadata).values({
           conversationId: data.id,
           metadata: meta,
+        });
+      }
+
+      if (normalizedScopeType === 'intent' && normalizedScopeId) {
+        await tx.insert(schema.chatSessionScopes).values({
+          conversationId: data.id,
+          userId: data.userId,
+          scopeType: normalizedScopeType,
+          scopeId: normalizedScopeId,
+          createdAt: now,
+          updatedAt: now,
         });
       }
     });
@@ -1402,10 +1436,90 @@ export class ConversationDatabaseAdapter {
   }
 
   /**
+   * Find a stable H2A chat session by canonical scope.
+   */
+  async getChatSessionByScope(
+    userId: string,
+    scopeType: ChatScopeType,
+    scopeId: string,
+  ): Promise<ChatSession | null> {
+    const normalizedScopeId = scopeId.trim();
+    if (!normalizedScopeId) return null;
+
+    if (scopeType === 'intent') {
+      const [row] = await db
+        .select({ conversationId: schema.chatSessionScopes.conversationId })
+        .from(schema.chatSessionScopes)
+        .where(
+          and(
+            eq(schema.chatSessionScopes.userId, userId),
+            eq(schema.chatSessionScopes.scopeType, scopeType),
+            eq(schema.chatSessionScopes.scopeId, normalizedScopeId),
+          ),
+        )
+        .limit(1);
+      return row ? this.getChatSession(row.conversationId) : null;
+    }
+
+    // Network-scoped sessions predate chat_session_scopes; look them up through metadata.
+    const rows = await db
+      .select({ conversationId: schema.conversationMetadata.conversationId })
+      .from(schema.conversationMetadata)
+      .where(
+        sql`(${schema.conversationMetadata.metadata}->>'scopeType' = ${scopeType} AND ${schema.conversationMetadata.metadata}->>'scopeId' = ${normalizedScopeId}) OR ${schema.conversationMetadata.metadata}->>'networkId' = ${normalizedScopeId}`,
+      )
+      .limit(10);
+
+    for (const row of rows) {
+      const session = await this.getChatSession(row.conversationId);
+      if (session?.userId === userId) return session;
+    }
+    return null;
+  }
+
+  /**
+   * Update chat session canonical scope metadata.
+   * Intent scope also upserts the stable scope mapping used by the resolver.
+   */
+  async updateChatSessionScope(
+    sessionId: string,
+    userId: string,
+    scopeType: ChatScopeType | null,
+    scopeId: string | null,
+  ): Promise<void> {
+    const normalizedScopeId = scopeId?.trim() || null;
+    const networkId = scopeType === 'network' ? normalizedScopeId : null;
+    await this._upsertConvMeta(sessionId, { scopeType, scopeId: normalizedScopeId, networkId });
+
+    await db.delete(schema.chatSessionScopes).where(eq(schema.chatSessionScopes.conversationId, sessionId));
+    if (scopeType === 'intent' && normalizedScopeId) {
+      const now = new Date();
+      await db.insert(schema.chatSessionScopes).values({
+        conversationId: sessionId,
+        userId,
+        scopeType,
+        scopeId: normalizedScopeId,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+
+    await db
+      .update(schema.conversations)
+      .set({ updatedAt: new Date() })
+      .where(eq(schema.conversations.id, sessionId));
+  }
+
+  /**
    * Update chat session network scope.
    */
   async updateChatSessionIndex(sessionId: string, networkId: string | null): Promise<void> {
-    await this._upsertConvMeta(sessionId, { networkId });
+    await this._upsertConvMeta(sessionId, {
+      networkId,
+      scopeType: networkId ? 'network' : null,
+      scopeId: networkId,
+    });
+    await db.delete(schema.chatSessionScopes).where(eq(schema.chatSessionScopes.conversationId, sessionId));
     await db
       .update(schema.conversations)
       .set({ updatedAt: new Date() })

--- a/services/api/src/adapters/database.shared.ts
+++ b/services/api/src/adapters/database.shared.ts
@@ -330,11 +330,18 @@ export function ownIntentsListWhere(
 /**
  * Database adapter for intent CRUD (Intent Graph).
  */
+export type ChatScopeType = 'network' | 'intent';
+
 export interface ChatSession {
   id: string;
   userId: string;
   title: string | null;
+  /** Legacy network alias. Prefer scopeType/scopeId for new code. */
   networkId: string | null;
+  /** Canonical focused scope for this orchestrator chat, when persisted. */
+  scopeType: ChatScopeType | null;
+  /** Canonical focused scope id. Network scope uses a network id; intent scope uses an intent id. */
+  scopeId: string | null;
   shareToken: string | null;
   createdAt: Date;
   updatedAt: Date;
@@ -355,7 +362,12 @@ export interface ChatMessage {
 /** Shape stored inside conversation_metadata.metadata for agent-chat sessions. */
 export interface ChatConversationMeta {
   title?: string | null;
+  /** Legacy network alias retained for existing clients and session rows. */
   networkId?: string | null;
+  /** Canonical focused scope for this orchestrator chat. */
+  scopeType?: ChatScopeType | null;
+  /** Canonical focused scope id. */
+  scopeId?: string | null;
   shareToken?: string | null;
   ghostInviteSent?: boolean;
   [key: string]: unknown;
@@ -384,7 +396,10 @@ export interface CreateSessionInput {
   id: string;
   userId: string;
   title?: string;
+  /** Legacy network alias. Prefer scopeType/scopeId for new code. */
   networkId?: string;
+  scopeType?: ChatScopeType;
+  scopeId?: string;
 }
 
 export interface CreateMessageInput {

--- a/services/api/src/adapters/questioner.adapter.ts
+++ b/services/api/src/adapters/questioner.adapter.ts
@@ -169,10 +169,16 @@ export class QuestionerAdapter {
     }
     if (filters?.scopeType === 'intent' && filters.scopeId) {
       conditions.push(sql`(
-        (
+        ${questions.detection}->>'triggeredBy' = ${filters.scopeId}
+        OR (
           ${questions.detection}->>'mode' = 'intent'
           AND ${questions.detection}->>'sourceType' = 'intent'
           AND ${questions.detection}->>'sourceId' = ${filters.scopeId}
+        )
+        OR (
+          ${questions.detection}->>'mode' = 'discovery'
+          AND ${questions.detection}->>'sourceType' = 'discovery'
+          AND ${questions.detection}->>'triggeredBy' = ${filters.scopeId}
         )
         OR (
           ${questions.detection}->>'mode' = 'negotiation'

--- a/services/api/src/controllers/chat.controller.ts
+++ b/services/api/src/controllers/chat.controller.ts
@@ -12,8 +12,56 @@ import { createDoneEvent, createErrorEvent, createStatusEvent, createSteerOrQueu
 import { emitChatInterrupt, onChatInterrupt } from '../lib/chat-interrupt.events';
 
 type RouteParams = Record<string, string>;
+type ChatScope = { scopeType: 'network' | 'intent'; scopeId: string };
 
 const logger = log.controller.from("chat");
+
+function normalizeChatScope(input: {
+  scopeType?: 'network' | 'intent' | null;
+  scopeId?: string | null;
+  networkId?: string | null;
+}): ChatScope | Response | undefined {
+  const explicitScopeType = input.scopeType ?? undefined;
+  const explicitScopeId = input.scopeId?.trim() || undefined;
+  const legacyNetworkId = input.networkId?.trim() || undefined;
+
+  if (explicitScopeType && !explicitScopeId) {
+    return Response.json({ error: 'scopeId is required when scopeType is provided' }, { status: 400 });
+  }
+  if (!explicitScopeType && explicitScopeId) {
+    return Response.json({ error: 'scopeType is required when scopeId is provided' }, { status: 400 });
+  }
+  if (explicitScopeType === 'intent' && legacyNetworkId) {
+    return Response.json({ error: 'networkId cannot be combined with intent scope' }, { status: 400 });
+  }
+  if (explicitScopeType === 'network' && legacyNetworkId && legacyNetworkId !== explicitScopeId) {
+    return Response.json({ error: 'networkId must match scopeId when scopeType is network' }, { status: 400 });
+  }
+
+  if (explicitScopeType && explicitScopeId) {
+    return { scopeType: explicitScopeType, scopeId: explicitScopeId };
+  }
+  if (legacyNetworkId) {
+    return { scopeType: 'network', scopeId: legacyNetworkId };
+  }
+  return undefined;
+}
+
+function sessionScope(session: { scopeType?: string | null; scopeId?: string | null; networkId?: string | null } | null): ChatScope | undefined {
+  if (!session) return undefined;
+  if ((session.scopeType === 'network' || session.scopeType === 'intent') && session.scopeId?.trim()) {
+    return { scopeType: session.scopeType, scopeId: session.scopeId.trim() };
+  }
+  if (session.networkId?.trim()) {
+    return { scopeType: 'network', scopeId: session.networkId.trim() };
+  }
+  return undefined;
+}
+
+function sameScope(a: ChatScope | undefined, b: ChatScope | undefined): boolean {
+  if (!a || !b) return a === b;
+  return a.scopeType === b.scopeType && a.scopeId === b.scopeId;
+}
 
 const streamBodySchema = z.object({
   message: z.string().nullish(),
@@ -22,7 +70,7 @@ const streamBodySchema = z.object({
   fileIds: z.array(z.string()).optional(),
   /** @deprecated Use scopeType/scopeId. Retained as the REST edge alias for network-scoped sessions. */
   networkId: z.string().nullish(),
-  scopeType: z.enum(['network']).nullish(),
+  scopeType: z.enum(['network', 'intent']).nullish(),
   scopeId: z.string().nullish(),
   /** The recipient user ID for DM-style chats (used for ghost invite emails). */
   recipientUserId: z.string().nullish(),
@@ -39,6 +87,11 @@ function getSuggestionGenerator(): SuggestionGenerator {
   }
   return suggestionGeneratorInstance;
 }
+
+const resolveSessionBodySchema = z.object({
+  scopeType: z.enum(['intent']),
+  scopeId: z.string().min(1),
+});
 
 const interruptBodySchema = z.object({
   sessionId: z.string(),
@@ -124,7 +177,7 @@ export class ChatController {
         return Response.json(
           {
             error:
-              "Invalid request body. Expected { message?: string | null, sessionId?: string | null, useCheckpointer?: boolean, fileIds?: string[], scopeType?: 'network' | null, scopeId?: string | null, networkId?: string | null }",
+              "Invalid request body. Expected { message?: string | null, sessionId?: string | null, useCheckpointer?: boolean, fileIds?: string[], scopeType?: 'network' | 'intent' | null, scopeId?: string | null, networkId?: string | null }",
           },
           { status: 400 },
         );
@@ -160,71 +213,72 @@ export class ChatController {
     }
 
     // 2. Validate or create session
-    const requestIndexId =
-      body.scopeType === 'network' && typeof body.scopeId === "string" && body.scopeId.trim()
-        ? body.scopeId.trim()
-        : typeof body.networkId === "string" && body.networkId.trim()
-          ? body.networkId.trim()
-          : undefined;
-    if (requestIndexId) {
-      const requestScopeValidation =
-        await chatSessionService.validateIndexScope(user.id, requestIndexId);
-      if (!requestScopeValidation.ok) {
+    const requestedScope = normalizeChatScope(body);
+    if (requestedScope instanceof Response) return requestedScope;
+
+    const validateScope = async (scope: ChatScope | undefined) => {
+      if (!scope) return undefined;
+      const validation = scope.scopeType === 'network'
+        ? await chatSessionService.validateIndexScope(user.id, scope.scopeId)
+        : await chatSessionService.validateIntentScope(user.id, scope.scopeId);
+      if (!validation.ok) {
         return Response.json(
-          { error: requestScopeValidation.error },
-          { status: requestScopeValidation.status },
+          { error: validation.error },
+          { status: validation.status },
         );
       }
-    }
+      return undefined;
+    };
+
+    const requestScopeError = await validateScope(requestedScope);
+    if (requestScopeError) return requestScopeError;
 
     let currentSessionId = body.sessionId;
-    let session: Awaited<
-      ReturnType<typeof chatSessionService.getSession>
-    > | null = null;
+    let effectiveScope = requestedScope;
     if (!currentSessionId) {
       const initialTitle = body.prefillMessages?.length
         ? "Set Up Your Social Agent"
         : undefined;
-      currentSessionId = await chatSessionService.createSession(
-        user.id,
-        initialTitle,
-        requestIndexId,
-      );
+      if (requestedScope?.scopeType === 'intent') {
+        const resolved = await chatSessionService.resolveSessionForScope(user.id, requestedScope);
+        if ('error' in resolved) {
+          return Response.json({ error: resolved.error }, { status: resolved.status });
+        }
+        currentSessionId = resolved.session.id;
+      } else {
+        currentSessionId = await chatSessionService.createSession(
+          user.id,
+          initialTitle,
+          requestedScope?.scopeType === 'network' ? requestedScope.scopeId : undefined,
+          requestedScope,
+        );
+      }
     } else {
-      session = await chatSessionService.getSession(
+      let loadedSession = await chatSessionService.getSession(
         currentSessionId,
         user.id,
       );
-      if (!session) {
+      if (!loadedSession) {
         return Response.json({ error: "Session not found" }, { status: 404 });
       }
-      if (requestIndexId !== undefined) {
-        await chatSessionService.updateSessionIndex(
-          currentSessionId,
-          user.id,
-          requestIndexId,
-        );
+      const persistedScope = sessionScope(loadedSession);
+      if (requestedScope && persistedScope && !sameScope(requestedScope, persistedScope)) {
+        return Response.json({ error: "Session is already scoped differently" }, { status: 409 });
       }
+      if (requestedScope && !persistedScope) {
+        await chatSessionService.updateSessionScope(currentSessionId, user.id, requestedScope);
+        loadedSession = await chatSessionService.getSession(currentSessionId, user.id);
+      }
+      effectiveScope = requestedScope ?? sessionScope(loadedSession);
     }
 
-    // Effective index for this run: request body overrides; otherwise use session's persisted index
-    const effectiveIndexId = requestIndexId ?? session?.networkId ?? undefined;
-    if (effectiveIndexId) {
-      const effectiveScopeValidation =
-        await chatSessionService.validateIndexScope(user.id, effectiveIndexId);
-      if (!effectiveScopeValidation.ok) {
-        return Response.json(
-          { error: effectiveScopeValidation.error },
-          { status: effectiveScopeValidation.status },
-        );
-      }
-    }
+    const effectiveScopeError = await validateScope(effectiveScope);
+    if (effectiveScopeError) return effectiveScopeError;
 
     // Capture for closure
     const sessionId = currentSessionId;
     const factory = chatSessionService.getGraphFactory();
     const useCheckpointer = body.useCheckpointer ?? true;
-    const networkIdForStream = effectiveIndexId;
     const runId = crypto.randomUUID();
     const streamAbortController = new AbortController();
     // Forward HTTP client disconnect into the stream abort controller
@@ -302,7 +356,7 @@ export class ChatController {
               message: messageContent,
               sessionId,
               maxContextMessages: 20,
-              ...(networkIdForStream ? { scopeType: 'network' as const, scopeId: networkIdForStream } : {}),
+              ...(effectiveScope ? { scopeType: effectiveScope.scopeType, scopeId: effectiveScope.scopeId } : {}),
               prefillMessages: body.prefillMessages,
               runId,
             },
@@ -516,6 +570,45 @@ export class ChatController {
   async getSessions(req: Request, user: AuthenticatedUser) {
     const sessions = await chatSessionService.getUserSessions(user.id);
     return Response.json({ sessions });
+  }
+
+  /**
+   * Resolve or create the stable orchestrator chat session for a selected intent.
+   *
+   * @param req - The HTTP request object (body: { scopeType: 'intent', scopeId: string })
+   * @param user - The authenticated user from AuthGuard
+   * @returns JSON response with the resolved session and whether it was created
+   */
+  @Post("/session/resolve")
+  @UseGuards(RateLimit('write'), AuthGuard)
+  async resolveSession(req: Request, user: AuthenticatedUser) {
+    let body: z.infer<typeof resolveSessionBodySchema>;
+    try {
+      const raw = await req.json();
+      const parsed = resolveSessionBodySchema.safeParse(raw);
+      if (!parsed.success) {
+        return Response.json(
+          { error: "Invalid request body. Expected { scopeType: 'intent', scopeId: string }" },
+          { status: 400 },
+        );
+      }
+      body = parsed.data;
+    } catch {
+      return Response.json(
+        { error: "Invalid JSON in request body" },
+        { status: 400 },
+      );
+    }
+
+    const result = await chatSessionService.resolveSessionForScope(user.id, {
+      scopeType: body.scopeType,
+      scopeId: body.scopeId,
+    });
+    if ('error' in result) {
+      return Response.json({ error: result.error }, { status: result.status });
+    }
+
+    return Response.json({ session: result.session, created: result.created });
   }
 
   /**

--- a/services/api/src/controllers/mcp.controller.ts
+++ b/services/api/src/controllers/mcp.controller.ts
@@ -628,6 +628,8 @@ function createMcpServerInstance(): McpServer {
         sourceType?: string;
         sourceId?: string;
         networkId?: string;
+        scopeType?: 'intent';
+        scopeId?: string;
         modes?: Array<'discovery' | 'intent' | 'enrichment' | 'negotiation'>;
         limit?: number;
       },

--- a/services/api/src/queues/questioner.queue.ts
+++ b/services/api/src/queues/questioner.queue.ts
@@ -151,6 +151,9 @@ export class QuestionerQueue {
     const actorNetworkId = data.scopeType === 'network' && data.scopeId?.trim()
       ? data.scopeId.trim()
       : undefined;
+    const triggeredByIntentId = data.scopeType === 'intent' && data.scopeId?.trim()
+      ? data.scopeId.trim()
+      : undefined;
 
     const batch: PersistableQuestion[] = result.questions.map((question, i) => ({
       detection: {
@@ -158,6 +161,7 @@ export class QuestionerQueue {
         sourceType: data.sourceType,
         sourceId: data.sourceId,
         timestamp: new Date().toISOString(),
+        ...(triggeredByIntentId ? { triggeredBy: triggeredByIntentId } : {}),
         ...(data.messageId ? { messageId: data.messageId } : {}),
       },
       actors: [{ userId: data.userId, ...(actorNetworkId ? { networkId: actorNetworkId } : {}), role: 'subject' as const }],

--- a/services/api/src/queues/tests/questioner.queue.spec.ts
+++ b/services/api/src/queues/tests/questioner.queue.spec.ts
@@ -57,6 +57,49 @@ describe('QuestionerQueue', () => {
     ]);
   });
 
+  it('persists selected intent scope as detection.triggeredBy without actor networkId', async () => {
+    let captured: PersistableQuestion[] = [];
+    const queue = new QuestionerQueue({
+      adapter: {
+        persist: async (batch) => {
+          captured = batch;
+          return ['question-1'];
+        },
+      },
+      agent: {
+        invoke: async () => ({
+          questions: [
+            {
+              title: 'Focus',
+              prompt: 'Which collaboration focus matters most?',
+              options: [
+                { label: 'Build', description: 'Build together' },
+                { label: 'Learn', description: 'Exchange knowledge' },
+              ],
+              multiSelect: false,
+            },
+          ],
+          strategies: ['surface_missing_detail'],
+        }),
+      },
+    });
+    queues.push(queue);
+
+    await queue.processJob('generate_questions', {
+      mode: 'discovery',
+      userId: 'user-1',
+      sourceType: 'discovery',
+      sourceId: 'session-1',
+      context: {} as never,
+      scopeType: 'intent',
+      scopeId: 'intent-1',
+      conversationId: 'session-1',
+    });
+
+    expect(captured[0].actors).toEqual([{ userId: 'user-1', role: 'subject' }]);
+    expect(captured[0].detection.triggeredBy).toBe('intent-1');
+  });
+
   it('omits actor networkId for unscoped question jobs', async () => {
     let captured: PersistableQuestion[] = [];
     const queue = new QuestionerQueue({

--- a/services/api/src/schemas/conversation.schema.ts
+++ b/services/api/src/schemas/conversation.schema.ts
@@ -192,6 +192,36 @@ export const conversationMetadata = pgTable('conversation_metadata', {
   updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 });
 
+/**
+ * Stable scope mapping for H2A/orchestrator chat sessions.
+ *
+ * Intent-scoped chats use this table to enforce one conversation per
+ * `(userId, scopeType, scopeId)` while keeping the canonical conversation
+ * metadata JSON backward-compatible for older network-scoped sessions.
+ */
+export const chatSessionScopes = pgTable(
+  'chat_session_scopes',
+  {
+    conversationId: text('conversation_id')
+      .primaryKey()
+      .references(() => conversations.id, { onDelete: 'cascade' }),
+    userId: text('user_id').notNull(),
+    scopeType: text('scope_type').notNull(),
+    scopeId: text('scope_id').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => ({
+    scopeUnique: uniqueIndex('chat_session_scopes_user_scope_unique').on(
+      table.userId,
+      table.scopeType,
+      table.scopeId,
+    ),
+    userIdx: index('chat_session_scopes_user_id_idx').on(table.userId),
+    scopeIdx: index('chat_session_scopes_scope_idx').on(table.scopeType, table.scopeId),
+  }),
+);
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Relations
 // ─────────────────────────────────────────────────────────────────────────────
@@ -247,6 +277,13 @@ export const conversationMetadataRelations = relations(conversationMetadata, ({ 
   }),
 }));
 
+export const chatSessionScopesRelations = relations(chatSessionScopes, ({ one }) => ({
+  conversation: one(conversations, {
+    fields: [chatSessionScopes.conversationId],
+    references: [conversations.id],
+  }),
+}));
+
 export const chatSessionSummariesRelations = relations(chatSessionSummaries, ({ one }) => ({
   conversation: one(conversations, {
     fields: [chatSessionSummaries.conversationId],
@@ -283,6 +320,9 @@ export type NewArtifact = typeof artifacts.$inferInsert;
 
 export type ConversationMetadata = typeof conversationMetadata.$inferSelect;
 export type NewConversationMetadata = typeof conversationMetadata.$inferInsert;
+
+export type ChatSessionScope = typeof chatSessionScopes.$inferSelect;
+export type NewChatSessionScope = typeof chatSessionScopes.$inferInsert;
 
 export type ChatSessionSummary = typeof chatSessionSummaries.$inferSelect;
 export type NewChatSessionSummary = typeof chatSessionSummaries.$inferInsert;

--- a/services/api/src/schemas/tests/conversation.schema.spec.ts
+++ b/services/api/src/schemas/tests/conversation.schema.spec.ts
@@ -2,7 +2,7 @@ import { config } from 'dotenv';
 config({ path: '.env.test', override: true });
 
 import { describe, it, expect } from 'bun:test';
-import { conversations, conversationParticipants, messages, tasks, artifacts, conversationMetadata, participantTypeEnum, messageRoleEnum, taskStateEnum } from '../conversation.schema';
+import { conversations, conversationParticipants, messages, tasks, artifacts, conversationMetadata, chatSessionScopes, participantTypeEnum, messageRoleEnum, taskStateEnum } from '../conversation.schema';
 
 describe('conversation schema', () => {
   it('exports all tables', () => {
@@ -12,6 +12,7 @@ describe('conversation schema', () => {
     expect(tasks).toBeDefined();
     expect(artifacts).toBeDefined();
     expect(conversationMetadata).toBeDefined();
+    expect(chatSessionScopes).toBeDefined();
   });
 
   it('exports all enums', () => {

--- a/services/api/src/services/chat.service.ts
+++ b/services/api/src/services/chat.service.ts
@@ -1,5 +1,6 @@
 import { log } from '../lib/log';
 import { conversationDatabaseAdapter, ConversationDatabaseAdapter, ChatDatabaseAdapter } from '../adapters/database.adapter';
+import type { ChatScopeType } from '../adapters/database.shared';
 import { ChatGraphFactory, ChatTitleGenerator } from '@indexnetwork/protocol';
 import type { ChatGraphCompositeDatabase } from '@indexnetwork/protocol';
 import { getCheckpointer } from '../adapters/checkpointer.adapter';
@@ -63,11 +64,28 @@ export class ChatSessionService {
    * @param networkId - Optional index (community) ID to scope the conversation
    * @returns The created session ID
    */
-  async createSession(userId: string, title?: string, networkId?: string): Promise<string> {
-    logger.verbose('Creating new session', { userId, hasTitle: Boolean(title?.trim()), networkId: networkId ?? undefined });
+  async createSession(
+    userId: string,
+    title?: string,
+    networkId?: string,
+    scope?: { scopeType: ChatScopeType; scopeId: string },
+  ): Promise<string> {
+    logger.verbose('Creating new session', {
+      userId,
+      hasTitle: Boolean(title?.trim()),
+      networkId: networkId ?? undefined,
+      scopeType: scope?.scopeType,
+      scopeId: scope?.scopeId,
+    });
 
     const id = crypto.randomUUID();
-    await this.db.createChatSession({ id, userId, title, networkId });
+    await this.db.createChatSession({
+      id,
+      userId,
+      title,
+      networkId,
+      ...(scope ? { scopeType: scope.scopeType, scopeId: scope.scopeId } : {}),
+    });
 
     return id;
   }
@@ -93,6 +111,30 @@ export class ChatSessionService {
   }
 
   /**
+   * Update the canonical focused scope for a session. Validates ownership.
+   */
+  async updateSessionScope(
+    sessionId: string,
+    userId: string,
+    scope: { scopeType: ChatScopeType; scopeId: string } | null,
+  ): Promise<boolean> {
+    const session = await this.getSession(sessionId, userId);
+    if (!session) {
+      return false;
+    }
+
+    await this.db.updateChatSessionScope(
+      sessionId,
+      userId,
+      scope?.scopeType ?? null,
+      scope?.scopeId ?? null,
+    );
+
+    logger.verbose('Session scope updated', { sessionId, scopeType: scope?.scopeType ?? null, scopeId: scope?.scopeId ?? null });
+    return true;
+  }
+
+  /**
    * Validate that a user can scope chat to an index.
    * Requires the index to exist and the user to be a member.
    */
@@ -112,6 +154,76 @@ export class ChatSessionService {
     }
 
     return { ok: true };
+  }
+
+  /**
+   * Validate that a user can scope chat to one of their intents.
+   * Intent scope is owner-only because intent listing pages show the user's own intents.
+   */
+  async validateIntentScope(
+    userId: string,
+    intentId: string,
+  ): Promise<{ ok: true; title: string } | { ok: false; status: 403 | 404; error: string }> {
+    const normalizedIntentId = intentId.trim();
+    const intent = await this.graphDb.getIntent(normalizedIntentId);
+    if (!intent || intent.archivedAt) {
+      return { ok: false, status: 404, error: 'Intent not found' };
+    }
+    if (intent.userId !== userId) {
+      return { ok: false, status: 403, error: 'You do not have access to this intent' };
+    }
+
+    const rawTitle = (intent.summary?.trim() || intent.payload?.trim() || 'Intent chat').replace(/\s+/g, ' ');
+    const title = rawTitle.length > 80 ? `${rawTitle.slice(0, 77)}…` : rawTitle;
+    return { ok: true, title };
+  }
+
+  /**
+   * Resolve or create the stable orchestrator session for a scoped entity.
+   */
+  async resolveSessionForScope(
+    userId: string,
+    scope: { scopeType: ChatScopeType; scopeId: string },
+  ) {
+    const normalizedScopeId = scope.scopeId.trim();
+    if (!normalizedScopeId) {
+      return { error: 'scopeId is required', status: 400 as const };
+    }
+
+    let title: string | undefined;
+    if (scope.scopeType === 'network') {
+      const validation = await this.validateIndexScope(userId, normalizedScopeId);
+      if (!validation.ok) return validation;
+    } else {
+      const validation = await this.validateIntentScope(userId, normalizedScopeId);
+      if (!validation.ok) return validation;
+      title = validation.title;
+    }
+
+    const existing = await this.db.getChatSessionByScope(userId, scope.scopeType, normalizedScopeId);
+    if (existing) return { session: existing, created: false };
+
+    try {
+      const id = await this.createSession(
+        userId,
+        title,
+        scope.scopeType === 'network' ? normalizedScopeId : undefined,
+        { scopeType: scope.scopeType, scopeId: normalizedScopeId },
+      );
+      const session = await this.getSession(id, userId);
+      if (!session) return { error: 'Failed to create session', status: 500 as const };
+      return { session, created: true };
+    } catch (err) {
+      if (this.isUniqueViolation(err)) {
+        const raced = await this.db.getChatSessionByScope(userId, scope.scopeType, normalizedScopeId);
+        if (raced) return { session: raced, created: false };
+      }
+      throw err;
+    }
+  }
+
+  private isUniqueViolation(err: unknown): boolean {
+    return typeof err === 'object' && err !== null && 'code' in err && (err as { code?: unknown }).code === '23505';
   }
 
   /**

--- a/services/api/src/services/tool.service.ts
+++ b/services/api/src/services/tool.service.ts
@@ -77,6 +77,8 @@ export class ToolService {
           sourceType?: string;
           sourceId?: string;
           networkId?: string;
+          scopeType?: 'intent';
+          scopeId?: string;
           modes?: Array<'discovery' | 'intent' | 'enrichment' | 'negotiation'>;
           limit?: number;
         },


### PR DESCRIPTION
## New Features
- Adds stable intent-scoped orchestrator chat sessions, resolving one conversation per user + intent and navigating intent clicks to `/d/:sessionId`.
- Persists canonical chat scope metadata with mutually exclusive network/intent scope support.
- Restricts intent-scoped chat tools to the selected intent and related opportunities/questions.

## Bug Fixes
- Registers `read_pending_questions` in chat tools so orchestrator calls no longer fail as unknown.
- Keeps empty `/d/:sessionId` conversations in chat mode instead of showing the home feed.

## Documentation & Tests
- Updates API docs for chat session resolution and scope fields.
- Adds/updates targeted tests for scope schema, chat service, pending questions, and tool registration.

## Verification
- `packages/protocol`: `bun run build`
- `services/api`: `bun run build`
- `apps/web`: `bun run build`
- Targeted protocol/API tests pass
- `git diff --check` clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785303512&installation_id=140549914&pr_number=1071&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1071&signature=8334971a8115d0dc9e4fe2a8317f05c3d7ff2e9d661d49d71ff6a761d6f443ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->