### PR TITLE
feat(chat): negotiator chat persona + client-scoped toolset (IND-402)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -246,6 +246,13 @@ S3_SECRET_ACCESS_KEY=your-secret-access-key
 # unaffected. DISABLED WHEN UNSET — must be exactly "true" to enable.
 CONTACTS_ENABLED=false
 
+# Negotiator chat feature flag (P4.1 / IND-402).
+# Gates the negotiator persona chat surface: POST /chat/negotiator/session and
+# negotiator-persona streaming on /chat/stream. Also surfaced to the web app as
+# features.negotiatorChat on GET /auth/me. DISABLED WHEN UNSET — must be exactly
+# "true" to enable.
+NEGOTIATOR_CHAT_ENABLED=false
+
 ########################################
 # 11. Telegram Bot
 # Scope: [api]

--- a/packages/protocol/src/chat/chat.graph.ts
+++ b/packages/protocol/src/chat/chat.graph.ts
@@ -69,6 +69,26 @@ export class ChatGraphFactory {
   }
 
   /**
+   * Returns a sibling factory sharing all dependencies but driven by a
+   * different persona. Used to derive per-session persona factories (e.g. the
+   * negotiator, whose identity comes from the user's personal agent row) from
+   * the composition-root orchestrator factory without re-wiring deps.
+   *
+   * @param persona - The persona config for the derived factory
+   * @returns A new ChatGraphFactory with identical deps and the given persona
+   */
+  public withPersona(persona: ChatPersonaConfig): ChatGraphFactory {
+    return new ChatGraphFactory(
+      this.database,
+      this.embedder,
+      this.scraper,
+      this.chatSession,
+      this.protocolDeps,
+      persona,
+    );
+  }
+
+  /**
    * Creates and compiles the Chat Graph without persistence.
    * @returns Compiled StateGraph ready for invocation
    */

--- a/packages/protocol/src/chat/negotiator.persona.ts
+++ b/packages/protocol/src/chat/negotiator.persona.ts
@@ -1,0 +1,88 @@
+import { createChatTools, type ChatTools, type ToolContext, type ResolvedToolContext } from "../shared/agent/tool.factory.js";
+import type { ChatPersonaConfig } from "./chat.persona.js";
+import { buildNegotiatorSystemContent, type NegotiatorPromptOptions } from "./negotiator.prompt.js";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// NEGOTIATOR PERSONA (P4.1)
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// A pure persona addition on the P4.0 persona-neutral chat runtime: advocate
+// prompt, client-scoped toolset, and all orchestrator loop behaviors OFF.
+// Unlike the orchestrator (a static singleton), the negotiator persona is
+// created per session because its identity comes from the user's
+// `type='personal'` agent row (name/description).
+
+/**
+ * Persona id for the user's personal negotiator. Matches the
+ * `conversations.persona` column value for negotiator DM sessions.
+ */
+export const NEGOTIATOR_PERSONA_ID = "negotiator";
+
+/**
+ * Client-scoped tool allowlist for the negotiator persona.
+ *
+ * Deliberately excludes every network-facing capability: no discovery
+ * (`discover_opportunities`), no network/membership management, no profile or
+ * intent writes, no contact import. This agent works for one client; as the
+ * orchestrator sunsets, network-facing capabilities migrate here deliberately
+ * (out of scope for P4.1).
+ */
+export const NEGOTIATOR_TOOL_NAMES = [
+  "list_negotiations",
+  "get_negotiation",
+  "respond_to_negotiation",
+  "list_opportunities",
+  "read_intents",
+  "read_premises",
+] as const;
+
+const NEGOTIATOR_TOOL_ALLOWLIST: ReadonlySet<string> = new Set(NEGOTIATOR_TOOL_NAMES);
+
+/**
+ * Filters a full chat-tool registry down to the negotiator allowlist.
+ * Exported separately so the scoping rule is unit-testable without
+ * constructing the full tool factory dependency graph.
+ */
+export function filterNegotiatorTools<T extends { name: string }>(tools: T[]): T[] {
+  return tools.filter((t) => NEGOTIATOR_TOOL_ALLOWLIST.has(t.name));
+}
+
+/**
+ * Creates the negotiator persona's client-scoped toolset.
+ *
+ * Reuses the standard chat tool factory (so context resolution, scope
+ * derivation, logging, and error handling stay identical) and filters the
+ * registry to the allowlist. The negotiation tools are already context-bound
+ * to `context.userId`, so every tool in this set can only read or act on the
+ * calling client's own data.
+ */
+export async function createNegotiatorTools(
+  deps: ToolContext,
+  preResolvedContext?: ResolvedToolContext,
+): Promise<ChatTools> {
+  const tools = await createChatTools(deps, preResolvedContext);
+  return filterNegotiatorTools(tools);
+}
+
+/**
+ * Creates a negotiator `ChatPersonaConfig` bound to the client's personal
+ * negotiator agent row identity.
+ *
+ * Loop behaviors are all OFF: no create-intent callback and no
+ * hallucinated-block auto-invoke/strip — the negotiator's toolset cannot
+ * legitimately produce opportunity/intent-proposal blocks, and it must never
+ * inherit the orchestrator's discovery auto-invocation.
+ *
+ * @param opts - Identity from the user's `type='personal'` agent row
+ */
+export function createNegotiatorPersona(opts: NegotiatorPromptOptions): ChatPersonaConfig {
+  return {
+    id: NEGOTIATOR_PERSONA_ID,
+    buildSystemContent: (ctx, iterCtx) => buildNegotiatorSystemContent(ctx, opts, iterCtx),
+    createTools: (deps, preResolvedContext) => createNegotiatorTools(deps, preResolvedContext),
+    loopBehaviors: {
+      createIntentCallback: false,
+      hallucinationRecovery: false,
+    },
+  };
+}

