### PR TITLE
feat(web): pinned Personal Agent sidebar entry for the negotiator DM (IND-411)

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useRef, useCallback } from 'react';
 import { useNavigate, useLocation } from 'react-router';
 import { Link } from 'react-router';
-import { Compass, MessagesSquare, ChevronDown, Settings, LogOut, History, Network, Bot, CircleHelp } from 'lucide-react';
+import { Compass, MessagesSquare, ChevronDown, Settings, LogOut, History, Network, Bot, BotMessageSquare, CircleHelp } from 'lucide-react';
 import { useAuthContext } from '@/contexts/AuthContext';
 import { useNetworkFilter } from '@/contexts/IndexFilterContext';
 import { useAIChatSessions } from '@/contexts/AIChatSessionsContext';
@@ -32,7 +32,7 @@ interface ChatSession {
 export default function Sidebar() {
   const navigate = useNavigate();
   const { pathname } = useLocation();
-  const { user, signOut } = useAuthContext();
+  const { user, features, signOut } = useAuthContext();
   useConversation();
   const totalUnreadCount = 0; // Unread tracking out of scope for now
   const { sessionsVersion } = useAIChatSessions();
@@ -53,17 +53,24 @@ export default function Sidebar() {
   const userDropdownRef = useRef<HTMLDivElement>(null);
   const { count: pendingQuestionsCount } = useQuestions();
 
+  // Pinned negotiator DM (IND-411). Flag-gated: the entry renders only when
+  // the backend reports the negotiator chat feature enabled on /auth/me.
+  const negotiatorEnabled = features?.negotiatorChat === true;
+  const [negotiatorSession, setNegotiatorSession] = useState<{ id: string; title: string | null } | null>(null);
+  const [openingNegotiator, setOpeningNegotiator] = useState(false);
+
+  // Get current AI session ID from pathname (e.g., /d/abc123 -> abc123)
+  const currentSessionId = pathname?.match(/^\/d\/([^/]+)/)?.[1] || null;
+
   const isMessagesView = pathname === '/chat' || (pathname?.includes('/chat') && pathname?.startsWith('/u/'));
   const isNetworksView = pathname?.startsWith('/networks');
-  const isHistoryView = pathname?.startsWith('/d/');
+  const isNegotiatorView = !!negotiatorSession && currentSessionId === negotiatorSession.id;
+  const isHistoryView = pathname?.startsWith('/d/') && !isNegotiatorView;
   const isSettingsView = pathname?.startsWith('/settings');
   const isAgentsView = pathname?.startsWith('/agents') || pathname?.startsWith('/agent');
   const isMyNetworkView = pathname?.startsWith('/mynetwork');
   const isQuestionsView = pathname?.startsWith('/questions');
-  const isHomeView = !isMessagesView && !isNetworksView && !isHistoryView && !isSettingsView && !isAgentsView && !isMyNetworkView && !isQuestionsView;
-
-  // Get current AI session ID from pathname (e.g., /d/abc123 -> abc123)
-  const currentSessionId = pathname?.match(/^\/d\/([^/]+)/)?.[1] || null;
+  const isHomeView = !isMessagesView && !isNetworksView && !isHistoryView && !isNegotiatorView && !isSettingsView && !isAgentsView && !isMyNetworkView && !isQuestionsView;
 
   const handleCreateIndex = useCallback(async (indexData: { name: string; prompt?: string; imageUrl?: string | null; joinPolicy?: 'anyone' | 'invite_only'; isExperiment?: boolean; type?: 'community' | 'event'; metadata?: Record<string, unknown> }) => {
     try {
@@ -138,6 +145,53 @@ export default function Sidebar() {
       setNavigatingToChat(false);
     }
   };
+
+  // Resolve the existing negotiator DM (if bootstrapped) so the pinned entry
+  // can show the agent's name and highlight when active — without creating a
+  // session as a side effect of rendering the sidebar.
+  useEffect(() => {
+    if (!user?.id || !negotiatorEnabled) return;
+    let active = true;
+    apiClient
+      .get<{ sessions: ChatSession[] }>('/chat/sessions?persona=negotiator')
+      .then((data) => {
+        if (!active) return;
+        const session = data.sessions?.[0];
+        if (session) setNegotiatorSession({ id: session.id, title: session.title });
+      })
+      .catch((error) => {
+        logger.error('Failed to fetch negotiator session', { error });
+      });
+    return () => { active = false; };
+  }, [user?.id, negotiatorEnabled]);
+
+  // One persistent DM per user: get-or-create on click, then navigate to the
+  // regular session route. Repeat clicks and reloads land in the same session.
+  const handleNegotiatorClick = async () => {
+    if (!user?.id || openingNegotiator) return;
+    if (negotiatorSession) {
+      navigate(`/d/${negotiatorSession.id}`);
+      return;
+    }
+    setOpeningNegotiator(true);
+    try {
+      const { session, agent } = await apiClient.post<{
+        session: { id: string; title: string | null };
+        created: boolean;
+        agent: { id: string; name: string; description: string | null };
+      }>('/chat/negotiator/session');
+      setNegotiatorSession({ id: session.id, title: session.title ?? agent.name });
+      navigate(`/d/${session.id}`);
+    } catch (err) {
+      logger.error('Failed to open negotiator chat', { error: err });
+      error('Failed to open Personal Agent chat');
+    } finally {
+      setOpeningNegotiator(false);
+    }
+  };
+
+  const negotiatorLabel = negotiatorSession?.title
+    || (user?.name ? `${user.name.split(' ')[0]}'s Negotiator` : 'Personal Agent');
 
   // Fetch AI chat sessions (cookie-based auth; credentials sent automatically)
   useEffect(() => {
@@ -221,6 +275,24 @@ export default function Sidebar() {
           )}
         </button>
 
+        {/* Pinned Personal Agent DM (IND-411) — flag-gated, above History; a
+            pinned surface, not a history entry (backend excludes it from
+            /chat/sessions). */}
+        {negotiatorEnabled && (
+          <button
+            onClick={handleNegotiatorClick}
+            disabled={openingNegotiator}
+            className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-md text-sm transition-colors ${
+              isNegotiatorView
+                ? 'bg-gray-100 text-black font-bold'
+                : 'text-black font-medium hover:bg-gray-50'
+            } ${openingNegotiator ? 'opacity-50 cursor-wait' : ''}`}
+          >
+            <BotMessageSquare className="w-5 h-5" />
+            <span className="flex-1 text-left truncate">{negotiatorLabel}</span>
+          </button>
+        )}
+
         {/* History menu item with submenu */}
         <div>
           <button
@@ -244,7 +316,7 @@ export default function Sidebar() {
               ) : chatSessions.length === 0 ? (
                 <div className="text-sm text-gray-400 py-2">No conversations yet</div>
               ) : (
-                chatSessions.map((session) => {
+                chatSessions.filter((session) => session.id !== negotiatorSession?.id).map((session) => {
                   const isSelected = currentSessionId === session.id;
                   const sessionIndex = session.networkId ? indexes.find(i => i.id === session.networkId) : null;
                   return (

--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -9,11 +9,21 @@ import { log } from '@/lib/logger';
 
 const logger = log.context.from('AuthContext');
 
+/**
+ * Server-driven feature flags returned alongside the user on GET /auth/me
+ * (sibling of `user`, not part of it). `negotiatorChat` gates the pinned
+ * Personal Agent entry in the sidebar (IND-411).
+ */
+export type UserFeatures = {
+  negotiatorChat?: boolean;
+};
+
 type AuthContextType = {
   isReady: boolean;
   isLoading: boolean;
   isAuthenticated: boolean;
   user: User | null;
+  features: UserFeatures | null;
   userLoading: boolean;
   error: string | null;
   refetchUser: () => Promise<void>;
@@ -29,6 +39,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const [isLoading, setIsLoading] = useState(true);
   const [user, setUser] = useState<User | null>(null);
+  const [features, setFeatures] = useState<UserFeatures | null>(null);
   const [userLoading, setUserLoading] = useState(false);
   const [userFetchAttempted, setUserFetchAttempted] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -64,9 +75,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUserFetchAttempted(true);
     setError(null);
     try {
-      const response = await api.get<APIResponse<User>>('/auth/me');
+      const response = await api.get<APIResponse<User> & { features?: UserFeatures }>('/auth/me');
       if (response.user) {
         setUser(response.user);
+        setFeatures(response.features ?? null);
 
         const browserTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
         if (browserTimezone && response.user.timezone !== browserTimezone) {
@@ -94,6 +106,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           logger.error('Failed to clear stale auth session', { error: signOutError });
         });
         setUser(null);
+        setFeatures(null);
         setUserFetchAttempted(false);
         setError(null);
         return;
@@ -101,6 +114,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
       setError('Failed to load user data. Please try refreshing the page.');
       setUser(null);
+      setFeatures(null);
     } finally {
       setUserLoading(false);
     }
@@ -111,6 +125,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       fetchUser();
     } else if (!authenticated) {
       setUser(null);
+      setFeatures(null);
       setUserLoading(false);
       setUserFetchAttempted(false);
       setError(null);
@@ -173,6 +188,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         isLoading,
         isAuthenticated: authenticated,
         user,
+        features,
         userLoading,
         error,
         refetchUser: fetchUser,

--- a/apps/web/tests/auth-context.test.tsx
+++ b/apps/web/tests/auth-context.test.tsx
@@ -2,7 +2,7 @@ import { screen } from '@testing-library/react';
 import { useLocation } from 'react-router';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { AuthProvider } from '@/contexts/AuthContext';
+import { AuthProvider, useAuthContext } from '@/contexts/AuthContext';
 import { renderWithRouter } from '@/test/test-utils';
 
 const mocks = vi.hoisted(() => {
@@ -61,6 +61,15 @@ function LocationProbe() {
   return <div data-testid="location">{location.pathname}</div>;
 }
 
+function FeaturesProbe() {
+  const { features } = useAuthContext();
+  return (
+    <div data-testid="features">
+      {features === null ? 'null' : JSON.stringify(features)}
+    </div>
+  );
+}
+
 function renderAuthProviderAt(route: string) {
   return renderWithRouter(
     <AuthProvider>
@@ -100,6 +109,37 @@ describe('AuthProvider onboarding routing', () => {
 
     expect(await screen.findByTestId('location')).toHaveTextContent('/');
     expect(mocks.apiClient.get).not.toHaveBeenCalled();
+  });
+
+  test('captures the sibling features object from /auth/me', async () => {
+    mocks.apiClient.get.mockResolvedValue({
+      user: incompleteUser(),
+      features: { negotiatorChat: true },
+    });
+
+    renderWithRouter(
+      <AuthProvider>
+        <FeaturesProbe />
+      </AuthProvider>,
+      { route: '/networks' }
+    );
+
+    expect(await screen.findByTestId('features')).toHaveTextContent('{"negotiatorChat":true}');
+  });
+
+  test('features stays null when /auth/me omits the features object', async () => {
+    mocks.apiClient.get.mockResolvedValue({ user: incompleteUser() });
+
+    renderWithRouter(
+      <AuthProvider>
+        <FeaturesProbe />
+      </AuthProvider>,
+      { route: '/networks' }
+    );
+
+    // Wait for the user fetch to settle, then assert features stayed null.
+    await screen.findByTestId('features');
+    expect(await screen.findByTestId('features')).toHaveTextContent('null');
   });
 
   test('opens the login modal with a preserved callbackURL when an unauthenticated user hits a protected deep link', async () => {

--- a/apps/web/tests/sidebar-negotiator.test.tsx
+++ b/apps/web/tests/sidebar-negotiator.test.tsx
@@ -1,0 +1,218 @@
+/**
+ * Pinned Personal Agent (negotiator DM) sidebar entry (IND-411).
+ *
+ * Verifies the flag-gated pinned entry: hidden when the backend does not
+ * report `features.negotiatorChat`, visible and labeled from the negotiator
+ * agent row when it does, get-or-create on first click, direct navigation on
+ * subsequent clicks, and exclusion of the negotiator DM from the history list.
+ */
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { useLocation } from 'react-router';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import Sidebar from '@/components/Sidebar';
+import { renderWithRouter } from '@/test/test-utils';
+
+const mocks = vi.hoisted(() => {
+  const apiClient = {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  };
+  return {
+    apiClient,
+    authState: {
+      user: null as Record<string, unknown> | null,
+      features: null as Record<string, unknown> | null,
+    },
+  };
+});
+
+vi.mock('@/lib/api', () => ({
+  apiClient: mocks.apiClient,
+  useAuthenticatedAPI: () => mocks.apiClient,
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuthContext: () => ({
+    isReady: true,
+    isLoading: false,
+    isAuthenticated: !!mocks.authState.user,
+    user: mocks.authState.user,
+    features: mocks.authState.features,
+    userLoading: false,
+    error: null,
+    refetchUser: vi.fn(),
+    updateUser: vi.fn(),
+    openLoginModal: vi.fn(),
+    signOut: vi.fn(),
+  }),
+}));
+
+vi.mock('@/contexts/IndexFilterContext', () => ({
+  useNetworkFilter: () => ({
+    selectedNetworkIds: [],
+    setSelectedNetworkIds: vi.fn(),
+  }),
+}));
+
+vi.mock('@/contexts/AIChatSessionsContext', () => ({
+  useAIChatSessions: () => ({ sessionsVersion: 0, refetchSessions: vi.fn() }),
+}));
+
+vi.mock('@/contexts/AIChatContext', () => ({
+  useAIChat: () => new Proxy({}, { get: () => vi.fn() }),
+}));
+
+vi.mock('@/contexts/ConversationContext', () => ({
+  useConversation: () => new Proxy({}, { get: () => vi.fn() }),
+}));
+
+vi.mock('@/contexts/IndexesContext', () => ({
+  useNetworksState: () => ({ indexes: [], addIndex: vi.fn() }),
+}));
+
+vi.mock('@/contexts/APIContext', () => {
+  const noopService = new Proxy({}, { get: () => vi.fn().mockResolvedValue([]) });
+  return {
+    useNetworks: () => noopService,
+    useOpportunities: () => noopService,
+  };
+});
+
+vi.mock('@/contexts/NotificationContext', () => ({
+  useNotifications: () => ({
+    success: vi.fn(),
+    error: vi.fn(),
+    addNotification: vi.fn(),
+  }),
+}));
+
+vi.mock('@/contexts/QuestionsContext', () => ({
+  useQuestions: () => ({ count: 0 }),
+}));
+
+vi.mock('@/components/modals/CreateIndexModal', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/components/MasterKeyDialog', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/components/UserAvatar', () => ({
+  default: () => <div data-testid="avatar" />,
+}));
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname}</div>;
+}
+
+function renderSidebar(route = '/') {
+  return renderWithRouter(
+    <>
+      <Sidebar />
+      <LocationProbe />
+    </>,
+    { route }
+  );
+}
+
+const aliceUser = { id: 'user-1', name: 'Alice Smith', avatar: null };
+
+/** Route apiClient.get by endpoint: history list vs pinned negotiator lookup. */
+function mockSessions({
+  history = [],
+  negotiator = [],
+}: {
+  history?: Array<Record<string, unknown>>;
+  negotiator?: Array<Record<string, unknown>>;
+}) {
+  mocks.apiClient.get.mockImplementation((endpoint: string) => {
+    if (endpoint === '/chat/sessions?persona=negotiator') {
+      return Promise.resolve({ sessions: negotiator });
+    }
+    if (endpoint === '/chat/sessions') {
+      return Promise.resolve({ sessions: history });
+    }
+    return Promise.resolve({});
+  });
+}
+
+describe('Sidebar pinned Personal Agent entry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.authState.user = aliceUser;
+    mocks.authState.features = null;
+    mockSessions({});
+  });
+
+  test('flag off → no negotiator entry, no persona lookup', async () => {
+    renderSidebar();
+
+    // Let the history-session fetch settle.
+    await waitFor(() => expect(mocks.apiClient.get).toHaveBeenCalledWith('/chat/sessions'));
+
+    expect(screen.queryByText(/Negotiator|Personal Agent/)).toBeNull();
+    expect(mocks.apiClient.get).not.toHaveBeenCalledWith('/chat/sessions?persona=negotiator');
+  });
+
+  test('flag on, no session yet → entry visible with derived label; click get-or-creates and navigates', async () => {
+    mocks.authState.features = { negotiatorChat: true };
+    mocks.apiClient.post.mockResolvedValue({
+      session: { id: 'neg-session-1', title: "Alice's Negotiator" },
+      created: true,
+      agent: { id: 'agent-1', name: "Alice's Negotiator", description: null },
+    });
+
+    renderSidebar();
+
+    const entry = await screen.findByText("Alice's Negotiator");
+    fireEvent.click(entry);
+
+    await waitFor(() =>
+      expect(mocks.apiClient.post).toHaveBeenCalledWith('/chat/negotiator/session')
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('location')).toHaveTextContent('/d/neg-session-1')
+    );
+  });
+
+  test('flag on, existing session → label from session title; click navigates without POST', async () => {
+    mocks.authState.features = { negotiatorChat: true };
+    mockSessions({
+      negotiator: [{ id: 'neg-session-1', title: "Alice's Negotiator", networkId: null, createdAt: '', updatedAt: '' }],
+    });
+
+    renderSidebar();
+
+    const entry = await screen.findByText("Alice's Negotiator");
+    fireEvent.click(entry);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('location')).toHaveTextContent('/d/neg-session-1')
+    );
+    expect(mocks.apiClient.post).not.toHaveBeenCalled();
+  });
+
+  test('negotiator session never renders in the history list', async () => {
+    mocks.authState.features = { negotiatorChat: true };
+    mockSessions({
+      // Defensive path: even if the backend ever leaked the negotiator DM
+      // into the history payload, the sidebar filters it out of History.
+      history: [
+        { id: 'neg-session-1', title: "Alice's Negotiator", networkId: null, createdAt: '', updatedAt: '' },
+        { id: 'other-1', title: 'Other chat', networkId: null, createdAt: '', updatedAt: '' },
+      ],
+      negotiator: [{ id: 'neg-session-1', title: "Alice's Negotiator", networkId: null, createdAt: '', updatedAt: '' }],
+    });
+
+    renderSidebar();
+
+    await screen.findByText('Other chat');
+    // Exactly one occurrence: the pinned entry, not a history row.
+    expect(screen.getAllByText("Alice's Negotiator")).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

First user-facing surface of the negotiator chat (Client-Advocate Protocol, IND-395): a **flag-gated pinned "Personal Agent" entry in the web sidebar** that opens the user's persistent negotiator DM shipped in IND-402 (#1097).

Closes IND-411.

## What changed

### `apps/web/src/contexts/AuthContext.tsx`
- Captures the **sibling `features` object** from `GET /auth/me` (it is not part of `user`) and exposes `features.negotiatorChat` on the auth context. Cleared on sign-out/stale-auth paths.

### `apps/web/src/components/Sidebar.tsx`
- New pinned entry **above the History section** (sibling of "Chat"), rendered only when `features.negotiatorChat === true`. Distinct `BotMessageSquare` icon.
- **Label**: negotiator session title (= agent row name, e.g. "Yanki's Negotiator"); before the DM exists, falls back to `"{firstName}'s Negotiator"` derived from the user's name (matches the server-side agent naming pattern), then "Personal Agent".
- **One persistent DM**: on mount (flag on) the sidebar resolves an existing DM via `GET /chat/sessions?persona=negotiator` — no session creation as a render side effect. First click calls `POST /chat/negotiator/session` (idempotent get-or-create) and navigates to the regular `/d/{sessionId}` route; subsequent clicks/reloads navigate straight to the same session.
- **Never in history**: backend already excludes the DM from `/chat/sessions`; the sidebar additionally filters it defensively. Active-state highlighting moves to the pinned entry (not History) when the DM is open.
- Mobile works via the existing hamburger drawer (same `Sidebar` component on all app routes).

### Reused as-is (zero changes)
`ChatContent`/`AIChatContext` streaming: `/d/{id}` loads the session normally (`POST /chat/session` is ownership-checked, not flag-gated) and `POST /chat/stream {sessionId}` routes to the negotiator persona server-side — session persona is the source of truth (IND-402).

## Flag-off behavior

Pixel-identical sidebar: `features` is `null`, the entry doesn't render, and the `?persona=negotiator` lookup never fires.

## Tests

- **New** `apps/web/tests/sidebar-negotiator.test.tsx` (4): flag off → no entry, no persona lookup; flag on + no session → derived label, click get-or-creates + navigates; flag on + existing session → label from title, click navigates without POST; negotiator DM filtered from History.
- **Extended** `apps/web/tests/auth-context.test.tsx` (+2): sibling `features` captured; stays `null` when omitted.
- Full web vitest run: my 10 specs pass; remaining failures (`routes.test.tsx` collection error, 12 DecisionQuestions specs) are **identical on clean dev** (broken `src/types` symlink, pre-existing).
- `vite build` green; eslint on touched files: 0 errors, warnings = dev baseline.

## Deploy note

`NEGOTIATOR_CHAT_ENABLED` is unset on dev → feature stays dark after merge. Flipping the flag on the protocol service makes the entry appear with no frontend redeploy needed.
