### PR TITLE
feat(protocol): negotiator toolset expansion — signals, knowledge writes, joins, contacts (IND-413)

### DIFF
--- a/packages/protocol/src/chat/negotiator.persona.ts
+++ b/packages/protocol/src/chat/negotiator.persona.ts
@@ -21,19 +21,64 @@ export const NEGOTIATOR_PERSONA_ID = "negotiator";
 /**
  * Client-scoped tool allowlist for the negotiator persona.
  *
- * Deliberately excludes every network-facing capability: no discovery
- * (`discover_opportunities`), no network/membership management, no profile or
- * intent writes, no contact import. This agent works for one client; as the
- * orchestrator sunsets, network-facing capabilities migrate here deliberately
- * (out of scope for P4.1).
+ * P4.5 (IND-413) expanded this from the read-mostly P4.1 set: with direct
+ * opportunity discovery retiring alongside the orchestrator, discovery is
+ * purely signal-based — so the negotiator (the surviving personal-agent chat
+ * surface) manages the client's signals, profile knowledge, memberships, and
+ * contacts.
+ *
+ * Still deliberately excluded:
+ * - discovery runs (`discover_opportunities`, `get/cancel_discovery_run`) —
+ *   retired capability; matching happens in the background from signals,
+ * - whole-network administration (`create/update/delete_network`) — a
+ *   human/UI act for now (joins/leaves are allowed),
+ * - onboarding plumbing (`complete_onboarding`,
+ *   `record_onboarding_privacy_consent`),
+ * - agent management (`register/update/delete_agent`, permission grants),
+ * - `confirm_opportunity_delivery` (OpenClaw ledger write, never chat).
  */
 export const NEGOTIATOR_TOOL_NAMES = [
+  // Negotiation record — the advocate core (P4.1)
   "list_negotiations",
   "get_negotiation",
   "respond_to_negotiation",
   "list_opportunities",
+  "update_opportunity",
+  // Signals — the input surface of signal-based discovery (P4.5)
   "read_intents",
+  "create_intent",
+  "update_intent",
+  "delete_intent",
+  "search_intents",
+  "read_intent_indexes",
+  "create_intent_index",
+  "delete_intent_index",
+  // Profile knowledge (P4.5)
+  "read_user_contexts",
+  "create_user_context",
+  "update_user_context",
+  "confirm_user_context",
+  "preview_user_context",
+  // Premises (P4.5; read was already in P4.1)
   "read_premises",
+  "create_premise",
+  "update_premise",
+  "retract_premise",
+  // Networks — joins/leaves only, no network administration (P4.5)
+  "read_networks",
+  "read_network_memberships",
+  "create_network_membership",
+  "delete_network_membership",
+  // Contacts — dormant while CONTACTS_ENABLED=false (P4.5)
+  "list_contacts",
+  "search_contacts",
+  "add_contact",
+  "remove_contact",
+  "import_contacts",
+  "import_gmail_contacts",
+  // Utility — create_intent's own contract instructs scraping pasted URLs
+  // before synthesizing a signal description (P4.5)
+  "scrape_url",
 ] as const;
 
 const NEGOTIATOR_TOOL_ALLOWLIST: ReadonlySet<string> = new Set(NEGOTIATOR_TOOL_NAMES);
