### PR TITLE
refactor(opportunity): extract shared safe-presentation primitive for all card surfaces

### DIFF
--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -173,7 +173,9 @@ export type { IntroducerDiscoveryDatabase, IntroducerDiscoveryQueue, ContactWith
 export { persistOpportunities } from "./opportunity/opportunity.persist.js";
 export { presentOpportunity } from "./opportunity/opportunity.presentation.js";
 export type { UserInfo } from "./opportunity/opportunity.presentation.js";
-export { stripUuids, stripIntroducerMentions } from "./opportunity/opportunity.presentation.js";
+export { stripUuids, stripIntroducerMentions, truncateAtBoundary } from "./opportunity/opportunity.presentation.js";
+export { safeFallbackSummary, getSafePresentationOrSkip, SAFE_FALLBACK_MAX_CHARS, DEFAULT_FALLBACK_HEADLINE, DEFAULT_FALLBACK_ACTION, DEFAULT_EMPTY_FALLBACK_TEXT } from "./opportunity/opportunity.safe-presentation.js";
+export type { SafeFallbackOptions, SafePresentation, SafePresentationOptions, SafePresentationSource } from "./opportunity/opportunity.safe-presentation.js";
 export { getOrCreateDeliveryCardBatch, DELIVERY_CARD_CACHE_TTL, type CachedDeliveryCard, type OpportunityWithContext } from "./opportunity/delivery-card.cache.js";
 
 // ─── Tools ────────────────────────────────────────────────────────────────────

--- a/packages/protocol/src/opportunity/feed/feed.graph.ts
+++ b/packages/protocol/src/opportunity/feed/feed.graph.ts
@@ -22,6 +22,7 @@ import { HomeCategorizerAgent } from './feed.categorizer.js';
 import { canUserSeeOpportunity, isActionableForViewer, selectByComposition } from '../opportunity.utils.js';
 import { resolveHomeSectionIcon, DEFAULT_HOME_SECTION_ICON } from '../../shared/ui/lucide.icon-catalog.js';
 import { getPrimaryActionLabel, SECONDARY_ACTION_LABEL } from '../opportunity.labels.js';
+import { safeFallbackSummary } from '../opportunity.safe-presentation.js';
 import type { DebugMetaAgent } from '../../chat/chat-streaming.types.js';
 import { protocolLogger } from '../../shared/observability/protocol.logger.js';
 import { timed } from '../../shared/observability/performance.js';
@@ -393,10 +394,18 @@ export class HomeGraphFactory {
               if (profileName) userName = profileName;
             }
             const userAvatar = otherUser?.avatar ?? null;
-            const reasoningSnippet =
-              (typeof opportunity.interpretation?.reasoning === 'string'
-                ? opportunity.interpretation.reasoning.replace(/\s+/g, ' ').trim().slice(0, MAX_REASONING_SNIPPET_LENGTH)
-                : '') || 'A promising connection.';
+            // Shared sanitization standard (UUID strip, viewer-centric rewrite,
+            // boundary truncation) — raw reasoning must never render verbatim.
+            const reasoningSnippet = safeFallbackSummary(
+              typeof opportunity.interpretation?.reasoning === 'string'
+                ? opportunity.interpretation.reasoning
+                : '',
+              {
+                counterpartName: userName !== 'Unknown' ? userName : undefined,
+                maxChars: MAX_REASONING_SNIPPET_LENGTH,
+                emptyText: 'A promising connection.',
+              },
+            );
 
             // Build secondParty for introducer arrow layout (the party that isn't the display counterpart)
             let secondPartyData: { name: string; avatar?: string | null; userId?: string } | undefined;
@@ -419,7 +428,7 @@ export class HomeGraphFactory {
               userId: otherActor?.userId ?? '',
               name: userName,
               avatar: userAvatar,
-              mainText: reasoningSnippet.slice(0, 300),
+              mainText: reasoningSnippet,
               cta: isIntroducer
                 ? (isPendingIntroducerFallback ? 'Share this introduction to get things started.' : 'Take a look and decide if this is a good match.')
                 : 'Take a look and decide whether to reach out.',

--- a/packages/protocol/src/opportunity/opportunity.discover.ts
+++ b/packages/protocol/src/opportunity/opportunity.discover.ts
@@ -17,7 +17,8 @@ import type { QuestionerEnqueueFn } from "../questioner/questioner.types.js";
 import type { ToolScopeType } from "../shared/agent/tool.scope.js";
 import { OpportunityPresenter, gatherPresenterContext, type OpportunityPresentationResult, type HomeCardPresentationResult, type HomeCardLLMResult, type HomeCardPresenterInput } from "./opportunity.presenter.js";
 import { MINIMAL_MAIN_TEXT_MAX_CHARS, getPrimaryActionLabel, SECONDARY_ACTION_LABEL } from "./opportunity.labels.js";
-import { viewerCentricCardSummary, narratorRemarkFromReasoning } from "./opportunity.presentation.js";
+import { narratorRemarkFromReasoning } from "./opportunity.presentation.js";
+import { safeFallbackSummary } from "./opportunity.safe-presentation.js";
 import { protocolLogger, withCallLogging } from "../shared/observability/protocol.logger.js";
 import type { ChatSummaryReader } from "../shared/interfaces/chat-summary.interface.js";
 import type { ChatContextDigest } from "../shared/schemas/chat-context.schema.js";
@@ -447,13 +448,14 @@ async function enrichOpportunities(
       }
 
       const isCounterpartGhost = isGhostByUserId.get(item.candidateUserId) ?? false;
-      const personalizedSummary = viewerCentricCardSummary(
-        reasoning,
-        name,
-        MINIMAL_MAIN_TEXT_MAX_CHARS,
+      // Shared sanitization standard — see opportunity.safe-presentation.ts.
+      const personalizedSummary = safeFallbackSummary(reasoning, {
+        counterpartName: name,
         viewerName,
         introducerName,
-      );
+        maxChars: MINIMAL_MAIN_TEXT_MAX_CHARS,
+        emptyText: "A suggested connection.",
+      });
       return {
         headline: viewerIsIntroducer && secondPartyName
           ? `${name} → ${secondPartyName}`

--- a/packages/protocol/src/opportunity/opportunity.presenter.ts
+++ b/packages/protocol/src/opportunity/opportunity.presenter.ts
@@ -61,7 +61,10 @@ const responseFormat = z.object({
   presentation: PresentationSchema,
 });
 
-export type OpportunityPresentationResult = z.infer<typeof PresentationSchema>;
+export type OpportunityPresentationResult = z.infer<typeof PresentationSchema> & {
+  /** True when the LLM call failed and this is fallback-shaped copy built from raw reasoning. */
+  isFallback?: boolean;
+};
 
 /** Input for home-card presenter call; extends PresenterInput with optional mutual intent count. */
 export interface HomeCardPresenterInput extends PresenterInput {
@@ -111,7 +114,15 @@ export const HomeCardLLMSchema = z.object({
 });
 
 /** LLM-generated result from presentHomeCard (callers append button labels from opportunity.constants). */
-export type HomeCardLLMResult = z.infer<typeof HomeCardLLMSchema>;
+export type HomeCardLLMResult = z.infer<typeof HomeCardLLMSchema> & {
+  /**
+   * True when the LLM call failed and this is fallback-shaped copy built from
+   * raw match reasoning. Callers with strict quality requirements (digests,
+   * long-lived caches) should check this before sending/persisting — fallback
+   * output is otherwise indistinguishable from genuine LLM output.
+   */
+  isFallback?: boolean;
+};
 
 /** Full home-card display contract including hardcoded button labels (assembled by callers). */
 export type HomeCardPresentationResult = HomeCardLLMResult & {
@@ -366,6 +377,7 @@ Produce headline, personalizedSummary (2-3 sentences in "you" language), suggest
         personalizedSummary: truncateAtBoundary(stripUuids(input.matchReasoning), 300),
         suggestedAction: "Take a look and decide whether to reach out.",
         greeting: "",
+        isFallback: true,
       };
     }
   }
@@ -481,6 +493,7 @@ Produce headline, personalizedSummary, digestSummary, suggestedAction, narratorR
             ? `${input.mutualIntentCount} mutual intent${input.mutualIntentCount !== 1 ? "s" : ""}`
             : "Shared interests",
         greeting: "",
+        isFallback: true,
       };
     }
   }