--- a/packages/protocol/src/chat/negotiator.prompt.ts
+++ b/packages/protocol/src/chat/negotiator.prompt.ts
@@ -1,0 +1,97 @@
+import type { ResolvedToolContext } from "../shared/agent/tool.factory.js";
+import type { IterationContext } from "./chat.prompt.modules.js";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// NEGOTIATOR PERSONA SYSTEM PROMPT (P4.1)
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// The direct chat line between a user and their personal negotiator agent
+// (the `type='personal'` agent row). Unlike the orchestrator prompt, this
+// persona works for exactly one client: it reports on the client's
+// negotiations and opportunities, explains decisions from the negotiation
+// record, and acts only on explicit client instruction. It has no
+// network-wide discovery capabilities.
+
+/** Identity options resolved from the user's personal negotiator agent row. */
+export interface NegotiatorPromptOptions {
+  /** The negotiator agent's display name (e.g. "Ada's Negotiator"). */
+  agentName: string;
+  /** The negotiator agent's description, when set on the agent row. */
+  agentDescription?: string;
+}
+
+/**
+ * Builds the system prompt for the negotiator chat persona.
+ *
+ * Grounded in the client's preloaded user/profile context; everything else
+ * (negotiations, opportunities, signals, premises) must be fetched through
+ * the client-scoped toolset each turn.
+ *
+ * @param ctx - Resolved tool context for the current session
+ * @param opts - Identity from the client's personal negotiator agent row
+ * @param _iterCtx - Iteration context (unused — the negotiator prompt has no
+ *                   dynamic modules; the nudge is injected by the agent loop)
+ * @returns The complete system prompt string
+ */
+export function buildNegotiatorSystemContent(
+  ctx: ResolvedToolContext,
+  opts: NegotiatorPromptOptions,
+  _iterCtx?: IterationContext,
+): string {
+  const userContext = JSON.stringify(ctx.user, null, 2);
+  const profileContext = ctx.userProfile
+    ? JSON.stringify(ctx.userProfile, null, 2)
+    : "null";
+  const descriptionLine = opts.agentDescription?.trim()
+    ? `\n${opts.agentDescription.trim()}\n`
+    : "";
+
+  return `You are ${opts.agentName}, the personal negotiator agent working for ${ctx.userName}.
+${descriptionLine}
+You work for exactly one client: ${ctx.userName}. You represent them in negotiations with other members' agents across the network, and this chat is your direct line to them. Your job here is to keep your client informed about what you have been doing on their behalf, explain your reasoning honestly, and act only on their explicit instructions.
+
+## What you do in this chat
+- **Report on negotiations**: when the client asks what is happening, look up their negotiations and summarize status, counterparties, and where things stand.
+- **Explain decisions**: when the client asks why something was pursued, declined, or stalled ("why did you pass on X?"), find the relevant negotiation and answer from the actual record — the messages, outcomes, and reasoning stored there. Never reconstruct a rationale from memory.
+- **Review opportunities**: show the client the opportunities currently waiting on them and what accepting or passing would mean.
+- **Stay grounded in their signals**: their active intents and premises define what you negotiate for. Read them before making claims about what the client is looking for.
+- **Act on instruction**: respond to a negotiation (accept, decline, or reply) only when the client explicitly tells you to in this conversation. Never take a negotiation action the client did not just ask for.
+
+## What you cannot do here
+- **No network-wide discovery.** You cannot look for new people, run matching, or create new connections from this chat. New matches are discovered by the system in the background and appear on the client's home page.
+- **No profile, community, or membership management.** If the client asks for those, tell them plainly that it is outside your remit as their negotiator and they can do it from the main chat or the app.
+- You cannot push updates after this conversation ends. You only report when asked.
+
+## Session
+- Client: ${ctx.userName} (${ctx.userEmail}), id: ${ctx.userId}
+
+### Client (preloaded context)
+\`\`\`json
+${userContext}
+\`\`\`
+
+### Client Context (preloaded context)
+\`\`\`json
+${profileContext}
+\`\`\`
+
+## Tools Reference
+
+| Tool | Params | What it does |
+|------|--------|-------------|
+| **list_negotiations** | status?, limit? | List the client's negotiations |
+| **get_negotiation** | negotiationId | Full negotiation record: messages, outcome, reasoning |
+| **respond_to_negotiation** | negotiationId, ... | Act on a negotiation — ONLY on explicit client instruction |
+| **list_opportunities** | — | List the client's actionable opportunities |
+| **read_intents** | — | The client's active signals (what they're looking for) |
+| **read_premises** | — | The client's premises (facts they've established) |
+
+## Grounding rules
+- **Never fabricate.** Every claim about a negotiation, opportunity, signal, or premise must come from a tool result in this conversation. If you have not looked it up this turn, look it up before answering. Only the client's identity and profile above are preloaded.
+- **Check tool results before confirming.** Never claim an action succeeded without a successful tool result for it.
+- **Be honest about your own actions.** If the record shows you made a judgment call the client disagrees with, explain the reasoning from the record — do not get defensive, and do not invent justifications the record does not support.
+- **Never expose IDs, UUIDs, tool names, or raw JSON** to the client. Translate everything into natural language; refer to people and opportunities by name.
+- **Respond in the language of the client's latest message.**
+- **Voice**: first person, loyal but candid, calm and concise. No hype, no networking clichés, no exaggeration. You are their agent, not a salesperson.
+- When calling tools, first write a short natural sentence plus a \`>\` blockquote describing what you are checking (e.g. "> Checking the record with Alice"), then leave an empty line after the blockquote.`;
+}