@@ -68,10 +113,17 @@ export async function createNegotiatorTools(
  * Creates a negotiator `ChatPersonaConfig` bound to the client's personal
  * negotiator agent row identity.
  *
- * Loop behaviors are all OFF: no create-intent callback and no
- * hallucinated-block auto-invoke/strip — the negotiator's toolset cannot
- * legitimately produce opportunity/intent-proposal blocks, and it must never
- * inherit the orchestrator's discovery auto-invocation.
+ * Loop behaviors (P4.5):
+ * - `hallucinationRecovery: true` — with `create_intent` in the toolset the
+ *   model can legitimately produce ```intent_proposal blocks, so unbacked
+ *   blocks must be detected/auto-invoked/stripped. The auto-invoke path is
+ *   confirm-safe: `create_intent` returns a proposal card that persists
+ *   nothing until the client approves it in the UI. A hallucinated
+ *   ```opportunity block maps to `discover_opportunities`, which is absent
+ *   from this toolset — the loop falls back to a correction message and the
+ *   final-response strip still removes the unbacked block.
+ * - `createIntentCallback: false` — discovery-coupled (fires only off
+ *   `discover_opportunities` results); retired along with direct discovery.
  *
  * @param opts - Identity from the user's `type='personal'` agent row
  */
@@ -82,7 +134,7 @@ export function createNegotiatorPersona(opts: NegotiatorPromptOptions): ChatPers
     createTools: (deps, preResolvedContext) => createNegotiatorTools(deps, preResolvedContext),
     loopBehaviors: {
       createIntentCallback: false,
-      hallucinationRecovery: false,
+      hallucinationRecovery: true,
     },
   };
 }

--- a/packages/protocol/src/chat/negotiator.prompt.ts
+++ b/packages/protocol/src/chat/negotiator.prompt.ts
@@ -9,8 +9,13 @@ import type { IterationContext } from "./chat.prompt.modules.js";
 // (the `type='personal'` agent row). Unlike the orchestrator prompt, this
 // persona works for exactly one client: it reports on the client's
 // negotiations and opportunities, explains decisions from the negotiation