--- a/packages/protocol/src/opportunity/opportunity.safe-presentation.ts
+++ b/packages/protocol/src/opportunity/opportunity.safe-presentation.ts
@@ -1,0 +1,164 @@
+/**
+ * Shared safe-presentation primitive for all user-facing opportunity surfaces.
+ *
+ * Historically every surface (home feed, list/discover cards, minimal chat
+ * cards, notification emails/Telegram, chat context, delivery cards) invented
+ * its own fallback chain for the case where genuine LLM presenter output is
+ * unavailable — some sliced raw `interpretation.reasoning` with no
+ * sanitization at all. This module is the single standard:
+ *
+ *   raw reasoning
+ *     → whitespace-normalize
+ *     → viewer-centric rewrite (incl. UUID stripping + introducer-mention stripping)
+ *     → boundary-aware truncation
+ *     → per-surface empty-text default
+ *
+ * Surfaces choose *policy* (send a sanitized fallback vs skip entirely) via
+ * `allowFallback`; they no longer choose (or forget) sanitization steps.
+ *
+ * See `.pi/skills/opportunity-presentation-safety/SKILL.md` for the review
+ * checklist this module exists to satisfy.
+ */
+
+import { truncateAtBoundary, viewerCentricCardSummary } from "./opportunity.presentation.js";
+
+/** Default max length for fallback summaries (matches presenter internal fallback). */
+export const SAFE_FALLBACK_MAX_CHARS = 300;
+
+/** Default copy when no reasoning text is available at all. */
+export const DEFAULT_EMPTY_FALLBACK_TEXT = "A promising connection.";
+
+/** Default headline for fallback presentations (matches presenter internal fallback). */
+export const DEFAULT_FALLBACK_HEADLINE = "A promising connection";
+
+/** Default CTA for fallback presentations (matches presenter internal fallback). */
+export const DEFAULT_FALLBACK_ACTION =
+  "Take a look and decide whether to reach out.";
+
+export interface SafeFallbackOptions {
+  /** Display name of the counterpart shown on the card (enables viewer-centric rewrite). */
+  counterpartName?: string;
+  /** Display name of the viewer; sentences describing the viewer are skipped/rewritten to "you". */
+  viewerName?: string;
+  /** Introducer display name; introducer mentions are stripped from the summary body. */
+  introducerName?: string | null;
+  /** Max output length (boundary-aware). Default {@link SAFE_FALLBACK_MAX_CHARS}. */
+  maxChars?: number;
+  /** Copy returned when reasoning is empty/blank. Default {@link DEFAULT_EMPTY_FALLBACK_TEXT}. */
+  emptyText?: string;
+}
+
+/**
+ * Produce safe user-facing fallback copy from raw match reasoning.
+ *
+ * This is the ONE sanitization standard: UUID stripping, introducer-mention
+ * stripping, and viewer-centric rewrite (via {@link viewerCentricCardSummary}),
+ * followed by whitespace normalization and boundary-aware truncation (via
+ * {@link truncateAtBoundary}). Never returns raw reasoning verbatim beyond
+ * these guarantees, and never returns an empty string.
+ *
+ * @param rawReasoning - Raw `interpretation.reasoning` / `matchReason` text (may be null/undefined).
+ * @param opts - Per-surface knobs (names for rewrite, max length, empty-text copy).
+ */
+export function safeFallbackSummary(
+  rawReasoning: string | null | undefined,
+  opts: SafeFallbackOptions = {},
+): string {
+  const emptyText = opts.emptyText ?? DEFAULT_EMPTY_FALLBACK_TEXT;
+  const maxChars = opts.maxChars ?? SAFE_FALLBACK_MAX_CHARS;
+
+  const normalized = (rawReasoning ?? "").replace(/\s+/g, " ").trim();
+  if (!normalized) return emptyText;
+
+  // viewerCentricCardSummary handles UUID stripping, introducer-mention
+  // stripping, and the viewer-centric rewrite. Pass Infinity so truncation is
+  // handled by boundary-aware logic below instead of a mid-word hard slice.
+  const rewritten = viewerCentricCardSummary(
+    normalized,
+    opts.counterpartName ?? "",
+    Number.POSITIVE_INFINITY,
+    opts.viewerName,
+    opts.introducerName ?? undefined,
+  );
+
+  const truncated = truncateAtBoundary(rewritten, maxChars);
+  return truncated || emptyText;
+}
+
+/** Minimal presenter-output shape the primitive inspects (subset of HomeCardPresentationResult). */
+export interface SafePresentationCandidate {
+  headline?: string;
+  personalizedSummary?: string;
+  suggestedAction?: string;
+  /** Set by OpportunityPresenter when its LLM call failed and it returned fallback-shaped copy. */
+  isFallback?: boolean;
+}
+
+/** Opportunity-ish source object accepted by {@link getSafePresentationOrSkip}. */
+export interface SafePresentationSource {
+  /** Presenter output attached to the record, when available. */
+  homeCardPresentation?: SafePresentationCandidate | null;
+  /** Pre-truncated raw reasoning carried on discovery/list card data. */
+  matchReason?: string | null;
+  /** Full opportunity interpretation, when the caller holds the record. */
+  interpretation?: { reasoning?: string | null } | null;
+}
+
+export interface SafePresentationOptions extends SafeFallbackOptions {
+  /**
+   * Policy switch: when false, return null instead of fallback copy so the
+   * surface can skip rendering entirely (e.g. scheduled digests where sending
+   * degraded copy is worse than sending nothing). Default true.
+   */
+  allowFallback?: boolean;
+}
+
+/** Resolved safe presentation for a surface to render. */
+export interface SafePresentation {
+  headline: string;
+  summary: string;
+  suggestedAction: string;
+  /** True when copy was derived from raw reasoning rather than genuine LLM presenter output. */
+  isFallback: boolean;
+}
+
+/**
+ * Resolve the safe user-facing presentation for an opportunity, or signal skip.
+ *
+ * Resolution order:
+ * 1. Genuine presenter output (`homeCardPresentation` present, non-empty, and
+ *    NOT tagged `isFallback` by the presenter) — returned as-is.
+ * 2. Otherwise, if `allowFallback` (default true): sanitized fallback copy
+ *    built from `matchReason` / `interpretation.reasoning` via
+ *    {@link safeFallbackSummary}.
+ * 3. Otherwise `null` — the surface must skip this opportunity.
+ *
+ * Raw `interpretation.reasoning` / `matchReason` never reaches the caller
+ * unsanitized through this function.
+ */
+export function getSafePresentationOrSkip(
+  source: SafePresentationSource,
+  opts: SafePresentationOptions = {},
+): SafePresentation | null {
+  const candidate = source.homeCardPresentation;
+  if (candidate?.personalizedSummary?.trim() && !candidate.isFallback) {
+    return {
+      headline: candidate.headline?.trim() || DEFAULT_FALLBACK_HEADLINE,
+      summary: candidate.personalizedSummary,
+      suggestedAction:
+        candidate.suggestedAction?.trim() || DEFAULT_FALLBACK_ACTION,
+      isFallback: false,
+    };
+  }
+
+  if (opts.allowFallback === false) return null;
+
+  const rawReasoning =
+    source.matchReason ?? source.interpretation?.reasoning ?? "";
+  return {
+    headline: DEFAULT_FALLBACK_HEADLINE,
+    summary: safeFallbackSummary(rawReasoning, opts),
+    suggestedAction: DEFAULT_FALLBACK_ACTION,
+    isFallback: true,
+  };
+}

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -6,7 +6,8 @@ import type { DefineTool, ToolDeps } from "../shared/agent/tool.helpers.js";
 import { success, error, UUID_REGEX } from "../shared/agent/tool.helpers.js";
 import { deriveDiscoveryNetworkIds, focusedIntentId, focusedNetworkId, focusedNetworkLabel } from "../shared/agent/tool.scope.js";
 import { MINIMAL_MAIN_TEXT_MAX_CHARS, getPrimaryActionLabel, SECONDARY_ACTION_LABEL } from "./opportunity.labels.js";