--- a/packages/protocol/src/chat/tests/negotiator.persona.spec.ts
+++ b/packages/protocol/src/chat/tests/negotiator.persona.spec.ts
@@ -1,0 +1,209 @@
+/**
+ * P4.1 negotiator persona — client-scoped persona unit tests.
+ *
+ * The negotiator persona is a pure addition on the P4.0 persona seam:
+ * advocate prompt bound to the personal agent row identity, client-scoped
+ * tool allowlist, and every orchestrator loop behavior OFF. These tests pin
+ * down the persona config shape, the prompt's identity/grounding content,
+ * and the tool-scoping rule (no discovery / network / write-the-world tools).
+ *
+ * No LLM calls, no DB, no module mocks.
+ */
+import { config } from "dotenv";
+config({ path: ".env.test", override: true });
+
+import { describe, expect, it } from "bun:test";
+
+import { NEGOTIATOR_PERSONA_ID, NEGOTIATOR_TOOL_NAMES, createNegotiatorPersona, filterNegotiatorTools } from "../negotiator.persona.js";
+import { buildNegotiatorSystemContent } from "../negotiator.prompt.js";
+import { ORCHESTRATOR_PERSONA_ID } from "../chat.persona.js";
+import type { ResolvedToolContext } from "../../shared/agent/tool.factory.js";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+function makeCtx(overrides: Partial<ResolvedToolContext> = {}): ResolvedToolContext {
+  return {
+    userId: "user-1",
+    userName: "Alice Test",
+    userEmail: "alice@example.com",
+    user: { id: "user-1", name: "Alice Test", email: "alice@example.com" },
+    userProfile: { bio: "Builder", skills: ["typescript"], interests: ["AI"] },
+    userNetworks: [],
+    indexName: undefined,
+    isOwner: false,
+    isOnboarding: false,
+    hasName: true,
+    contactsEnabled: false,
+    ...overrides,
+  } as unknown as ResolvedToolContext;
+}
+
+const AGENT_OPTS = {
+  agentName: "Alice's Negotiator",
+  agentDescription: "Negotiates on your behalf across the network.",
+};
+
+// ─── Persona config ──────────────────────────────────────────────────────────
+
+describe("createNegotiatorPersona", () => {
+  it("uses the negotiator persona id (matches the conversations.persona value)", () => {
+    const persona = createNegotiatorPersona(AGENT_OPTS);
+    expect(persona.id).toBe(NEGOTIATOR_PERSONA_ID);
+    expect(persona.id).toBe("negotiator");
+    expect(persona.id).not.toBe(ORCHESTRATOR_PERSONA_ID);
+  });
+
+  it("has every orchestrator loop behavior OFF", () => {
+    const persona = createNegotiatorPersona(AGENT_OPTS);
+    expect(persona.loopBehaviors.createIntentCallback).toBe(false);
+    expect(persona.loopBehaviors.hallucinationRecovery).toBe(false);
+  });
+
+  it("builds its prompt from the negotiator prompt module", () => {
+    const persona = createNegotiatorPersona(AGENT_OPTS);
+    const ctx = makeCtx();
+    expect(persona.buildSystemContent(ctx, { iteration: 1 } as never)).toBe(
+      buildNegotiatorSystemContent(ctx, AGENT_OPTS),
+    );
+  });
+});
+
+// ─── Prompt content ──────────────────────────────────────────────────────────
+
+describe("buildNegotiatorSystemContent", () => {
+  const ctx = makeCtx();
+  const prompt = buildNegotiatorSystemContent(ctx, AGENT_OPTS);
+
+  it("identifies as the user's personal negotiator agent by name", () => {
+    expect(prompt).toContain("You are Alice's Negotiator");
+    expect(prompt).toContain("working for Alice Test");
+    expect(prompt).toContain(AGENT_OPTS.agentDescription);
+  });
+
+  it("is not the orchestrator identity", () => {
+    expect(prompt).not.toContain("You are Index.");
+    // No orchestrator-only capabilities in the tool table.
+    expect(prompt).not.toContain("discover_opportunities");
+    expect(prompt).not.toContain("create_intent");
+    expect(prompt).not.toContain("read_networks");
+    expect(prompt).not.toContain("import_gmail_contacts");
+  });
+
+  it("includes the preloaded client context", () => {
+    expect(prompt).toContain('"id": "user-1"');
+    expect(prompt).toContain('"bio": "Builder"');
+    expect(prompt).toContain("alice@example.com");
+  });
+
+  it("references every allowlisted tool and no others in the tools table", () => {
+    for (const name of NEGOTIATOR_TOOL_NAMES) {
+      expect(prompt).toContain(name);
+    }
+  });
+
+  it("omits the description line when the agent row has none", () => {
+    const noDesc = buildNegotiatorSystemContent(ctx, { agentName: "Alice's Negotiator" });
+    expect(noDesc).not.toContain("Negotiates on your behalf");
+    expect(noDesc).toContain("You are Alice's Negotiator");
+  });
+
+  it("is deterministic (snapshot-safe across iterations)", () => {
+    expect(buildNegotiatorSystemContent(ctx, AGENT_OPTS)).toBe(prompt);
+    expect(buildNegotiatorSystemContent(ctx, AGENT_OPTS, { iteration: 3 } as never)).toBe(prompt);
+  });
+});
+
+// ─── Tool scoping ────────────────────────────────────────────────────────────
+
+/** Representative orchestrator registry (superset of the negotiator allowlist). */
+const ORCHESTRATOR_REGISTRY_NAMES = [
+  // enrichment / profile
+  "read_user_contexts",
+  "create_user_context",
+  "update_user_context",
+  "complete_onboarding",
+  // intents
+  "read_intents",
+  "create_intent",
+  "update_intent",
+  "delete_intent",
+  "create_intent_index",
+  "read_intent_indexes",
+  "delete_intent_index",
+  "search_intents",
+  // networks
+  "read_networks",
+  "create_network",
+  "update_network",
+  "delete_network",
+  "read_network_memberships",
+  "create_network_membership",
+  // opportunities / discovery
+  "discover_opportunities",
+  "list_opportunities",
+  "update_opportunity",
+  "get_discovery_run",
+  "cancel_discovery_run",
+  // utilities / integrations / contacts / agents
+  "scrape_url",
+  "read_docs",
+  "import_gmail_contacts",
+  "import_contacts",
+  "list_contacts",
+  "add_contact",
+  "remove_contact",
+  "register_agent",
+  "list_agents",
+  "update_agent",
+  "delete_agent",
+  "grant_agent_permission",
+  "revoke_agent_permission",
+  // negotiations
+  "list_negotiations",
+  "get_negotiation",
+  "respond_to_negotiation",
+  // premises / questioner
+  "create_premise",
+  "read_premises",
+  "update_premise",
+  "retract_premise",
+  "read_pending_questions",
+  "ask_user_question",
+];
+
+describe("filterNegotiatorTools", () => {
+  const registry = ORCHESTRATOR_REGISTRY_NAMES.map((name) => ({ name }));
+  const filtered = filterNegotiatorTools(registry);
+  const filteredNames = filtered.map((t) => t.name);
+
+  it("keeps exactly the negotiator allowlist", () => {
+    expect(new Set(filteredNames)).toEqual(new Set(NEGOTIATOR_TOOL_NAMES));
+  });
+
+  it("drops every discovery and network-facing tool", () => {
+    for (const banned of [
+      "discover_opportunities",
+      "read_networks",
+      "create_network",
+      "create_network_membership",
+      "create_intent",
+      "update_opportunity",
+      "import_gmail_contacts",
+      "register_agent",
+      "scrape_url",
+    ]) {
+      expect(filteredNames).not.toContain(banned);
+    }
+  });
+
+  it("is a no-op on an already-scoped registry (idempotent)", () => {
+    expect(filterNegotiatorTools(filtered)).toEqual(filtered);
+  });
+
+  it("the allowlist itself contains no discovery/network tool names", () => {
+    const names = new Set<string>(NEGOTIATOR_TOOL_NAMES);
+    expect(names.has("discover_opportunities")).toBe(false);
+    expect(names.has("read_networks")).toBe(false);
+    expect(names.has("create_intent")).toBe(false);
+  });
+});

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -115,6 +115,14 @@ export {
   type ChatPersonaConfig,
   type ChatPersonaLoopBehaviors,
 } from "./chat/chat.persona.js";
+export {
+  NEGOTIATOR_PERSONA_ID,
+  NEGOTIATOR_TOOL_NAMES,
+  createNegotiatorPersona,
+  createNegotiatorTools,
+  filterNegotiatorTools,
+} from "./chat/negotiator.persona.js";
+export { buildNegotiatorSystemContent, type NegotiatorPromptOptions } from "./chat/negotiator.prompt.js";
 export { HomeGraphFactory } from "./opportunity/feed/feed.graph.js";
 export { HydeGraphFactory } from "./shared/hyde/hyde.graph.js";
 export { NetworkGraphFactory } from "./network/network.graph.js";

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -1,5 +1,20 @@
-import { readUserContext, schema, Artifact, ChatConversationMeta, ChatMessage, ChatMessageMeta, ChatScopeType, ChatSession, Conversation, ConversationParticipant, ConversationSummary, CreateMessageInput, CreateSessionInput, Message, ResolvedParticipant, SYSTEM_AGENT_ID, Task, and, asc, count, db, desc, eq, gt, inArray, isNull, lt, opportunities, or, sql } from './database.shared';
+import { readUserContext, schema, Artifact, ChatConversationMeta, ChatMessage, ChatMessageMeta, ChatScopeType, ChatSession, Conversation, ConversationParticipant, ConversationSummary, CreateMessageInput, CreateSessionInput, Message, ResolvedParticipant, SYSTEM_AGENT_ID, Task, and, asc, count, db, desc, eq, gt, inArray, isNull, lt, ne, opportunities, or, sql } from './database.shared';
 
+/**
+ * Persona value for the user's negotiator DM session (P4.1 / IND-402).
+ * Mirrors `NEGOTIATOR_PERSONA_ID` in @indexnetwork/protocol; kept as a local
+ * literal so the data layer does not import the protocol package.
+ */
+const NEGOTIATOR_PERSONA = 'negotiator';
+
+/**
+ * Stable-session registry key for the negotiator DM in `chat_session_scopes`.
+ * The table's `(user_id, scope_type, scope_id)` unique index is what makes
+ * get-or-create race-safe. `scope_type='persona'` is deliberately outside the
+ * `ChatScopeType` ('network' | 'intent') envelope: `_normalizeScopeType`
+ * ignores it, so the negotiator session presents as an unscoped chat session.
+ */
+const NEGOTIATOR_SCOPE = { scopeType: 'persona', scopeId: NEGOTIATOR_PERSONA } as const;
 
 export class ConversationDatabaseAdapter {
   /**
@@ -1205,7 +1220,12 @@ export class ConversationDatabaseAdapter {
    * Get all chat sessions for a user, ordered by most recent.
    * Queries conversation_participants to find conversations with system-agent.
    */
-  async getUserChatSessions(userId: string, limit: number, persona?: string): Promise<ChatSession[]> {
+  async getUserChatSessions(
+    userId: string,
+    limit: number,
+    persona?: string,
+    excludePersona?: string,
+  ): Promise<ChatSession[]> {
     // Subquery: conversation IDs that include the system agent (i.e. chat sessions, not DMs)
     const chatSessionIds = db
       .select({ conversationId: schema.conversationParticipants.conversationId })
@@ -1236,6 +1256,7 @@ export class ConversationDatabaseAdapter {
           isNull(schema.conversationParticipants.hiddenAt),
           inArray(schema.conversations.id, chatSessionIds),
           ...(persona ? [eq(schema.conversations.persona, persona)] : []),
+          ...(excludePersona ? [ne(schema.conversations.persona, excludePersona)] : []),
         ),
       )
       .orderBy(desc(schema.conversations.updatedAt))
@@ -1299,6 +1320,9 @@ export class ConversationDatabaseAdapter {
             gt(schema.conversations.lastMessageAt, schema.conversationParticipants.hiddenAt),
           ),
           inArray(schema.conversations.id, chatSessionIds),
+          // The negotiator DM is a private persona surface — keep it out of
+          // generic chat-history summaries (MCP listSessions, chat summary).
+          ne(schema.conversations.persona, NEGOTIATOR_PERSONA),
         ),
       )
       .orderBy(desc(schema.conversations.updatedAt))