-// record, and acts only on explicit client instruction. It has no
-// network-wide discovery capabilities.
+// record, and acts only on explicit client instruction.
+//
+// P4.5 (IND-413): the negotiator also manages the client's signals, profile
+// knowledge, premises, community memberships, and contacts — discovery is
+// purely signal-based, so shaping signals here IS how the client steers
+// matching. It still has no direct discovery capability: matching runs in
+// the background from the signals.
 
 /** Identity options resolved from the user's personal negotiator agent row. */
 export interface NegotiatorPromptOptions {
@@ -53,13 +58,16 @@ You work for exactly one client: ${ctx.userName}. You represent them in negotiat
 ## What you do in this chat
 - **Report on negotiations**: when the client asks what is happening, look up their negotiations and summarize status, counterparties, and where things stand.
 - **Explain decisions**: when the client asks why something was pursued, declined, or stalled ("why did you pass on X?"), find the relevant negotiation and answer from the actual record — the messages, outcomes, and reasoning stored there. Never reconstruct a rationale from memory.
-- **Review opportunities**: show the client the opportunities currently waiting on them and what accepting or passing would mean.
-- **Stay grounded in their signals**: their active intents and premises define what you negotiate for. Read them before making claims about what the client is looking for.
-- **Act on instruction**: respond to a negotiation (accept, decline, or reply) only when the client explicitly tells you to in this conversation. Never take a negotiation action the client did not just ask for.
+- **Review and act on opportunities**: show the client the opportunities currently waiting on them and what accepting or passing would mean; accept or pass on one only when they explicitly say so.
+- **Manage their signals**: their active intents (signals) define what you negotiate for — and matching is driven entirely by them. When the client tells you what they are looking for, draft a clear, specific signal and create it; refine or retire signals when they ask. If a signal request is vague, read their profile and existing signals first, then propose a sharper wording before creating it. If they paste a link describing what they want, read it first and synthesize the signal from its content.
+- **Keep their knowledge current**: when the client shares a new fact about themselves ("I moved to Berlin", "I stopped consulting"), update their profile context or premises so future negotiations reflect reality. Read before you write — update the existing entry instead of duplicating it.
+- **Handle memberships**: list the communities they belong to and join or leave communities when they ask.
+- **Manage their contacts**: look up, add, remove, or import contacts when they ask (when contact features are enabled).
+- **Act on instruction**: every write — a negotiation response, an opportunity decision, a signal, a profile or premise change, a membership change, a contact change — happens only when the client explicitly asks for it in this conversation. Never write anything the client did not just ask for.
 
 ## What you cannot do here
-- **No network-wide discovery.** You cannot look for new people, run matching, or create new connections from this chat. New matches are discovered by the system in the background and appear on the client's home page.
-- **No profile, community, or membership management.** If the client asks for those, tell them plainly that it is outside your remit as their negotiator and they can do it from the main chat or the app.
+- **No direct discovery.** You cannot run matching or search for people yourself. Matching happens automatically in the background from the client's signals — shaping the signals is how you steer it. New matches appear on the client's home page and in this chat as opportunities.
+- **No community administration.** You can join or leave communities for the client, but you cannot create, rename, or delete communities — point them to the app for that.
 - You cannot push updates after this conversation ends. You only report when asked.
 
 ## Session
@@ -83,14 +91,26 @@ ${profileContext}
 | **get_negotiation** | negotiationId | Full negotiation record: messages, outcome, reasoning |
 | **respond_to_negotiation** | negotiationId, ... | Act on a negotiation — ONLY on explicit client instruction |
 | **list_opportunities** | — | List the client's actionable opportunities |
-| **read_intents** | — | The client's active signals (what they're looking for) |
-| **read_premises** | — | The client's premises (facts they've established) |
+| **update_opportunity** | opportunityId, status | Accept/pass an opportunity — ONLY on explicit client instruction |
+| **read_intents** / **search_intents** | — / query | The client's active signals (what they're looking for) |
+| **create_intent** | description, networkId? | Draft a new signal — returns a proposal card the client approves in the UI |
+| **update_intent** / **delete_intent** | intentId, ... | Refine or retire a signal on instruction |
+| **read_intent_indexes** / **create_intent_index** / **delete_intent_index** | intentId, networkId | Where a signal is placed across communities |
+| **read_user_contexts** / **create_user_context** / **update_user_context** | ... | The client's profile knowledge — read before writing |
+| **preview_user_context** / **confirm_user_context** | ... | Preview/confirm profile updates from sources |
+| **read_premises** / **create_premise** / **update_premise** / **retract_premise** | ... | The client's premises (facts they've established) |
+| **read_networks** / **read_network_memberships** | — | The client's communities and memberships |
+| **create_network_membership** / **delete_network_membership** | networkId | Join/leave a community on instruction |
+| **list_contacts** / **search_contacts** / **add_contact** / **remove_contact** | ... | The client's contacts |
+| **import_contacts** / **import_gmail_contacts** | ... | Bulk contact import on instruction |
+| **scrape_url** | url, objective | Read a link the client pasted (e.g. before drafting a signal from it) |
 
 ## Grounding rules
 - **Never fabricate.** Every claim about a negotiation, opportunity, signal, or premise must come from a tool result in this conversation. If you have not looked it up this turn, look it up before answering. Only the client's identity and profile above are preloaded.
 - **Check tool results before confirming.** Never claim an action succeeded without a successful tool result for it.
 - **Be honest about your own actions.** If the record shows you made a judgment call the client disagrees with, explain the reasoning from the record — do not get defensive, and do not invent justifications the record does not support.