-import { viewerCentricCardSummary, narratorRemarkFromReasoning, stripUuids } from "./opportunity.presentation.js";
+import { narratorRemarkFromReasoning, stripUuids } from "./opportunity.presentation.js";
+import { safeFallbackSummary, getSafePresentationOrSkip } from "./opportunity.safe-presentation.js";
 import { runDiscoverFromQuery, continueDiscovery } from "./opportunity.discover.js";
 import { OpportunityPresenter, gatherPresenterContext, type PresenterDatabase } from "./opportunity.presenter.js";
 import { loadNegotiationContext } from "./negotiation-context.loader.js";
@@ -310,13 +311,14 @@ export function buildMinimalOpportunityCard(
     (a) => a.role === "introducer" && a.userId === viewerId,
   );
   const reasoning = opp.interpretation?.reasoning ?? "";
-  const mainText = viewerCentricCardSummary(
-    reasoning,
+  // Shared sanitization standard — see opportunity.safe-presentation.ts.
+  const mainText = safeFallbackSummary(reasoning, {
     counterpartName,
-    MINIMAL_MAIN_TEXT_MAX_CHARS,
     viewerName,
-    introducerName ?? undefined,
-  );
+    introducerName: introducerName ?? undefined,
+    maxChars: MINIMAL_MAIN_TEXT_MAX_CHARS,
+    emptyText: "A suggested connection.",
+  });
   const score =
     typeof opp.interpretation?.confidence === "number"
       ? opp.interpretation.confidence
