### PR TITLE
feat(protocol): runnable-level retry + cross-model fallbacks for LLM calls (IND-386)

### DIFF
--- a/.pi/skills/git-worktree-workflow/SKILL.md
+++ b/.pi/skills/git-worktree-workflow/SKILL.md
@@ -1,6 +1,17 @@
 ---
 name: git-worktree-workflow
-description: Create and operate git worktrees in the index monorepo using the project's `bun run worktree:*` helpers instead of raw git. Use whenever you need an isolated branch checkout to make changes (the canonical root must stay on dev and is read-only for the assistant, enforced by the root-dev-guard extension), or when a worktree is missing env files, node_modules, or git hooks, or when a tool/bash call is blocked for touching the canonical root, or when `git commit`/`git rebase` fails with "gpg: signing failed: Inappropriate ioctl for device" in a non-interactive shell. Covers the dashed-folder / slashed-branch naming convention, why `worktree:setup` is mandatory after creating a worktree, and how to disable GPG signing worktree-locally without touching the user's repo-wide signing config.
+description: >-
+  Create and operate git worktrees in the index monorepo using the project's
+  `bun run worktree:*` helpers instead of raw git. Use whenever you need an
+  isolated branch checkout to make changes (the canonical root must stay on dev
+  and is read-only for the assistant, enforced by the root-dev-guard extension),
+  or when a worktree is missing env files, node_modules, or git hooks, or when a
+  tool/bash call is blocked for touching the canonical root, or when
+  `git commit`/`git rebase` fails with "gpg: signing failed: Inappropriate ioctl
+  for device" in a non-interactive shell. Covers the dashed-folder /
+  slashed-branch naming convention, why `worktree:setup` is mandatory after
+  creating a worktree, and how to disable GPG signing worktree-locally without
+  touching the user's repo-wide signing config.
 ---
 
 # git-worktree-workflow

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "4.4.1",
+  "version": "4.5.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/chat/chat.interrupt.classifier.ts
+++ b/packages/protocol/src/chat/chat.interrupt.classifier.ts
@@ -1,9 +1,8 @@
-import type { ChatOpenAI } from "@langchain/openai";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 
 import { log } from "../shared/observability/log.js";
 import { Timed } from "../shared/observability/performance.js";
