### PR TITLE
fix(migrations): recreate agent_type enum instead of ADD VALUE (IND-410 deploy fix)

### DIFF
--- a/services/api/drizzle/0088_jazzy_havok.sql
+++ b/services/api/drizzle/0088_jazzy_havok.sql
@@ -1,2 +1,12 @@
-ALTER TYPE "public"."agent_type" ADD VALUE 'external' BEFORE 'system';--> statement-breakpoint
-ALTER TABLE "agents" ALTER COLUMN "type" DROP DEFAULT;
+-- IND-410: agent_type gains 'external'.
+-- NOTE: `ALTER TYPE ... ADD VALUE` is deliberately NOT used here. drizzle-kit
+-- applies all pending migrations of a run inside a single transaction, and
+-- Postgres forbids using a value added by ADD VALUE before that transaction
+-- commits (55P04: unsafe use of new value "external") — which breaks 0089's
+-- backfill in the same deploy. Recreating the type sidesteps this: values of a
+-- freshly CREATED type are usable immediately within the same transaction.
+ALTER TABLE "agents" ALTER COLUMN "type" DROP DEFAULT;--> statement-breakpoint
+CREATE TYPE "public"."agent_type_v2" AS ENUM('personal', 'external', 'system');--> statement-breakpoint
+ALTER TABLE "agents" ALTER COLUMN "type" SET DATA TYPE "public"."agent_type_v2" USING ("type"::text::"public"."agent_type_v2");--> statement-breakpoint
+DROP TYPE "public"."agent_type";--> statement-breakpoint
+ALTER TYPE "public"."agent_type_v2" RENAME TO "agent_type";


### PR DESCRIPTION
## Deploy fix for #1094

The dev `protocol` deploy failed at `drizzle-kit migrate` — **PG 55P04: unsafe use of new value "external" of enum type agent_type**. drizzle-kit applies all pending migrations in **one transaction**, and Postgres forbids using an `ALTER TYPE … ADD VALUE` member before that transaction commits; `0089`'s re-type UPDATE uses `'external'` in the same run.

### Fix
Rewrite `0088` to **recreate the type** instead:
```sql
ALTER TABLE agents ALTER COLUMN type DROP DEFAULT;
CREATE TYPE agent_type_v2 AS ENUM('personal','external','system');
ALTER TABLE agents ALTER COLUMN type SET DATA TYPE agent_type_v2 USING (type::text::agent_type_v2);
DROP TYPE agent_type;
ALTER TYPE agent_type_v2 RENAME TO agent_type;
```
Values of a freshly *created* type are usable immediately, so 0088+0089 apply cleanly in a single transaction. Only `agents.type` references the enum (verified via `pg_attribute`); the dependent `agents_type_idx` is rebuilt automatically.

Rewriting the already-merged file is safe: **0088 never successfully applied anywhere** — the failed deploy rolled back (dev still at 87 migrations, journal untouched), prod untouched.

### Verification (ephemeral Neon branch off prod, real deploy command)
- `bunx drizzle-kit migrate` → exit 0, journal at 89
- 296 negotiators = 296 non-ghost users · 252 external · 2 system · 0 ghosts · 0 dupes · unique index + agents_type_idx present · default gone · enum `[personal, external, system]`
- second `drizzle-kit migrate` run → clean no-op (deploys run it on every start)

Unblocks the failed dev deployment of IND-410.