@@ -825,7 +827,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
           userId: opp.userId,
           name: opp.name,
           avatar: opp.avatar,
-          mainText: opp.homeCardPresentation?.personalizedSummary ?? opp.matchReason ?? "",
+          mainText: getSafePresentationOrSkip(opp, { counterpartName: opp.name })?.summary ?? "",
           cta: opp.homeCardPresentation?.suggestedAction,
           headline: opp.homeCardPresentation?.headline,
           primaryActionLabel: opp.homeCardPresentation?.primaryActionLabel,
@@ -1005,13 +1007,13 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
             (firstEntity?.profile as { avatar?: string | null } | undefined)
               ?.avatar ??
             null,
-          mainText: viewerCentricCardSummary(
-            reasoning,
+          mainText: safeFallbackSummary(reasoning, {
             counterpartName,
-            MINIMAL_MAIN_TEXT_MAX_CHARS,
-            undefined, // viewerName not available in this context; introducer name passed separately
-            introducerUser?.name ?? undefined,
-          ),
+            // viewerName not available in this context; introducer name passed separately
+            introducerName: introducerUser?.name ?? undefined,
+            maxChars: MINIMAL_MAIN_TEXT_MAX_CHARS,
+            emptyText: "A suggested connection.",
+          }),
           cta: "Start a conversation to connect.",
           headline,
           primaryActionLabel,