-- **Never expose IDs, UUIDs, tool names, or raw JSON** to the client. Translate everything into natural language; refer to people and opportunities by name.
+- **Pass proposal cards through verbatim.** When a tool result contains a fenced code block meant for the app (e.g. \`\`\`intent_proposal from create_intent), include that block verbatim in your reply — the app renders it as an interactive card the client approves or skips. Never write such a block yourself without a backing tool result.
+- **Never expose IDs, UUIDs, tool names, or raw JSON** to the client. Translate everything into natural language; refer to people and opportunities by name. (Fenced proposal blocks from tool results are the one exception — they are rendered as cards, not shown as JSON.)
 - **Respond in the language of the client's latest message.**
 - **Voice**: first person, loyal but candid, calm and concise. No hype, no networking clichés, no exaggeration. You are their agent, not a salesperson.
 - When calling tools, first write a short natural sentence plus a \`>\` blockquote describing what you are checking (e.g. "> Checking the record with Alice"), then leave an empty line after the blockquote.`;

--- a/packages/protocol/src/chat/tests/negotiator.persona.spec.ts
+++ b/packages/protocol/src/chat/tests/negotiator.persona.spec.ts
@@ -2,10 +2,14 @@
  * P4.1 negotiator persona — client-scoped persona unit tests.
  *
  * The negotiator persona is a pure addition on the P4.0 persona seam:
- * advocate prompt bound to the personal agent row identity, client-scoped
- * tool allowlist, and every orchestrator loop behavior OFF. These tests pin
- * down the persona config shape, the prompt's identity/grounding content,
- * and the tool-scoping rule (no discovery / network / write-the-world tools).
+ * advocate prompt bound to the personal agent row identity and a
+ * client-scoped tool allowlist. P4.5 (IND-413) expanded the allowlist —
+ * signals, profile/premise writes, network joins, contacts — and enabled
+ * hallucinationRecovery (create_intent makes ```intent_proposal blocks
+ * legitimate). Direct discovery, network administration, onboarding
+ * plumbing, and agent management stay excluded. These tests pin down the
+ * persona config shape, the prompt's identity/grounding content, and the
+ * tool-scoping rule.
  *
  * No LLM calls, no DB, no module mocks.
  */
@@ -53,10 +57,14 @@ describe("createNegotiatorPersona", () => {
     expect(persona.id).not.toBe(ORCHESTRATOR_PERSONA_ID);
   });
 
-  it("has every orchestrator loop behavior OFF", () => {
+  it("keeps the discovery-coupled loop behavior OFF and hallucination recovery ON (P4.5)", () => {
     const persona = createNegotiatorPersona(AGENT_OPTS);
+    // createIntentCallback only fires off discover_opportunities results —
+    // discovery is retired for this persona, so it must stay off.
     expect(persona.loopBehaviors.createIntentCallback).toBe(false);
-    expect(persona.loopBehaviors.hallucinationRecovery).toBe(false);
+    // With create_intent in the toolset, ```intent_proposal blocks are
+    // legitimate output — unbacked ones must be detected and stripped.
+    expect(persona.loopBehaviors.hallucinationRecovery).toBe(true);
   });
 
   it("builds its prompt from the negotiator prompt module", () => {
@@ -82,11 +90,11 @@ describe("buildNegotiatorSystemContent", () => {
 
   it("is not the orchestrator identity", () => {
     expect(prompt).not.toContain("You are Index.");
-    // No orchestrator-only capabilities in the tool table.
+    // Retired/excluded capabilities never appear in the tool table.
     expect(prompt).not.toContain("discover_opportunities");
-    expect(prompt).not.toContain("create_intent");
-    expect(prompt).not.toContain("read_networks");
-    expect(prompt).not.toContain("import_gmail_contacts");
+    expect(prompt).not.toContain("create_network ");
+    expect(prompt).not.toContain("complete_onboarding");
+    expect(prompt).not.toContain("register_agent");
   });
 
   it("includes the preloaded client context", () => {
@@ -121,7 +129,10 @@ const ORCHESTRATOR_REGISTRY_NAMES = [
   "read_user_contexts",
   "create_user_context",
   "update_user_context",
+  "preview_user_context",
+  "confirm_user_context",
   "complete_onboarding",
+  "record_onboarding_privacy_consent",
   // intents
   "read_intents",
   "create_intent",
@@ -138,18 +149,21 @@ const ORCHESTRATOR_REGISTRY_NAMES = [
   "delete_network",
   "read_network_memberships",
   "create_network_membership",
+  "delete_network_membership",
   // opportunities / discovery
   "discover_opportunities",
   "list_opportunities",
   "update_opportunity",
   "get_discovery_run",
   "cancel_discovery_run",
+  "confirm_opportunity_delivery",
   // utilities / integrations / contacts / agents
   "scrape_url",
   "read_docs",
   "import_gmail_contacts",
   "import_contacts",
   "list_contacts",
+  "search_contacts",
   "add_contact",
   "remove_contact",
   "register_agent",
@@ -180,17 +194,52 @@ describe("filterNegotiatorTools", () => {
     expect(new Set(filteredNames)).toEqual(new Set(NEGOTIATOR_TOOL_NAMES));
   });
 
-  it("drops every discovery and network-facing tool", () => {
-    for (const banned of [
-      "discover_opportunities",
-      "read_networks",
-      "create_network",
-      "create_network_membership",
+  it("keeps the P4.5 capability groups (signals, knowledge writes, joins, contacts)", () => {
+    for (const allowed of [
       "create_intent",
-      "update_opportunity",
+      "update_intent",
+      "delete_intent",
+      "search_intents",
+      "create_user_context",
+      "update_user_context",
+      "create_premise",
+      "retract_premise",
+      "read_networks",
+      "create_network_membership",
+      "delete_network_membership",
+      "list_contacts",
+      "import_contacts",
       "import_gmail_contacts",
-      "register_agent",
+      "update_opportunity",
       "scrape_url",
+    ]) {
+      expect(filteredNames).toContain(allowed);
+    }
+  });
+
+  it("drops every retired/excluded tool", () => {
+    for (const banned of [
+      // discovery is retired — matching is signal-based
+      "discover_opportunities",
+      "get_discovery_run",
+      "cancel_discovery_run",
+      // network administration stays a human/UI act
+      "create_network",
+      "update_network",
+      "delete_network",
+      // onboarding plumbing
+      "complete_onboarding",
+      "record_onboarding_privacy_consent",
+      // agent management
+      "register_agent",
+      "update_agent",
+      "delete_agent",
+      "grant_agent_permission",
+      "revoke_agent_permission",
+      // never chat-callable
+      "confirm_opportunity_delivery",
+      "read_docs",
+      "ask_user_question",
     ]) {
       expect(filteredNames).not.toContain(banned);
     }
@@ -200,10 +249,12 @@ describe("filterNegotiatorTools", () => {
     expect(filterNegotiatorTools(filtered)).toEqual(filtered);
   });
 
-  it("the allowlist itself contains no discovery/network tool names", () => {
+  it("the allowlist itself contains no retired or admin tool names", () => {
     const names = new Set<string>(NEGOTIATOR_TOOL_NAMES);
     expect(names.has("discover_opportunities")).toBe(false);
-    expect(names.has("read_networks")).toBe(false);
-    expect(names.has("create_intent")).toBe(false);
+    expect(names.has("create_network")).toBe(false);
+    expect(names.has("delete_network")).toBe(false);
+    expect(names.has("complete_onboarding")).toBe(false);
+    expect(names.has("register_agent")).toBe(false);
   });
 });

--- a/services/api/src/controllers/tests/chat.negotiator.spec.ts
+++ b/services/api/src/controllers/tests/chat.negotiator.spec.ts
@@ -225,8 +225,10 @@ describe("Negotiator chat persona (IND-402)", () => {
     // The negotiator persona (not the orchestrator default) drove the run.
     expect(capturedPersonas.length).toBe(1);
     expect(capturedPersonas[0].id).toBe("negotiator");
+    // P4.5 (IND-413): discovery-coupled callback stays off; hallucination
+    // recovery is on now that create_intent makes proposal blocks legitimate.
     expect(capturedPersonas[0].loopBehaviors.createIntentCallback).toBe(false);
-    expect(capturedPersonas[0].loopBehaviors.hallucinationRecovery).toBe(false);
+    expect(capturedPersonas[0].loopBehaviors.hallucinationRecovery).toBe(true);
 
     expect(capturedStreamInputs.length).toBe(1);
     expect(capturedStreamInputs[0].sessionId).toBe(negotiatorSessionId);


### PR DESCRIPTION
## Summary

First deliberate capability migration from the orchestrator to the negotiator (Client-Advocate Protocol, IND-395). Product direction: **direct opportunity discovery retires alongside the orchestrator — discovery becomes purely signal-based**. That makes intents the only steering wheel for matching, so the negotiator DM must be able to manage them (and the rest of the client's own data).

Closes IND-413.

## What changed

### `packages/protocol/src/chat/negotiator.persona.ts`
`NEGOTIATOR_TOOL_NAMES` grows 6 → 33, grouped:

| Group | Tools |
|---|---|
| Negotiation core (P4.1, unchanged) | `list_negotiations`, `get_negotiation`, `respond_to_negotiation`, `list_opportunities` |
| **Signals** (the core enabler) | `read_intents`, `create_intent`, `update_intent`, `delete_intent`, `search_intents`, `read_intent_indexes`, `create_intent_index`, `delete_intent_index` |
| **Profile knowledge** | `read/create/update/preview/confirm_user_context` |
| **Premises** | `create/update/retract_premise` (read was already in) |
| **Networks — joins/leaves only** | `read_networks`, `read_network_memberships`, `create_network_membership`, `delete_network_membership` |
| **Contacts** | `list/search/add/remove_contact`, `import_contacts`, `import_gmail_contacts` — dormant while `CONTACTS_ENABLED=false` |

**Two additions beyond the issue's literal list — flagging for approval:**
- `update_opportunity` — "accept that opportunity for me" is the most advocate-like action there is; parity with `respond_to_negotiation`. Same explicit-instruction contract.
- `scrape_url` — `create_intent`'s own tool contract instructs scraping pasted URLs before synthesizing a signal description; without it, link-based signal creation degrades.

**Still excluded** (spec-pinned): `discover_opportunities` + discovery runs (retired), `create/update/delete_network` (administration stays human/UI), onboarding plumbing, agent management, `confirm_opportunity_delivery`, `read_docs`, `ask_user_question`.

### Loop behaviors
- `hallucinationRecovery: true` — with `create_intent` in the toolset, ` ```intent_proposal ` blocks are legitimate output; unbacked ones are now detected/auto-invoked/stripped. **Confirm-safe**: `create_intent` returns a proposal card that persists nothing until the client approves it in the UI (verified in `intent.tools.ts` — `autoApprove` defaults off for web chat). A hallucinated ` ```opportunity ` block maps to `discover_opportunities`, which is absent → the loop falls back to a correction message and the final-response strip removes the block (verified in `chat.agent.ts` tool-not-found branch).
- `createIntentCallback: false` — fires only off `discover_opportunities` results (`createIntentSuggested`); retired path, dead without the tool.

### `negotiator.prompt.ts`
New capability sections (signal management incl. vague-request refinement + URL synthesis, knowledge upkeep with read-before-write, memberships, contacts) — with the advocate write contract **generalized**: *every* write (negotiation response, opportunity decision, signal, profile/premise, membership, contact) only on explicit client instruction. Proposal cards passed through verbatim (rendered as interactive approve/skip cards by the existing ChatContent UI in the DM). "No direct discovery" and "no community administration" stated plainly.

## Deployability

Allowlist + prompt + loop-flag only. No migration, no new env var — rides `NEGOTIATOR_CHAT_ENABLED` (currently **on** on dev). Orchestrator persona byte-identical. All added tools are context-bound to `context.userId` via the shared factory — no new ownership surface.

## Tests

- `negotiator.persona.spec.ts` — 14 pass: capability groups present, every excluded tool absent (discovery trio, network CRUD, onboarding pair, agent tools), loop flags pinned (`createIntentCallback=false`, `hallucinationRecovery=true`), prompt references all 33 tools, idempotent filter.
- `chat.negotiator.spec.ts` (API, DB-backed) — 11 pass; hallucination-recovery pin updated with rationale.
- protocol + api `bun run build` exit 0; eslint clean on touched files.

## Post-merge smoke (flag already on, dev)

In the DM: *"Create a signal that I'm looking for a technical co-founder in Berlin"* → intent-proposal card appears → approve → intent row exists. *"I moved to Berlin, update my profile"* → user context updated. *"Find me people"* → no discovery attempt; explains matching runs from signals.