-import { createModel } from "../shared/agent/model.config.js";
+import { createResilientModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = log.lib.from("ChatInterruptClassifier");
@@ -32,10 +31,10 @@ export interface ClassifyInterruptInput {
  * Uses a low-temperature, minimal-token model for sub-1 s latency.
  */
 export class ChatInterruptClassifier {
-  private model: ChatOpenAI;
+  private model: ReturnType<typeof createResilientModel>;
 
   constructor() {
-    this.model = createModel("interruptClassifier");
+    this.model = createResilientModel("interruptClassifier");
   }
 
   /**

--- a/packages/protocol/src/chat/chat.suggester.ts
+++ b/packages/protocol/src/chat/chat.suggester.ts
@@ -1,10 +1,9 @@
-import type { ChatOpenAI } from "@langchain/openai";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { z } from "zod";
 import type { ChatSuggestion } from "./chat-streaming.types.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { Timed } from "../shared/observability/performance.js";
-import { createModel } from "../shared/agent/model.config.js";
+import { createStructuredModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("SuggestionGenerator");
@@ -47,11 +46,10 @@ export interface SuggestionGeneratorInput {
  * Uses a fast model and structured output to return 3-5 suggestions per call.
  */
 export class SuggestionGenerator {
-  private model: ReturnType<ChatOpenAI["withStructuredOutput"]>;
+  private model: ReturnType<typeof createStructuredModel>;
 
   constructor() {
-    const llm = createModel("suggestionGenerator");
-    this.model = llm.withStructuredOutput(suggestionsSchema, { name: "chat_suggestions" });
+    this.model = createStructuredModel("suggestionGenerator", suggestionsSchema, { name: "chat_suggestions" });
   }
 
   /**

--- a/packages/protocol/src/chat/chat.summarizer.ts
+++ b/packages/protocol/src/chat/chat.summarizer.ts
@@ -7,11 +7,10 @@
  * The model is instructed to drop entries in the previous digest that newer
  * messages override, keeping the digest bounded as the session grows.
  */
-import type { ChatOpenAI } from "@langchain/openai";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 
 import { ChatContextDigestSchema, type ChatContextDigest } from "../shared/schemas/chat-context.schema.js";
-import { createModel } from "../shared/agent/model.config.js";
+import { createStructuredModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { Timed } from "../shared/observability/performance.js";
@@ -46,11 +45,10 @@ export interface ChatSummarizerInput {
 
 /** Pure LLM summarizer; no DB, no events. */
 export class ChatSummarizer {
-  private model: ReturnType<ChatOpenAI["withStructuredOutput"]>;
+  private model: ReturnType<typeof createStructuredModel>;
 
   constructor() {
-    const llm = createModel("chatContextSummarizer");
-    this.model = llm.withStructuredOutput(ChatContextDigestSchema, {
+    this.model = createStructuredModel("chatContextSummarizer", ChatContextDigestSchema, {
       name: "chat_context_digest",
     });
   }

--- a/packages/protocol/src/chat/chat.title.generator.ts
+++ b/packages/protocol/src/chat/chat.title.generator.ts
@@ -1,10 +1,9 @@
-import type { ChatOpenAI } from "@langchain/openai";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 
 import { log } from "../shared/observability/log.js";
 import { Timed } from "../shared/observability/performance.js";
 
-import { createModel } from "../shared/agent/model.config.js";
+import { createResilientModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = log.lib.from("ChatTitleGenerator");
@@ -26,10 +25,10 @@ export interface TitleGeneratorInput {
  * Only meaningful when there is at least one user message and one assistant message.
  */
 export class ChatTitleGenerator {
-  private model: ChatOpenAI;
+  private model: ReturnType<typeof createResilientModel>;
 
   constructor() {
-    this.model = createModel("chatTitleGenerator");
+    this.model = createResilientModel("chatTitleGenerator");
   }
 
   /**

--- a/packages/protocol/src/contact/contact.inviter.ts
+++ b/packages/protocol/src/contact/contact.inviter.ts
@@ -9,9 +9,7 @@
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { z } from "zod";
 
-import { createModel } from "../shared/agent/model.config.js";
-
-const model = createModel("inviteGenerator");
+import { createStructuredModel } from "../shared/agent/model.config.js";
 
 const InviteInputSchema = z.object({
   recipientName: z.string(),
@@ -51,7 +49,7 @@ Do NOT use placeholder brackets like [Name]. Use the actual names provided.`;
 export async function generateInviteMessage(input: InviteInput): Promise<InviteOutput> {
   const validated = InviteInputSchema.parse(input);
 
-  const structuredModel = model.withStructuredOutput(InviteOutputSchema);
+  const structuredModel = createStructuredModel("inviteGenerator", InviteOutputSchema);
 
   const userPrompt = `Generate an invite message with this context:
 - Sender: ${validated.senderName}

--- a/packages/protocol/src/context/context.generator.ts
+++ b/packages/protocol/src/context/context.generator.ts
@@ -13,7 +13,7 @@
 
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 
-import { createModel } from "../shared/agent/model.config.js";
+import { createResilientModel } from "../shared/agent/model.config.js";
 import { getAbortSignalConfig, invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 import type { EmbeddingGenerator } from "../shared/interfaces/embedder.interface.js";
 
@@ -66,7 +66,7 @@ const GLOBAL_INCREMENTAL_SYSTEM_PROMPT = `You maintain a person's global identit
  * Uses LLM synthesis to produce focused context and an embedding vector.
  */
 export class UserContextGenerator {
-  private model = createModel('userContextGenerator');
+  private model = createResilientModel('userContextGenerator');
 
   constructor(private embeddingGenerator: EmbeddingGenerator) {}
 

--- a/packages/protocol/src/enrichment/enrichment.generator.ts
+++ b/packages/protocol/src/enrichment/enrichment.generator.ts
@@ -3,7 +3,7 @@ import { tool } from "@langchain/core/tools";
 import { z } from "zod/v4";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { Timed } from "../shared/observability/performance.js";
-import { createModel } from "../shared/agent/model.config.js";
+import { createStructuredModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("EnrichmentGenerator");
@@ -37,12 +37,11 @@ type Profile = z.infer<typeof responseFormat>;
 export type GeneratedProfile = Profile & { userId: string };
 
 export class EnrichmentGenerator {
-  private static baseModel: ReturnType<typeof createModel> | undefined;
+  private static sharedModel: ReturnType<typeof createStructuredModel> | undefined;
   private model: { invoke(input: unknown, config?: { signal?: AbortSignal }): Promise<unknown> };
 
   constructor() {
-    const baseModel = EnrichmentGenerator.baseModel ??= createModel("profileGenerator");
-    this.model = baseModel.withStructuredOutput(responseFormat, {
+    this.model = EnrichmentGenerator.sharedModel ??= createStructuredModel("profileGenerator", responseFormat, {
       name: "profile_generator"
     });
   }

--- a/packages/protocol/src/intent/intent.clarifier.ts
+++ b/packages/protocol/src/intent/intent.clarifier.ts
@@ -1,16 +1,15 @@
-import type { ChatOpenAI } from "@langchain/openai";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { z } from "zod";
 
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { Timed } from "../shared/observability/performance.js";
 
-import { createModel } from "../shared/agent/model.config.js";
+import { createStructuredModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("IntentClarifier");
 
-type ClarifierStructuredModel = ReturnType<ChatOpenAI["withStructuredOutput"]>;
+type ClarifierStructuredModel = ReturnType<typeof createStructuredModel>;
 
 const clarificationSchema = z.object({
   needsClarification: z.boolean(),
@@ -76,14 +75,14 @@ export class IntentClarifier {
   private readonly clarificationDraftModel: ClarifierStructuredModel;
 
   constructor() {
-    const baseModel = createModel("intentClarifier");
-    this.model = baseModel.withStructuredOutput(clarificationSchema, {
+    this.model = createStructuredModel("intentClarifier", clarificationSchema, {
       name: "intent_clarifier",
     });
-    this.suggestionModel = baseModel.withStructuredOutput(suggestionSchema, {
+    this.suggestionModel = createStructuredModel("intentClarifier", suggestionSchema, {
       name: "intent_clarifier_suggestion",
     });
-    this.clarificationDraftModel = baseModel.withStructuredOutput(
+    this.clarificationDraftModel = createStructuredModel(
+      "intentClarifier",
       clarificationDraftSchema,
       { name: "intent_clarifier_message" }
     );

--- a/packages/protocol/src/intent/intent.indexer.ts
+++ b/packages/protocol/src/intent/intent.indexer.ts
@@ -1,10 +1,9 @@
-import type { ChatOpenAI } from "@langchain/openai";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { tool } from "@langchain/core/tools";
 import { z } from "zod";
 import { log } from "../shared/observability/log.js";
 import { Timed } from "../shared/observability/performance.js";
-import { createModel } from "../shared/agent/model.config.js";
+import { createStructuredModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 // ──────────────────────────────────────────────────────────────
@@ -24,7 +23,6 @@ export type IntentIndexerOutput = z.infer<typeof IntentIndexerOutputSchema>;
 
 const logger = log.lib.from("IntentIndexer");
 
-const model = createModel("intentIndexer");
 
 // ──────────────────────────────────────────────────────────────
 // 1. SYSTEM PROMPT
@@ -79,10 +77,10 @@ type ResponseType = z.infer<typeof responseFormat>;
 // ──────────────────────────────────────────────────────────────
 
 export class IntentIndexer {
-  private model: ReturnType<ChatOpenAI["withStructuredOutput"]>;
+  private model: ReturnType<typeof createStructuredModel>;
 
   constructor() {
-    this.model = model.withStructuredOutput(responseFormat, {
+    this.model = createStructuredModel("intentIndexer", responseFormat, {
       name: "intent_indexer",
     });
   }

--- a/packages/protocol/src/intent/intent.inferrer.ts
+++ b/packages/protocol/src/intent/intent.inferrer.ts
@@ -3,7 +3,7 @@ import { tool } from "@langchain/core/tools";
 import { z } from "zod";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { Timed } from "../shared/observability/performance.js";
-import { createModel } from "../shared/agent/model.config.js";
+import { createStructuredModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("ExplicitIntentInferrer");
@@ -135,11 +135,10 @@ export type InferredIntent = z.infer<typeof InferredIntentSchema>;
 // ──────────────────────────────────────────────────────────────
 
 export class ExplicitIntentInferrer {
-  private model: any;
+  private model: ReturnType<typeof createStructuredModel>;
 
   constructor() {
-    const model = createModel("intentInferrer");
-    this.model = model.withStructuredOutput(responseFormat, {
+    this.model = createStructuredModel("intentInferrer", responseFormat, {
       name: "intent_inferrer"
     });
   }

--- a/packages/protocol/src/intent/intent.reconciler.ts
+++ b/packages/protocol/src/intent/intent.reconciler.ts
@@ -3,12 +3,11 @@ import { tool } from "@langchain/core/tools";
 import { z } from "zod";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { Timed } from "../shared/observability/performance.js";
-import { createModel } from "../shared/agent/model.config.js";
+import { createStructuredModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("IntentReconciler");
 
-const model = createModel("intentReconciler");
 
 const CreateActionTypeSchema = z.union([z.literal("create"), z.literal("CREATE")]);
 const UpdateActionTypeSchema = z.union([z.literal("update"), z.literal("UPDATE")]);
@@ -134,10 +133,10 @@ const normalizeActionType = (type: string): "create" | "update" | "expire" => {
 // ──────────────────────────────────────────────────────────────
 
 export class IntentReconciler {
-  private model: any;
+  private model: ReturnType<typeof createStructuredModel>;
 
   constructor() {
-    this.model = model.withStructuredOutput(responseFormat, {
+    this.model = createStructuredModel("intentReconciler", responseFormat, {
       name: "intent_reconciler"
     });
   }

--- a/packages/protocol/src/intent/intent.verifier.ts
+++ b/packages/protocol/src/intent/intent.verifier.ts
@@ -3,7 +3,7 @@ import { tool } from "@langchain/core/tools";
 import { z } from "zod";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { Timed } from "../shared/observability/performance.js";
-import { createModel } from "../shared/agent/model.config.js";
+import { createStructuredModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("SemanticVerifier");
@@ -18,7 +18,6 @@ const missingSelectionalConstraintSchema = z.enum([
   "concrete_need",
 ]);
 
-const model = createModel("intentVerifier");
 // ──────────────────────────────────────────────────────────────
 // 1. SYSTEM PROMPT
 // ──────────────────────────────────────────────────────────────
@@ -230,10 +229,10 @@ export type SemanticVerifierOutput = z.infer<typeof responseFormat>;
 // ──────────────────────────────────────────────────────────────
 
 export class SemanticVerifier {
-  private model: any;
+  private model: ReturnType<typeof createStructuredModel>;
 
   constructor() {
-    this.model = model.withStructuredOutput(responseFormat, {
+    this.model = createStructuredModel("intentVerifier", responseFormat, {
       name: "semantic_verifier"
     });
   }

--- a/packages/protocol/src/negotiation/insight.generator.ts
+++ b/packages/protocol/src/negotiation/insight.generator.ts
@@ -6,13 +6,12 @@
  * opportunity trends, and interesting signals from recent activity.
  */
 
-import type { ChatOpenAI } from "@langchain/openai";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 
 import { log } from "../shared/observability/log.js";
 import { Timed } from "../shared/observability/performance.js";
 
-import { createModel } from "../shared/agent/model.config.js";
+import { createResilientModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = log.lib.from("NegotiationInsightsGenerator");
@@ -48,10 +47,10 @@ export interface NegotiationDigest {
  * @remarks Lightweight single-call agent; no DB access, no side effects.
  */
 export class NegotiationInsightsGenerator {
-  private model: ChatOpenAI;
+  private model: ReturnType<typeof createResilientModel>;
 
   constructor() {
-    this.model = createModel("negotiationInsights");
+    this.model = createResilientModel("negotiationInsights");
   }
 
   /**

--- a/packages/protocol/src/negotiation/negotiation.agent.ts
+++ b/packages/protocol/src/negotiation/negotiation.agent.ts
@@ -1,4 +1,4 @@
-import { createModel } from "../shared/agent/model.config.js";
+import { createStructuredModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 import { SystemNegotiationTurnSchema, FinalNegotiationTurnSchema, type NegotiationTurn, type UserNegotiationContext, type SeedAssessment } from "./negotiation.state.js";
 import type { NegotiationUserAnswer } from "../shared/interfaces/database.interface.js";
@@ -99,7 +99,7 @@ export class IndexNegotiator {
    */
   async invoke(input: NegotiationAgentInput): Promise<NegotiationTurn> {
     const schema = input.isFinalTurn ? FinalNegotiationTurnSchema : SystemNegotiationTurnSchema;
-    const model = createModel("negotiator").withStructuredOutput(schema, { name: "index_negotiator" });
+    const model = createStructuredModel("negotiator", schema, { name: "index_negotiator" });
 
     const userName = input.ownUser.profile.name ?? "your user";
     const role = input.seedAssessment.valencyRole || "peer";

--- a/packages/protocol/src/negotiation/negotiation.summarizer.ts
+++ b/packages/protocol/src/negotiation/negotiation.summarizer.ts
@@ -9,10 +9,10 @@
  * dropped the connection at ~3 minutes. Per-negotiation summarization caps
  * the question-generator input at a fixed, predictable size.
  */
-import type { ChatOpenAI } from "@langchain/openai";
+
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 
-import { createModel } from "../shared/agent/model.config.js";
+import { createStructuredModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { DiscoveryNegotiationDigestSchema, type DiscoveryNegotiationDigest } from "../shared/schemas/negotiation-digest.schema.js";
@@ -53,11 +53,10 @@ function buildUserPrompt(n: DiscoveryNegotiation): string {
 }
 
 export class NegotiationSummarizer {
-  private model: ReturnType<ChatOpenAI["withStructuredOutput"]>;
+  private model: ReturnType<typeof createStructuredModel>;
 
   constructor() {
-    const llm = createModel("negotiationSummarizer");
-    this.model = llm.withStructuredOutput(DiscoveryNegotiationDigestSchema, {
+    this.model = createStructuredModel("negotiationSummarizer", DiscoveryNegotiationDigestSchema, {
       name: "negotiation_digest",
     });
   }

--- a/packages/protocol/src/network/network.recommender.ts
+++ b/packages/protocol/src/network/network.recommender.ts
@@ -1,10 +1,9 @@
-import type { ChatOpenAI } from "@langchain/openai";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { z } from "zod";
 
 import { log } from "../shared/observability/log.js";
 import { Timed } from "../shared/observability/performance.js";
-import { createModel } from "../shared/agent/model.config.js";
+import { createStructuredModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 // ─── Response schema ───────────────────────────────────────────────────────────
@@ -73,11 +72,10 @@ OUTPUT RULES:
  * be set — tests that import `createNetworkTools` without a live LLM env are unaffected.
  */
 export class NetworkRecommender {
-  private model: ReturnType<ChatOpenAI["withStructuredOutput"]>;
+  private model: ReturnType<typeof createStructuredModel>;
 
   constructor() {
-    const model = createModel("networkRecommender");
-    this.model = model.withStructuredOutput(NetworkRecommenderOutputSchema, {
+    this.model = createStructuredModel("networkRecommender", NetworkRecommenderOutputSchema, {
       name: "network_recommender",
     });
   }

--- a/packages/protocol/src/opportunity/feed/feed.categorizer.ts
+++ b/packages/protocol/src/opportunity/feed/feed.categorizer.ts
@@ -6,7 +6,6 @@
  * generateCardText.
  */
 
-import type { ChatOpenAI } from "@langchain/openai";
 import { HumanMessage, SystemMessage } from '@langchain/core/messages';
 import { z } from 'zod';
 
@@ -14,7 +13,7 @@ import type { HomeSectionProposal } from './feed.state.js';
 import { getIconNamesForPrompt, DEFAULT_HOME_SECTION_ICON } from '../../shared/ui/lucide.icon-catalog.js';
 import { protocolLogger } from '../../shared/observability/protocol.logger.js';
 import { Timed } from "../../shared/observability/performance.js";
-import { createModel } from "../../shared/agent/model.config.js";
+import { createStructuredModel } from "../../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../../shared/agent/model-signal.js";
 
 const logger = protocolLogger('HomeCategorizer');
@@ -127,11 +126,10 @@ function reconcileSections(sections: HomeSectionProposal[], maxIndex: number): H
 }
 
 export class HomeCategorizerAgent {
-  private model: ReturnType<ChatOpenAI['withStructuredOutput']>;
+  private model: ReturnType<typeof createStructuredModel>;
 
   constructor() {
-    const llm = createModel("homeCategorizer");
-    this.model = llm.withStructuredOutput(categorizationSchema, { name: 'home_sections' });
+    this.model = createStructuredModel("homeCategorizer", categorizationSchema, { name: 'home_sections' });
   }
 
   /**

--- a/packages/protocol/src/opportunity/opportunity.evaluator.ts
+++ b/packages/protocol/src/opportunity/opportunity.evaluator.ts
@@ -7,14 +7,13 @@ import type { Lens } from "../shared/hyde/lens.inferrer.js";
 import type { OpportunityStatus } from "../shared/interfaces/database.interface.js";
 import { Timed } from "../shared/observability/performance.js";
 import { stripUuids } from "./opportunity.presentation.js";
-import { createModel } from "../shared/agent/model.config.js";
+import { createStructuredModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 import type { OpportunityEvidence } from '../shared/schemas/network-assignment.schema.js';
 import { renderOpportunityEvidenceForPrompt } from './opportunity.evidence.js';
 
 const logger = protocolLogger("OpportunityEvaluator");
 
-const model = createModel("opportunityEvaluator");
 
 // ──────────────────────────────────────────────────────────────
 // 1. SYSTEM PROMPT
@@ -281,10 +280,10 @@ export class OpportunityEvaluator {
   private entityBundleModel: Runnable;
 
   constructor(options?: OpportunityEvaluatorOptionsConstructor) {
-    this.model = model.withStructuredOutput(responseFormat, {
+    this.model = createStructuredModel("opportunityEvaluator", responseFormat, {
       name: "opportunity_evaluator"
     });
-    this.entityBundleModel = options?.entityBundleModel ?? model.withStructuredOutput(entityBundleResponseFormat, {
+    this.entityBundleModel = options?.entityBundleModel ?? createStructuredModel("opportunityEvaluator", entityBundleResponseFormat, {
       name: "opportunity_evaluator_entity_bundle"
     });
   }

--- a/packages/protocol/src/opportunity/opportunity.presenter.ts
+++ b/packages/protocol/src/opportunity/opportunity.presenter.ts
@@ -14,7 +14,7 @@ import { z } from "zod";
 import { Timed } from "../shared/observability/performance.js";
 
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
-import { createModel } from "../shared/agent/model.config.js";
+import { createStructuredModel } from "../shared/agent/model.config.js";
 import { viewerCentricCardSummary } from "./opportunity.presentation.js";
 import type { Opportunity } from "../shared/interfaces/database.interface.js";
 import type { ChatGraphCompositeDatabase } from "../shared/interfaces/database.interface.js";
@@ -33,7 +33,6 @@ export type PresenterDatabase = Pick<
 const logger = protocolLogger("OpportunityPresenter");
 const LLM_TIMEOUT_MS = 20_000;
 
-const model = createModel("opportunityPresenter");
 
 const GREETING_DESCRIPTION =
   "A 2-4 sentence first-person message the viewer could send to the counterpart, in the viewer's voice, referencing what they have in common. Plain prose only — no markdown, no greeting prefix like 'Hey {Name},'. Example body: 'Saw we're both working on regenerative coordination tooling — your post on consent flows resonated. Would love to compare notes if you have time this week.'";
@@ -285,10 +284,10 @@ export class OpportunityPresenter {
   private homeCardModel: Runnable;
 
   constructor() {
-    this.model = model.withStructuredOutput(responseFormat, {
+    this.model = createStructuredModel("opportunityPresenter", responseFormat, {
       name: "opportunity_presenter",
     });
-    this.homeCardModel = model.withStructuredOutput(homeCardResponseFormat, {
+    this.homeCardModel = createStructuredModel("opportunityPresenter", homeCardResponseFormat, {
       name: "opportunity_presenter_home_card",
     });
   }

--- a/packages/protocol/src/opportunity/question.generator.ts
+++ b/packages/protocol/src/opportunity/question.generator.ts
@@ -13,11 +13,10 @@
  *   5. If empty, return null. Otherwise split into public Question[] + parallel
  *      QuestionStrategy[] (debug-only; strategy is NEVER on the public shape).
  */
-import type { ChatOpenAI } from "@langchain/openai";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 
 import { QuestionGeneratorResponseSchema, type Question, type QuestionGenerationResult, type QuestionStrategy, type QuestionWithStrategy } from "../shared/schemas/question.schema.js";
-import { createModel } from "../shared/agent/model.config.js";
+import { createStructuredModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { Timed } from "../shared/observability/performance.js";
@@ -30,11 +29,10 @@ const MAX_SAME_STRATEGY = 2;
 
 /** @deprecated Use QuestionerAgent instead. Will be removed in a future version. */
 export class QuestionGenerator {
-  private model: ReturnType<ChatOpenAI["withStructuredOutput"]>;
+  private model: ReturnType<typeof createStructuredModel>;
 
   constructor() {
-    const llm = createModel("discoveryQuestionGenerator");
-    this.model = llm.withStructuredOutput(QuestionGeneratorResponseSchema, {
+    this.model = createStructuredModel("discoveryQuestionGenerator", QuestionGeneratorResponseSchema, {
       name: "clarifying_questions",
     });
   }

--- a/packages/protocol/src/premise/premise.analyzer.ts
+++ b/packages/protocol/src/premise/premise.analyzer.ts
@@ -2,7 +2,7 @@ import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { z } from "zod";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { Timed } from "../shared/observability/performance.js";
-import { createModel } from "../shared/agent/model.config.js";
+import { createStructuredModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("PremiseAnalyzer");
@@ -91,11 +91,10 @@ export type PremiseAnalyzerOutput = z.infer<typeof responseFormat>;
  * Classifies a premise using adapted Speech Act Theory and scores felicity conditions.
  */
 export class PremiseAnalyzer {
-  private model: ReturnType<ReturnType<typeof createModel>["withStructuredOutput"]>;
+  private model: ReturnType<typeof createStructuredModel>;
 
   constructor() {
-    const model = createModel("premiseAnalyzer");
-    this.model = model.withStructuredOutput(responseFormat, {
+    this.model = createStructuredModel("premiseAnalyzer", responseFormat, {
       name: "premise_analyzer"
     });
   }

--- a/packages/protocol/src/premise/premise.decomposer.ts
+++ b/packages/protocol/src/premise/premise.decomposer.ts
@@ -2,7 +2,7 @@ import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { z } from "zod";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { Timed } from "../shared/observability/performance.js";
-import { createModel } from "../shared/agent/model.config.js";
+import { createStructuredModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("PremiseDecomposer");
@@ -168,11 +168,10 @@ export type DecomposedPremise = z.infer<typeof premiseItemSchema>;
  * individual atomic premises suitable for the premise graph.
  */
 export class PremiseDecomposer {
-  private model: ReturnType<ReturnType<typeof createModel>["withStructuredOutput"]>;
+  private model: ReturnType<typeof createStructuredModel>;
 
   constructor() {
-    const model = createModel("premiseDecomposer");
-    this.model = model.withStructuredOutput(responseFormat, {
+    this.model = createStructuredModel("premiseDecomposer", responseFormat, {
       name: "premise_decomposer",
     });
   }

--- a/packages/protocol/src/premise/premise.indexer.ts
+++ b/packages/protocol/src/premise/premise.indexer.ts
@@ -2,7 +2,7 @@ import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { z } from "zod";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { Timed } from "../shared/observability/performance.js";
-import { createModel } from "../shared/agent/model.config.js";
+import { createStructuredModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("PremiseIndexer");
@@ -43,11 +43,10 @@ export type PremiseIndexerOutput = z.infer<typeof responseFormat>;
  * Scores a premise's relevancy to a network based on the index and member prompts.
  */
 export class PremiseIndexer {
-  private model: ReturnType<ReturnType<typeof createModel>["withStructuredOutput"]>;
+  private model: ReturnType<typeof createStructuredModel>;
 
   constructor() {
-    const model = createModel("premiseIndexer");
-    this.model = model.withStructuredOutput(responseFormat, {
+    this.model = createStructuredModel("premiseIndexer", responseFormat, {
       name: "premise_indexer"
     });
   }

--- a/packages/protocol/src/questioner/questioner.agent.ts
+++ b/packages/protocol/src/questioner/questioner.agent.ts
@@ -7,11 +7,10 @@
  * The LLM model is bound once at construction; the preset (system prompt +
  * builder) is selected per invocation based on `input.mode`.
  */
-import type { ChatOpenAI } from "@langchain/openai";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 
 import { QuestionGeneratorResponseSchema, type Question, type QuestionGenerationResult, type QuestionStrategy, type QuestionWithStrategy } from "../shared/schemas/question.schema.js";
-import { createModel } from "../shared/agent/model.config.js";
+import { createStructuredModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { Timed } from "../shared/observability/performance.js";
@@ -25,7 +24,7 @@ const MAX_SAME_STRATEGY = 2;
 
 export interface QuestionerAgentConfig {
   /** Optional model config override. */
-  modelConfig?: Parameters<typeof createModel>[1];
+  modelConfig?: Parameters<typeof createStructuredModel>[3];
 }
 
 /**
@@ -34,13 +33,12 @@ export interface QuestionerAgentConfig {
  * guardrails (dedup + strategy diversity).
  */
 export class QuestionerAgent {
-  private model: ReturnType<ChatOpenAI["withStructuredOutput"]>;
+  private model: ReturnType<typeof createStructuredModel>;
 
   constructor(config?: QuestionerAgentConfig) {
-    const llm = createModel("questioner", config?.modelConfig);
-    this.model = llm.withStructuredOutput(QuestionGeneratorResponseSchema, {
+    this.model = createStructuredModel("questioner", QuestionGeneratorResponseSchema, {
       name: "clarifying_questions",
-    });
+    }, config?.modelConfig);
   }
 
   /**

--- a/packages/protocol/src/shared/agent/model.config.ts
+++ b/packages/protocol/src/shared/agent/model.config.ts
@@ -1,4 +1,8 @@
 import { ChatOpenAI } from "@langchain/openai";
+import type { AIMessageChunk } from "@langchain/core/messages";
+import type { BaseLanguageModelInput, StructuredOutputMethodOptions } from "@langchain/core/language_models/base";
+import type { Runnable } from "@langchain/core/runnables";
+import type { InteropZodType } from "@langchain/core/utils/types";
 
 /** Settings that can be configured per agent. */
 export interface ModelSettings {
@@ -66,12 +70,15 @@ function getModelConfig(config?: ModelConfig) {
   } as const;
 }
 
+/** Key identifying one of the per-agent model configurations. */
+export type ModelAgent = keyof ReturnType<typeof getModelConfig>;
+
 /**
  * Returns the model name string for the given agent key.
  * @param agent - Key from MODEL_CONFIG identifying which agent's settings to use.
  * @param config - Optional runtime config overrides.
  */
-export function getModelName(agent: keyof ReturnType<typeof getModelConfig>, config?: ModelConfig): string {
+export function getModelName(agent: ModelAgent, config?: ModelConfig): string {
   return getModelConfig(config)[agent].model;
 }
 
@@ -80,12 +87,17 @@ export function getModelName(agent: keyof ReturnType<typeof getModelConfig>, con
  * @param agent - Key identifying which agent's model settings to use.
  * @param config - Optional runtime config overrides.
  */
-export function createModel(agent: keyof ReturnType<typeof getModelConfig>, config?: ModelConfig): ChatOpenAI {
+export function createModel(agent: ModelAgent, config?: ModelConfig): ChatOpenAI {
+  const cfg = getModelConfig(config)[agent] as ModelSettings;
+  return instantiateModel(agent, cfg, config);
+}
+
+/** Instantiates a ChatOpenAI from explicit settings (shared by primary + fallback creation). */
+function instantiateModel(agent: string, cfg: ModelSettings, config?: ModelConfig): ChatOpenAI {
   const apiKey = config?.apiKey ?? process.env.OPENROUTER_API_KEY;
   if (!apiKey?.trim()) {
     throw new Error(`createModel(${agent}): OPENROUTER_API_KEY is required. Pass via the config argument, ToolContext.modelConfig.apiKey, or set the OPENROUTER_API_KEY environment variable.`);
   }
-  const cfg = getModelConfig(config)[agent] as ModelSettings;
   // Hard upper bound on a single LLM call. Without this, langchain's HTTP
   // client waits until the upstream cuts the socket (~3 minutes via
   // OpenRouter), blocking the entire chat response. 60 s is generous enough
@@ -111,4 +123,110 @@ export function createModel(agent: keyof ReturnType<typeof getModelConfig>, conf
     maxRetries,
     ...(cfg.reasoning && { modelKwargs: { reasoning: cfg.reasoning } }),
   });
+}
+
+/**
+ * Default cross-vendor fallback model. The per-agent primaries run on Google's
+ * provider lane (gemini-2.5-flash); a same-key OpenRouter fallback on a
+ * different vendor survives Google-side outages.
+ * Override via OPENROUTER_FALLBACK_MODEL; set it to "none" (or "off") to disable.
+ */
+const DEFAULT_FALLBACK_MODEL = "openai/gpt-4o-mini";
+
+function getFallbackModelName(): string | undefined {
+  const raw = process.env.OPENROUTER_FALLBACK_MODEL;
+  if (raw === undefined) return DEFAULT_FALLBACK_MODEL;
+  const value = raw.trim();
+  if (!value || value.toLowerCase() === "none" || value.toLowerCase() === "off") return undefined;
+  return value;
+}
+
+/**
+ * Creates the fallback ChatOpenAI for an agent, or undefined when fallbacks
+ * are disabled or the fallback would be the same model as the primary.
+ * Reuses the agent's sampling settings but drops `reasoning` kwargs, which are
+ * primary-model specific.
+ */
+export function createFallbackModel(agent: ModelAgent, config?: ModelConfig): ChatOpenAI | undefined {
+  const fallbackName = getFallbackModelName();
+  if (!fallbackName) return undefined;
+  const cfg = getModelConfig(config)[agent] as ModelSettings;
+  if (cfg.model === fallbackName) return undefined;
+  return instantiateModel(agent, { ...cfg, model: fallbackName, reasoning: undefined }, config);
+}
+
+/**
+ * Number of attempts (1 = no retry) for runnable-level retries added by
+ * `createStructuredModel` / `createResilientModel`. These wrap ChatOpenAI's
+ * own HTTP-level `maxRetries` and additionally cover structured-output
+ * parse/validation failures. Configurable via OPENROUTER_RUNNABLE_MAX_ATTEMPTS.
+ */
+function getRunnableMaxAttempts(): number {
+  const env = Number.parseInt(process.env.OPENROUTER_RUNNABLE_MAX_ATTEMPTS ?? "", 10);
+  return Number.isFinite(env) && env >= 1 ? env : 2;
+}
+
+/**
+ * Stops runnable-level retries when the failure was a caller abort —
+ * retrying a cancelled request only delays cancellation. Thrown errors from
+ * `onFailedAttempt` abort the retry loop.
+ */
+function abortAwareFailedAttemptHandler(error: Error): void {
+  if (error?.name === "AbortError" || error?.name === "APIUserAbortError") throw error;
+}
+
+function withResilience<RunOutput>(
+  primary: Runnable<BaseLanguageModelInput, RunOutput>,
+  fallback: Runnable<BaseLanguageModelInput, RunOutput> | undefined,
+): Runnable<BaseLanguageModelInput, RunOutput> {
+  const attempts = getRunnableMaxAttempts();
+  let runnable: Runnable<BaseLanguageModelInput, RunOutput> = attempts > 1
+    ? primary.withRetry({ stopAfterAttempt: attempts, onFailedAttempt: abortAwareFailedAttemptHandler })
+    : primary;
+  if (fallback) runnable = runnable.withFallbacks([fallback]);
+  return runnable;
+}
+
+/**
+ * Creates a structured-output model with runnable-level retry and cross-model
+ * fallback. Equivalent to `createModel(agent).withStructuredOutput(schema, options)`
+ * plus `.withRetry(...)` and `.withFallbacks([...])`.
+ *
+ * Retry covers transient provider errors *and* schema parse/validation
+ * failures; the fallback model (see OPENROUTER_FALLBACK_MODEL) is bound to the
+ * same schema so a provider outage degrades to a different vendor instead of
+ * failing the call. Abort signals pass through: aborts are never retried and
+ * skip the fallback.
+ *
+ * @param agent - Key identifying which agent's model settings to use.
+ * @param outputSchema - Zod schema or JSON-schema response format.
+ * @param options - Same options as `withStructuredOutput` (e.g. `{ name }`).
+ * @param config - Optional runtime model config overrides.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- mirrors ChatOpenAI.withStructuredOutput's constraint; `unknown` rejects zod-inferred interface types
+export function createStructuredModel<RunOutput extends Record<string, any> = Record<string, any>>(
+  agent: ModelAgent,
+  outputSchema: InteropZodType<RunOutput> | Record<string, unknown>,
+  options?: StructuredOutputMethodOptions<false>,
+  config?: ModelConfig,
+): Runnable<BaseLanguageModelInput, RunOutput> {
+  const primary = createModel(agent, config).withStructuredOutput<RunOutput>(outputSchema, options);
+  const fallbackModel = createFallbackModel(agent, config);
+  const fallback = fallbackModel?.withStructuredOutput<RunOutput>(outputSchema, options);
+  return withResilience(primary, fallback);
+}
+
+/**
+ * Creates a plain-completion model with runnable-level retry and cross-model
+ * fallback, for call sites that `invoke()` the model directly (no
+ * `withStructuredOutput`/`bindTools`/`stream` chaining).
+ *
+ * @param agent - Key identifying which agent's model settings to use.
+ * @param config - Optional runtime model config overrides.
+ */
+export function createResilientModel(
+  agent: ModelAgent,
+  config?: ModelConfig,
+): Runnable<BaseLanguageModelInput, AIMessageChunk> {
+  return withResilience(createModel(agent, config), createFallbackModel(agent, config));
 }

--- a/packages/protocol/src/shared/agent/tests/model.config.spec.ts
+++ b/packages/protocol/src/shared/agent/tests/model.config.spec.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect } from "bun:test";
-import { getModelName } from "../model.config.js";
+// Stub API key so createModel()/createStructuredModel() don't throw in tests
+process.env.OPENROUTER_API_KEY ??= "test-key-unused";
+
+import { describe, it, expect, afterEach } from "bun:test";
+import { RunnableRetry, RunnableWithFallbacks } from "@langchain/core/runnables";
+import { z } from "zod";
+import { createFallbackModel, createResilientModel, createStructuredModel, getModelName } from "../model.config.js";
 
 describe("getModelName", () => {
   it("returns the hardcoded default when CHAT_MODEL env var is unset", () => {
@@ -31,5 +36,88 @@ describe("getModelName", () => {
   it("returns the hardcoded model for non-chat agents regardless of config", () => {
     const model = getModelName("opportunityEvaluator", { chatModel: "test/override-model" });
     expect(model).toBe("google/gemini-2.5-flash");
+  });
+});
+
+describe("createFallbackModel", () => {
+  const savedFallback = process.env.OPENROUTER_FALLBACK_MODEL;
+
+  afterEach(() => {
+    if (savedFallback !== undefined) process.env.OPENROUTER_FALLBACK_MODEL = savedFallback;
+    else delete process.env.OPENROUTER_FALLBACK_MODEL;
+  });
+
+  it("defaults to openai/gpt-4o-mini when env is unset", () => {
+    delete process.env.OPENROUTER_FALLBACK_MODEL;
+    const fallback = createFallbackModel("opportunityEvaluator");
+    expect(fallback?.model).toBe("openai/gpt-4o-mini");
+  });
+
+  it("respects OPENROUTER_FALLBACK_MODEL override", () => {
+    process.env.OPENROUTER_FALLBACK_MODEL = "anthropic/claude-3-5-haiku";
+    const fallback = createFallbackModel("opportunityEvaluator");
+    expect(fallback?.model).toBe("anthropic/claude-3-5-haiku");
+  });
+
+  it.each(["none", "off", "  ", "NONE"])("returns undefined when env is %p", (value) => {
+    process.env.OPENROUTER_FALLBACK_MODEL = value as string;
+    expect(createFallbackModel("opportunityEvaluator")).toBeUndefined();
+  });
+
+  it("returns undefined when the fallback equals the primary model", () => {
+    process.env.OPENROUTER_FALLBACK_MODEL = getModelName("opportunityEvaluator");
+    expect(createFallbackModel("opportunityEvaluator")).toBeUndefined();
+  });
+
+  it("inherits the agent's sampling settings but never reasoning kwargs", () => {
+    delete process.env.OPENROUTER_FALLBACK_MODEL;
+    const fallback = createFallbackModel("suggestionGenerator");
+    expect(fallback?.temperature).toBe(0.4);
+    expect(fallback?.maxTokens).toBe(512);
+    const chatFallback = createFallbackModel("chat");
+    expect(chatFallback?.modelKwargs?.reasoning).toBeUndefined();
+  });
+});
+
+describe("resilient model wiring", () => {
+  const savedFallback = process.env.OPENROUTER_FALLBACK_MODEL;
+  const savedAttempts = process.env.OPENROUTER_RUNNABLE_MAX_ATTEMPTS;
+
+  afterEach(() => {
+    if (savedFallback !== undefined) process.env.OPENROUTER_FALLBACK_MODEL = savedFallback;
+    else delete process.env.OPENROUTER_FALLBACK_MODEL;
+    if (savedAttempts !== undefined) process.env.OPENROUTER_RUNNABLE_MAX_ATTEMPTS = savedAttempts;
+    else delete process.env.OPENROUTER_RUNNABLE_MAX_ATTEMPTS;
+  });
+
+  const schema = z.object({ answer: z.string() });
+
+  it("wraps structured models in retry + fallbacks by default", () => {
+    delete process.env.OPENROUTER_FALLBACK_MODEL;
+    delete process.env.OPENROUTER_RUNNABLE_MAX_ATTEMPTS;
+    const model = createStructuredModel("opportunityEvaluator", schema, { name: "test" });
+    expect(model).toBeInstanceOf(RunnableWithFallbacks);
+  });
+
+  it("skips the fallback wrapper when fallbacks are disabled", () => {
+    process.env.OPENROUTER_FALLBACK_MODEL = "none";
+    delete process.env.OPENROUTER_RUNNABLE_MAX_ATTEMPTS;
+    const model = createStructuredModel("opportunityEvaluator", schema, { name: "test" });
+    expect(model).toBeInstanceOf(RunnableRetry);
+  });
+
+  it("skips the retry wrapper when max attempts is 1", () => {
+    process.env.OPENROUTER_FALLBACK_MODEL = "none";
+    process.env.OPENROUTER_RUNNABLE_MAX_ATTEMPTS = "1";
+    const model = createStructuredModel("opportunityEvaluator", schema, { name: "test" });
+    expect(model).not.toBeInstanceOf(RunnableRetry);
+    expect(model).not.toBeInstanceOf(RunnableWithFallbacks);
+  });
+
+  it("wraps plain-completion models in retry + fallbacks by default", () => {
+    delete process.env.OPENROUTER_FALLBACK_MODEL;
+    delete process.env.OPENROUTER_RUNNABLE_MAX_ATTEMPTS;
+    const model = createResilientModel("chatTitleGenerator");
+    expect(model).toBeInstanceOf(RunnableWithFallbacks);
   });
 });

--- a/packages/protocol/src/shared/hyde/hyde.generator.ts
+++ b/packages/protocol/src/shared/hyde/hyde.generator.ts
@@ -8,7 +8,7 @@ import { HYDE_CORPUS_PROMPTS } from './hyde.strategies.js';
 import type { HydeTargetCorpus } from './lens.inferrer.js';
 import { Timed } from "../observability/performance.js";
 import { protocolLogger } from '../observability/protocol.logger.js';
-import { createModel } from "../agent/model.config.js";
+import { createStructuredModel } from "../agent/model.config.js";
 import { invokeWithAbortSignal } from "../agent/model-signal.js";
 
 const logger = protocolLogger("HydeGenerator");
@@ -29,8 +29,6 @@ const responseFormat = z.object({
     .describe('The hypothetical document text in the target voice, suitable for embedding and retrieval'),
 });
 
-const model = createModel("hydeGenerator");
-
 export interface HydeGeneratorOutput {
   text: string;
 }
@@ -49,7 +47,7 @@ export interface HydeGenerateInput {
  * Uses free-text lens labels (from LensInferrer) instead of enum strategies.
  */
 export class HydeGenerator {
-  private model = model.withStructuredOutput(responseFormat, {
+  private model = createStructuredModel("hydeGenerator", responseFormat, {
     name: "hyde_generator",
   });
 

--- a/packages/protocol/src/shared/hyde/lens.inferrer.ts
+++ b/packages/protocol/src/shared/hyde/lens.inferrer.ts
@@ -7,7 +7,7 @@ import { HumanMessage, SystemMessage } from '@langchain/core/messages';
 import { z } from 'zod';
 import { Timed } from "../observability/performance.js";
 import { protocolLogger } from '../observability/protocol.logger.js';
-import { createModel } from "../agent/model.config.js";
+import { createStructuredModel } from "../agent/model.config.js";
 import { invokeWithAbortSignal } from "../agent/model-signal.js";
 
 export type HydeTargetCorpus = 'profiles' | 'intents' | 'premises';
@@ -59,8 +59,6 @@ const responseFormat = z.object({
   })).min(1).max(5).describe('Inferred search lenses'),
 });
 
-const model = createModel("lensInferrer");
-
 const logger = protocolLogger("LensInferrer");
 
 /**
@@ -69,7 +67,7 @@ const logger = protocolLogger("LensInferrer");
  * (profiles or intents) for downstream HyDE document generation.
  */
 export class LensInferrer {
-  private model = model.withStructuredOutput(responseFormat, {
+  private model = createStructuredModel("lensInferrer", responseFormat, {
     name: "lens_inferrer",
   });
 


### PR DESCRIPTION
## Summary

Implements [IND-386](https://linear.app/indexnetwork/issue/IND-386): zero retry/fallback usage → every protocol LLM call now gets runnable-level retry and cross-vendor failover.

### Design note (deviation from the issue sketch)

`.withRetry()`/`.withFallbacks()` return a generic `Runnable`, so they **cannot** be applied inside `createModel()` — ~25 call sites chain `.withStructuredOutput()`/`.bindTools()`/`.stream()` on the returned `ChatOpenAI`, and those methods don't exist on the wrapped runnable. Resilience is therefore applied **after** structured-output binding via two new factories in `model.config.ts`:

- **`createStructuredModel(agent, schema, opts?, config?)`** — `withStructuredOutput → withRetry → withFallbacks`. The fallback model is bound to the **same schema**, so failover preserves structured output. Runnable-level retry also covers schema parse/validation failures, which HTTP-level `maxRetries` never could.
- **`createResilientModel(agent, config?)`** — same wrapping for plain-completion call sites (insights, context generator, title generator, interrupt classifier).

### Behavior

- **Fallback model**: `OPENROUTER_FALLBACK_MODEL`, default `openai/gpt-4o-mini` (different vendor lane than the `gemini-2.5-flash` primaries → survives Google-side outages). `none`/`off`/empty disables. Fallback inherits per-agent sampling settings but drops `reasoning` kwargs; skipped entirely when it would equal the primary.
- **Retry**: `OPENROUTER_RUNNABLE_MAX_ATTEMPTS` (default 2, `1` disables). Abort-aware: user aborts are never retried, and `RunnableWithFallbacks` checks `signal.throwIfAborted()` before each candidate — `invokeWithAbortSignal` semantics are preserved end-to-end.
- **Excluded**: `chat.agent.ts` (bindTools/stream loop) intentionally keeps built-in `maxRetries` — fallbacks over a token stream is a separate concern.

### Migration

All 26 `createModel()` call sites outside the chat agent migrated mechanically. Several stale patterns cleaned up along the way (`private model: any` → typed, unused module-level model instances removed).

## Testing

- 12 new unit tests in `model.config.spec.ts` (fallback resolution, env gating, retry/fallback wrapper wiring) — all pass
- `tsc` clean for `packages/protocol` and `services/api`; `eslint` clean
- Full isolated suite (`bun run test:isolated`): 1524 pass; the 21 failures are **pre-existing on dev** (verified per-file against the root checkout: identical snapshot drift in `chat.prompt.modules`, LLM-flaky prompt evals, connect-link wiring tests)

Closes IND-386.