@@ -1363,9 +1365,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         name: opp.name,
         avatar: opp.avatar,
         mainText:
-          opp.homeCardPresentation?.personalizedSummary ??
-          opp.matchReason ??
-          "",
+          getSafePresentationOrSkip(opp, { counterpartName: opp.name })?.summary ?? "",
         cta: opp.homeCardPresentation?.suggestedAction,
         headline: opp.homeCardPresentation?.headline,
         primaryActionLabel: opp.homeCardPresentation?.primaryActionLabel,

--- a/packages/protocol/src/opportunity/tests/opportunity.safe-presentation.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.safe-presentation.spec.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "bun:test";
+import { safeFallbackSummary, getSafePresentationOrSkip, SAFE_FALLBACK_MAX_CHARS, DEFAULT_EMPTY_FALLBACK_TEXT, DEFAULT_FALLBACK_HEADLINE, DEFAULT_FALLBACK_ACTION } from "../opportunity.safe-presentation.js";
+
+const UUID = "123e4567-e89b-12d3-a456-426614174000";
+
+describe("safeFallbackSummary", () => {
+  it("strips UUIDs from raw reasoning", () => {
+    const out = safeFallbackSummary(
+      `Alex Chen (${UUID}) is building AI tooling that matches your interests.`,
+    );
+    expect(out).not.toContain(UUID);
+    expect(out).toContain("Alex Chen");
+  });
+
+  it("returns emptyText for empty/null/whitespace reasoning", () => {
+    expect(safeFallbackSummary(null)).toBe(DEFAULT_EMPTY_FALLBACK_TEXT);
+    expect(safeFallbackSummary(undefined)).toBe(DEFAULT_EMPTY_FALLBACK_TEXT);
+    expect(safeFallbackSummary("   \n  ")).toBe(DEFAULT_EMPTY_FALLBACK_TEXT);
+    expect(safeFallbackSummary("", { emptyText: "Custom copy." })).toBe(
+      "Custom copy.",
+    );
+  });
+
+  it("normalizes whitespace", () => {
+    const out = safeFallbackSummary("Line one.\n\nLine   two\ttabbed.");
+    expect(out).toBe("Line one. Line two tabbed.");
+  });
+
+  it("truncates at a boundary without cutting mid-word", () => {
+    const long = "word ".repeat(200).trim() + ".";
+    const out = safeFallbackSummary(long, { maxChars: 100 });
+    expect(out.length).toBeLessThanOrEqual(101); // + ellipsis char
+    expect(out.endsWith("\u2026") || out.endsWith(".")).toBe(true);
+    expect(out).not.toMatch(/wor\u2026$/); // never mid-word
+  });
+
+  it("defaults to SAFE_FALLBACK_MAX_CHARS", () => {
+    const long = "sentence about a match. ".repeat(50);
+    const out = safeFallbackSummary(long);
+    expect(out.length).toBeLessThanOrEqual(SAFE_FALLBACK_MAX_CHARS + 1);
+  });
+
+  it("rewrites viewer-centric: prefers sentences describing the counterpart", () => {
+    const out = safeFallbackSummary(
+      "Sam Viewer is a designer seeking collaborators. Alex Chen builds open-source agent tooling and wants design help.",
+      { counterpartName: "Alex Chen", viewerName: "Sam Viewer" },
+    );
+    expect(out.startsWith("Alex Chen")).toBe(true);
+  });
+
+  it("strips introducer mentions when introducerName is provided", () => {
+    const out = safeFallbackSummary(
+      "Maya Introducer introduced you to Alex Chen, who builds agent tooling.",
+      { counterpartName: "Alex Chen", introducerName: "Maya Introducer" },
+    );
+    expect(out).not.toContain("Maya");
+  });
+});
+
+describe("getSafePresentationOrSkip", () => {
+  const genuine = {
+    headline: "A React expert who needs your design skills",
+    personalizedSummary: "You both care about design systems.",
+    suggestedAction: "Send a message.",
+  };
+
+  it("returns genuine presenter output untouched, isFallback false", () => {
+    const res = getSafePresentationOrSkip({ homeCardPresentation: genuine });
+    expect(res).toEqual({
+      headline: genuine.headline,
+      summary: genuine.personalizedSummary,
+      suggestedAction: genuine.suggestedAction,
+      isFallback: false,
+    });
+  });
+
+  it("treats presenter output tagged isFallback as fallback (the silent-fallback pitfall)", () => {
+    const res = getSafePresentationOrSkip({
+      homeCardPresentation: { ...genuine, isFallback: true },
+      matchReason: `Raw reasoning with ${UUID} inside.`,
+    });
+    expect(res?.isFallback).toBe(true);
+    expect(res?.summary).not.toContain(UUID);
+  });
+
+  it("skips (returns null) when allowFallback is false and no genuine output exists", () => {
+    expect(
+      getSafePresentationOrSkip(
+        { matchReason: "raw" },
+        { allowFallback: false },
+      ),
+    ).toBeNull();
+    expect(
+      getSafePresentationOrSkip(
+        { homeCardPresentation: { ...genuine, isFallback: true } },
+        { allowFallback: false },
+      ),
+    ).toBeNull();
+  });
+
+  it("still returns genuine output when allowFallback is false", () => {
+    const res = getSafePresentationOrSkip(
+      { homeCardPresentation: genuine },
+      { allowFallback: false },
+    );
+    expect(res?.isFallback).toBe(false);
+  });
+
+  it("builds sanitized fallback from matchReason, then interpretation.reasoning", () => {
+    const fromMatchReason = getSafePresentationOrSkip({
+      matchReason: `Match reason with ${UUID}.`,
+      interpretation: { reasoning: "interp reasoning" },
+    });
+    expect(fromMatchReason?.summary).toContain("Match reason");
+    expect(fromMatchReason?.summary).not.toContain(UUID);
+
+    const fromInterp = getSafePresentationOrSkip({
+      interpretation: { reasoning: `Interp reasoning with ${UUID}.` },
+    });
+    expect(fromInterp?.summary).toContain("Interp reasoning");
+    expect(fromInterp?.summary).not.toContain(UUID);
+  });
+
+  it("uses default headline/action and empty-text default when nothing is available", () => {
+    const res = getSafePresentationOrSkip({});
+    expect(res).toEqual({
+      headline: DEFAULT_FALLBACK_HEADLINE,
+      summary: DEFAULT_EMPTY_FALLBACK_TEXT,
+      suggestedAction: DEFAULT_FALLBACK_ACTION,
+      isFallback: true,
+    });
+  });
+
+  it("ignores empty/blank presenter summaries", () => {
+    const res = getSafePresentationOrSkip({
+      homeCardPresentation: { ...genuine, personalizedSummary: "  " },
+      matchReason: "Fallback source text.",
+    });
+    expect(res?.isFallback).toBe(true);
+    expect(res?.summary).toContain("Fallback source text");
+  });
+});

