### PR TITLE
chore(logging): consistent labelled logging across api, protocol, web, and cli

### DIFF
--- a/apps/web/src/app/dev/intent-proposal/page.tsx
+++ b/apps/web/src/app/dev/intent-proposal/page.tsx
@@ -2,6 +2,9 @@ import { useState } from "react";
 import { RotateCcw } from "lucide-react";
 import IntentProposalCard, { type IntentProposalData } from "@/components/chat/IntentProposalCard";
 import { useNotifications } from "@/contexts/NotificationContext";
+import { log } from "@/lib/logger";
+
+const logger = log.page.from("dev/intent-proposal");
 
 const MOCK_CARD: IntentProposalData = {
   proposalId: "test-proposal-123",
@@ -19,7 +22,7 @@ export default function IntentProposalTestPage() {
     networkId?: string
   ) => {
     await new Promise((r) => setTimeout(r, 800));
-    console.log("Approve:", { proposalId, description, networkId });
+    logger.debug("Approve", { proposalId, description, networkId });
     addNotification({
       type: "intent_broadcast",
       title: "Broadcasting Signal",
@@ -27,19 +30,19 @@ export default function IntentProposalTestPage() {
       duration: 10000,
       onAction: async () => {
         await new Promise((r) => setTimeout(r, 400));
-        console.log("Undo from notification:", proposalId);
+        logger.debug("Undo from notification", { proposalId });
       },
     });
   };
 
   const handleReject = async (proposalId: string) => {
     await new Promise((r) => setTimeout(r, 400));
-    console.log("Reject:", proposalId);
+    logger.debug("Reject", { proposalId });
   };
 
   const handleUndo = async (proposalId: string) => {
     await new Promise((r) => setTimeout(r, 400));
-    console.log("Undo:", proposalId);
+    logger.debug("Undo", { proposalId });
   };
 
   return (

--- a/apps/web/src/app/index/[indexId]/page.tsx
+++ b/apps/web/src/app/index/[indexId]/page.tsx
@@ -11,6 +11,9 @@ import { Users, Loader2, Globe } from 'lucide-react';
 import { useNotifications } from '@/contexts/NotificationContext';
 import { useNetworksState } from '@/contexts/IndexesContext';
 import { useAuthContext } from '@/contexts/AuthContext';
+import { log } from '@/lib/logger';
+
+const logger = log.page.from('index/[indexId]');
 
 type PageStep = 'loading' | 'auth-required' | 'ready-to-join' | 'joining' | 'error' | 'already-member';
 
@@ -83,7 +86,7 @@ export default function PublicJoinPage() {
 
               await refreshIndexes();
             } catch (err) {
-              console.error('Failed to join network:', err);
+              logger.error('Failed to join network', { error: err });
               setState(prev => ({
                 ...prev,
                 step: 'error',
@@ -96,7 +99,7 @@ export default function PublicJoinPage() {
             navigate('/');
           }
         } catch (err) {
-          console.error('Failed to fetch user:', err);
+          logger.error('Failed to fetch user', { error: err });
           setState(prev => ({
             ...prev,
             step: 'error',
@@ -104,7 +107,7 @@ export default function PublicJoinPage() {
           }));
         }
       } catch (err) {
-        console.error('Failed to load network:', err);
+        logger.error('Failed to load network', { error: err });
         setState(prev => ({
           ...prev,
           step: 'error',
@@ -143,7 +146,7 @@ export default function PublicJoinPage() {
         navigate(`/`);
       }
     } catch (err) {
-      console.error('Failed to join network:', err);
+      logger.error('Failed to join network', { error: err });
       notifyError((err as Error)?.message || 'Failed to join network');
       setState(prev => ({
         ...prev,

--- a/apps/web/src/app/l/[code]/page.tsx
+++ b/apps/web/src/app/l/[code]/page.tsx
@@ -11,6 +11,9 @@ import { Lock, Users, Loader2 } from 'lucide-react';
 import { useNotifications } from '@/contexts/NotificationContext';
 import { useNetworksState } from '@/contexts/IndexesContext';
 import { useAuthContext } from '@/contexts/AuthContext';
+import { log } from '@/lib/logger';
+
+const logger = log.page.from('l/[code]');
 
 type PageStep = 'loading' | 'auth-required' | 'onboarding-required' | 'ready-to-join' | 'joining' | 'error' | 'already-member';
 
@@ -88,7 +91,7 @@ export default function InvitationPage() {
             setState(prev => ({ ...prev, user: response.user || null, step: 'ready-to-join' }));
           }
         } catch (err) {
-          console.error('Failed to fetch user:', err);
+          logger.error('Failed to fetch user', { error: err });
           setState(prev => ({
             ...prev,
             step: 'error',
@@ -96,7 +99,7 @@ export default function InvitationPage() {
           }));
         }
       } catch (err) {
-        console.error('Failed to load network:', err);
+        logger.error('Failed to load network', { error: err });
         setState(prev => ({
           ...prev,
           step: 'error',
@@ -136,7 +139,7 @@ export default function InvitationPage() {
         navigate(`/`);
       }
     } catch (err) {
-      console.error('Failed to accept invitation:', err);
+      logger.error('Failed to accept invitation', { error: err });
       notifyError((err as Error)?.message || 'Failed to accept invitation');
       setState(prev => ({
         ...prev,

--- a/apps/web/src/app/networks/[id]/page.tsx
+++ b/apps/web/src/app/networks/[id]/page.tsx
@@ -12,6 +12,9 @@ import { useAuthContext } from '@/contexts/AuthContext';
 import { useNetworksState } from '@/contexts/IndexesContext';
 import { useNetworks } from '@/contexts/APIContext';
 import { Network } from '@/lib/types';
+import { log } from '@/lib/logger';
+
+const logger = log.page.from('networks/[id]');
 
 export type TabValue = 'overview' | 'settings' | 'access' | 'integrations';
 
@@ -68,7 +71,7 @@ export default function NetworkDetailPage({ networkIdOverride, basePath }: Netwo
       const memberSettings = await indexesService.getCurrentUserMemberSettings(networkId);
       return memberSettings.isOwner;
     } catch (err) {
-      console.error('Error loading member settings:', err);
+      logger.error('Error loading member settings', { error: err });
       return networkData?.user ? user?.id === networkData.user.id : false;
     }
   }, [indexesService, user?.id]);
@@ -90,7 +93,7 @@ export default function NetworkDetailPage({ networkIdOverride, basePath }: Netwo
         setNetwork(fetchedNetwork);
         setIsOwner(ownerStatus);
       } catch (err) {
-        console.error('Error loading network:', err);
+        logger.error('Error loading network', { error: err });
         setNotFound(true);
       } finally {
         setLoading(false);

--- a/apps/web/src/app/networks/page.tsx
+++ b/apps/web/src/app/networks/page.tsx
@@ -13,6 +13,9 @@ import { useNotifications } from '@/contexts/NotificationContext';
 import { useNetworks } from '@/contexts/APIContext';
 import { useNetworksState } from '@/contexts/IndexesContext';
 import { Network as NetworkType } from '@/lib/types';
+import { log } from '@/lib/logger';
+
+const logger = log.page.from('networks');
 
 export default function NetworksPage() {
   const navigate = useNavigate();
@@ -40,7 +43,7 @@ export default function NetworksPage() {
       const response = await indexesService.discoverPublicIndexes(1, 50);
       setPublicNetworks(response.data);
     } catch (err) {
-      console.error('Error loading public networks:', err);
+      logger.error('Error loading public networks', { error: err });
     } finally {
       setLoadingPublic(false);
     }
@@ -58,7 +61,7 @@ export default function NetworksPage() {
       }
       await loadPublicNetworks();
     } catch (err) {
-      console.error('Error joining network:', err);
+      logger.error('Error joining network', { error: err });
       error('Failed to join network');
     } finally {
       setJoiningNetwork(null);
@@ -86,7 +89,7 @@ export default function NetworksPage() {
       }
       success('Network created successfully');
     } catch (err) {
-      console.error('Error creating network:', err);
+      logger.error('Error creating network', { error: err });
       error('Failed to create network');
     }
   }, [indexesService, addIndex, navigate, success, error]);

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -19,6 +19,9 @@ import { cn } from "@/lib/utils";
 import { mentionsToMarkdownLinks } from "@/lib/mentions";
 import type { Suggestion } from "@/hooks/useSuggestions";
 import NetworksPanel from "@/components/chat/NetworksPanel";
+import { log } from "@/lib/logger";
+
+const logger = log.page.from("onboarding");
 
 /** Step-specific suggestions for onboarding. */
 const ONBOARDING_STEP_SUGGESTIONS: Record<string, Suggestion[]> = {
@@ -205,7 +208,7 @@ export default function OnboardingPage() {
         })
         .catch((err) => {
           // Keep code in localStorage so user can retry via the invitation link
-          console.error('Failed to accept deferred invitation:', err);
+          logger.error('Failed to accept deferred invitation', { error: err });
           showError('Could not join the network from your invitation link. Please try the link again.');
         });
     }

--- a/apps/web/src/app/u/[id]/chat/page.tsx
+++ b/apps/web/src/app/u/[id]/chat/page.tsx
@@ -5,6 +5,9 @@ import { useAuthContext } from "@/contexts/AuthContext";
 import { useUsers, useOpportunities } from "@/contexts/APIContext";
 import { User } from "@/lib/types";
 import ChatView from "@/components/chat/ChatView";
+import { log } from "@/lib/logger";
+
+const logger = log.page.from("u/[id]/chat");
 
 export default function ChatPage() {
   const { id } = useParams();
@@ -46,7 +49,7 @@ export default function ChatPage() {
         const profile = await usersService.getUserProfile(id!);
         setProfileData(profile);
       } catch (err) {
-        console.error('Failed to fetch profile:', err);
+        logger.error('Failed to fetch profile', { error: err });
         setError('User not found');
       } finally {
         setIsLoading(false);
@@ -61,7 +64,7 @@ export default function ChatPage() {
     try {
       await opportunitiesService.updateStatus(pendingOpportunityId, "accepted");
     } catch (err) {
-      console.error('[ChatPage] Failed to accept opportunity after message sent:', err);
+      logger.error('Failed to accept opportunity after message sent', { error: err });
     }
   };
 

--- a/apps/web/src/app/u/[id]/page.tsx
+++ b/apps/web/src/app/u/[id]/page.tsx
@@ -12,6 +12,9 @@ import { ContentContainer } from "@/components/layout";
 import InviteMessageModal from "@/components/InviteMessageModal";
 import NegotiationHistory from "@/components/NegotiationHistory";
 import { getPublicUserProfile } from "@/services/users";
+import { log } from "@/lib/logger";
+
+const logger = log.page.from("u/[id]");
 
 export default function UserProfilePage() {
   const { id } = useParams();
@@ -37,7 +40,7 @@ export default function UserProfilePage() {
     try {
       return await usersService.triggerDiscoveryNegotiation(targetId);
     } catch (err) {
-      console.error('Failed to trigger negotiation:', err);
+      logger.error('Failed to trigger negotiation', { error: err });
     } finally {
       setIsTriggering(false);
     }
@@ -59,14 +62,14 @@ export default function UserProfilePage() {
             const networks = await indexesService.getSharedIndexes(id!);
             setSharedNetworks(networks);
           } catch (err) {
-            console.error('Failed to fetch shared networks:', err);
+            logger.error('Failed to fetch shared networks', { error: err });
             setSharedNetworks([]);
           }
         } else {
           setSharedNetworks([]);
         }
       } catch (err) {
-        console.error('Failed to fetch profile:', err);
+        logger.error('Failed to fetch profile', { error: err });
         setError('User not found');
       } finally {
         setIsLoading(false);

--- a/apps/web/src/components/ChatContent.tsx
+++ b/apps/web/src/components/ChatContent.tsx
@@ -32,6 +32,9 @@ import { useSuggestions } from "@/hooks/useSuggestions";
 import { mentionsToMarkdownLinks } from "@/lib/mentions";
 import type { HomeViewSection } from "@/services/opportunities";
 import { DynamicIcon, type IconName } from "lucide-react/dynamic";
+import { log } from "@/lib/logger";
+
+const logger = log.ui.from("ChatContent");
 
 /**
  * When true, use GET /opportunities/home for dynamic sections; when false, use static/mock data.
@@ -733,7 +736,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
         attachmentNames.push(...selectedFiles.map(({ file }) => file.name));
         setSelectedFiles([]);
       } catch (err) {
-        console.error("[AI Chat] Upload failed:", err);
+        logger.error("Upload failed", { error: err });
         showError(err instanceof Error ? err.message : "Failed to upload file(s)");
         setIsUploadingFiles(false);
         inputRef.current?.focus();

--- a/apps/web/src/components/ConnectionActions.tsx
+++ b/apps/web/src/components/ConnectionActions.tsx
@@ -3,6 +3,9 @@ import { useNavigate } from "react-router";
 import { X, Check, RotateCcw } from "lucide-react";
 import { useNotifications } from "@/contexts/NotificationContext";
 import InviteMessageModal from "@/components/InviteMessageModal";
+import { log } from "@/lib/logger";
+
+const logger = log.ui.from("ConnectionActions");
 
 export type ConnectionAction = 'REQUEST' | 'SKIP' | 'CANCEL' | 'ACCEPT' | 'DECLINE';
 
@@ -73,7 +76,7 @@ export default function ConnectionActions({
           break;
       }
     } catch (err) {
-      console.error('Connection action failed:', err);
+      logger.error('Connection action failed', { error: err });
       error("Action failed", "Please try again later.");
     } finally {
       setIsLoading(false);

--- a/apps/web/src/components/FeedbackWidget.tsx
+++ b/apps/web/src/components/FeedbackWidget.tsx
@@ -3,6 +3,9 @@ import { Loader2, MessageSquare } from "lucide-react";
 import { useAIChat } from "@/contexts/AIChatContext";
 import { useSaveBarVisible } from "@/contexts/SaveBarContext";
 import { getJwtToken } from "@/lib/auth-client";
+import { log } from "@/lib/logger";
+
+const logger = log.ui.from("FeedbackWidget");
 
 export default function FeedbackWidget() {
   const [isOpen, setIsOpen] = useState(false);
@@ -60,7 +63,7 @@ export default function FeedbackWidget() {
       setFeedback("");
       setIsOpen(false);
     } catch (error) {
-      console.error("Error submitting feedback:", error);
+      logger.error("Error submitting feedback", { error });
     } finally {
       setIsSubmitting(false);
     }

--- a/apps/web/src/components/NetworkOverviewPanel.tsx
+++ b/apps/web/src/components/NetworkOverviewPanel.tsx
@@ -11,6 +11,9 @@ import { useAIChat } from '@/contexts/AIChatContext';
 import { useNetworkFilter } from '@/contexts/IndexFilterContext';
 import { useAuthenticatedAPI } from '@/lib/api';
 import { useNetworks } from '@/contexts/APIContext';
+import { log } from '@/lib/logger';
+
+const logger = log.ui.from('NetworkOverviewPanel');
 
 interface NetworkOverviewPanelProps {
   index: Network;
@@ -61,7 +64,7 @@ export default function NetworkOverviewPanel({ index, isOwner, onLeft, onLeaveRe
         setPremises(overview.premises);
         setUserContext(overview.userContext);
       } catch (err) {
-        console.error('Error loading network overview:', err);
+        logger.error('Error loading network overview', { error: err });
       } finally {
         setIntentsLoading(false);
       }
@@ -90,7 +93,7 @@ export default function NetworkOverviewPanel({ index, isOwner, onLeft, onLeaveRe
       setShowLeaveConfirmation(false);
       onLeft?.();
     } catch (err) {
-      console.error('Error leaving network:', err);
+      logger.error('Error leaving network', { error: err });
       error('Failed to leave network');
     } finally {
       setIsLeaving(false);

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -16,6 +16,9 @@ import { useNotifications } from '@/contexts/NotificationContext';
 import CreateNetworkModal from '@/components/modals/CreateIndexModal';
 import MasterKeyDialog from '@/components/MasterKeyDialog';
 import { useQuestions } from '@/contexts/QuestionsContext';
+import { log } from '@/lib/logger';
+
+const logger = log.ui.from('Sidebar');
 
 
 interface ChatSession {
@@ -84,7 +87,7 @@ export default function Sidebar() {
         success('Index created successfully');
       }
     } catch (err) {
-      console.error('Error creating index:', err);
+      logger.error('Error creating index', { error: err });
       error('Failed to create network');
     }
   }, [indexesService, addIndex, success, error]);
@@ -131,7 +134,7 @@ export default function Sidebar() {
 
       navigate('/chat');
     } catch (err) {
-      console.error('Failed to fetch most recent chat:', err);
+      logger.error('Failed to fetch most recent chat', { error: err });
     } finally {
       setNavigatingToChat(false);
     }
@@ -149,7 +152,7 @@ export default function Sidebar() {
         const data = await apiClient.get<{ sessions: ChatSession[] }>('/chat/sessions');
         setChatSessions(data.sessions.slice(0, 10));
       } catch (error) {
-        console.error('Failed to fetch chat sessions:', error);
+        logger.error('Failed to fetch chat sessions', { error });
       } finally {
         if (isInitialLoad) setLoadingSessions(false);
       }

--- a/apps/web/src/components/SynthesisMarkdown.tsx
+++ b/apps/web/src/components/SynthesisMarkdown.tsx
@@ -6,6 +6,9 @@ import { useNavigate } from 'react-router';
 import { useIntents } from '@/contexts/APIContext';
 import { useDiscoveryFilter } from '@/contexts/DiscoveryFilterContext';
 import { useNotifications } from '@/contexts/NotificationContext';
+import { log } from '@/lib/logger';
+
+const logger = log.ui.from('SynthesisMarkdown');
 
 interface SynthesisMarkdownProps {
   content: string;
@@ -110,7 +113,7 @@ export default function SynthesisMarkdown({ content, className = '', onArchive, 
         // Navigate directly to intent route
         navigate(`/i/${currentLink.intentId}`);
       } catch (err) {
-        console.error('Failed to navigate to intent:', err);
+        logger.error('Failed to navigate to intent', { error: err });
         error('Failed to load intent');
       }
     }
@@ -128,7 +131,7 @@ export default function SynthesisMarkdown({ content, className = '', onArchive, 
           onArchive();
         }
       } catch (err) {
-        console.error('Failed to archive intent:', err);
+        logger.error('Failed to archive intent', { error: err });
         error('Failed to archive intent');
       }
     }

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -13,6 +13,9 @@ import { useOpportunities } from '@/contexts/APIContext';
 import type { ChatContextOpportunity } from '@/services/opportunities';
 import { buildChatTimeline } from './timeline';
 import OpportunityDivider from './OpportunityDivider';
+import { log } from '@/lib/logger';
+
+const logger = log.ui.from('ChatView');
 
 interface ChatViewProps {
   userId: string;
@@ -83,7 +86,7 @@ export default function ChatView({ userId, userName, userAvatar, isGhost = false
       })
       .catch((err: unknown) => {
         if (controller.signal.aborted) return;
-        console.error('[ChatView] Failed to load chat context:', err);
+        logger.error('Failed to load chat context', { error: err });
       });
     return () => {
       controller.abort();
@@ -116,7 +119,7 @@ export default function ChatView({ userId, userName, userAvatar, isGhost = false
         const cid = initialGroupId ?? conv.id;
         if (cid && !conversationId) setConversationId(cid);
       } catch (err) {
-        console.error('[ChatView] DM init error:', err);
+        logger.error('DM init error', { error: err });
       } finally {
         if (mounted) setContextLoading(false);
       }
@@ -162,7 +165,7 @@ export default function ChatView({ userId, userName, userAvatar, isGhost = false
         }
       } catch (err) {
         hasAutoSentRef.current = false;
-        console.error('[ChatView] Auto-send error:', err);
+        logger.error('Auto-send error', { error: err });
       } finally {
         setSending(false);
       }
@@ -189,7 +192,7 @@ export default function ChatView({ userId, userName, userAvatar, isGhost = false
       }
       inputRef.current?.focus();
     } catch (err) {
-      console.error('[ChatView] Send error:', err);
+      logger.error('Send error', { error: err });
       setMessageText(text);
     } finally {
       setSending(false);

--- a/apps/web/src/components/modals/CreateIndexModal.tsx
+++ b/apps/web/src/components/modals/CreateIndexModal.tsx
@@ -6,6 +6,9 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { validateFiles } from '@/lib/file-validation';
 import NetworkAvatar from '@/components/IndexAvatar';
+import { log } from '@/lib/logger';
+
+const logger = log.ui.from('CreateIndexModal');
 
 interface CreateNetworkModalProps {
   open: boolean;
@@ -112,7 +115,7 @@ export default function CreateNetworkModal({ open, onOpenChange, onSubmit, uploa
       resetForm();
       onOpenChange(false);
     } catch (error) {
-      console.error('Error creating index:', error);
+      logger.error('Error creating index', { error });
     } finally {
       setIsSubmitting(false);
     }

--- a/apps/web/src/components/settings/AccessTab.tsx
+++ b/apps/web/src/components/settings/AccessTab.tsx
@@ -17,6 +17,9 @@ import CsvPreviewModal from '@/components/modals/CsvPreviewModal';
 import UserAvatar from '@/components/UserAvatar';
 import GhostBadge from '@/components/GhostBadge';
 import { useNavigate } from 'react-router';
+import { log } from '@/lib/logger';
+
+const logger = log.ui.from('AccessTab');
 
 type ProfileEnrichmentPolicy = 'auto' | 'consent_required' | 'disabled';
 
@@ -110,7 +113,7 @@ export default function AccessTab({
       const response = await networkService.getMembers(networkId, {});
       setMembers(response.members);
     } catch (err) {
-      console.error('Error loading members:', err);
+      logger.error('Error loading members', { error: err });
     } finally {
       setIsMembersLoading(false);
     }
@@ -132,7 +135,7 @@ export default function AccessTab({
       setSuggestedUsers(users.map(u => ({ ...u, permissions: [] })));
       setSearchHasQueried(true);
     } catch (err) {
-      console.error('Error searching users:', err);
+      logger.error('Error searching users', { error: err });
       setSuggestedUsers([]);
     } finally {
       setSearchIsLoading(false);
@@ -169,7 +172,7 @@ export default function AccessTab({
         setInvitationLink({ code: updatedNetwork.permissions.invitationLink.code });
       }
     } catch (err) {
-      console.error('Error updating permissions:', err);
+      logger.error('Error updating permissions', { error: err });
       error('Failed to update permissions');
     }
   };
@@ -182,7 +185,7 @@ export default function AccessTab({
       onUpdated(updatedNetwork);
       success('Automatic member enrichment policy updated');
     } catch (err) {
-      console.error('Error updating profile enrichment policy:', err);
+      logger.error('Error updating profile enrichment policy', { error: err });
       error('Failed to update profile enrichment policy');
     } finally {
       setIsUpdatingProfilePolicy(false);
@@ -217,7 +220,7 @@ export default function AccessTab({
       setShowSuggestions(false);
       setSearchHasQueried(false);
     } catch (err) {
-      console.error('Error adding member:', err);
+      logger.error('Error adding member', { error: err });
     }
   };
 
@@ -230,7 +233,7 @@ export default function AccessTab({
       }
       setMembers(prev => prev.filter(m => m.id !== memberId));
     } catch (err) {
-      console.error('Error removing member:', err);
+      logger.error('Error removing member', { error: err });
     }
   };
 
@@ -241,7 +244,7 @@ export default function AccessTab({
       setMembers(prev => prev.map(m => m.id === memberId ? { ...m, permissions: updated.permissions } : m));
       success(`Role updated to ${newRole}`);
     } catch (err) {
-      console.error('Error updating member role:', err);
+      logger.error('Error updating member role', { error: err });
       error(err instanceof Error ? err.message : 'Failed to update role');
     }
   };
@@ -258,7 +261,7 @@ export default function AccessTab({
       await loadMembers();
       success('Contact added');
     } catch (err) {
-      console.error('Error adding contact:', err);
+      logger.error('Error adding contact', { error: err });
       error('Failed to add contact');
     } finally {
       setIsAddingMember(false);
@@ -282,7 +285,7 @@ export default function AccessTab({
           : 'Member added';
       success(toast);
     } catch (err) {
-      console.error('Error inviting member:', err);
+      logger.error('Error inviting member', { error: err });
       error('Failed to invite member');
     } finally {
       setIsAddingMember(false);
@@ -297,7 +300,7 @@ export default function AccessTab({
       success(`Invitation resent to ${result.email}${result.rotated ? ' (key rotated)' : ''}`);
       setResendTarget(null);
     } catch (err) {
-      console.error('Resend invite failed', err);
+      logger.error('Resend invite failed', { error: err });
       error('Failed to resend invitation');
     } finally {
       setIsResendInFlight(false);

--- a/apps/web/src/components/settings/IntegrationsTab.tsx
+++ b/apps/web/src/components/settings/IntegrationsTab.tsx
@@ -9,6 +9,9 @@ import { useAuthenticatedAPI } from '@/lib/api';
 import { createIntegrationsService, type ComposioConnection } from '@/services/integrations';
 import CopyableBox from '@/components/CopyableBox';
 import MasterKeyDialog from '@/components/MasterKeyDialog';
+import { log } from '@/lib/logger';
+
+const logger = log.ui.from('IntegrationsTab');
 
 /** Toolkits available for connection, keyed by network type. */
 const COMMUNITY_TOOLKITS = ['gmail', 'slack'] as const;
@@ -92,7 +95,7 @@ export default function IntegrationsTab({
       const response = await integrationsService.getConnections(networkId);
       setConnections(response.connections);
     } catch (err) {
-      console.error('Failed to load connections:', err);
+      logger.error('Failed to load connections', { error: err });
       setConnections([]);
     } finally {
       setConnectionsLoaded(true);
@@ -230,7 +233,7 @@ export default function IntegrationsTab({
       setRotatedMasterKey(result.masterKey);
       success('Master key rotated — old key is now invalid');
     } catch (err) {
-      console.error('Master key rotation failed', err);
+      logger.error('Master key rotation failed', { error: err });
       error('Failed to rotate master key');
     } finally {
       setIsRotating(false);

--- a/apps/web/src/components/settings/SettingsTab.tsx
+++ b/apps/web/src/components/settings/SettingsTab.tsx
@@ -8,6 +8,9 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { validateFiles } from '@/lib/file-validation';
 import NetworkAvatar, { resolveNetworkImageSrc } from '@/components/IndexAvatar';
+import { log } from '@/lib/logger';
+
+const logger = log.ui.from('SettingsTab');
 
 interface SettingsTabProps {
   network: Network;
@@ -163,7 +166,7 @@ export default function SettingsTab({
       onUpdated(updatedIndex);
       success('Settings updated');
     } catch (err) {
-      console.error('Error updating index:', err);
+      logger.error('Error updating index', { error: err });
       error('Failed to update settings');
     } finally {
       setIsSavingSettings(false);
@@ -205,7 +208,7 @@ export default function SettingsTab({
       onUpdated(updatedNetwork);
       success('Event details updated');
     } catch (err) {
-      console.error('Error updating event metadata:', err);
+      logger.error('Error updating event metadata', { error: err });
       error('Failed to update event details');
     } finally {
       setIsSavingMeta(false);
@@ -229,7 +232,7 @@ export default function SettingsTab({
       setShowDeleteConfirmation(false);
       onDeleted?.();
     } catch (err) {
-      console.error('Error deleting index:', err);
+      logger.error('Error deleting index', { error: err });
       error('Failed to delete network');
     } finally {
       setIsDeletingIndex(false);

--- a/apps/web/src/contexts/AIChatContext.tsx
+++ b/apps/web/src/contexts/AIChatContext.tsx
@@ -5,6 +5,9 @@ import { apiClient } from "@/lib/api";
 import type { Suggestion } from "@/hooks/useSuggestions";
 import type { Question } from "@/components/DecisionQuestions/types";
 import type { PendingQuestion } from "@/services/questions";
+import { log } from "@/lib/logger";
+
+const logger = log.context.from("AIChatContext");
 
 export interface DiscoveryOpportunity {
   candidateId: string;
@@ -925,7 +928,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
                     break;
                 }
               } catch (e) {
-                console.error("Failed to parse SSE event:", e);
+                logger.error("Failed to parse SSE event", { error: e });
               }
             }
           }
@@ -933,7 +936,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
       } catch (error) {
         if (error instanceof Error && error.name === "AbortError") {
           const isSteerAbort = abortControllerRef.current?.signal.reason === 'steer';
-          console.log(isSteerAbort ? "Chat stream interrupted by steer" : "Chat stream aborted");
+          logger.debug(isSteerAbort ? "Chat stream interrupted by steer" : "Chat stream aborted");
           const stoppedAt = Date.now();
           setMessages((prev) =>
             prev.map((msg) =>
@@ -949,7 +952,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
             ),
           );
         } else {
-          console.error("Chat error:", error);
+          logger.error("Chat error", { error });
           setMessages((prev) =>
             prev.map((msg) =>
               msg.id === assistantMessageId
@@ -1120,7 +1123,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
         })),
       );
     } catch (err) {
-      console.error("Load session error:", err);
+      logger.error("Load session error", { error: err });
     }
   }, []);
 
@@ -1137,7 +1140,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
         refetchSessions();
         return true;
       } catch (err) {
-        console.error("Update session title error:", err);
+        logger.error("Update session title error", { error: err });
         return false;
       }
     },

--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -5,6 +5,9 @@ import { APIError, useAuthenticatedAPI } from '../lib/api';
 import { useAuthService } from '../services/auth';
 import { User, APIResponse } from '../lib/types';
 import AuthModal from '@/components/AuthModal';
+import { log } from '@/lib/logger';
+
+const logger = log.context.from('AuthContext');
 
 type AuthContextType = {
   isReady: boolean;
@@ -72,14 +75,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
               setUser(updatedUser);
             })
             .catch(err => {
-              console.error('Failed to update timezone:', err);
+              logger.error('Failed to update timezone', { error: err });
             });
         }
       } else {
         throw new Error('No user data received');
       }
     } catch (error) {
-      console.error('Failed to fetch user:', error);
+      logger.error('Failed to fetch user', { error });
 
       // The browser can retain a Better Auth session/JWT for a user that no
       // longer exists in the currently selected dev database. Treat auth/user
@@ -88,7 +91,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       if (error instanceof APIError && (error.status === 401 || error.status === 404)) {
         clearJwtToken();
         await authClient.signOut().catch(signOutError => {
-          console.error('Failed to clear stale auth session:', signOutError);
+          logger.error('Failed to clear stale auth session', { error: signOutError });
         });
         setUser(null);
         setUserFetchAttempted(false);

--- a/apps/web/src/contexts/ConversationContext.tsx
+++ b/apps/web/src/contexts/ConversationContext.tsx
@@ -3,6 +3,9 @@ import { apiClient } from '@/lib/api';
 import { getJwtToken } from '@/lib/auth-client';
 import { useAuthContext } from '@/contexts/AuthContext';
 import type { ConversationSummary, ConversationMessage } from '@/services/conversation';
+import { log } from '@/lib/logger';
+
+const logger = log.context.from('ConversationContext');
 
 const PROTOCOL_BASE = import.meta.env.VITE_PROTOCOL_URL || '';
 const SSE_URL = `${PROTOCOL_BASE}/api/conversations/stream`;
@@ -45,7 +48,7 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
       const data = await apiClient.get<{ conversations: ConversationSummary[] }>('/conversations');
       setConversations(data.conversations);
     } catch (err) {
-      console.error('[ConversationContext] Failed to fetch conversations:', err);
+      logger.error('Failed to fetch conversations', { error: err });
     }
   }, []);
   useEffect(() => { refreshConversationsRef.current = refreshConversations; }, [refreshConversations]);
@@ -55,7 +58,7 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
       const data = await apiClient.get<{ conversations: ConversationSummary[] }>('/conversations/negotiations');
       setNegotiations(data.conversations);
     } catch (err) {
-      console.error('[ConversationContext] Failed to fetch negotiations:', err);
+      logger.error('Failed to fetch negotiations', { error: err });
     }
   }, []);
 
@@ -83,13 +86,13 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
         return next;
       });
     } catch (err) {
-      console.error('[ConversationContext] Failed to load messages:', err);
+      logger.error('Failed to load messages', { error: err });
     }
   }, []);
 
   const sendMessage = useCallback(async (conversationId: string, parts: unknown[]): Promise<ConversationMessage | null> => {
     if (!user?.id) {
-      console.error('[ConversationContext] Cannot send message: user not authenticated');
+      logger.error('Cannot send message: user not authenticated');
       return null;
     }
     // Optimistic update
@@ -142,7 +145,7 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
       });
       return data.message;
     } catch (err) {
-      console.error('[ConversationContext] Failed to send message:', err);
+      logger.error('Failed to send message', { error: err });
       // Roll back optimistic update (messages + conversation sidebar)
       setMessages((prev) => {
         const next = new Map(prev);
@@ -172,7 +175,7 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
         return next;
       });
     } catch (err) {
-      console.error('[ConversationContext] Failed to hide conversation:', err);
+      logger.error('Failed to hide conversation', { error: err });
     }
   }, []);
 
@@ -267,11 +270,11 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
           const delay = Math.min(5000 * Math.pow(2, retryCountRef.current - 1), 60000);
           retryTimeoutRef.current = setTimeout(() => { connectSSERef.current(); }, delay);
         } else {
-          console.error('[ConversationContext] SSE max retries reached, giving up');
+          logger.error('SSE max retries reached, giving up');
         }
       };
     } catch (err) {
-      console.error('[ConversationContext] SSE connection failed:', err);
+      logger.error('SSE connection failed', { error: err });
       retryCountRef.current += 1;
       if (retryCountRef.current <= 10) {
         const delay = Math.min(5000 * Math.pow(2, retryCountRef.current - 1), 60000);

--- a/apps/web/src/contexts/IndexesContext.tsx
+++ b/apps/web/src/contexts/IndexesContext.tsx
@@ -3,6 +3,9 @@ import { Network } from '@/lib/types';
 import { useAuthContext } from '@/contexts/AuthContext';
 import { useIndexesV2 } from '@/services/v2/networks.service';
 import { useNetworks as useIndexesAPI } from '@/contexts/APIContext';
+import { log } from '@/lib/logger';
+
+const logger = log.context.from('IndexesContext');
 
 interface NetworksContextType {
   indexes: Network[];
@@ -38,7 +41,7 @@ export function NetworksProvider({ children }: { children: ReactNode }) {
       hasFetchedRef.current = true;
       hasDataRef.current = true;
     } catch (err) {
-      console.error('Error fetching networks:', err);
+      logger.error('Error fetching networks', { error: err });
       setError('Failed to load networks');
       setIndexes([]);
     } finally {
@@ -89,7 +92,7 @@ export function NetworksProvider({ children }: { children: ReactNode }) {
 
     indexesAPI.joinIndex(pendingNetworkId)
       .then(() => refreshIndexes())
-      .catch((err) => console.error('Failed to auto-join pending network:', err));
+      .catch((err) => logger.error('Failed to auto-join pending network', { error: err }));
   }, [isAuthenticated, indexesAPI, refreshIndexes]);
 
   return (

--- a/apps/web/src/contexts/QuestionsContext.tsx
+++ b/apps/web/src/contexts/QuestionsContext.tsx
@@ -2,6 +2,9 @@ import { createContext, useContext, useState, useEffect, useCallback, type React
 import { useQuestionsService } from '@/contexts/APIContext';
 import { useAuthContext } from '@/contexts/AuthContext';
 import type { PendingQuestion, AnswerBody } from '@/services/questions';
+import { log } from '@/lib/logger';
+
+const logger = log.context.from('QuestionsContext');
 
 interface QuestionsContextType {
   /** All pending questions for the current user. */
@@ -34,7 +37,7 @@ export function QuestionsProvider({ children }: { children: ReactNode }) {
       const pending = await questionsService.getPending({ noConversation: true });
       setQuestions(pending);
     } catch (err) {
-      console.error('Failed to fetch pending questions:', err);
+      logger.error('Failed to fetch pending questions', { error: err });
     }
   }, [questionsService, user?.id]);
 

--- a/apps/web/src/hooks/useMentionableUsers.ts
+++ b/apps/web/src/hooks/useMentionableUsers.ts
@@ -1,6 +1,9 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useNetworksState } from '@/contexts/IndexesContext';
 import { useNetworkService } from '@/services/networks';
+import { log } from '@/lib/logger';
+
+const logger = log.hook.from('useMentionableUsers');
 
 export interface MentionableUser {
   id: string;
@@ -62,7 +65,7 @@ export function useMentionableUsers({
       cacheRef.current = userMap;
       setUsers(Array.from(userMap.values()));
     } catch (error) {
-      console.error('Failed to fetch mentionable users:', error);
+      logger.error('Failed to fetch mentionable users', { error });
       setUsers([]);
     } finally {
       setIsLoading(false);

--- a/apps/web/src/hooks/useSuggestions.ts
+++ b/apps/web/src/hooks/useSuggestions.ts
@@ -1,4 +1,7 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
+import { log } from '@/lib/logger';
+
+const logger = log.hook.from('useSuggestions');
 
 export interface Suggestion {
   label: string;
@@ -61,7 +64,7 @@ export function useSuggestions({
         ];
         setFetchedSuggestions(mockDynamicSuggestions);
       } catch (error) {
-        console.error('Failed to fetch suggestions:', error);
+        logger.error('Failed to fetch suggestions', { error });
         setFetchedSuggestions([]);
       } finally {
         setIsLoading(false);

--- a/apps/web/src/lib/logger.ts
+++ b/apps/web/src/lib/logger.ts
@@ -1,0 +1,112 @@
+/* eslint-disable no-console */
+/**
+ * Web logger — labelled, level-aware wrapper around the browser console.
+ *
+ * Mirrors the server logger API (`log.<context>.from(source)`) from
+ * `services/api/src/lib/log.ts` so log call sites look the same across the
+ * repo. Every line is prefixed `[context:source]`, debug output is stripped
+ * in production builds, and oversized meta payloads are truncated so we never
+ * dump big data into the console.
+ *
+ * Usage:
+ * ```ts
+ * import { log } from '@/lib/logger';
+ * const logger = log.context.from('ConversationContext');
+ * logger.error('Failed to fetch conversations', { error: err });
+ * ```
+ */
+
+type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+/** Where in the web app the log originates. */
+export type LogContext = 'ui' | 'context' | 'hook' | 'page' | 'lib';
+
+type LogMethod = (message: string, meta?: Record<string, unknown>) => void;
+
+export type LoggerWithSource = {
+  debug: LogMethod;
+  info: LogMethod;
+  warn: LogMethod;
+  error: LogMethod;
+};
+
+const order: Record<LogLevel, number> = { debug: 10, info: 20, warn: 30, error: 40 };
+
+/** Debug lines are visible in dev; production builds start at info. */
+const currentLevel: LogLevel = import.meta.env.DEV ? 'debug' : 'info';
+
+function shouldLog(level: LogLevel): boolean {
+  return order[level] >= order[currentLevel];
+}
+
+/** Truncation limits — logs must stay readable, never dump payloads. */
+const MAX_STRING_LENGTH = 1000;
+const MAX_ARRAY_ITEMS = 20;
+const MAX_DEPTH = 4;
+
+function sanitize(value: unknown, depth = 0): unknown {
+  if (value == null) return value;
+  if (typeof value === 'string') {
+    return value.length > MAX_STRING_LENGTH
+      ? `${value.slice(0, MAX_STRING_LENGTH)}… [truncated ${value.length - MAX_STRING_LENGTH} chars]`
+      : value;
+  }
+  if (Array.isArray(value)) {
+    if (value.length > 0 && typeof value[0] === 'number') return `[redacted: ${value.length} values]`;
+    if (depth >= MAX_DEPTH) return `[truncated: array(${value.length})]`;
+    const items = value.slice(0, MAX_ARRAY_ITEMS).map((item) => sanitize(item, depth + 1));
+    if (value.length > MAX_ARRAY_ITEMS) items.push(`… [truncated ${value.length - MAX_ARRAY_ITEMS} more items]`);
+    return items;
+  }
+  if (value instanceof Error) {
+    return { name: value.name, message: sanitize(value.message, depth + 1) };
+  }
+  if (typeof value === 'object' && value.constructor === Object) {
+    if (depth >= MAX_DEPTH) return `[truncated: object(${Object.keys(value).length} keys)]`;
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, sanitize(v, depth + 1)])
+    );
+  }
+  return value;
+}
+
+const LEVEL_CONSOLE: Record<LogLevel, (...args: unknown[]) => void> = {
+  debug: console.debug,
+  info: console.info,
+  warn: console.warn,
+  error: console.error,
+};
+
+function createLogger(context: LogContext, source: string): LoggerWithSource {
+  const prefix = `[${context}:${source}]`;
+  const emit = (level: LogLevel, message: string, meta?: Record<string, unknown>) => {
+    if (!shouldLog(level)) return;
+    LEVEL_CONSOLE[level](prefix, message, ...(meta ? [sanitize(meta)] : []));
+  };
+  return {
+    debug: (message, meta) => emit('debug', message, meta),
+    info: (message, meta) => emit('info', message, meta),
+    warn: (message, meta) => emit('warn', message, meta),
+    error: (message, meta) => emit('error', message, meta),
+  };
+}
+
+function withFrom(context: LogContext) {
+  return { from: (source: string) => createLogger(context, source) };
+}
+
+/**
+ * Pre-bound context loggers. Pick the context matching the file's location:
+ * - `log.ui`      — components/
+ * - `log.context` — contexts/
+ * - `log.hook`    — hooks/
+ * - `log.page`    — app/ (route pages)
+ * - `log.lib`     — lib/, services/
+ */
+export const log = {
+  ui: withFrom('ui'),
+  context: withFrom('context'),
+  hook: withFrom('hook'),
+  page: withFrom('page'),
+  lib: withFrom('lib'),
+};

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -104,6 +104,50 @@ export default tseslint.config(
     },
   },
 
+  // ── Protocol runtime: route logs through shared/observability/log ────
+  // (log.ts itself carries inline eslint-disable comments for its console
+  // sink — the default implementation used when no host logger is wired.)
+  {
+    files: ["packages/protocol/src/**/*.ts"],
+    ignores: [
+      "packages/protocol/src/**/*.spec.ts",
+      "packages/protocol/src/**/*.test.ts",
+      "packages/protocol/src/**/tests/**",
+    ],
+    rules: {
+      "no-console": "error",
+    },
+  },
+
+  // ── Web runtime: route logs through lib/logger (labelled + truncated) ─
+  // (lib/logger.ts itself carries a file-level eslint-disable — it is the
+  // console sink.)
+  {
+    files: ["apps/web/src/**/*.{ts,tsx}"],
+    ignores: [
+      "apps/web/src/**/*.spec.{ts,tsx}",
+      "apps/web/src/**/*.test.{ts,tsx}",
+      "apps/web/src/test/**",
+    ],
+    rules: {
+      "no-console": "error",
+    },
+  },
+
+  // ── CLI surfaces: stdout (console.log) is the product; warnings and
+  // errors go to stderr (console.warn/error). Only debug/info/trace are
+  // banned so diagnostics never drift onto pipeable stdout. ─────────────
+  {
+    files: [
+      "packages/cli/src/**/*.ts",
+      "packages/cli/scripts/**/*.ts",
+      "services/api/src/cli/**/*.ts",
+    ],
+    rules: {
+      "no-console": ["error", { allow: ["log", "warn", "error"] }],
+    },
+  },
+
   // ── Web app: React-specific rules ──────────────────────────────────
   {
     files: ["apps/web/src/**/*.{ts,tsx}"],

--- a/packages/cli/src/output/base.ts
+++ b/packages/cli/src/output/base.ts
@@ -46,9 +46,9 @@ export function info(message: string): void {
   console.log(`${CYAN}${message}${RESET}`);
 }
 
-/** Print a warning message. */
+/** Print a warning message to stderr (keeps piped stdout output clean, e.g. --json). */
 export function warn(message: string): void {
-  console.log(`${YELLOW}${message}${RESET}`);
+  console.warn(`${YELLOW}${message}${RESET}`);
 }
 
 /** Print a dim/secondary message. */

--- a/packages/cli/tests/output.base.spec.ts
+++ b/packages/cli/tests/output.base.spec.ts
@@ -60,11 +60,11 @@ describe("warn", () => {
   let spy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
-    spy = spyOn(console, "log").mockImplementation(() => {});
+    spy = spyOn(console, "warn").mockImplementation(() => {});
   });
   afterEach(() => spy.mockRestore());
 
-  it("prints a yellow warning message", () => {
+  it("prints a yellow warning message to stderr", () => {
     warn("careful");
     const msg = spy.mock.calls[0][0] as string;
     expect(msg).toContain("careful");

--- a/packages/protocol/src/agent/agent.tools.ts
+++ b/packages/protocol/src/agent/agent.tools.ts
@@ -4,7 +4,7 @@ import type { DefineTool, ToolDeps } from '../shared/agent/tool.helpers.js';
 import { error, success } from '../shared/agent/tool.helpers.js';
 import { protocolLogger } from '../shared/observability/protocol.logger.js';
 
-const logger = protocolLogger('AgentTools');
+const logger = protocolLogger('ChatTools:Agent');
 
 const AGENT_ACTIONS = [
   'manage:profile',

--- a/packages/protocol/src/chat/chat.interrupt.classifier.ts
+++ b/packages/protocol/src/chat/chat.interrupt.classifier.ts
@@ -61,7 +61,7 @@ export class ChatInterruptClassifier {
       // Default to steer on any ambiguity or unexpected output
       return "steer";
     } catch (error) {
-      logger.warn("[ChatInterruptClassifier.classify] Classification failed, defaulting to steer", {
+      logger.warn("Classification failed, defaulting to steer", {
         error: error instanceof Error ? error.message : String(error),
       });
       return "steer";

--- a/packages/protocol/src/chat/chat.suggester.ts
+++ b/packages/protocol/src/chat/chat.suggester.ts
@@ -77,7 +77,7 @@ export class SuggestionGenerator {
       ]);
       const parsed = suggestionsSchema.safeParse(result);
       if (!parsed.success) {
-        logger.warn("[SuggestionGenerator] Parse failed", { error: parsed.error.message });
+        logger.warn("Parse failed", { error: parsed.error.message });
         return [];
       }
       const out: ChatSuggestion[] = parsed.data.suggestions.map((s) => ({
@@ -86,10 +86,10 @@ export class SuggestionGenerator {
         ...(s.type === "direct" && s.followupText != null && { followupText: s.followupText }),
         ...(s.type === "prompt" && s.prefill != null && { prefill: s.prefill }),
       }));
-      logger.verbose("[SuggestionGenerator] Generated", { count: out.length });
+      logger.verbose("Generated", { count: out.length });
       return out;
     } catch (error) {
-      logger.warn("[SuggestionGenerator] Failed", {
+      logger.warn("Failed", {
         error: error instanceof Error ? error.message : String(error),
       });
       return [];

--- a/packages/protocol/src/chat/chat.title.generator.ts
+++ b/packages/protocol/src/chat/chat.title.generator.ts
@@ -53,10 +53,10 @@ export class ChatTitleGenerator {
 
       const text = typeof response.content === "string" ? response.content : String(response.content ?? "").trim();
       const title = text.slice(0, 80).trim() || "New chat";
-      logger.verbose("[ChatTitleGenerator.invoke] Title generated", { titleLength: title.length });
+      logger.verbose("Title generated", { titleLength: title.length });
       return title;
     } catch (error) {
-      logger.warn("[ChatTitleGenerator.invoke] Failed to generate title", {
+      logger.warn("Failed to generate title", {
         error: error instanceof Error ? error.message : String(error),
       });
       return "New chat";

--- a/packages/protocol/src/contact/contact.tools.ts
+++ b/packages/protocol/src/contact/contact.tools.ts
@@ -3,7 +3,7 @@ import type { DefineTool, ToolDeps } from '../shared/agent/tool.helpers.js';
 import { success, error } from '../shared/agent/tool.helpers.js';
 import { protocolLogger } from '../shared/observability/protocol.logger.js';
 
-const logger = protocolLogger('ContactTools');
+const logger = protocolLogger('ChatTools:Contact');
 
 /**
  * Creates contact management tools for the chat agent.

--- a/packages/protocol/src/enrichment/enrichment.graph.ts
+++ b/packages/protocol/src/enrichment/enrichment.graph.ts
@@ -634,7 +634,9 @@ export class EnrichmentGraphFactory {
             }
           }
           if (retracted > 0) {
-            logger.verbose(`Retracted ${retracted}/${retractionIds.length} premise(s) disavowed by input`, {
+            logger.verbose('Retracted premises disavowed by input', {
+              retracted,
+              requested: retractionIds.length,
               userId: state.userId,
             });
           }
@@ -669,7 +671,8 @@ export class EnrichmentGraphFactory {
             };
           }
 
-          logger.verbose(`Creating ${result.premises.length} premise(s) via premise graph`, {
+          logger.verbose('Creating premises via premise graph', {
+            count: result.premises.length,
             userId: state.userId,
           });
 
@@ -714,7 +717,10 @@ export class EnrichmentGraphFactory {
             }
           }
 
-          logger.verbose(`Created ${created}/${result.premises.length} premise(s) (${skippedDuplicates} skipped as near-duplicates)`, {
+          logger.verbose('Created premises', {
+            created,
+            requested: result.premises.length,
+            skippedDuplicates,
             userId: state.userId,
           });
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -31,6 +31,8 @@ export {
 } from "./shared/agent/tool.scope.js";
 export type { ToolScopeEnvelope, ToolScopeType, ScopeMembership, DeriveNetworkScopeInput } from "./shared/agent/tool.scope.js";
 export { requestContext } from "./shared/observability/request-context.js";
+export { setLoggerFactory } from "./shared/observability/log.js";
+export type { LoggerWithSource as ProtocolLoggerWithSource } from "./shared/observability/log.js";
 export { setTimingWrapper } from "./shared/observability/performance.js";
 export { ToolRuntimeError, getToolTimeoutPolicy, invokeToolRuntime, toolRuntimeErrorToResult } from "./shared/agent/tool.runtime.js";
 export type { ToolRuntimeErrorCode, ToolTimeoutClass, ToolTimeoutPolicy } from "./shared/agent/tool.runtime.js";

--- a/packages/protocol/src/integration/integration.tools.ts
+++ b/packages/protocol/src/integration/integration.tools.ts
@@ -4,7 +4,7 @@ import { success, error } from '../shared/agent/tool.helpers.js';
 import { requestContext } from "../shared/observability/request-context.js";
 import { protocolLogger } from '../shared/observability/protocol.logger.js';
 
-const logger = protocolLogger('IntegrationTools');
+const logger = protocolLogger('ChatTools:Integration');
 
 /**
  * Creates integration tools for the chat agent.

--- a/packages/protocol/src/intent/intent.graph.ts
+++ b/packages/protocol/src/intent/intent.graph.ts
@@ -223,7 +223,7 @@ export class IntentGraphFactory {
           return { verifiedIntents: [], agentTimings: [] };
         }
 
-        logger.verbose(`Verifying ${intents.length} intents in parallel...`);
+        logger.verbose('Verifying intents in parallel', { count: intents.length });
 
         const agentTimingsAccum: DebugMetaAgent[] = [];
 
@@ -268,12 +268,13 @@ export class IntentGraphFactory {
               // Filter Logic: Must be a Commissive, Directive, or Declaration
               const VALID_TYPES = ['COMMISSIVE', 'DIRECTIVE', 'DECLARATION'];
               if (!VALID_TYPES.includes(verdict.classification)) {
-                logger.warn(`Dropping intent: "${description}" (Type: ${verdict.classification})`);
+                logger.warn('Dropping intent', { description, classification: verdict.classification });
                 return null;
               }
 
               if (isVague(description, verdict.semantic_entropy, verdict.felicity_scores.clarity)) {
-                logger.warn(`Dropping vague intent after verification: "${description}"`, {
+                logger.warn('Dropping vague intent after verification', {
+                  description,
                   entropy: verdict.semantic_entropy,
                   clarity: verdict.felicity_scores.clarity,
                 });
@@ -281,7 +282,8 @@ export class IntentGraphFactory {
               }
 
               if (state.operationMode !== 'propose' && verdict.referential_breadth === 'broad') {
-                logger.warn(`Dropping broad attributive intent before persistence: "${description}"`, {
+                logger.warn('Dropping broad attributive intent before persistence', {
+                  description,
                   referentialBreadth: verdict.referential_breadth,
                   missingSelectionalConstraints: verdict.missing_selectional_constraints,
                   warning: getSpecificityWarning(verdict),
@@ -304,7 +306,7 @@ export class IntentGraphFactory {
                 score
               };
             } catch (e) {
-              logger.error(`Error verifying intent: ${intent.description}`, { error: e });
+              logger.error('Error verifying intent', { description: intent.description, error: e });
               return null;
             }
           })
@@ -511,7 +513,7 @@ export class IntentGraphFactory {
           return { executionResults: [] };
         }
 
-        logger.verbose(`Executing ${actions.length} actions...`);
+        logger.verbose('Executing actions', { count: actions.length });
         const results: ExecutionResult[] = [];
         const scopeEnvelope = state.scopeType && state.scopeId
           ? { scopeType: state.scopeType, scopeId: state.scopeId }
@@ -564,7 +566,7 @@ export class IntentGraphFactory {
               });
 
               results.push({ actionType: 'create', success: true, intentId: created.id, payload: sanitizedPayload });
-              logger.verbose(`Created intent: ${created.id}`);
+              logger.verbose('Created intent', { intentId: created.id });
 
               this.intentQueue?.addGenerateHydeJob({
                 intentId: created.id,
@@ -628,7 +630,7 @@ export class IntentGraphFactory {
                 payload: sanitizedPayload,
                 error: updated ? undefined : 'Intent not found'
               });
-              logger.verbose(`Updated intent: ${updateAction.id}`);
+              logger.verbose('Updated intent', { intentId: updateAction.id });
               if (updated) {
                 this.intentQueue?.addGenerateHydeJob({
                   intentId: updateAction.id,
@@ -648,7 +650,7 @@ export class IntentGraphFactory {
                 intentId: expireAction.id,
                 error: result.error
               });
-              logger.verbose(`Archived intent: ${expireAction.id}`);
+              logger.verbose('Archived intent', { intentId: expireAction.id });
               if (result.success) {
                 this.intentQueue?.addDeleteHydeJob({ intentId: expireAction.id }).catch((err) =>
                   logger.error('Failed to enqueue intent HyDE delete job', { intentId: expireAction.id, error: err })
@@ -656,7 +658,7 @@ export class IntentGraphFactory {
               }
             }
           } catch (error) {
-            logger.error(`Failed to execute ${action.type}:`, { error });
+            logger.error('Failed to execute action', { actionType: action.type, error });
             results.push({
               actionType,
               success: false,

--- a/packages/protocol/src/intent/intent.indexer.ts
+++ b/packages/protocol/src/intent/intent.indexer.ts
@@ -22,6 +22,7 @@ export const IntentIndexerOutputSchema = z.object({
 export type IntentIndexerOutput = z.infer<typeof IntentIndexerOutputSchema>;
 
 const logger = log.lib.from("IntentIndexer");
+const invokeLog = log.lib.from("IntentIndexer:invoke");
 
 
 // ──────────────────────────────────────────────────────────────
@@ -115,7 +116,7 @@ export class IntentIndexer {
     sourceName?: string | null,
     networkContext?: string | null
   ): Promise<IntentIndexerOutput | null> {
-    logger.verbose("[IntentIndexer.invoke] Evaluating intent");
+    invokeLog.verbose("Evaluating intent");
 
     const contextParts: string[] = [];
     if (sourceName) contextParts.push(`Source: ${sourceName}`);
@@ -142,13 +143,13 @@ export class IntentIndexer {
       const result = await invokeWithAbortSignal(this.model, messages);
       const output = responseFormat.parse(result) as IntentIndexerOutput;
 
-      logger.verbose("[IntentIndexer.invoke] Evaluation complete", {
+      invokeLog.verbose("Evaluation complete", {
         indexScore: output.indexScore,
         memberScore: output.memberScore,
       });
       return output;
     } catch (error) {
-      logger.error("[IntentIndexer] Error during execution", { error });
+      logger.error("Error during execution", { error });
       return null;
     }
   }

--- a/packages/protocol/src/intent/intent.inferrer.ts
+++ b/packages/protocol/src/intent/intent.inferrer.ts
@@ -224,7 +224,8 @@ export class ExplicitIntentInferrer {
       const result = await invokeWithAbortSignal(this.model, messages);
       const output = responseFormat.parse(result);
 
-      logger.verbose(`invoke: found ${output.intents.length} intents`, {
+      logger.verbose('invoke: found intents', {
+        count: output.intents.length,
         operationMode,
         allowedFallback: allowProfileFallback,
         usedFallback: !content && allowProfileFallback,

--- a/packages/protocol/src/intent/intent.reconciler.ts
+++ b/packages/protocol/src/intent/intent.reconciler.ts
@@ -7,6 +7,7 @@ import { createStructuredModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("IntentReconciler");
+const invokeLog = protocolLogger("IntentReconciler:invoke");
 
 
 const CreateActionTypeSchema = z.union([z.literal("create"), z.literal("CREATE")]);
@@ -148,7 +149,7 @@ export class IntentReconciler {
    */
   @Timed()
   public async invoke(inferredIntentsFormatted: string, activeIntentsContext: string) {
-    logger.verbose(`[IntentReconciler.invoke] Reconciling intents...`);
+    invokeLog.verbose(`Reconciling intents...`);
 
     const prompt = `
       # Active Intents
@@ -176,10 +177,10 @@ export class IntentReconciler {
         type: normalizeActionType(action.type),
       })) as NormalizedIntentAction[];
 
-      logger.verbose(`[IntentReconciler.invoke] Decision: ${normalizedActions.length} actions.`);
+      invokeLog.verbose(`Decision: ${normalizedActions.length} actions.`);
       return { actions: normalizedActions };
     } catch (error) {
-      logger.error("[IntentReconciler] Error during invocation", { error });
+      logger.error("Error during invocation", { error });
       return { actions: [] };
     }
   }

--- a/packages/protocol/src/intent/intent.reconciler.ts
+++ b/packages/protocol/src/intent/intent.reconciler.ts
@@ -125,7 +125,7 @@ const normalizeActionType = (type: string): "create" | "update" | "expire" => {
   if (normalized === "create" || normalized === "update" || normalized === "expire") {
     return normalized;
   }
-  logger.warn(`normalizeActionType: unexpected action type "${type}", defaulting to "create"`);
+  logger.warn('normalizeActionType: unexpected action type, defaulting to "create"', { type });
   return "create";
 };
 
@@ -177,7 +177,7 @@ export class IntentReconciler {
         type: normalizeActionType(action.type),
       })) as NormalizedIntentAction[];
 
-      invokeLog.verbose(`Decision: ${normalizedActions.length} actions.`);
+      invokeLog.verbose('Decision computed', { actionCount: normalizedActions.length });
       return { actions: normalizedActions };
     } catch (error) {
       logger.error("Error during invocation", { error });

--- a/packages/protocol/src/intent/intent.verifier.ts
+++ b/packages/protocol/src/intent/intent.verifier.ts
@@ -245,7 +245,7 @@ export class SemanticVerifier {
    */
   @Timed()
   public async invoke(content: string, context: string) {
-    invokeLog.verbose(`Verifying: "${content.substring(0, 30)}..."`);
+    invokeLog.verbose('Verifying content', { preview: content.substring(0, 30) });
 
     const prompt = `
       # User Profile (Context)
@@ -266,7 +266,7 @@ export class SemanticVerifier {
       const result = await invokeWithAbortSignal(this.model, messages);
       const output = responseFormat.parse(result);
 
-      invokeLog.verbose(`Verdict: ${output.classification} Entropy: ${output.semantic_entropy}`);
+      invokeLog.verbose('Verdict computed', { classification: output.classification, semanticEntropy: output.semantic_entropy });
       return output;
     } catch (error) {
       logger.error("Error during invocation", { error });

--- a/packages/protocol/src/intent/intent.verifier.ts
+++ b/packages/protocol/src/intent/intent.verifier.ts
@@ -7,6 +7,7 @@ import { createStructuredModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("SemanticVerifier");
+const invokeLog = protocolLogger("SemanticVerifier:invoke");
 
 const referentialBreadthSchema = z.enum(["narrow", "moderate", "broad"]);
 const missingSelectionalConstraintSchema = z.enum([
@@ -244,7 +245,7 @@ export class SemanticVerifier {
    */
   @Timed()
   public async invoke(content: string, context: string) {
-    logger.verbose(`[SemanticVerifier.invoke] Verifying: "${content.substring(0, 30)}..."`);
+    invokeLog.verbose(`Verifying: "${content.substring(0, 30)}..."`);
 
     const prompt = `
       # User Profile (Context)
@@ -265,10 +266,10 @@ export class SemanticVerifier {
       const result = await invokeWithAbortSignal(this.model, messages);
       const output = responseFormat.parse(result);
 
-      logger.verbose(`[SemanticVerifier.invoke] Verdict: ${output.classification} Entropy: ${output.semantic_entropy}`);
+      invokeLog.verbose(`Verdict: ${output.classification} Entropy: ${output.semantic_entropy}`);
       return output;
     } catch (error) {
-      logger.error("[SemanticVerifier] Error during invocation", { error });
+      logger.error("Error during invocation", { error });
       throw error;
     }
   }

--- a/packages/protocol/src/maintenance/maintenance.graph.ts
+++ b/packages/protocol/src/maintenance/maintenance.graph.ts
@@ -118,7 +118,12 @@ export class MaintenanceGraphFactory {
           freshnessWindowMs: FRESHNESS_WINDOW_MS,
         });
 
-        logger.verbose(`[MaintenanceGraph] Feed health scored — userId=${state.userId} score=${healthResult.score} shouldMaintain=${healthResult.shouldMaintain} connectorFlowCount=${connectorFlowCount}`);
+        logger.verbose('Feed health scored', {
+          userId: state.userId,
+          score: healthResult.score,
+          shouldMaintain: healthResult.shouldMaintain,
+          connectorFlowCount,
+        });
 
         return { healthResult, connectorFlowCount };
       } catch (e) {
@@ -151,7 +156,7 @@ export class MaintenanceGraphFactory {
         for (const r of results) {
           if (r.status === 'rejected') {
             const errMsg = r.reason instanceof Error ? r.reason.message : String(r.reason);
-            logger.error(`[MaintenanceGraph] Rediscovery job enqueue failed: ${errMsg}`);
+            logger.error('Rediscovery job enqueue failed', { error: errMsg });
           }
         }
         const enqueued = results.filter((r) => r.status === 'fulfilled').length;
@@ -180,7 +185,11 @@ export class MaintenanceGraphFactory {
       try {
         const connectorFlowTarget = FEED_SOFT_TARGETS.connectorFlow;
         if (!shouldRunIntroducerDiscovery(state.connectorFlowCount, connectorFlowTarget)) {
-          logger.verbose(`[MaintenanceGraph] Introducer discovery skipped — connector-flow target met — userId=${state.userId} connectorFlowCount=${state.connectorFlowCount} connectorFlowTarget=${connectorFlowTarget}`);
+          logger.verbose('Introducer discovery skipped — connector-flow target met', {
+            userId: state.userId,
+            connectorFlowCount: state.connectorFlowCount,
+            connectorFlowTarget,
+          });
           return {};
         }
 
@@ -191,7 +200,12 @@ export class MaintenanceGraphFactory {
           state.userId,
         );
 
-        logger.info(`[MaintenanceGraph] Introducer discovery complete — userId=${state.userId} contactsEvaluated=${result.contactsEvaluated} jobsEnqueued=${result.jobsEnqueued}${result.skippedReason ? ` skippedReason=${result.skippedReason}` : ''}`);
+        logger.info('Introducer discovery complete', {
+          userId: state.userId,
+          contactsEvaluated: result.contactsEvaluated,
+          jobsEnqueued: result.jobsEnqueued,
+          skippedReason: result.skippedReason,
+        });
 
         return { introducerDiscoveryJobsEnqueued: result.jobsEnqueued };
       } catch (e) {
@@ -202,7 +216,15 @@ export class MaintenanceGraphFactory {
     };
 
     const logMaintenanceNode = async (state: typeof MaintenanceGraphState.State) => {
-      logger.info(`[MaintenanceGraph] Maintenance complete — userId=${state.userId} score=${state.healthResult?.score} shouldMaintain=${state.healthResult?.shouldMaintain} rediscoveryJobs=${state.rediscoveryJobsEnqueued} introducerDiscoveryJobs=${state.introducerDiscoveryJobsEnqueued} activeIntents=${state.activeIntents.length} connectorFlowCount=${state.connectorFlowCount}`);
+      logger.info('Maintenance complete', {
+        userId: state.userId,
+        score: state.healthResult?.score,
+        shouldMaintain: state.healthResult?.shouldMaintain,
+        rediscoveryJobs: state.rediscoveryJobsEnqueued,
+        introducerDiscoveryJobs: state.introducerDiscoveryJobsEnqueued,
+        activeIntents: state.activeIntents.length,
+        connectorFlowCount: state.connectorFlowCount,
+      });
       return {};
     };
 

--- a/packages/protocol/src/mcp/mcp.server.ts
+++ b/packages/protocol/src/mcp/mcp.server.ts
@@ -91,7 +91,7 @@ export function getCachedMcpToolMetadata(deps: ToolDeps): readonly McpToolRegist
   });
 
   mcpToolMetadataCache.set(cacheKey, metadata);
-  logger.verbose(`MCP tool metadata cached with ${metadata.length} tools`, { cacheKey });
+  logger.verbose('MCP tool metadata cached', { toolCount: metadata.length, cacheKey });
   return metadata;
 }
 
@@ -579,7 +579,8 @@ export function createMcpServer(
                 toolName,
               });
             } catch (rlErr) {
-              logger.warn(`MCP rate limiter threw for "${toolName}" — failing open`, {
+              logger.warn('MCP rate limiter threw — failing open', {
+                toolName,
                 error: rlErr instanceof Error ? rlErr.message : String(rlErr),
               });
             }
@@ -755,7 +756,7 @@ export function createMcpServer(
           };
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
-          logger.error(`MCP tool "${toolName}" failed`, { error: message });
+          logger.error('MCP tool failed', { toolName, error: message });
           if (shouldReportMcpToolError(err)) {
             reportDeps.reportToolError?.(err, {
               subsystem: 'mcp',
@@ -783,6 +784,6 @@ export function createMcpServer(
     );
   }
 
-  logger.verbose(`MCP server created with ${toolMetadata.length} tools`);
+  logger.verbose('MCP server created', { toolCount: toolMetadata.length });
   return server;
 }

--- a/packages/protocol/src/negotiation/insight.generator.ts
+++ b/packages/protocol/src/negotiation/insight.generator.ts
@@ -103,10 +103,10 @@ export class NegotiationInsightsGenerator {
 
       if (!text) return null;
 
-      logger.verbose("[NegotiationInsightsGenerator.invoke] Insights generated", { length: text.length });
+      logger.verbose("Insights generated", { length: text.length });
       return text;
     } catch (error) {
-      logger.warn("[NegotiationInsightsGenerator.invoke] Failed to generate insights", {
+      logger.warn("Failed to generate insights", {
         error: error instanceof Error ? error.message : String(error),
       });
       return null;

--- a/packages/protocol/src/negotiation/negotiation.graph.ts
+++ b/packages/protocol/src/negotiation/negotiation.graph.ts
@@ -11,6 +11,10 @@ import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import type { QuestionerEnqueueFn } from "../questioner/questioner.types.js";
 
 const logger = protocolLogger("NegotiationGraph");
+const initLog = protocolLogger("NegotiationGraph:Init");
+const turnLog = protocolLogger("NegotiationGraph:Turn");
+const finalizeLog = protocolLogger("NegotiationGraph:Finalize");
+const negotiateCandidatesLog = protocolLogger("NegotiationGraph:negotiateCandidates");
 
 /** Extracts the ordered NegotiationTurn list from A2A message data parts. */
 function turnsFromMessages(messages: Array<{ parts: unknown[] }>): NegotiationTurn[] {
@@ -61,7 +65,7 @@ export class NegotiationGraphFactory {
         }
 
         if (isLocked) {
-          logger.info('[Graph:Init] Conversation locked by active task, returning busy', {
+          initLog.info('Conversation locked by active task, returning busy', {
             conversationId: conversation.id,
             opportunityId: state.opportunityId,
           });
@@ -106,14 +110,14 @@ export class NegotiationGraphFactory {
 
         if (state.opportunityId) {
           await database.updateOpportunityStatus(state.opportunityId, 'negotiating').catch((err) => {
-            logger.error('[Graph:Init] Failed to set opportunity status to negotiating', { opportunityId: state.opportunityId, error: err });
+            initLog.error('Failed to set opportunity status to negotiating', { opportunityId: state.opportunityId, error: err });
           });
         }
 
         // Load user answers collected by the questioner between sessions
         const userAnswers = (isContinuation && state.opportunityId)
           ? await database.getOpportunityUserAnswers(state.opportunityId).catch((err) => {
-              logger.error('[Graph:Init] Failed to load user answers', { opportunityId: state.opportunityId, error: err });
+              initLog.error('Failed to load user answers', { opportunityId: state.opportunityId, error: err });
               return [];
             })
           : [];
@@ -226,7 +230,7 @@ export class NegotiationGraphFactory {
 
         // First turn must be "propose" (unless continuing a prior conversation)
         if (state.turnCount === 0 && !state.isContinuation && turn.action !== "propose") {
-          logger.warn("[Graph:Turn] Agent returned unexpected action on turn 0, forcing to propose", { action: turn.action });
+          turnLog.warn("Agent returned unexpected action on turn 0, forcing to propose", { action: turn.action });
           turn.action = "propose";
         }
 
@@ -270,7 +274,7 @@ export class NegotiationGraphFactory {
         };
       } catch (err) {
         const errMsg = err instanceof Error ? err.message : String(err);
-        logger.error("[Graph:Turn] Agent invocation failed", { error: errMsg, stack: err instanceof Error ? err.stack : undefined, turnCount: state.turnCount });
+        turnLog.error("Agent invocation failed", { error: errMsg, stack: err instanceof Error ? err.stack : undefined, turnCount: state.turnCount });
         traceEmitter?.({ type: "agent_end", name: agentName, durationMs: Date.now() - agentStart, summary: `error: ${errMsg}` });
         return {
           lastTurn: {
@@ -349,7 +353,7 @@ export class NegotiationGraphFactory {
           metadata: { hasOpportunity, turnCount: state.turnCount },
         });
 
-        logger.info('[Graph:Finalize] Session complete', {
+        finalizeLog.info('Session complete', {
           conversationId: state.conversationId,
           taskId: state.taskId,
           isContinuation: state.isContinuation,
@@ -366,11 +370,11 @@ export class NegotiationGraphFactory {
               ? 'rejected'
               : 'stalled';
           await database.updateOpportunityStatus(state.opportunityId, nextStatus).catch((err) => {
-            logger.error("[Graph:Finalize] Failed to update opportunity status", { opportunityId: state.opportunityId, nextStatus, error: err });
+            finalizeLog.error("Failed to update opportunity status", { opportunityId: state.opportunityId, nextStatus, error: err });
           });
         }
       } catch (err) {
-        logger.error("[Graph:Finalize] Failed to persist outcome", { error: err });
+        finalizeLog.error("Failed to persist outcome", { error: err });
       }
 
       if (state.opportunityId) {
@@ -427,7 +431,7 @@ export class NegotiationGraphFactory {
             userContext,
           },
         }).catch((err) =>
-          logger.error('[Graph:Finalize] Failed to enqueue negotiation question generation', {
+          finalizeLog.error('Failed to enqueue negotiation question generation', {
             opportunityId: state.opportunityId,
             error: err,
           })
@@ -620,7 +624,7 @@ export async function negotiateCandidates(
             // Hook failures must not sink the candidate result — the aggregate
             // return is still useful, and the orchestrator branch logs its own
             // failures inline.
-            logger.error("[negotiateCandidates] onCandidateResolved hook threw", {
+            negotiateCandidatesLog.error("onCandidateResolved hook threw", {
               candidateUserId: candidate.userId,
               error: hookErr,
             });
@@ -639,7 +643,7 @@ export async function negotiateCandidates(
             durationMs: Date.now() - start,
           });
         }
-        logger.error("[negotiateCandidates] Negotiation failed", { candidateUserId: candidate.userId, error: err });
+        negotiateCandidatesLog.error("Negotiation failed", { candidateUserId: candidate.userId, error: err });
         if (onCandidateResolved) {
           try {
             await onCandidateResolved({

--- a/packages/protocol/src/negotiation/negotiation.tools.ts
+++ b/packages/protocol/src/negotiation/negotiation.tools.ts
@@ -8,7 +8,7 @@ import type { NegotiationTurnPayload } from '../shared/interfaces/agent-dispatch
 import { protocolLogger } from '../shared/observability/protocol.logger.js';
 import { focusedNetworkId } from '../shared/agent/tool.scope.js';
 
-const logger = protocolLogger('NegotiationTools');
+const logger = protocolLogger('ChatTools:Negotiation');
 
 /**
  * Default park-window budget for ambient (background) negotiations. When a personal

--- a/packages/protocol/src/network/network.recommender.ts
+++ b/packages/protocol/src/network/network.recommender.ts
@@ -35,6 +35,7 @@ export interface NetworkRecommenderInput {
 // ─── Logger ───────────────────────────────────────────────────────────────────
 
 const logger = log.lib.from("NetworkRecommender");
+const invokeLog = log.lib.from("NetworkRecommender:invoke");
 
 // ─── System prompt ────────────────────────────────────────────────────────────
 
@@ -90,7 +91,7 @@ export class NetworkRecommender {
   public async invoke(input: NetworkRecommenderInput): Promise<NetworkRecommenderOutput | null> {
     if (input.networks.length === 0) return null;
 
-    logger.verbose("[NetworkRecommender.invoke] Ranking communities", {
+    invokeLog.verbose("Ranking communities", {
       networkCount: input.networks.length,
     });
 
@@ -111,15 +112,15 @@ export class NetworkRecommender {
       const result = await invokeWithAbortSignal(this.model, messages);
       const parsed = NetworkRecommenderOutputSchema.safeParse(result);
       if (!parsed.success) {
-        logger.error("[NetworkRecommender] Schema validation failed", { error: parsed.error });
+        logger.error("Schema validation failed", { error: parsed.error });
         return null;
       }
-      logger.verbose("[NetworkRecommender.invoke] Ranking complete", {
+      invokeLog.verbose("Ranking complete", {
         top: parsed.data.rankedNetworkIds[0],
       });
       return parsed.data;
     } catch (error) {
-      logger.error("[NetworkRecommender] Error during execution", { error });
+      logger.error("Error during execution", { error });
       return null;
     }
   }

--- a/packages/protocol/src/network/network.tools.ts
+++ b/packages/protocol/src/network/network.tools.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { requestContext } from "../shared/observability/request-context.js";
+import { log } from "../shared/observability/log.js";
 import { renderNetworkContext } from '../shared/network/metadata.renderer.js';
 
 import type { DefineTool, ToolDeps } from "../shared/agent/tool.helpers.js";
@@ -10,6 +11,8 @@ import { NetworkRecommender } from "./network.recommender.js";
 // Lazy singleton — only instantiated on first onboarding ranking call so that
 // importing this module does not require OPENROUTER_API_KEY at load time.
 let recommender: NetworkRecommender | undefined;
+
+const logger = log.protocol.from("network.tools");
 
 export function createNetworkTools(defineTool: DefineTool, deps: ToolDeps) {
   const { graphs, userDb, systemDb } = deps;
@@ -105,7 +108,7 @@ export function createNetworkTools(defineTool: DefineTool, deps: ToolDeps) {
               return await recommender.invoke(input);
             } catch (err) {
               // e.g. missing OPENROUTER_API_KEY — degrade gracefully, omit orderedNetworkIds
-              console.warn("[read_networks] NetworkRecommender unavailable, skipping ranking:", err);
+              logger.warn("read_networks: NetworkRecommender unavailable, skipping ranking", { error: err });
               return null;
             }
           });
@@ -115,7 +118,7 @@ export function createNetworkTools(defineTool: DefineTool, deps: ToolDeps) {
           }).catch((err: unknown) => {
             // Catches errors from a custom deps.networkRanker (the default fallback
             // handles its own errors internally). Degrade gracefully: omit orderedNetworkIds.
-            console.warn("[read_networks] networkRanker threw, skipping ranking:", err);
+            logger.warn("read_networks: networkRanker threw, skipping ranking", { error: err });
             deps.reportToolError?.(err, { operation: "network-ranking", toolName: "read_networks", userId: context.userId });
             return null;
           });

--- a/packages/protocol/src/network/network.tools.ts
+++ b/packages/protocol/src/network/network.tools.ts
@@ -12,7 +12,7 @@ import { NetworkRecommender } from "./network.recommender.js";
 // importing this module does not require OPENROUTER_API_KEY at load time.
 let recommender: NetworkRecommender | undefined;
 
-const logger = log.protocol.from("network.tools");
+const logger = log.protocol.from("ChatTools:Network");
 
 export function createNetworkTools(defineTool: DefineTool, deps: ToolDeps) {
   const { graphs, userDb, systemDb } = deps;

--- a/packages/protocol/src/opportunity/feed/feed.graph.ts
+++ b/packages/protocol/src/opportunity/feed/feed.graph.ts
@@ -29,6 +29,13 @@ import { timed } from '../../shared/observability/performance.js';
 import { requestContext } from "../../shared/observability/request-context.js";
 
 const logger = protocolLogger('HomeGraph');
+const checkCategorizerCacheLog = protocolLogger('HomeGraph:checkCategorizerCache');
+const cacheCategorizerResultsLog = protocolLogger('HomeGraph:cacheCategorizerResults');
+const checkPresenterCacheLog = protocolLogger('HomeGraph:checkPresenterCache');
+const cachePresenterResultsLog = protocolLogger('HomeGraph:cachePresenterResults');
+const categorizeDynamicallyLog = protocolLogger('HomeGraph:categorizeDynamically');
+const normalizeAndSortLog = protocolLogger('HomeGraph:normalizeAndSort');
+const generateCardTextLog = protocolLogger('HomeGraph:generateCardText');
 
 /** Database must satisfy both HomeGraphDatabase and presenter context (getProfile, getActiveIntents, getNetwork, getUser). */
 type HomeGraphDb = HomeGraphDatabase;
@@ -252,7 +259,7 @@ export class HomeGraphFactory {
         }
 
         if (state.noCache) {
-          logger.verbose('[HomeGraph:checkPresenterCache] noCache=true, skipping cache');
+          checkPresenterCacheLog.verbose('noCache=true, skipping cache');
           return { cachedCards: new Map(), uncachedOpportunities: opportunities };
         }
 
@@ -285,7 +292,7 @@ export class HomeGraphFactory {
             }
           }
 
-          logger.verbose('[HomeGraph:checkPresenterCache]', {
+          checkPresenterCacheLog.verbose('', {
             total: opportunities.length,
             cacheHits: cachedCards.size,
             cacheMisses: uncachedOpportunities.length,
@@ -293,7 +300,7 @@ export class HomeGraphFactory {
 
           return { cachedCards, uncachedOpportunities };
         } catch (e) {
-          logger.warn('[HomeGraph:checkPresenterCache] cache unavailable, skipping', { error: e });
+          checkPresenterCacheLog.warn('cache unavailable, skipping', { error: e });
           return { cachedCards: new Map(), uncachedOpportunities: opportunities };
         }
       });
@@ -303,7 +310,7 @@ export class HomeGraphFactory {
       if (state.uncachedOpportunities.length > 0) {
         return 'generate';
       }
-      logger.verbose('[HomeGraph] All presenter results cached, skipping generation');
+      logger.verbose('All presenter results cached, skipping generation');
       return 'skip';
     };
 
@@ -312,9 +319,9 @@ export class HomeGraphFactory {
       const opportunities = state.uncachedOpportunities.length > 0
         ? state.uncachedOpportunities
         : state.opportunities;
-      logger.verbose('[HomeGraph:generateCardText] entry', { opportunitiesLength: opportunities.length, userId: state.userId });
+      generateCardTextLog.verbose('entry', { opportunitiesLength: opportunities.length, userId: state.userId });
       if (opportunities.length === 0) {
-        logger.verbose('[HomeGraph:generateCardText] exit', { totalOpportunities: 0, totalSections: 0 });
+        generateCardTextLog.verbose('exit', { totalOpportunities: 0, totalSections: 0 });
         return { cards: [], agentTimings: [], meta: { totalOpportunities: 0, totalSections: 0 } };
       }
       const db = this.database as PresenterDatabase & HomeGraphDb;
@@ -387,7 +394,7 @@ export class HomeGraphFactory {
             // Fallback to profile identity name when users.name is missing (e.g. profile has display name, users row does not)
             if ((userName === 'Unknown' || !userName?.trim()) && otherActor?.userId && db.getProfile) {
               const profile = await db.getProfile(otherActor.userId).catch((err) => {
-                logger.debug('[HomeGraph] getProfile fallback failed', { otherActorUserId: otherActor.userId, error: err });
+                logger.debug('getProfile fallback failed', { otherActorUserId: otherActor.userId, error: err });
                 return null;
               });
               const profileName = profile?.identity?.name?.trim();
@@ -510,7 +517,7 @@ export class HomeGraphFactory {
         );
         cards.push(...chunkCards);
       }
-      logger.verbose('[HomeGraph:generateCardText] exit', { totalOpportunities: state.opportunities.length, totalSections: 0 });
+      generateCardTextLog.verbose('exit', { totalOpportunities: state.opportunities.length, totalSections: 0 });
       return {
         cards,
         agentTimings: agentTimingsAccum,
@@ -544,7 +551,7 @@ export class HomeGraphFactory {
             })
           );
         } catch (e) {
-          logger.warn('[HomeGraph:cachePresenterResults] cache write failed, continuing', { error: e });
+          cachePresenterResultsLog.warn('cache write failed, continuing', { error: e });
         }
 
         // Merge cached cards into full card list
@@ -558,7 +565,7 @@ export class HomeGraphFactory {
         // Re-sort by _cardIndex to maintain original ordering
         allCards.sort((a, b) => a._cardIndex - b._cardIndex);
 
-        logger.verbose('[HomeGraph:cachePresenterResults]', {
+        cachePresenterResultsLog.verbose('', {
           newlyCached: newCards.length,
           totalCards: allCards.length,
         });
@@ -577,7 +584,7 @@ export class HomeGraphFactory {
         }
 
         if (state.noCache) {
-          logger.verbose('[HomeGraph:checkCategorizerCache] noCache=true, skipping cache');
+          checkCategorizerCacheLog.verbose('noCache=true, skipping cache');
           return { categoryCacheHit: false };
         }
 
@@ -586,13 +593,13 @@ export class HomeGraphFactory {
 
           const cached = await this.cache.get<HomeSectionProposal[]>(key);
           if (cached) {
-            logger.verbose('[HomeGraph:checkCategorizerCache] cache hit');
+            checkCategorizerCacheLog.verbose('cache hit');
             return { sectionProposals: cached, categoryCacheHit: true };
           }
 
-          logger.verbose('[HomeGraph:checkCategorizerCache] cache miss');
+          checkCategorizerCacheLog.verbose('cache miss');
         } catch (e) {
-          logger.warn('[HomeGraph:checkCategorizerCache] cache unavailable, skipping', { error: e });
+          checkCategorizerCacheLog.warn('cache unavailable, skipping', { error: e });
         }
         return { categoryCacheHit: false };
       });
@@ -600,7 +607,7 @@ export class HomeGraphFactory {
 
     const shouldCategorize = (state: typeof HomeGraphState.State): string => {
       if (state.categoryCacheHit) {
-        logger.verbose('[HomeGraph] Categorizer results cached, skipping');
+        logger.verbose('Categorizer results cached, skipping');
         return 'skip';
       }
       return 'categorize';
@@ -608,9 +615,9 @@ export class HomeGraphFactory {
 
     const categorizeDynamicallyNode = async (state: typeof HomeGraphState.State) => {
       return timed("HomeGraph.categorizeDynamically", async () => {
-        logger.verbose('[HomeGraph:categorizeDynamically] entry', { cardsLength: state.cards.length });
+        categorizeDynamicallyLog.verbose('entry', { cardsLength: state.cards.length });
         if (state.cards.length === 0) {
-          logger.verbose('[HomeGraph:categorizeDynamically] exit', { sectionProposalsCount: 0 });
+          categorizeDynamicallyLog.verbose('exit', { sectionProposalsCount: 0 });
           return { sectionProposals: [], agentTimings: [] };
         }
         const agentTimingsAccum: DebugMetaAgent[] = [];
@@ -633,7 +640,7 @@ export class HomeGraphFactory {
           ...s,
           itemIndices: s.itemIndices.filter((i) => i >= 0 && i < state.cards.length),
         }));
-        logger.verbose('[HomeGraph:categorizeDynamically] exit', { sectionProposalsCount: proposals.length });
+        categorizeDynamicallyLog.verbose('exit', { sectionProposalsCount: proposals.length });
         return { sectionProposals: proposals, agentTimings: agentTimingsAccum };
       });
     };
@@ -649,11 +656,11 @@ export class HomeGraphFactory {
 
           await this.cache.set(key, state.sectionProposals, { ttl: HOME_CACHE_TTL });
 
-          logger.verbose('[HomeGraph:cacheCategorizerResults] cached', {
+          cacheCategorizerResultsLog.verbose('cached', {
             sectionCount: state.sectionProposals.length,
           });
         } catch (e) {
-          logger.warn('[HomeGraph:cacheCategorizerResults] cache write failed, continuing', { error: e });
+          cacheCategorizerResultsLog.warn('cache write failed, continuing', { error: e });
         }
 
         return {};
@@ -664,9 +671,9 @@ export class HomeGraphFactory {
       return timed("HomeGraph.normalizeAndSort", async () => {
         const cards = state.cards;
         const proposals = state.sectionProposals;
-        logger.verbose('[HomeGraph:normalizeAndSort] entry', { cardsLength: cards.length, proposalsLength: proposals.length });
+        normalizeAndSortLog.verbose('entry', { cardsLength: cards.length, proposalsLength: proposals.length });
         if (cards.length === 0) {
-          logger.verbose('[HomeGraph:normalizeAndSort] exit', { totalOpportunities: 0, totalSections: 0 });
+          normalizeAndSortLog.verbose('exit', { totalOpportunities: 0, totalSections: 0 });
           return { sections: [], meta: { totalOpportunities: 0, totalSections: 0 } };
         }
         const usedIndices = new Set<number>();
@@ -705,7 +712,7 @@ export class HomeGraphFactory {
           totalOpportunities: state.opportunities.length,
           totalSections: sections.length,
         };
-        logger.verbose('[HomeGraph:normalizeAndSort] exit', { totalOpportunities: meta.totalOpportunities, totalSections: meta.totalSections });
+        normalizeAndSortLog.verbose('exit', { totalOpportunities: meta.totalOpportunities, totalSections: meta.totalSections });
         return { sections, meta };
       });
     };

--- a/packages/protocol/src/opportunity/opportunity.discover.ts
+++ b/packages/protocol/src/opportunity/opportunity.discover.ts
@@ -33,6 +33,8 @@ import { buildDiscoveryQuestionInput } from "./discovery-question.helper.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("OpportunityDiscover");
+const discoverFromQueryLog = protocolLogger("OpportunityDiscover:runDiscoverFromQuery");
+const enrichLog = protocolLogger("OpportunityDiscover:enrichOpportunities");
 
 /**
  * Per-negotiation summarizer budget. The summarizer fires one LLM call per
@@ -409,7 +411,7 @@ async function enrichOpportunities(
         avatarByUserId.set(r.id, r.user.avatar);
       }
     }
-    logger.verbose("[enrichOpportunities] Retried name lookup for candidates with missing names", {
+    enrichLog.verbose("Retried name lookup for candidates with missing names", {
       attempted: missingNameIds.length,
       resolved: retried.filter((r) => r.profile?.identity?.name ?? r.user?.name).length,
     });
@@ -864,7 +866,7 @@ export async function runDiscoverFromQuery(
         }),
       );
       if (existingConnections.length > 0) {
-        logger.verbose("[runDiscoverFromQuery] Skipped duplicates; existing connections", {
+        discoverFromQueryLog.verbose("Skipped duplicates; existing connections", {
           count: existingConnections.length,
           userIds: existingConnections.map((c) => c.userId),
         });
@@ -884,7 +886,7 @@ export async function runDiscoverFromQuery(
         );
         const validExistingOpps = existingOpps.filter((o): o is Opportunity => o != null);
         if (validExistingOpps.length > 0) {
-          logger.verbose("[runDiscoverFromQuery] Including existing opportunities as cards", {
+          discoverFromQueryLog.verbose("Including existing opportunities as cards", {
             count: validExistingOpps.length,
             ids: validExistingOpps.map((o) => o.id),
           });
@@ -898,7 +900,7 @@ export async function runDiscoverFromQuery(
       // may set status to pending/latent when merging with related opportunities, so filtering to
       // "draft" would incorrectly drop them.
       if (chatSessionId && (result.opportunities?.length ?? 0) > 0) {
-        logger.verbose("[runDiscoverFromQuery] Chat session opportunities from graph", {
+        discoverFromQueryLog.verbose("Chat session opportunities from graph", {
           count: opportunities.length,
           statuses: opportunities.map((o) => o.status),
         });

--- a/packages/protocol/src/opportunity/opportunity.enricher.ts
+++ b/packages/protocol/src/opportunity/opportunity.enricher.ts
@@ -277,7 +277,7 @@ export async function enrichOrCreate(
           }
         }
       } catch (e) {
-        logger.warn('[Enricher] Embedding check failed; intent-matched opportunities already captured', { error: e });
+        logger.warn('Embedding check failed; intent-matched opportunities already captured', { error: e });
         // Phase 1 matches are preserved; remaining opps without shared intents are not related
       }
     }
@@ -309,7 +309,7 @@ export async function enrichOrCreate(
 
   const resolvedStatus = resolveEnrichedStatus(related.map((o) => o.status), newData.status);
 
-  logger.verbose('[Enricher] Enriched opportunity', {
+  logger.verbose('Enriched opportunity', {
     enrichedFrom,
     actorCount: mergedActors.length,
   });

--- a/packages/protocol/src/opportunity/opportunity.evaluator.ts
+++ b/packages/protocol/src/opportunity/opportunity.evaluator.ts
@@ -306,7 +306,7 @@ export class OpportunityEvaluator {
   ): Promise<Opportunity[]> {
     const minScore = options.minScore || 70;
 
-    invokeLog.verbose(`Analyzing ${candidates.length} candidates...`);
+    invokeLog.verbose('Analyzing candidates', { count: candidates.length });
 
     if (candidates.length === 0) {
       logger.verbose('No candidates provided.');
@@ -381,7 +381,7 @@ export class OpportunityEvaluator {
       return mappedOpportunities;
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);
-      logger.warn(`Analysis failed for candidate ${candidateUserId}`, { message });
+      logger.warn('Analysis failed for candidate', { candidateUserId, message });
       throw e;
     }
   }

--- a/packages/protocol/src/opportunity/opportunity.evaluator.ts
+++ b/packages/protocol/src/opportunity/opportunity.evaluator.ts
@@ -13,6 +13,8 @@ import type { OpportunityEvidence } from '../shared/schemas/network-assignment.s
 import { renderOpportunityEvidenceForPrompt } from './opportunity.evidence.js';
 
 const logger = protocolLogger("OpportunityEvaluator");
+const invokeLog = protocolLogger("OpportunityEvaluator:invoke");
+const invokeEntityBundleLog = protocolLogger("OpportunityEvaluator:invokeEntityBundle");
 
 
 // ──────────────────────────────────────────────────────────────
@@ -304,10 +306,10 @@ export class OpportunityEvaluator {
   ): Promise<Opportunity[]> {
     const minScore = options.minScore || 70;
 
-    logger.verbose(`[OpportunityEvaluator.invoke] Analyzing ${candidates.length} candidates...`);
+    invokeLog.verbose(`Analyzing ${candidates.length} candidates...`);
 
     if (candidates.length === 0) {
-      logger.verbose('[OpportunityEvaluator] No candidates provided.');
+      logger.verbose('No candidates provided.');
       return [];
     }
 
@@ -329,7 +331,7 @@ export class OpportunityEvaluator {
 
     // Sort by score and take top 1
     const out = opportunities.sort((a, b) => b.score - a.score).slice(0, 1);
-    logger.verbose('[OpportunityEvaluator.invoke] Done', { accepted: out.length });
+    invokeLog.verbose('Done', { accepted: out.length });
     return out;
   }
 
@@ -379,7 +381,7 @@ export class OpportunityEvaluator {
       return mappedOpportunities;
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);
-      logger.warn(`[OpportunityEvaluator] Analysis failed for candidate ${candidateUserId}`, { message });
+      logger.warn(`Analysis failed for candidate ${candidateUserId}`, { message });
       throw e;
     }
   }
@@ -396,7 +398,7 @@ export class OpportunityEvaluator {
     const returnAll = options.returnAll ?? false;
     const totalEntities = input.entities?.length ?? 0;
     if (!input.entities?.length) {
-      logger.verbose('[OpportunityEvaluator.invokeEntityBundle] No entities.');
+      invokeEntityBundleLog.verbose('No entities.');
       return [];
     }
     const existingPart = input.existingOpportunities
@@ -507,7 +509,7 @@ ${renderOpportunityEvidenceForPrompt(e.evidence ?? [])}`;
           ? parsed.opportunities.filter((op) => op.actors.length === 2)
           : parsed.opportunities;
       const filtered = introGuard.filter((op) => op.score >= minScore);
-      logger.verbose('[OpportunityEvaluator.invokeEntityBundle] Done', {
+      invokeEntityBundleLog.verbose('Done', {
         total: parsed.opportunities.length,
         afterIntroGuard: introGuard.length,
         accepted: filtered.length,
@@ -515,7 +517,7 @@ ${renderOpportunityEvidenceForPrompt(e.evidence ?? [])}`;
       });
       return returnAll ? introGuard : filtered;
     } catch (llmError) {
-      logger.error('[OpportunityEvaluator.invokeEntityBundle] Failed', {
+      invokeEntityBundleLog.error('Failed', {
         discovererId: input.discovererId,
         totalEntities,
         parsedTotal,

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -60,6 +60,24 @@ import type { OpportunityEvidence } from '../shared/schemas/network-assignment.s
 import { mergeOpportunityEvidence, withCandidateEvidence, withMatchedStrategies } from './opportunity.evidence.js';
 
 const logger = protocolLogger('OpportunityGraph');
+const prepLog = protocolLogger('OpportunityGraph:Prep');
+const scopeLog = protocolLogger('OpportunityGraph:Scope');
+const resolveLog = protocolLogger('OpportunityGraph:Resolve');
+const discoveryLog = protocolLogger('OpportunityGraph:Discovery');
+const evaluationLog = protocolLogger('OpportunityGraph:Evaluation');
+const negotiateLog = protocolLogger('OpportunityGraph:Negotiate');
+const rankingLog = protocolLogger('OpportunityGraph:Ranking');
+const introValidationLog = protocolLogger('OpportunityGraph:IntroValidation');
+const introEvaluationLog = protocolLogger('OpportunityGraph:IntroEvaluation');
+const persistLog = protocolLogger('OpportunityGraph:Persist');
+const persistPathLog = protocolLogger('OpportunityGraph:Persist:PathSelect');
+const persistDedupLog = protocolLogger('OpportunityGraph:Persist:Dedup');
+const readLog = protocolLogger('OpportunityGraph:Read');
+const updateLog = protocolLogger('OpportunityGraph:Update');
+const deleteLog = protocolLogger('OpportunityGraph:Delete');
+const sendLog = protocolLogger('OpportunityGraph:Send');
+const negotiateExistingLog = protocolLogger('OpportunityGraph:NegotiateExisting');
+const routingLog = protocolLogger('OpportunityGraph:Routing');
 
 /** Time window for persist-node dedup. Suppresses a second opportunity with the same person while a recent one (within 30 days) is still in flight, so a person is not re-surfaced multiple times within a month (EDG-23). */
 const DEDUP_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
@@ -248,8 +266,8 @@ export class OpportunityGraphFactory {
       async (state: typeof OpportunityGraphState.State) =>
       timed("OpportunityGraph.prep", async () =>
         withCallLogging(
-          logger,
-          '[Graph:Prep] prepNode',
+          prepLog,
+          'prepNode',
           {
             userId: state.userId,
             hasSearchQuery: !!state.searchQuery,
@@ -261,7 +279,7 @@ export class OpportunityGraphFactory {
             const memberships = await this.database.getNetworkMemberships(state.userId);
             const userNetworkIds = memberships.map(m => m.networkId) as Id<'networks'>[];
             if (userNetworkIds.length === 0) {
-              logger.verbose('[Graph:Prep] User has no network memberships - cannot find opportunities');
+              prepLog.verbose('User has no network memberships - cannot find opportunities');
               return {
                 userNetworks: [] as Id<'networks'>[],
                 sourceProfile: null,
@@ -318,7 +336,7 @@ export class OpportunityGraphFactory {
           { context: { userId: state.userId }, logOutput: true }
         ).catch((error) => {
           const errMsg = error instanceof Error ? error.message : String(error);
-          logger.error('[Graph:Prep] Failed', { error });
+          prepLog.error('Failed', { error });
           return {
             error: 'Failed to prepare opportunity search. Please try again.',
             trace: [{
@@ -348,7 +366,7 @@ export class OpportunityGraphFactory {
       "opportunity-scope",
       async (state: typeof OpportunityGraphState.State) => {
       return timed("OpportunityGraph.scope", async () => {
-        logger.verbose('[Graph:Scope] Determining search scope', {
+        scopeLog.verbose('Determining search scope', {
           requestedIndexId: state.networkId,
           userNetworksCount: state.userNetworks.length,
         });
@@ -361,7 +379,7 @@ export class OpportunityGraphFactory {
             const isInScope = state.userNetworks.includes(state.networkId);
             const isOwner = !isInScope && await this.database.isIndexOwner(state.networkId, state.userId);
             if (!isInScope && !isOwner) {
-              logger.warn('[Graph:Scope] User not member of requested network', {
+              scopeLog.warn('User not member of requested network', {
                 networkId: state.networkId,
               });
               return {
@@ -376,7 +394,7 @@ export class OpportunityGraphFactory {
             // reaches networks outside the agent's bound scope.
             const allowed = new Set(state.indexScope);
             targetIndexIds = state.userNetworks.filter((n) => allowed.has(n));
-            logger.verbose('[Graph:Scope] Applied indexScope intersection', {
+            scopeLog.verbose('Applied indexScope intersection', {
               indexScopeCount: state.indexScope.length,
               userNetworksCount: state.userNetworks.length,
               targetCount: targetIndexIds.length,
@@ -399,7 +417,7 @@ export class OpportunityGraphFactory {
             })
           );
 
-          logger.verbose('[Graph:Scope] Scope determined', {
+          scopeLog.verbose('Scope determined', {
             targetIndexesCount: targetNetworks.length,
             indexes: targetNetworks.map(i => i.title),
           });
@@ -417,7 +435,7 @@ export class OpportunityGraphFactory {
                 }
               }
             } catch (err) {
-              logger.warn('[Graph:Scope] Failed to load intent index scores', { triggerIntentId: state.triggerIntentId, error: err });
+              scopeLog.warn('Failed to load intent index scores', { triggerIntentId: state.triggerIntentId, error: err });
             }
           } else if (state.searchQuery?.trim()) {
             // Chat path: score query against target indexes in parallel
@@ -471,7 +489,7 @@ export class OpportunityGraphFactory {
                 };
               }
             } catch (err) {
-              logger.warn('[Graph:Scope] Failed to score query against indexes', { error: err });
+              scopeLog.warn('Failed to score query against indexes', { error: err });
             }
           }
 
@@ -487,7 +505,7 @@ export class OpportunityGraphFactory {
           };
         } catch (error) {
           const errMsg = error instanceof Error ? error.message : String(error);
-          logger.error('[Graph:Scope] Failed', { error });
+          scopeLog.error('Failed', { error });
           return {
             targetNetworks: [],
             error: 'Failed to determine search scope.',
@@ -517,7 +535,7 @@ export class OpportunityGraphFactory {
       "opportunity-resolve",
       async (state: typeof OpportunityGraphState.State) => {
       return timed("OpportunityGraph.resolve", async () => {
-        logger.verbose('[Graph:Resolve] Resolving intent and network membership', {
+        resolveLog.verbose('Resolving intent and network membership', {
           triggerIntentId: state.triggerIntentId,
           hasSearchQuery: !!state.searchQuery,
           indexedIntentsCount: state.indexedIntents.length,
@@ -554,7 +572,7 @@ export class OpportunityGraphFactory {
                 discoverySource,
               };
             }
-            logger.warn('[Graph:Resolve] No intent matched search query; leaving resolvedIntentId unset', {
+            resolveLog.warn('No intent matched search query; leaving resolvedIntentId unset', {
               searchQuery: state.searchQuery,
               indexedIntentsCount: state.indexedIntents.length,
             });
@@ -567,7 +585,7 @@ export class OpportunityGraphFactory {
           };
         } catch (err) {
           const errMsg = err instanceof Error ? err.message : String(err);
-          logger.error('[Graph:Resolve] Failed', {
+          resolveLog.error('Failed', {
             triggerIntentId: state.triggerIntentId,
             searchQuery: state.searchQuery,
             error: err,
@@ -609,7 +627,7 @@ export class OpportunityGraphFactory {
         const filterByTarget = (candidates: CandidateMatch[]): CandidateMatch[] => {
           if (!state.targetUserId) return candidates;
           const filtered = candidates.filter(c => c.candidateUserId === state.targetUserId);
-          logger.verbose('[Graph:Discovery] targetUserId filter applied', {
+          discoveryLog.verbose('targetUserId filter applied', {
             targetUserId: state.targetUserId,
             before: candidates.length,
             after: filtered.length,
@@ -622,7 +640,7 @@ export class OpportunityGraphFactory {
         // Shared variable to capture HyDE output (lenses + documents) for trace entries
         let discoveryHydeOutput: { lenses: Array<{ label: string; corpus: string }>; hydeDocuments: Record<string, { hydeText?: string }> } | undefined;
 
-        logger.verbose('[Graph:Discovery] Starting semantic search', {
+        discoveryLog.verbose('Starting semantic search', {
           targetIndexesCount: state.targetNetworks.length,
           discoverySource: state.discoverySource,
           searchQueryPreview: state.searchQuery?.trim().slice(0, 60) ?? '(none)',
@@ -630,7 +648,7 @@ export class OpportunityGraphFactory {
 
         try {
           if (state.targetNetworks.length === 0) {
-            logger.warn('[Graph:Discovery] No target indexes for search');
+            discoveryLog.warn('No target indexes for search');
             return { candidates: [] };
           }
 
@@ -639,7 +657,7 @@ export class OpportunityGraphFactory {
           // and construct candidates directly from shared networks.
           if (state.targetUserId) {
             if (state.targetUserId === discoveryUserId) {
-              logger.warn('[Graph:Discovery] Direct-connection target matches discoverer; skipping self-match', {
+              discoveryLog.warn('Direct-connection target matches discoverer; skipping self-match', {
                 targetUserId: state.targetUserId,
               });
               return {
@@ -651,7 +669,7 @@ export class OpportunityGraphFactory {
                 }],
               };
             }
-            logger.verbose('[Graph:Discovery] Direct-connection mode — bypassing vector search', {
+            discoveryLog.verbose('Direct-connection mode — bypassing vector search', {
               targetUserId: state.targetUserId,
             });
             const targetMemberships = await this.database.getNetworkMemberships(state.targetUserId);
@@ -661,7 +679,7 @@ export class OpportunityGraphFactory {
               .map(ti => ti.networkId);
 
             if (sharedIndexIds.length === 0) {
-              logger.warn('[Graph:Discovery] Target user shares no indexes with discoverer', {
+              discoveryLog.warn('Target user shares no indexes with discoverer', {
                 targetUserId: state.targetUserId,
                 discovererIndexes: state.targetNetworks.map(ti => ti.networkId),
               });
@@ -712,7 +730,7 @@ export class OpportunityGraphFactory {
               }));
             }
 
-            logger.verbose('[Graph:Discovery] Direct candidates constructed', {
+            discoveryLog.verbose('Direct candidates constructed', {
               count: directCandidates.length,
               sharedIndexes: sharedIndexIds.length,
               targetIntents: targetIntents.length,
@@ -743,11 +761,11 @@ export class OpportunityGraphFactory {
           if (state.discoverySource === 'context') {
             // Context discovery: HyDE (when search query exists) + premise-to-premise.
             if (state.searchQuery?.trim()) {
-              logger.verbose('[Graph:Discovery] Context source with searchQuery → running query HyDE + premise paths', {
+              discoveryLog.verbose('Context source with searchQuery → running query HyDE + premise paths', {
                 searchQuery: state.searchQuery.trim().substring(0, 80),
               });
               const queryCandidates = await runQueryHydeDiscovery();
-              logger.verbose('[Graph:Discovery] Query HyDE path complete', { candidatesFound: queryCandidates.length });
+              discoveryLog.verbose('Query HyDE path complete', { candidatesFound: queryCandidates.length });
 
               // Build trace entries for this path
               const traceEntries: Array<{ node: string; detail?: string; data?: Record<string, unknown> }> = [];
@@ -845,7 +863,7 @@ export class OpportunityGraphFactory {
           async function runQueryHydeDiscovery(): Promise<CandidateMatch[]> {
             const searchText = state.searchQuery?.trim() ?? '';
             if (!searchText) return [];
-            logger.verbose('[Graph:Discovery] runQueryHydeDiscovery start', { searchText: searchText.slice(0, 80) });
+            discoveryLog.verbose('runQueryHydeDiscovery start', { searchText: searchText.slice(0, 80) });
             const discovererContext = buildDiscovererContext(state.sourceProfile, state.indexedIntents);
             discoveryLensInput = {
               profileContext: discovererContext,
@@ -864,7 +882,7 @@ export class OpportunityGraphFactory {
               hydeDocuments: (hydeResult.hydeDocuments ?? {}) as Record<string, { hydeText?: string }>,
             };
             const embeddingKeys = hydeEmbeddings ? Object.keys(hydeEmbeddings) : [];
-            logger.verbose('[Graph:Discovery] HyDE generator result', {
+            discoveryLog.verbose('HyDE generator result', {
               lensCount: embeddingKeys.length,
               lenses: embeddingKeys,
             });
@@ -915,7 +933,7 @@ export class OpportunityGraphFactory {
             );
             const intentCount = all.filter((c) => c.candidateIntentId).length;
             const premiseCount = all.filter((c) => c.candidatePremiseId).length;
-            logger.verbose('[Graph:Discovery] searchWithHydeEmbeddings raw results', {
+            discoveryLog.verbose('searchWithHydeEmbeddings raw results', {
               total: all.length,
               fromIntent: intentCount,
               fromPremise: premiseCount,
@@ -944,7 +962,7 @@ export class OpportunityGraphFactory {
 
             const sourceLimit = getSourcePremiseDiscoveryLimit();
             if (sourceLimit === 0) {
-              logger.verbose('[Graph:Discovery] runPremiseDiscovery disabled by DISCOVERY_SOURCE_PREMISE_LIMIT=0');
+              discoveryLog.verbose('runPremiseDiscovery disabled by DISCOVERY_SOURCE_PREMISE_LIMIT=0');
               return [];
             }
 
@@ -961,7 +979,7 @@ export class OpportunityGraphFactory {
 
             if (sourcePremises.length === 0) return [];
 
-            logger.verbose('[Graph:Discovery] runPremiseDiscovery start', {
+            discoveryLog.verbose('runPremiseDiscovery start', {
               premiseCount: sourcePremises.length,
               sourceLimit,
               targetNetworks: targetNetworkIds.length,
@@ -1010,7 +1028,7 @@ export class OpportunityGraphFactory {
               }
             }
             const deduped = Array.from(byKey.values());
-            logger.verbose('[Graph:Discovery] runPremiseDiscovery complete', {
+            discoveryLog.verbose('runPremiseDiscovery complete', {
               sourcePremiseCount: sourcePremises.length,
               rawCount: premiseCandidates.length,
               dedupedCount: deduped.length,
@@ -1032,7 +1050,7 @@ export class OpportunityGraphFactory {
             const targetNetworkIds = state.targetNetworks.map(t => t.networkId);
             if (targetNetworkIds.length === 0) return [];
 
-            logger.verbose('[Graph:Discovery] runContextToIntentDiscovery start', {
+            discoveryLog.verbose('runContextToIntentDiscovery start', {
               contextCount: state.sourceContexts.length,
               targetNetworks: targetNetworkIds.length,
             });
@@ -1105,7 +1123,7 @@ export class OpportunityGraphFactory {
               }
             }
             const deduped = Array.from(byKey.values());
-            logger.verbose('[Graph:Discovery] runContextToIntentDiscovery complete', {
+            discoveryLog.verbose('runContextToIntentDiscovery complete', {
               rawCount: contextCandidates.length,
               dedupedCount: deduped.length,
             });
@@ -1155,7 +1173,7 @@ export class OpportunityGraphFactory {
             : state.indexedIntents[0];
           const searchText = state.searchQuery ?? resolvedIntent?.payload ?? '';
           if (!searchText) {
-            logger.warn('[Graph:Discovery] No search text available for intent path');
+            discoveryLog.warn('No search text available for intent path');
             const [premiseCands, contextCands] = await Promise.all([
               runPremiseDiscovery(),
               runContextToIntentDiscovery(),
@@ -1251,7 +1269,7 @@ export class OpportunityGraphFactory {
             }
           }
           const candidates = Array.from(byUserAndIndex.values());
-          logger.verbose('[Graph:Discovery] Intent-path discovery complete', { candidatesFound: candidates.length });
+          discoveryLog.verbose('Intent-path discovery complete', { candidatesFound: candidates.length });
           const usedLenses = Object.keys(hydeEmbeddings);
 
           // Build trace with individual candidate similarity scores
@@ -1350,7 +1368,7 @@ export class OpportunityGraphFactory {
           };
         } catch (error) {
           const errMsg = error instanceof Error ? error.message : String(error);
-          logger.error('[Graph:Discovery] Failed', { error });
+          discoveryLog.error('Failed', { error });
           return {
             candidates: [],
             error: 'Failed to search for candidates.',
@@ -1378,12 +1396,12 @@ export class OpportunityGraphFactory {
     const evaluationNode = async (state: typeof OpportunityGraphState.State) => {
       return timed("OpportunityGraph.evaluation", async () => {
         const startTime = Date.now();
-        logger.verbose('[Graph:Evaluation] Starting evaluation', {
+        evaluationLog.verbose('Starting evaluation', {
           candidatesCount: state.candidates.length,
         });
 
         if (state.candidates.length === 0) {
-          logger.verbose('[Graph:Evaluation] No candidates to evaluate');
+          evaluationLog.verbose('No candidates to evaluate');
           return { evaluatedOpportunities: [], agentTimings: [] };
         }
 
@@ -1414,7 +1432,7 @@ export class OpportunityGraphFactory {
         dedupedCandidates.sort((a, b) => b.similarity - a.similarity);
 
         if (dedupedCandidates.length < sortedCandidates.length) {
-          logger.info("[Graph:Evaluation] Deduped candidates by userId", {
+          evaluationLog.info("Deduped candidates by userId", {
             before: sortedCandidates.length,
             after: dedupedCandidates.length,
             removed: sortedCandidates.length - dedupedCandidates.length,
@@ -1434,8 +1452,8 @@ export class OpportunityGraphFactory {
           isQueryDriven && queryRemaining.length === 0 ? [] : remaining;
 
         if (isQueryDriven && remaining.length > 0 && queryRemaining.length === 0) {
-          logger.info(
-            "[Graph:Evaluation] Early termination: no query-sourced candidates remain",
+          evaluationLog.info(
+            "Early termination: no query-sourced candidates remain",
             {
               droppedCandidates: remaining.length,
             },
@@ -1443,7 +1461,7 @@ export class OpportunityGraphFactory {
         }
 
         if (effectiveRemaining.length > 0) {
-          logger.verbose('[Graph:Evaluation] Batched candidates for evaluation', {
+          evaluationLog.verbose('Batched candidates for evaluation', {
             evaluating: batchToEvaluate.length,
             remaining: effectiveRemaining.length,
             total: sortedCandidates.length,
@@ -1551,7 +1569,7 @@ export class OpportunityGraphFactory {
 
           if (runParallel) {
             // Experimental: one LLM call per candidate, all fired in parallel
-            logger.verbose('[Graph:Evaluation] Running parallel evaluation', { candidates: candidateEntities.length });
+            evaluationLog.verbose('Running parallel evaluation', { candidates: candidateEntities.length });
             const parallelResults = await Promise.all(
               candidateEntities.map((candidateEntity) => {
                 const input: EvaluatorInput = {
@@ -1579,7 +1597,7 @@ export class OpportunityGraphFactory {
                     const _errMsg = err instanceof Error ? err.message : String(err);
                     agentTimingsAccum.push({ name: 'opportunity.evaluator', durationMs: _evalDuration });
                     _traceEmitter?.({ type: "agent_end", name: "opportunity-evaluator", durationMs: _evalDuration, summary: `${_candidateName}: error — ${_errMsg}` });
-                    logger.warn('[Graph:Evaluation] Parallel eval failed for candidate', {
+                    evaluationLog.warn('Parallel eval failed for candidate', {
                       candidateUserId: candidateEntity.userId,
                       error: err,
                     });
@@ -1652,7 +1670,7 @@ export class OpportunityGraphFactory {
               if (nonViewerActors.length <= 1) {
                 pairwiseOpportunities.push(op);
               } else {
-                logger.warn('[Graph:Evaluation] Splitting multi-actor opportunity; LLM returned bundled actors instead of one-per-candidate', {
+                evaluationLog.warn('Splitting multi-actor opportunity; LLM returned bundled actors instead of one-per-candidate', {
                   actorCount: nonViewerActors.length,
                   userIds: nonViewerActors.map(a => a.userId),
                 });
@@ -1724,7 +1742,7 @@ export class OpportunityGraphFactory {
           }));
 
           const passed = evaluatedOpportunities.filter((o) => o.score >= minScore);
-          logger.verbose('[Graph:Evaluation] Evaluation complete', {
+          evaluationLog.verbose('Evaluation complete', {
             evaluatedCount: evaluatedOpportunities.length,
             passed: passed.length,
           });
@@ -1820,7 +1838,7 @@ export class OpportunityGraphFactory {
           };
         } catch (error) {
           const errMsg = error instanceof Error ? error.message : String(error);
-          logger.error('[Graph:Evaluation] Failed', { error });
+          evaluationLog.error('Failed', { error });
           return {
             evaluatedOpportunities: [],
             error: 'Failed to evaluate candidates.',
@@ -1880,7 +1898,7 @@ export class OpportunityGraphFactory {
 
         // Build candidates from persisted opportunities. Each opportunity carries its DB id
         // so the negotiation graph's finalize node can update its status from the outcome.
-        logger.verbose('[Graph:Negotiate] Building candidates from opportunities', {
+        negotiateLog.verbose('Building candidates from opportunities', {
           opportunityCount: state.opportunities.length,
           discoveryUserId,
         });
@@ -1891,7 +1909,7 @@ export class OpportunityGraphFactory {
             const introducerActors = (opp.actors as OpportunityActor[])
               .filter(a => a.role === 'introducer');
             if (introducerActors.length > 0 && !introducerActors.every(a => a.approved === true)) {
-              logger.verbose('[Graph:Negotiate] Skipping opportunity: introducer not approved', {
+              negotiateLog.verbose('Skipping opportunity: introducer not approved', {
                 opportunityId: opp.id,
                 introducerCount: introducerActors.length,
                 approvedCount: introducerActors.filter(a => a.approved === true).length,
@@ -1902,7 +1920,7 @@ export class OpportunityGraphFactory {
             const candidateActor = (opp.actors as Array<{ userId: string; role?: string; networkId?: string; intentId?: string }>)
               .find(a => a.userId !== discoveryUserId);
             if (!candidateActor) {
-              logger.verbose('[Graph:Negotiate] Skipping opportunity: no candidateActor found', {
+              negotiateLog.verbose('Skipping opportunity: no candidateActor found', {
                 opportunityId: opp.id,
                 discoveryUserId,
                 actors: (opp.actors as OpportunityActor[])?.map(a => ({ userId: a.userId, role: a.role })) ?? [],
@@ -1913,7 +1931,7 @@ export class OpportunityGraphFactory {
           })
           .filter((e): e is NonNullable<typeof e> => e !== null);
 
-        logger.verbose('[Graph:Negotiate] Candidate filtering complete', {
+        negotiateLog.verbose('Candidate filtering complete', {
           inputOpportunities: state.opportunities.length,
           outputCandidates: candidateEntries.length,
         });
@@ -2080,7 +2098,7 @@ export class OpportunityGraphFactory {
           const updated = await this.database
             .updateOpportunityStatus(candidate.opportunityId, 'draft')
             .catch((err) => {
-              logger.warn('[Graph:Negotiate] failed to flip opp to draft; suppressing draft-ready event', {
+              negotiateLog.warn('failed to flip opp to draft; suppressing draft-ready event', {
                 opportunityId: candidate.opportunityId,
                 error: err,
               });
@@ -2151,9 +2169,9 @@ export class OpportunityGraphFactory {
           if (raced === NEGOTIATE_TIMER_SENTINEL) {
             // Floating promise is intentional — see comment above.
             void negotiationWork.catch((err) => {
-              logger.warn('[Graph:Negotiate] background negotiation failed after timer fired', { error: err });
+              negotiateLog.warn('background negotiation failed after timer fired', { error: err });
             });
-            logger.warn('[Graph:Negotiate] timed out — returning partial results to caller', {
+            negotiateLog.warn('timed out — returning partial results to caller', {
               discoveryUserId,
               candidateCount: candidates.length,
               negotiateTimeoutMs: budgetMs,
@@ -2235,7 +2253,7 @@ export class OpportunityGraphFactory {
           discoverySummary,
         };
       } catch (err) {
-        logger.error("[Graph:Negotiate] Negotiation stage failed", { error: err });
+        negotiateLog.error("Negotiation stage failed", { error: err });
         traceEmitter?.({ type: "graph_end", name: "Negotiation graph", durationMs: Date.now() - graphStart });
         return {
           trace: [{
@@ -2257,7 +2275,7 @@ export class OpportunityGraphFactory {
       "opportunity-ranking",
       async (state: typeof OpportunityGraphState.State) => {
       return timed("OpportunityGraph.ranking", async () => {
-        logger.verbose('[Graph:Ranking] Starting ranking', {
+        rankingLog.verbose('Starting ranking', {
           evaluatedCount: state.evaluatedOpportunities.length,
         });
 
@@ -2279,7 +2297,7 @@ export class OpportunityGraphFactory {
             return true;
           });
 
-          logger.verbose('[Graph:Ranking] Ranking complete', {
+          rankingLog.verbose('Ranking complete', {
             sorted: sorted.length,
             afterLimit: ranked.length,
             afterDedup: deduplicated.length,
@@ -2287,7 +2305,7 @@ export class OpportunityGraphFactory {
           return { evaluatedOpportunities: deduplicated };
         } catch (error) {
           const errMsg = error instanceof Error ? error.message : String(error);
-          logger.error('[Graph:Ranking] Failed', { error });
+          rankingLog.error('Failed', { error });
           return {
             evaluatedOpportunities: [],
             error: 'Failed to rank opportunities.',
@@ -2314,7 +2332,7 @@ export class OpportunityGraphFactory {
      */
     const introValidationNode = async (state: typeof OpportunityGraphState.State) => {
       return timed("OpportunityGraph.introValidation", async () => {
-        logger.verbose('[Graph:IntroValidation] Starting', {
+        introValidationLog.verbose('Starting', {
           userId: state.userId,
           networkId: state.networkId,
           entitiesCount: state.introductionEntities?.length ?? 0,
@@ -2367,11 +2385,11 @@ export class OpportunityGraphFactory {
             return { error: 'An opportunity already exists between these people.' };
           }
 
-          logger.verbose('[Graph:IntroValidation] Validation passed');
+          introValidationLog.verbose('Validation passed');
           return {};
         } catch (err) {
           const errMsg = err instanceof Error ? err.message : String(err);
-          logger.error('[Graph:IntroValidation] Failed', {
+          introValidationLog.error('Failed', {
             userId: state.userId,
             networkId: state.networkId,
             error: err,
@@ -2416,7 +2434,7 @@ export class OpportunityGraphFactory {
      */
     const introEvaluationNode = async (state: typeof OpportunityGraphState.State) => {
       return timed("OpportunityGraph.introEvaluation", async () => {
-        logger.verbose('[Graph:IntroEvaluation] Starting', { userId: state.userId });
+        introEvaluationLog.verbose('Starting', { userId: state.userId });
 
         if (state.error) {
           return { evaluatedOpportunities: [], agentTimings: [] };
@@ -2481,7 +2499,7 @@ export class OpportunityGraphFactory {
             _traceEmitterIntro?.({ type: "agent_end", name: "intro-evaluator", durationMs: _introErrDuration, summary: `error — ${errMsg}` });
             agentTimingsAccum.push({ name: 'opportunity.evaluator', durationMs: _introErrDuration });
           }
-          logger.warn('[Graph:IntroEvaluation] Evaluator or getUser failed, using fallback', { error: evalErr });
+          introEvaluationLog.warn('Evaluator or getUser failed, using fallback', { error: evalErr });
           const fallback = buildIntroFallback(entities, state, primaryNetworkId, introducerName);
           reasoning = fallback.reasoning;
           score = fallback.score;
@@ -2524,14 +2542,14 @@ export class OpportunityGraphFactory {
       return timed("OpportunityGraph.persist", async () => {
         const startTime = Date.now();
         const initialStatus = resolveInitialStatus(state.trigger, state.options.initialStatus);
-        logger.verbose('[Graph:Persist] Starting persistence (dedup-v2)', {
+        persistLog.verbose('Starting persistence (dedup-v2)', {
           opportunitiesToCreate: state.evaluatedOpportunities.length,
           trigger: state.trigger,
           initialStatus,
         });
 
         if (state.evaluatedOpportunities.length === 0) {
-          logger.verbose('[Graph:Persist] No opportunities to persist');
+          persistLog.verbose('No opportunities to persist');
           return { opportunities: [] };
         }
 
@@ -2579,7 +2597,7 @@ export class OpportunityGraphFactory {
                 const accepted = await this.database
                   .findOpportunitiesByActors([dedupUserId, counterpartyUserId], { includeIntroducers: true, statuses: ['accepted'] })
                   .catch((err: unknown) => {
-                    logger.warn('[Graph:Persist] findOpportunitiesByActors (sibling-accept) failed', {
+                    persistLog.warn('findOpportunitiesByActors (sibling-accept) failed', {
                       userId: dedupUserId,
                       counterpartyUserId,
                       error: err,
@@ -2597,7 +2615,7 @@ export class OpportunityGraphFactory {
             let actors: OpportunityActor[];
             let data: CreateOpportunityData;
 
-            logger.verbose('[Graph:Persist:PathSelect]', {
+            persistPathLog.verbose('Selecting persistence path', {
               isIntroduction: !!state.introductionContext,
               stateUserId: state.userId,
               stateIndexId: state.networkId,
@@ -2606,7 +2624,7 @@ export class OpportunityGraphFactory {
 
             if (state.introductionContext) {
               if (indexIdForActors === undefined) {
-                logger.warn('[Graph:Persist] Introduction path missing networkId; skipping opportunity', {
+                persistLog.warn('Introduction path missing networkId; skipping opportunity', {
                   userId: state.userId,
                   actorsCount: evaluated.actors.length,
                 });
@@ -2655,7 +2673,7 @@ export class OpportunityGraphFactory {
               };
             } else if (state.onBehalfOfUserId) {
               if (indexIdForActors === undefined) {
-                logger.warn('[Graph:Persist] Introducer discovery path missing networkId; skipping opportunity', {
+                persistLog.warn('Introducer discovery path missing networkId; skipping opportunity', {
                   userId: state.userId,
                   actorsCount: evaluated.actors.length,
                 });
@@ -2701,7 +2719,7 @@ export class OpportunityGraphFactory {
                     // initialStatus, because introductions are always chat-initiated, not background-discovered.
                     const reactivated = await this.database.updateOpportunityStatus(existing.id, 'draft');
                     if (reactivated) {
-                      logger.verbose('[Graph:Persist] Reactivated opportunity (introduction path)', {
+                      persistLog.verbose('Reactivated opportunity (introduction path)', {
                         opportunityId: existing.id,
                         candidateUserId,
                         previousStatus: existing.status,
@@ -2723,7 +2741,7 @@ export class OpportunityGraphFactory {
                         existingOpportunityId: existing.id as Id<'opportunities'>,
                         existingStatus: existing.status,
                       });
-                      logger.verbose('[Graph:Persist] Skipping negotiating opportunity with active task (introduction path)', {
+                      persistLog.verbose('Skipping negotiating opportunity with active task (introduction path)', {
                         opportunityId: existing.id,
                         candidateUserId,
                         taskState: priorTask.state,
@@ -2733,7 +2751,7 @@ export class OpportunityGraphFactory {
                   }
                   const reactivated = await this.database.updateOpportunityStatus(existing.id, 'draft');
                   if (reactivated) {
-                    logger.info('[Graph:Persist] Resuming orphaned negotiating opportunity (introduction path)', {
+                    persistLog.info('Resuming orphaned negotiating opportunity (introduction path)', {
                       opportunityId: existing.id,
                       candidateUserId,
                       priorTaskState: priorTask?.state,
@@ -2745,7 +2763,7 @@ export class OpportunityGraphFactory {
                   // Upgrade latent to draft for introduction path
                   const upgraded = await this.database.updateOpportunityStatus(existing.id, 'draft');
                   if (upgraded) {
-                    logger.verbose('[Graph:Persist] Upgraded latent opportunity to draft (introduction path)', {
+                    persistLog.verbose('Upgraded latent opportunity to draft (introduction path)', {
                       opportunityId: existing.id,
                       candidateUserId,
                     });
@@ -2760,7 +2778,7 @@ export class OpportunityGraphFactory {
                     existingOpportunityId: existing.id as Id<'opportunities'>,
                     existingStatus: existing.status,
                   });
-                  logger.verbose('[Graph:Persist] Skipping recent duplicate (introduction path)', {
+                  persistLog.verbose('Skipping recent duplicate (introduction path)', {
                     candidateUserId,
                     existingStatus: existing.status,
                     existingOpportunityId: existing.id,
@@ -2768,7 +2786,7 @@ export class OpportunityGraphFactory {
                   continue;
                 }
                 // Else: existing opportunity is old enough, allow new opportunity creation
-                logger.verbose('[Graph:Persist] Allowing new opportunity; existing is outside dedup window (introduction path)', {
+                persistLog.verbose('Allowing new opportunity; existing is outside dedup window (introduction path)', {
                   candidateUserId,
                   existingStatus: existing.status,
                   existingOpportunityId: existing.id,
@@ -2835,7 +2853,7 @@ export class OpportunityGraphFactory {
                   if (counterpartIdx >= 0) {
                     actors[counterpartIdx] = { ...actors[counterpartIdx], role: 'agent' };
                   }
-                  logger.verbose('[Graph:Persist] Swapped discoverer from agent to patient for lifecycle visibility', {
+                  persistLog.verbose('Swapped discoverer from agent to patient for lifecycle visibility', {
                     discovererId: state.userId,
                   });
                 }
@@ -2844,7 +2862,7 @@ export class OpportunityGraphFactory {
               // Index-agnostic dedup: find ANY existing opportunity between these users,
               // regardless of which index it was created in or whether a focused network scope is set.
               const candidateUserId = evaluated.actors.find((a) => a.userId !== state.userId)?.userId;
-              logger.verbose('[Graph:Persist:Dedup] Checking overlapping opportunities', {
+              persistDedupLog.verbose('Checking overlapping opportunities', {
                 stateUserId: state.userId,
                 candidateUserId: candidateUserId ?? 'NONE',
                 evaluatedActors: evaluated.actors.map(a => ({ userId: a.userId, role: a.role })),
@@ -2855,7 +2873,7 @@ export class OpportunityGraphFactory {
                     { excludeStatuses: DEDUP_SKIP_STATUSES },
                   )
                 : [];
-              logger.verbose('[Graph:Persist:Dedup] findOpportunitiesByActors result', {
+              persistDedupLog.verbose('findOpportunitiesByActors result', {
                 count: overlapping.length,
                 results: overlapping.map(o => ({ id: o.id, status: o.status, actors: o.actors?.map((a: OpportunityActor) => ({ userId: a.userId, role: a.role })) })),
               });
@@ -2871,7 +2889,7 @@ export class OpportunityGraphFactory {
                   // is still in-flight for this pair, so we resume it rather than create a parallel one.
                   const reactivated = await this.database.updateOpportunityStatus(existing.id, initialStatus);
                   if (reactivated) {
-                    logger.verbose('[Graph:Persist] Reactivated opportunity', {
+                    persistLog.verbose('Reactivated opportunity', {
                       opportunityId: existing.id,
                       candidateUserId,
                       previousStatus: existing.status,
@@ -2895,7 +2913,7 @@ export class OpportunityGraphFactory {
                         existingOpportunityId: existing.id as Id<'opportunities'>,
                         existingStatus: existing.status,
                       });
-                      logger.verbose('[Graph:Persist] Skipping negotiating opportunity with active task', {
+                      persistLog.verbose('Skipping negotiating opportunity with active task', {
                         opportunityId: existing.id,
                         candidateUserId,
                         taskState: priorTask.state,
@@ -2906,7 +2924,7 @@ export class OpportunityGraphFactory {
                   // Task is stale or missing — reactivate the orphaned negotiating opportunity
                   const reactivated = await this.database.updateOpportunityStatus(existing.id, initialStatus);
                   if (reactivated) {
-                    logger.info('[Graph:Persist] Resuming orphaned negotiating opportunity', {
+                    persistLog.info('Resuming orphaned negotiating opportunity', {
                       opportunityId: existing.id,
                       candidateUserId,
                       priorTaskState: priorTask?.state,
@@ -2918,7 +2936,7 @@ export class OpportunityGraphFactory {
                   // Upgrade latent (background-discovered) to the higher-priority status (e.g. pending)
                   const upgraded = await this.database.updateOpportunityStatus(existing.id, initialStatus);
                   if (upgraded) {
-                    logger.verbose('[Graph:Persist] Upgraded latent opportunity to higher-priority status', {
+                    persistLog.verbose('Upgraded latent opportunity to higher-priority status', {
                       opportunityId: existing.id,
                       candidateUserId,
                       previousStatus: 'latent',
@@ -2936,7 +2954,7 @@ export class OpportunityGraphFactory {
                     existingOpportunityId: existing.id as Id<'opportunities'>,
                     existingStatus: existing.status,
                   });
-                  logger.verbose('[Graph:Persist] Skipping recent duplicate; opportunity created within dedup window', {
+                  persistLog.verbose('Skipping recent duplicate; opportunity created within dedup window', {
                     candidateUserId,
                     existingStatus: existing.status,
                     existingOpportunityId: existing.id,
@@ -2945,7 +2963,7 @@ export class OpportunityGraphFactory {
                   continue;
                 }
                 // Else: existing opportunity is old enough (outside the 30-day dedup window), allow new opportunity creation
-                logger.verbose('[Graph:Persist] Allowing new opportunity; existing is outside dedup window', {
+                persistLog.verbose('Allowing new opportunity; existing is outside dedup window', {
                   candidateUserId,
                   existingStatus: existing.status,
                   existingOpportunityId: existing.id,
@@ -2990,7 +3008,7 @@ export class OpportunityGraphFactory {
             try {
               validateOpportunityActors(data.actors);
             } catch (err) {
-              logger.warn('[Graph:Persist] Skipping opportunity with invalid actors', {
+              persistLog.warn('Skipping opportunity with invalid actors', {
                 error: err instanceof Error ? err.message : String(err),
                 opportunityReasoning: evaluated.reasoning?.slice(0, 80),
               });
@@ -3008,7 +3026,7 @@ export class OpportunityGraphFactory {
 
           const allOpportunities = [...reactivatedOpportunities, ...createdList];
 
-          logger.verbose('[Graph:Persist] Persistence complete', {
+          persistLog.verbose('Persistence complete', {
             created: createdList.length,
             reactivated: reactivatedOpportunities.length,
             existingBetweenActorsCount: existingBetweenActors.length,
@@ -3033,7 +3051,7 @@ export class OpportunityGraphFactory {
           };
         } catch (error) {
           const errMsg = error instanceof Error ? error.message : String(error);
-          logger.error('[Graph:Persist] Failed', { error });
+          persistLog.error('Failed', { error });
           return {
             opportunities: [],
             existingBetweenActors: [],
@@ -3065,7 +3083,7 @@ export class OpportunityGraphFactory {
      */
     const readNode = async (state: typeof OpportunityGraphState.State) => {
       return timed("OpportunityGraph.read", async () => {
-        logger.verbose('[Graph:Read] Listing opportunities', {
+        readLog.verbose('Listing opportunities', {
           userId: state.userId,
           networkId: state.networkId,
         });
@@ -3182,7 +3200,7 @@ export class OpportunityGraphFactory {
             },
           };
         } catch (err) {
-          logger.error('[Graph:Read] Failed', { error: err });
+          readLog.error('Failed', { error: err });
           return {
             readResult: { count: 0, opportunities: [], message: 'Failed to list opportunities.' },
           };
@@ -3199,7 +3217,7 @@ export class OpportunityGraphFactory {
      */
     const updateNode = async (state: typeof OpportunityGraphState.State) => {
       return timed("OpportunityGraph.update", async () => {
-        logger.verbose('[Graph:Update] Updating opportunity status', {
+        updateLog.verbose('Updating opportunity status', {
           userId: state.userId,
           opportunityId: state.opportunityId,
           newStatus: state.newStatus,
@@ -3269,7 +3287,7 @@ export class OpportunityGraphFactory {
             },
           };
         } catch (err) {
-          logger.error('[Graph:Update] Failed', { error: err });
+          updateLog.error('Failed', { error: err });
           return { mutationResult: { success: false, error: 'Failed to update opportunity.' } };
         }
       });
@@ -3280,7 +3298,7 @@ export class OpportunityGraphFactory {
      */
     const deleteNode = async (state: typeof OpportunityGraphState.State) => {
       return timed("OpportunityGraph.delete", async () => {
-        logger.verbose('[Graph:Delete] Expiring opportunity', {
+        deleteLog.verbose('Expiring opportunity', {
           userId: state.userId,
           opportunityId: state.opportunityId,
         });
@@ -3309,7 +3327,7 @@ export class OpportunityGraphFactory {
             },
           };
         } catch (err) {
-          logger.error('[Graph:Delete] Failed', { error: err });
+          deleteLog.error('Failed', { error: err });
           return { mutationResult: { success: false, error: 'Failed to delete opportunity.' } };
         }
       });
@@ -3320,7 +3338,7 @@ export class OpportunityGraphFactory {
      */
     const sendNode = async (state: typeof OpportunityGraphState.State) => {
       return timed("OpportunityGraph.send", async () => {
-        logger.verbose('[Graph:Send] Sending opportunity', {
+        sendLog.verbose('Sending opportunity', {
           userId: state.userId,
           opportunityId: state.opportunityId,
         });
@@ -3391,7 +3409,7 @@ export class OpportunityGraphFactory {
             },
           };
         } catch (err) {
-          logger.error('[Graph:Send] Failed', { error: err });
+          sendLog.error('Failed', { error: err });
           return { mutationResult: { success: false, error: 'Failed to send opportunity.' } };
         }
       });
@@ -3404,7 +3422,7 @@ export class OpportunityGraphFactory {
     const negotiateExistingNode = async (state: typeof OpportunityGraphState.State) => {
       if (!state.opportunityId) return {};
       if (!this.negotiationGraph) {
-        logger.warn('[Graph:NegotiateExisting] No negotiationGraph wired; skipping', {
+        negotiateExistingLog.warn('No negotiationGraph wired; skipping', {
           opportunityId: state.opportunityId,
         });
         return {};
@@ -3413,7 +3431,7 @@ export class OpportunityGraphFactory {
       try {
         const opp = await this.database.getOpportunity(state.opportunityId as string);
         if (!opp) {
-          logger.warn('[Graph:NegotiateExisting] Opportunity not found', { opportunityId: state.opportunityId });
+          negotiateExistingLog.warn('Opportunity not found', { opportunityId: state.opportunityId });
           return {};
         }
 
@@ -3424,14 +3442,14 @@ export class OpportunityGraphFactory {
         const sourceActor = nonIntroducerActors.find(a => a.role === 'patient' || a.role === 'party')
           ?? nonIntroducerActors[0];
         if (!sourceActor) {
-          logger.warn('[Graph:NegotiateExisting] No source actor found', { opportunityId: state.opportunityId });
+          negotiateExistingLog.warn('No source actor found', { opportunityId: state.opportunityId });
           return {};
         }
 
         // Find the candidateActor: non-introducer that is NOT the sourceActor
         const candidateActor = nonIntroducerActors.find(a => a.userId !== sourceActor.userId);
         if (!candidateActor) {
-          logger.warn('[Graph:NegotiateExisting] No candidate actor found', { opportunityId: state.opportunityId });
+          negotiateExistingLog.warn('No candidate actor found', { opportunityId: state.opportunityId });
           return {};
         }
 
@@ -3507,17 +3525,17 @@ export class OpportunityGraphFactory {
         if (acceptedResults.length > 0 && this.queueNotification) {
           for (const actor of nonIntroducerActors) {
             await this.queueNotification(opp.id, actor.userId, 'high').catch((err) => {
-              logger.warn('[Graph:NegotiateExisting] Failed to queue notification', { actorId: actor.userId, error: err });
+              negotiateExistingLog.warn('Failed to queue notification', { actorId: actor.userId, error: err });
             });
           }
         }
 
-        logger.info('[Graph:NegotiateExisting] Negotiation complete', {
+        negotiateExistingLog.info('Negotiation complete', {
           opportunityId: opp.id,
           accepted: acceptedResults.length > 0,
         });
       } catch (err) {
-        logger.error('[Graph:NegotiateExisting] Failed', { opportunityId: state.opportunityId, error: err });
+        negotiateExistingLog.error('Failed', { opportunityId: state.opportunityId, error: err });
         return { error: `Failed to load opportunity: ${err instanceof Error ? err.message : String(err)}` };
       }
 
@@ -3593,17 +3611,17 @@ export class OpportunityGraphFactory {
      */
     const shouldContinueAfterPrep = (state: typeof OpportunityGraphState.State): string => {
       if (state.error) {
-        logger.verbose('[Graph:Routing] Error in prep - ending early');
+        routingLog.verbose('Error in prep - ending early');
         return END;
       }
       // Continuation mode: skip scope/resolve/discovery, go straight to evaluation
       if (state.operationMode === 'continue_discovery') {
-        logger.verbose('[Graph:Routing] Continue discovery → skipping to evaluation', {
+        routingLog.verbose('Continue discovery → skipping to evaluation', {
           candidatesLoaded: state.candidates.length,
         });
         return 'evaluation';
       }
-      logger.verbose('[Graph:Routing] Continuing to scope');
+      routingLog.verbose('Continuing to scope');
       return 'scope';
     };
 
@@ -3612,10 +3630,10 @@ export class OpportunityGraphFactory {
      */
     const shouldContinueAfterScope = (state: typeof OpportunityGraphState.State): string => {
       if (state.error || state.targetNetworks.length === 0) {
-        logger.verbose('[Graph:Routing] No target indexes - ending early');
+        routingLog.verbose('No target indexes - ending early');
         return END;
       }
-      logger.verbose('[Graph:Routing] Continuing to resolve');
+      routingLog.verbose('Continuing to resolve');
       return 'resolve';
     };
 
@@ -3624,7 +3642,7 @@ export class OpportunityGraphFactory {
      */
     const shouldContinueAfterDiscovery = (state: typeof OpportunityGraphState.State): string => {
       if (state.createIntentSuggested) {
-        logger.verbose('[Graph:Routing] Create-intent suggested - ending for tool signal');
+        routingLog.verbose('Create-intent suggested - ending for tool signal');
         return END;
       }
       return 'evaluation';
@@ -3635,7 +3653,7 @@ export class OpportunityGraphFactory {
      */
     const routeAfterIntroValidation = (state: typeof OpportunityGraphState.State): string => {
       if (state.error) {
-        logger.verbose('[Graph:Routing] Intro validation error - ending early');
+        routingLog.verbose('Intro validation error - ending early');
         return END;
       }
       return 'intro_evaluation';

--- a/packages/protocol/src/opportunity/opportunity.introducer.ts
+++ b/packages/protocol/src/opportunity/opportunity.introducer.ts
@@ -72,7 +72,7 @@ export async function selectContactsForDiscovery(
 ): Promise<ContactWithIntents[]> {
   const personalIndexId = await database.getPersonalIndexId(userId);
   if (!personalIndexId) {
-    logger.verbose(`[IntroducerDiscovery] No personal network found — userId=${userId}`);
+    logger.verbose('No personal network found', { userId });
     return [];
   }
 
@@ -82,7 +82,7 @@ export async function selectContactsForDiscovery(
     limit,
   );
 
-  logger.verbose(`[IntroducerDiscovery] Selected contacts for discovery — userId=${userId} totalContacts=${contacts.length} limit=${limit}`);
+  logger.verbose('Selected contacts for discovery', { userId, totalContacts: contacts.length, limit });
 
   return contacts;
 }
@@ -149,7 +149,7 @@ export async function runIntroducerDiscovery(
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         if (/duplicate|already exists|job.*id/i.test(message)) {
-          logger.verbose(`[IntroducerDiscovery] Job skipped (duplicate) — userId=${userId} contactUserId=${contact.userId} error=${message}`);
+          logger.verbose('Job skipped (duplicate)', { userId, contactUserId: contact.userId, error: message });
           return false;
         }
         throw err;
@@ -160,12 +160,12 @@ export async function runIntroducerDiscovery(
   for (const r of results) {
     if (r.status === 'rejected') {
       const errMsg = r.reason instanceof Error ? r.reason.message : String(r.reason);
-      logger.error(`[IntroducerDiscovery] Job enqueue failed: ${errMsg}`);
+      logger.error('Job enqueue failed', { error: errMsg });
     }
   }
   const jobsEnqueued = results.filter((r) => r.status === 'fulfilled' && r.value).length;
 
-  logger.info(`[IntroducerDiscovery] Discovery cycle complete — userId=${userId} contactsEvaluated=${contacts.length} jobsEnqueued=${jobsEnqueued}`);
+  logger.info('Discovery cycle complete', { userId, contactsEvaluated: contacts.length, jobsEnqueued });
 
   return { contactsEvaluated: contacts.length, jobsEnqueued };
 }

--- a/packages/protocol/src/opportunity/opportunity.persist.ts
+++ b/packages/protocol/src/opportunity/opportunity.persist.ts
@@ -87,12 +87,12 @@ export async function persistOpportunities(params: PersistOpportunitiesParams): 
       const lastCreated = created[created.length - 1];
       if (lastCreated?.status === 'pending' && injectChat) {
         await injectChat(lastCreated).catch((err) => {
-          logger.warn('[PersistOpportunities] Chat injection failed', { opportunityId: lastCreated.id, error: err });
+          logger.warn('Chat injection failed', { opportunityId: lastCreated.id, error: err });
         });
       }
     } catch (err) {
       errors.push({ itemIndex, error: err });
-      logger.warn('[PersistOpportunities] Item failed', { itemIndex, error: err });
+      logger.warn('Item failed', { itemIndex, error: err });
     }
   }
 

--- a/packages/protocol/src/opportunity/opportunity.presenter.ts
+++ b/packages/protocol/src/opportunity/opportunity.presenter.ts
@@ -31,6 +31,8 @@ export type PresenterDatabase = Pick<
 >;
 
 const logger = protocolLogger("OpportunityPresenter");
+const presentLog = protocolLogger("OpportunityPresenter:present");
+const presentHomeCardLog = protocolLogger("OpportunityPresenter:presentHomeCard");
 const LLM_TIMEOUT_MS = 20_000;
 
 
@@ -361,8 +363,8 @@ Produce headline, personalizedSummary (2-3 sentences in "you" language), suggest
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       const timeoutReason = message.includes("timed out") ? message : undefined;
-      logger.warn(
-        "[OpportunityPresenter.present] LLM failed, returning fallback",
+      presentLog.warn(
+        "LLM failed, returning fallback",
         {
           event: "presenter_fallback",
           presenter: "opportunity",
@@ -462,8 +464,8 @@ Produce headline, personalizedSummary, digestSummary, suggestedAction, narratorR
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       const timeoutReason = message.includes("timed out") ? message : undefined;
-      logger.warn(
-        "[OpportunityPresenter.presentHomeCard] LLM failed, returning fallback",
+      presentHomeCardLog.warn(
+        "LLM failed, returning fallback",
         {
           event: "presenter_fallback",
           presenter: "home_card",

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -42,6 +42,7 @@ import { mergePendingQuestions } from "./opportunity.pending-questions.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("ChatTools:Opportunity");
+const discoverOpportunitiesLog = protocolLogger("ChatTools:Opportunity:discover_opportunities");
 
 /**
  * Pure status × role → ConnectLinkKind matrix.
@@ -1349,7 +1350,7 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
           }
           // 'pending' / 'latent' / unknown — not expected post-IND-287. Treat as
           // negotiating (count only) and log so we can spot wiring regressions.
-          logger.warn('[discover_opportunities] unexpected refreshed status — counting as negotiating', {
+          discoverOpportunitiesLog.warn('unexpected refreshed status — counting as negotiating', {
             opportunityId: card.opportunityId,
             refreshedStatus,
           });

--- a/packages/protocol/src/opportunity/opportunity.utils.ts
+++ b/packages/protocol/src/opportunity/opportunity.utils.ts
@@ -10,6 +10,8 @@ import type { HydeTargetCorpus } from '../shared/hyde/lens.inferrer.js';
 import { log } from '../shared/observability/log.js';
 
 const logger = log.graph.from('SelectByComposition');
+const dedupeByPersonLog = log.graph.from('DeduplicateByPerson');
+const digestCandidatesLog = log.graph.from('SelectDigestCandidates');
 
 /** Actor roles in the opportunity model (agent / patient / peer). */
 export type OpportunityActorRole = 'agent' | 'patient' | 'peer';
@@ -285,7 +287,19 @@ export function selectByComposition<T extends { actors: Array<{ userId: string; 
   selected['connector-flow'].sort(sortByOriginal);
   selected.expired.sort(sortByOriginal);
 
-  logger.info(`[selectByComposition] input=${opportunities.length} buckets: connection=${buckets.connection.length} connector-flow=${buckets['connector-flow'].length} expired=${buckets.expired.length} → selected: connection=${selected.connection.length} connector-flow=${selected['connector-flow'].length} expired=${selected.expired.length}`);
+  logger.info('Selected opportunities by composition', {
+    input: opportunities.length,
+    buckets: {
+      connection: buckets.connection.length,
+      connectorFlow: buckets['connector-flow'].length,
+      expired: buckets.expired.length,
+    },
+    selected: {
+      connection: selected.connection.length,
+      connectorFlow: selected['connector-flow'].length,
+      expired: selected.expired.length,
+    },
+  });
 
   return [
     ...selected.connection,
@@ -344,9 +358,10 @@ export function deduplicateByPerson<T extends {
 
   const result = all.map((entry) => entry.opp);
   if (result.length < opportunities.length) {
-    logger.info(
-      `[deduplicateByPerson] deduped ${opportunities.length} → ${result.length} opportunities`,
-    );
+    dedupeByPersonLog.info('Deduped opportunities by person', {
+      input: opportunities.length,
+      output: result.length,
+    });
   }
   return result;
 }
@@ -420,9 +435,10 @@ export function selectDigestCandidates<T extends {
     return !counterpart || !acceptedCounterpartIds.has(counterpart.userId);
   });
   if (afterAccepted.length < candidates.length) {
-    logger.info(
-      `[selectDigestCandidates] accepted-counterpart suppression dropped ${candidates.length - afterAccepted.length} of ${candidates.length} candidates`,
-    );
+    digestCandidatesLog.info('Accepted-counterpart suppression dropped candidates', {
+      dropped: candidates.length - afterAccepted.length,
+      total: candidates.length,
+    });
   }
 
   // Rule 2: delivery-ledger dedup keyed (opportunityId, deliveredAtStatus).
@@ -439,9 +455,9 @@ export function selectDigestCandidates<T extends {
   const fresh = afterAccepted.filter((opp) => !lastDeliveredByKey.has(`${opp.id}:${opp.status}`));
   if (fresh.length > 0) {
     if (fresh.length < afterAccepted.length) {
-      logger.info(
-        `[selectDigestCandidates] ledger dedup dropped ${afterAccepted.length - fresh.length} already-shown candidates`,
-      );
+      digestCandidatesLog.info('Ledger dedup dropped already-shown candidates', {
+        dropped: afterAccepted.length - fresh.length,
+      });
     }
     return { pool: fresh, redeliveryIds: new Set<string>() };
   }
@@ -457,9 +473,9 @@ export function selectDigestCandidates<T extends {
     .sort((a, b) => a.at.getTime() - b.at.getTime());
 
   if (cooled.length > 0) {
-    logger.info(
-      `[selectDigestCandidates] no fresh candidates — re-showing ${cooled.length} past-cooldown candidate(s)`,
-    );
+    digestCandidatesLog.info('No fresh candidates — re-showing past-cooldown candidates', {
+      count: cooled.length,
+    });
   }
   return {
     pool: cooled.map((entry) => entry.opp),

--- a/packages/protocol/src/premise/premise.analyzer.ts
+++ b/packages/protocol/src/premise/premise.analyzer.ts
@@ -102,7 +102,7 @@ export class PremiseAnalyzer {
 
   @Timed()
   public async invoke(premiseText: string, profileContext?: string): Promise<PremiseAnalyzerOutput> {
-    invokeLog.verbose(`Analyzing: "${premiseText.substring(0, 50)}..."`);
+    invokeLog.verbose('Analyzing premise text', { preview: premiseText.substring(0, 50) });
 
     const contextBlock = profileContext
       ? `\n# Speaker Profile (Context)\n${profileContext}\n`
@@ -122,7 +122,7 @@ Classify this premise and score its felicity conditions.`;
     const result = await invokeWithAbortSignal(this.model, messages);
     const output = responseFormat.parse(result);
 
-    invokeLog.verbose(`Result: ${output.speechActType} entropy=${output.semanticEntropy}`);
+    invokeLog.verbose('Analysis result', { speechActType: output.speechActType, semanticEntropy: output.semanticEntropy });
     return output;
   }
 }

--- a/packages/protocol/src/premise/premise.analyzer.ts
+++ b/packages/protocol/src/premise/premise.analyzer.ts
@@ -6,6 +6,7 @@ import { createStructuredModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("PremiseAnalyzer");
+const invokeLog = protocolLogger("PremiseAnalyzer:invoke");
 
 const systemPrompt = `
 You are the Premise Analyzer for the Index Network — an intent-driven discovery protocol.
@@ -101,7 +102,7 @@ export class PremiseAnalyzer {
 
   @Timed()
   public async invoke(premiseText: string, profileContext?: string): Promise<PremiseAnalyzerOutput> {
-    logger.verbose(`[PremiseAnalyzer.invoke] Analyzing: "${premiseText.substring(0, 50)}..."`);
+    invokeLog.verbose(`Analyzing: "${premiseText.substring(0, 50)}..."`);
 
     const contextBlock = profileContext
       ? `\n# Speaker Profile (Context)\n${profileContext}\n`
@@ -121,7 +122,7 @@ Classify this premise and score its felicity conditions.`;
     const result = await invokeWithAbortSignal(this.model, messages);
     const output = responseFormat.parse(result);
 
-    logger.verbose(`[PremiseAnalyzer.invoke] Result: ${output.speechActType} entropy=${output.semanticEntropy}`);
+    invokeLog.verbose(`Result: ${output.speechActType} entropy=${output.semanticEntropy}`);
     return output;
   }
 }

--- a/packages/protocol/src/premise/premise.decomposer.ts
+++ b/packages/protocol/src/premise/premise.decomposer.ts
@@ -179,7 +179,11 @@ export class PremiseDecomposer {
 
   @Timed()
   public async invoke(input: string, existingPremises?: ExistingPremiseRef[], currentBio?: string): Promise<PremiseDecomposerOutput> {
-    invokeLog.verbose(`Decomposing input (${input.length} chars, ${existingPremises?.length ?? 0} existing premise(s), bio: ${currentBio ? 'yes' : 'no'})`);
+    invokeLog.verbose('Decomposing input', {
+      inputChars: input.length,
+      existingPremiseCount: existingPremises?.length ?? 0,
+      hasBio: Boolean(currentBio),
+    });
 
     const existingBlock = existingPremises?.length
       ? `\n\nEXISTING PREMISES (retract by id when the input disavows them):\n${existingPremises
@@ -205,7 +209,7 @@ export class PremiseDecomposer {
     const knownIds = new Set((existingPremises ?? []).map((p) => p.id));
     const droppedIds = output.retractedPremiseIds.filter((id) => !knownIds.has(id));
     if (droppedIds.length > 0) {
-      invokeLog.warn(`Dropped ${droppedIds.length} unknown retraction id(s)`, { droppedIds });
+      invokeLog.warn('Dropped unknown retraction ids', { count: droppedIds.length, droppedIds });
     }
     output.retractedPremiseIds = output.retractedPremiseIds.filter((id) => knownIds.has(id));
 
@@ -224,7 +228,11 @@ export class PremiseDecomposer {
       output.revisedBio = normalizedBio;
     }
 
-    invokeLog.verbose(`Extracted ${output.premises.length} premise(s), ${output.retractedPremiseIds.length} retraction(s), revisedBio: ${output.revisedBio ? 'yes' : 'no'}`);
+    invokeLog.verbose('Extracted premises and retractions', {
+      premiseCount: output.premises.length,
+      retractionCount: output.retractedPremiseIds.length,
+      hasRevisedBio: Boolean(output.revisedBio),
+    });
     return output;
   }
 }

--- a/packages/protocol/src/premise/premise.decomposer.ts
+++ b/packages/protocol/src/premise/premise.decomposer.ts
@@ -6,6 +6,7 @@ import { createStructuredModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("PremiseDecomposer");
+const invokeLog = protocolLogger("PremiseDecomposer:invoke");
 
 const systemPrompt = `
 You are the Premise Decomposer for the Index Network — an intent-driven discovery protocol.
@@ -178,7 +179,7 @@ export class PremiseDecomposer {
 
   @Timed()
   public async invoke(input: string, existingPremises?: ExistingPremiseRef[], currentBio?: string): Promise<PremiseDecomposerOutput> {
-    logger.verbose(`[PremiseDecomposer.invoke] Decomposing input (${input.length} chars, ${existingPremises?.length ?? 0} existing premise(s), bio: ${currentBio ? 'yes' : 'no'})`);
+    invokeLog.verbose(`Decomposing input (${input.length} chars, ${existingPremises?.length ?? 0} existing premise(s), bio: ${currentBio ? 'yes' : 'no'})`);
 
     const existingBlock = existingPremises?.length
       ? `\n\nEXISTING PREMISES (retract by id when the input disavows them):\n${existingPremises
@@ -204,7 +205,7 @@ export class PremiseDecomposer {
     const knownIds = new Set((existingPremises ?? []).map((p) => p.id));
     const droppedIds = output.retractedPremiseIds.filter((id) => !knownIds.has(id));
     if (droppedIds.length > 0) {
-      logger.warn(`[PremiseDecomposer.invoke] Dropped ${droppedIds.length} unknown retraction id(s)`, { droppedIds });
+      invokeLog.warn(`Dropped ${droppedIds.length} unknown retraction id(s)`, { droppedIds });
     }
     output.retractedPremiseIds = output.retractedPremiseIds.filter((id) => knownIds.has(id));
 
@@ -223,7 +224,7 @@ export class PremiseDecomposer {
       output.revisedBio = normalizedBio;
     }
 
-    logger.verbose(`[PremiseDecomposer.invoke] Extracted ${output.premises.length} premise(s), ${output.retractedPremiseIds.length} retraction(s), revisedBio: ${output.revisedBio ? 'yes' : 'no'}`);
+    invokeLog.verbose(`Extracted ${output.premises.length} premise(s), ${output.retractedPremiseIds.length} retraction(s), revisedBio: ${output.revisedBio ? 'yes' : 'no'}`);
     return output;
   }
 }

--- a/packages/protocol/src/premise/premise.graph.ts
+++ b/packages/protocol/src/premise/premise.graph.ts
@@ -15,6 +15,12 @@ import { timed } from "../shared/observability/performance.js";
 import type { DebugMetaAgent } from "../chat/chat-streaming.types.js";
 
 const logger = protocolLogger("PremiseGraphFactory");
+const queryLog = protocolLogger("PremiseGraph:query");
+const analyzeLog = protocolLogger("PremiseGraph:analyze");
+const embedLog = protocolLogger("PremiseGraph:embed");
+const persistLog = protocolLogger("PremiseGraph:persist");
+const indexLog = protocolLogger("PremiseGraph:index");
+const dedupeLog = protocolLogger("PremiseGraph:dedupe");
 
 /**
  * Minimum cosine similarity (0-1) at which a freshly-decomposed premise is treated
@@ -63,7 +69,7 @@ export class PremiseGraphFactory {
 
     const queryNode = async (state: typeof PremiseGraphState.State) => {
       return timed("PremiseGraph.query", async () => {
-        logger.verbose(`[PremiseGraph.query] Fetching premises for user ${state.userId}`);
+        queryLog.verbose(`Fetching premises for user ${state.userId}`);
         const premises = await this.database.getPremisesForUser(state.userId, 'ACTIVE');
         return {
           readResult: {
@@ -80,7 +86,7 @@ export class PremiseGraphFactory {
           return { error: "assertionText is required for create/update mode" };
         }
 
-        logger.verbose(`[PremiseGraph.analyze] Analyzing: "${state.assertionText.substring(0, 50)}..."`);
+        analyzeLog.verbose(`Analyzing: "${state.assertionText.substring(0, 50)}..."`);
 
         const start = Date.now();
         const result = await analyzer.invoke(state.assertionText);
@@ -109,7 +115,7 @@ export class PremiseGraphFactory {
           return { error: "assertionText is required for embedding" };
         }
 
-        logger.verbose(`[PremiseGraph.embed] Generating embedding for premise`);
+        embedLog.verbose(`Generating embedding for premise`);
 
         // Embedder.generate returns number[] | number[][], cast for single string input
         const embedding = await this.embedder.generate(state.assertionText, undefined, getAbortSignalConfig()) as number[];
@@ -138,9 +144,11 @@ export class PremiseGraphFactory {
         });
 
         if (match) {
-          logger.verbose(
-            `[PremiseGraph.dedupe] Skipping near-duplicate (similarity=${match.similarity.toFixed(3)} >= ${DEDUP_SIMILARITY_THRESHOLD}) of premise ${match.premiseId}`,
-          );
+          dedupeLog.verbose('Skipping near-duplicate premise', {
+            similarity: Number(match.similarity.toFixed(3)),
+            threshold: DEDUP_SIMILARITY_THRESHOLD,
+            premiseId: match.premiseId,
+          });
           return { duplicateOf: match };
         }
         return {};
@@ -156,7 +164,7 @@ export class PremiseGraphFactory {
         }
 
         if (state.operationMode === 'update' && state.targetPremiseId) {
-          logger.verbose(`[PremiseGraph.persist] Updating premise ${state.targetPremiseId}`);
+          persistLog.verbose(`Updating premise ${state.targetPremiseId}`);
 
           const updated = await this.database.updatePremise(state.targetPremiseId, {
             assertion: {
@@ -174,7 +182,7 @@ export class PremiseGraphFactory {
           return { premise: updated };
         }
 
-        logger.verbose(`[PremiseGraph.persist] Creating new premise for user ${state.userId}`);
+        persistLog.verbose(`Creating new premise for user ${state.userId}`);
 
         // Provenance confidence: prefer an explicit caller-supplied value; otherwise
         // derive it from the analyzer's felicity scores (how authoritative, sincere,
@@ -209,7 +217,7 @@ export class PremiseGraphFactory {
       return timed("PremiseGraph.index", async () => {
         if (!state.premise) return {};
 
-        logger.verbose(`[PremiseGraph.index] Scoring premise against user networks`);
+        indexLog.verbose(`Scoring premise against user networks`);
 
         const assignmentMemberships = await this.database.getAssignmentNetworkMembershipsForUser(state.userId);
         const requestScope = state.scopeType && state.scopeId
@@ -272,11 +280,11 @@ export class PremiseGraphFactory {
               assignments.push({ networkId, relevancyScore: decision.finalScore });
             }
           } catch (err) {
-            logger.verbose(`[PremiseGraph.index] Failed to score network ${networkId}, skipping: ${err}`);
+            indexLog.verbose(`Failed to score network ${networkId}, skipping: ${err}`);
           }
         }
 
-        logger.verbose(`[PremiseGraph.index] Assigned to ${assignments.length} networks`);
+        indexLog.verbose(`Assigned to ${assignments.length} networks`);
 
         return { networkAssignments: assignments, agentTimings };
       });

--- a/packages/protocol/src/premise/premise.graph.ts
+++ b/packages/protocol/src/premise/premise.graph.ts
@@ -69,7 +69,7 @@ export class PremiseGraphFactory {
 
     const queryNode = async (state: typeof PremiseGraphState.State) => {
       return timed("PremiseGraph.query", async () => {
-        queryLog.verbose(`Fetching premises for user ${state.userId}`);
+        queryLog.verbose('Fetching premises for user', { userId: state.userId });
         const premises = await this.database.getPremisesForUser(state.userId, 'ACTIVE');
         return {
           readResult: {
@@ -86,7 +86,7 @@ export class PremiseGraphFactory {
           return { error: "assertionText is required for create/update mode" };
         }
 
-        analyzeLog.verbose(`Analyzing: "${state.assertionText.substring(0, 50)}..."`);
+        analyzeLog.verbose('Analyzing assertion text', { preview: state.assertionText.substring(0, 50) });
 
         const start = Date.now();
         const result = await analyzer.invoke(state.assertionText);
@@ -164,7 +164,7 @@ export class PremiseGraphFactory {
         }
 
         if (state.operationMode === 'update' && state.targetPremiseId) {
-          persistLog.verbose(`Updating premise ${state.targetPremiseId}`);
+          persistLog.verbose('Updating premise', { premiseId: state.targetPremiseId });
 
           const updated = await this.database.updatePremise(state.targetPremiseId, {
             assertion: {
@@ -182,7 +182,7 @@ export class PremiseGraphFactory {
           return { premise: updated };
         }
 
-        persistLog.verbose(`Creating new premise for user ${state.userId}`);
+        persistLog.verbose('Creating new premise for user', { userId: state.userId });
 
         // Provenance confidence: prefer an explicit caller-supplied value; otherwise
         // derive it from the analyzer's felicity scores (how authoritative, sincere,
@@ -280,11 +280,11 @@ export class PremiseGraphFactory {
               assignments.push({ networkId, relevancyScore: decision.finalScore });
             }
           } catch (err) {
-            indexLog.verbose(`Failed to score network ${networkId}, skipping: ${err}`);
+            indexLog.verbose('Failed to score network, skipping', { networkId, error: err });
           }
         }
 
-        indexLog.verbose(`Assigned to ${assignments.length} networks`);
+        indexLog.verbose('Assigned to networks', { count: assignments.length });
 
         return { networkAssignments: assignments, agentTimings };
       });

--- a/packages/protocol/src/premise/premise.indexer.ts
+++ b/packages/protocol/src/premise/premise.indexer.ts
@@ -6,6 +6,7 @@ import { createStructuredModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("PremiseIndexer");
+const invokeLog = protocolLogger("PremiseIndexer:invoke");
 
 const systemPrompt = `
 You are a Premise Evaluator for a social networking protocol.
@@ -64,7 +65,7 @@ export class PremiseIndexer {
     memberPrompt?: string;
     networkContext?: string;
   }): Promise<PremiseIndexerOutput> {
-    logger.verbose(`[PremiseIndexer.invoke] Scoring premise against index`);
+    invokeLog.verbose(`Scoring premise against index`);
 
     const prompt = [
       "# Premise",

--- a/packages/protocol/src/premise/premise.tools.ts
+++ b/packages/protocol/src/premise/premise.tools.ts
@@ -7,6 +7,10 @@ import type { PremiseRecord, PremiseValidity } from "../shared/interfaces/databa
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
 const logger = protocolLogger("ChatTools:Premise");
+const createPremiseLog = protocolLogger("ChatTools:Premise:createPremise");
+const readPremisesLog = protocolLogger("ChatTools:Premise:readPremises");
+const updatePremiseLog = protocolLogger("ChatTools:Premise:updatePremise");
+const retractPremiseLog = protocolLogger("ChatTools:Premise:retractPremise");
 
 export function createPremiseTools(defineTool: DefineTool, deps: ToolDeps) {
   const database = deps.database;
@@ -48,7 +52,7 @@ export function createPremiseTools(defineTool: DefineTool, deps: ToolDeps) {
         ? { scopeType: context.scopeType, scopeId: context.scopeId }
         : {};
 
-      logger.verbose(`[createPremise] Creating premise for user ${context.userId}: "${query.text.substring(0, 60)}..."`);
+      createPremiseLog.verbose(`Creating premise for user ${context.userId}: "${query.text.substring(0, 60)}..."`);
 
       const result = await invokeWithAbortSignal(premiseGraph, {
         userId: context.userId,
@@ -110,7 +114,7 @@ export function createPremiseTools(defineTool: DefineTool, deps: ToolDeps) {
         return error("Invalid userId format.");
       }
 
-      logger.verbose(`[readPremises] Fetching premises for user ${targetUserId}`);
+      readPremisesLog.verbose(`Fetching premises for user ${targetUserId}`);
 
       // Query DB directly (bypassing graph) to support status filtering.
       // The graph's query node hardcodes ACTIVE status, so includeRetracted
@@ -171,7 +175,7 @@ export function createPremiseTools(defineTool: DefineTool, deps: ToolDeps) {
         return error("Cannot update a retracted premise. Retracted premises are immutable.");
       }
 
-      logger.verbose(`[updatePremise] Updating premise ${query.premiseId} for user ${context.userId}`);
+      updatePremiseLog.verbose(`Updating premise ${query.premiseId} for user ${context.userId}`);
 
       // When text is unchanged, skip the graph (avoids unnecessary LLM
       // re-analysis and non-deterministic re-embedding). Only route through
@@ -271,7 +275,7 @@ export function createPremiseTools(defineTool: DefineTool, deps: ToolDeps) {
         return error("Premise is already retracted.");
       }
 
-      logger.verbose(`[retractPremise] Retracting premise ${query.premiseId} for user ${context.userId}`);
+      retractPremiseLog.verbose(`Retracting premise ${query.premiseId} for user ${context.userId}`);
 
       await database.updatePremise(query.premiseId, {
         status: "RETRACTED",

--- a/packages/protocol/src/premise/premise.tools.ts
+++ b/packages/protocol/src/premise/premise.tools.ts
@@ -52,7 +52,7 @@ export function createPremiseTools(defineTool: DefineTool, deps: ToolDeps) {
         ? { scopeType: context.scopeType, scopeId: context.scopeId }
         : {};
 
-      createPremiseLog.verbose(`Creating premise for user ${context.userId}: "${query.text.substring(0, 60)}..."`);
+      createPremiseLog.verbose('Creating premise for user', { userId: context.userId, preview: query.text.substring(0, 60) });
 
       const result = await invokeWithAbortSignal(premiseGraph, {
         userId: context.userId,
@@ -114,7 +114,7 @@ export function createPremiseTools(defineTool: DefineTool, deps: ToolDeps) {
         return error("Invalid userId format.");
       }
 
-      readPremisesLog.verbose(`Fetching premises for user ${targetUserId}`);
+      readPremisesLog.verbose('Fetching premises for user', { userId: targetUserId });
 
       // Query DB directly (bypassing graph) to support status filtering.
       // The graph's query node hardcodes ACTIVE status, so includeRetracted
@@ -175,7 +175,7 @@ export function createPremiseTools(defineTool: DefineTool, deps: ToolDeps) {
         return error("Cannot update a retracted premise. Retracted premises are immutable.");
       }
 
-      updatePremiseLog.verbose(`Updating premise ${query.premiseId} for user ${context.userId}`);
+      updatePremiseLog.verbose('Updating premise for user', { premiseId: query.premiseId, userId: context.userId });
 
       // When text is unchanged, skip the graph (avoids unnecessary LLM
       // re-analysis and non-deterministic re-embedding). Only route through
@@ -275,7 +275,7 @@ export function createPremiseTools(defineTool: DefineTool, deps: ToolDeps) {
         return error("Premise is already retracted.");
       }
 
-      retractPremiseLog.verbose(`Retracting premise ${query.premiseId} for user ${context.userId}`);
+      retractPremiseLog.verbose('Retracting premise for user', { premiseId: query.premiseId, userId: context.userId });
 
       await database.updatePremise(query.premiseId, {
         status: "RETRACTED",

--- a/packages/protocol/src/shared/agent/tool.factory.ts
+++ b/packages/protocol/src/shared/agent/tool.factory.ts
@@ -99,7 +99,8 @@ export async function createChatTools(
   }) {
     return tool(
       async (query: z.infer<T>) => {
-        logger.info(`Tool: ${opts.name}`, {
+        logger.info('Tool invoked', {
+          toolName: opts.name,
           context: { userId: resolvedContext.userId, scopeType: resolvedContext.scopeType, scopeId: resolvedContext.scopeId },
           query: redactSensitiveFields(query),
         });
@@ -111,7 +112,8 @@ export async function createChatTools(
             query,
           });
         } catch (err) {
-          logger.error(`${opts.name} failed`, {
+          logger.error('Tool failed', {
+            toolName: opts.name,
             error: err instanceof Error ? err.message : String(err),
           });
           const runtimeResult = toolRuntimeErrorToResult(err);

--- a/packages/protocol/src/shared/agent/tool.registry.ts
+++ b/packages/protocol/src/shared/agent/tool.registry.ts
@@ -43,7 +43,8 @@ export function createToolRegistry(deps: ToolDeps): ToolRegistry {
       description: opts.description,
       schema: opts.querySchema,
       handler: async (input: { context: ResolvedToolContext; query: unknown }) => {
-        logger.verbose(`Tool: ${opts.name}`, {
+        logger.verbose('Tool invoked', {
+          toolName: opts.name,
           context: { userId: input.context.userId, scopeType: input.context.scopeType, scopeId: input.context.scopeId },
           query: redactSensitiveFields(input.query),
         });
@@ -54,7 +55,8 @@ export function createToolRegistry(deps: ToolDeps): ToolRegistry {
           if (abortSignal?.aborted) {
             throw err;
           }
-          logger.error(`${opts.name} failed`, {
+          logger.error('Tool failed', {
+            toolName: opts.name,
             error: err instanceof Error ? err.message : String(err),
           });
           return error(`Failed to execute ${opts.name}: ${err instanceof Error ? err.message : String(err)}`);
@@ -104,7 +106,7 @@ export function createToolRegistry(deps: ToolDeps): ToolRegistry {
   for (const [oldName, canonicalName] of DEPRECATED_TOOL_ALIASES) {
     const canonical = registry.get(canonicalName);
     if (!canonical) {
-      logger.warn(`Cannot register deprecated alias ${oldName}: canonical ${canonicalName} not found`);
+      logger.warn('Cannot register deprecated alias: canonical tool not found', { alias: oldName, canonicalName });
       continue;
     }
     registry.set(oldName, {
@@ -114,6 +116,6 @@ export function createToolRegistry(deps: ToolDeps): ToolRegistry {
     });
   }
 
-  logger.verbose(`Tool registry created with ${registry.size} tools`);
+  logger.verbose('Tool registry created', { toolCount: registry.size });
   return registry;
 }

--- a/packages/protocol/src/shared/interfaces/database.interface.ts
+++ b/packages/protocol/src/shared/interfaces/database.interface.ts
@@ -699,7 +699,7 @@ export interface Database {
    * // After graph outputs EXPIRE action
    * const result = await db.archiveIntent(action.id);
    * if (!result.success) {
-   *   console.error(`Failed to archive: ${result.error}`);
+   *   console.error('Failed to archive intent', { error: result.error });
    * }
    * ```
    */

--- a/packages/protocol/src/shared/observability/log.ts
+++ b/packages/protocol/src/shared/observability/log.ts
@@ -32,16 +32,50 @@ export type LogLevel = 'verbose' | 'debug' | 'info' | 'warn' | 'error';
 
 function defaultCreateLogger(_context: string, source: string): LoggerWithSource {
   const prefix = `[${source}]`;
+  const emit = (sink: (...args: unknown[]) => void, msg: string, meta?: Record<string, unknown>) =>
+    sink(prefix, msg, ...(meta ? [sanitizeFn(meta)] : []));
   return {
-    verbose: (msg, meta) => console.debug(prefix, msg, ...(meta ? [meta] : [])),
-    debug: (msg, meta) => console.debug(prefix, msg, ...(meta ? [meta] : [])),
-    info: (msg, meta) => console.info(prefix, msg, ...(meta ? [meta] : [])),
-    warn: (msg, meta) => console.warn(prefix, msg, ...(meta ? [meta] : [])),
-    error: (msg, meta) => console.error(prefix, msg, ...(meta ? [meta] : [])),
+    // eslint-disable-next-line no-console
+    verbose: (msg, meta) => emit(console.debug, msg, meta),
+    // eslint-disable-next-line no-console
+    debug: (msg, meta) => emit(console.debug, msg, meta),
+    // eslint-disable-next-line no-console
+    info: (msg, meta) => emit(console.info, msg, meta),
+    // eslint-disable-next-line no-console
+    warn: (msg, meta) => emit(console.warn, msg, meta),
+    // eslint-disable-next-line no-console
+    error: (msg, meta) => emit(console.error, msg, meta),
   };
 }
 
-function defaultSanitize(value: unknown): unknown {
+/** Truncation limits for the default (host-less) sanitizer — never dump big payloads. */
+const MAX_STRING_LENGTH = 2000;
+const MAX_ARRAY_ITEMS = 25;
+const MAX_DEPTH = 6;
+
+function defaultSanitize(value: unknown, depth = 0): unknown {
+  if (value == null) return value;
+  if (typeof value === 'string') {
+    return value.length > MAX_STRING_LENGTH
+      ? `${value.slice(0, MAX_STRING_LENGTH)}… [truncated ${value.length - MAX_STRING_LENGTH} chars]`
+      : value;
+  }
+  if (Array.isArray(value)) {
+    if (value.length > 0 && typeof value[0] === 'number') return `[redacted: ${value.length} values]`;
+    if (depth >= MAX_DEPTH) return `[truncated: array(${value.length})]`;
+    const items = value.slice(0, MAX_ARRAY_ITEMS).map((item) => defaultSanitize(item, depth + 1));
+    if (value.length > MAX_ARRAY_ITEMS) items.push(`… [truncated ${value.length - MAX_ARRAY_ITEMS} more items]`);
+    return items;
+  }
+  if (value instanceof Error) {
+    return { name: value.name, message: defaultSanitize(value.message, depth + 1) };
+  }
+  if (typeof value === 'object' && value.constructor === Object) {
+    if (depth >= MAX_DEPTH) return `[truncated: object(${Object.keys(value).length} keys)]`;
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, defaultSanitize(v, depth + 1)])
+    );
+  }
   return value;
 }
 
@@ -54,6 +88,8 @@ type SanitizeFn = (value: unknown) => unknown;
 
 let createLoggerFn: LoggerFactory = defaultCreateLogger;
 let sanitizeFn: SanitizeFn = defaultSanitize;
+/** Bumped on every setLoggerFactory() call; invalidates cached logger instances. */
+let factoryGeneration = 0;
 
 /**
  * Override the logger factory used by all protocol-internal logging.
@@ -73,6 +109,7 @@ let sanitizeFn: SanitizeFn = defaultSanitize;
 export function setLoggerFactory(factory: LoggerFactory, sanitize?: SanitizeFn) {
   createLoggerFn = factory;
   if (sanitize) sanitizeFn = sanitize;
+  factoryGeneration++;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -84,9 +121,34 @@ export function sanitizeForLog(value: unknown): unknown {
   return sanitizeFn(value);
 }
 
+/**
+ * Late-bound logger: resolves the current factory at emit time (cached per
+ * factory generation). This makes `const logger = log.lib.from('X')` at module
+ * import time safe — loggers created BEFORE the host calls `setLoggerFactory()`
+ * still pick up the rich implementation afterwards.
+ */
+function makeLateBoundLogger(context: string, source: string): LoggerWithSource {
+  let cached: LoggerWithSource | undefined;
+  let cachedGeneration = -1;
+  const resolve = (): LoggerWithSource => {
+    if (!cached || cachedGeneration !== factoryGeneration) {
+      cached = createLoggerFn(context, source);
+      cachedGeneration = factoryGeneration;
+    }
+    return cached;
+  };
+  return {
+    verbose: (msg, meta) => resolve().verbose(msg, meta),
+    debug: (msg, meta) => resolve().debug(msg, meta),
+    info: (msg, meta) => resolve().info(msg, meta),
+    warn: (msg, meta) => resolve().warn(msg, meta),
+    error: (msg, meta) => resolve().error(msg, meta),
+  };
+}
+
 function lazyContext(context: string) {
   return {
-    from: (source: string) => createLoggerFn(context, source),
+    from: (source: string) => makeLateBoundLogger(context, source),
   };
 }
 
@@ -97,8 +159,9 @@ function lazyContext(context: string) {
  * logger.info('started');
  * ```
  *
- * Logger creation is deferred to call time so `setLoggerFactory()` can be
- * called at app startup and all subsequent `.from()` calls use the new factory.
+ * Loggers are late-bound: the factory is resolved at emit time, so
+ * `setLoggerFactory()` at app startup upgrades even loggers that were created
+ * at module import time.
  */
 export const log = {
   protocol: lazyContext('protocol'),

--- a/packages/protocol/src/shared/observability/protocol.logger.ts
+++ b/packages/protocol/src/shared/observability/protocol.logger.ts
@@ -36,7 +36,7 @@ export async function withCallLogging<T>(
   const { logOutput = true, context = {} } = options;
   const start = Date.now();
   const sanitizedInputs = sanitizeForLog(inputs) as Record<string, unknown>;
-  logger.verbose(`[Call] ${callName} start`, { inputs: sanitizedInputs, ...context });
+  logger.verbose(`${callName} start`, { inputs: sanitizedInputs, ...context });
 
   try {
     const result = await fn();
@@ -48,11 +48,11 @@ export async function withCallLogging<T>(
     if (logOutput) {
       outMeta.output = sanitizeForLog(result);
     }
-    logger.verbose(`[Call] ${callName} end`, outMeta);
+    logger.verbose(`${callName} end`, outMeta);
     return result;
   } catch (err) {
     const durationMs = Date.now() - start;
-    logger.error(`[Call] ${callName} failed`, {
+    logger.error(`${callName} failed`, {
       error: err,
       durationMs,
       ...context,

--- a/packages/protocol/src/shared/observability/protocol.logger.ts
+++ b/packages/protocol/src/shared/observability/protocol.logger.ts
@@ -36,23 +36,25 @@ export async function withCallLogging<T>(
   const { logOutput = true, context = {} } = options;
   const start = Date.now();
   const sanitizedInputs = sanitizeForLog(inputs) as Record<string, unknown>;
-  logger.verbose(`${callName} start`, { inputs: sanitizedInputs, ...context });
+  logger.verbose('call start', { callName, inputs: sanitizedInputs, ...context });
 
   try {
     const result = await fn();
     const durationMs = Date.now() - start;
     const outMeta: Record<string, unknown> = {
+      callName,
       durationMs,
       ...context,
     };
     if (logOutput) {
       outMeta.output = sanitizeForLog(result);
     }
-    logger.verbose(`${callName} end`, outMeta);
+    logger.verbose('call end', outMeta);
     return result;
   } catch (err) {
     const durationMs = Date.now() - start;
-    logger.error(`${callName} failed`, {
+    logger.error('call failed', {
+      callName,
       error: err,
       durationMs,
       ...context,

--- a/packages/protocol/src/shared/observability/tests/log.spec.ts
+++ b/packages/protocol/src/shared/observability/tests/log.spec.ts
@@ -63,7 +63,7 @@ describe("default logger", () => {
 });
 
 describe("setLoggerFactory()", () => {
-  it("overrides the logger — subsequent .from() calls use the new factory", () => {
+  it("overrides the logger — the factory is resolved (lazily) with context and source on first emit", () => {
     const calls: Array<{ context: string; source: string }> = [];
     setLoggerFactory((context, source) => {
       calls.push({ context, source });
@@ -76,12 +76,34 @@ describe("setLoggerFactory()", () => {
       };
     });
 
-    log.protocol.from("MyAgent");
-    log.agent.from("AnotherAgent");
-
+    const a = log.protocol.from("MyAgent");
+    const b = log.agent.from("AnotherAgent");
+    // Late-bound: the factory has not run yet at .from() time…
+    expect(calls).toHaveLength(0);
+    // …it runs on first emit, with the right context/source, and is cached.
+    a.info("x");
+    b.info("y");
+    a.info("z");
     expect(calls).toHaveLength(2);
     expect(calls[0]).toEqual({ context: "protocol", source: "MyAgent" });
     expect(calls[1]).toEqual({ context: "agent", source: "AnotherAgent" });
+  });
+
+  it("upgrades loggers created BEFORE setLoggerFactory (late binding)", () => {
+    // Simulates a module-level `const logger = log.lib.from(...)` executed at
+    // import time, before the host application wires its logger at startup.
+    const early = log.protocol.from("EarlyModule");
+    const seen: string[] = [];
+    setLoggerFactory((_context, source) => ({
+      verbose: () => {},
+      debug: () => {},
+      info: (msg) => seen.push(`${source}: ${msg}`),
+      warn: () => {},
+      error: () => {},
+    }));
+
+    early.info("after wiring");
+    expect(seen).toEqual(["EarlyModule: after wiring"]);
   });
 
   it("the custom logger's methods are called when logging", () => {
@@ -102,10 +124,24 @@ describe("setLoggerFactory()", () => {
 });
 
 describe("sanitizeForLog()", () => {
-  it("returns the value as-is with the default (no sanitize function set)", () => {
-    const obj = { name: "Alice", embedding: [0.1, 0.2] };
-    const result = sanitizeForLog(obj);
-    expect(result).toBe(obj);
+  it("redacts number arrays and truncates big payloads with the default (no sanitize function set)", () => {
+    const obj = {
+      name: "Alice",
+      embedding: [0.1, 0.2],
+      blob: "x".repeat(5000),
+      items: Array.from({ length: 100 }, (_, i) => i.toString()),
+    };
+    const result = sanitizeForLog(obj) as Record<string, unknown>;
+    expect(result.name).toBe("Alice");
+    expect(result.embedding).toBe("[redacted: 2 values]");
+    expect(result.blob).toContain("[truncated 3000 chars]");
+    expect((result.blob as string).length).toBeLessThan(2100);
+    const items = result.items as unknown[];
+    expect(items.length).toBe(26); // 25 items + truncation marker
+    expect(items[25]).toContain("truncated 75 more items");
+    // primitives pass through untouched
+    expect(sanitizeForLog(42)).toBe(42);
+    expect(sanitizeForLog("short")).toBe("short");
   });
 
   it("delegates to the injected sanitize function after setLoggerFactory(factory, sanitize)", () => {

--- a/services/api/src/adapters/chat.database.adapter.ts
+++ b/services/api/src/adapters/chat.database.adapter.ts
@@ -3219,7 +3219,7 @@ export class ChatDatabaseAdapter {
     // opportunity cascade + user_contexts regeneration without per-surface wiring.
     // The bus defaults to no-ops; main.ts subscribes the queue handlers.
     try { PremiseEvents.onCreated(row.id, row.userId); }
-    catch (e) { logger.error('[createPremise] PremiseEvents.onCreated failed', { premiseId: row.id, error: e }); }
+    catch (e) { logger.error('PremiseEvents.onCreated failed after premise create', { premiseId: row.id, error: e }); }
     return {
       id: row.id,
       userId: row.userId,
@@ -3396,7 +3396,7 @@ export class ChatDatabaseAdapter {
       else if (updates.status === 'EXPIRED') PremiseEvents.onExpired(row.id, row.userId);
       else PremiseEvents.onUpdated(row.id, row.userId);
     } catch (e) {
-      logger.error('[updatePremise] PremiseEvents emit failed', { premiseId: row.id, error: e });
+      logger.error('PremiseEvents emit failed after premise update', { premiseId: row.id, error: e });
     }
     return {
       id: row.id,

--- a/services/api/src/adapters/checkpointer.adapter.ts
+++ b/services/api/src/adapters/checkpointer.adapter.ts
@@ -54,7 +54,7 @@ export async function getCheckpointer(): Promise<PostgresSaver> {
     );
   }
 
-  logger.verbose("[getCheckpointer] Initializing PostgresSaver checkpointer");
+  logger.verbose("Initializing shared PostgresSaver checkpointer");
 
   // Create checkpointer from connection string
   checkpointerInstance = PostgresSaver.fromConnString(connectionString);
@@ -62,9 +62,9 @@ export async function getCheckpointer(): Promise<PostgresSaver> {
   // Setup creates required tables if they don't exist
   // Store the promise so concurrent calls can await it
   setupPromise = checkpointerInstance.setup().then(() => {
-    logger.verbose("[getCheckpointer] PostgresSaver setup complete");
+    logger.verbose("Shared PostgresSaver setup complete");
   }).catch((error) => {
-    logger.error("[getCheckpointer] PostgresSaver setup failed", {
+    logger.error("Shared PostgresSaver setup failed", {
       error: error instanceof Error ? error.message : String(error),
     });
     // Reset instance on failure so next call retries
@@ -101,11 +101,11 @@ export async function createCheckpointer(
     );
   }
 
-  logger.verbose("[createCheckpointer] Creating new PostgresSaver instance");
+  logger.verbose("Creating new PostgresSaver instance");
 
   const checkpointer = PostgresSaver.fromConnString(connStr);
   await checkpointer.setup();
-  logger.verbose("[createCheckpointer] PostgresSaver setup complete");
+  logger.verbose("New PostgresSaver instance setup complete");
   return checkpointer;
 }
 
@@ -117,7 +117,7 @@ export async function createCheckpointer(
  * Use with caution in production.
  */
 export function resetCheckpointer(): void {
-  logger.verbose("[resetCheckpointer] Resetting checkpointer instance");
+  logger.verbose("Resetting checkpointer instance");
   checkpointerInstance = null;
   setupPromise = null;
 }

--- a/services/api/src/controllers/conversation.controller.ts
+++ b/services/api/src/controllers/conversation.controller.ts
@@ -35,7 +35,7 @@ export class ConversationController {
       return Response.json({ conversations });
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
-      logger.error('[listConversations] Error', { userId: user.id, error: message });
+      logger.error('listConversations failed', { userId: user.id, error: message });
       return Response.json({ error: message }, { status: 500 });
     }
   }
@@ -51,7 +51,7 @@ export class ConversationController {
       return Response.json({ conversations });
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
-      logger.error('[listNegotiations] Error', { userId: user.id, error: message });
+      logger.error('listNegotiations failed', { userId: user.id, error: message });
       return Response.json({ error: message }, { status: 500 });
     }
   }
@@ -92,7 +92,7 @@ export class ConversationController {
       return Response.json({ conversation }, { status: 201 });
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
-      logger.error('[createConversation] Error', { userId: user.id, error: message });
+      logger.error('createConversation failed', { userId: user.id, error: message });
       return Response.json({ error: message }, { status: 500 });
     }
   }
@@ -133,7 +133,7 @@ export class ConversationController {
       if (message.startsWith('Forbidden')) {
         return Response.json({ error: message }, { status: 403 });
       }
-      logger.error('[getMessages] Error', { userId: user.id, conversationId, error: message });
+      logger.error('getMessages failed', { userId: user.id, conversationId, error: message });
       return Response.json({ error: message }, { status: 500 });
     }
   }
@@ -182,7 +182,7 @@ export class ConversationController {
       if (message.startsWith('Forbidden')) {
         return Response.json({ error: message }, { status: 403 });
       }
-      logger.error('[sendMessage] Error', { userId: user.id, conversationId, error: message });
+      logger.error('sendMessage failed', { userId: user.id, conversationId, error: message });
       return Response.json({ error: message }, { status: 500 });
     }
   }
@@ -213,7 +213,7 @@ export class ConversationController {
       return Response.json({ conversation });
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
-      logger.error('[getOrCreateDM] Error', { userId: user.id, error: message });
+      logger.error('getOrCreateDM failed', { userId: user.id, error: message });
       return Response.json({ error: message }, { status: 500 });
     }
   }
@@ -260,7 +260,7 @@ export class ConversationController {
       if (message.startsWith('Forbidden')) {
         return Response.json({ error: message }, { status: 403 });
       }
-      logger.error('[updateMetadata] Error', { userId: user.id, conversationId, error: message });
+      logger.error('updateMetadata failed', { userId: user.id, conversationId, error: message });
       return Response.json({ error: message }, { status: 500 });
     }
   }
@@ -296,7 +296,7 @@ export class ConversationController {
       if (message.startsWith('Forbidden')) {
         return Response.json({ error: message }, { status: 403 });
       }
-      logger.error('[hideConversation] Error', { userId: user.id, conversationId, error: message });
+      logger.error('hideConversation failed', { userId: user.id, conversationId, error: message });
       return Response.json({ error: message }, { status: 500 });
     }
   }
@@ -333,7 +333,7 @@ export class ConversationController {
       if (message.startsWith('Forbidden')) {
         return Response.json({ error: message }, { status: 403 });
       }
-      logger.error('[listTasks] Error', { userId: user.id, conversationId, error: message });
+      logger.error('listTasks failed', { userId: user.id, conversationId, error: message });
       return Response.json({ error: message }, { status: 500 });
     }
   }
@@ -374,7 +374,7 @@ export class ConversationController {
       if (message.startsWith('Forbidden')) {
         return Response.json({ error: 'Task not found' }, { status: 404 });
       }
-      logger.error('[getTask] Error', { userId: user.id, conversationId, taskId, error: message });
+      logger.error('getTask failed', { userId: user.id, conversationId, taskId, error: message });
       return Response.json({ error: message }, { status: 500 });
     }
   }
@@ -412,7 +412,7 @@ export class ConversationController {
       if (message.startsWith('Forbidden')) {
         return Response.json({ error: 'Task not found' }, { status: 404 });
       }
-      logger.error('[getArtifacts] Error', { userId: user.id, conversationId, taskId, error: message });
+      logger.error('getArtifacts failed', { userId: user.id, conversationId, taskId, error: message });
       return Response.json({ error: message }, { status: 500 });
     }
   }

--- a/services/api/src/controllers/opportunity.controller.ts
+++ b/services/api/src/controllers/opportunity.controller.ts
@@ -154,7 +154,7 @@ export class OpportunityController {
       return Response.json(result);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
-      logger.error('[getChatContext] Error', { userId: user.id, error: message });
+      logger.error('getChatContext failed', { userId: user.id, error: message });
       return Response.json({ error: 'Internal server error' }, { status: 500 });
     }
   }

--- a/services/api/src/guards/auth.guard.ts
+++ b/services/api/src/guards/auth.guard.ts
@@ -7,7 +7,7 @@ import { apikeys, users } from '../schemas/database.schema';
 import { API_URL, JWT_AUDIENCE } from '../lib/betterauth/betterauth';
 import { log } from '../lib/log';
 
-const logger = log.server.from('auth-guard');
+const logger = log.server.from('auth.guard');
 
 export interface AuthenticatedUser {
   id: string;

--- a/services/api/src/lib/bullmq/bullmq.ts
+++ b/services/api/src/lib/bullmq/bullmq.ts
@@ -87,7 +87,7 @@ export class QueueFactory {
    * @returns Configured BullMQ Queue instance.
    */
   static createQueue<T = any>(name: string, options?: Omit<QueueOptions, 'connection'>): Queue<T> {
-    logger.info(`[QueueFactory] Initializing Queue: ${name}`);
+    logger.info(`Initializing Queue: ${name}`);
     return new Queue<T>(name, {
       connection: SHARED_REDIS_OPTS,
       defaultJobOptions: DEFAULT_JOB_OPTS,
@@ -107,7 +107,7 @@ export class QueueFactory {
    * @returns Configured BullMQ Worker instance.
    */
   static createWorker<T = any>(name: string, processor: Processor<T>, options?: Omit<WorkerOptions, 'connection'>): Worker<T> {
-    logger.info(`[QueueFactory] Initializing Worker: ${name}`);
+    logger.info(`Initializing Worker: ${name}`);
     const tracedProcessor: Processor<T> = (job, token) => traceAppOperation(
       {
         name: `queue ${name} ${job.name}`,

--- a/services/api/src/lib/bullmq/bullmq.ts
+++ b/services/api/src/lib/bullmq/bullmq.ts
@@ -87,7 +87,7 @@ export class QueueFactory {
    * @returns Configured BullMQ Queue instance.
    */
   static createQueue<T = any>(name: string, options?: Omit<QueueOptions, 'connection'>): Queue<T> {
-    logger.info(`Initializing Queue: ${name}`);
+    logger.info('Initializing queue', { name });
     return new Queue<T>(name, {
       connection: SHARED_REDIS_OPTS,
       defaultJobOptions: DEFAULT_JOB_OPTS,
@@ -107,7 +107,7 @@ export class QueueFactory {
    * @returns Configured BullMQ Worker instance.
    */
   static createWorker<T = any>(name: string, processor: Processor<T>, options?: Omit<WorkerOptions, 'connection'>): Worker<T> {
-    logger.info(`Initializing Worker: ${name}`);
+    logger.info('Initializing worker', { name });
     const tracedProcessor: Processor<T> = (job, token) => traceAppOperation(
       {
         name: `queue ${name} ${job.name}`,

--- a/services/api/src/lib/bullmq/queue-template.md
+++ b/services/api/src/lib/bullmq/queue-template.md
@@ -64,16 +64,16 @@ import { log } from '../../lib/log';
 async function processMyJob(job: Job<MyJobPayload>) {
   const { userId, action } = job.data;
   
-  log.info(`[MyWorker] Processing job ${job.id} for user ${userId}`);
+  log.info(`Processing job ${job.id}`, { userId });
 
   try {
     // Perform task logic here
     await performAction(userId, action);
     
-    log.info(`[MyWorker] Job ${job.id} completed`);
+    log.info(`Job ${job.id} completed`);
     return { success: true };
   } catch (error) {
-    log.error(`[MyWorker] Job ${job.id} failed`, { error });
+    log.error(`Job ${job.id} failed`, { error });
     throw error; // Throwing allows BullMQ to handle retries
   }
 }

--- a/services/api/src/lib/bullmq/queue-template.md
+++ b/services/api/src/lib/bullmq/queue-template.md
@@ -64,16 +64,16 @@ import { log } from '../../lib/log';
 async function processMyJob(job: Job<MyJobPayload>) {
   const { userId, action } = job.data;
   
-  log.info(`Processing job ${job.id}`, { userId });
+  log.info('Processing job', { jobId: job.id, userId });
 
   try {
     // Perform task logic here
     await performAction(userId, action);
     
-    log.info(`Job ${job.id} completed`);
+    log.info('Job completed', { jobId: job.id });
     return { success: true };
   } catch (error) {
-    log.error(`Job ${job.id} failed`, { error });
+    log.error('Job failed', { jobId: job.id, error });
     throw error; // Throwing allows BullMQ to handle retries
   }
 }

--- a/services/api/src/lib/email/transport.helper.ts
+++ b/services/api/src/lib/email/transport.helper.ts
@@ -2,7 +2,7 @@ import { Resend } from 'resend';
 
 import { log } from '../log';
 
-const logger = log.lib.from("lib/email/transport.helper.ts");
+const logger = log.lib.from("email/transport.helper");
 const resend = process.env.RESEND_API_KEY ? new Resend(process.env.RESEND_API_KEY) : null;
 
 export const executeSendEmail = async (options: {

--- a/services/api/src/lib/email/transport.helper.ts
+++ b/services/api/src/lib/email/transport.helper.ts
@@ -13,7 +13,7 @@ export const executeSendEmail = async (options: {
   headers?: Record<string, string>;
 }) => {
   if (!process.env.RESEND_API_KEY || !resend || process.env.RESEND_API_KEY === 'DISABLED') {
-    logger.warn('[EmailTransport] RESEND_API_KEY not configured or disabled - email not sent');
+    logger.warn('RESEND_API_KEY not configured or disabled - email not sent');
     return { data: null, skipped: true, reason: 'resend_not_configured' };
   }
 
@@ -23,7 +23,7 @@ export const executeSendEmail = async (options: {
   if (!isProduction) {
     const testAddress = process.env.TESTING_EMAIL_ADDRESS;
     if (!testAddress) {
-      logger.debug('[EmailTransport] Non-production and no TESTING_EMAIL_ADDRESS - skipping');
+      logger.debug('Non-production and no TESTING_EMAIL_ADDRESS - skipping');
       return { data: null, skipped: true, reason: 'no_test_recipient' };
     }
     recipient = testAddress;
@@ -59,7 +59,7 @@ ${options.html}
     }
   }
 
-  logger.verbose('[EmailTransport] Sending email', {
+  logger.verbose('Sending email', {
     recipient: String(recipient),
     originalTo: String(options.to),
     production: isProduction,
@@ -77,7 +77,7 @@ ${options.html}
     });
 
     if (result.error) {
-      logger.error('[EmailTransport] Resend API returned error', {
+      logger.error('Resend API returned error', {
         errorName: result.error.name,
         errorMessage: result.error.message,
         recipient: String(recipient),
@@ -86,13 +86,13 @@ ${options.html}
       throw new Error(`Resend error: ${result.error.message}`);
     }
 
-    logger.info('[EmailTransport] Email sent successfully', {
+    logger.info('Email sent successfully', {
       messageId: result.data?.id,
       recipient: String(recipient),
     });
     return result;
   } catch (error) {
-    logger.error('[EmailTransport] Failed to send email via Resend API', {
+    logger.error('Failed to send email via Resend API', {
       error: error instanceof Error ? error.message : String(error),
       recipient: String(recipient),
       subject: options.subject,

--- a/services/api/src/lib/email/transport.producer.ts
+++ b/services/api/src/lib/email/transport.producer.ts
@@ -35,7 +35,7 @@ export const sendEmail = async (options: {
 
       // If job is still waiting/active, the timeout was hit or worker didn't process it
       if (jobState === 'waiting' || jobState === 'active' || jobState === 'delayed') {
-        logger.error(`[EmailTransport] Email job ${job.id} timed out or not processed`, { jobState });
+        logger.error(`Email job ${job.id} timed out or not processed`, { jobState });
       } else if (jobState === 'completed') {
         // Job actually completed, QueueEvents missed the event - return the stored result
         return returnValue;
@@ -48,7 +48,7 @@ export const sendEmail = async (options: {
   } catch (error) {
     // Handle timeout or other errors
     const jobState = await job.getState().catch(() => 'unknown');
-    logger.error(`[EmailTransport] Email job ${job.id} error while waiting`, {
+    logger.error(`Email job ${job.id} error while waiting`, {
       error: error instanceof Error ? error.message : String(error),
       jobState,
     });

--- a/services/api/src/lib/email/transport.producer.ts
+++ b/services/api/src/lib/email/transport.producer.ts
@@ -2,7 +2,7 @@ import { emailQueue } from '../../queues/email.queue';
 
 import { log } from '../log';
 
-const logger = log.lib.from("lib/email/transport.producer.ts");
+const logger = log.lib.from("email/transport.producer");
 
 /**
  * Enqueue an email job and block until the worker finishes it (or times out).
@@ -35,7 +35,7 @@ export const sendEmail = async (options: {
 
       // If job is still waiting/active, the timeout was hit or worker didn't process it
       if (jobState === 'waiting' || jobState === 'active' || jobState === 'delayed') {
-        logger.error(`Email job ${job.id} timed out or not processed`, { jobState });
+        logger.error('Email job timed out or not processed', { jobId: job.id, jobState });
       } else if (jobState === 'completed') {
         // Job actually completed, QueueEvents missed the event - return the stored result
         return returnValue;
@@ -48,7 +48,8 @@ export const sendEmail = async (options: {
   } catch (error) {
     // Handle timeout or other errors
     const jobState = await job.getState().catch(() => 'unknown');
-    logger.error(`Email job ${job.id} error while waiting`, {
+    logger.error('Email job error while waiting', {
+      jobId: job.id,
       error: error instanceof Error ? error.message : String(error),
       jobState,
     });

--- a/services/api/src/lib/log.ts
+++ b/services/api/src/lib/log.ts
@@ -346,13 +346,19 @@ function addFrom<T extends LogContext>(context: T): LoggerWithSource & { from: (
 
 const base = createLogger(undefined, undefined);
 
-/** Logger with optional context (emoji + color). Use .from('filename.ts') for consistent source in every line. */
+/** Logger with optional context (emoji + color). Use .from(source) for a consistent source label in every line — see the per-layer conventions on the pre-bound loggers below. */
 export const log = {
   ...base,
   withContext(context: LogContext, source?: string) {
     return source ? createLogger(context, source) : addFrom(context);
   },
-  /** Pre-bound logger. Pass path relative to src/ (e.g. "controllers/chat.controller.ts"). Non-blessed paths get [DEPRECATED] in output. */
+  /**
+   * Pre-bound loggers. Source label conventions per layer:
+   * controllers = lowercase feature ('chat'); services = PascalCase class name ('IntentService');
+   * queues = 'XxxJob'/'XxxQueue'; adapters = '<name>.adapter'; guards = '<name>.guard';
+   * lib = module name without lib/ prefix or extension ('email/transport.helper');
+   * protocol components = PascalCase with optional ':SubScope' ('OpportunityGraph:Prep').
+   */
   controller: addFrom('controller'),
   service: addFrom('service'),
   agent: addFrom('agent'),

--- a/services/api/src/lib/log.ts
+++ b/services/api/src/lib/log.ts
@@ -119,6 +119,20 @@ const EMBEDDING_KEYS = new Set([
   'embeddings',
 ]);
 
+/**
+ * Truncation limits for logged meta. Logs are for humans and Sentry —
+ * never dump large payloads (full entities, LLM outputs, API responses).
+ */
+const MAX_LOG_STRING_LENGTH = 2000;
+const MAX_LOG_ARRAY_ITEMS = 25;
+const MAX_LOG_OBJECT_KEYS = 50;
+const MAX_LOG_DEPTH = 6;
+
+function truncateLogString(value: string): string {
+  if (value.length <= MAX_LOG_STRING_LENGTH) return value;
+  return `${value.slice(0, MAX_LOG_STRING_LENGTH)}… [truncated ${value.length - MAX_LOG_STRING_LENGTH} chars]`;
+}
+
 function isNumberArray(value: unknown): value is number[] {
   return (
     Array.isArray(value) &&
@@ -269,12 +283,16 @@ function wrapWithContext(
   const colorOn = useColor() && effectiveColor;
   const ansi = colorOn ? hexToAnsi(effectiveColor) : '';
   const reset = colorOn ? RESET : '';
+  // Path-based deprecation only applies to api-internal file-path sources
+  // (e.g. "routes/foo.ts"). Protocol/graph/agent sources are component names
+  // (e.g. "OpportunityGraph:Prep") and are never deprecated by path.
+  const looksLikePath = (s: string) => s.endsWith('.ts') || s.includes('/');
   const deprecatedTag =
     context === 'cli' || context === 'route'
       ? '[DEPRECATED] '
       : context === 'lib' || context === 'job' || context === 'service' || context === 'server' || context === 'controller' || context === 'protocol' || context === 'queue'
         ? ''
-        : (source && isDeprecatedSource(source))
+        : (source && looksLikePath(source) && isDeprecatedSource(source))
           ? '[DEPRECATED] '
           : '';
   const prefix = source ? `${emoji} ${deprecatedTag}${source}: ` : `${emoji} `;
@@ -349,37 +367,56 @@ export const log = {
   lib: addFrom('lib'),
 };
 
-/** Sanitize an object for logging: redact embedding/vector arrays. Use before logging objects that may contain embeddings. */
+/**
+ * Sanitize an object for logging: redact embedding/vector arrays and truncate
+ * oversized strings/arrays/objects. Use before logging objects that may contain
+ * embeddings or large payloads.
+ */
 export function sanitizeForLog(value: unknown): unknown {
   return sanitizeForLogInternal(value);
 }
 
-function sanitizeForLogInternal(value: unknown): unknown {
+function sanitizeForLogInternal(value: unknown, depth = 0): unknown {
   if (value == null) return value;
+  if (typeof value === 'string') return truncateLogString(value);
   if (isNumberArray(value)) return `[redacted: ${value.length} values]`;
   if (Array.isArray(value)) {
     if (value.length > 0 && typeof value[0] === 'number') return `[redacted: ${value.length} values]`;
-    return value.map(sanitizeForLogInternal);
+    if (depth >= MAX_LOG_DEPTH) return `[truncated: array(${value.length})]`;
+    const items = value
+      .slice(0, MAX_LOG_ARRAY_ITEMS)
+      .map((item) => sanitizeForLogInternal(item, depth + 1));
+    if (value.length > MAX_LOG_ARRAY_ITEMS) {
+      items.push(`… [truncated ${value.length - MAX_LOG_ARRAY_ITEMS} more items]`);
+    }
+    return items;
   }
   if (value instanceof Error) {
     const out: Record<string, unknown> = {
-      message: value.message,
+      message: truncateLogString(value.message),
       name: value.name,
     };
     // Capture any extra enumerable own properties (e.g. Drizzle/postgres driver fields: query, parameters, code, constraint)
     for (const [k, v] of Object.entries(value as unknown as Record<string, unknown>)) {
-      if (!(k in out)) out[k] = sanitizeForLogInternal(v);
+      if (!(k in out)) out[k] = sanitizeForLogInternal(v, depth + 1);
     }
     return out;
   }
   if (typeof value === 'object' && value.constructor === Object) {
+    if (depth >= MAX_LOG_DEPTH) return `[truncated: object(${Object.keys(value).length} keys)]`;
     const out: Record<string, unknown> = {};
+    let keyCount = 0;
     for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (keyCount >= MAX_LOG_OBJECT_KEYS) {
+        out['…'] = `[truncated ${Object.keys(value).length - MAX_LOG_OBJECT_KEYS} more keys]`;
+        break;
+      }
+      keyCount++;
       if (EMBEDDING_KEYS.has(k) || isNumberArray(v)) {
-        out[k] = isNumberArray(v) ? `[redacted: ${v.length} values]` : sanitizeForLogInternal(v);
+        out[k] = isNumberArray(v) ? `[redacted: ${v.length} values]` : sanitizeForLogInternal(v, depth + 1);
       } else if (v != null && typeof v === 'object' && !Array.isArray(v) && v.constructor === Object) {
         const nested = v as Record<string, unknown>;
-        if (Object.keys(nested).every((key) => isNumberArray(nested[key]))) {
+        if (Object.keys(nested).length > 0 && Object.keys(nested).every((key) => isNumberArray(nested[key]))) {
           out[k] = Object.fromEntries(
             Object.entries(nested).map(([key, val]) => [
               key,
@@ -387,10 +424,10 @@ function sanitizeForLogInternal(value: unknown): unknown {
             ])
           );
         } else {
-          out[k] = sanitizeForLogInternal(v);
+          out[k] = sanitizeForLogInternal(v, depth + 1);
         }
       } else {
-        out[k] = sanitizeForLogInternal(v);
+        out[k] = sanitizeForLogInternal(v, depth + 1);
       }
     }
     return out;

--- a/services/api/src/lib/parallel/parallel.ts
+++ b/services/api/src/lib/parallel/parallel.ts
@@ -4,7 +4,7 @@ import OpenAI from 'openai';
 import { z } from 'zod';
 
 import { log } from '../log';
-const logger = log.lib.from("lib/parallel/parallel.ts");
+const logger = log.lib.from("parallel");
 
 const PARALLEL_API_URL = 'https://api.parallel.ai/v1beta/search';
 const PARALLELS_API_KEY = process.env.PARALLELS_API_KEY || '';

--- a/services/api/src/main.ts
+++ b/services/api/src/main.ts
@@ -37,7 +37,7 @@ import { SessionRequiredError } from './guards/auth.guard';
 import { RateLimiterError } from './lib/limiter/error';
 import { getRateLimitInfo } from './guards/limiter.guard';
 import { bindLimiterServer } from './lib/limiter/identifier';
-import { log } from './lib/log';
+import { log, sanitizeForLog } from './lib/log';
 import { getCorsHeaders } from './lib/cors';
 import { captureAppException } from './lib/sentry';
 import { setSpanAttributes, setSpanHttpStatus, traceAppOperation } from './lib/sentry-performance';
@@ -80,12 +80,20 @@ import { userContextQueue } from './queues/usercontext.queue';
 import { init as initTelegramGateway } from './gateways/telegram.gateway';
 import { setWebhook } from './lib/telegram/bot-api';
 import { opportunityService } from './services/opportunity.service';
-import { IntentGraphFactory, NegotiationGraphFactory, PremiseGraphFactory, setTimingWrapper } from '@indexnetwork/protocol';
+import { IntentGraphFactory, NegotiationGraphFactory, PremiseGraphFactory, setLoggerFactory, setTimingWrapper } from '@indexnetwork/protocol';
 import type { PremiseGraphDatabase } from '@indexnetwork/protocol';
 import { conversationDatabaseAdapter, chatDatabaseAdapter } from './adapters/database.adapter';
 import { embedderAdapter } from './adapters/embedder.adapter';
 import { agentService } from './services/agent.service';
 import { AgentDispatcherImpl } from './services/agent-dispatcher.service';
+
+// Wire the protocol library's logging into the rich API logger (context colors,
+// emoji, LOG_FILTER/LOG_LEVEL, Sentry, embedding redaction + payload truncation).
+// Protocol loggers are late-bound, so this upgrades loggers created at import time too.
+setLoggerFactory(
+  (context, source) => log.withContext(context as Parameters<typeof log.withContext>[0], source),
+  sanitizeForLog,
+);
 
 // Wire ChatGraphFactory into chat service at startup
 chatSessionService.setFactory(chatFactory);

--- a/services/api/src/queues/email.queue.ts
+++ b/services/api/src/queues/email.queue.ts
@@ -61,7 +61,7 @@ export class EmailQueue {
       priority: options?.priority,
       jobId: options?.jobId,
     });
-    this.queueLogger.debug(`[EmailQueue] Job added with ID: ${job.id}`, {
+    this.queueLogger.debug(`Job added with ID: ${job.id}`, {
       priority: options?.priority,
       jobId: options?.jobId,
     });
@@ -79,7 +79,7 @@ export class EmailQueue {
         await this.handleSendEmail(data);
         break;
       default:
-        this.queueLogger.warn(`[EmailProcessor] Unknown job name: ${name}`);
+        this.queueLogger.warn(`Unknown job name: ${name}`);
     }
   }
 
@@ -89,7 +89,7 @@ export class EmailQueue {
   startWorker(): void {
     if (this.worker) return;
     const processor = async (job: Job<EmailJobData>) => {
-      this.queueLogger.info(`[EmailProcessor] Processing job ${job.id} (${job.name})`);
+      this.queueLogger.info(`Processing job ${job.id} (${job.name})`);
       await this.processJob(job.name, job.data);
     };
     this.worker = QueueFactory.createWorker<EmailJobData>(QUEUE_NAME, processor, {

--- a/services/api/src/queues/email.queue.ts
+++ b/services/api/src/queues/email.queue.ts
@@ -61,9 +61,9 @@ export class EmailQueue {
       priority: options?.priority,
       jobId: options?.jobId,
     });
-    this.queueLogger.debug(`Job added with ID: ${job.id}`, {
+    this.queueLogger.debug('Job added', {
+      jobId: job.id,
       priority: options?.priority,
-      jobId: options?.jobId,
     });
     return job;
   }
@@ -79,7 +79,7 @@ export class EmailQueue {
         await this.handleSendEmail(data);
         break;
       default:
-        this.queueLogger.warn(`Unknown job name: ${name}`);
+        this.queueLogger.warn('Unknown job name', { name });
     }
   }
 
@@ -89,7 +89,7 @@ export class EmailQueue {
   startWorker(): void {
     if (this.worker) return;
     const processor = async (job: Job<EmailJobData>) => {
-      this.queueLogger.info(`Processing job ${job.id} (${job.name})`);
+      this.queueLogger.info('Processing job', { jobId: job.id, jobName: job.name });
       await this.processJob(job.name, job.data);
     };
     this.worker = QueueFactory.createWorker<EmailJobData>(QUEUE_NAME, processor, {

--- a/services/api/src/queues/enrichment-run.queue.ts
+++ b/services/api/src/queues/enrichment-run.queue.ts
@@ -67,14 +67,14 @@ export class EnrichmentRunQueue {
         await this.handleRun(data.runId);
         break;
       default:
-        this.queueLogger.warn(`[EnrichmentRunProcessor] Unknown job name: ${name}`);
+        this.queueLogger.warn(`Unknown job name: ${name}`);
     }
   }
 
   startWorker(): void {
     if (this.worker) return;
     const processor = async (job: Job<EnrichmentRunJobData>) => {
-      this.queueLogger.info(`[EnrichmentRunProcessor] Processing job ${job.id}`);
+      this.queueLogger.info(`Processing job ${job.id}`);
       await this.processJob(job.name, job.data);
     };
     this.worker = QueueFactory.createWorker<EnrichmentRunJobData>(QUEUE_NAME, processor);
@@ -104,7 +104,7 @@ export class EnrichmentRunQueue {
             abortController.abort(new Error('Profile run cancelled'));
           }
         })
-        .catch((err) => this.logger.warn('[EnrichmentRun] cancel poll failed', {
+        .catch((err) => this.logger.warn('Cancel poll failed', {
           runId,
           error: err instanceof Error ? err.message : String(err),
         }));
@@ -118,7 +118,7 @@ export class EnrichmentRunQueue {
         return;
       }
       await enrichmentRunAdapter.markSucceeded(runId, result);
-      this.logger.info('[EnrichmentRun] Completed', { runId, userId: run.userId, operation: run.operation });
+      this.logger.info('Completed', { runId, userId: run.userId, operation: run.operation });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       if (abortController.signal.aborted || await enrichmentRunAdapter.isCancelRequested(runId)) {
@@ -126,7 +126,7 @@ export class EnrichmentRunQueue {
         return;
       }
       await enrichmentRunAdapter.markFailed(runId, message);
-      this.logger.error('[EnrichmentRun] Failed', { runId, userId: run.userId, operation: run.operation, error: message });
+      this.logger.error('Failed', { runId, userId: run.userId, operation: run.operation, error: message });
       captureAppException(err, {
         subsystem: 'protocol',
         operation: 'enrichment-run.queue',

--- a/services/api/src/queues/enrichment-run.queue.ts
+++ b/services/api/src/queues/enrichment-run.queue.ts
@@ -67,14 +67,14 @@ export class EnrichmentRunQueue {
         await this.handleRun(data.runId);
         break;
       default:
-        this.queueLogger.warn(`Unknown job name: ${name}`);
+        this.queueLogger.warn('Unknown job name', { name });
     }
   }
 
   startWorker(): void {
     if (this.worker) return;
     const processor = async (job: Job<EnrichmentRunJobData>) => {
-      this.queueLogger.info(`Processing job ${job.id}`);
+      this.queueLogger.info('Processing job', { jobId: job.id });
       await this.processJob(job.name, job.data);
     };
     this.worker = QueueFactory.createWorker<EnrichmentRunJobData>(QUEUE_NAME, processor);

--- a/services/api/src/queues/enrichment.queue.ts
+++ b/services/api/src/queues/enrichment.queue.ts
@@ -159,7 +159,7 @@ export class EnrichmentQueue {
         await this.handleEnrichUser(data);
         break;
       default:
-        this.queueLogger.warn(`Unknown job name: ${name}`);
+        this.queueLogger.warn('Unknown job name', { name });
     }
   }
 
@@ -170,7 +170,9 @@ export class EnrichmentQueue {
     if (this.worker) return;
     const processor = async (job: Job<EnrichmentJobPayload>) => {
       const { userId, networkId, reason } = job.data as EnsureProfileHydeData;
-      this.queueLogger.info(`Processing job ${job.id} (${job.name})`, {
+      this.queueLogger.info('Processing job', {
+        jobId: job.id,
+        jobName: job.name,
         userId,
         networkId,
         reason,

--- a/services/api/src/queues/enrichment.queue.ts
+++ b/services/api/src/queues/enrichment.queue.ts
@@ -66,6 +66,8 @@ export class EnrichmentQueue {
   readonly queue = QueueFactory.createQueue<EnrichmentJobPayload>(QUEUE_NAME);
 
   private readonly logger = log.job.from('EnrichmentJob');
+  private readonly profileHydeLogger = log.job.from('EnrichmentJob:ProfileHyde');
+  private readonly enrichUserLogger = log.job.from('EnrichmentJob:EnrichUser');
   private readonly queueLogger = log.queue.from('EnrichmentQueue');
   private readonly deps: EnrichmentQueueDeps | undefined;
   private worker: ReturnType<typeof QueueFactory.createWorker<EnrichmentJobPayload>> | null = null;
@@ -157,7 +159,7 @@ export class EnrichmentQueue {
         await this.handleEnrichUser(data);
         break;
       default:
-        this.queueLogger.warn(`[EnrichmentProcessor] Unknown job name: ${name}`);
+        this.queueLogger.warn(`Unknown job name: ${name}`);
     }
   }
 
@@ -168,7 +170,7 @@ export class EnrichmentQueue {
     if (this.worker) return;
     const processor = async (job: Job<EnrichmentJobPayload>) => {
       const { userId, networkId, reason } = job.data as EnsureProfileHydeData;
-      this.queueLogger.info(`[EnrichmentProcessor] Processing job ${job.id} (${job.name})`, {
+      this.queueLogger.info(`Processing job ${job.id} (${job.name})`, {
         userId,
         networkId,
         reason,
@@ -198,7 +200,7 @@ export class EnrichmentQueue {
     const { userId } = data;
     const privacy = await this.resolvePrivacyDecision('ensure_profile_hyde', data);
     if (!privacy.allowed) {
-      this.queueLogger.info('[ProfileHyde] Skipped by profile enrichment policy', {
+      this.profileHydeLogger.info('Skipped by profile enrichment policy', {
         userId,
         networkId: data.networkId,
         reason: data.reason,
@@ -213,9 +215,9 @@ export class EnrichmentQueue {
     }
     try {
       await this.invokeProfileGraph(userId, 'write');
-      this.logger.verbose('[ProfileHyde] Ensured profile HyDE for user', { userId, networkId: data.networkId, reason: data.reason });
+      this.profileHydeLogger.verbose('Ensured profile HyDE for user', { userId, networkId: data.networkId, reason: data.reason });
     } catch (err) {
-      this.logger.error('[ProfileHyde] Failed to ensure profile HyDE', { userId, networkId: data.networkId, reason: data.reason, error: err });
+      this.profileHydeLogger.error('Failed to ensure profile HyDE', { userId, networkId: data.networkId, reason: data.reason, error: err });
       throw err;
     }
   }
@@ -224,7 +226,7 @@ export class EnrichmentQueue {
     const { userId } = data;
     const privacy = await this.resolvePrivacyDecision('enrich.user', data);
     if (!privacy.allowed) {
-      this.queueLogger.info('[EnrichUser] Skipped by profile enrichment policy', {
+      this.enrichUserLogger.info('Skipped by profile enrichment policy', {
         userId,
         networkId: data.networkId,
         reason: data.reason,
@@ -240,10 +242,10 @@ export class EnrichmentQueue {
     }
     try {
       await this.invokeProfileGraph(userId, 'generate');
-      this.queueLogger.info('[EnrichUser] Profile enrichment completed', { userId, networkId: data.networkId, reason: data.reason });
+      this.enrichUserLogger.info('Profile enrichment completed', { userId, networkId: data.networkId, reason: data.reason });
       this.fireEnrichmentComplete(userId);
     } catch (err) {
-      this.queueLogger.error('[EnrichUser] Failed to enrich user', {
+      this.enrichUserLogger.error('Failed to enrich user', {
         userId,
         networkId: data.networkId,
         reason: data.reason,
@@ -308,7 +310,7 @@ export class EnrichmentQueue {
     try {
       this.onEnrichmentComplete?.(userId);
     } catch (err) {
-      this.queueLogger.error('[EnrichUser] onEnrichmentComplete callback failed', {
+      this.enrichUserLogger.error('onEnrichmentComplete callback failed', {
         userId,
         error: err instanceof Error ? err.message : String(err),
       });

--- a/services/api/src/queues/hyde.queue.ts
+++ b/services/api/src/queues/hyde.queue.ts
@@ -57,7 +57,7 @@ export class HydeQueue {
     const db = this.database;
     this.cleanupLogger.verbose('Starting expired HyDE cleanup');
     const deletedCount = await db.deleteExpiredHydeDocuments();
-    this.cleanupLogger.info(`Deleted ${deletedCount} expired HyDE documents`);
+    this.cleanupLogger.info('Deleted expired HyDE documents', { deletedCount });
     return deletedCount;
   }
 
@@ -70,7 +70,7 @@ export class HydeQueue {
     this.refreshLogger.verbose('Starting stale HyDE refresh');
     const staleThreshold = new Date(Date.now() - STALE_HYDE_DAYS_MS);
     const staleDocuments = await db.getStaleHydeDocuments(staleThreshold);
-    this.refreshLogger.verbose(`Found ${staleDocuments.length} stale HyDE documents`);
+    this.refreshLogger.verbose('Found stale HyDE documents', { count: staleDocuments.length });
 
     const embedder = new EmbedderAdapter();
     const cache = new RedisCacheAdapter();
@@ -107,7 +107,7 @@ export class HydeQueue {
       }
     }
 
-    this.refreshLogger.info(`Refreshed ${refreshedCount} HyDE documents`);
+    this.refreshLogger.info('Refreshed HyDE documents', { refreshedCount });
     return refreshedCount;
   }
 

--- a/services/api/src/queues/hyde.queue.ts
+++ b/services/api/src/queues/hyde.queue.ts
@@ -37,6 +37,8 @@ export interface HydeQueueDeps {
  */
 export class HydeQueue {
   private readonly logger = log.job.from('HydeJob');
+  private readonly cleanupLogger = log.job.from('HydeJob:Cleanup');
+  private readonly refreshLogger = log.job.from('HydeJob:Refresh');
   private readonly database: HydeQueueDatabase | ChatDatabaseAdapter;
 
   /**
@@ -53,9 +55,9 @@ export class HydeQueue {
    */
   async cleanupExpiredHyde(): Promise<number> {
     const db = this.database;
-    this.logger.verbose('[HydeJob:Cleanup] Starting expired HyDE cleanup');
+    this.cleanupLogger.verbose('Starting expired HyDE cleanup');
     const deletedCount = await db.deleteExpiredHydeDocuments();
-    this.logger.info(`[HydeJob:Cleanup] Deleted ${deletedCount} expired HyDE documents`);
+    this.cleanupLogger.info(`Deleted ${deletedCount} expired HyDE documents`);
     return deletedCount;
   }
 
@@ -65,10 +67,10 @@ export class HydeQueue {
    */
   async refreshStaleHyde(): Promise<number> {
     const db = this.database;
-    this.logger.verbose('[HydeJob:Refresh] Starting stale HyDE refresh');
+    this.refreshLogger.verbose('Starting stale HyDE refresh');
     const staleThreshold = new Date(Date.now() - STALE_HYDE_DAYS_MS);
     const staleDocuments = await db.getStaleHydeDocuments(staleThreshold);
-    this.logger.verbose(`[HydeJob:Refresh] Found ${staleDocuments.length} stale HyDE documents`);
+    this.refreshLogger.verbose(`Found ${staleDocuments.length} stale HyDE documents`);
 
     const embedder = new EmbedderAdapter();
     const cache = new RedisCacheAdapter();
@@ -97,7 +99,7 @@ export class HydeQueue {
         });
         refreshedCount++;
       } catch (error) {
-        this.logger.error('[HydeJob:Refresh] Failed to refresh HyDE', {
+        this.refreshLogger.error('Failed to refresh HyDE', {
           sourceId: doc.sourceId,
           strategy: doc.strategy,
           error: error instanceof Error ? error.message : String(error),
@@ -105,7 +107,7 @@ export class HydeQueue {
       }
     }
 
-    this.logger.info(`[HydeJob:Refresh] Refreshed ${refreshedCount} HyDE documents`);
+    this.refreshLogger.info(`Refreshed ${refreshedCount} HyDE documents`);
     return refreshedCount;
   }
 
@@ -115,17 +117,17 @@ export class HydeQueue {
   startCrons(): void {
     cron.schedule('0 3 * * *', () => {
       this.cleanupExpiredHyde().catch((err) =>
-        this.logger.error('[HydeJob:Cleanup] Cron failed', { error: err })
+        this.cleanupLogger.error('Cron failed', { error: err })
       );
     });
-    this.logger.info('📅 [HydeJob] Cleanup scheduled (daily at 03:00)');
+    this.logger.info('📅 Cleanup scheduled (daily at 03:00)');
 
     cron.schedule('0 4 * * 0', () => {
       this.refreshStaleHyde().catch((err) =>
-        this.logger.error('[HydeJob:Refresh] Cron failed', { error: err })
+        this.refreshLogger.error('Cron failed', { error: err })
       );
     });
-    this.logger.info('📅 [HydeJob] Refresh scheduled (weekly Sunday at 04:00)');
+    this.logger.info('📅 Refresh scheduled (weekly Sunday at 04:00)');
   }
 }
 

--- a/services/api/src/queues/integration.queue.ts
+++ b/services/api/src/queues/integration.queue.ts
@@ -80,7 +80,7 @@ export class IntegrationSyncQueue {
     });
 
     const processor = async (job: Job<IntegrationSyncPayload>) => {
-      this.queueLogger.info(`Processing job ${job.id} (${job.name})`);
+      this.queueLogger.info('Processing job', { jobId: job.id, jobName: job.name });
       await this.processJob(job.name, job.data);
     };
 
@@ -97,7 +97,7 @@ export class IntegrationSyncQueue {
         await this.handleTick();
         break;
       default:
-        this.queueLogger.warn(`Unknown job name: ${name}`);
+        this.queueLogger.warn('Unknown job name', { name });
     }
   }
 

--- a/services/api/src/queues/integration.queue.ts
+++ b/services/api/src/queues/integration.queue.ts
@@ -80,7 +80,7 @@ export class IntegrationSyncQueue {
     });
 
     const processor = async (job: Job<IntegrationSyncPayload>) => {
-      this.queueLogger.info(`[IntegrationSyncProcessor] Processing job ${job.id} (${job.name})`);
+      this.queueLogger.info(`Processing job ${job.id} (${job.name})`);
       await this.processJob(job.name, job.data);
     };
 
@@ -97,7 +97,7 @@ export class IntegrationSyncQueue {
         await this.handleTick();
         break;
       default:
-        this.queueLogger.warn(`[IntegrationSyncProcessor] Unknown job name: ${name}`);
+        this.queueLogger.warn(`Unknown job name: ${name}`);
     }
   }
 

--- a/services/api/src/queues/intent.queue.ts
+++ b/services/api/src/queues/intent.queue.ts
@@ -181,7 +181,7 @@ export class IntentQueue implements IntentGraphQueue {
         await this.handleDeleteHyde(data as IntentDeleteData);
         break;
       default:
-        this.queueLogger.warn(`Unknown job name: ${name}`);
+        this.queueLogger.warn('Unknown job name', { name });
     }
   }
 
@@ -252,7 +252,7 @@ export class IntentQueue implements IntentGraphQueue {
   startWorker(): void {
     if (this.worker) return;
     const processor = async (job: Job<IntentJobPayload>) => {
-      this.queueLogger.info(`Processing job ${job.id} (${job.name})`);
+      this.queueLogger.info('Processing job', { jobId: job.id, jobName: job.name });
       await this.processJob(job.name, job.data);
     };
     this.worker = QueueFactory.createWorker<IntentJobPayload>(QUEUE_NAME, processor);

--- a/services/api/src/queues/intent.queue.ts
+++ b/services/api/src/queues/intent.queue.ts
@@ -114,6 +114,9 @@ export class IntentQueue implements IntentGraphQueue {
   }
 
   private readonly logger = log.job.from('IntentJob');
+  private readonly hydeLogger = log.job.from('IntentJob:Hyde');
+  private readonly assignLogger = log.job.from('IntentJob:Assign');
+  private readonly reconcileLogger = log.job.from('IntentJob:Reconcile');
   private readonly queueLogger = log.queue.from('IntentQueue');
   private readonly database: IntentQueueDatabase | ChatDatabaseAdapter;
   private readonly graphDb: HydeGraphDatabase;
@@ -178,7 +181,7 @@ export class IntentQueue implements IntentGraphQueue {
         await this.handleDeleteHyde(data as IntentDeleteData);
         break;
       default:
-        this.queueLogger.warn(`[IntentProcessor] Unknown job name: ${name}`);
+        this.queueLogger.warn(`Unknown job name: ${name}`);
     }
   }
 
@@ -219,11 +222,11 @@ export class IntentQueue implements IntentGraphQueue {
     await Promise.all(
       intents.map((i) =>
         this.addReconcileJob({ intentId: i.id, userId, scopeType: 'network', scopeId: networkId }).catch((err) =>
-          this.logger.warn('[IntentReconcile] enqueue failed', { intentId: i.id, networkId, userId, error: err }),
+          this.reconcileLogger.warn('Enqueue failed', { intentId: i.id, networkId, userId, error: err }),
         ),
       ),
     );
-    this.logger.info('[IntentReconcile] Enqueued network reconcile for member', { userId, networkId, intentCount: intents.length });
+    this.reconcileLogger.info('Enqueued network reconcile for member', { userId, networkId, intentCount: intents.length });
     return intents.length;
   }
 
@@ -249,7 +252,7 @@ export class IntentQueue implements IntentGraphQueue {
   startWorker(): void {
     if (this.worker) return;
     const processor = async (job: Job<IntentJobPayload>) => {
-      this.queueLogger.info(`[IntentProcessor] Processing job ${job.id} (${job.name})`);
+      this.queueLogger.info(`Processing job ${job.id} (${job.name})`);
       await this.processJob(job.name, job.data);
     };
     this.worker = QueueFactory.createWorker<IntentJobPayload>(QUEUE_NAME, processor);
@@ -272,13 +275,13 @@ export class IntentQueue implements IntentGraphQueue {
     const db = this.deps?.database ?? this.database;
     const intent = await db.getIntentForIndexing(intentId);
     if (!intent) {
-      this.logger.warn('[IntentHyde] Intent not found, skipping', { intentId });
+      this.hydeLogger.warn('Intent not found, skipping', { intentId });
       return;
     }
-    this.logger.info('[IntentHyde] Starting HyDE generation', { intentId, userId });
-    this.logger.debug('[IntentHyde] Intent payload preview', { intentId, payload: intent.payload?.slice(0, 80) });
+    this.hydeLogger.info('Starting HyDE generation', { intentId, userId });
+    this.hydeLogger.debug('Intent payload preview', { intentId, payload: intent.payload?.slice(0, 80) });
     const { assignedNetworkIds } = await this.assignIntentToNetworks(intentId, userId, scope);
-    this.logger.info('[IntentHyde] Index assignment complete', { intentId, assignedIndexCount: assignedNetworkIds.length });
+    this.hydeLogger.info('Index assignment complete', { intentId, assignedIndexCount: assignedNetworkIds.length });
 
     // Fetch discoverer global context + active intents for HyDE context (best-effort).
     // The global user_context paragraph replaces the old identity/narrative/attributes
@@ -306,7 +309,7 @@ export class IntentQueue implements IntentGraphQueue {
         profileContext = lines.join('\n');
       }
     } catch (ctxErr) {
-      this.logger.warn('[IntentHyde] Failed to fetch discoverer context for HyDE, proceeding without', { intentId, userId, error: ctxErr });
+      this.hydeLogger.warn('Failed to fetch discoverer context for HyDE, proceeding without', { intentId, userId, error: ctxErr });
     }
 
     if (this.deps?.invokeHyde) {
@@ -331,7 +334,7 @@ export class IntentQueue implements IntentGraphQueue {
         profileContext,
       });
     }
-    this.logger.info('[IntentHyde] HyDE generation complete, enqueuing opportunity discovery', { intentId, userId });
+    this.hydeLogger.info('HyDE generation complete, enqueuing opportunity discovery', { intentId, userId });
     const addJob =
       overrides?.addOpportunityJob ??
       this.deps?.addOpportunityJob ??
@@ -343,7 +346,7 @@ export class IntentQueue implements IntentGraphQueue {
         const assignmentMemberships = await this.getAssignmentMemberships(userId);
         return deriveIntentDiscoveryNetworkIds(assignmentMemberships, scope);
       } catch (err) {
-        this.logger.warn('[IntentHyde] Failed to resolve assignment memberships for discovery scope, falling back to focused scope', { intentId, userId, error: err });
+        this.hydeLogger.warn('Failed to resolve assignment memberships for discovery scope, falling back to focused scope', { intentId, userId, error: err });
         return scope.scopeType && scope.scopeId ? { networkIds: [scope.scopeId] } : {};
       }
     })();
@@ -352,7 +355,7 @@ export class IntentQueue implements IntentGraphQueue {
       userId,
       ...discoveryScope,
     }).catch((err: unknown) =>
-      this.logger.error('[IntentHyde] Failed to enqueue opportunity discovery', { intentId, error: err })
+      this.hydeLogger.error('Failed to enqueue opportunity discovery', { intentId, error: err })
     );
   }
 
@@ -382,7 +385,7 @@ export class IntentQueue implements IntentGraphQueue {
     const db = this.deps?.database ?? this.database;
     const intent = await db.getIntentForIndexing(intentId);
     if (!intent) {
-      this.logger.warn('[IntentAssign] Intent not found, skipping', { intentId });
+      this.assignLogger.warn('Intent not found, skipping', { intentId });
       return { assignedNetworkIds: [], evaluatedCount: 0 };
     }
 
@@ -392,7 +395,7 @@ export class IntentQueue implements IntentGraphQueue {
       const assignmentMemberships = await this.getAssignmentMemberships(userId);
       const userIndexIds = resolveAssignmentNetworkScope({ memberships: assignmentMemberships, ...scope });
       evaluatedCount = userIndexIds.length;
-      this.logger.info('[IntentAssign] User assignment networks found', { intentId, userId, indexCount: userIndexIds.length, indexIds: userIndexIds });
+      this.assignLogger.info('User assignment networks found', { intentId, userId, indexCount: userIndexIds.length, indexIds: userIndexIds });
 
       // Instantiate once per run so the same withStructuredOutput binding is
       // reused across all network evaluations in the Promise.all below (the
@@ -415,7 +418,7 @@ export class IntentQueue implements IntentGraphQueue {
         userIndexIds.map(async (networkId) => {
           const ctx = await db.getNetworkAssignmentContext(networkId, userId);
           if (!ctx) {
-            this.logger.warn('[IntentAssign] Assignment context missing for network, skipping fail-closed', { intentId, userId, networkId });
+            this.assignLogger.warn('Assignment context missing for network, skipping fail-closed', { intentId, userId, networkId });
             return null;
           }
           const indexPrompt = ctx.indexPrompt ?? null;
@@ -426,7 +429,7 @@ export class IntentQueue implements IntentGraphQueue {
             try {
               result = await evaluateIntentAssignment({ intent: intent.payload, indexPrompt, memberPrompt, sourceName });
             } catch (err) {
-              this.logger.warn('[IntentAssign] IntentIndexer failed for network', { intentId, networkId, error: err });
+              this.assignLogger.warn('IntentIndexer failed for network', { intentId, networkId, error: err });
             }
           }
 
@@ -454,18 +457,18 @@ export class IntentQueue implements IntentGraphQueue {
           await db.assignIntentToNetwork(intentId, networkId, decision.finalScore, decision.metadata);
           assignedNetworkIds.push(networkId);
         } catch (assignErr) {
-          this.logger.debug('[IntentAssign] Assign intent to network skipped', { intentId, networkId, error: assignErr });
+          this.assignLogger.debug('Assign intent to network skipped', { intentId, networkId, error: assignErr });
         }
       }
     } catch (err) {
-      this.logger.warn('[IntentAssign] Failed to assign intent to user networks', { intentId, userId, error: err });
+      this.assignLogger.warn('Failed to assign intent to user networks', { intentId, userId, error: err });
     }
 
     if (assignedNetworkIds.length === 0) {
       // Explicit orphan signal: an intent registered to no network is invisible
       // in every network UI. Surface it so it can be alerted on or swept rather
       // than silently lost.
-      this.logger.warn('[IntentAssign] Intent assigned to NO networks', { intentId, userId, scopeType: scope.scopeType, scopeId: scope.scopeId, evaluatedCount });
+      this.assignLogger.warn('Intent assigned to NO networks', { intentId, userId, scopeType: scope.scopeType, scopeId: scope.scopeId, evaluatedCount });
     }
     return { assignedNetworkIds, evaluatedCount };
   }
@@ -485,7 +488,7 @@ export class IntentQueue implements IntentGraphQueue {
     const { intentId } = data;
     const db = this.deps?.database ?? this.database;
     await db.deleteHydeDocumentsForSource('intent', intentId);
-    this.logger.verbose('[IntentHyde] Deleted HyDE documents for intent', { intentId });
+    this.hydeLogger.verbose('Deleted HyDE documents for intent', { intentId });
   }
 }
 

--- a/services/api/src/queues/negotiations/claim-timeout.queue.ts
+++ b/services/api/src/queues/negotiations/claim-timeout.queue.ts
@@ -141,7 +141,7 @@ export class NegotiationClaimTimeoutQueue {
         await this.handleClaimTimeout(data);
         break;
       default:
-        this.queueLogger.warn(`Unknown job name: ${name}`);
+        this.queueLogger.warn('Unknown job name', { name });
     }
   }
 
@@ -152,7 +152,7 @@ export class NegotiationClaimTimeoutQueue {
     if (this.worker) return;
 
     const processor = async (job: Job<NegotiationClaimTimeoutJobData>) => {
-      this.queueLogger.info(`Processing job ${job.id} (${job.name})`);
+      this.queueLogger.info('Processing job', { jobId: job.id, jobName: job.name });
       await this.processJob(job.name, job.data);
     };
 
@@ -223,7 +223,6 @@ export class NegotiationClaimTimeoutQueue {
       database,
       logger: this.logger,
       labels: {
-        job: '[NegotiationClaimTimeoutJob]',
         fallback: 'Claimed agent timed out, running AI fallback',
         finalized: 'Negotiation finalized after claim timeout',
         statusUpdateFailed: 'Failed to update opportunity status on claim-timeout finalization',

--- a/services/api/src/queues/negotiations/claim-timeout.queue.ts
+++ b/services/api/src/queues/negotiations/claim-timeout.queue.ts
@@ -95,7 +95,7 @@ export class NegotiationClaimTimeoutQueue {
       removeOnFail: { age: 7 * 24 * 3600 },
     });
 
-    this.logger.info('[NegotiationClaimTimeoutJob] Claim timeout enqueued', {
+    this.logger.info('Claim timeout enqueued', {
       negotiationId,
       turnNumber,
       agentId,
@@ -118,11 +118,11 @@ export class NegotiationClaimTimeoutQueue {
         const state = await job.getState();
         if (state === 'delayed' || state === 'waiting') {
           await job.remove();
-          this.logger.info('[NegotiationClaimTimeoutJob] Claim timeout cancelled', { negotiationId, jobId });
+          this.logger.info('Claim timeout cancelled', { negotiationId, jobId });
         }
       }
     } catch (err) {
-      this.logger.warn('[NegotiationClaimTimeoutJob] Failed to cancel claim timeout', {
+      this.logger.warn('Failed to cancel claim timeout', {
         negotiationId,
         error: err instanceof Error ? err.message : String(err),
       });
@@ -141,7 +141,7 @@ export class NegotiationClaimTimeoutQueue {
         await this.handleClaimTimeout(data);
         break;
       default:
-        this.queueLogger.warn(`[NegotiationClaimTimeoutProcessor] Unknown job name: ${name}`);
+        this.queueLogger.warn(`Unknown job name: ${name}`);
     }
   }
 
@@ -152,7 +152,7 @@ export class NegotiationClaimTimeoutQueue {
     if (this.worker) return;
 
     const processor = async (job: Job<NegotiationClaimTimeoutJobData>) => {
-      this.queueLogger.info(`[NegotiationClaimTimeoutProcessor] Processing job ${job.id} (${job.name})`);
+      this.queueLogger.info(`Processing job ${job.id} (${job.name})`);
       await this.processJob(job.name, job.data);
     };
 
@@ -194,7 +194,7 @@ export class NegotiationClaimTimeoutQueue {
       .returning();
 
     if (!task) {
-      this.logger.info('[NegotiationClaimTimeoutJob] Task no longer claimed, skipping (stale job)', {
+      this.logger.info('Task no longer claimed, skipping (stale job)', {
         negotiationId,
       });
       return;
@@ -205,7 +205,7 @@ export class NegotiationClaimTimeoutQueue {
 
     // Check if turnNumber still matches (response may have come in between)
     if (currentTurnCount !== turnNumber) {
-      this.logger.info('[NegotiationClaimTimeoutJob] Turn count mismatch, skipping (stale job)', {
+      this.logger.info('Turn count mismatch, skipping (stale job)', {
         negotiationId,
         expectedTurn: turnNumber,
         actualTurn: currentTurnCount,
@@ -215,7 +215,7 @@ export class NegotiationClaimTimeoutQueue {
 
     const meta = task.metadata as NegotiationTaskMeta | null;
     if (meta?.type !== 'negotiation') {
-      this.logger.warn('[NegotiationClaimTimeoutJob] Task is not a negotiation, skipping', { negotiationId });
+      this.logger.warn('Task is not a negotiation, skipping', { negotiationId });
       return;
     }
 

--- a/services/api/src/queues/negotiations/run-existing.queue.ts
+++ b/services/api/src/queues/negotiations/run-existing.queue.ts
@@ -64,7 +64,7 @@ export class NegotiationRunExistingQueue {
         await this.handleNegotiate(data);
         break;
       default:
-        this.queueLogger.warn(`[RunExistingQueueProcessor] Unknown job name: ${name}`);
+        this.queueLogger.warn(`Unknown job name: ${name}`);
     }
   }
 
@@ -72,11 +72,11 @@ export class NegotiationRunExistingQueue {
     const { opportunityId, userId } = data;
 
     if (!opportunityId) {
-      this.logger.warn('[RunExisting] Missing opportunityId, skipping', { userId });
+      this.logger.warn('Missing opportunityId, skipping', { userId });
       return;
     }
 
-    this.logger.info('[RunExisting] Starting negotiation', { opportunityId, userId });
+    this.logger.info('Starting negotiation', { opportunityId, userId });
 
     if (this.deps?.invokeOpportunityGraph) {
       await this.deps.invokeOpportunityGraph({
@@ -85,7 +85,7 @@ export class NegotiationRunExistingQueue {
         opportunityId,
         options: {},
       });
-      this.logger.info('[RunExisting] Negotiation complete', { opportunityId, userId });
+      this.logger.info('Negotiation complete', { opportunityId, userId });
       return;
     }
 
@@ -112,9 +112,9 @@ export class NegotiationRunExistingQueue {
         opportunityId,
         options: {},
       });
-      this.logger.info('[RunExisting] Negotiation complete', { opportunityId, userId });
+      this.logger.info('Negotiation complete', { opportunityId, userId });
     } catch (err) {
-      this.logger.error('[RunExisting] Graph failed', { opportunityId, userId, error: err });
+      this.logger.error('Graph failed', { opportunityId, userId, error: err });
       throw err;
     }
   }
@@ -122,7 +122,7 @@ export class NegotiationRunExistingQueue {
   startWorker(): void {
     if (this.worker) return;
     const processor = async (job: Job<RunExistingJobData>) => {
-      this.queueLogger.info(`[RunExistingProcessor] Processing job ${job.id}`);
+      this.queueLogger.info(`Processing job ${job.id}`);
       await this.processJob(job.name, job.data);
     };
     this.worker = QueueFactory.createWorker<RunExistingJobData>(QUEUE_NAME, processor);

--- a/services/api/src/queues/negotiations/run-existing.queue.ts
+++ b/services/api/src/queues/negotiations/run-existing.queue.ts
@@ -64,7 +64,7 @@ export class NegotiationRunExistingQueue {
         await this.handleNegotiate(data);
         break;
       default:
-        this.queueLogger.warn(`Unknown job name: ${name}`);
+        this.queueLogger.warn('Unknown job name', { name });
     }
   }
 
@@ -122,7 +122,7 @@ export class NegotiationRunExistingQueue {
   startWorker(): void {
     if (this.worker) return;
     const processor = async (job: Job<RunExistingJobData>) => {
-      this.queueLogger.info(`Processing job ${job.id}`);
+      this.queueLogger.info('Processing job', { jobId: job.id });
       await this.processJob(job.name, job.data);
     };
     this.worker = QueueFactory.createWorker<RunExistingJobData>(QUEUE_NAME, processor);

--- a/services/api/src/queues/negotiations/timeout.queue.ts
+++ b/services/api/src/queues/negotiations/timeout.queue.ts
@@ -114,7 +114,7 @@ export class NegotiationTimeoutQueue {
         await this.handleTimeout(data);
         break;
       default:
-        this.queueLogger.warn(`Unknown job name: ${name}`);
+        this.queueLogger.warn('Unknown job name', { name });
     }
   }
 
@@ -125,7 +125,7 @@ export class NegotiationTimeoutQueue {
     if (this.worker) return;
 
     const processor = async (job: Job<NegotiationTimeoutJobData>) => {
-      this.queueLogger.info(`Processing job ${job.id} (${job.name})`);
+      this.queueLogger.info('Processing job', { jobId: job.id, jobName: job.name });
       await this.processJob(job.name, job.data);
     };
 
@@ -189,7 +189,6 @@ export class NegotiationTimeoutQueue {
       database,
       logger: this.logger,
       labels: {
-        job: '[NegotiationTimeoutJob]',
         fallback: 'External agent timed out, running AI fallback',
         finalized: 'Negotiation finalized after timeout',
         statusUpdateFailed: 'Failed to update opportunity status on timeout finalization',

--- a/services/api/src/queues/negotiations/timeout.queue.ts
+++ b/services/api/src/queues/negotiations/timeout.queue.ts
@@ -77,7 +77,7 @@ export class NegotiationTimeoutQueue {
       removeOnFail: { age: 7 * 24 * 3600 },
     });
 
-    this.logger.info('[NegotiationTimeoutJob] Timeout enqueued', { negotiationId, turnNumber, delayMs, jobId: job.id });
+    this.logger.info('Timeout enqueued', { negotiationId, turnNumber, delayMs, jobId: job.id });
     return job.id ?? jobId;
   }
 
@@ -94,11 +94,11 @@ export class NegotiationTimeoutQueue {
         const state = await job.getState();
         if (state === 'delayed' || state === 'waiting') {
           await job.remove();
-          this.logger.info('[NegotiationTimeoutJob] Timeout cancelled', { negotiationId, jobId });
+          this.logger.info('Timeout cancelled', { negotiationId, jobId });
         }
       }
     } catch (err) {
-      this.logger.warn('[NegotiationTimeoutJob] Failed to cancel timeout', {
+      this.logger.warn('Failed to cancel timeout', {
         negotiationId,
         error: err instanceof Error ? err.message : String(err),
       });
@@ -114,7 +114,7 @@ export class NegotiationTimeoutQueue {
         await this.handleTimeout(data);
         break;
       default:
-        this.queueLogger.warn(`[NegotiationTimeoutProcessor] Unknown job name: ${name}`);
+        this.queueLogger.warn(`Unknown job name: ${name}`);
     }
   }
 
@@ -125,7 +125,7 @@ export class NegotiationTimeoutQueue {
     if (this.worker) return;
 
     const processor = async (job: Job<NegotiationTimeoutJobData>) => {
-      this.queueLogger.info(`[NegotiationTimeoutProcessor] Processing job ${job.id} (${job.name})`);
+      this.queueLogger.info(`Processing job ${job.id} (${job.name})`);
       await this.processJob(job.name, job.data);
     };
 
@@ -153,13 +153,13 @@ export class NegotiationTimeoutQueue {
     // Load the negotiation task
     const task = await database.getTask(negotiationId);
     if (!task) {
-      this.logger.warn('[NegotiationTimeoutJob] Task not found, skipping', { negotiationId });
+      this.logger.warn('Task not found, skipping', { negotiationId });
       return;
     }
 
     // Only process if still waiting_for_agent and turn matches
     if (task.state !== 'waiting_for_agent') {
-      this.logger.info('[NegotiationTimeoutJob] Task no longer waiting, skipping (stale job)', {
+      this.logger.info('Task no longer waiting, skipping (stale job)', {
         negotiationId,
         currentState: task.state,
       });
@@ -171,7 +171,7 @@ export class NegotiationTimeoutQueue {
 
     // Check if turnNumber still matches (response may have come in between)
     if (currentTurnCount !== turnNumber) {
-      this.logger.info('[NegotiationTimeoutJob] Turn count mismatch, skipping (stale job)', {
+      this.logger.info('Turn count mismatch, skipping (stale job)', {
         negotiationId,
         expectedTurn: turnNumber,
         actualTurn: currentTurnCount,
@@ -181,7 +181,7 @@ export class NegotiationTimeoutQueue {
 
     const meta = task.metadata as NegotiationTaskMeta | null;
     if (meta?.type !== 'negotiation') {
-      this.logger.warn('[NegotiationTimeoutJob] Task is not a negotiation, skipping', { negotiationId });
+      this.logger.warn('Task is not a negotiation, skipping', { negotiationId });
       return;
     }
 

--- a/services/api/src/queues/negotiations/timeout.shared.ts
+++ b/services/api/src/queues/negotiations/timeout.shared.ts
@@ -16,8 +16,6 @@ export interface NegotiationTaskMeta {
 
 /** Per-worker log strings — the only textual difference between the two timeout workers. */
 export interface TimeoutFallbackLabels {
-  /** Bracketed job tag, e.g. `[NegotiationTimeoutJob]`. */
-  job: string;
   /** "...running AI fallback" line. */
   fallback: string;
   /** "Negotiation finalized after <x>" line. */
@@ -104,7 +102,7 @@ export async function runTimeoutFallback(params: {
   const activeUserId = isSource ? meta.sourceUserId! : meta.candidateUserId!;
   const otherUserId = isSource ? meta.candidateUserId! : meta.sourceUserId!;
 
-  logger.info(`${labels.job} ${labels.fallback}`, {
+  logger.info(labels.fallback, {
     negotiationId,
     ...fallbackLogExtra,
     activeUserId,
@@ -167,7 +165,7 @@ export async function runTimeoutFallback(params: {
         : aiTurn.action === 'reject' ? 'rejected'
         : 'stalled';
       await database.updateOpportunityStatus(opportunityId, nextStatus).catch((err: unknown) => {
-        logger.error(`${labels.job} ${labels.statusUpdateFailed}`, {
+        logger.error(labels.statusUpdateFailed, {
           opportunityId,
           nextStatus,
           error: err,
@@ -175,7 +173,7 @@ export async function runTimeoutFallback(params: {
       });
     }
 
-    logger.info(`${labels.job} ${labels.finalized}`, {
+    logger.info(labels.finalized, {
       negotiationId,
       outcome: outcomeStr,
       turnCount: newTurnCount,
@@ -187,7 +185,7 @@ export async function runTimeoutFallback(params: {
   await database.updateTaskState(taskId, 'waiting_for_agent');
   await rearm(newTurnCount);
 
-  logger.info(`${labels.job} AI agent countered, armed timeout for next speaker`, {
+  logger.info('AI agent countered, armed timeout for next speaker', {
     negotiationId,
     action: aiTurn.action,
     turnCount: newTurnCount,

--- a/services/api/src/queues/notification.queue.ts
+++ b/services/api/src/queues/notification.queue.ts
@@ -116,7 +116,7 @@ export class NotificationQueue {
         await this.processOpportunityNotification(data as NotificationJobData);
         break;
       default:
-        this.queueLogger.warn(`Unknown job name: ${name}`);
+        this.queueLogger.warn('Unknown job name', { name });
     }
   }
 
@@ -126,7 +126,7 @@ export class NotificationQueue {
   startWorker(): void {
     if (this.worker) return;
     const processor = async (job: Job<NotificationJobData>) => {
-      this.queueLogger.info(`Processing job ${job.id} (${job.name})`);
+      this.queueLogger.info('Processing job', { jobId: job.id, jobName: job.name });
       await this.processJob(job.name, job.data);
     };
     this.worker = QueueFactory.createWorker<NotificationJobData>(QUEUE_NAME, processor);

--- a/services/api/src/queues/notification.queue.ts
+++ b/services/api/src/queues/notification.queue.ts
@@ -116,7 +116,7 @@ export class NotificationQueue {
         await this.processOpportunityNotification(data as NotificationJobData);
         break;
       default:
-        this.queueLogger.warn(`[NotificationProcessor] Unknown job name: ${name}`);
+        this.queueLogger.warn(`Unknown job name: ${name}`);
     }
   }
 
@@ -126,7 +126,7 @@ export class NotificationQueue {
   startWorker(): void {
     if (this.worker) return;
     const processor = async (job: Job<NotificationJobData>) => {
-      this.queueLogger.info(`[NotificationProcessor] Processing job ${job.id} (${job.name})`);
+      this.queueLogger.info(`Processing job ${job.id} (${job.name})`);
       await this.processJob(job.name, job.data);
     };
     this.worker = QueueFactory.createWorker<NotificationJobData>(QUEUE_NAME, processor);
@@ -144,7 +144,7 @@ export class NotificationQueue {
     const { opportunityId, recipientId, priority } = data;
     const db = this.database;
 
-    this.logger.verbose('[NotificationJob] Processing opportunity notification', {
+    this.logger.verbose('Processing opportunity notification', {
       opportunityId,
       recipientId,
       priority,
@@ -152,7 +152,7 @@ export class NotificationQueue {
 
     const opportunity = await db.getOpportunity(opportunityId);
     if (!opportunity) {
-      this.logger.warn('[NotificationJob] Opportunity not found, skipping', { opportunityId });
+      this.logger.warn('Opportunity not found, skipping', { opportunityId });
       return;
     }
 
@@ -165,7 +165,7 @@ export class NotificationQueue {
     switch (priority) {
       case 'immediate': {
         emitOpportunityNotification({ opportunityId, recipientId });
-        this.logger.info('[NotificationJob] Emitted opportunity notification (WebSocket)', {
+        this.logger.info('Emitted opportunity notification (WebSocket)', {
           opportunityId,
           recipientId,
         });
@@ -180,7 +180,7 @@ export class NotificationQueue {
         break;
       }
       default: {
-        this.logger.warn('[NotificationJob] Unknown priority, treating as low', { priority });
+        this.logger.warn('Unknown priority, treating as low', { priority });
         await this.addToDigest(recipientId, opportunityId);
       }
     }
@@ -194,7 +194,7 @@ export class NotificationQueue {
         message: `New connection: ${summary}`,
         inlineButtons: [{ text: 'View opportunity', url: `${appUrl}/opportunities/${opportunityId}` }],
       });
-      this.logger.info('[NotificationJob] Emitted Telegram opportunity notification', {
+      this.logger.info('Emitted Telegram opportunity notification', {
         opportunityId,
         recipientId,
       });
@@ -208,19 +208,19 @@ export class NotificationQueue {
   ): Promise<void> {
     const recipient = await userService.getUserForNewsletter(recipientId);
     if (!recipient?.email) {
-      this.logger.warn('[NotificationJob] Recipient not found or no email, skipping email', {
+      this.logger.warn('Recipient not found or no email, skipping email', {
         recipientId,
       });
       return;
     }
     if (!recipient.onboarding?.completedAt) {
-      this.logger.verbose('[NotificationJob] Recipient has not completed onboarding, skipping email', {
+      this.logger.verbose('Recipient has not completed onboarding, skipping email', {
         recipientId,
       });
       return;
     }
     if (recipient.prefs?.connectionUpdates === false) {
-      this.logger.verbose('[NotificationJob] Recipient has connection/opportunity updates disabled', {
+      this.logger.verbose('Recipient has connection/opportunity updates disabled', {
         recipientId,
       });
       return;
@@ -236,7 +236,7 @@ export class NotificationQueue {
     const emailDedupeKey = `${EMAIL_OPPORTUNITY_DEDUPE_PREFIX}${recipientId}:${opportunityId}`;
     const setResult = await redis.set(emailDedupeKey, '1', 'EX', DIGEST_TTL_SEC, 'NX');
     if (setResult !== 'OK') {
-      this.logger.verbose('[NotificationJob] Skipped duplicate opportunity email (dedupe key already set)', {
+      this.logger.verbose('Skipped duplicate opportunity email (dedupe key already set)', {
         recipientId,
         opportunityId,
       });
@@ -265,7 +265,7 @@ export class NotificationQueue {
       },
       { jobId: `opportunity-email-${recipientId}-${opportunityId}` }
     );
-    this.logger.info('[NotificationJob] Enqueued high-priority opportunity email', {
+    this.logger.info('Enqueued high-priority opportunity email', {
       recipientId,
       opportunityId,
     });
@@ -277,7 +277,7 @@ export class NotificationQueue {
       const dedupeKey = `${DIGEST_DEDUPE_PREFIX}${recipientId}:${opportunityId}`;
       const setResult = await redis.set(dedupeKey, '1', 'EX', DIGEST_TTL_SEC, 'NX');
       if (setResult !== 'OK') {
-        this.logger.verbose('[NotificationJob] Skipped duplicate digest entry (dedupe key already set)', {
+        this.logger.verbose('Skipped duplicate digest entry (dedupe key already set)', {
           recipientId,
           opportunityId,
         });
@@ -286,12 +286,12 @@ export class NotificationQueue {
       const listKey = `${DIGEST_LIST_PREFIX}${recipientId}`;
       await redis.rpush(listKey, opportunityId);
       await redis.expire(listKey, DIGEST_TTL_SEC);
-      this.logger.verbose('[NotificationJob] Added opportunity to weekly digest list', {
+      this.logger.verbose('Added opportunity to weekly digest list', {
         recipientId,
         opportunityId,
       });
     } catch (err) {
-      this.logger.error('[NotificationJob] Failed to add to digest list', {
+      this.logger.error('Failed to add to digest list', {
         recipientId,
         opportunityId,
         error: err instanceof Error ? err.message : String(err),

--- a/services/api/src/queues/opportunity/discovery-run.queue.ts
+++ b/services/api/src/queues/opportunity/discovery-run.queue.ts
@@ -93,14 +93,14 @@ export class DiscoveryRunQueue {
         await this.handleRun(data.runId);
         break;
       default:
-        this.queueLogger.warn(`[DiscoveryRunProcessor] Unknown job name: ${name}`);
+        this.queueLogger.warn(`Unknown job name: ${name}`);
     }
   }
 
   startWorker(): void {
     if (this.worker) return;
     const processor = async (job: Job<DiscoveryRunJobData>) => {
-      this.queueLogger.info(`[DiscoveryRunProcessor] Processing job ${job.id}`);
+      this.queueLogger.info(`Processing job ${job.id}`);
       await this.processJob(job.name, job.data);
     };
     this.worker = QueueFactory.createWorker<DiscoveryRunJobData>(QUEUE_NAME, processor);
@@ -130,7 +130,7 @@ export class DiscoveryRunQueue {
             abortController.abort(new Error('Discovery run cancelled'));
           }
         })
-        .catch((err) => this.logger.warn('[DiscoveryRun] cancel poll failed', {
+        .catch((err) => this.logger.warn('Cancel poll failed', {
           runId,
           error: err instanceof Error ? err.message : String(err),
         }));
@@ -144,7 +144,7 @@ export class DiscoveryRunQueue {
         return;
       }
       await discoveryRunAdapter.markSucceeded(runId, result);
-      this.logger.info('[DiscoveryRun] Completed', { runId, userId: run.userId });
+      this.logger.info('Completed', { runId, userId: run.userId });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       if (abortController.signal.aborted || await discoveryRunAdapter.isCancelRequested(runId)) {
@@ -152,7 +152,7 @@ export class DiscoveryRunQueue {
         return;
       }
       await discoveryRunAdapter.markFailed(runId, message);
-      this.logger.error('[DiscoveryRun] Failed', { runId, userId: run.userId, error: message });
+      this.logger.error('Failed', { runId, userId: run.userId, error: message });
       captureAppException(err, {
         subsystem: 'protocol',
         operation: 'discovery-run.queue',

--- a/services/api/src/queues/opportunity/discovery-run.queue.ts
+++ b/services/api/src/queues/opportunity/discovery-run.queue.ts
@@ -93,14 +93,14 @@ export class DiscoveryRunQueue {
         await this.handleRun(data.runId);
         break;
       default:
-        this.queueLogger.warn(`Unknown job name: ${name}`);
+        this.queueLogger.warn('Unknown job name', { name });
     }
   }
 
   startWorker(): void {
     if (this.worker) return;
     const processor = async (job: Job<DiscoveryRunJobData>) => {
-      this.queueLogger.info(`Processing job ${job.id}`);
+      this.queueLogger.info('Processing job', { jobId: job.id });
       await this.processJob(job.name, job.data);
     };
     this.worker = QueueFactory.createWorker<DiscoveryRunJobData>(QUEUE_NAME, processor);

--- a/services/api/src/queues/opportunity/discovery.shared.ts
+++ b/services/api/src/queues/opportunity/discovery.shared.ts
@@ -55,19 +55,19 @@ type OpportunityInvokeOptions = Parameters<ReturnType<typeof buildOpportunityGra
  * Encapsulates the block that was copy-pasted across the three `from-*` queues:
  * the `invokeOpportunityGraph` test short-circuit, graph assembly + invocation,
  * `result.error` handling, and the candidates/opportunities (and optional trace)
- * completion logging. Per-queue variation is passed in via `label`/`logContext`/`logTrace`.
+ * completion logging. Per-queue variation is passed in via `errorLabel`/`logContext`/`logTrace`.
  */
 export async function runOpportunityDiscovery<TOpts extends OpportunityInvokeOptions>(params: {
   graphDb: OpportunityGraphDb;
   deps?: OpportunityDiscoveryDeps & { invokeOpportunityGraph?: (opts: TOpts) => Promise<void> };
   invokeOpts: TOpts;
   logger: DiscoveryLogger;
-  /** Human label for log-line prefixes, e.g. `'FromIntent'`. */
+  /** Human label for the queue, e.g. `'FromIntent'`. */
   label: string;
   /**
    * Label for the thrown fallback error message, e.g. `'from-intent'`. Kept
    * distinct from `label` so the thrown message stays lowercase-dashed (matching
-   * the pre-split queues) while log prefixes stay PascalCase. Defaults to `label`.
+   * the pre-split queues). Defaults to `label`.
    */
   errorLabel?: string;
   /** Identifier fields merged into every log line (e.g. `{ intentId, userId }`). */
@@ -85,14 +85,14 @@ export async function runOpportunityDiscovery<TOpts extends OpportunityInvokeOpt
   const opportunityGraph = buildOpportunityGraph(graphDb, deps);
   const result = await opportunityGraph.invoke(invokeOpts);
   if (result.error) {
-    logger.error(`[${label}] Graph failed`, { ...logContext, error: result.error });
+    logger.error('Graph failed', { ...logContext, error: result.error });
     throw new Error(typeof result.error === 'string' ? result.error : `${errorLabel} graph failed`);
   }
 
   const candidates = Array.isArray(result.candidates) ? result.candidates : [];
   const opportunitiesArr = Array.isArray(result.opportunities) ? result.opportunities : [];
 
-  logger.info(`[${label}] Graph complete`, {
+  logger.info('Graph complete', {
     ...logContext,
     candidatesFound: candidates.length,
     opportunitiesCreated: opportunitiesArr.length,
@@ -100,7 +100,7 @@ export async function runOpportunityDiscovery<TOpts extends OpportunityInvokeOpt
 
   if (logTrace) {
     const trace = Array.isArray(result.trace) ? result.trace : [];
-    logger.verbose(`[${label}] Graph trace`, {
+    logger.verbose('Graph trace', {
       ...logContext,
       trace: trace.map((t: { node: string; detail?: string; data?: Record<string, unknown> }) => ({
         node: t.node,

--- a/services/api/src/queues/opportunity/expiration.queue.ts
+++ b/services/api/src/queues/opportunity/expiration.queue.ts
@@ -27,7 +27,7 @@ export class OpportunityExpirationCron {
       this.expireStale()
         .then((count) => {
           if (count > 0) {
-            this.logger.info(`Expired ${count} opportunit${count === 1 ? 'y' : 'ies'}`);
+            this.logger.info('Expired opportunities', { count });
           }
         })
         .catch((err) => this.logger.error('Cron failed', { error: err }));

--- a/services/api/src/queues/opportunity/from-enrichment.queue.ts
+++ b/services/api/src/queues/opportunity/from-enrichment.queue.ts
@@ -76,7 +76,7 @@ export class FromEnrichmentQueue {
         await this.handleDiscover(data);
         break;
       default:
-        this.queueLogger.warn(`Unknown job name: ${name}`);
+        this.queueLogger.warn('Unknown job name', { name });
     }
   }
 
@@ -107,7 +107,7 @@ export class FromEnrichmentQueue {
   startWorker(): void {
     if (this.worker) return;
     const processor = async (job: Job<FromEnrichmentJobData>) => {
-      this.queueLogger.info(`Processing job ${job.id}`);
+      this.queueLogger.info('Processing job', { jobId: job.id });
       await this.processJob(job.name, job.data);
     };
     this.worker = QueueFactory.createWorker<FromEnrichmentJobData>(QUEUE_NAME, processor);

--- a/services/api/src/queues/opportunity/from-enrichment.queue.ts
+++ b/services/api/src/queues/opportunity/from-enrichment.queue.ts
@@ -76,14 +76,14 @@ export class FromEnrichmentQueue {
         await this.handleDiscover(data);
         break;
       default:
-        this.queueLogger.warn(`[FromEnrichmentQueueProcessor] Unknown job name: ${name}`);
+        this.queueLogger.warn(`Unknown job name: ${name}`);
     }
   }
 
   private async handleDiscover(data: FromEnrichmentJobData): Promise<void> {
     const { userId, networkId } = data;
 
-    this.logger.info('[FromEnrichment] Starting profile-based discovery', { userId, networkId });
+    this.logger.info('Starting profile-based discovery', { userId, networkId });
 
     const invokeOpts: FromEnrichmentGraphInvokeOptions = {
       userId: userId as Id<'users'>,
@@ -107,7 +107,7 @@ export class FromEnrichmentQueue {
   startWorker(): void {
     if (this.worker) return;
     const processor = async (job: Job<FromEnrichmentJobData>) => {
-      this.queueLogger.info(`[FromEnrichmentProcessor] Processing job ${job.id}`);
+      this.queueLogger.info(`Processing job ${job.id}`);
       await this.processJob(job.name, job.data);
     };
     this.worker = QueueFactory.createWorker<FromEnrichmentJobData>(QUEUE_NAME, processor);

--- a/services/api/src/queues/opportunity/from-intent.queue.ts
+++ b/services/api/src/queues/opportunity/from-intent.queue.ts
@@ -76,7 +76,7 @@ export class FromIntentQueue {
         await this.handleDiscover(data);
         break;
       default:
-        this.queueLogger.warn(`Unknown job name: ${name}`);
+        this.queueLogger.warn('Unknown job name', { name });
     }
   }
 
@@ -123,7 +123,7 @@ export class FromIntentQueue {
   startWorker(): void {
     if (this.worker) return;
     const processor = async (job: Job<FromIntentJobData>) => {
-      this.queueLogger.info(`Processing job ${job.id}`);
+      this.queueLogger.info('Processing job', { jobId: job.id });
       await this.processJob(job.name, job.data);
     };
     this.worker = QueueFactory.createWorker<FromIntentJobData>(QUEUE_NAME, processor);

--- a/services/api/src/queues/opportunity/from-intent.queue.ts
+++ b/services/api/src/queues/opportunity/from-intent.queue.ts
@@ -76,7 +76,7 @@ export class FromIntentQueue {
         await this.handleDiscover(data);
         break;
       default:
-        this.queueLogger.warn(`[FromIntentQueueProcessor] Unknown job name: ${name}`);
+        this.queueLogger.warn(`Unknown job name: ${name}`);
     }
   }
 
@@ -86,19 +86,19 @@ export class FromIntentQueue {
     // setRuntimeDeps never replaces `database`, so this is the injected db when provided.
     const intent = await this.database.getIntentForIndexing(intentId);
     if (!intent) {
-      this.logger.warn('[FromIntent] Intent not found, skipping', { intentId });
+      this.logger.warn('Intent not found, skipping', { intentId });
       return;
     }
 
     if (networkIds && networkIds.length === 0) {
-      this.logger.warn('[FromIntent] Empty scoped networkIds provided, skipping fail-closed', { intentId, userId });
+      this.logger.warn('Empty scoped networkIds provided, skipping fail-closed', { intentId, userId });
       return;
     }
 
     if (networkIds && networkIds.length > 1) {
-      this.logger.warn('[FromIntent] Multiple networkIds provided, only first used', { intentId, networkIds });
+      this.logger.warn('Multiple networkIds provided, only first used', { intentId, networkIds });
     }
-    this.logger.info('[FromIntent] Starting discovery', { intentId, userId, networkIds });
+    this.logger.info('Starting discovery', { intentId, userId, networkIds });
 
     const invokeOpts: FromIntentGraphInvokeOptions = {
       userId: userId as Id<'users'>,
@@ -123,7 +123,7 @@ export class FromIntentQueue {
   startWorker(): void {
     if (this.worker) return;
     const processor = async (job: Job<FromIntentJobData>) => {
-      this.queueLogger.info(`[FromIntentProcessor] Processing job ${job.id}`);
+      this.queueLogger.info(`Processing job ${job.id}`);
       await this.processJob(job.name, job.data);
     };
     this.worker = QueueFactory.createWorker<FromIntentJobData>(QUEUE_NAME, processor);

--- a/services/api/src/queues/opportunity/from-introducer.queue.ts
+++ b/services/api/src/queues/opportunity/from-introducer.queue.ts
@@ -76,7 +76,7 @@ export class FromIntroducerQueue {
         await this.handleDiscover(data);
         break;
       default:
-        this.queueLogger.warn(`Unknown job name: ${name}`);
+        this.queueLogger.warn('Unknown job name', { name });
     }
   }
 
@@ -118,7 +118,7 @@ export class FromIntroducerQueue {
   startWorker(): void {
     if (this.worker) return;
     const processor = async (job: Job<FromIntroducerJobData>) => {
-      this.queueLogger.info(`Processing job ${job.id}`);
+      this.queueLogger.info('Processing job', { jobId: job.id });
       await this.processJob(job.name, job.data);
     };
     this.worker = QueueFactory.createWorker<FromIntroducerJobData>(QUEUE_NAME, processor);

--- a/services/api/src/queues/opportunity/from-introducer.queue.ts
+++ b/services/api/src/queues/opportunity/from-introducer.queue.ts
@@ -76,7 +76,7 @@ export class FromIntroducerQueue {
         await this.handleDiscover(data);
         break;
       default:
-        this.queueLogger.warn(`[FromIntroducerQueueProcessor] Unknown job name: ${name}`);
+        this.queueLogger.warn(`Unknown job name: ${name}`);
     }
   }
 
@@ -86,14 +86,14 @@ export class FromIntroducerQueue {
     // setRuntimeDeps never replaces `database`, so this is the injected db when provided.
     const contactIntents = await this.database.getActiveIntents(contactUserId);
     if (contactIntents.length === 0) {
-      this.logger.warn('[FromIntroducer] Contact has no active intents, skipping', { contactUserId, userId });
+      this.logger.warn('Contact has no active intents, skipping', { contactUserId, userId });
       return;
     }
 
     if (networkIds && networkIds.length > 1) {
-      this.logger.warn('[FromIntroducer] Multiple networkIds provided, only first used', { userId, contactUserId, networkIds });
+      this.logger.warn('Multiple networkIds provided, only first used', { userId, contactUserId, networkIds });
     }
-    this.logger.info('[FromIntroducer] Starting discovery', { userId, contactUserId, networkIds });
+    this.logger.info('Starting discovery', { userId, contactUserId, networkIds });
 
     const invokeOpts: FromIntroducerGraphInvokeOptions = {
       userId: userId as Id<'users'>,
@@ -118,7 +118,7 @@ export class FromIntroducerQueue {
   startWorker(): void {
     if (this.worker) return;
     const processor = async (job: Job<FromIntroducerJobData>) => {
-      this.queueLogger.info(`[FromIntroducerProcessor] Processing job ${job.id}`);
+      this.queueLogger.info(`Processing job ${job.id}`);
       await this.processJob(job.name, job.data);
     };
     this.worker = QueueFactory.createWorker<FromIntroducerJobData>(QUEUE_NAME, processor);

--- a/services/api/src/queues/premise.queue.ts
+++ b/services/api/src/queues/premise.queue.ts
@@ -212,7 +212,7 @@ export class PremiseQueue {
         await this.handleProfileRegen(data as ProfileRegenData);
         break;
       default:
-        this.queueLogger.warn(`Unknown job name: ${name}`);
+        this.queueLogger.warn('Unknown job name', { name });
     }
   }
 
@@ -226,7 +226,7 @@ export class PremiseQueue {
   startWorker(): void {
     if (this.worker) return;
     const processor = async (job: Job<PremiseJobPayload>) => {
-      this.queueLogger.info(`Processing job ${job.id} (${job.name})`);
+      this.queueLogger.info('Processing job', { jobId: job.id, jobName: job.name });
       await this.processJob(job.name, job.data);
     };
     this.worker = QueueFactory.createWorker<PremiseJobPayload>(QUEUE_NAME, processor);
@@ -261,7 +261,7 @@ export class PremiseQueue {
       ((id: string) => this.defaultExpirePremise(id));
 
     const expired = await getExpiredPremises();
-    this.expiryLogger.verbose(`Found ${expired.length} expired premises`);
+    this.expiryLogger.verbose('Found expired premises', { count: expired.length });
 
     for (const { id } of expired) {
       // onExpired fires inside the adapter's updatePremise (status EXPIRED) —
@@ -269,7 +269,7 @@ export class PremiseQueue {
       await expirePremise(id);
     }
 
-    this.expiryLogger.info(`Expired ${expired.length} premises`);
+    this.expiryLogger.info('Expired premises', { count: expired.length });
     return expired.length;
   }
 

--- a/services/api/src/queues/premise.queue.ts
+++ b/services/api/src/queues/premise.queue.ts
@@ -121,6 +121,9 @@ export class PremiseQueue {
   readonly queue = QueueFactory.createQueue<PremiseJobPayload>(QUEUE_NAME);
 
   private readonly logger = log.job.from('PremiseJob');
+  private readonly expiryLogger = log.job.from('PremiseJob:ExpiryCheck');
+  private readonly cascadeLogger = log.job.from('PremiseJob:Cascade');
+  private readonly profileRegenLogger = log.job.from('PremiseJob:ProfileRegen');
   private readonly queueLogger = log.queue.from('PremiseQueue');
   private readonly deps: PremiseQueueDeps | undefined;
   private worker: ReturnType<typeof QueueFactory.createWorker<PremiseJobPayload>> | null = null;
@@ -209,7 +212,7 @@ export class PremiseQueue {
         await this.handleProfileRegen(data as ProfileRegenData);
         break;
       default:
-        this.queueLogger.warn(`[PremiseProcessor] Unknown job name: ${name}`);
+        this.queueLogger.warn(`Unknown job name: ${name}`);
     }
   }
 
@@ -223,7 +226,7 @@ export class PremiseQueue {
   startWorker(): void {
     if (this.worker) return;
     const processor = async (job: Job<PremiseJobPayload>) => {
-      this.queueLogger.info(`[PremiseProcessor] Processing job ${job.id} (${job.name})`);
+      this.queueLogger.info(`Processing job ${job.id} (${job.name})`);
       await this.processJob(job.name, job.data);
     };
     this.worker = QueueFactory.createWorker<PremiseJobPayload>(QUEUE_NAME, processor);
@@ -236,9 +239,9 @@ export class PremiseQueue {
     if (this.cronTask) return; // idempotent
     this.cronTask = cron.schedule('0 * * * *', () => {
       this.checkExpiredPremises()
-        .catch((err) => this.logger.error('[ExpiryCheck] Cron failed', { error: err }));
+        .catch((err) => this.expiryLogger.error('Cron failed', { error: err }));
     });
-    this.queueLogger.info('📅 [PremiseJob] Expiry check scheduled (every hour)');
+    this.queueLogger.info('📅 Expiry check scheduled (every hour)');
   }
 
   /**
@@ -247,7 +250,7 @@ export class PremiseQueue {
    * @returns Number of premises expired
    */
   async checkExpiredPremises(): Promise<number> {
-    this.logger.verbose('[ExpiryCheck] Starting expired premise check');
+    this.expiryLogger.verbose('Starting expired premise check');
 
     const getExpiredPremises =
       this.deps?.getExpiredPremises ??
@@ -258,7 +261,7 @@ export class PremiseQueue {
       ((id: string) => this.defaultExpirePremise(id));
 
     const expired = await getExpiredPremises();
-    this.logger.verbose(`[ExpiryCheck] Found ${expired.length} expired premises`);
+    this.expiryLogger.verbose(`Found ${expired.length} expired premises`);
 
     for (const { id } of expired) {
       // onExpired fires inside the adapter's updatePremise (status EXPIRED) —
@@ -266,7 +269,7 @@ export class PremiseQueue {
       await expirePremise(id);
     }
 
-    this.logger.info(`[ExpiryCheck] Expired ${expired.length} premises`);
+    this.expiryLogger.info(`Expired ${expired.length} premises`);
     return expired.length;
   }
 
@@ -340,7 +343,7 @@ export class PremiseQueue {
 
   private async handlePremiseCascade(data: PremiseCascadeData): Promise<void> {
     const { premiseId, userId, event } = data;
-    this.logger.info('[PremiseCascade] Starting cascade', { premiseId, userId, event });
+    this.cascadeLogger.info('Starting cascade', { premiseId, userId, event });
 
     const getUserOpportunities =
       this.deps?.getUserOpportunities ??
@@ -361,7 +364,7 @@ export class PremiseQueue {
       await updateOpportunityStatus(opp.id, 'expired');
     }
 
-    this.logger.info('[PremiseCascade] Cascade complete', {
+    this.cascadeLogger.info('Cascade complete', {
       premiseId,
       userId,
       event,
@@ -372,7 +375,7 @@ export class PremiseQueue {
 
   private async handleProfileRegen(data: ProfileRegenData): Promise<void> {
     const { userId, trigger } = data;
-    this.logger.info('[ProfileRegen] Starting profile regeneration', { userId, trigger });
+    this.profileRegenLogger.info('Starting profile regeneration', { userId, trigger });
 
     const enqueueContextRegen =
       this.deps?.enqueueContextRegen ??
@@ -384,7 +387,7 @@ export class PremiseQueue {
     // Log completion only after the enqueue settles so a failed/retried job is not
     // preceded by a misleading "complete" line.
     await enqueueContextRegen(userId);
-    this.logger.info('[ProfileRegen] Profile regeneration complete', { userId, trigger });
+    this.profileRegenLogger.info('Profile regeneration complete', { userId, trigger });
   }
 
   /**

--- a/services/api/src/queues/questioner.queue.ts
+++ b/services/api/src/queues/questioner.queue.ts
@@ -102,7 +102,7 @@ export class QuestionerQueue {
         await this.handleGenerateQuestions(data);
         break;
       default:
-        this.queueLogger.warn(`Unknown job name: ${name}`);
+        this.queueLogger.warn('Unknown job name', { name });
     }
   }
 
@@ -113,7 +113,7 @@ export class QuestionerQueue {
   startWorker(): void {
     if (this.worker) return;
     const processor = async (job: Job<QuestionerJobData>) => {
-      this.queueLogger.info(`Processing job ${job.id} (${job.name})`);
+      this.queueLogger.info('Processing job', { jobId: job.id, jobName: job.name });
       await this.processJob(job.name, job.data);
     };
     this.worker = QueueFactory.createWorker<QuestionerJobData>(QUEUE_NAME, processor);

--- a/services/api/src/queues/questioner.queue.ts
+++ b/services/api/src/queues/questioner.queue.ts
@@ -102,7 +102,7 @@ export class QuestionerQueue {
         await this.handleGenerateQuestions(data);
         break;
       default:
-        this.queueLogger.warn(`[QuestionerProcessor] Unknown job name: ${name}`);
+        this.queueLogger.warn(`Unknown job name: ${name}`);
     }
   }
 
@@ -113,7 +113,7 @@ export class QuestionerQueue {
   startWorker(): void {
     if (this.worker) return;
     const processor = async (job: Job<QuestionerJobData>) => {
-      this.queueLogger.info(`[QuestionerProcessor] Processing job ${job.id} (${job.name})`);
+      this.queueLogger.info(`Processing job ${job.id} (${job.name})`);
       await this.processJob(job.name, job.data);
     };
     this.worker = QueueFactory.createWorker<QuestionerJobData>(QUEUE_NAME, processor);
@@ -131,7 +131,7 @@ export class QuestionerQueue {
   }
 
   private async handleGenerateQuestions(data: QuestionerJobData): Promise<void> {
-    this.logger.info('[QuestionerJob] Starting question generation', {
+    this.logger.info('Starting question generation', {
       mode: data.mode,
       userId: data.userId,
       sourceType: data.sourceType,
@@ -141,7 +141,7 @@ export class QuestionerQueue {
     const result: QuestionGenerationResult | null = await this.getAgent().invoke(data);
 
     if (!result) {
-      this.logger.info('[QuestionerJob] Agent returned null, skipping persist', {
+      this.logger.info('Agent returned null, skipping persist', {
         mode: data.mode,
         sourceId: data.sourceId,
       });
@@ -172,7 +172,7 @@ export class QuestionerQueue {
 
     const ids = await this.adapter.persist(batch);
 
-    this.logger.info('[QuestionerJob] Persisted questions', {
+    this.logger.info('Persisted questions', {
       mode: data.mode,
       sourceId: data.sourceId,
       count: batch.length,

--- a/services/api/src/queues/queue.template.md
+++ b/services/api/src/queues/queue.template.md
@@ -73,14 +73,14 @@ export class MyQueue {
         await this.handleAnalyze(data);
         break;
       default:
-        this.queueLogger.warn(`[MyProcessor] Unknown job name: ${name}`);
+        this.queueLogger.warn(`Unknown job name: ${name}`);
     }
   }
 
   startWorker(): void {
     if (this.worker) return;
     const processor = async (job: Job<MyJobData>) => {
-      this.queueLogger.info(`[MyProcessor] Processing job ${job.id} (${job.name})`);
+      this.queueLogger.info(`Processing job ${job.id} (${job.name})`);
       await this.processJob(job.name, job.data);
     };
     this.worker = QueueFactory.createWorker<MyJobData>(QUEUE_NAME, processor);
@@ -91,7 +91,7 @@ export class MyQueue {
     const db = this.deps?.database ?? this.getDefaultDb();
     // Orchestrate only: call service, protocol graph, or adapter—no business logic.
     // await myService.process(data.entityId);  or  await someGraph.invoke(...);
-    this.logger.info('[MyJob] Processed', { entityId: data.entityId });
+    this.logger.info('Processed', { entityId: data.entityId });
   }
 
   private async handleAnalyze(data: MyJobData): Promise<void> {

--- a/services/api/src/queues/queue.template.md
+++ b/services/api/src/queues/queue.template.md
@@ -73,14 +73,14 @@ export class MyQueue {
         await this.handleAnalyze(data);
         break;
       default:
-        this.queueLogger.warn(`Unknown job name: ${name}`);
+        this.queueLogger.warn('Unknown job name', { name });
     }
   }
 
   startWorker(): void {
     if (this.worker) return;
     const processor = async (job: Job<MyJobData>) => {
-      this.queueLogger.info(`Processing job ${job.id} (${job.name})`);
+      this.queueLogger.info('Processing job', { jobId: job.id, jobName: job.name });
       await this.processJob(job.name, job.data);
     };
     this.worker = QueueFactory.createWorker<MyJobData>(QUEUE_NAME, processor);

--- a/services/api/src/queues/usercontext.queue.ts
+++ b/services/api/src/queues/usercontext.queue.ts
@@ -120,7 +120,7 @@ export class UserContextQueue {
         await this.handleRegenerate(data);
         break;
       default:
-        this.queueLogger.warn(`[UserContextProcessor] Unknown job name: ${name}`);
+        this.queueLogger.warn(`Unknown job name: ${name}`);
     }
   }
 
@@ -128,7 +128,7 @@ export class UserContextQueue {
   startWorker(): void {
     if (this.worker) return;
     const processor = async (job: Job<UserContextJobData>) => {
-      this.queueLogger.info(`[UserContextProcessor] Processing job ${job.id} (${job.name})`);
+      this.queueLogger.info(`Processing job ${job.id} (${job.name})`);
       await this.processJob(job.name, job.data);
     };
     this.worker = QueueFactory.createWorker<UserContextJobData>(QUEUE_NAME, processor);

--- a/services/api/src/queues/usercontext.queue.ts
+++ b/services/api/src/queues/usercontext.queue.ts
@@ -120,7 +120,7 @@ export class UserContextQueue {
         await this.handleRegenerate(data);
         break;
       default:
-        this.queueLogger.warn(`Unknown job name: ${name}`);
+        this.queueLogger.warn('Unknown job name', { name });
     }
   }
 
@@ -128,7 +128,7 @@ export class UserContextQueue {
   startWorker(): void {
     if (this.worker) return;
     const processor = async (job: Job<UserContextJobData>) => {
-      this.queueLogger.info(`Processing job ${job.id} (${job.name})`);
+      this.queueLogger.info('Processing job', { jobId: job.id, jobName: job.name });
       await this.processJob(job.name, job.data);
     };
     this.worker = QueueFactory.createWorker<UserContextJobData>(QUEUE_NAME, processor);

--- a/services/api/src/services/agent-dispatcher.service.ts
+++ b/services/api/src/services/agent-dispatcher.service.ts
@@ -5,7 +5,7 @@ import type { AgentWithRelations } from '../adapters/agent.database.adapter';
 
 import { log } from '../lib/log';
 
-const logger = log.service.from('AgentDispatcherImpl');
+const logger = log.service.from('AgentDispatcher');
 
 /** How recently a personal agent must have polled to be considered live. */
 const FRESHNESS_THRESHOLD_MS = 90_000;

--- a/services/api/src/services/contact.service.ts
+++ b/services/api/src/services/contact.service.ts
@@ -154,7 +154,7 @@ export class ContactService {
     // Enqueue enrichment for new ghosts
     if (isNew && isGhost) {
       await enrichmentQueue.addEnrichUserJob({ userId: user.id });
-      logger.info('[ContactService] Enrichment job enqueued for new ghost', { userId: user.id });
+      logger.info('Enrichment job enqueued for new ghost', { userId: user.id });
     }
 
     return { userId: user.id, isNew, isGhost };
@@ -190,7 +190,7 @@ export class ContactService {
       if (seenEmails.has(email)) { skipped++; continue; }
       const name = contact.name?.trim() || '';
       if (!isHumanContact(email, name)) {
-        logger.debug('[ContactService] Skipped non-human contact', { domain: email.split('@')[1] });
+        logger.debug('Skipped non-human contact', { domain: email.split('@')[1] });
         skipped++;
         continue;
       }
@@ -247,7 +247,7 @@ export class ContactService {
   ): Promise<ImportResult> {
     if (!isContactsEnabled()) throw new ContactsDisabledError();
 
-    logger.info('[ContactService] Importing contacts', { ownerId, count: contacts.length });
+    logger.info('Importing contacts', { ownerId, count: contacts.length });
 
     const resolved = await this.resolveUsers(ownerId, contacts);
 
@@ -261,7 +261,7 @@ export class ContactService {
     const nameSkipped = dedupResult.removed.length;
 
     if (dedupResult.removed.length > 0) {
-      logger.info('[ContactService] Dedup removed contacts', {
+      logger.info('Dedup removed contacts', {
         ownerId,
         removed: dedupResult.removed.map(r => ({
           email: r.email,
@@ -281,7 +281,7 @@ export class ContactService {
       .map(d => d.userId);
     if (newGhostIdsToEnrich.length > 0) {
       await enrichmentQueue.addEnrichUserJobBulk(newGhostIdsToEnrich.map(id => ({ userId: id })));
-      logger.info('[ContactService] Enrichment jobs enqueued for new ghosts', { count: newGhostIdsToEnrich.length });
+      logger.info('Enrichment jobs enqueued for new ghosts', { count: newGhostIdsToEnrich.length });
     }
 
     const newCount = dedupResult.kept.filter(d => d.isNew).length;
@@ -293,7 +293,7 @@ export class ContactService {
       details: dedupResult.kept,
     };
 
-    logger.info('[ContactService] Import completed', {
+    logger.info('Import completed', {
       ownerId,
       imported: result.imported,
       skipped: result.skipped,
@@ -341,7 +341,7 @@ export class ContactService {
    * @param contactUserId - The contact user ID to remove
    */
   async removeContact(ownerId: string, contactUserId: string): Promise<void> {
-    logger.info('[ContactService] Removing contact', { ownerId, contactUserId });
+    logger.info('Removing contact', { ownerId, contactUserId });
     await this.db.hardDeleteContactMembership(ownerId, contactUserId);
   }
 }

--- a/services/api/src/services/conversation.service.ts
+++ b/services/api/src/services/conversation.service.ts
@@ -136,7 +136,7 @@ export class ConversationService {
         await pubClient.publish(`conversations:user:${p.participantId}`, event);
       }
     } catch (err) {
-      logger.error('[sendMessage] Failed to publish SSE event', {
+      logger.error('Failed to publish SSE event', {
         conversationId,
         error: err instanceof Error ? err.message : String(err),
       });
@@ -147,7 +147,7 @@ export class ConversationService {
       try {
         await this.sendGhostInviteIfNeeded(conversationId, senderId, parts, participants);
       } catch (err) {
-        logger.error('[sendMessage] Ghost invite email failed', {
+        logger.error('Ghost invite email failed', {
           conversationId,
           error: err instanceof Error ? err.message : String(err),
         });
@@ -252,7 +252,7 @@ export class ConversationService {
         ghostInviteSent: true,
       });
 
-      logger.info('[sendMessage] Ghost invite email queued', {
+      logger.info('Ghost invite email queued', {
         conversationId,
         recipientId: recipient.id,
       });
@@ -276,7 +276,7 @@ export class ConversationService {
           if (!cancelled) handler(data);
         });
         sub.subscribe(channel).catch((err) => {
-          logger.error('[subscribe] Redis subscribe failed', {
+          logger.error('Redis subscribe failed', {
             userId,
             error: err instanceof Error ? err.message : String(err),
           });

--- a/services/api/src/services/enrichment.service.ts
+++ b/services/api/src/services/enrichment.service.ts
@@ -37,7 +37,7 @@ export class EnrichmentService {
    *   sourced from `users.intro` (the canonical identity bio home).
    */
   async syncProfile(userId: string): Promise<Record<string, unknown>> {
-    logger.verbose('[EnrichmentService] Syncing profile', { userId });
+    logger.verbose('Syncing profile', { userId });
 
     const graph = this.factory.createGraph();
     const result = await graph.invoke({ userId });
@@ -72,13 +72,13 @@ export class EnrichmentService {
         const result = await graph.invoke({ userId, operationMode: 'write' });
         if (result.error) {
           embedFailures++;
-          logger.warn('[EnrichmentService] Embed failed', { name, error: result.error });
+          logger.warn('Embed failed', { name, error: result.error });
         } else {
           embedded++;
         }
       } catch (err: unknown) {
         embedFailures++;
-        logger.warn('[EnrichmentService] Embed error', {
+        logger.warn('Embed error', {
           name,
           error: err instanceof Error ? err.message : String(err),
         });

--- a/services/api/src/services/experiment.service.ts
+++ b/services/api/src/services/experiment.service.ts
@@ -69,7 +69,7 @@ export interface ExperimentSignupResult {
 class ExperimentService {
   async signup(networkId: string, payload: SignupPayload): Promise<ExperimentSignupResult> {
     const normalizedEmail = payload.email.toLowerCase().trim();
-    logger.verbose('[ExperimentService] Signup attempt', { networkId, email: normalizedEmail });
+    logger.verbose('Signup attempt', { networkId, email: normalizedEmail });
 
     const result = await networkInvitationService.ensureMembership({
       networkId,
@@ -102,10 +102,10 @@ class ExperimentService {
     try {
       await enrichmentQueue.addEnrichUserJob({ userId: result.user.id, networkId, reason: 'experiment_signup' });
     } catch (err) {
-      logger.warn('[ExperimentService] Failed to enqueue profile enrichment (non-fatal)', { error: err });
+      logger.warn('Failed to enqueue profile enrichment (non-fatal)', { error: err });
     }
 
-    logger.info('[ExperimentService] Signup complete', {
+    logger.info('Signup complete', {
       userId: result.user.id,
       networkId,
       created: result.created,
@@ -188,7 +188,7 @@ class ExperimentService {
         });
         imported++;
       } catch (err) {
-        logger.warn('[ExperimentService] Import row failed', { email: row.email, error: err });
+        logger.warn('Import row failed', { email: row.email, error: err });
         skipped++;
       }
     }
@@ -200,9 +200,9 @@ class ExperimentService {
     if (importedUserIds.length > 0) {
       try {
         await enrichmentQueue.addEnrichUserJobBulk(importedUserIds.map(id => ({ userId: id, networkId, reason: 'experiment_import' })));
-        logger.info('[ExperimentService] Enqueued profile enrichment', { count: importedUserIds.length });
+        logger.info('Enqueued profile enrichment', { count: importedUserIds.length });
       } catch (err) {
-        logger.warn('[ExperimentService] Failed to enqueue profile enrichment (non-fatal)', { error: err });
+        logger.warn('Failed to enqueue profile enrichment (non-fatal)', { error: err });
       }
     }
 
@@ -210,7 +210,7 @@ class ExperimentService {
       ? await this.dispatchOwnerCredentialsEmail(networkId, credentials)
       : 0;
 
-    logger.info('[ExperimentService] Import complete', { networkId, imported, skipped, ownersNotified });
+    logger.info('Import complete', { networkId, imported, skipped, ownersNotified });
     return { imported, skipped, ownersNotified };
   }
 
@@ -231,7 +231,7 @@ class ExperimentService {
       .where(eq(schema.networks.id, networkId))
       .limit(1);
     if (!network) {
-      logger.warn('[ExperimentService] Owner email skipped: network not found', { networkId });
+      logger.warn('Owner email skipped: network not found', { networkId });
       return 0;
     }
 
@@ -247,7 +247,7 @@ class ExperimentService {
 
     const recipients = owners.map(o => o.email).filter(Boolean);
     if (recipients.length === 0) {
-      logger.warn('[ExperimentService] Owner email skipped: no owners with email', { networkId });
+      logger.warn('Owner email skipped: no owners with email', { networkId });
       return 0;
     }
 
@@ -265,7 +265,7 @@ class ExperimentService {
       });
       return recipients.length;
     } catch (err) {
-      logger.error('[ExperimentService] Owner credentials email failed', {
+      logger.error('Owner credentials email failed', {
         networkId,
         recipients: recipients.length,
         error: err,

--- a/services/api/src/services/experiment.service.ts
+++ b/services/api/src/services/experiment.service.ts
@@ -20,7 +20,7 @@ import { enrichmentQueue } from '../queues/enrichment.queue';
 // eslint-disable-next-line boundaries/dependencies
 import { networkInvitationService } from './network-invitation.service';
 
-const logger = log.service.from('experiment');
+const logger = log.service.from('ExperimentService');
 
 /**
  * Thrown by {@link ExperimentService.lookupSignup} when the (network, email)

--- a/services/api/src/services/file.service.ts
+++ b/services/api/src/services/file.service.ts
@@ -133,7 +133,7 @@ export class FileService {
   async getFilesByIds(userId: string, fileIds: string[]) {
     if (!fileIds?.length) return [];
 
-    logger.verbose('[FileService] Getting files by IDs', { userId, count: fileIds.length });
+    logger.verbose('Getting files by IDs', { userId, count: fileIds.length });
 
     return this.db.getFilesByIds(userId, fileIds);
   }
@@ -189,7 +189,7 @@ export class FileService {
    * @returns File record or null if not found
    */
   async getById(fileId: string, userId: string) {
-    logger.verbose('[FileService] Getting file by ID', { fileId, userId });
+    logger.verbose('Getting file by ID', { fileId, userId });
 
     return this.db.getById(fileId, userId);
   }
@@ -206,7 +206,7 @@ export class FileService {
     const limit = Math.min(100, Math.max(1, options.limit || 100));
     const skip = (page - 1) * limit;
 
-    logger.verbose('[FileService] Listing files', { userId, page, limit });
+    logger.verbose('Listing files', { userId, page, limit });
 
     const result = await this.db.listFiles(userId, { skip, limit });
 
@@ -228,7 +228,7 @@ export class FileService {
    * @returns The created file record
    */
   async createFile(data: CreateFileInput) {
-    logger.verbose('[FileService] Creating file', { id: data.id, userId: data.userId });
+    logger.verbose('Creating file', { id: data.id, userId: data.userId });
 
     return this.db.createFile(data);
   }
@@ -241,7 +241,7 @@ export class FileService {
    * @returns True if deleted, false if not found or unauthorized
    */
   async softDelete(fileId: string, userId: string): Promise<boolean> {
-    logger.verbose('[FileService] Soft deleting file', { fileId, userId });
+    logger.verbose('Soft deleting file', { fileId, userId });
 
     return this.db.softDelete(fileId, userId);
   }

--- a/services/api/src/services/integration.service.ts
+++ b/services/api/src/services/integration.service.ts
@@ -129,7 +129,7 @@ export class IntegrationService {
     const nameSkipped = dedupResult.removed.length;
 
     if (dedupResult.removed.length > 0) {
-      logger.info('[IntegrationService] Dedup removed contacts', {
+      logger.info('Dedup removed contacts', {
         networkId,
         removed: dedupResult.removed.map(r => ({
           email: r.email,
@@ -148,7 +148,7 @@ export class IntegrationService {
       .map(d => d.userId);
     if (newGhostIdsToEnrich.length > 0) {
       await enrichmentQueue.addEnrichUserJobBulk(newGhostIdsToEnrich.map(id => ({ userId: id, networkId, reason: `integration_${toolkit}_import` })));
-      logger.info('[IntegrationService] Enrichment jobs enqueued for new ghosts', { count: newGhostIdsToEnrich.length });
+      logger.info('Enrichment jobs enqueued for new ghosts', { count: newGhostIdsToEnrich.length });
     }
 
     const newCount = dedupResult.kept.filter(d => d.isNew).length;

--- a/services/api/src/services/intent.service.ts
+++ b/services/api/src/services/intent.service.ts
@@ -66,7 +66,7 @@ export class IntentService {
     userProfile: string,
     content?: string
   ): Promise<Record<string, unknown>> {
-    logger.verbose('[IntentService] Processing intent', { userId });
+    logger.verbose('Processing intent', { userId });
 
     const graph = this.factory.createGraph();
     const result = await graph.invoke(
@@ -98,7 +98,7 @@ export class IntentService {
     const limit = Math.min(100, Math.max(1, options.limit || 20));
     const archived = options.archived ?? false;
 
-    logger.verbose('[IntentService] Listing intents', { userId, page, limit, archived });
+    logger.verbose('Listing intents', { userId, page, limit, archived });
 
     const { rows, total } = await this.adapter.listIntents(userId, {
       page,
@@ -143,7 +143,7 @@ export class IntentService {
    * @returns Intent record or null if not found or unauthorized
    */
   async getById(intentId: string, userId: string) {
-    logger.verbose('[IntentService] Getting intent by ID', { intentId, userId });
+    logger.verbose('Getting intent by ID', { intentId, userId });
 
     return this.adapter.getIntentById(intentId, userId);
   }
@@ -162,7 +162,7 @@ export class IntentService {
    * @returns The created or existing intent record (at least { id }).
    */
   async createFromProposal(userId: string, description: string, proposalId: string, networkId?: string) {
-    logger.verbose('[IntentService] Creating intent from proposal', { userId, proposalId });
+    logger.verbose('Creating intent from proposal', { userId, proposalId });
 
     const existing = await this.adapter.getIntentBySourceId(proposalId, userId);
     if (existing) {
@@ -171,7 +171,7 @@ export class IntentService {
 
     const embedding = await this.generateEmbeddingOrZero(
       description,
-      '[IntentService] Embedding generation failed (intent will be created with zero vector)',
+      'Embedding generation failed (intent will be created with zero vector)',
       { userId, proposalId },
     );
 
@@ -187,7 +187,7 @@ export class IntentService {
       try {
         await this.adapter.assignIntentToNetwork(created.id, networkId);
       } catch (err) {
-        logger.warn('[IntentService] Failed to associate intent with index', {
+        logger.warn('Failed to associate intent with index', {
           intentId: created.id,
           networkId,
           error: err,
@@ -202,7 +202,7 @@ export class IntentService {
         ...(networkId ? { scopeType: 'network' as const, scopeId: networkId } : {}),
       });
     } catch (err) {
-      logger.warn('[IntentService] Failed to enqueue HyDE job', { intentId: created.id, userId, error: err });
+      logger.warn('Failed to enqueue HyDE job', { intentId: created.id, userId, error: err });
     }
 
     IntentEvents.onCreated(created.id, userId);
@@ -220,11 +220,11 @@ export class IntentService {
    * @returns The created intent record
    */
   async createIntentForSeed(userId: string, description: string): Promise<{ id: string }> {
-    logger.verbose('[IntentService] Creating intent for seed', { userId });
+    logger.verbose('Creating intent for seed', { userId });
 
     const embedding = await this.generateEmbeddingOrZero(
       description,
-      '[IntentService] Embedding failed (intent created with zero vector)',
+      'Embedding failed (intent created with zero vector)',
       { userId },
     );
 
@@ -243,7 +243,7 @@ export class IntentService {
         { skipOpportunity: true }
       );
     } catch (err) {
-      logger.warn('[IntentService] HyDE sync failed for seed intent', {
+      logger.warn('HyDE sync failed for seed intent', {
         intentId: created.id,
         userId,
         error: err,
@@ -288,7 +288,7 @@ export class IntentService {
    * @returns Result with success flag and optional error
    */
   async archive(intentId: string, userId: string) {
-    logger.verbose('[IntentService] Archiving intent', { intentId, userId });
+    logger.verbose('Archiving intent', { intentId, userId });
 
     // Verify ownership
     const owned = await this.adapter.isOwnedByUser(intentId, userId);
@@ -302,22 +302,22 @@ export class IntentService {
     try {
       await this.adapter.deleteIntentIndexAssociations(intentId);
     } catch (err) {
-      logger.error('[IntentService] Failed to delete intent-network associations', { intentId, error: err });
+      logger.error('Failed to delete intent-network associations', { intentId, error: err });
     }
 
     try {
       const expiredCount = await this.adapter.expireOpportunitiesByIntentActor(intentId);
       if (expiredCount > 0) {
-        logger.verbose('[IntentService] Expired opportunities referencing intent', { intentId, expiredCount });
+        logger.verbose('Expired opportunities referencing intent', { intentId, expiredCount });
       }
     } catch (err) {
-      logger.error('[IntentService] Failed to expire opportunities', { intentId, error: err });
+      logger.error('Failed to expire opportunities', { intentId, error: err });
     }
 
     try {
       await intentQueue.addDeleteHydeJob({ intentId });
     } catch (err) {
-      logger.error('[IntentService] Failed to enqueue HyDE deletion', { intentId, error: err });
+      logger.error('Failed to enqueue HyDE deletion', { intentId, error: err });
     }
 
     IntentEvents.onArchived(intentId, userId);

--- a/services/api/src/services/link.service.ts
+++ b/services/api/src/services/link.service.ts
@@ -24,7 +24,7 @@ export class LinkService {
    * @returns Array of link records
    */
   async listLinks(userId: string): Promise<LinkRow[]> {
-    logger.verbose('[LinkService] Listing links', { userId });
+    logger.verbose('Listing links', { userId });
     
     return this.db.listLinks(userId);
   }
@@ -37,7 +37,7 @@ export class LinkService {
    * @returns The created link record
    */
   async createLink(userId: string, url: string): Promise<LinkRow> {
-    logger.verbose('[LinkService] Creating link', { userId, url });
+    logger.verbose('Creating link', { userId, url });
     
     return this.db.createLink(userId, url);
   }
@@ -50,7 +50,7 @@ export class LinkService {
    * @returns True if deleted, false if not found or unauthorized
    */
   async deleteLink(linkId: string, userId: string): Promise<boolean> {
-    logger.verbose('[LinkService] Deleting link', { linkId, userId });
+    logger.verbose('Deleting link', { linkId, userId });
     
     return this.db.deleteLink(linkId, userId);
   }
@@ -68,7 +68,7 @@ export class LinkService {
     lastSyncAt: Date | null;
     lastStatus: string | null;
   } | null> {
-    logger.verbose('[LinkService] Getting link content', { linkId, userId });
+    logger.verbose('Getting link content', { linkId, userId });
     
     return this.db.getLinkContent(linkId, userId);
   }

--- a/services/api/src/services/negotiation-polling.service.ts
+++ b/services/api/src/services/negotiation-polling.service.ts
@@ -183,7 +183,7 @@ export class NegotiationPollingService {
       .limit(1);
 
     if (existingClaim) {
-      logger.info('[NegotiationPollingService] Returning existing claimed turn', {
+      logger.info('Returning existing claimed turn', {
         agentId,
         taskId: existingClaim.id,
       });
@@ -239,7 +239,7 @@ export class NegotiationPollingService {
 
     if (!claimed) {
       // Another agent won the race
-      logger.info('[NegotiationPollingService] Lost race to claim task', {
+      logger.info('Lost race to claim task', {
         agentId,
         taskId: pendingTask.id,
       });
@@ -264,7 +264,7 @@ export class NegotiationPollingService {
     const remainingMs = computeRemainingBudgetMs(pendingTask.updatedAt, AMBIENT_PARK_WINDOW_MS);
     await negotiationClaimTimeoutQueue.enqueueTimeout(claimed.id, turnNumber, agentId, remainingMs);
 
-    logger.info('[NegotiationPollingService] Turn claimed', {
+    logger.info('Turn claimed', {
       agentId,
       userId,
       taskId: claimed.id,
@@ -401,7 +401,7 @@ export class NegotiationPollingService {
           : input.action === 'reject' ? 'rejected'
           : 'stalled';
         await new ChatDatabaseAdapter().updateOpportunityStatus(meta.opportunityId, nextStatus).catch((err) => {
-          logger.error('[NegotiationPollingService] Failed to update opportunity status on finalization', {
+          logger.error('Failed to update opportunity status on finalization', {
             opportunityId: meta.opportunityId,
             nextStatus,
             error: err,
@@ -409,7 +409,7 @@ export class NegotiationPollingService {
         });
       }
 
-      logger.info('[NegotiationPollingService] Negotiation finalized', {
+      logger.info('Negotiation finalized', {
         negotiationId,
         outcome: outcomeStr,
         turnCount: newTurnCount,
@@ -420,7 +420,7 @@ export class NegotiationPollingService {
 
       await negotiationTimeoutQueue.enqueueTimeout(negotiationId, newTurnCount, AMBIENT_PARK_WINDOW_MS);
 
-      logger.info('[NegotiationPollingService] Turn submitted, waiting for next agent', {
+      logger.info('Turn submitted, waiting for next agent', {
         negotiationId,
         action: input.action,
         turnCount: newTurnCount,

--- a/services/api/src/services/network-invitation.service.ts
+++ b/services/api/src/services/network-invitation.service.ts
@@ -102,7 +102,7 @@ class NetworkInvitationService {
         });
         return { user, apiKey: token.key, created, alreadyMember };
       }
-      logger.info('[NetworkInvitation] Skipping provisioning; scoped agent already exists', {
+      logger.info('Skipping provisioning; scoped agent already exists', {
         userId: user.id,
         networkId: params.networkId,
       });
@@ -142,7 +142,7 @@ class NetworkInvitationService {
         apiKey: result.apiKey,
         connectCommand,
       });
-      logger.info('[NetworkInvitation] Provisioned scoped agent + invited', {
+      logger.info('Provisioned scoped agent + invited', {
         userId: result.user.id,
         networkId: params.networkId,
       });
@@ -203,13 +203,13 @@ class NetworkInvitationService {
         text: rendered.text,
       })) as { skipped?: boolean; reason?: string };
       if (result.skipped) {
-        logger.info('[NetworkInvitation] Email send skipped', {
+        logger.info('Email send skipped', {
           to: params.to,
           reason: result.reason,
         });
       }
     } catch (err) {
-      logger.error('[NetworkInvitation] Failed to send invitation email', { to: params.to, error: err });
+      logger.error('Failed to send invitation email', { to: params.to, error: err });
       // Fail-soft: provisioning succeeded; organizer can re-issue the invitation.
     }
   }
@@ -337,7 +337,7 @@ class NetworkInvitationService {
       isResend: true,
     });
 
-    logger.info('[NetworkInvitation] Resent invite', {
+    logger.info('Resent invite', {
       userId: memberId,
       networkId,
       rotated,

--- a/services/api/src/services/network-invitation.service.ts
+++ b/services/api/src/services/network-invitation.service.ts
@@ -10,7 +10,7 @@ import { networkInvitationTemplate } from '../lib/email/templates/network-invita
 import { executeSendEmail } from '../lib/email/transport.helper';
 import { buildConnectCommand } from '../lib/openclaw/connect-command';
 
-const logger = log.service.from('network-invitation');
+const logger = log.service.from('NetworkInvitationService');
 
 export interface InviteParams {
   networkId: string;

--- a/services/api/src/services/network.service.ts
+++ b/services/api/src/services/network.service.ts
@@ -30,7 +30,7 @@ export class NetworkService {
    * Get all networks that a user is a member of, including their personal network.
    */
   async getNetworksForUser(userId: string) {
-    logger.verbose('[NetworkService] Getting networks for user', { userId });
+    logger.verbose('Getting networks for user', { userId });
     return this.adapter.getNetworksForUser(userId);
   }
 
@@ -43,7 +43,7 @@ export class NetworkService {
     const validatedProfileEnrichment = data.profileEnrichment !== undefined
       ? ProfileEnrichmentPolicySchema.parse(data.profileEnrichment)
       : undefined;
-    logger.verbose('[NetworkService] Creating index', { userId, title: data.title, type: networkType });
+    logger.verbose('Creating index', { userId, title: data.title, type: networkType });
     const index = await this.adapter.createNetwork({
       ...data,
       type: networkType,
@@ -68,7 +68,7 @@ export class NetworkService {
    * @returns The created network detail and the plaintext master key
    */
   async createExperimentNetwork(userId: string, data: { title: string; prompt?: string; imageUrl?: string | null }): Promise<{ network: unknown; masterKey: string }> {
-    logger.verbose('[NetworkService] Creating experiment network', { userId, title: data.title });
+    logger.verbose('Creating experiment network', { userId, title: data.title });
 
     // Generate master key
     const { key: masterKey, hash: masterKeyHash } = await generateMasterKey();
@@ -105,7 +105,7 @@ export class NetworkService {
    * Get a public network by ID (no auth required). Returns null if not public.
    */
   async getPublicNetworkById(networkId: string) {
-    logger.verbose('[NetworkService] Getting public network by id', { networkId });
+    logger.verbose('Getting public network by id', { networkId });
     return this.adapter.getPublicIndexDetail(networkId);
   }
 
@@ -114,7 +114,7 @@ export class NetworkService {
    * Only members of the index can view it.
    */
   async getNetworkById(networkId: string, userId: string) {
-    logger.verbose('[NetworkService] Getting index by id', { networkId });
+    logger.verbose('Getting index by id', { networkId });
     return this.adapter.getNetworkDetail(networkId, userId);
   }
 
@@ -124,7 +124,7 @@ export class NetworkService {
    * @throws Error if attempting to change join policy on an experiment network.
    */
   async updateNetwork(networkId: string, userId: string, data: { title?: string; prompt?: string | null; imageUrl?: string | null; joinPolicy?: 'anyone' | 'invite_only'; allowGuestVibeCheck?: boolean; profileEnrichment?: schema.ProfileEnrichmentPolicy; type?: 'community' | 'event'; metadata?: Record<string, unknown>; contextInjection?: { discovery: boolean } }) {
-    logger.verbose('[NetworkService] Updating index', { networkId, userId });
+    logger.verbose('Updating index', { networkId, userId });
     if (await this.adapter.isPersonalNetwork(networkId)) {
       // Personal networks can't be renamed/deleted/repurposed (see assertNotPersonal),
       // but the owner may set or clear a discovery prompt to curate what auto-assigns
@@ -173,7 +173,7 @@ export class NetworkService {
     const validatedProfileEnrichment = data.profileEnrichment !== undefined
       ? ProfileEnrichmentPolicySchema.parse(data.profileEnrichment)
       : undefined;
-    logger.verbose('[NetworkService] Updating permissions', { networkId, userId });
+    logger.verbose('Updating permissions', { networkId, userId });
     return this.adapter.updateIndexSettings(networkId, userId, {
       ...data,
       contextInjection: validatedContextInjection,
@@ -191,7 +191,7 @@ export class NetworkService {
    */
   async regenerateInvitationLink(networkId: string, userId: string) {
     await this.assertNotPersonal(networkId);
-    logger.verbose('[NetworkService] Regenerating invitation link', { networkId, userId });
+    logger.verbose('Regenerating invitation link', { networkId, userId });
     return this.adapter.regenerateInvitationLink(networkId, userId);
   }
 
@@ -208,7 +208,7 @@ export class NetworkService {
    * @throws Error if the index is a personal network.
    */
   async addMember(networkId: string, userId: string, requestingUserId: string, role: 'owner' | 'member' = 'member') {
-    logger.verbose('[NetworkService] Adding member', { networkId, userId, role });
+    logger.verbose('Adding member', { networkId, userId, role });
     await this.assertNotPersonal(networkId);
     return this.adapter.addMemberForOwner(networkId, userId, requestingUserId, role);
   }
@@ -218,7 +218,7 @@ export class NetworkService {
    * @throws Error if the index is personal, member not found, or last owner.
    */
   async updateMemberRole(networkId: string, targetUserId: string, requestingUserId: string, role: 'owner' | 'member') {
-    logger.verbose('[NetworkService] Updating member role', { networkId, targetUserId, role });
+    logger.verbose('Updating member role', { networkId, targetUserId, role });
     await this.assertNotPersonal(networkId);
     return this.adapter.updateMemberRole(networkId, targetUserId, requestingUserId, role);
   }
@@ -228,7 +228,7 @@ export class NetworkService {
    * @throws Error if the index is a personal network.
    */
   async removeMember(networkId: string, memberId: string, userId: string) {
-    logger.verbose('[NetworkService] Removing member', { networkId, memberId, userId });
+    logger.verbose('Removing member', { networkId, memberId, userId });
     await this.assertNotPersonal(networkId);
     return this.adapter.removeMemberForOwner(networkId, memberId, userId);
   }
@@ -238,7 +238,7 @@ export class NetworkService {
    * @throws Error if the index is a personal network.
    */
   async deleteNetwork(networkId: string, userId: string) {
-    logger.verbose('[NetworkService] Deleting index', { networkId, userId });
+    logger.verbose('Deleting index', { networkId, userId });
     await this.assertNotPersonal(networkId);
 
     // Check if this is an experiment network
@@ -262,7 +262,7 @@ export class NetworkService {
    * Get members of an index. Only owners can call this.
    */
   async getMembersForOwner(networkId: string, userId: string) {
-    logger.verbose('[NetworkService] Getting members for owner', { networkId, userId });
+    logger.verbose('Getting members for owner', { networkId, userId });
     const raw = await this.adapter.getNetworkMembersForOwner(networkId, userId);
     return raw.map(m => ({
       id: m.userId,
@@ -281,7 +281,7 @@ export class NetworkService {
    * Used for mentionable users / @mentions.
    */
   async getMembersFromMyNetworks(userId: string) {
-    logger.verbose('[NetworkService] Getting members from user indexes', { userId });
+    logger.verbose('Getting members from user indexes', { userId });
     const raw = await this.adapter.getMembersFromUserIndexes(userId);
     return raw.map(m => ({
       id: m.userId,
@@ -297,7 +297,7 @@ export class NetworkService {
    * @returns Shared non-personal networks with member counts.
    */
   async getSharedNetworks(currentUserId: string, targetUserId: string) {
-    logger.verbose('[NetworkService] Getting shared networks', { currentUserId, targetUserId });
+    logger.verbose('Getting shared networks', { currentUserId, targetUserId });
     return this.adapter.getSharedNetworks(currentUserId, targetUserId);
   }
 
@@ -305,7 +305,7 @@ export class NetworkService {
    * Get public networks that the user has not joined (for discovery).
    */
   async getPublicNetworks(userId: string) {
-    logger.verbose('[NetworkService] Getting public networks for user', { userId });
+    logger.verbose('Getting public networks for user', { userId });
     return this.adapter.getPublicIndexesNotJoined(userId);
   }
 
@@ -315,7 +315,7 @@ export class NetworkService {
    * @returns The index with owner info and member count, or null if not found
    */
   async getNetworkByShareCode(code: string) {
-    logger.verbose('[NetworkService] Getting index by share code');
+    logger.verbose('Getting index by share code');
     return this.adapter.getNetworkByShareCode(code);
   }
 
@@ -327,7 +327,7 @@ export class NetworkService {
    * @throws Error if the invitation code is invalid or the index is not found
    */
   async acceptInvitation(code: string, userId: string) {
-    logger.verbose('[NetworkService] Accepting invitation', { userId });
+    logger.verbose('Accepting invitation', { userId });
     return this.adapter.acceptIndexInvitation(code, userId);
   }
 
@@ -335,7 +335,7 @@ export class NetworkService {
    * Join a public network.
    */
   async joinPublicNetwork(networkId: string, userId: string) {
-    logger.verbose('[NetworkService] Joining public network', { networkId, userId });
+    logger.verbose('Joining public network', { networkId, userId });
     await this.adapter.joinPublicNetwork(networkId, userId);
     return this.adapter.getNetworkDetail(networkId, userId);
   }
@@ -345,7 +345,7 @@ export class NetworkService {
    * @throws Error if the index is a personal network.
    */
   async leaveNetwork(networkId: string, userId: string) {
-    logger.verbose('[NetworkService] Leaving index', { networkId, userId });
+    logger.verbose('Leaving index', { networkId, userId });
     await this.assertNotPersonal(networkId);
     await this.adapter.leaveNetwork(networkId, userId);
   }
@@ -354,7 +354,7 @@ export class NetworkService {
    * Get current user's member settings (permissions and ownership status).
    */
   async getMemberSettings(networkId: string, userId: string) {
-    logger.verbose('[NetworkService] Getting member settings', { networkId, userId });
+    logger.verbose('Getting member settings', { networkId, userId });
     const settings = await this.adapter.getMemberSettings(networkId, userId);
     if (!settings) {
       throw new Error('Not a member of this network');
@@ -366,7 +366,7 @@ export class NetworkService {
    * Get current user's intents in an index. Members only.
    */
   async getMyIntentsInNetwork(networkId: string, userId: string) {
-    logger.verbose('[NetworkService] Getting my intents in index', { networkId, userId });
+    logger.verbose('Getting my intents in index', { networkId, userId });
     const intents = await this.adapter.getNetworkIntentsForMember(networkId, userId);
     return intents.filter((i) => i.userId === userId);
   }
@@ -380,7 +380,7 @@ export class NetworkService {
    * consistent with the premise count beside them. See EDG-53.
    */
   async getNetworkOverview(networkId: string, userId: string) {
-    logger.verbose('[NetworkService] Getting network overview', { networkId, userId });
+    logger.verbose('Getting network overview', { networkId, userId });
     const isMember = await this.adapter.isNetworkMember(networkId, userId);
     if (!isMember) {
       throw new Error('Access denied: Not a member of this network');
@@ -403,7 +403,7 @@ export class NetworkService {
    * @returns The network UUID, or null if not found
    */
   async resolveIndexId(idOrKey: string): Promise<string | null> {
-    logger.verbose('[NetworkService] Resolving network ID or key', { idOrKey });
+    logger.verbose('Resolving network ID or key', { idOrKey });
     return this.adapter.resolveIndexId(idOrKey);
   }
 
@@ -500,7 +500,7 @@ export class NetworkService {
    * @throws Error('Owner-only operation') when the caller is not an owner.
    */
   async rotateExperimentMasterKey(networkId: string, userId: string): Promise<{ masterKey: string }> {
-    logger.verbose('[NetworkService] Rotating experiment master key', { networkId, userId });
+    logger.verbose('Rotating experiment master key', { networkId, userId });
 
     const [network] = await db
       .select({
@@ -547,7 +547,7 @@ export class NetworkService {
 
     // Dispatch emails fire-and-forget — rotation has already committed.
     this.dispatchRotationEmails(network.id, network.title, userId, key, owners)
-      .catch((err) => logger.error('[NetworkService] Rotation email dispatch failed', { networkId, error: err }));
+      .catch((err) => logger.error('Rotation email dispatch failed', { networkId, error: err }));
 
     return { masterKey: key };
   }
@@ -593,7 +593,7 @@ export class NetworkService {
           text: rendered.text,
         });
       } catch (err) {
-        logger.error('[NetworkService] Rotation email failed for owner', { to: o.email, error: err });
+        logger.error('Rotation email failed for owner', { to: o.email, error: err });
       }
     }));
   }

--- a/services/api/src/services/opportunity.service.ts
+++ b/services/api/src/services/opportunity.service.ts
@@ -15,6 +15,8 @@ import { userSocials } from '../schemas/database.schema';
 import { normalizeTelegramHandle } from '@indexnetwork/protocol';
 
 const logger = log.service.from("OpportunityService");
+const startChatLogger = log.service.from("OpportunityService.startChat");
+const updateStatusLogger = log.service.from("OpportunityService.updateOpportunityStatus");
 
 /**
  * Lifecycle statuses surfaced in the default opportunity list (when no explicit
@@ -223,7 +225,7 @@ export class OpportunityService {
       );
       return cards.get(opportunityId)?.greeting ?? '';
     } catch (err) {
-      logger.warn('[OpportunityService] getGreetingForCard failed', { opportunityId, error: err });
+      logger.warn('getGreetingForCard failed', { opportunityId, error: err });
       return '';
     }
   }
@@ -235,7 +237,7 @@ export class OpportunityService {
     userId: string,
     options?: { networkId?: string; scopeType?: 'intent'; scopeId?: string; limit?: number; noCache?: boolean; statuses?: OpportunityStatus[] }
   ): Promise<{ sections: Array<{ id: string; title: string; subtitle?: string; iconName: string; items: unknown[] }>; meta: { totalOpportunities: number; totalSections: number; maintenanceTriggered: boolean } } | { error: string }> {
-    logger.verbose('[OpportunityService] Getting home view', { userId, options });
+    logger.verbose('Getting home view', { userId, options });
     if (!this.homeGraph) {
       return { error: 'Home view not available' };
     }
@@ -264,15 +266,15 @@ export class OpportunityService {
       // the existing unscoped maintenance trigger. Network scope retains current behavior.
       if (this.maintenanceGraph && !options?.networkId) {
         meta.maintenanceTriggered = true;
-        logger.info('[OpportunityService] Triggering maintenance via health scoring', { userId, source: 'home-view' });
+        logger.info('Triggering maintenance via health scoring', { userId, source: 'home-view' });
         this.maintenanceGraph.invoke({ userId }).catch((err) =>
-          logger.warn('[OpportunityService] Maintenance graph failed', { userId, error: err })
+          logger.warn('Maintenance graph failed', { userId, error: err })
         );
       }
 
       return { sections, meta };
     } catch (e) {
-      logger.error('[OpportunityService] getHomeView failed', { userId, error: e });
+      logger.error('getHomeView failed', { userId, error: e });
       return { error: 'Failed to load home view' };
     }
   }
@@ -313,7 +315,7 @@ export class OpportunityService {
       offset?: number;
     }
   ) {
-    logger.verbose('[OpportunityService] Getting opportunities for user', { userId, options });
+    logger.verbose('Getting opportunities for user', { userId, options });
 
     // No explicit status filter ⇒ show only live statuses, hiding terminal-stale
     // expired/rejected from the default list (IND-254). An explicit `status` or
@@ -381,7 +383,7 @@ export class OpportunityService {
 
         const visibilityError = this.assertOpportunityVisible(candidate, viewerId);
         if (visibilityError) {
-          logger.warn('[OpportunityService] Enriched replacement hidden from viewer', {
+          logger.warn('Enriched replacement hidden from viewer', {
             originalOpportunityId: original.id,
             replacementOpportunityId: candidate.id,
             viewerId,
@@ -412,7 +414,7 @@ export class OpportunityService {
    * @returns Opportunity with presentation data or null
    */
   async getOpportunityWithPresentation(opportunityId: string, viewerId: string) {
-    logger.verbose('[OpportunityService] Getting opportunity', { opportunityId, viewerId });
+    logger.verbose('Getting opportunity', { opportunityId, viewerId });
 
     let opp = await this.db.getOpportunity(opportunityId);
     if (!opp) {
@@ -500,7 +502,7 @@ export class OpportunityService {
     userId: string,
     options?: IntentScopeOptions,
   ): Promise<OpportunityStatusUpdateResult | { error: string; status: number }> {
-    logger.verbose('[OpportunityService] Updating opportunity status', {
+    logger.verbose('Updating opportunity status', {
       opportunityId,
       status,
       userId,
@@ -535,7 +537,7 @@ export class OpportunityService {
       try {
         await this.db.getOrCreateDM(userId, counterpart.userId);
       } catch (err) {
-        logger.error('[OpportunityService.updateOpportunityStatus] getOrCreateDM failed; status left untouched', {
+        updateStatusLogger.error('getOrCreateDM failed; status left untouched', {
           opportunityId,
           userId,
           counterpartUserId: counterpart.userId,
@@ -566,7 +568,7 @@ export class OpportunityService {
 
     if (options?.scopeType !== 'intent') {
       await this.db.acceptSiblingOpportunities(userId, counterpartUserId, opportunityId).catch((err) => {
-        logger.error('[OpportunityService.updateOpportunityStatus] acceptSiblingOpportunities failed (non-blocking)', {
+        updateStatusLogger.error('acceptSiblingOpportunities failed (non-blocking)', {
           opportunityId,
           userId,
           counterpartUserId,
@@ -578,7 +580,7 @@ export class OpportunityService {
     // Accepter explicitly acted — restore if previously removed.
     // Counterpart: add them to the accepter but honour any prior opt-out on their side.
     await this.db.upsertContactMembership(userId, counterpartUserId, { restore: true }).catch((err) => {
-      logger.error('[OpportunityService.updateOpportunityStatus] upsertContactMembership failed (non-blocking)', {
+      updateStatusLogger.error('upsertContactMembership failed (non-blocking)', {
         opportunityId,
         userId,
         counterpartUserId,
@@ -586,7 +588,7 @@ export class OpportunityService {
       });
     });
     await this.db.upsertContactMembership(counterpartUserId, userId, { restore: false }).catch((err) => {
-      logger.error('[OpportunityService.updateOpportunityStatus] upsertContactMembership (counterpart) failed (non-blocking)', {
+      updateStatusLogger.error('upsertContactMembership (counterpart) failed (non-blocking)', {
         opportunityId,
         userId,
         counterpartUserId,
@@ -642,7 +644,7 @@ export class OpportunityService {
     // Transition to pending (triggers negotiation)
     const statusResult = await this.updateOpportunityStatus(opportunityId, 'pending', userId);
     if (statusResult && 'error' in statusResult) {
-      logger.error('[OpportunityService.approveIntroduction] status transition failed', {
+      logger.error('Status transition failed during introduction approval', {
         opportunityId,
         userId,
         error: statusResult.error,
@@ -714,13 +716,13 @@ export class OpportunityService {
       try {
         conversation = await this.db.getOrCreateDM(userId, counterpart.userId);
       } catch (err) {
-        logger.error('[OpportunityService.startChat] getOrCreateDM failed for accepted opp', {
+        startChatLogger.error('getOrCreateDM failed for accepted opp', {
           opportunityId, userId, counterpartUserId: counterpart.userId, error: err,
         });
         return { error: 'Failed to resolve conversation for this opportunity', status: 500 };
       }
       await this.db.unhideConversation(userId, conversation.id).catch((err) => {
-        logger.error('[OpportunityService.startChat] unhideConversation failed (non-blocking)', {
+        startChatLogger.error('unhideConversation failed (non-blocking)', {
           conversationId: conversation.id, userId, error: err,
         });
       });
@@ -757,7 +759,7 @@ export class OpportunityService {
     try {
       conversation = await this.db.getOrCreateDM(userId, counterpart.userId);
     } catch (err) {
-      logger.error('[OpportunityService.startChat] getOrCreateDM failed; opp left untouched', {
+      startChatLogger.error('getOrCreateDM failed; opp left untouched', {
         opportunityId,
         userId,
         counterpartUserId: counterpart.userId,
@@ -770,7 +772,7 @@ export class OpportunityService {
     // user previously hid it. This must happen before returning — the frontend
     // immediately calls refreshConversations() and expects to see the DM.
     await this.db.unhideConversation(userId, conversation.id).catch((err) => {
-      logger.error('[OpportunityService.startChat] unhideConversation failed (non-blocking)', {
+      startChatLogger.error('unhideConversation failed (non-blocking)', {
         conversationId: conversation.id,
         userId,
         error: err,
@@ -788,7 +790,7 @@ export class OpportunityService {
     // resolved; these keep the home feed and contacts view in sync.
     if (options?.scopeType !== 'intent') {
       await this.db.acceptSiblingOpportunities(userId, counterpart.userId, opportunityId).catch((err) => {
-        logger.error('[OpportunityService.startChat] acceptSiblingOpportunities failed (non-blocking)', {
+        startChatLogger.error('acceptSiblingOpportunities failed (non-blocking)', {
           opportunityId,
           userId,
           counterpartUserId: counterpart.userId,
@@ -797,7 +799,7 @@ export class OpportunityService {
       });
     }
     await this.db.upsertContactMembership(userId, counterpart.userId, { restore: true }).catch((err) => {
-      logger.error('[OpportunityService.startChat] upsertContactMembership failed (non-blocking)', {
+      startChatLogger.error('upsertContactMembership failed (non-blocking)', {
         opportunityId,
         userId,
         counterpartUserId: counterpart.userId,
@@ -805,7 +807,7 @@ export class OpportunityService {
       });
     });
     await this.db.upsertContactMembership(counterpart.userId, userId, { restore: false }).catch((err) => {
-      logger.error('[OpportunityService.startChat] upsertContactMembership (counterpart) failed (non-blocking)', {
+      startChatLogger.error('upsertContactMembership (counterpart) failed (non-blocking)', {
         opportunityId,
         userId,
         counterpartUserId: counterpart.userId,
@@ -829,7 +831,7 @@ export class OpportunityService {
    * @returns Discovery results
    */
   async discoverOpportunities(userId: string, query: string, limit: number = 5) {
-    logger.verbose('[OpportunityService] Discovering opportunities', { userId, query, limit });
+    logger.verbose('Discovering opportunities', { userId, query, limit });
 
     if (!this.graph) {
       return { error: 'Discovery not available; graph dependencies not configured', status: 503 };
@@ -874,7 +876,7 @@ export class OpportunityService {
       offset?: number;
     }
   ) {
-    logger.verbose('[OpportunityService] Getting opportunities for index', { networkId, userId, options });
+    logger.verbose('Getting opportunities for index', { networkId, userId, options });
 
     const isOwner = await this.db.isIndexOwner(networkId, userId);
     const isMember = await this.db.isNetworkMember(networkId, userId);
@@ -912,7 +914,7 @@ export class OpportunityService {
       confidence?: number;
     }
   ) {
-    logger.verbose('[OpportunityService] Creating manual opportunity', { networkId, creatorId });
+    logger.verbose('Creating manual opportunity', { networkId, creatorId });
 
     // Check permission
     const permission = await this.checkCreatePermission(creatorId, data.parties, networkId);
@@ -973,7 +975,7 @@ export class OpportunityService {
       if (!created?.length) {
         const message =
           errors?.length ? (errors[0].error instanceof Error ? errors[0].error.message : String(errors[0].error)) : 'Failed to persist opportunity';
-        logger.warn('[OpportunityService] createManualOpportunity persistence failed', { errors, creatorId, networkId });
+        logger.warn('createManualOpportunity persistence failed', { errors, creatorId, networkId });
         return { error: message, status: 500 };
       }
 
@@ -984,7 +986,7 @@ export class OpportunityService {
       return created[0];
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to persist opportunity';
-      logger.warn('[OpportunityService] createManualOpportunity persistence failed', { error: err, creatorId, networkId });
+      logger.warn('createManualOpportunity persistence failed', { error: err, creatorId, networkId });
       return { error: message, status: 500 };
     }
   }
@@ -998,7 +1000,7 @@ export class OpportunityService {
    * @returns Opportunity cards and peer info for chat context
    */
   async getChatContext(userId: string, peerUserId: string) {
-    logger.verbose('[OpportunityService] Getting chat context', { userId, peerUserId });
+    logger.verbose('Getting chat context', { userId, peerUserId });
 
     const [allRows, peerUser] = await Promise.all([
       this.db.findOpportunitiesByActors([userId, peerUserId], { includeIntroducers: true, statuses: ['accepted'] }),
@@ -1019,7 +1021,7 @@ export class OpportunityService {
       const cacheKeys = rows.map((opp) => `chat:card:${opp.id}:${userId}`);
       cachedResults = await this.cache.mget<ChatCardCached>(cacheKeys);
     } catch (e) {
-      logger.warn('[OpportunityService] getChatContext cache read failed, skipping', { error: e });
+      logger.warn('getChatContext cache read failed, skipping', { error: e });
       cachedResults = rows.map(() => null);
     }
 
@@ -1057,7 +1059,7 @@ export class OpportunityService {
           }
           return card;
         } catch (err) {
-          logger.warn('[OpportunityService] getChatContext presenter failed, using fallback', { error: err, opportunityId: opp.id });
+          logger.warn('getChatContext presenter failed, using fallback', { error: err, opportunityId: opp.id });
           const introducerActor = opp.actors.find((a) => a.role === 'introducer');
           const introducerName = introducerActor ? opp.detection?.createdByName ?? null : null;
           // Shared sanitization standard — see opportunity.safe-presentation.ts in protocol.
@@ -1153,12 +1155,12 @@ export class OpportunityService {
    */
   triggerMaintenance(userId: string, source: string): void {
     if (!this.maintenanceGraph) {
-      logger.warn('[OpportunityService] Maintenance graph not available', { userId, source });
+      logger.warn('Maintenance graph not available', { userId, source });
       return;
     }
-    logger.info('[OpportunityService] Triggering maintenance', { userId, source });
+    logger.info('Triggering maintenance', { userId, source });
     this.maintenanceGraph.invoke({ userId }).catch((err) =>
-      logger.warn('[OpportunityService] Maintenance graph failed', { userId, source, error: err })
+      logger.warn('Maintenance graph failed', { userId, source, error: err })
     );
   }
 
@@ -1243,7 +1245,7 @@ export class OpportunityService {
       const dm = await this.db.getOrCreateDM(viewerUserId, counterpart.userId);
       return dm.id;
     } catch (err) {
-      logger.error('[OpportunityService.getConversationIdForOpp] getOrCreateDM failed', {
+      logger.error('getOrCreateDM failed while resolving conversation for opportunity', {
         opportunityId, viewerUserId, counterpartUserId: counterpart.userId, error: err,
       });
       return null;

--- a/services/api/src/services/service.template.md
+++ b/services/api/src/services/service.template.md
@@ -158,7 +158,7 @@ export class MyService {
    * @returns [Return description]
    */
   async getById(id: string) {
-    logger.info('[MyService] Getting item', { id });
+    logger.info('Getting item', { id });
     
     // Use adapter method - NO direct database access
     return this.db.getById(id);
@@ -169,12 +169,12 @@ export class MyService {
    */
   async createItem(data: { name: string; userId: string }) {
     try {
-      logger.info('[MyService] Creating item', { userId: data.userId });
+      logger.info('Creating item', { userId: data.userId });
 
       // Use adapter method
       return this.db.createItem(data);
     } catch (error) {
-      logger.error('[MyService] Failed to create item', { error, data });
+      logger.error('Failed to create item', { error, data });
       throw error; // Or handle gracefully depending on requirement
     }
   }
@@ -264,8 +264,8 @@ export class EnrichmentService {
 
 ### 2. Logging
 - Use standard logger: \`import { log } from '../lib/log';\`.
-- Structure logs with the service name prefix: \`[MyService] ...\`.
-- Log important state changes and errors.
+- Create a module logger: \`const logger = log.service.from('MyService');\` — the source label is rendered automatically, so never bake \`[MyService]\`-style prefixes into message text.
+- Log important state changes and errors with plain human-readable messages.
 - Pass metadata objects as the second argument to \`log.info/error\`.
 
 ### 3. Dependencies

--- a/services/api/src/services/tool.service.ts
+++ b/services/api/src/services/tool.service.ts
@@ -20,7 +20,7 @@ import db from '../lib/drizzle/drizzle';
 
 import { log } from '../lib/log';
 
-const logger = log.service.from('tool');
+const logger = log.service.from('ToolService');
 
 const questionerAdapter = new QuestionerAdapter(db);
 

--- a/services/api/src/services/user.service.ts
+++ b/services/api/src/services/user.service.ts
@@ -36,7 +36,7 @@ export class UserService {
     private readonly deps?: UserServiceDeps,
   ) {}
     async findById(userId: string) {
-        logger.verbose('[UserService] Finding user by ID', { userId });
+        logger.verbose('Finding user by ID', { userId });
         return this.db.findById(userId);
     }
 
@@ -65,7 +65,7 @@ export class UserService {
     }
 
     async update(userId: string, data: Partial<User>) {
-        logger.verbose('[UserService] Updating user', { userId, fields: Object.keys(data) });
+        logger.verbose('Updating user', { userId, fields: Object.keys(data) });
         return this.db.update(userId, data);
     }
 
@@ -74,7 +74,7 @@ export class UserService {
     }
 
     async setSocials(userId: string, socials: { label: string; value: string }[]): Promise<void> {
-        logger.verbose('[UserService] Setting socials', { userId, count: socials.length });
+        logger.verbose('Setting socials', { userId, count: socials.length });
         await this.db.setSocials(userId, socials);
         await this.retractIntegrationPremises(userId);
     }
@@ -103,7 +103,7 @@ export class UserService {
 
         const toRetract = await getPremisesBySource(userId, 'integration');
 
-        logger.verbose('[UserService] Retracting integration premises before re-enrich', {
+        logger.verbose('Retracting integration premises before re-enrich', {
             userId,
             count: toRetract.length,
         });
@@ -114,7 +114,7 @@ export class UserService {
 
         // Re-enrichment is fire-and-forget — failure is logged but does not propagate to caller.
         enqueueEnrichment(userId).catch(err =>
-            logger.error('[UserService] Failed to enqueue re-enrichment after social update', {
+            logger.error('Failed to enqueue re-enrichment after social update', {
                 userId,
                 error: err,
             }),
@@ -122,7 +122,7 @@ export class UserService {
     }
 
     async softDelete(userId: string) {
-        logger.verbose('[UserService] Soft deleting user', { userId });
+        logger.verbose('Soft deleting user', { userId });
         await this.db.deleteUserSessions(userId);
         await this.db.softDelete(userId);
         return true;
@@ -155,7 +155,7 @@ export class UserService {
      * @returns User record or null
      */
     async findByIdOrKey(idOrKey: string) {
-        logger.verbose('[UserService] Finding user by ID or key', { idOrKey });
+        logger.verbose('Finding user by ID or key', { idOrKey });
         return this.db.findByIdOrKey(idOrKey);
     }
 


### PR DESCRIPTION
## Summary

Enforces one logging convention across the whole project: everything goes through a labelled, level-aware logger; no \`console.*\` in runtime code; no big data dumps in logs.

### Root-cause fix: protocol logs never reached the rich logger
- \`setLoggerFactory\` was documented but **never called** in \`services/api\` — every protocol log fell back to the plain \`[Source]\` console sink, producing two visibly different log formats in the same process. Now wired in \`main.ts\` and exported from \`@indexnetwork/protocol\`.
- Protocol loggers are now **late-bound** (factory resolved at emit time, cached per generation), so module-level \`log.lib.from(...)\` created at import time upgrades once the host wires in. Regression-tested.
- Fixed spurious \`[DEPRECATED]\` tag: path-based deprecation now only applies to file-path sources, not protocol component names.

### Label consistency (~500 call sites)
- Manual \`[Bracket]\` tags stripped from all log messages in \`services/api\` and \`packages/protocol\`; sub-scopes moved into source labels (e.g. \`OpportunityGraph:Prep\`).
- Uniform per-layer label conventions, documented in \`lib/log.ts\` and the service/queue templates: controllers lowercase feature · services \`XxxService\` · queues \`XxxJob\`/\`XxxQueue\` · adapters \`<name>.adapter\` · guards \`<name>.guard\` · lib module path · protocol \`PascalCase[:SubScope]\` · chat tool modules \`ChatTools:<Domain>\`.
- All runtime log messages are **static strings** — dynamic values live in meta (93 sites). Stable Sentry grouping; the sanitizer sees every dynamic value.

### No big data dumps
- Payload truncation added to all log sanitizers (strings 2000 chars, arrays 25 items, depth 6, 50 keys) on top of the existing embedding/vector redaction — applied in the API logger, the protocol default sink, and the new web logger.

### apps/web
- New \`apps/web/src/lib/logger.ts\`: \`[context:source]\` labels, debug stripped in prod, truncating sanitizer. All 73 \`console.*\` call sites migrated; contexts match directories (ui/context/hook/page/lib).

### CLI surfaces
- stdout stays the product (JSON/formatters/help); \`warn()\` now writes to **stderr** so piped \`--json\` output stays clean.

### Enforcement
- ESLint \`no-console: error\` now covers \`services/api/src\`, \`packages/protocol/src\`, and \`apps/web/src\` (logger sinks carry explicit disables); CLI surfaces allow \`log/warn/error\` only, banning \`debug/info/trace\` drift.

Exempt by design: CLI output layers, \`src/cli\` maintenance scripts, \`startup.env.ts\`, protocol evals, repo scripts, tests, edge-city submodules.

## Verification
- Root lint: 0 errors · protocol \`tsc\` build ✓ · api \`tsc --noEmit\` ✓ · web typecheck ✓
- Tests: cli 343/343 · protocol observability 25/25 · api suite at baseline parity (zero new failures by name-level diff)
- Every failure encountered during the work was reproduced on unmodified \`dev\` (LLM-auth 401s, coalesce spec, contact/integration error-propagation asserts, one live-LLM timeout flake)
- Runtime output verified end-to-end: \`⏰ FromIntroducerJob: Starting discovery {"userId":"…"}\` and \`🕸️ OpportunityGraph:Prep: prepNode start {…}\` — one pipeline, one format