### PR TITLE
feat(api): checkpoint retention cron + PostgresSaver hardening (IND-387)

### DIFF
--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -259,3 +259,17 @@ QUESTIONER_ENABLED=false
 # MCP_TOOL_TIMEOUT_ASYNC_CANDIDATE_MS=50000
 # MCP_TOOL_TIMEOUT_INTERACTIVE_MS=300000
 # MCP_TOOL_MAX_OUTPUT_BYTES=1000000
+
+########################################
+# 16. LangGraph checkpoint retention
+########################################
+
+# Retention window for PostgresSaver checkpoint threads (whole days).
+# Chat runs checkpoint under a per-run thread_id and are never resumed after
+# the run ends, so aged-out threads are pruned by an hourly cron.
+# Set to 0/off/none to disable pruning entirely. Default: 7.
+# CHECKPOINT_RETENTION_DAYS=7
+
+# Max stale threads deleted per batch (clamped to [1, 1000]; up to 10 batches
+# per hourly run). Default: 100.
+# CHECKPOINT_PRUNE_BATCH_SIZE=100

--- a/services/api/src/adapters/checkpointer.adapter.ts
+++ b/services/api/src/adapters/checkpointer.adapter.ts
@@ -16,7 +16,9 @@
  */
 
 import { PostgresSaver } from "@langchain/langgraph-checkpoint-postgres";
+import { sql } from "drizzle-orm";
 
+import db from "../lib/drizzle/drizzle";
 import { log } from "../lib/log";
 
 const logger = log.lib.from("checkpointer.adapter");
@@ -118,4 +120,82 @@ export function resetCheckpointer(): void {
   logger.verbose("[resetCheckpointer] Resetting checkpointer instance");
   checkpointerInstance = null;
   setupPromise = null;
+}
+
+/** Row counts removed by a single {@link pruneStaleCheckpointThreads} batch. */
+export interface CheckpointPruneResult {
+  /** Distinct thread_ids removed in this batch. */
+  threads: number;
+  /** Rows deleted from `checkpoints`. */
+  checkpoints: number;
+  /** Rows deleted from `checkpoint_blobs`. */
+  blobs: number;
+  /** Rows deleted from `checkpoint_writes`. */
+  writes: number;
+}
+
+const EMPTY_PRUNE_RESULT: CheckpointPruneResult = Object.freeze({
+  threads: 0,
+  checkpoints: 0,
+  blobs: 0,
+  writes: 0,
+});
+
+/** postgres.js result lists carry the affected-row count on `.count`. */
+function affectedRows(result: unknown): number {
+  const count = (result as { count?: unknown })?.count;
+  return typeof count === "number" ? count : 0;
+}
+
+/**
+ * Delete one batch of stale LangGraph checkpoint threads.
+ *
+ * A thread is stale when its NEWEST checkpoint is older than `retentionDays`.
+ * Chat threads use a per-run composite thread_id (`sessionId:runId`), so a
+ * thread whose latest checkpoint has aged out can never be resumed again —
+ * conversation continuity is rebuilt from `chat_messages`, not checkpoints.
+ *
+ * Deletes rows from `checkpoints`, `checkpoint_blobs`, and `checkpoint_writes`
+ * inside a single transaction. Call repeatedly (until `threads < batchSize`)
+ * to drain a large backlog incrementally.
+ *
+ * @param opts.retentionDays - Age threshold in whole days (must be >= 1)
+ * @param opts.batchSize - Max threads to delete per call (must be >= 1)
+ * @returns Row counts removed in this batch
+ */
+export async function pruneStaleCheckpointThreads(opts: {
+  retentionDays: number;
+  batchSize: number;
+}): Promise<CheckpointPruneResult> {
+  const retentionDays = Math.max(1, Math.floor(opts.retentionDays));
+  const batchSize = Math.max(1, Math.floor(opts.batchSize));
+
+  const stale = await db.execute<{ thread_id: string }>(sql`
+    SELECT thread_id
+    FROM checkpoints
+    GROUP BY thread_id
+    HAVING max((checkpoint->>'ts')::timestamptz) < now() - make_interval(days => ${retentionDays})
+    LIMIT ${batchSize}
+  `);
+  const threadIds = Array.from(stale, (row) => row.thread_id);
+  if (threadIds.length === 0) {
+    return EMPTY_PRUNE_RESULT;
+  }
+
+  // drizzle expands a JS array in a template into a row constructor `($1, $2)`,
+  // not a PG array — build an explicit IN list instead.
+  const idList = sql.join(threadIds.map((id) => sql`${id}`), sql`, `);
+
+  return db.transaction(async (tx) => {
+    const writes = affectedRows(
+      await tx.execute(sql`DELETE FROM checkpoint_writes WHERE thread_id IN (${idList})`),
+    );
+    const blobs = affectedRows(
+      await tx.execute(sql`DELETE FROM checkpoint_blobs WHERE thread_id IN (${idList})`),
+    );
+    const checkpoints = affectedRows(
+      await tx.execute(sql`DELETE FROM checkpoints WHERE thread_id IN (${idList})`),
+    );
+    return { threads: threadIds.length, checkpoints, blobs, writes };
+  });
 }