@@ -1437,6 +1461,66 @@ export class ConversationDatabaseAdapter {
       createdAt: conv.createdAt,
       messages,
     };
+  }
+
+  /**
+   * Find the user's stable negotiator DM session, if provisioned.
+   */
+  async getNegotiatorChatSession(userId: string): Promise<ChatSession | null> {
+    const [row] = await db
+      .select({ conversationId: schema.chatSessionScopes.conversationId })
+      .from(schema.chatSessionScopes)
+      .where(
+        and(
+          eq(schema.chatSessionScopes.userId, userId),
+          eq(schema.chatSessionScopes.scopeType, NEGOTIATOR_SCOPE.scopeType),
+          eq(schema.chatSessionScopes.scopeId, NEGOTIATOR_SCOPE.scopeId),
+        ),
+      )
+      .limit(1);
+    return row ? this.getChatSession(row.conversationId) : null;
+  }
+
+  /**
+   * Create the user's stable negotiator DM session (one per user).
+   *
+   * Same transaction shape as {@link createChatSession} (conversation +
+   * user/system-agent participants + title metadata) plus the
+   * `chat_session_scopes` registry row whose unique index guarantees at most
+   * one negotiator session per user — concurrent creates lose with a 23505
+   * unique violation the caller resolves by re-reading.
+   */
+  async createNegotiatorChatSession(data: { id: string; userId: string; title?: string }): Promise<void> {
+    const now = new Date();
+    await db.transaction(async (tx) => {
+      await tx.insert(schema.conversations).values({
+        id: data.id,
+        persona: NEGOTIATOR_PERSONA,
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      await tx.insert(schema.conversationParticipants).values([
+        { conversationId: data.id, participantId: data.userId, participantType: 'user' as const },
+        { conversationId: data.id, participantId: SYSTEM_AGENT_ID, participantType: 'agent' as const },
+      ]);
+
+      if (data.title) {
+        await tx.insert(schema.conversationMetadata).values({
+          conversationId: data.id,
+          metadata: { title: data.title } satisfies ChatConversationMeta,
+        });
+      }
+
+      await tx.insert(schema.chatSessionScopes).values({
+        conversationId: data.id,
+        userId: data.userId,
+        scopeType: NEGOTIATOR_SCOPE.scopeType,
+        scopeId: NEGOTIATOR_SCOPE.scopeId,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
   }
 
   /**

--- a/services/api/src/controllers/auth.controller.ts
+++ b/services/api/src/controllers/auth.controller.ts
@@ -6,6 +6,7 @@ import { AuthGuard, SessionOnlyGuard } from '../guards/auth.guard';
 import type { AuthenticatedUser } from '../guards/auth.guard';
 import { userService } from '../services/user.service';
 import { enrichmentService } from '../services/enrichment.service';
+import { isNegotiatorChatEnabled } from '../lib/negotiator-feature';
 import { log } from '../lib/log';
 
 const logger = log.controller.from('auth');
@@ -84,6 +85,11 @@ export class AuthController {
       user: {
         ...userFields,
         notificationPreferences,
+      },
+      // Feature flags the web app reads off the session bootstrap (no separate
+      // config channel). negotiatorChat gates the sidebar negotiator entry (P4.4).
+      features: {
+        negotiatorChat: isNegotiatorChatEnabled(),
       },
     });
   }

--- a/services/api/src/controllers/chat.controller.ts
+++ b/services/api/src/controllers/chat.controller.ts
@@ -7,7 +7,9 @@ import { log } from "../lib/log";
 import { Controller, Get, Post, UseGuards } from "../lib/router/router.decorators";
 import { chatSessionService } from "../services/chat.service";
 import { fileService } from "../services/file.service";
-import { SuggestionGenerator, ChatInterruptClassifier } from '@indexnetwork/protocol';
+import { agentService } from "../services/agent.service";
+import { isNegotiatorChatEnabled } from "../lib/negotiator-feature";
+import { SuggestionGenerator, ChatInterruptClassifier, NEGOTIATOR_PERSONA_ID } from '@indexnetwork/protocol';
 import { createDoneEvent, createErrorEvent, createStatusEvent, createSteerOrQueueEvent, formatSSEEvent, type DebugMetaDiscoveryQuestions } from "../types/chat-streaming.types";
 import { emitChatInterrupt, onChatInterrupt } from '../lib/chat-interrupt.events';
 
@@ -74,6 +76,8 @@ const streamBodySchema = z.object({
   scopeId: z.string().nullish(),
   /** The recipient user ID for DM-style chats (used for ghost invite emails). */
   recipientUserId: z.string().nullish(),
+  /** Chat persona. 'negotiator' bootstraps/streams the user's negotiator DM (P4.1). */
+  persona: z.enum(['negotiator']).nullish(),
   prefillMessages: z.array(z.object({
     role: z.enum(["assistant", "user"]),
     content: z.string().max(10000),
@@ -99,6 +103,15 @@ const interruptBodySchema = z.object({
   messageId: z.string().uuid(),
   traceSnapshot: z.array(z.string()).max(20).default([]),
 });
+
+/**
+ * Resolve the caller's personal negotiator agent row (provisioning it when
+ * missing — idempotent). Returns null for ghost or missing users, which
+ * callers treat as 404.
+ */
+async function resolveNegotiatorAgent(userId: string) {
+  return agentService.getNegotiatorAgent(userId);
+}
 
 let interruptClassifierInstance: ChatInterruptClassifier | null = null;
 function getInterruptClassifier(): ChatInterruptClassifier {
@@ -230,12 +243,37 @@ export class ChatController {
       return undefined;
     };
 
+    // Negotiator persona routing (P4.1): flag-gated, never scoped. Checked
+    // before scope validation — both rejections are cheap and unambiguous.
+    const requestedPersona = body.persona ?? undefined;
+    if (requestedPersona === NEGOTIATOR_PERSONA_ID) {
+      if (!isNegotiatorChatEnabled()) {
+        return Response.json({ error: "Not found" }, { status: 404 });
+      }
+      if (requestedScope) {
+        return Response.json({ error: "Negotiator chat cannot be scoped" }, { status: 400 });
+      }
+    }
+
     const requestScopeError = await validateScope(requestedScope);
     if (requestScopeError) return requestScopeError;
 
     let currentSessionId = body.sessionId;
     let effectiveScope = requestedScope;
-    if (!currentSessionId) {
+    let sessionPersona: string = "orchestrator";
+    let negotiatorAgent: Awaited<ReturnType<typeof resolveNegotiatorAgent>> = null;
+    if (!currentSessionId && requestedPersona === NEGOTIATOR_PERSONA_ID) {
+      negotiatorAgent = await resolveNegotiatorAgent(user.id);
+      if (!negotiatorAgent) {
+        return Response.json({ error: "Negotiator agent not available" }, { status: 404 });
+      }
+      const resolved = await chatSessionService.resolveNegotiatorSession(user.id, negotiatorAgent.name);
+      if ('error' in resolved) {
+        return Response.json({ error: resolved.error }, { status: resolved.status });
+      }
+      currentSessionId = resolved.session.id;
+      sessionPersona = NEGOTIATOR_PERSONA_ID;
+    } else if (!currentSessionId) {
       const initialTitle = body.prefillMessages?.length
         ? "Set Up Your Social Agent"
         : undefined;
@@ -261,6 +299,17 @@ export class ChatController {
       if (!loadedSession) {
         return Response.json({ error: "Session not found" }, { status: 404 });
       }
+      sessionPersona = loadedSession.persona ?? "orchestrator";
+      if (sessionPersona === NEGOTIATOR_PERSONA_ID) {
+        if (!isNegotiatorChatEnabled()) {
+          return Response.json({ error: "Not found" }, { status: 404 });
+        }
+        if (requestedScope) {
+          return Response.json({ error: "Negotiator chat cannot be scoped" }, { status: 400 });
+        }
+      } else if (requestedPersona === NEGOTIATOR_PERSONA_ID) {
+        return Response.json({ error: "Session persona mismatch" }, { status: 409 });
+      }
       const persistedScope = sessionScope(loadedSession);
       if (requestedScope && persistedScope && !sameScope(requestedScope, persistedScope)) {
         return Response.json({ error: "Session is already scoped differently" }, { status: 409 });
@@ -275,9 +324,18 @@ export class ChatController {
     const effectiveScopeError = await validateScope(effectiveScope);
     if (effectiveScopeError) return effectiveScopeError;
 
+    if (sessionPersona === NEGOTIATOR_PERSONA_ID && !negotiatorAgent) {
+      negotiatorAgent = await resolveNegotiatorAgent(user.id);
+      if (!negotiatorAgent) {
+        return Response.json({ error: "Negotiator agent not available" }, { status: 404 });
+      }
+    }
+
     // Capture for closure
     const sessionId = currentSessionId;
-    const factory = chatSessionService.getGraphFactory();
+    const factory = sessionPersona === NEGOTIATOR_PERSONA_ID && negotiatorAgent
+      ? chatSessionService.getNegotiatorGraphFactory(negotiatorAgent)
+      : chatSessionService.getGraphFactory();
     const useCheckpointer = body.useCheckpointer ?? true;
     const runId = crypto.randomUUID();
     const streamAbortController = new AbortController();
@@ -565,8 +623,8 @@ export class ChatController {
   @Get("/sessions")
   @UseGuards(RateLimit('read'), AuthGuard)
   async getSessions(req: Request, user: AuthenticatedUser) {
-    // Optional persona filter (e.g. ?persona=orchestrator). Omitted → all sessions,
-    // which is today's behavior (every existing session is 'orchestrator').
+    // Optional persona filter (e.g. ?persona=orchestrator). Omitted → all
+    // sessions except the negotiator DM, which is a pinned surface, not history.
     const personaParam = new URL(req.url).searchParams.get("persona")?.trim();
     const sessions = await chatSessionService.getUserSessions(
       user.id,
@@ -574,6 +632,40 @@ export class ChatController {
       personaParam || undefined,
     );
     return Response.json({ sessions });
+  }
+
+  /**
+   * Get-or-create the user's stable negotiator DM session (P4.1).
+   * Idempotent: repeat calls return the same session — one persistent DM per
+   * user, keyed by the chat_session_scopes unique index. Gated by
+   * NEGOTIATOR_CHAT_ENABLED (404 when off, as if the route does not exist).
+   *
+   * @param _req - The HTTP request object (no body)
+   * @param user - The authenticated user from AuthGuard
+   * @returns JSON with the session, whether it was created, and the negotiator agent identity
+   */
+  @Post("/negotiator/session")
+  @UseGuards(RateLimit('write'), AuthGuard)
+  async negotiatorSession(_req: Request, user: AuthenticatedUser) {
+    if (!isNegotiatorChatEnabled()) {
+      return Response.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const agent = await resolveNegotiatorAgent(user.id);
+    if (!agent) {
+      return Response.json({ error: "Negotiator agent not available" }, { status: 404 });
+    }
+
+    const result = await chatSessionService.resolveNegotiatorSession(user.id, agent.name);
+    if ('error' in result) {
+      return Response.json({ error: result.error }, { status: result.status });
+    }
+
+    return Response.json({
+      session: result.session,
+      created: result.created,
+      agent: { id: agent.id, name: agent.name, description: agent.description },
+    });
   }
 
   /**

--- a/services/api/src/controllers/tests/chat.negotiator.spec.ts
+++ b/services/api/src/controllers/tests/chat.negotiator.spec.ts
@@ -1,0 +1,315 @@
+/**
+ * P4.1 negotiator chat persona — controller/service/adapter integration tests.
+ *
+ * Covers the IND-402 acceptance criteria that live in the API layer:
+ * - NEGOTIATOR_CHAT_ENABLED=false → negotiator endpoints 404 (as if absent)
+ * - get-or-create is idempotent: two calls → same sessionId, one session row,
+ *   persona='negotiator', title = the personal negotiator agent's name
+ * - the negotiator DM is excluded from the default /chat/sessions listing and
+ *   visible with an explicit ?persona=negotiator filter
+ * - streaming a negotiator session runs on the negotiator persona factory
+ *   (client-scoped, loop behaviors off) and persists the turn
+ * - scope params are rejected for negotiator sessions; persona/session
+ *   mismatches are rejected
+ *
+ * Uses the real database adapters against the test DB; the graph factory is
+ * stubbed (no LLM).
+ */
+import { config } from "dotenv";
+config({ path: '.env.test', override: true });
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { eq } from "drizzle-orm/sql";
+import { ChatController } from "../chat.controller";
+import { AuthController } from "../auth.controller";
+import { UserDatabaseAdapter, conversationDatabaseAdapter } from "../../adapters/database.adapter";
+import { chatSessionService } from "../../services/chat.service";
+import type { ChatGraphFactory, ChatPersonaConfig } from "@indexnetwork/protocol";
+import db from "../../lib/drizzle/drizzle";
+import { agents } from "../../schemas/database.schema";
+import type { AuthenticatedUser } from "../../guards/auth.guard";
+
+const EMAIL = "test-chat-negotiator@example.com";
+
+describe("Negotiator chat persona (IND-402)", () => {
+  let controller: ChatController;
+  const userAdapter = new UserDatabaseAdapter();
+  let testUserId: string;
+  let prevFlag: string | undefined;
+  const createdSessionIds: string[] = [];
+
+  /** Personas captured whenever the controller derives a persona factory. */
+  const capturedPersonas: ChatPersonaConfig[] = [];
+  /** Inputs captured from streamChatEventsWithContext calls. */
+  const capturedStreamInputs: Array<{ userId: string; sessionId: string; message: string }> = [];
+
+  const stubFactory = {
+    withPersona(persona: ChatPersonaConfig) {
+      capturedPersonas.push(persona);
+      return stubFactory;
+    },
+    async *streamChatEventsWithContext(input: { userId: string; sessionId: string; message: string }) {
+      capturedStreamInputs.push(input);
+      yield { type: "token", content: "Here is " };
+      yield { type: "token", content: "the record." };
+      yield { type: "response_complete", response: "Here is the record." };
+    },
+  } as unknown as ChatGraphFactory;
+
+  const mockUser = (): AuthenticatedUser => ({
+    id: testUserId,
+    email: EMAIL,
+    name: "Test Negotiator User",
+  });
+
+  const negotiatorSessionReq = () =>
+    new Request("http://localhost/chat/negotiator/session", { method: "POST" });
+
+  const streamReq = (body: Record<string, unknown>) =>
+    new Request("http://localhost/chat/stream", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ useCheckpointer: false, ...body }),
+    });
+
+  beforeAll(async () => {
+    prevFlag = process.env.NEGOTIATOR_CHAT_ENABLED;
+
+    const existingUser = await userAdapter.findByEmail(EMAIL);
+    if (existingUser) {
+      await db.delete(agents).where(eq(agents.ownerId, existingUser.id));
+      await userAdapter.deleteByEmail(EMAIL);
+    }
+
+    const user = await userAdapter.create({
+      email: EMAIL,
+      name: "Test Negotiator User",
+    });
+    testUserId = user.id;
+
+    chatSessionService.setFactory(stubFactory);
+    controller = new ChatController();
+  });
+
+  afterAll(async () => {
+    if (prevFlag === undefined) delete process.env.NEGOTIATOR_CHAT_ENABLED;
+    else process.env.NEGOTIATOR_CHAT_ENABLED = prevFlag;
+
+    for (const sessionId of createdSessionIds) {
+      await conversationDatabaseAdapter.deleteChatSession(sessionId).catch(() => {});
+    }
+    if (testUserId) {
+      await db.delete(agents).where(eq(agents.ownerId, testUserId));
+      await userAdapter.deleteById(testUserId);
+    }
+  });
+
+  // ── Flag surface on the session bootstrap ──────────────────────────────
+
+  test("features.negotiatorChat on /auth/me tracks the flag", async () => {
+    const authController = new AuthController();
+    const meReq = () => new Request("http://localhost/auth/me");
+
+    process.env.NEGOTIATOR_CHAT_ENABLED = 'false';
+    const offRes = await authController.me(meReq(), mockUser());
+    expect(offRes.status).toBe(200);
+    const offData = (await offRes.json()) as { features: { negotiatorChat: boolean } };
+    expect(offData.features.negotiatorChat).toBe(false);
+
+    process.env.NEGOTIATOR_CHAT_ENABLED = 'true';
+    const onRes = await authController.me(meReq(), mockUser());
+    const onData = (await onRes.json()) as { features: { negotiatorChat: boolean } };
+    expect(onData.features.negotiatorChat).toBe(true);
+  }, 60000);
+
+  // ── Flag off: endpoints behave as if they do not exist ────────────────────
+
+  test("flag off → get-or-create endpoint returns 404", async () => {
+    process.env.NEGOTIATOR_CHAT_ENABLED = 'false';
+    const res = await controller.negotiatorSession(negotiatorSessionReq(), mockUser());
+    expect(res.status).toBe(404);
+  }, 60000);
+
+  test("flag off → streaming with persona=negotiator returns 404", async () => {
+    process.env.NEGOTIATOR_CHAT_ENABLED = 'false';
+    const res = await controller.messageStream(
+      streamReq({ message: "hello", persona: "negotiator" }),
+      mockUser(),
+    );
+    expect(res.status).toBe(404);
+  }, 60000);
+
+  // ── Flag on: get-or-create is idempotent ──────────────────────────────────
+
+  test("get-or-create is idempotent: same sessionId, persona and title from the agent row", async () => {
+    process.env.NEGOTIATOR_CHAT_ENABLED = 'true';
+
+    const first = await controller.negotiatorSession(negotiatorSessionReq(), mockUser());
+    expect(first.status).toBe(200);
+    const firstData = (await first.json()) as {
+      session: { id: string; persona: string; title: string | null; scopeType: string | null };
+      created: boolean;
+      agent: { id: string; name: string };
+    };
+    createdSessionIds.push(firstData.session.id);
+
+    expect(firstData.created).toBe(true);
+    expect(firstData.session.persona).toBe("negotiator");
+    // Provisioned agent row drives identity and the session title.
+    expect(firstData.agent.name).toBe("Test's Negotiator");
+    expect(firstData.session.title).toBe("Test's Negotiator");
+    // The persona registry key must not leak as a chat scope.
+    expect(firstData.session.scopeType).toBeNull();
+
+    const second = await controller.negotiatorSession(negotiatorSessionReq(), mockUser());
+    expect(second.status).toBe(200);
+    const secondData = (await second.json()) as { session: { id: string }; created: boolean };
+    expect(secondData.created).toBe(false);
+    expect(secondData.session.id).toBe(firstData.session.id);
+
+    // Exactly one negotiator session row for the user.
+    const stable = await conversationDatabaseAdapter.getNegotiatorChatSession(testUserId);
+    expect(stable?.id).toBe(firstData.session.id);
+  }, 60000);
+
+  // ── History exclusion ──────────────────────────────────────────────────────
+
+  test("negotiator DM is excluded from default /chat/sessions and visible with ?persona=negotiator", async () => {
+    process.env.NEGOTIATOR_CHAT_ENABLED = 'true';
+
+    // A regular orchestrator session shows up in history.
+    const orchestratorSessionId = await chatSessionService.createSession(testUserId, "Regular chat");
+    createdSessionIds.push(orchestratorSessionId);
+
+    const negotiatorSessionId = (await conversationDatabaseAdapter.getNegotiatorChatSession(testUserId))!.id;
+
+    const defaultRes = await controller.getSessions(
+      new Request("http://localhost/chat/sessions"),
+      mockUser(),
+    );
+    const defaultData = (await defaultRes.json()) as { sessions: Array<{ id: string }> };
+    const defaultIds = defaultData.sessions.map((s) => s.id);
+    expect(defaultIds).toContain(orchestratorSessionId);
+    expect(defaultIds).not.toContain(negotiatorSessionId);
+
+    const filteredRes = await controller.getSessions(
+      new Request("http://localhost/chat/sessions?persona=negotiator"),
+      mockUser(),
+    );
+    const filteredData = (await filteredRes.json()) as { sessions: Array<{ id: string; persona: string }> };
+    expect(filteredData.sessions.map((s) => s.id)).toContain(negotiatorSessionId);
+    expect(filteredData.sessions.every((s) => s.persona === "negotiator")).toBe(true);
+  }, 60000);
+
+  // ── Streaming ──────────────────────────────────────────────────────────────
+
+  test("streaming with persona=negotiator uses the negotiator persona factory and persists the turn", async () => {
+    process.env.NEGOTIATOR_CHAT_ENABLED = 'true';
+    capturedPersonas.length = 0;
+    capturedStreamInputs.length = 0;
+
+    const res = await controller.messageStream(
+      streamReq({ message: "Why did you pass on the fintech intro?", persona: "negotiator" }),
+      mockUser(),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("text/event-stream");
+
+    const negotiatorSessionId = (await conversationDatabaseAdapter.getNegotiatorChatSession(testUserId))!.id;
+    expect(res.headers.get("X-Session-Id")).toBe(negotiatorSessionId);
+
+    const sse = await res.text();
+    expect(sse).toContain("token");
+    expect(sse).toContain("done");
+
+    // The negotiator persona (not the orchestrator default) drove the run.
+    expect(capturedPersonas.length).toBe(1);
+    expect(capturedPersonas[0].id).toBe("negotiator");
+    expect(capturedPersonas[0].loopBehaviors.createIntentCallback).toBe(false);
+    expect(capturedPersonas[0].loopBehaviors.hallucinationRecovery).toBe(false);
+
+    expect(capturedStreamInputs.length).toBe(1);
+    expect(capturedStreamInputs[0].sessionId).toBe(negotiatorSessionId);
+    expect(capturedStreamInputs[0].userId).toBe(testUserId);
+
+    // Turn persisted on the negotiator session.
+    const messages = await chatSessionService.getSessionMessages(negotiatorSessionId);
+    const contents = messages.map((m) => m.content);
+    expect(contents).toContain("Why did you pass on the fintech intro?");
+    expect(contents).toContain("Here is the record.");
+  }, 60000);
+
+  test("streaming an existing negotiator session by sessionId alone also uses the negotiator persona", async () => {
+    process.env.NEGOTIATOR_CHAT_ENABLED = 'true';
+    capturedPersonas.length = 0;
+
+    const negotiatorSessionId = (await conversationDatabaseAdapter.getNegotiatorChatSession(testUserId))!.id;
+    const res = await controller.messageStream(
+      streamReq({ message: "Status update please", sessionId: negotiatorSessionId }),
+      mockUser(),
+    );
+    expect(res.status).toBe(200);
+    await res.text();
+
+    expect(capturedPersonas.length).toBe(1);
+    expect(capturedPersonas[0].id).toBe("negotiator");
+  }, 60000);
+
+  test("flag off → streaming an existing negotiator session returns 404", async () => {
+    const negotiatorSessionId = (await conversationDatabaseAdapter.getNegotiatorChatSession(testUserId))!.id;
+    process.env.NEGOTIATOR_CHAT_ENABLED = 'false';
+
+    const res = await controller.messageStream(
+      streamReq({ message: "hello", sessionId: negotiatorSessionId }),
+      mockUser(),
+    );
+    expect(res.status).toBe(404);
+  }, 60000);
+
+  // ── Guardrails ─────────────────────────────────────────────────────────────
+
+  test("negotiator chat cannot be scoped", async () => {
+    process.env.NEGOTIATOR_CHAT_ENABLED = 'true';
+    const res = await controller.messageStream(
+      streamReq({
+        message: "hello",
+        persona: "negotiator",
+        scopeType: "network",
+        scopeId: "00000000-0000-0000-0000-000000000000",
+      }),
+      mockUser(),
+    );
+    expect(res.status).toBe(400);
+    const data = (await res.json()) as { error: string };
+    expect(data.error).toContain("cannot be scoped");
+  }, 60000);
+
+  test("persona=negotiator with an orchestrator session is a 409 mismatch", async () => {
+    process.env.NEGOTIATOR_CHAT_ENABLED = 'true';
+    const orchestratorSessionId = await chatSessionService.createSession(testUserId, "Mismatch test");
+    createdSessionIds.push(orchestratorSessionId);
+
+    const res = await controller.messageStream(
+      streamReq({ message: "hello", sessionId: orchestratorSessionId, persona: "negotiator" }),
+      mockUser(),
+    );
+    expect(res.status).toBe(409);
+  }, 60000);
+
+  test("orchestrator streaming path never derives a persona factory", async () => {
+    process.env.NEGOTIATOR_CHAT_ENABLED = 'true';
+    capturedPersonas.length = 0;
+
+    const orchestratorSessionId = await chatSessionService.createSession(testUserId, "Plain chat");
+    createdSessionIds.push(orchestratorSessionId);
+
+    const res = await controller.messageStream(
+      streamReq({ message: "hello", sessionId: orchestratorSessionId }),
+      mockUser(),
+    );
+    expect(res.status).toBe(200);
+    await res.text();
+
+    expect(capturedPersonas.length).toBe(0);
+  }, 60000);
+});

--- a/services/api/src/lib/negotiator-feature.ts
+++ b/services/api/src/lib/negotiator-feature.ts
@@ -1,0 +1,18 @@
+/**
+ * Negotiator chat feature flag (P4.1 / IND-402).
+ *
+ * Gates the negotiator persona chat surface: the get-or-create negotiator
+ * session endpoint and negotiator-persona streaming. When off, those code
+ * paths behave as if they do not exist (404), and the flag is surfaced as
+ * `features.negotiatorChat = false` on the `/auth/me` bootstrap response so
+ * the web app can gate the sidebar entry (P4.4 / IND-411) without a new
+ * config channel.
+ *
+ * Disabled when unset: the feature is OFF unless `NEGOTIATOR_CHAT_ENABLED` is
+ * exactly the string `"true"`. This is a fail-closed default.
+ */
+
+/** @returns true when the negotiator chat surface is enabled. */
+export function isNegotiatorChatEnabled(): boolean {
+  return process.env.NEGOTIATOR_CHAT_ENABLED === 'true';
+}

--- a/services/api/src/services/agent.service.ts
+++ b/services/api/src/services/agent.service.ts
@@ -79,6 +79,18 @@ export class AgentService {
     });
   }
 
+  /**
+   * Resolve the user's personal negotiator agent row (`type='personal'`),
+   * provisioning it when missing — `ensureNegotiatorAgent` is idempotent.
+   * Returns null for ghost or missing users, which callers treat as
+   * "negotiator not available" (404-equivalent).
+   */
+  async getNegotiatorAgent(userId: string): Promise<AgentRow | null> {
+    const agentId = await this.db.ensureNegotiatorAgent(userId);
+    if (!agentId) return null;
+    return this.db.getAgent(agentId);
+  }
+
   async getById(agentId: string, userId: string): Promise<AgentWithRelations> {
     const agent = await this.db.getAgentWithRelations(agentId);
     if (!agent) {

--- a/services/api/src/services/chat.service.ts
+++ b/services/api/src/services/chat.service.ts
@@ -1,7 +1,7 @@
 import { log } from '../lib/log';
 import { conversationDatabaseAdapter, ConversationDatabaseAdapter, ChatDatabaseAdapter } from '../adapters/database.adapter';
 import type { ChatScopeType } from '../adapters/database.shared';
-import { ChatGraphFactory, ChatTitleGenerator } from '@indexnetwork/protocol';
+import { ChatGraphFactory, ChatTitleGenerator, NEGOTIATOR_PERSONA_ID, createNegotiatorPersona } from '@indexnetwork/protocol';
 import type { ChatGraphCompositeDatabase } from '@indexnetwork/protocol';
 import { getCheckpointer } from '../adapters/checkpointer.adapter';
 import { HumanMessage } from '@langchain/core/messages';
@@ -222,6 +222,36 @@ export class ChatSessionService {
     }
   }
 
+  /**
+   * Resolve or create the user's stable negotiator DM session (P4.1).
+   * Idempotent: repeat calls return the same session. Race-safe via the
+   * chat_session_scopes unique index (concurrent creates re-read on 23505).
+   *
+   * @param userId - The client user
+   * @param title - Session title used on first creation (the negotiator agent's name)
+   */
+  async resolveNegotiatorSession(
+    userId: string,
+    title?: string,
+  ): Promise<{ session: NonNullable<Awaited<ReturnType<ChatSessionService['getSession']>>>; created: boolean } | { error: string; status: 500 }> {
+    const existing = await this.db.getNegotiatorChatSession(userId);
+    if (existing) return { session: existing, created: false };
+
+    try {
+      const id = crypto.randomUUID();
+      await this.db.createNegotiatorChatSession({ id, userId, title });
+      const session = await this.getSession(id, userId);
+      if (!session) return { error: 'Failed to create negotiator session', status: 500 as const };
+      return { session, created: true };
+    } catch (err) {
+      if (this.isUniqueViolation(err)) {
+        const raced = await this.db.getNegotiatorChatSession(userId);
+        if (raced) return { session: raced, created: false };
+      }
+      throw err;
+    }
+  }
+
   private isUniqueViolation(err: unknown): boolean {
     return typeof err === 'object' && err !== null && 'code' in err && (err as { code?: unknown }).code === '23505';
   }
@@ -257,7 +287,10 @@ export class ChatSessionService {
   async getUserSessions(userId: string, limit = 10, persona?: string) {
     logger.verbose('Getting user sessions', { userId, limit, persona });
 
-    return this.db.getUserChatSessions(userId, limit, persona);
+    // The negotiator DM is a pinned surface, not history: without an explicit
+    // persona filter it is excluded from the recent-sessions listing.
+    const excludePersona = persona ? undefined : NEGOTIATOR_PERSONA_ID;
+    return this.db.getUserChatSessions(userId, limit, persona, excludePersona);
   }
 
   /**
@@ -434,6 +467,22 @@ export class ChatSessionService {
    */
   getGraphFactory(): ChatGraphFactory {
     return this.factory;
+  }
+
+  /**
+   * Derive a negotiator-persona graph factory bound to the client's personal
+   * negotiator agent identity. Shares all dependencies with the orchestrator
+   * factory; only prompt/toolset/loop behaviors differ.
+   *
+   * @param agent - Identity from the user's `type='personal'` agent row
+   */
+  getNegotiatorGraphFactory(agent: { name: string; description?: string | null }): ChatGraphFactory {
+    return this.factory.withPersona(
+      createNegotiatorPersona({
+        agentName: agent.name,
+        ...(agent.description?.trim() ? { agentDescription: agent.description } : {}),
+      }),
+    );
   }
 
   /**

--- a/services/api/src/services/tests/chat.service.spec.ts
+++ b/services/api/src/services/tests/chat.service.spec.ts
@@ -185,7 +185,7 @@ describe("ChatSessionService.getSession", () => {
 // ─── getUserSessions ──────────────────────────────────────────────────────────
 
 describe("ChatSessionService.getUserSessions", () => {
-  it("delegates to db and returns sessions", async () => {
+  it("delegates to db and returns sessions, excluding the negotiator DM by default", async () => {
     const sessions = [makeSession(), makeSession({ id: "session-002" })];
     const db = createMockDb({
       getUserChatSessions: mock(() => Promise.resolve(sessions)),
@@ -195,7 +195,7 @@ describe("ChatSessionService.getUserSessions", () => {
     const result = await svc.getUserSessions(USER_ID, 10);
 
     expect(result).toEqual(sessions);
-    expect(db.getUserChatSessions).toHaveBeenCalledWith(USER_ID, 10, undefined);
+    expect(db.getUserChatSessions).toHaveBeenCalledWith(USER_ID, 10, undefined, "negotiator");
   });
 
   it("passes the persona filter through to the adapter", async () => {
@@ -208,7 +208,7 @@ describe("ChatSessionService.getUserSessions", () => {
     const result = await svc.getUserSessions(USER_ID, 10, "orchestrator");
 
     expect(result).toEqual(sessions);
-    expect(db.getUserChatSessions).toHaveBeenCalledWith(USER_ID, 10, "orchestrator");
+    expect(db.getUserChatSessions).toHaveBeenCalledWith(USER_ID, 10, "orchestrator", undefined);
   });
 });
 


### PR DESCRIPTION
## Summary

**P4.1 (IND-402)**: a direct chat line between a user and their **personal negotiator agent** (the `type='personal'` row from IND-410), built as a *pure persona addition* on the P4.0 persona-neutral chat runtime (IND-412). Backend only; **zero migration**; flag-gated **off by default**; orchestrator behavior untouched.

## Protocol

- **`negotiator.prompt.ts`** — advocate system prompt bound to the personal agent row identity (name/description), grounded in the preloaded client user/profile context. Explicit rules: report/explain from the negotiation record only, act on a negotiation **only on explicit client instruction**, no network-wide discovery, never fabricate.
- **`negotiator.persona.ts`** — `NEGOTIATOR_PERSONA_ID = 'negotiator'`; client-scoped tool allowlist (`list_negotiations`, `get_negotiation`, `respond_to_negotiation`, `list_opportunities`, `read_intents`, `read_premises`); `createNegotiatorTools` reuses `createChatTools` and filters to the allowlist so context resolution, ownership binding (`context.userId`), logging, and error handling stay identical; `createNegotiatorPersona()` with **all loop behaviors OFF** (no create-intent callback, no hallucination auto-invoke/strip).
- **`ChatGraphFactory.withPersona()`** — derive a sibling factory sharing all deps; the negotiator persona is per-session because its identity comes from the agent row.

## API

- **`POST /chat/negotiator/session`** — idempotent get-or-create of the single persistent negotiator DM per user (the P4.4/IND-411 frontend contract). Returns `{ session, created, agent }`. **Race-safe with zero migration**: uniqueness rides the existing `chat_session_scopes (user_id, scope_type, scope_id)` unique index using the registry key `('persona','negotiator')` — deliberately outside the `ChatScopeType` envelope, so `_normalizeScopeType` ignores it and the session presents as a normal unscoped chat session with `persona='negotiator'` (P4.0 column). 23505 races resolve by re-read, mirroring `resolveSessionForScope`.
- **`/chat/stream`** — new optional `persona: 'negotiator'` body param bootstraps the DM in one call (curl-SSE smoke-testable); any session with `persona='negotiator'` always runs on the negotiator factory regardless of params. Scope params rejected (400); `persona` vs. session mismatch → 409; flag off → 404 even for existing sessions.
- **`/chat/sessions`** — negotiator DM **excluded from the default listing** (pinned surface, not history); visible with explicit `?persona=negotiator`. `listChatSessionSummaries` (MCP `listSessions` / chat-summary surface) also excludes it so the orchestrator never sees the negotiator DM.
- **`NEGOTIATOR_CHAT_ENABLED`** (fail-closed, `.env.example` documented) — endpoints 404 when off, as if absent; surfaced as `features.negotiatorChat` on `GET /auth/me` (the session bootstrap the web app already reads) for the P4.4 sidebar gate.
- **`agentService.getNegotiatorAgent()`** — ensure+fetch of the personal agent row (null for ghosts → 404-equivalent), keeping the controller behind the controllers→services boundary.

## Tests

- `packages/protocol/src/chat/tests/negotiator.persona.spec.ts` (**13 pass**): persona id + loop behaviors off; prompt identity (agent name/description, client grounding, not the orchestrator prompt, no discovery tools); allowlist filter drops every discovery/network/write-the-world tool and is idempotent.
- `services/api/src/controllers/tests/chat.negotiator.spec.ts` (**11 pass**, DB-backed, stubbed graph factory): flag gating on both endpoints + `features.negotiatorChat` on `/auth/me`; get-or-create idempotency (same sessionId, one row, `persona='negotiator'`, title = agent name, no scope leak); default history exclusion + explicit filter; streaming runs on the negotiator persona (id + behaviors asserted) and persists the turn; existing-session streaming; scope rejection (400), mismatch (409); orchestrator path never derives a persona factory.
- `chat.service.spec.ts` updated for the default negotiator exclusion (adapter called with `excludePersona='negotiator'`).
- Regression: protocol `src/chat/` = **28 fails, identical to dev baseline** (known LLM-key/mock-contamination set, zero new); `chat.controller.spec` + `decisionQuestions` + `conversation.persona.spec` + `auth.controller.spec` all green; protocol tsc / api tsc / api build exit 0; lint 0 errors (47 warnings = baseline).

## Deployment

- No migration. Flag unset on dev → feature dormant; enabling is config-only (`NEGOTIATOR_CHAT_ENABLED=true` on Railway).
- Deployed check plan: flip flag on dev → `curl -N POST /chat/stream {"message":"…","persona":"negotiator"}` → grounded SSE answer; `select persona, count(*) from conversations group by 1` shows negotiator rows only for bootstrapped DMs; default `/chat/sessions` payload unchanged.

Refs IND-402 (unblocks IND-403, IND-404, IND-411).