--- a/services/api/src/queues/notification.queue.ts
+++ b/services/api/src/queues/notification.queue.ts
@@ -1,4 +1,5 @@
 import { Job } from 'bullmq';
+import { safeFallbackSummary } from '@indexnetwork/protocol';
 import { log } from '../lib/log';
 import { QueueFactory } from '../lib/bullmq/bullmq';
 import { ChatDatabaseAdapter } from '../adapters/database.adapter';
@@ -155,9 +156,11 @@ export class NotificationQueue {
       return;
     }
 
-    const summary =
-      opportunity.interpretation.reasoning ??
-      'A new match that might be relevant to you.';
+    // Shared sanitization standard (UUID strip, truncation) — raw evaluator
+    // reasoning must never reach email/Telegram copy verbatim.
+    const summary = safeFallbackSummary(opportunity.interpretation.reasoning, {
+      emptyText: 'A new match that might be relevant to you.',
+    });
 
     switch (priority) {
       case 'immediate': {

--- a/services/api/src/services/opportunity-delivery.service.ts
+++ b/services/api/src/services/opportunity-delivery.service.ts
@@ -15,7 +15,7 @@
 import { and, eq, inArray, isNotNull, isNull, sql } from 'drizzle-orm/sql';
 import { randomUUID } from 'node:crypto';
 
-import { OpportunityPresenter, canUserSeeOpportunity, classifyOpportunity, gatherPresenterContext, getOrCreateDeliveryCardBatch, isActionableForViewer, type PresenterDatabase } from '@indexnetwork/protocol';
+import { OpportunityPresenter, canUserSeeOpportunity, classifyOpportunity, gatherPresenterContext, getOrCreateDeliveryCardBatch, isActionableForViewer, type PresenterDatabase, safeFallbackSummary, truncateAtBoundary } from '@indexnetwork/protocol';
 
 import type { Cache } from '../adapters/cache.adapter';
 import { RedisCacheAdapter } from '../adapters/cache.adapter';
@@ -674,12 +674,15 @@ export class OpportunityDeliveryService {
         narratorRemark: presented.narratorRemark,
       };
     } catch {
-      // LLM fallback — follow opportunity.service.ts:getChatContext fallback shape
-      const rawReasoning =
-        (opp.interpretation as { reasoning?: string } | null)?.reasoning ?? '';
+      // LLM fallback — shared sanitization standard (see opportunity.safe-presentation.ts
+      // in protocol); follows opportunity.service.ts:getChatContext fallback shape.
+      const fallbackSummary = safeFallbackSummary(
+        (opp.interpretation as { reasoning?: string } | null)?.reasoning,
+        { emptyText: 'Connection opportunity' },
+      );
       return {
-        headline: rawReasoning.substring(0, 80) || 'Connection opportunity',
-        personalizedSummary: rawReasoning,
+        headline: truncateAtBoundary(fallbackSummary, 80) || 'Connection opportunity',
+        personalizedSummary: fallbackSummary,
         suggestedAction: 'Open Index Network to see the full context and decide.',
         narratorRemark: '',
       };

--- a/services/api/src/services/opportunity.service.ts
+++ b/services/api/src/services/opportunity.service.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 import { log } from '../lib/log';
 import type { Id } from '../types/common.types';
-import { OpportunityGraphFactory, HydeGraphFactory, HomeGraphFactory, MaintenanceGraphFactory, type MaintenanceGraphDatabase, type MaintenanceGraphCache, type MaintenanceGraphQueue, HydeGenerator, LensInferrer, presentOpportunity, type UserInfo, canUserSeeOpportunity, validateOpportunityActors, persistOpportunities, getPrimaryActionLabel, OpportunityPresenter, gatherPresenterContext, getOrCreateDeliveryCardBatch, type PresenterDatabase, stripUuids, stripIntroducerMentions } from '@indexnetwork/protocol';
+import { OpportunityGraphFactory, HydeGraphFactory, HomeGraphFactory, MaintenanceGraphFactory, type MaintenanceGraphDatabase, type MaintenanceGraphCache, type MaintenanceGraphQueue, HydeGenerator, LensInferrer, presentOpportunity, type UserInfo, canUserSeeOpportunity, validateOpportunityActors, persistOpportunities, getPrimaryActionLabel, OpportunityPresenter, gatherPresenterContext, getOrCreateDeliveryCardBatch, type PresenterDatabase, safeFallbackSummary, truncateAtBoundary } from '@indexnetwork/protocol';
 import type { OpportunityControllerDatabase, OpportunityGraphDatabase, HydeGraphDatabase, HomeGraphDatabase, CreateOpportunityData, Opportunity, OpportunityActor, OpportunityStatus, Embedder, HydeCache, OpportunityCache } from '@indexnetwork/protocol';
 import { and, eq } from 'drizzle-orm/sql';
 
@@ -1060,15 +1060,16 @@ export class OpportunityService {
           logger.warn('[OpportunityService] getChatContext presenter failed, using fallback', { error: err, opportunityId: opp.id });
           const introducerActor = opp.actors.find((a) => a.role === 'introducer');
           const introducerName = introducerActor ? opp.detection?.createdByName ?? null : null;
-          let rawReasoning = opp.interpretation?.reasoning ?? '';
-          rawReasoning = stripUuids(rawReasoning);
-          if (introducerName) {
-            rawReasoning = stripIntroducerMentions(rawReasoning, introducerName);
-          }
+          // Shared sanitization standard — see opportunity.safe-presentation.ts in protocol.
+          const fallbackSummary = safeFallbackSummary(opp.interpretation?.reasoning, {
+            counterpartName: peerUser?.name ?? undefined,
+            introducerName,
+            emptyText: 'Connection opportunity',
+          });
           return {
             opportunityId: opp.id,
-            headline: rawReasoning.substring(0, 80) || 'Connection opportunity',
-            personalizedSummary: rawReasoning,
+            headline: truncateAtBoundary(fallbackSummary, 80) || 'Connection opportunity',
+            personalizedSummary: fallbackSummary,
             narratorRemark: '',
             introducerName,
             peerName: peerUser?.name ?? 'Someone',


### PR DESCRIPTION
## Summary

Implements recommendation 1 from the opportunity-presentation-safety review: introduce **one shared safe-presentation primitive** in the protocol package and route all six user-facing opportunity surfaces through it, replacing six divergent (and partially unsanitized) fallback chains.

### New module: `packages/protocol/src/opportunity/opportunity.safe-presentation.ts`

- **`safeFallbackSummary(rawReasoning, opts)`** — the single sanitization standard:
  whitespace-normalize → viewer-centric rewrite (incl. UUID stripping + introducer-mention stripping via `viewerCentricCardSummary`) → boundary-aware truncation (`truncateAtBoundary`) → per-surface `emptyText` default. Never returns raw reasoning verbatim, never returns an empty string.
- **`getSafePresentationOrSkip(source, {allowFallback, ...})`** — resolution order: genuine presenter output → sanitized fallback → `null` (skip) when `allowFallback: false`. One policy switch per surface.

### Presenter: fallback is now detectable

`OpportunityPresenter.present()` / `presentHomeCard()` catch-path output is now tagged `isFallback: true` (types widened with an optional field). Previously, presenter-shaped fallback copy was **indistinguishable from genuine LLM output** — a `try/catch` around the presenter gave false confidence. The primitive treats tagged output as fallback.

### Surfaces routed (worst offenders first)

| Surface | Before | After |
|---|---|---|
| Delivery service (`opportunity-delivery.service.ts`) | **raw reasoning, zero sanitization** | `safeFallbackSummary` |
| Notification queue email/Telegram (`notification.queue.ts`) | **raw reasoning, zero sanitization** | `safeFallbackSummary` |
| List/discover cards (`opportunity.tools.ts` ×2) | raw `matchReason` verbatim, no sanitization | `getSafePresentationOrSkip` |
| Home feed `fallbackCard` (`feed.graph.ts`) | raw reasoning `slice(0,240)` | `safeFallbackSummary` + viewer-centric |
| Chat context (`opportunity.service.ts` `getChatContext`) | hand-rolled `stripUuids` + `substring(0,80)` | shared standard + boundary truncation |
| Minimal no-LLM cards (`buildMinimalOpportunityCard`, draft-intro card, discover minimal path) | already viewer-centric | same standard, gains boundary-aware truncation |

### Behavior notes

- **Surface policies are unchanged**: every surface still sends sanitized fallback (`allowFallback` defaults to true). The user-visible change is strictly safer copy (no UUIDs, no introducer leaks, no mid-word cuts) on failure paths only.
- Enabled follow-ups (deliberately not in this PR): flip scheduled digests to `allowFallback: false` (skip instead of send), and gate `home:card:*` / `delivery:card:*` / `chat:card:*` cache writes on `isFallback`.

## Testing

- 14 new regression tests (`opportunity.safe-presentation.spec.ts`): UUID-leak prevention, silent-fallback detection, skip semantics, empty-text defaults, boundary truncation.
- All 18 affected protocol + API suites pass per-file (280 + 75 tests), `tsc` clean for protocol and api, eslint clean on changed files (remaining warnings verified pre-existing on dev).
- Built and ran locally from the worktree: web + API boot cleanly, smoke-tested endpoints.
- Audit grep from `.pi/skills/opportunity-presentation-safety/SKILL.md` confirms no raw fallback chains remain outside the primitive.

See `.pi/skills/opportunity-presentation-safety/SKILL.md` for the incident context this closes out.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1076"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785854235&installation_id=140549914&pr_number=1076&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1076&signature=52b94875d7eb9a1e443c06ca4107ced4decf696fb8786358a88a6c1d0628ec1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->