--- a/services/api/src/controllers/chat.controller.ts
+++ b/services/api/src/controllers/chat.controller.ts
@@ -347,8 +347,6 @@ export class ChatController {
           let decisionQuestions: import("@indexnetwork/protocol").Question[] | undefined;
 
           // Use context-aware streaming to load previous messages
-          // checkpointer is PostgresSaver from the local install; the package expects
-          // BaseCheckpointSaver from the root install — structurally identical at runtime.
 
           for await (const event of factory.streamChatEventsWithContext(
             {
@@ -360,8 +358,7 @@ export class ChatController {
               prefillMessages: body.prefillMessages,
               runId,
             },
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            checkpointer as any,
+            checkpointer,
             streamAbortController.signal,
           )) {
             if (streamInterruptedBySteer) break;

--- a/services/api/src/main.ts
+++ b/services/api/src/main.ts
@@ -54,6 +54,8 @@ import { discoveryRunQueue } from './queues/opportunity/discovery-run.queue';
 import { enrichmentRunQueue } from './queues/enrichment-run.queue';
 import { negotiationRunExistingQueue } from './queues/negotiations/run-existing.queue';
 import { opportunityExpirationCron } from './queues/opportunity/expiration.queue';
+import { checkpointRetentionCron } from './queues/checkpoint/retention.queue';
+import { getCheckpointer } from './adapters/checkpointer.adapter';
 import { notificationQueue } from './queues/notification.queue';
 import { hydeQueue } from './queues/hyde.queue';
 import { emailQueue } from './queues/email.queue';
@@ -271,6 +273,7 @@ discoveryRunQueue.startWorker();
 enrichmentRunQueue.startWorker();
 negotiationRunExistingQueue.startWorker();
 opportunityExpirationCron.start();
+checkpointRetentionCron.start();
 notificationQueue.startWorker();
 enrichmentQueue.startWorker();
 hydeQueue.startCrons();
@@ -304,6 +307,15 @@ const GLOBAL_PREFIX = '/api';
 const IS_PRODUCTION = process.env.NODE_ENV === 'production';
 
 const logger = log.server.from("main");
+
+// Warm up the PostgresSaver checkpointer at boot so the first chat request
+// doesn't pay the table-setup round trip and misconfiguration surfaces at
+// startup instead of mid-stream. Non-fatal: chat degrades to no checkpointer.
+getCheckpointer().catch((err) => {
+  logger.warn('Checkpointer warm-up failed; chat will run without persistence', {
+    error: err instanceof Error ? err.message : String(err),
+  });
+});
 
 // ── Telegram bot startup ────────────────────────────────────────────────────
 if (process.env.TELEGRAM_BOT_TOKEN && process.env.TELEGRAM_WEBHOOK_SECRET) {

--- a/services/api/src/queues/checkpoint/retention.queue.ts
+++ b/services/api/src/queues/checkpoint/retention.queue.ts
@@ -1,0 +1,137 @@
+// services/api/src/queues/checkpoint/retention.queue.ts
+//
+// Hourly retention sweep for LangGraph PostgresSaver checkpoint tables.
+//
+// Every chat run checkpoints under a fresh composite thread_id
+// (`sessionId:runId`), and conversation continuity is rebuilt from
+// `chat_messages` — so once a run finishes, its checkpoints are unreachable
+// write-only data. Without this sweep the checkpoint tables grow without
+// bound (they reached ~40% of the prod database before this cron existed).
+import cron from 'node-cron';
+import { log } from '../../lib/log';
+import { pruneStaleCheckpointThreads, type CheckpointPruneResult } from '../../adapters/checkpointer.adapter';
+
+/** The persistence surface the cron needs: one stale-thread delete batch. */
+export interface CheckpointRetentionDeps {
+  pruneStaleCheckpointThreads: (opts: {
+    retentionDays: number;
+    batchSize: number;
+  }) => Promise<CheckpointPruneResult>;
+}
+
+/** Aggregate of one cron run (possibly multiple delete batches). */
+export interface CheckpointRetentionRunResult extends CheckpointPruneResult {
+  /** Number of delete batches executed in this run. */
+  batches: number;
+}
+
+const DEFAULT_RETENTION_DAYS = 7;
+const DEFAULT_BATCH_SIZE = 100;
+const MAX_BATCH_SIZE = 1000;
+/** Cap batches per run so a huge backlog drains over a few runs instead of one long transaction storm. */
+const MAX_BATCHES_PER_RUN = 10;
+/** Hourly, offset from the top of the hour to avoid stacking with other crons. */
+const CRON_EXPRESSION = '43 * * * *';
+
+const DISABLED_VALUES = new Set(['0', 'off', 'none', 'never', 'disabled', 'false']);
+
+/**
+ * Resolve the retention window from CHECKPOINT_RETENTION_DAYS.
+ *
+ * @returns Whole days (>= 1), or null when retention is disabled
+ *   (`0`, `off`, `none`, `never`, `disabled`, `false`, or a non-positive number).
+ *   Unset or unparseable values fall back to the 7-day default.
+ */
+export function resolveRetentionDays(
+  raw: string | undefined = process.env.CHECKPOINT_RETENTION_DAYS,
+): number | null {
+  const trimmed = raw?.trim().toLowerCase();
+  if (!trimmed) return DEFAULT_RETENTION_DAYS;
+  if (DISABLED_VALUES.has(trimmed)) return null;
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed)) return DEFAULT_RETENTION_DAYS;
+  if (parsed <= 0) return null;
+  return Math.max(1, Math.floor(parsed));
+}
+
+/**
+ * Resolve the per-batch thread limit from CHECKPOINT_PRUNE_BATCH_SIZE.
+ * Unset or invalid values fall back to 100; the value is clamped to [1, 1000].
+ */
+export function resolveBatchSize(
+  raw: string | undefined = process.env.CHECKPOINT_PRUNE_BATCH_SIZE,
+): number {
+  const parsed = Number(raw?.trim());
+  if (!Number.isFinite(parsed) || parsed < 1) return DEFAULT_BATCH_SIZE;
+  return Math.min(MAX_BATCH_SIZE, Math.floor(parsed));
+}
+
+export class CheckpointRetentionCron {
+  private readonly logger = log.queue.from('CheckpointRetention');
+  private task: ReturnType<typeof cron.schedule> | null = null;
+  private readonly deps: CheckpointRetentionDeps;
+
+  constructor(deps?: CheckpointRetentionDeps) {
+    this.deps = deps ?? { pruneStaleCheckpointThreads };
+  }
+
+  /**
+   * Run one retention sweep: delete stale checkpoint threads in batches until
+   * a batch comes back short (backlog drained) or MAX_BATCHES_PER_RUN is hit.
+   * No-op (all zeros) when retention is disabled via env.
+   */
+  async prune(): Promise<CheckpointRetentionRunResult> {
+    const totals: CheckpointRetentionRunResult = {
+      threads: 0,
+      checkpoints: 0,
+      blobs: 0,
+      writes: 0,
+      batches: 0,
+    };
+    const retentionDays = resolveRetentionDays();
+    if (retentionDays === null) return totals;
+    const batchSize = resolveBatchSize();
+
+    for (let i = 0; i < MAX_BATCHES_PER_RUN; i++) {
+      const batch = await this.deps.pruneStaleCheckpointThreads({ retentionDays, batchSize });
+      totals.batches += 1;
+      totals.threads += batch.threads;
+      totals.checkpoints += batch.checkpoints;
+      totals.blobs += batch.blobs;
+      totals.writes += batch.writes;
+      if (batch.threads < batchSize) break;
+    }
+    return totals;
+  }
+
+  start(): void {
+    if (this.task) return;
+    const retentionDays = resolveRetentionDays();
+    if (retentionDays === null) {
+      this.logger.info('Checkpoint retention disabled (CHECKPOINT_RETENTION_DAYS)');
+      return;
+    }
+    this.task = cron.schedule(CRON_EXPRESSION, () => {
+      this.prune()
+        .then((totals) => {
+          if (totals.threads > 0) {
+            this.logger.info(
+              `Pruned ${totals.threads} checkpoint thread${totals.threads === 1 ? '' : 's'}`,
+              { ...totals },
+            );
+          }
+        })
+        .catch((err) => this.logger.error('Checkpoint retention cron failed', { error: err }));
+    });
+    this.logger.info('Checkpoint retention cron scheduled (hourly)', { retentionDays });
+  }
+
+  stop(): void {
+    if (this.task) {
+      this.task.stop();
+      this.task = null;
+    }
+  }
+}
+
+export const checkpointRetentionCron = new CheckpointRetentionCron();

--- a/services/api/src/queues/tests/checkpoint-retention.queue.spec.ts
+++ b/services/api/src/queues/tests/checkpoint-retention.queue.spec.ts
@@ -1,0 +1,257 @@
+/**
+ * Unit tests for CheckpointRetentionCron. node-cron is mocked and the delete
+ * batch is injected via deps, so no DB/Redis/drizzle is touched.
+ */
+import { config } from 'dotenv';
+config({ path: '.env.test', override: true });
+
+import { describe, expect, it, mock, beforeEach, afterEach, afterAll } from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// node-cron mock — captures scheduled callbacks so we can trigger them manually
+// ---------------------------------------------------------------------------
+const cronCallbacks: Array<() => void | Promise<void>> = [];
+const mockCronStop = mock(() => {});
+const mockCronSchedule = mock((_expr: string, fn: () => void | Promise<void>) => {
+  cronCallbacks.push(fn);
+  return { start: () => {}, stop: mockCronStop };
+});
+
+mock.module('node-cron', () => ({
+  default: {
+    schedule: mockCronSchedule,
+  },
+}));
+
+afterAll(() => {
+  mock.restore();
+});
+
+import { CheckpointRetentionCron, resolveRetentionDays, resolveBatchSize } from '../checkpoint/retention.queue';
+import type { CheckpointRetentionDeps } from '../checkpoint/retention.queue';
+import type { CheckpointPruneResult } from '../../adapters/checkpointer.adapter';
+
+// ---------------------------------------------------------------------------
+// helpers — an injectable stub for the delete batch
+// ---------------------------------------------------------------------------
+const emptyBatch: CheckpointPruneResult = { threads: 0, checkpoints: 0, blobs: 0, writes: 0 };
+const mockPrune = mock(async (_opts: { retentionDays: number; batchSize: number }): Promise<CheckpointPruneResult> => emptyBatch);
+const deps: CheckpointRetentionDeps = { pruneStaleCheckpointThreads: mockPrune };
+
+const ENV_KEYS = ['CHECKPOINT_RETENTION_DAYS', 'CHECKPOINT_PRUNE_BATCH_SIZE'] as const;
+const savedEnv: Record<string, string | undefined> = {};
+
+// ---------------------------------------------------------------------------
+// tests
+// ---------------------------------------------------------------------------
+describe('checkpoint retention config', () => {
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+  });
+
+  describe('resolveRetentionDays', () => {
+    it('defaults to 7 days when unset or blank', () => {
+      expect(resolveRetentionDays(undefined)).toBe(7);
+      expect(resolveRetentionDays('')).toBe(7);
+      expect(resolveRetentionDays('   ')).toBe(7);
+    });
+
+    it('parses a positive number of days (floored, min 1)', () => {
+      expect(resolveRetentionDays('14')).toBe(14);
+      expect(resolveRetentionDays('2.9')).toBe(2);
+      expect(resolveRetentionDays('0.5')).toBe(1);
+    });
+
+    it('returns null (disabled) for 0, negatives, and the disable keywords', () => {
+      expect(resolveRetentionDays('0')).toBeNull();
+      expect(resolveRetentionDays('-3')).toBeNull();
+      for (const keyword of ['off', 'none', 'never', 'disabled', 'false', 'OFF', ' Never ']) {
+        expect(resolveRetentionDays(keyword)).toBeNull();
+      }
+    });
+
+    it('falls back to the default for unparseable values', () => {
+      expect(resolveRetentionDays('soon')).toBe(7);
+    });
+
+    it('reads CHECKPOINT_RETENTION_DAYS when no argument is given', () => {
+      process.env.CHECKPOINT_RETENTION_DAYS = '3';
+      expect(resolveRetentionDays()).toBe(3);
+    });
+  });
+
+  describe('resolveBatchSize', () => {
+    it('defaults to 100 when unset or invalid', () => {
+      expect(resolveBatchSize(undefined)).toBe(100);
+      expect(resolveBatchSize('abc')).toBe(100);
+      expect(resolveBatchSize('0')).toBe(100);
+      expect(resolveBatchSize('-5')).toBe(100);
+    });
+
+    it('parses and clamps to [1, 1000]', () => {
+      expect(resolveBatchSize('50')).toBe(50);
+      expect(resolveBatchSize('5000')).toBe(1000);
+      expect(resolveBatchSize('1')).toBe(1);
+    });
+  });
+});
+
+describe('CheckpointRetentionCron', () => {
+  beforeEach(() => {
+    cronCallbacks.length = 0;
+    mockCronSchedule.mockClear();
+    mockCronStop.mockClear();
+    mockPrune.mockClear();
+    mockPrune.mockImplementation(async () => emptyBatch);
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+  });
+
+  describe('prune', () => {
+    it('returns zeros without touching the DB when retention is disabled', async () => {
+      process.env.CHECKPOINT_RETENTION_DAYS = 'off';
+      const cron = new CheckpointRetentionCron(deps);
+      const totals = await cron.prune();
+      expect(totals).toEqual({ threads: 0, checkpoints: 0, blobs: 0, writes: 0, batches: 0 });
+      expect(mockPrune).not.toHaveBeenCalled();
+    });
+
+    it('passes the resolved retention window and batch size to the delete batch', async () => {
+      process.env.CHECKPOINT_RETENTION_DAYS = '3';
+      process.env.CHECKPOINT_PRUNE_BATCH_SIZE = '25';
+      const cron = new CheckpointRetentionCron(deps);
+      await cron.prune();
+      expect(mockPrune).toHaveBeenCalledWith({ retentionDays: 3, batchSize: 25 });
+    });
+
+    it('stops after one batch when the batch comes back short', async () => {
+      mockPrune.mockImplementation(async () => ({ threads: 4, checkpoints: 40, blobs: 80, writes: 60 }));
+      const cron = new CheckpointRetentionCron(deps);
+      const totals = await cron.prune();
+      expect(mockPrune).toHaveBeenCalledTimes(1);
+      expect(totals).toEqual({ threads: 4, checkpoints: 40, blobs: 80, writes: 60, batches: 1 });
+    });
+
+    it('keeps draining full batches and aggregates the totals', async () => {
+      process.env.CHECKPOINT_PRUNE_BATCH_SIZE = '2';
+      const batches: CheckpointPruneResult[] = [
+        { threads: 2, checkpoints: 20, blobs: 40, writes: 30 },
+        { threads: 2, checkpoints: 10, blobs: 20, writes: 15 },
+        { threads: 1, checkpoints: 5, blobs: 10, writes: 5 },
+      ];
+      let call = 0;
+      mockPrune.mockImplementation(async () => batches[call++] ?? emptyBatch);
+      const cron = new CheckpointRetentionCron(deps);
+      const totals = await cron.prune();
+      expect(mockPrune).toHaveBeenCalledTimes(3);
+      expect(totals).toEqual({ threads: 5, checkpoints: 35, blobs: 70, writes: 50, batches: 3 });
+    });
+
+    it('caps a single run at 10 batches even when every batch is full', async () => {
+      process.env.CHECKPOINT_PRUNE_BATCH_SIZE = '2';
+      mockPrune.mockImplementation(async () => ({ threads: 2, checkpoints: 8, blobs: 16, writes: 12 }));
+      const cron = new CheckpointRetentionCron(deps);
+      const totals = await cron.prune();
+      expect(mockPrune).toHaveBeenCalledTimes(10);
+      expect(totals.batches).toBe(10);
+      expect(totals.threads).toBe(20);
+    });
+  });
+
+  describe('start', () => {
+    it('is idempotent: calling start twice schedules only one cron task', () => {
+      const cron = new CheckpointRetentionCron(deps);
+      cron.start();
+      cron.start();
+      expect(mockCronSchedule).toHaveBeenCalledTimes(1);
+    });
+
+    it('schedules cron with an hourly expression', () => {
+      const cron = new CheckpointRetentionCron(deps);
+      cron.start();
+      const expr = mockCronSchedule.mock.calls[0]?.[0] as string | undefined;
+      expect(expr).toBe('43 * * * *');
+    });
+
+    it('does not schedule anything when retention is disabled', () => {
+      process.env.CHECKPOINT_RETENTION_DAYS = '0';
+      const cron = new CheckpointRetentionCron(deps);
+      cron.start();
+      expect(mockCronSchedule).not.toHaveBeenCalled();
+    });
+
+    it('cron callback runs prune when triggered', async () => {
+      mockPrune.mockImplementation(async () => ({ threads: 1, checkpoints: 2, blobs: 3, writes: 4 }));
+      const cron = new CheckpointRetentionCron(deps);
+      cron.start();
+      expect(cronCallbacks.length).toBe(1);
+      cronCallbacks[0]();
+      await new Promise((r) => setTimeout(r, 10));
+      expect(mockPrune).toHaveBeenCalled();
+    });
+
+    it('cron callback catches and does not rethrow when prune rejects', async () => {
+      mockPrune.mockImplementationOnce(async () => {
+        throw new Error('db down');
+      });
+      const cron = new CheckpointRetentionCron(deps);
+      cron.start();
+      // The catch handler should swallow the error — no unhandled rejection
+      cronCallbacks[0]();
+      await new Promise((r) => setTimeout(r, 10));
+    });
+  });
+
+  describe('stop', () => {
+    it('calls task.stop() and clears the internal task reference', () => {
+      const cron = new CheckpointRetentionCron(deps);
+      cron.start();
+      cron.stop();
+      expect(mockCronStop).toHaveBeenCalledTimes(1);
+    });
+
+    it('stop() after stop() is a no-op (does not double-stop)', () => {
+      const cron = new CheckpointRetentionCron(deps);
+      cron.start();
+      cron.stop();
+      cron.stop();
+      expect(mockCronStop).toHaveBeenCalledTimes(1);
+    });
+
+    it('start() after stop() re-registers a new cron task', () => {
+      const cron = new CheckpointRetentionCron(deps);
+      cron.start();
+      cron.stop();
+      mockCronSchedule.mockClear();
+      cron.start();
+      expect(mockCronSchedule).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('default construction', () => {
+    it('constructs without deps (wires the real pruneStaleCheckpointThreads)', () => {
+      // Smoke: no-arg construction must not throw; the adapter is lazily used only on prune().
+      const cron = new CheckpointRetentionCron();
+      expect(cron).toBeInstanceOf(CheckpointRetentionCron);
+    });
+  });
+});


### PR DESCRIPTION
## What

Closes the real gaps left by the earlier PostgresSaver adoption (re-scoped [IND-387](https://linear.app/indexnetwork/issue/IND-387)):

1. **Retention cron** — `CheckpointRetentionCron` (hourly at :43) deletes LangGraph checkpoint threads whose **newest** checkpoint is older than `CHECKPOINT_RETENTION_DAYS` (default **7**; `0`/`off`/`none` disables), batched via `CHECKPOINT_PRUNE_BATCH_SIZE` (default 100, clamped [1,1000], ≤10 batches/run).
2. **Boot-time warm-up** — `getCheckpointer()` is now called at startup in `main.ts`; the first chat request no longer pays the `setup()` round trip and misconfiguration surfaces at boot (non-fatal: chat degrades to no checkpointer, same as today).
3. **Removed stale `checkpointer as any` cast** in `chat.controller.ts` — `@langchain/langgraph` is a single hoisted install; typechecks clean without it.

## Why

Every chat run checkpoints under a fresh composite `thread_id` (`sessionId:runId`) that is **never read again** after the run ends — continuity is rebuilt from `chat_messages`. Nothing ever deleted these rows:

| prod table | rows | size |
|---|---|---|
| checkpoints | 46.7k | 61 MB |
| checkpoint_blobs | 194k | 258 MB |
| checkpoint_writes | 157k | 253 MB |

**~572 MB ≈ 40% of the entire prod DB**, 95% older than 7 days, growing linearly with chat usage. The backlog drains automatically over the cron's first few runs after deploy — no manual prod mutation needed.

## How it deletes

`pruneStaleCheckpointThreads()` (in `checkpointer.adapter.ts`): selects up to `batchSize` thread_ids by `max((checkpoint->>'ts')::timestamptz) < now() - retention`, then transactionally deletes from `checkpoint_writes`, `checkpoint_blobs`, `checkpoints`. Threads whose latest checkpoint is inside the window are untouched — IND-388's interrupt/resume flows fit comfortably inside 7 days.

## Verification

- 21 new unit tests (env resolution, batch loop/cap, cron scheduling/idempotence/error-swallowing) — mirrors `expiration.queue.spec.ts` pattern
- **Live smoke on Neon dev branch**: pruned 5 stale threads → 113 checkpoints / 391 blobs / 278 writes deleted, counts consistent before/after (this also caught a drizzle gotcha: JS arrays expand to row constructors, not PG arrays — hence the `IN` list)
- `tsc --noEmit` and `eslint` clean for services/api

## Notes

- No `packages/protocol` changes → no protocol version bump
- Telegram/MCP checkpointer parity intentionally out of scope (noted in the Linear issue)