### PR TITLE
fix(protocol): use presenter for opportunity list cards

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -84,7 +84,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "4.3.5",
+      "version": "4.3.6",
       "dependencies": {
         "@langchain/core": "^1.1.17",
         "@langchain/langgraph": "^1.1.2",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "4.3.5",
+  "version": "4.3.6",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -1816,12 +1816,10 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
       const allUserIds = [
         ...new Set([...counterpartUserIds, ...introducerUserIds]),
       ];
-      const [viewerUser, profileResults, userResults] = await Promise.all([
-        database.getUser(context.userId),
+      const [profileResults, userResults] = await Promise.all([
         Promise.all(allUserIds.map((id) => database.getProfile(id))),
         Promise.all(allUserIds.map((id) => database.getUser(id))),
       ]);
-      const viewerName = viewerUser?.name ?? undefined;
       const profileMap = new Map<string, Awaited<ReturnType<typeof database.getProfile>>>();
       const userMap = new Map<string, Awaited<ReturnType<typeof database.getUser>>>();
       allUserIds.forEach((userId, i) => {
@@ -2024,106 +2022,171 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
           }
         }
       } else {
-        // ── Chat mode: fast heuristic path (no LLM) ──
-        for (const opp of opportunities) {
-          if (seenOpportunityIds.has(opp.id)) continue;
-          seenOpportunityIds.add(opp.id);
-          try {
-            const counterpartActor = opp.actors.find(
-              (a) => a.userId !== context.userId && a.role !== "introducer",
-            );
-            const counterpartUserId = counterpartActor?.userId;
-            if (!counterpartUserId) continue;
+        // ── Chat/list mode: use OpportunityPresenter for user-facing card copy ──
+        const presenter = createOpportunityPresenter();
+        const presenterDb: PresenterDatabase = database;
+        const PRESENTER_CONCURRENCY = 6;
 
-            const viewerIsIntroducerHere = opp.actors.some(
-              (a) => a.role === "introducer" && a.userId === context.userId,
-            );
-            const secondPartyActorForHeadline = viewerIsIntroducerHere
-              ? opp.actors.find(
-                  (a) =>
-                    a.userId !== context.userId &&
-                    a.userId !== counterpartUserId &&
-                    a.role !== "introducer",
-                )
-              : undefined;
-            const secondPartyNameForHeadline = secondPartyActorForHeadline
-              ? (profileMap.get(secondPartyActorForHeadline.userId)?.identity?.name ??
-                userMap.get(secondPartyActorForHeadline.userId)?.name ??
-                undefined)
-              : undefined;
+        for (let i = 0; i < opportunities.length; i += PRESENTER_CONCURRENCY) {
+          const chunk = opportunities.slice(i, i + PRESENTER_CONCURRENCY);
+          const chunkCards = await Promise.all(
+            chunk.map(async (opp) => {
+              if (seenOpportunityIds.has(opp.id)) return null;
+              seenOpportunityIds.add(opp.id);
+              try {
+                const counterpartActor = opp.actors.find(
+                  (a) => a.userId !== context.userId && a.role !== "introducer",
+                );
+                const counterpartUserId = counterpartActor?.userId;
+                if (!counterpartUserId) return null;
 
-            const introducerActor = opp.actors.find(
-              (a) => a.role === "introducer" && a.userId !== context.userId,
-            );
-            const createdByName = opp.detection.createdByName;
+                const viewerIsIntroducerHere = opp.actors.some(
+                  (a) => a.role === "introducer" && a.userId === context.userId,
+                );
+                const secondPartyActorForHeadline = viewerIsIntroducerHere
+                  ? opp.actors.find(
+                      (a) =>
+                        a.userId !== context.userId &&
+                        a.userId !== counterpartUserId &&
+                        a.role !== "introducer",
+                    )
+                  : undefined;
 
-            const counterpartProfile = profileMap.get(counterpartUserId) ?? null;
-            const counterpartUser = userMap.get(counterpartUserId) ?? null;
-            const introducerProfile =
-              introducerActor && !createdByName
-                ? profileMap.get(introducerActor.userId) ?? null
-                : null;
+                const introducerActor = opp.actors.find(
+                  (a) => a.role === "introducer" && a.userId !== context.userId,
+                );
+                const createdByName = opp.detection.createdByName;
 
-            const counterpartName =
-              counterpartProfile?.identity?.name ??
-              counterpartUser?.name ??
-              "Someone";
-            const introducerName =
-              createdByName ??
-              (introducerActor ? introducerProfile?.identity?.name ?? null : null);
-            const introducerUser = introducerActor
-              ? userMap.get(introducerActor.userId) ?? null
-              : null;
+                const counterpartProfile = profileMap.get(counterpartUserId) ?? null;
+                const counterpartUser = userMap.get(counterpartUserId) ?? null;
+                const introducerProfile =
+                  introducerActor && !createdByName
+                    ? profileMap.get(introducerActor.userId) ?? null
+                    : null;
 
-            const secondPartyUser = secondPartyActorForHeadline
-              ? userMap.get(secondPartyActorForHeadline.userId) ?? null
-              : null;
-            const cardData = buildMinimalOpportunityCard(
-              opp,
-              context.userId,
-              counterpartUserId,
-              counterpartName,
-              counterpartUser?.avatar ?? null,
-              introducerName,
-              introducerUser?.avatar ?? null,
-              viewerName,
-              secondPartyNameForHeadline,
-              secondPartyUser?.avatar ?? null,
-              secondPartyActorForHeadline?.userId,
-            );
+                const counterpartName =
+                  counterpartProfile?.identity?.name ??
+                  counterpartUser?.name ??
+                  "Someone";
+                const introducerName =
+                  createdByName ??
+                  (introducerActor ? introducerProfile?.identity?.name ?? null : null);
+                const introducerUser = introducerActor
+                  ? userMap.get(introducerActor.userId) ?? null
+                  : null;
 
-            // For MCP callers (e.g. Edge Claw), mint a connect token and attach
-            // acceptUrl + profileUrl when the (status, viewerRole) is actionable
-            // for the viewer. Non-actionable combos (sender-on-draft,
-            // pending-on-introducer-waiting, rejected, etc.) deliberately get
-            // no link — the LLM would otherwise hallucinate `/api/.../connect`
-            // URLs from the exposed opportunityId.
-            if (context.isMcp && deps.mintConnectLink) {
-              const viewerActor = opp.actors.find((a) => a.userId === context.userId);
-              const viewerApproved =
-                viewerActor?.role === "introducer" ? viewerActor.approved === true : undefined;
-              await attachActionableLinks(cardData as Record<string, unknown> & {
-                opportunityId: string;
-                viewerRole: string;
-                status: string;
-              }, {
-                viewerId: context.userId,
-                viewerApproved,
-                counterpartUserId,
-                mintConnectLink: deps.mintConnectLink,
-                frontendUrl: deps.frontendUrl,
-                preferredSurface: context.clientSurface,
-              });
-            }
+                const secondPartyUser = secondPartyActorForHeadline
+                  ? userMap.get(secondPartyActorForHeadline.userId) ?? null
+                  : null;
+                const secondPartyNameForHeadline = secondPartyActorForHeadline
+                  ? (profileMap.get(secondPartyActorForHeadline.userId)?.identity?.name ??
+                    secondPartyUser?.name ??
+                    undefined)
+                  : undefined;
 
-            cardDataList.push(cardData);
-          } catch (err) {
-            logger.warn("Skipping opportunity that failed to build minimal card", {
-              opportunityId: opp.id,
-              err,
-            });
-            skippedIds.push(opp.id);
-            continue;
+                const viewerActor = opp.actors.find((a) => a.userId === context.userId);
+                const viewerRole = viewerActor?.role ?? "party";
+                const isCounterpartGhost = counterpartUser?.isGhost ?? false;
+
+                const [ctx, negotiationContext] = await Promise.all([
+                  gatherOpportunityPresenterContext(
+                    presenterDb,
+                    opp,
+                    context.userId,
+                    counterpartUserId,
+                  ),
+                  loadNegotiationContext(deps.negotiationDatabase, opp.id, opp.status),
+                ]);
+
+                const presentation = await presenter.presentHomeCard({
+                  ...ctx,
+                  opportunityStatus: opp.status,
+                  ...(negotiationContext ? { negotiationContext } : {}),
+                });
+
+                let narratorChip: { name: string; text: string; avatar?: string | null; userId?: string };
+                const introducerIsCounterpart = introducerActor && counterpartActor && introducerActor.userId === counterpartActor.userId;
+                if (introducerActor && introducerActor.userId !== context.userId && !introducerIsCounterpart) {
+                  const narratorName = introducerName?.trim() || "Someone";
+                  narratorChip = {
+                    name: narratorName,
+                    text: stripLeadingNarratorName(presentation.narratorRemark, narratorName),
+                    avatar: introducerUser?.avatar ?? null,
+                    userId: introducerActor.userId,
+                  };
+                } else if (introducerActor?.userId === context.userId) {
+                  narratorChip = { name: "You", text: presentation.narratorRemark, userId: context.userId };
+                } else {
+                  narratorChip = { name: "Index", text: presentation.narratorRemark };
+                }
+
+                const cardData: Record<string, unknown> & { opportunityId: string } = {
+                  opportunityId: opp.id,
+                  userId: counterpartUserId,
+                  name: counterpartName,
+                  avatar: counterpartUser?.avatar ?? null,
+                  mainText: stripUuids(presentation.personalizedSummary),
+                  cta: presentation.suggestedAction,
+                  headline: viewerIsIntroducerHere && secondPartyNameForHeadline
+                    ? `${counterpartName} → ${secondPartyNameForHeadline}`
+                    : presentation.headline,
+                  primaryActionLabel: getPrimaryActionLabel(viewerRole),
+                  secondaryActionLabel: SECONDARY_ACTION_LABEL,
+                  mutualIntentsLabel: presentation.mutualIntentsLabel,
+                  narratorChip,
+                  viewerRole,
+                  score: typeof opp.interpretation?.confidence === "number"
+                    ? opp.interpretation.confidence
+                    : undefined,
+                  status: opp.status,
+                  isGhost: isCounterpartGhost,
+                  ...(viewerIsIntroducerHere && secondPartyNameForHeadline
+                    ? {
+                        secondParty: {
+                          name: secondPartyNameForHeadline,
+                          ...(secondPartyUser?.avatar != null ? { avatar: secondPartyUser.avatar } : {}),
+                          ...(secondPartyActorForHeadline?.userId ? { userId: secondPartyActorForHeadline.userId } : {}),
+                        },
+                      }
+                    : {}),
+                };
+
+                // For MCP callers (e.g. Edge Claw), mint a connect token and attach
+                // acceptUrl + profileUrl when the (status, viewerRole) is actionable
+                // for the viewer. Non-actionable combos (sender-on-draft,
+                // pending-on-introducer-waiting, rejected, etc.) deliberately get
+                // no link — the LLM would otherwise hallucinate `/api/.../connect`
+                // URLs from the exposed opportunityId.
+                if (context.isMcp && deps.mintConnectLink) {
+                  const viewerApproved =
+                    viewerActor?.role === "introducer" ? viewerActor.approved === true : undefined;
+                  await attachActionableLinks(cardData as Record<string, unknown> & {
+                    opportunityId: string;
+                    viewerRole: string;
+                    status: string;
+                  }, {
+                    viewerId: context.userId,
+                    viewerApproved,
+                    counterpartUserId,
+                    mintConnectLink: deps.mintConnectLink,
+                    frontendUrl: deps.frontendUrl,
+                    preferredSurface: context.clientSurface,
+                  });
+                }
+
+                return cardData;
+              } catch (err) {
+                logger.warn("Skipping opportunity that failed to build presenter card", {
+                  opportunityId: opp.id,
+                  err,
+                });
+                skippedIds.push(opp.id);
+                return null;
+              }
+            }),
+          );
+          for (const card of chunkCards) {
+            if (card) cardDataList.push(card);
           }
         }
       }

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts
@@ -183,6 +183,45 @@ describe('list_opportunities digest presenter path', () => {
     expect(String(result.data?.message)).not.toContain('Test personalized summary');
   });
 
+  it('uses OpportunityPresenter text for regular chat list cards', async () => {
+    candidateOpps = [makeOpp('opp-chat', 'c-chat')];
+    getUser = mock(async (userId?: string) => ({ id: userId ?? testUserId, name: userId === 'c-chat' ? 'Chris' : 'Viewer' }) as UserRecord | null);
+    getProfile = mock(async () => ({ identity: { name: 'Chris', bio: '', location: '' }, userId: 'c-chat' }) as unknown as UserIdentity | null);
+    presentHomeCardMock = mock(async () => ({
+      headline: 'Meet Chris',
+      personalizedSummary: 'Chris is a strong fit for your current search.',
+      digestSummary: 'Digest text should not be used for regular chat.',
+      suggestedAction: 'Start with a focused intro.',
+      narratorRemark: 'Relevant match.',
+      mutualIntentsLabel: 'Shared interests',
+      greeting: '',
+    }));
+
+    const deps = makeDeps();
+    const tools = createOpportunityTools(defineTool as unknown as DefineTool, deps);
+    const listTool = tools.find((t: { name: string }) => t.name === 'list_opportunities')!;
+
+    const result = parseResult(
+      await listTool.handler({
+        context: {
+          userId: testUserId,
+          isMcp: false,
+          networkId: undefined,
+          sessionId: 'chat-session',
+          userName: 'Viewer',
+          userNetworks: [],
+        },
+        query: {},
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(gatherPresenterContextMock).toHaveBeenCalled();
+    expect(presentHomeCardMock).toHaveBeenCalled();
+    expect(String(result.data?.message)).toContain('Chris is a strong fit for your current search.');
+    expect(String(result.data?.message)).not.toContain('Reasoning for c-chat');
+  });
+
   it('emits a negotiationUrl marker and feeds negotiationContext to the presenter when a negotiation exists', async () => {
     candidateOpps = [makeOpp('opp-neg', 'c-neg', 'pending')];
     getUser = mock(async () => ({ id: testUserId, name: 'Viewer' }) as UserRecord | null);


### PR DESCRIPTION
## Summary
- Replace the regular `list_opportunities` minimal heuristic card path with `OpportunityPresenter.presentHomeCard`
- Preserve narrator chips, intro arrow layout, action links, status, and score fields
- Add regression coverage to ensure chat list cards use presenter text instead of raw `interpretation.reasoning`
- Bump `@indexnetwork/protocol` to 4.3.6

## Verification
- `cd packages/protocol && bun test src/opportunity/tests/opportunity.tools.digest-presenter.spec.ts`
- `cd packages/protocol && bun test src/opportunity/tests/opportunity.tools.spec.ts`
- `cd packages/protocol && bun run build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785335099&installation_id=140549914&pr_number=1073&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1073&signature=b546b84c205f85a766a08e9aa32fde0dc0084b927180d043a0732c3986e83eef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->