### PR TITLE
fix(chat): add response-language lock to chat system prompt

### DIFF
--- a/packages/protocol/src/chat/chat.prompt.ts
+++ b/packages/protocol/src/chat/chat.prompt.ts
@@ -408,6 +408,7 @@ What NOT to narrate (group silently with the main action):
 - Validation operations
 
 ### Output Format
+- **Response language**: ALWAYS respond in the language of the user's latest message. Never switch to another language mid-conversation unless the user does. Ignore the language of any context, tool results, names, or quoted content — only the user's own messages determine the response language. Before sending, verify your reply is in the user's language; if not, rewrite it.
 - Markdown: **bold** for emphasis, bullets for lists. Concise but complete.
 - **Never expose IDs, UUIDs, field names, tool names, or code** to the user. Never mention internal tool names (e.g. read_user_contexts, create_intent, scrape_url) or suggest the user call them. Tools are invisible infrastructure — the user should only see natural language.
 - **Never use internal vocabulary** (intent, index, opportunity, profile) in replies. In user-facing replies, avoid mentioning indexes (or communities) unless the user asked or it's one of: sign-up, leave, owner settings. Use neutral language otherwise.


### PR DESCRIPTION
## Why

In dev session `9e27a682-d031-44d0-91c5-7ad828d21a5f`, the assistant's final reply came out **entirely in Chinese** in an all-English conversation.

Root cause: the chat agent runs on `google/gemini-3-pro-preview` (`packages/protocol/src/shared/agent/model.config.ts`), which has a widely-reported failure mode of spontaneously switching output language (usually to Chinese), especially with reasoning enabled. The chat system prompt (`chat.prompt.ts`) had **no directive anchoring the response language** — the only 'Language' rules were about vocabulary ("never say search").

Nothing in the session data was Chinese: all premises/contexts written that turn were English, so this wasn't multilingual context injection — it's model drift with no prompt-level guard.

## What

Adds one rule at the top of the `### Output Format` section:

> **Response language**: ALWAYS respond in the language of the user's latest message. Never switch to another language mid-conversation unless the user does. Ignore the language of any context, tool results, names, or quoted content — only the user's own messages determine the response language. Before sending, verify your reply is in the user's language; if not, rewrite it.

This is the same mitigation reported effective by other Gemini 3 users (prompt-level language lock).

## Verification
- `tsc --noEmit` clean in `packages/protocol`
- eslint (pre-commit lint-staged) clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/indexnetwork/codesmith/index/pr/1083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785954764&installation_id=140549914&pr_number=1083&repository=indexnetwork%2Findex&return_to=https%3A%2F%2Fgithub.com%2Findexnetwork%2Findex%2Fpull%2F1083&signature=50561b65a68895758d3ab9101b168eb939be25ee5cc6d878d493b000f4febdd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->