### PR TITLE
fix: connect-link actionability — no links the viewer can't act on, cascade expires instead of stalls

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "4.3.6",
+  "version": "4.3.7",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/opportunity/opportunity.discover.ts
+++ b/packages/protocol/src/opportunity/opportunity.discover.ts
@@ -194,6 +194,8 @@ export interface FormattedDiscoveryCandidate {
   viewerRole?: string;
   /** Whether the viewer (as introducer) has approved the introduction. */
   viewerApproved?: boolean;
+  /** Timestamp set once this viewer has already acted on the opportunity. */
+  viewerActedAt?: string | null;
   /** Full user record for the candidate (needed for socials / Telegram fallback). */
   candidateUser?: UserRecord | null;
   /** Whether the counterpart is a ghost (not yet onboarded) user. */
@@ -340,6 +342,7 @@ async function enrichOpportunities(
         candidateUserId,
         viewerRole: viewerActor?.role ?? "party",
         viewerApproved: viewerActor?.approved === true,
+        viewerActedAt: viewerActor?.actedAt ?? null,
         candidateUser,
         profile,
         confidence,
@@ -604,6 +607,7 @@ async function enrichOpportunities(
         status: chatSessionId && !existingOpportunityIds?.has(item.opportunity.id) ? "draft" : item.opportunity.status,
         viewerRole: item.viewerRole,
         viewerApproved: item.viewerApproved,
+        viewerActedAt: item.viewerActedAt,
         candidateUser: item.candidateUser,
         isGhost,
         ...(presentations?.[idx] && { presentation: presentations[idx] }),

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -70,17 +70,19 @@ export function resolveActionableLinkKind(input: {
   status: string;
   viewerRole: string;
   viewerApproved?: boolean;
+  viewerActedAt?: string | null;
 }): ConnectLinkKind | null {
-  const { status, viewerRole, viewerApproved } = input;
+  const { status, viewerRole, viewerApproved, viewerActedAt } = input;
   const isIntroducer = viewerRole === "introducer";
+  const hasViewerActed = !!viewerActedAt;
   if (status === "accepted") {
     return isIntroducer ? null : "outreach";
   }
   if (status === "pending") {
-    return isIntroducer ? null : "connect";
+    return isIntroducer || hasViewerActed ? null : "connect";
   }
   if (status === "draft" || status === "latent") {
-    if (!isIntroducer) return "send_direct";
+    if (!isIntroducer) return hasViewerActed ? null : "send_direct";
     return viewerApproved === true ? null : "approve_introduction";
   }
   return null;
@@ -146,6 +148,7 @@ export async function attachActionableLinks(
   opts: {
     viewerId: string;
     viewerApproved?: boolean;
+    viewerActedAt?: string | null;
     counterpartUserId: string;
     mintConnectLink: NonNullable<ToolDeps["mintConnectLink"]>;
     frontendUrl: string | undefined;
@@ -166,12 +169,14 @@ export async function attachActionableLinks(
     status: card.status,
     viewerRole: card.viewerRole,
     viewerApproved: opts.viewerApproved,
+    viewerActedAt: opts.viewerActedAt,
   });
   logger.info("Opportunity actionability decision", {
     opportunityId: card.opportunityId,
     status: card.status,
     viewerRole: card.viewerRole,
     viewerApproved: opts.viewerApproved,
+    viewerActedAt: opts.viewerActedAt,
     kind: kind ?? "none",
   });
   if (kind === null) return;
@@ -831,6 +836,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
           isGhost: opp.isGhost ?? false,
           score: opp.score,
           status: opp.status,
+          viewerActedAt: opp.viewerActedAt,
         }));
         const displayedCards = allCardData.slice(0, CHAT_DISPLAY_LIMIT);
         const extraFromCap = allCardData.length - displayedCards.length;
@@ -1387,6 +1393,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
             }, {
               viewerId: context.userId,
               viewerApproved: source?.viewerApproved,
+              viewerActedAt: source?.viewerActedAt,
               counterpartUserId: source?.userId ?? card.userId,
               mintConnectLink,
               frontendUrl: deps.frontendUrl,
@@ -1987,6 +1994,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
                     }, {
                       viewerId: context.userId,
                       viewerApproved,
+                      viewerActedAt: viewerActor?.actedAt ?? null,
                       counterpartUserId,
                       mintConnectLink: deps.mintConnectLink,
                       frontendUrl: deps.frontendUrl,
@@ -2167,6 +2175,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
                   }, {
                     viewerId: context.userId,
                     viewerApproved,
+                    viewerActedAt: viewerActor?.actedAt ?? null,
                     counterpartUserId,
                     mintConnectLink: deps.mintConnectLink,
                     frontendUrl: deps.frontendUrl,

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.spec.ts
@@ -278,10 +278,20 @@ describe("resolveActionableLinkKind — actionability matrix", () => {
     expect(resolveActionableLinkKind({ status: "accepted", viewerRole: "introducer" })).toBeNull();
   });
 
-  test("pending + non-introducer → connect", () => {
+  test("pending + non-introducer without actedAt → connect", () => {
     expect(resolveActionableLinkKind({ status: "pending", viewerRole: "party" })).toBe("connect");
     expect(resolveActionableLinkKind({ status: "pending", viewerRole: "patient" })).toBe("connect");
     expect(resolveActionableLinkKind({ status: "pending", viewerRole: "agent" })).toBe("connect");
+  });
+
+  test("pending + non-introducer with actedAt → null", () => {
+    expect(
+      resolveActionableLinkKind({
+        status: "pending",
+        viewerRole: "agent",
+        viewerActedAt: "2026-06-26T16:21:49.649Z",
+      }),
+    ).toBeNull();
   });
 
   test("pending + introducer → null", () => {
@@ -309,9 +319,37 @@ describe("resolveActionableLinkKind — actionability matrix", () => {
     expect(resolveActionableLinkKind({ status: "draft", viewerRole: "agent" })).toBe("send_direct");
   });
 
-  test("terminal / unknown statuses → null", () => {
+  test("draft/latent + non-introducer with actedAt → null (send_direct suppressed)", () => {
+    expect(
+      resolveActionableLinkKind({
+        status: "draft",
+        viewerRole: "party",
+        viewerActedAt: "2026-06-26T16:21:49.649Z",
+      }),
+    ).toBeNull();
+    expect(
+      resolveActionableLinkKind({
+        status: "latent",
+        viewerRole: "agent",
+        viewerActedAt: "2026-06-26T16:21:49.649Z",
+      }),
+    ).toBeNull();
+  });
+
+  test("accepted + non-introducer with actedAt → outreach (acting doesn't kill outreach)", () => {
+    expect(
+      resolveActionableLinkKind({
+        status: "accepted",
+        viewerRole: "party",
+        viewerActedAt: "2026-06-26T16:21:49.649Z",
+      }),
+    ).toBe("outreach");
+  });
+
+  test("terminal / internal / unknown statuses → null", () => {
     expect(resolveActionableLinkKind({ status: "rejected", viewerRole: "party" })).toBeNull();
     expect(resolveActionableLinkKind({ status: "expired", viewerRole: "introducer", viewerApproved: false })).toBeNull();
+    expect(resolveActionableLinkKind({ status: "stalled", viewerRole: "party" })).toBeNull();
   });
 
   test("latent + introducer + unapproved → approve_introduction (connector-flow before approval)", () => {
@@ -452,6 +490,21 @@ describe("attachActionableLinks — mutation and resilience", () => {
     expect(calls.length).toBe(0);
     expect(card.acceptUrl).toBeUndefined();
     expect(card.profileUrl).toBe("https://app.test/u/counterpart-6?link_preview=false");
+  });
+
+  test("pending + already-acted viewer → no mint, profileUrl still attached", async () => {
+    const card = makeCard({ opportunityId: "opp-6b", viewerRole: "agent", status: "pending" });
+    const { mintConnectLink, calls } = makeMintSpy();
+    await attachActionableLinks(card, {
+      viewerId: "user-6b",
+      viewerActedAt: "2026-06-26T16:21:49.649Z",
+      counterpartUserId: "counterpart-6b",
+      mintConnectLink,
+      frontendUrl: "https://app.test",
+    });
+    expect(calls.length).toBe(0);
+    expect(card.acceptUrl).toBeUndefined();
+    expect(card.profileUrl).toBe("https://app.test/u/counterpart-6b?link_preview=false");
   });
 
   test("accepted + introducer → no mint, profileUrl still attached", async () => {

--- a/services/api/src/events/tests/premise.event.spec.ts
+++ b/services/api/src/events/tests/premise.event.spec.ts
@@ -182,13 +182,12 @@ describe('PremiseQueue — premise_cascade', () => {
     ]);
   });
 
-  it('transitions pending, negotiating, and accepted opportunities to stalled', async () => {
+  it('transitions pending and negotiating opportunities to expired, never stalled', async () => {
     const transitions: Array<[string, string]> = [];
     const deps: PremiseQueueDeps = {
       getUserOpportunities: async () => [
         { id: 'opp-1', status: 'pending' as NonTerminalStatus },
         { id: 'opp-2', status: 'negotiating' as NonTerminalStatus },
-        { id: 'opp-3', status: 'accepted' as NonTerminalStatus },
       ],
       updateOpportunityStatus: async (id, status) => {
         transitions.push([id, status]);
@@ -197,20 +196,19 @@ describe('PremiseQueue — premise_cascade', () => {
     const queue = new PremiseQueue(deps);
     await queue.processJob('premise_cascade', { premiseId: 'p-2', userId: 'u-2', event: 'expired' });
     expect(transitions).toEqual([
-      ['opp-1', 'stalled'],
-      ['opp-2', 'stalled'],
-      ['opp-3', 'stalled'],
+      ['opp-1', 'expired'],
+      ['opp-2', 'expired'],
     ]);
   });
 
-  it('handles mixed statuses: early ones expire, in-progress ones stall', async () => {
+  it('handles mixed statuses: every cascade-eligible opportunity expires', async () => {
     const transitions: Array<[string, string]> = [];
     const deps: PremiseQueueDeps = {
       getUserOpportunities: async () => [
         { id: 'opp-a', status: 'draft' as NonTerminalStatus },
         { id: 'opp-b', status: 'pending' as NonTerminalStatus },
         { id: 'opp-c', status: 'latent' as NonTerminalStatus },
-        { id: 'opp-d', status: 'accepted' as NonTerminalStatus },
+        { id: 'opp-d', status: 'negotiating' as NonTerminalStatus },
       ],
       updateOpportunityStatus: async (id, status) => {
         transitions.push([id, status]);
@@ -220,9 +218,9 @@ describe('PremiseQueue — premise_cascade', () => {
     await queue.processJob('premise_cascade', { premiseId: 'p-3', userId: 'u-3', event: 'retracted' });
     expect(transitions).toEqual([
       ['opp-a', 'expired'],
-      ['opp-b', 'stalled'],
+      ['opp-b', 'expired'],
       ['opp-c', 'expired'],
-      ['opp-d', 'stalled'],
+      ['opp-d', 'expired'],
     ]);
   });
 
@@ -238,7 +236,7 @@ describe('PremiseQueue — premise_cascade', () => {
   });
 
   it('calls updateOpportunityStatus once per opportunity', async () => {
-    const updateOpportunityStatus = mock(async (_id: string, _status: 'expired' | 'stalled') => {});
+    const updateOpportunityStatus = mock(async (_id: string, _status: 'expired') => {});
     const deps: PremiseQueueDeps = {
       getUserOpportunities: async () => [
         { id: 'opp-1', status: 'draft' as NonTerminalStatus },

--- a/services/api/src/queues/premise.queue.ts
+++ b/services/api/src/queues/premise.queue.ts
@@ -40,15 +40,21 @@ export type PremiseJobPayload = PremiseCascadeData | ProfileRegenData;
 // Opportunity status helpers (kept local to avoid importing schema at queue layer)
 // ---------------------------------------------------------------------------
 
-/** Non-terminal statuses that are "in-progress" and should be stalled. */
-const IN_PROGRESS_STATUSES = ['pending', 'negotiating', 'accepted'] as const;
+/**
+ * In-flight statuses (sent or mid-negotiation) that expire when the premise
+ * that motivated them lapses. `accepted` is deliberately excluded: a made
+ * connection outlives its originating premise. `stalled` is reserved for
+ * negotiation outcomes (turn cap / timeout / no consensus) and is never
+ * written by this cascade.
+ */
+const IN_FLIGHT_STATUSES = ['pending', 'negotiating'] as const;
 
 /** Statuses that represent early-stage (not yet sent) opportunities; they expire. */
 const EARLY_STATUSES = ['draft', 'latent'] as const;
 
-export type InProgressStatus = (typeof IN_PROGRESS_STATUSES)[number];
+export type InFlightStatus = (typeof IN_FLIGHT_STATUSES)[number];
 export type EarlyStatus = (typeof EARLY_STATUSES)[number];
-export type NonTerminalStatus = InProgressStatus | EarlyStatus;
+export type NonTerminalStatus = InFlightStatus | EarlyStatus;
 
 // ---------------------------------------------------------------------------
 // Deps interface
@@ -61,15 +67,15 @@ export type NonTerminalStatus = InProgressStatus | EarlyStatus;
  */
 export interface PremiseQueueDeps {
   /**
-   * Retrieve non-terminal opportunities where `userId` is an actor.
-   * Returns a minimal shape: id + current status.
+   * Retrieve cascade-eligible (non-terminal, non-accepted) opportunities
+   * where `userId` is an actor. Returns a minimal shape: id + current status.
    */
   getUserOpportunities?: (userId: string) => Promise<Array<{ id: string; status: NonTerminalStatus }>>;
 
   /**
-   * Transition an opportunity to a new status.
+   * Transition an opportunity to a new status. The cascade only ever expires.
    */
-  updateOpportunityStatus?: (opportunityId: string, status: 'expired' | 'stalled') => Promise<void>;
+  updateOpportunityStatus?: (opportunityId: string, status: 'expired') => Promise<void>;
 
   /**
    * Enqueue user-context regeneration (global + per-network) for the user.
@@ -97,9 +103,11 @@ export interface PremiseQueueDeps {
 /**
  * Premise cascade and profile regeneration queue.
  *
- * `premise_cascade` — when a premise is retracted or expired, transitions
- * non-terminal opportunities owned by the user: draft/latent → expired,
- * pending/negotiating/accepted → stalled.
+ * `premise_cascade` — when a premise is retracted or expired, expires the
+ * opportunities it motivated: draft/latent/pending/negotiating → expired.
+ * `accepted` opportunities are left untouched (the connection already
+ * happened), and `stalled` is never written here — it is strictly a
+ * negotiation outcome (turn cap / timeout / no consensus).
  *
  * `profile_regen` — when any premise lifecycle event fires, regenerates the
  * user's profile from their current active premises via the profile graph's
@@ -282,19 +290,21 @@ export class PremiseQueue {
   // -------------------------------------------------------------------------
 
   /**
-   * Default production implementation: fetch all non-terminal opportunities for
-   * a user from the database using a single filtered query.
+   * Default production implementation: fetch all cascade-eligible
+   * opportunities for a user from the database using a single filtered query.
+   * `accepted` is intentionally outside the fetch scope — the cascade must
+   * never touch a made connection.
    */
   private async defaultGetUserOpportunities(
     userId: string
   ): Promise<Array<{ id: string; status: NonTerminalStatus }>> {
     const adapter = new OpportunityDatabaseAdapter();
-    const nonTerminalStatuses: NonTerminalStatus[] = [
+    const cascadeStatuses: NonTerminalStatus[] = [
       ...EARLY_STATUSES,
-      ...IN_PROGRESS_STATUSES,
+      ...IN_FLIGHT_STATUSES,
     ];
     const rows = await adapter.getOpportunitiesForUser(userId, {
-      statuses: nonTerminalStatuses,
+      statuses: cascadeStatuses,
     });
     return rows.map((row) => ({ id: row.id, status: row.status as NonTerminalStatus }));
   }
@@ -305,7 +315,7 @@ export class PremiseQueue {
    */
   private async defaultUpdateOpportunityStatus(
     opportunityId: string,
-    status: 'expired' | 'stalled'
+    status: 'expired'
   ): Promise<void> {
     const adapter = new OpportunityDatabaseAdapter();
     await adapter.updateOpportunityStatus(opportunityId, status);
@@ -338,21 +348,17 @@ export class PremiseQueue {
 
     const updateOpportunityStatus =
       this.deps?.updateOpportunityStatus ??
-      ((oppId: string, status: 'expired' | 'stalled') =>
+      ((oppId: string, status: 'expired') =>
         this.defaultUpdateOpportunityStatus(oppId, status));
 
     const opportunities = await getUserOpportunities(userId);
 
-    let expiredCount = 0;
-    let stalledCount = 0;
-
+    // The premise that motivated these opportunities no longer holds, so they
+    // all expire — regardless of how far along they were. `stalled` is never
+    // written here: it is reserved for negotiation outcomes, and `accepted`
+    // rows are outside the fetch scope entirely.
     for (const opp of opportunities) {
-      const newStatus = (EARLY_STATUSES as readonly string[]).includes(opp.status)
-        ? 'expired'
-        : 'stalled';
-      await updateOpportunityStatus(opp.id, newStatus);
-      if (newStatus === 'expired') expiredCount++;
-      else stalledCount++;
+      await updateOpportunityStatus(opp.id, 'expired');
     }
 
     this.logger.info('[PremiseCascade] Cascade complete', {
@@ -360,8 +366,7 @@ export class PremiseQueue {
       userId,
       event,
       total: opportunities.length,
-      expired: expiredCount,
-      stalled: stalledCount,
+      expired: opportunities.length,
     });
   }
 

--- a/services/api/src/services/connect-link.service.ts
+++ b/services/api/src/services/connect-link.service.ts
@@ -9,7 +9,7 @@ const CODE_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz01234
 const CODE_LENGTH = 10;
 const TTL_DAYS = 30;
 
-const TERMINAL_STATUSES = new Set(['expired', 'rejected']);
+const TERMINAL_STATUSES = new Set(['expired', 'rejected', 'stalled']);
 
 function generateCode(): string {
   const bytes = new Uint8Array(CODE_LENGTH);
@@ -206,13 +206,19 @@ function toResolvedLink(row: typeof connectLinks.$inferSelect, opportunityId: st
   };
 }
 
+type LinkOpportunity = {
+  id: string;
+  status: typeof opportunities.$inferSelect.status;
+  actors: Array<{ userId: string; role: string; approved?: boolean; actedAt?: string | null }>;
+};
+
 async function resolveOpportunityForLink(
   opportunityId: string,
   userId: string,
-): Promise<{ id: string; status: typeof opportunities.$inferSelect.status } | null> {
+): Promise<LinkOpportunity | null> {
   const seenIds = new Set<string>();
   let currentId = opportunityId;
-  let current: { id: string; status: typeof opportunities.$inferSelect.status } | null = null;
+  let current: LinkOpportunity | null = null;
 
   for (let depth = 0; depth < 5; depth++) {
     if (seenIds.has(currentId)) break;
@@ -224,7 +230,7 @@ async function resolveOpportunityForLink(
       .where(eq(opportunities.id, currentId))
       .limit(1);
     if (!opp) return current;
-    current = { id: opp.id, status: opp.status };
+    current = { id: opp.id, status: opp.status, actors: opp.actors };
 
     if (opp.status !== 'expired') return current;
 
@@ -245,6 +251,35 @@ async function resolveOpportunityForLink(
   }
 
   return current;
+}
+
+function hasActorActed(actor: { actedAt?: string | null }): boolean {
+  return !!actor.actedAt;
+}
+
+function isLinkUsableForOpportunity(
+  kind: ConnectLinkKind,
+  opp: LinkOpportunity,
+  userId: string,
+): boolean {
+  const viewerActors = opp.actors.filter((actor) => actor.userId === userId);
+  if (viewerActors.length === 0) return false;
+
+  return viewerActors.some((actor) => {
+    const isIntroducer = actor.role === 'introducer';
+    if (kind === 'approve_introduction') {
+      return (opp.status === 'latent' || opp.status === 'draft') && isIntroducer && actor.approved !== true;
+    }
+
+    if (isIntroducer) return false;
+    if (opp.status === 'accepted' && (kind === 'connect' || kind === 'send_direct' || kind === 'outreach')) {
+      return true;
+    }
+    if ((kind === 'connect' || kind === 'send_direct') && ['pending', 'draft', 'latent'].includes(opp.status)) {
+      return !hasActorActed(actor);
+    }
+    return false;
+  });
 }
 
 /**
@@ -269,6 +304,7 @@ export async function resolveConnectLink(code: string): Promise<ResolvedLink | n
   if (!opp) return null;
 
   if (TERMINAL_STATUSES.has(opp.status)) return null;
+  if (!isLinkUsableForOpportunity(row.kind as ConnectLinkKind, opp, row.userId)) return null;
 
   const resolvedLink = toResolvedLink(row, opp.id);
   if (row.expiresAt > now) {
@@ -313,6 +349,7 @@ export async function resolveConnectLinkForUser(
   if (!opp) return null;
 
   if (TERMINAL_STATUSES.has(opp.status)) return null;
+  if (!isLinkUsableForOpportunity(row.kind as ConnectLinkKind, opp, userId)) return null;
 
   const resolvedLink = toResolvedLink(row, opp.id);
   if (row.expiresAt > now) {

--- a/services/api/src/services/tests/connect-link.service.spec.ts
+++ b/services/api/src/services/tests/connect-link.service.spec.ts
@@ -7,11 +7,17 @@ import { eq } from 'drizzle-orm/sql';
 
 import db from '../../lib/drizzle/drizzle';
 import { connectLinks, opportunities, users } from '../../schemas/database.schema';
-import { mintConnectLink, resolveConnectLink, buildConnectShortUrl } from '../connect-link.service';
+import { mintConnectLink, resolveConnectLink, resolveConnectLinkForUser, buildConnectShortUrl } from '../connect-link.service';
 
 const USER_ID = `cl-svc-user-${Date.now()}`;
 const OPP_ID = `cl-svc-opp-${Date.now()}`;
 const EXPIRED_OPP_ID = `cl-svc-expired-opp-${Date.now()}`;
+const STALLED_OPP_ID = `cl-svc-stalled-opp-${Date.now()}`;
+const ROTATE_INTRO_OPP_ID = `cl-svc-rotate-intro-opp-${Date.now()}`;
+const ACTED_OPP_ID = `cl-svc-acted-opp-${Date.now()}`;
+const ACCEPTED_OPP_ID = `cl-svc-accepted-opp-${Date.now()}`;
+const APPROVED_INTRO_OPP_ID = `cl-svc-approved-intro-opp-${Date.now()}`;
+const NON_ACTOR_OPP_ID = `cl-svc-non-actor-opp-${Date.now()}`;
 const SUPERSEDED_OPP_ID = `cl-svc-superseded-opp-${Date.now()}`;
 const REPLACEMENT_OPP_ID = `cl-svc-replacement-opp-${Date.now()}`;
 
@@ -41,6 +47,62 @@ describe('connect-link service', () => {
       status: 'expired',
     });
     await db.insert(opportunities).values({
+      id: STALLED_OPP_ID,
+      actors: [{ userId: USER_ID, networkId: 'n/a', role: 'seeker' }],
+      detection: { source: 'test', timestamp: new Date().toISOString(), createdBy: USER_ID },
+      interpretation: { category: 'test', reasoning: 'test', confidence: 0.9 },
+      context: { networkId: 'n/a' },
+      confidence: '0.9',
+      status: 'stalled',
+    });
+    await db.insert(opportunities).values({
+      id: ROTATE_INTRO_OPP_ID,
+      actors: [{ userId: USER_ID, networkId: 'n/a', role: 'introducer', approved: false }],
+      detection: { source: 'test', timestamp: new Date().toISOString(), createdBy: USER_ID },
+      interpretation: { category: 'test', reasoning: 'test', confidence: 0.9 },
+      context: { networkId: 'n/a' },
+      confidence: '0.9',
+      status: 'latent',
+    });
+    await db.insert(opportunities).values({
+      id: ACTED_OPP_ID,
+      actors: [{ userId: USER_ID, networkId: 'n/a', role: 'seeker', actedAt: new Date().toISOString() }],
+      detection: { source: 'test', timestamp: new Date().toISOString(), createdBy: USER_ID },
+      interpretation: { category: 'test', reasoning: 'test', confidence: 0.9 },
+      context: { networkId: 'n/a' },
+      confidence: '0.9',
+      status: 'pending',
+    });
+    await db.insert(opportunities).values({
+      id: ACCEPTED_OPP_ID,
+      // actedAt is set on purpose: the accepted branch must win over the
+      // already-acted check (outreach links stay live after acceptance).
+      actors: [{ userId: USER_ID, networkId: 'n/a', role: 'seeker', actedAt: new Date().toISOString() }],
+      detection: { source: 'test', timestamp: new Date().toISOString(), createdBy: USER_ID },
+      interpretation: { category: 'test', reasoning: 'test', confidence: 0.9 },
+      context: { networkId: 'n/a' },
+      confidence: '0.9',
+      status: 'accepted',
+    });
+    await db.insert(opportunities).values({
+      id: APPROVED_INTRO_OPP_ID,
+      actors: [{ userId: USER_ID, networkId: 'n/a', role: 'introducer', approved: true }],
+      detection: { source: 'test', timestamp: new Date().toISOString(), createdBy: USER_ID },
+      interpretation: { category: 'test', reasoning: 'test', confidence: 0.9 },
+      context: { networkId: 'n/a' },
+      confidence: '0.9',
+      status: 'latent',
+    });
+    await db.insert(opportunities).values({
+      id: NON_ACTOR_OPP_ID,
+      actors: [{ userId: `${USER_ID}-someone-else`, networkId: 'n/a', role: 'seeker' }],
+      detection: { source: 'test', timestamp: new Date().toISOString(), createdBy: USER_ID },
+      interpretation: { category: 'test', reasoning: 'test', confidence: 0.9 },
+      context: { networkId: 'n/a' },
+      confidence: '0.9',
+      status: 'pending',
+    });
+    await db.insert(opportunities).values({
       id: SUPERSEDED_OPP_ID,
       actors: [{ userId: USER_ID, networkId: 'n/a', role: 'seeker' }],
       detection: { source: 'test', timestamp: new Date().toISOString(), createdBy: USER_ID },
@@ -64,6 +126,12 @@ describe('connect-link service', () => {
     await db.delete(connectLinks).where(eq(connectLinks.userId, USER_ID));
     await db.delete(opportunities).where(eq(opportunities.id, OPP_ID));
     await db.delete(opportunities).where(eq(opportunities.id, EXPIRED_OPP_ID));
+    await db.delete(opportunities).where(eq(opportunities.id, STALLED_OPP_ID));
+    await db.delete(opportunities).where(eq(opportunities.id, ROTATE_INTRO_OPP_ID));
+    await db.delete(opportunities).where(eq(opportunities.id, ACTED_OPP_ID));
+    await db.delete(opportunities).where(eq(opportunities.id, ACCEPTED_OPP_ID));
+    await db.delete(opportunities).where(eq(opportunities.id, APPROVED_INTRO_OPP_ID));
+    await db.delete(opportunities).where(eq(opportunities.id, NON_ACTOR_OPP_ID));
     await db.delete(opportunities).where(eq(opportunities.id, REPLACEMENT_OPP_ID));
     await db.delete(opportunities).where(eq(opportunities.id, SUPERSEDED_OPP_ID));
     await db.delete(users).where(eq(users.id, USER_ID));
@@ -124,7 +192,7 @@ describe('connect-link service', () => {
     // Mint a fresh link.
     const a = await mintConnectLink({
       userId: USER_ID,
-      opportunityId: OPP_ID,
+      opportunityId: ROTATE_INTRO_OPP_ID,
       kind: 'approve_introduction',
       greeting: 'first greeting',
     });
@@ -141,7 +209,7 @@ describe('connect-link service', () => {
     // insert and the retry loop would throw after 3 attempts.
     const b = await mintConnectLink({
       userId: USER_ID,
-      opportunityId: OPP_ID,
+      opportunityId: ROTATE_INTRO_OPP_ID,
       kind: 'approve_introduction',
       greeting: 'second greeting',
     });
@@ -248,6 +316,107 @@ describe('connect-link service', () => {
 
     // Terminal opportunity — should NOT self-heal.
     expect(await resolveConnectLink(r.code)).toBeNull();
+  });
+
+  test('resolve returns null for stalled opportunity links', async () => {
+    const r = await mintConnectLink({
+      userId: USER_ID,
+      opportunityId: STALLED_OPP_ID,
+      kind: 'connect',
+      greeting: 'should be unavailable',
+    });
+
+    expect(await resolveConnectLink(r.code)).toBeNull();
+  });
+
+  test('resolve returns null when the recipient has already acted on a pending opportunity', async () => {
+    const r = await mintConnectLink({
+      userId: USER_ID,
+      opportunityId: ACTED_OPP_ID,
+      kind: 'connect',
+      greeting: 'already acted',
+    });
+
+    expect(await resolveConnectLink(r.code)).toBeNull();
+  });
+
+  test('resolve keeps accepted-opportunity links usable even after the recipient acted', async () => {
+    const outreach = await mintConnectLink({
+      userId: USER_ID,
+      opportunityId: ACCEPTED_OPP_ID,
+      kind: 'outreach',
+      greeting: 'follow up',
+    });
+    const connect = await mintConnectLink({
+      userId: USER_ID,
+      opportunityId: ACCEPTED_OPP_ID,
+      kind: 'connect',
+      greeting: 'late click on the original link',
+    });
+
+    expect((await resolveConnectLink(outreach.code))?.opportunityId).toBe(ACCEPTED_OPP_ID);
+    expect((await resolveConnectLink(connect.code))?.opportunityId).toBe(ACCEPTED_OPP_ID);
+  });
+
+  test('resolve returns null for approve_introduction links after the introducer approved', async () => {
+    const r = await mintConnectLink({
+      userId: USER_ID,
+      opportunityId: APPROVED_INTRO_OPP_ID,
+      kind: 'approve_introduction',
+      greeting: 'already approved',
+    });
+
+    expect(await resolveConnectLink(r.code)).toBeNull();
+  });
+
+  test('resolve returns null when the link owner is not an actor on the opportunity', async () => {
+    const r = await mintConnectLink({
+      userId: USER_ID,
+      opportunityId: NON_ACTOR_OPP_ID,
+      kind: 'connect',
+      greeting: 'not my opportunity',
+    });
+
+    expect(await resolveConnectLink(r.code)).toBeNull();
+  });
+
+  // Nested so the shared user/opportunity fixtures are still alive (the outer
+  // afterAll deletes them once every nested test has run).
+  describe('resolveConnectLinkForUser', () => {
+  test('resolves for the bound recipient on an actionable opportunity', async () => {
+    const r = await mintConnectLink({
+      userId: USER_ID,
+      opportunityId: OPP_ID,
+      kind: 'connect',
+      greeting: 'Hi there.',
+    });
+
+    const resolved = await resolveConnectLinkForUser(r.code, USER_ID);
+    expect(resolved?.opportunityId).toBe(OPP_ID);
+    expect(resolved?.userId).toBe(USER_ID);
+  });
+
+  test('returns null for a different authenticated user', async () => {
+    const r = await mintConnectLink({
+      userId: USER_ID,
+      opportunityId: OPP_ID,
+      kind: 'connect',
+      greeting: 'Hi there.',
+    });
+
+    expect(await resolveConnectLinkForUser(r.code, `${USER_ID}-intruder`)).toBeNull();
+  });
+
+  test('applies the usability gate: already-acted recipient gets null', async () => {
+    const r = await mintConnectLink({
+      userId: USER_ID,
+      opportunityId: ACTED_OPP_ID,
+      kind: 'connect',
+      greeting: 'already acted',
+    });
+
+    expect(await resolveConnectLinkForUser(r.code, USER_ID)).toBeNull();
+  });
   });
 });
 


### PR DESCRIPTION
## Problem

Recipients at Edge Village hit dead connect links from daily digests: one `expired`, two `stalled` opportunities behind them. Two distinct defects:

1. Links were minted/kept resolvable for viewers who could no longer act (already acted, introducer already approved, opportunity stalled).
2. The premise cascade wrote `pending/negotiating/accepted → stalled` when a premise was retracted or lapsed — diluting `stalled` (which should strictly mean a negotiation outcome: turn cap / timeout / no consensus) and producing dead links with no supersession chain to self-heal through.

## Commit 1 — connect-link actionability

**Mint side** (`packages/protocol`):
- `resolveActionableLinkKind` takes `viewerActedAt`: already-acted viewers get no `connect`/`send_direct` on `pending/draft/latent` (accepted keeps `outreach`).
- `viewerActedAt` threaded from the viewer actor through `FormattedDiscoveryCandidate` and every `attachActionableLinks` call site.

**Resolution side** (`services/api`):
- `stalled` joins `TERMINAL_STATUSES`.
- New `isLinkUsableForOpportunity` gate in `resolveConnectLink` / `resolveConnectLinkForUser` re-validates already-minted links: owner must still be an actor; `approve_introduction` only while the introducer is unapproved on `draft/latent`; `connect`/`send_direct` on `pending/draft/latent` only while the actor hasn't acted; `accepted` keeps `connect`/`send_direct`/`outreach` usable.
- Links sent before a status change now mask as 404 instead of dropping the recipient into a dead negotiation. `expired` links still self-heal through the `enrichedFrom` supersession chain.

## Commit 2 — premise cascade semantics

- Cascade now expires everything it touches: `draft/latent/pending/negotiating → expired`. `stalled` is never written by the cascade — dep signatures narrowed to `status: 'expired'` so the compiler enforces it.
- `accepted` removed from the cascade fetch scope entirely: a made connection outlives its originating premise.
- Forward-only: existing prod rows stalled by the old cascade stay `stalled` (indistinguishable from negotiation-stalled rows; the new terminal handling covers them).

## Tests

- `connect-link.service.spec.ts` 14 → 21: every `isLinkUsableForOpportunity` branch (already-acted → null; accepted stays usable even after acting; approved introducer → null; non-actor → null; stalled → null) + first-ever coverage of `resolveConnectLinkForUser` (bound recipient / wrong user / usability gate).
- `opportunity.tools.spec.ts` 48 → 50: `draft/latent + actedAt → null`, `accepted + actedAt → outreach`.
- `premise.event.spec.ts`: cascade all-expire matrix, accepted excluded (type-enforced).
- `tsc --noEmit` clean in `services/api` and `packages/protocol`.

## Related

- Edge-City/agentvillage#130 closes the digest-side inclusion leak (stalled/expired cards filtered from daily brief on both MCP and file-replay paths).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1079"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785928057&installation_id=140549914&pr_number=1079&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1079&signature=0fa0f18de71ba1b7b245d7e60377e0159ceef262564e15d6096d8573c25ba68e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->