### PR TITLE
feat: intent-scoped negotiator chat + intent page embed (IND-403)

### DIFF
--- a/apps/web/src/app/i/[intentId]/page.tsx
+++ b/apps/web/src/app/i/[intentId]/page.tsx
@@ -6,6 +6,8 @@ import ClientLayout from "@/components/ClientLayout";
 import { ContentContainer } from "@/components/layout";
 import OpportunityCard from "@/components/chat/OpportunityCardInChat";
 import { InjectedQuestions } from "@/components/InjectedQuestions/InjectedQuestions";
+import IntentNegotiatorChat from "@/components/IntentNegotiatorChat";
+import { useAuthContext } from "@/contexts/AuthContext";
 import { useIntents, useOpportunities, useQuestionsService } from "@/contexts/APIContext";
 import { useNotifications } from "@/contexts/NotificationContext";
 import { useOpportunityActions } from "@/hooks/useOpportunityActions";
@@ -164,6 +166,7 @@ export default function IntentDetailPage() {
   const opportunitiesService = useOpportunities();
   const questionsService = useQuestionsService();
   const { error: showError } = useNotifications();
+  const { features } = useAuthContext();
 
   const [intent, setIntent] = useState<
     Awaited<ReturnType<typeof intentsService.getIntent>> | null
@@ -176,6 +179,11 @@ export default function IntentDetailPage() {
   const [refining, setRefining] = useState(false);
   const [showRefine, setShowRefine] = useState(false);
   const [selectedBucket, setSelectedBucket] = useState("pending");
+  // Backend-surfaced flag (features on /auth/me): when on, the static
+  // questions block becomes the negotiator chat window (P4.2/IND-403).
+  // `chatUnavailable` is the runtime fallback if the bootstrap fails.
+  const [chatUnavailable, setChatUnavailable] = useState(false);
+  const negotiatorChatEnabled = features?.negotiatorChat === true && !chatUnavailable;
 
   const scope = useMemo(
     () =>
@@ -417,24 +425,47 @@ export default function IntentDetailPage() {
               </div>
 
               <div className="grid grid-cols-1 lg:grid-cols-5 gap-8 items-start">
-                <Panel
-                  title="Questions"
-                  count={questions.length}
-                  description="Answer pending follow-ups for this intent."
-                  className="lg:col-span-2"
-                >
-                  {questions.length === 0 ? (
-                    <div className="text-sm text-gray-500 font-ibm-plex-mono py-8 text-center border border-dashed border-gray-200 rounded-lg">
-                      No pending questions right now.
-                    </div>
-                  ) : (
-                    <InjectedQuestions
+                {negotiatorChatEnabled && intentId ? (
+                  <Panel
+                    title="Personal Agent"
+                    count={questions.length}
+                    description="Chat with your negotiator about this signal."
+                    className="lg:col-span-2"
+                  >
+                    <IntentNegotiatorChat
+                      key={intentId}
+                      intentId={intentId}
                       questions={questions}
-                      onAnswer={handleAnswer}
-                      onDismiss={handleDismiss}
+                      onAnswerQuestion={handleAnswer}
+                      onDismissQuestion={handleDismiss}
+                      opportunityStatusMap={opportunityStatusMap}
+                      opportunityActionLoading={opportunityActionLoading}
+                      onOpportunityAction={(id, action, userId, role, name) =>
+                        handleOpportunityAction(id, action, userId, role, name)
+                      }
+                      onUnavailable={() => setChatUnavailable(true)}
                     />
-                  )}
-                </Panel>
+                  </Panel>
+                ) : (
+                  <Panel
+                    title="Questions"
+                    count={questions.length}
+                    description="Answer pending follow-ups for this intent."
+                    className="lg:col-span-2"
+                  >
+                    {questions.length === 0 ? (
+                      <div className="text-sm text-gray-500 font-ibm-plex-mono py-8 text-center border border-dashed border-gray-200 rounded-lg">
+                        No pending questions right now.
+                      </div>
+                    ) : (
+                      <InjectedQuestions
+                        questions={questions}
+                        onAnswer={handleAnswer}
+                        onDismiss={handleDismiss}
+                      />
+                    )}
+                  </Panel>
+                )}
 
                 <Panel
                   title="Radar"

--- a/apps/web/src/components/IntentNegotiatorChat.tsx
+++ b/apps/web/src/components/IntentNegotiatorChat.tsx
@@ -1,0 +1,266 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ArrowUp, BotMessageSquare, Loader2, Square } from "lucide-react";
+
+import { useAIChat } from "@/contexts/AIChatContext";
+import { InjectedQuestions } from "@/components/InjectedQuestions/InjectedQuestions";
+import AssistantMessageContent from "@/components/chat/AssistantMessageContent";
+import { ToolCallsDisplay } from "@/components/chat/ToolCallsDisplay";
+import type { PendingQuestion, AnswerBody } from "@/services/questions";
+import { apiClient } from "@/lib/api";
+import { cn } from "@/lib/utils";
+import { log } from "@/lib/logger";
+
+const logger = log.ui.from("IntentNegotiatorChat");
+
+export interface IntentNegotiatorChatProps {
+  /** The intent this chat is pinned to. */
+  intentId: string;
+  /** Pending questions for the intent — rendered as the chat's opening turns. */
+  questions: PendingQuestion[];
+  onAnswerQuestion: (questionId: string, body: AnswerBody) => Promise<void>;
+  onDismissQuestion: (questionId: string) => Promise<void>;
+  /** Opportunity card plumbing shared with the page's Radar panel. */
+  opportunityStatusMap: Record<string, string>;
+  opportunityActionLoading: Record<string, boolean>;
+  onOpportunityAction: (
+    opportunityId: string,
+    action: "accepted" | "rejected",
+    userId: string,
+    viewerRole?: string,
+    counterpartName?: string,
+  ) => void;
+  /**
+   * Called when the negotiator chat cannot be bootstrapped (e.g. the backend
+   * flag turned off between /auth/me and now). The parent falls back to the
+   * static questions block.
+   */
+  onUnavailable: () => void;
+}
+
+/**
+ * Intent-pinned negotiator chat (P4.2 / IND-403).
+ *
+ * Replaces the static questions block on the intent page with a chat window
+ * to the user's personal negotiator, pinned to this intent. Pending intent
+ * questions render as the opening turns (cards, answered through the
+ * existing questions pipeline); everything conversational streams through
+ * the shared AIChatContext against the per-intent negotiator session.
+ */
+export default function IntentNegotiatorChat({
+  intentId,
+  questions,
+  onAnswerQuestion,
+  onDismissQuestion,
+  opportunityStatusMap,
+  opportunityActionLoading,
+  onOpportunityAction,
+  onUnavailable,
+}: IntentNegotiatorChatProps) {
+  const {
+    messages,
+    isLoading,
+    sendMessage,
+    stopStream,
+    loadSession,
+    clearChat,
+    sessionId,
+  } = useAIChat();
+
+  const [agentName, setAgentName] = useState<string | null>(null);
+  const [ready, setReady] = useState(false);
+  const [input, setInput] = useState("");
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const clearChatRef = useRef(clearChat);
+  useEffect(() => {
+    clearChatRef.current = clearChat;
+  }, [clearChat]);
+
+  // Intent-proposal card status (lean subset of ChatContent's tracking).
+  const [proposalStatusMap, setProposalStatusMap] = useState<Record<string, "pending" | "created" | "rejected">>({});
+  const [proposalIntentMap, setProposalIntentMap] = useState<Record<string, string>>({});
+
+  // Bootstrap: get-or-create the per-intent negotiator session, then load it
+  // into the shared chat context. One session per (user, intent, persona) —
+  // repeat visits land in the same conversation. The parent remounts this
+  // component per intent (key={intentId}), so state resets are structural.
+  useEffect(() => {
+    let active = true;
+    apiClient
+      .post<{
+        session: { id: string };
+        created: boolean;
+        agent: { id: string; name: string; description: string | null };
+      }>("/chat/negotiator/session", { intentId })
+      .then(async ({ session, agent }) => {
+        if (!active) return;
+        setAgentName(agent.name);
+        await loadSession(session.id);
+        if (active) setReady(true);
+      })
+      .catch((err) => {
+        logger.error("Failed to bootstrap intent negotiator chat", { error: err, intentId });
+        if (active) onUnavailable();
+      });
+    return () => {
+      active = false;
+      // Leave the intent page → release the shared chat context so the
+      // negotiator session does not leak into the home chat.
+      clearChatRef.current({ abortStream: false });
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [intentId]);
+
+  // Follow the stream.
+  useEffect(() => {
+    scrollRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+  }, [messages, questions.length, ready]);
+
+  const handleSend = useCallback(async () => {
+    const text = input.trim();
+    if (!text || isLoading || !ready) return;
+    setInput("");
+    await sendMessage(text);
+  }, [input, isLoading, ready, sendMessage]);
+
+  const handleProposalApprove = useCallback(
+    async (proposalId: string, description: string, networkId?: string) => {
+      const res = await apiClient.post<{ intentId: string }>("/intents/confirm", { proposalId, description, networkId });
+      setProposalStatusMap((prev) => ({ ...prev, [proposalId]: "created" }));
+      setProposalIntentMap((prev) => ({ ...prev, [proposalId]: res.intentId }));
+    },
+    [],
+  );
+
+  const handleProposalReject = useCallback(async (proposalId: string) => {
+    await apiClient.post("/intents/reject", { proposalId });
+    setProposalStatusMap((prev) => ({ ...prev, [proposalId]: "rejected" }));
+  }, []);
+
+  const handleProposalUndo = useCallback(
+    async (proposalId: string) => {
+      const createdIntentId = proposalIntentMap[proposalId];
+      if (!createdIntentId) return;
+      await apiClient.patch(`/intents/${createdIntentId}/archive`);
+      setProposalStatusMap((prev) => ({ ...prev, [proposalId]: "rejected" }));
+    },
+    [proposalIntentMap],
+  );
+
+  const placeholder = agentName ? `Message ${agentName}…` : "Message your negotiator…";
+
+  return (
+    <div className="flex h-[520px] flex-col" data-testid="intent-negotiator-chat">
+      <div className="flex-1 space-y-4 overflow-y-auto pr-1">
+        {!ready ? (
+          <div className="flex justify-center py-10">
+            <Loader2 className="h-5 w-5 animate-spin text-gray-400" />
+          </div>
+        ) : (
+          <>
+            {messages.length === 0 && questions.length === 0 && (
+              <div className="flex items-start gap-2 text-sm text-gray-600 font-ibm-plex-mono">
+                <BotMessageSquare className="mt-0.5 h-4 w-4 shrink-0 text-gray-400" />
+                <p>
+                  This is your direct line to {agentName ?? "your negotiator"} about this signal —
+                  ask what's happening, refine what you're looking for, or answer follow-ups here.
+                </p>
+              </div>
+            )}
+
+            {questions.length > 0 && (
+              <div data-testid="negotiator-opening-questions">
+                <p className="mb-2 text-xs uppercase tracking-wider text-gray-500 font-ibm-plex-mono">
+                  Open questions for this signal
+                </p>
+                <InjectedQuestions
+                  questions={questions}
+                  onAnswer={onAnswerQuestion}
+                  onDismiss={onDismissQuestion}
+                />
+              </div>
+            )}
+
+            {messages.map((msg) =>
+              msg.role === "user" ? (
+                <div key={msg.id} className="flex justify-end">
+                  <div className="max-w-[85%] rounded-2xl rounded-br-md bg-[#041729] px-4 py-2 text-sm text-white whitespace-pre-wrap">
+                    {msg.content}
+                  </div>
+                </div>
+              ) : (
+                <div key={msg.id} className="text-sm text-gray-900">
+                  {msg.traceEvents && msg.traceEvents.length > 0 && (
+                    <ToolCallsDisplay
+                      traceEvents={msg.traceEvents}
+                      isStreaming={msg.isStreaming}
+                      wasStoppedByUser={msg.wasStoppedByUser}
+                      stoppedAt={msg.stoppedAt}
+                    />
+                  )}
+                  <AssistantMessageContent
+                    content={msg.content}
+                    isStreaming={msg.isStreaming ?? false}
+                    onOpportunityPrimaryAction={(id, userId, role, name) =>
+                      onOpportunityAction(id, "accepted", userId, role, name)
+                    }
+                    onOpportunitySecondaryAction={(id, userId, role, name) =>
+                      onOpportunityAction(id, "rejected", userId, role, name)
+                    }
+                    opportunityLoadingMap={opportunityActionLoading}
+                    currentStatusMap={opportunityStatusMap}
+                    onIntentProposalApprove={handleProposalApprove}
+                    onIntentProposalReject={handleProposalReject}
+                    onIntentProposalUndo={handleProposalUndo}
+                    intentProposalStatusMap={proposalStatusMap}
+                  />
+                </div>
+              ),
+            )}
+          </>
+        )}
+        <div ref={scrollRef} />
+      </div>
+
+      <div className="mt-3 flex items-center gap-2 border-t border-gray-100 pt-3">
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              void handleSend();
+            }
+          }}
+          placeholder={placeholder}
+          disabled={!ready}
+          data-testid="negotiator-chat-input"
+          className="flex-1 rounded-full border border-[#E9E9E9] bg-[#FCFCFC] px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#4091BB]/30 disabled:opacity-60"
+        />
+        {isLoading && sessionId ? (
+          <button
+            type="button"
+            onClick={stopStream}
+            aria-label="Stop response"
+            className="shrink-0 rounded-full bg-[#041729] p-2 text-white hover:bg-[#0a2d4a]"
+          >
+            <Square className="h-4 w-4" />
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => void handleSend()}
+            disabled={!ready || !input.trim()}
+            aria-label="Send message"
+            className={cn(
+              "shrink-0 rounded-full bg-[#041729] p-2 text-white hover:bg-[#0a2d4a]",
+              (!ready || !input.trim()) && "cursor-not-allowed opacity-50",
+            )}
+          >
+            <ArrowUp className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -25,6 +25,8 @@ interface ChatSession {
   id: string;
   title: string | null;
   networkId: string | null;
+  /** Canonical scope; intent-pinned negotiator sessions carry 'intent' (IND-403). */
+  scopeType?: 'network' | 'intent' | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -156,7 +158,9 @@ export default function Sidebar() {
       .get<{ sessions: ChatSession[] }>('/chat/sessions?persona=negotiator')
       .then((data) => {
         if (!active) return;
-        const session = data.sessions?.[0];
+        // The pinned entry is the unscoped DM — intent-pinned negotiator
+        // sessions (IND-403) also carry persona=negotiator but have a scope.
+        const session = data.sessions?.find((s) => !s.scopeType);
         if (session) setNegotiatorSession({ id: session.id, title: session.title });
       })
       .catch((error) => {

--- a/apps/web/tests/intent-negotiator-chat.test.tsx
+++ b/apps/web/tests/intent-negotiator-chat.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * Intent-pinned negotiator chat embed (P4.2 / IND-403).
+ *
+ * Component tests for IntentNegotiatorChat: session bootstrap against
+ * POST /chat/negotiator/session { intentId }, load-into-shared-context,
+ * pending questions as opening turns (existing questions pipeline), send
+ * flow, unavailable fallback, and context release on unmount.
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import IntentNegotiatorChat from '@/components/IntentNegotiatorChat';
+import type { PendingQuestion } from '@/services/questions';
+
+const mocks = vi.hoisted(() => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+  chat: {
+    messages: [] as Array<Record<string, unknown>>,
+    isLoading: false,
+    sessionId: null as string | null,
+    sendMessage: vi.fn(),
+    stopStream: vi.fn(),
+    loadSession: vi.fn().mockResolvedValue(undefined),
+    clearChat: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/api', () => ({
+  apiClient: mocks.apiClient,
+  useAuthenticatedAPI: () => mocks.apiClient,
+}));
+
+vi.mock('@/contexts/AIChatContext', () => ({
+  useAIChat: () => mocks.chat,
+}));
+
+vi.mock('@/components/InjectedQuestions/InjectedQuestions', () => ({
+  InjectedQuestions: ({ questions }: { questions: PendingQuestion[] }) => (
+    <div data-testid="injected-questions">
+      {questions.map((q) => (
+        <div key={q.id}>{q.title}</div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('@/components/chat/AssistantMessageContent', () => ({
+  default: ({ content }: { content: string }) => <div data-testid="assistant-content">{content}</div>,
+}));
+
+vi.mock('@/components/chat/ToolCallsDisplay', () => ({
+  ToolCallsDisplay: () => null,
+}));
+
+const SESSION_RESPONSE = {
+  session: { id: 'neg-intent-sess-1' },
+  created: true,
+  agent: { id: 'agent-1', name: "Alice's Negotiator", description: null },
+};
+
+const QUESTION: PendingQuestion = {
+  id: 'q-1',
+  title: 'Which city should we prioritize?',
+  prompt: 'Which city should we prioritize?',
+  options: [],
+  multiSelect: false,
+  mode: 'intent',
+  sourceType: 'intent',
+  sourceId: 'intent-1',
+  createdAt: new Date().toISOString(),
+} as unknown as PendingQuestion;
+
+function renderChat(overrides: Partial<Parameters<typeof IntentNegotiatorChat>[0]> = {}) {
+  const props = {
+    intentId: 'intent-1',
+    questions: [] as PendingQuestion[],
+    onAnswerQuestion: vi.fn(),
+    onDismissQuestion: vi.fn(),
+    opportunityStatusMap: {},
+    opportunityActionLoading: {},
+    onOpportunityAction: vi.fn(),
+    onUnavailable: vi.fn(),
+    ...overrides,
+  };
+  return { ...render(<IntentNegotiatorChat {...props} />), props };
+}
+
+describe('IntentNegotiatorChat', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.chat.messages = [];
+    mocks.chat.isLoading = false;
+    mocks.chat.sessionId = null;
+    mocks.chat.loadSession.mockResolvedValue(undefined);
+    mocks.apiClient.post.mockResolvedValue(SESSION_RESPONSE);
+  });
+
+  test('bootstraps the per-intent session and loads it into the shared context', async () => {
+    renderChat();
+
+    await waitFor(() =>
+      expect(mocks.apiClient.post).toHaveBeenCalledWith('/chat/negotiator/session', { intentId: 'intent-1' })
+    );
+    await waitFor(() => expect(mocks.chat.loadSession).toHaveBeenCalledWith('neg-intent-sess-1'));
+
+    // Ready: input enabled with the agent-name placeholder.
+    const input = await screen.findByTestId('negotiator-chat-input');
+    expect(input).toBeEnabled();
+    expect(input).toHaveAttribute('placeholder', "Message Alice's Negotiator…");
+  });
+
+  test('renders pending intent questions as the opening turns (existing pipeline)', async () => {
+    renderChat({ questions: [QUESTION] });
+
+    await screen.findByTestId('negotiator-opening-questions');
+    expect(screen.getByTestId('injected-questions')).toHaveTextContent('Which city should we prioritize?');
+  });
+
+  test('falls back via onUnavailable when the bootstrap fails', async () => {
+    mocks.apiClient.post.mockRejectedValue(new Error('404'));
+    const { props } = renderChat();
+
+    await waitFor(() => expect(props.onUnavailable).toHaveBeenCalled());
+    expect(mocks.chat.loadSession).not.toHaveBeenCalled();
+  });
+
+  test('sends the typed message through the shared chat context', async () => {
+    renderChat();
+    const input = await screen.findByTestId('negotiator-chat-input');
+    await waitFor(() => expect(input).toBeEnabled());
+
+    fireEvent.change(input, { target: { value: 'Any progress on this signal?' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() =>
+      expect(mocks.chat.sendMessage).toHaveBeenCalledWith('Any progress on this signal?')
+    );
+    expect((input as HTMLInputElement).value).toBe('');
+  });
+
+  test('releases the shared chat context on unmount', async () => {
+    const { unmount } = renderChat();
+    await waitFor(() => expect(mocks.chat.loadSession).toHaveBeenCalled());
+
+    unmount();
+    expect(mocks.chat.clearChat).toHaveBeenCalledWith({ abortStream: false });
+  });
+
+  test('renders streamed messages from the shared context', async () => {
+    mocks.chat.messages = [
+      { id: 'm1', role: 'user', content: 'Status?', timestamp: new Date() },
+      { id: 'm2', role: 'assistant', content: 'Two matches are in negotiation.', timestamp: new Date() },
+    ];
+    renderChat();
+
+    await screen.findByText('Status?');
+    expect(screen.getByTestId('assistant-content')).toHaveTextContent('Two matches are in negotiation.');
+  });
+});

--- a/apps/web/tests/intent-page-negotiator.test.tsx
+++ b/apps/web/tests/intent-page-negotiator.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * Intent page questions-block ⇄ negotiator-chat gating (P4.2 / IND-403).
+ *
+ * The chat window replaces the static questions block only when the
+ * backend-surfaced flag (`features.negotiatorChat` on /auth/me) is on; the
+ * fallback (flag off or runtime bootstrap failure) is the unchanged
+ * questions block.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import { Route, Routes } from 'react-router';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import IntentDetailPage from '@/app/i/[intentId]/page';
+
+const mocks = vi.hoisted(() => ({
+  authState: {
+    features: null as Record<string, unknown> | null,
+  },
+  chatStubBehavior: { failBootstrap: false },
+}));
+
+vi.mock('@/components/ClientLayout', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/chat/OpportunityCardInChat', () => ({
+  default: () => null,
+  OpportunitySkeleton: () => null,
+}));
+
+vi.mock('@/components/InjectedQuestions/InjectedQuestions', () => ({
+  InjectedQuestions: () => <div data-testid="injected-questions" />,
+}));
+
+vi.mock('@/components/IntentNegotiatorChat', () => ({
+  default: ({ onUnavailable }: { onUnavailable: () => void }) => {
+    if (mocks.chatStubBehavior.failBootstrap) {
+      // Simulate a runtime bootstrap failure (e.g. backend flag flipped off).
+      setTimeout(onUnavailable, 0);
+      return null;
+    }
+    return <div data-testid="intent-negotiator-chat-stub" />;
+  },
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuthContext: () => ({
+    isReady: true,
+    isLoading: false,
+    isAuthenticated: true,
+    user: { id: 'user-1', name: 'Alice Smith' },
+    features: mocks.authState.features,
+    userLoading: false,
+    error: null,
+    refetchUser: vi.fn(),
+    updateUser: vi.fn(),
+    openLoginModal: vi.fn(),
+    signOut: vi.fn(),
+  }),
+}));
+
+vi.mock('@/contexts/APIContext', () => ({
+  useIntents: () => ({
+    getIntent: vi.fn().mockResolvedValue({
+      id: 'intent-1',
+      payload: 'Looking for a technical co-founder',
+      summary: 'Looking for a technical co-founder',
+      createdAt: new Date().toISOString(),
+    }),
+    archiveIntent: vi.fn(),
+    refineIntent: vi.fn(),
+  }),
+  useOpportunities: () => ({
+    getHomeView: vi.fn().mockResolvedValue({ sections: [] }),
+  }),
+  useQuestionsService: () => ({
+    getPending: vi.fn().mockResolvedValue([
+      {
+        id: 'q-1',
+        title: 'Which city?',
+        prompt: 'Which city?',
+        options: [],
+        multiSelect: false,
+        mode: 'intent',
+        sourceType: 'intent',
+        sourceId: 'intent-1',
+        createdAt: new Date().toISOString(),
+      },
+    ]),
+    answer: vi.fn(),
+    dismiss: vi.fn(),
+  }),
+}));
+
+vi.mock('@/contexts/NotificationContext', () => ({
+  useNotifications: () => ({
+    success: vi.fn(),
+    error: vi.fn(),
+    addNotification: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useOpportunityActions', () => ({
+  useOpportunityActions: () => ({
+    opportunityStatusMap: {},
+    setOpportunityStatusMap: vi.fn(),
+    opportunityActionLoading: {},
+    handleOpportunityAction: vi.fn(),
+    handleStreamingDraftStartChat: vi.fn(),
+    inviteModalElement: null,
+  }),
+}));
+
+function renderIntentPage() {
+  return render(
+    <MemoryRouter initialEntries={['/i/intent-1']}>
+      <Routes>
+        <Route path="/i/:intentId" element={<IntentDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('Intent page — negotiator chat gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.authState.features = null;
+    mocks.chatStubBehavior.failBootstrap = false;
+  });
+
+  test('flag off → static questions block, no chat window', async () => {
+    renderIntentPage();
+
+    await screen.findByText('Looking for a technical co-founder');
+    await screen.findByTestId('injected-questions');
+    expect(screen.queryByTestId('intent-negotiator-chat-stub')).toBeNull();
+    expect(screen.getByText(/^Questions \(/)).toBeInTheDocument();
+  });
+
+  test('flag on → chat window replaces the questions block', async () => {
+    mocks.authState.features = { negotiatorChat: true };
+    renderIntentPage();
+
+    await screen.findByText('Looking for a technical co-founder');
+    await screen.findByTestId('intent-negotiator-chat-stub');
+    expect(screen.queryByTestId('injected-questions')).toBeNull();
+    expect(screen.getByText(/^Personal Agent \(/)).toBeInTheDocument();
+    expect(screen.queryByText(/^Questions \(/)).toBeNull();
+  });
+
+  test('runtime bootstrap failure → falls back to the questions block', async () => {
+    mocks.authState.features = { negotiatorChat: true };
+    mocks.chatStubBehavior.failBootstrap = true;
+    renderIntentPage();
+
+    await screen.findByText('Looking for a technical co-founder');
+    await waitFor(() => expect(screen.queryByTestId('intent-negotiator-chat-stub')).toBeNull());
+    await screen.findByTestId('injected-questions');
+    expect(screen.getByText(/^Questions \(/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/sidebar-negotiator.test.tsx
+++ b/apps/web/tests/sidebar-negotiator.test.tsx
@@ -197,6 +197,29 @@ describe('Sidebar pinned Personal Agent entry', () => {
     expect(mocks.apiClient.post).not.toHaveBeenCalled();
   });
 
+  test('pinned entry resolves the unscoped DM, skipping intent-pinned negotiator sessions (IND-403)', async () => {
+    mocks.authState.features = { negotiatorChat: true };
+    mockSessions({
+      negotiator: [
+        // Most-recent first: an intent-pinned negotiator session must NOT
+        // become the pinned sidebar entry.
+        { id: 'pinned-intent-1', title: 'Find a co-founder', scopeType: 'intent', networkId: null, createdAt: '', updatedAt: '' },
+        { id: 'neg-dm-1', title: "Alice's Negotiator", scopeType: null, networkId: null, createdAt: '', updatedAt: '' },
+      ],
+    });
+
+    renderSidebar();
+
+    const entry = await screen.findByText("Alice's Negotiator");
+    expect(screen.queryByText('Find a co-founder')).toBeNull();
+    fireEvent.click(entry);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('location')).toHaveTextContent('/d/neg-dm-1')
+    );
+    expect(mocks.apiClient.post).not.toHaveBeenCalled();
+  });
+
   test('negotiator session never renders in the history list', async () => {
     mocks.authState.features = { negotiatorChat: true };
     mockSessions({

--- a/packages/protocol/src/chat/negotiator.persona.ts
+++ b/packages/protocol/src/chat/negotiator.persona.ts
@@ -44,6 +44,10 @@ export const NEGOTIATOR_TOOL_NAMES = [
   "respond_to_negotiation",
   "list_opportunities",
   "update_opportunity",
+  // Pending questions — the system's open questions for the client. Added for
+  // intent-pinned sessions (P4.2/IND-403); the tool clamps itself to the
+  // focused intent scope when one is set.
+  "read_pending_questions",
   // Signals — the input surface of signal-based discovery (P4.5)
   "read_intents",
   "create_intent",

--- a/packages/protocol/src/chat/negotiator.prompt.ts
+++ b/packages/protocol/src/chat/negotiator.prompt.ts
@@ -1,4 +1,5 @@
 import type { ResolvedToolContext } from "../shared/agent/tool.factory.js";
+import { focusedIntentId } from "../shared/agent/tool.scope.js";
 import type { IterationContext } from "./chat.prompt.modules.js";
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -23,6 +24,29 @@ export interface NegotiatorPromptOptions {
   agentName: string;
   /** The negotiator agent's description, when set on the agent row. */
   agentDescription?: string;
+  /**
+   * Human-readable label for the pinned signal when the session is
+   * intent-scoped (P4.2/IND-403). The pin itself comes from the resolved
+   * context's scope envelope; this label just saves a tool round-trip for
+   * naming it. Ignored when the session has no intent scope.
+   */
+  pinnedIntentLabel?: string;
+}
+
+/**
+ * Renders the pinned-signal section for intent-scoped sessions (P4.2).
+ * Awareness, not a sandbox: the conversation orbits this signal, but the
+ * negotiator may still reference the client's other knowledge.
+ */
+function buildPinnedSignalSection(intentId: string, label?: string): string {
+  const labelLine = label?.trim() ? ` — “${label.trim()}”` : "";
+  return `
+## Pinned signal
+This conversation was opened from one of the client's signals (intent id: ${intentId}${labelLine}). Treat it as the working focus of this chat:
+- Open questions listed by read_pending_questions here are this signal's open questions — surface them early and work through them conversationally; the client answers them via the question cards shown in this chat.
+- list_opportunities and read_pending_questions are automatically restricted to this signal in this session; use them to report matches, negotiations, and follow-ups that grew out of it.
+- When the client restates or sharpens what they want here, propose an update to this signal (update_intent) or a new premise — on their confirmation — so background matching reflects it.
+- This is a focus, not a wall: you may still read the client's profile, premises, and other signals when the conversation needs the fuller picture, and general questions about their negotiations remain fair game.`;
 }
 
 /**
@@ -50,6 +74,10 @@ export function buildNegotiatorSystemContent(
   const descriptionLine = opts.agentDescription?.trim()
     ? `\n${opts.agentDescription.trim()}\n`
     : "";
+  const pinnedIntentId = focusedIntentId(ctx);
+  const pinnedSignalSection = pinnedIntentId
+    ? buildPinnedSignalSection(pinnedIntentId, opts.pinnedIntentLabel)
+    : "";
 
   return `You are ${opts.agentName}, the personal negotiator agent working for ${ctx.userName}.
 ${descriptionLine}
@@ -64,7 +92,7 @@ You work for exactly one client: ${ctx.userName}. You represent them in negotiat
 - **Handle memberships**: list the communities they belong to and join or leave communities when they ask.
 - **Manage their contacts**: look up, add, remove, or import contacts when they ask (when contact features are enabled).
 - **Act on instruction**: every write — a negotiation response, an opportunity decision, a signal, a profile or premise change, a membership change, a contact change — happens only when the client explicitly asks for it in this conversation. Never write anything the client did not just ask for.
-
+${pinnedSignalSection}
 ## What you cannot do here
 - **No direct discovery.** You cannot run matching or search for people yourself. Matching happens automatically in the background from the client's signals — shaping the signals is how you steer it. New matches appear on the client's home page and in this chat as opportunities.
 - **No community administration.** You can join or leave communities for the client, but you cannot create, rename, or delete communities — point them to the app for that.
@@ -91,6 +119,7 @@ ${profileContext}
 | **get_negotiation** | negotiationId | Full negotiation record: messages, outcome, reasoning |
 | **respond_to_negotiation** | negotiationId, ... | Act on a negotiation — ONLY on explicit client instruction |
 | **list_opportunities** | — | List the client's actionable opportunities |
+| **read_pending_questions** | limit? | The system's open questions for the client (clamped to the pinned signal when one is set) |
 | **update_opportunity** | opportunityId, status | Accept/pass an opportunity — ONLY on explicit client instruction |
 | **read_intents** / **search_intents** | — / query | The client's active signals (what they're looking for) |
 | **create_intent** | description, networkId? | Draft a new signal — returns a proposal card the client approves in the UI |

--- a/packages/protocol/src/chat/tests/negotiator.persona.spec.ts
+++ b/packages/protocol/src/chat/tests/negotiator.persona.spec.ts
@@ -121,6 +121,43 @@ describe("buildNegotiatorSystemContent", () => {
   });
 });
 
+// ─── Intent pin (P4.2 / IND-403) ─────────────────────────────────────────────
+
+describe("buildNegotiatorSystemContent — pinned signal (intent scope)", () => {
+  const scopedCtx = makeCtx({ scopeType: "intent", scopeId: "intent-42" } as Partial<ResolvedToolContext>);
+
+  it("renders the pinned-signal section when the session is intent-scoped", () => {
+    const prompt = buildNegotiatorSystemContent(scopedCtx, AGENT_OPTS);
+    expect(prompt).toContain("## Pinned signal");
+    expect(prompt).toContain("intent id: intent-42");
+    // Awareness, not a sandbox — the prompt must say the focus is not a wall.
+    expect(prompt).toContain("This is a focus, not a wall");
+  });
+
+  it("includes the human-readable label when provided", () => {
+    const prompt = buildNegotiatorSystemContent(scopedCtx, {
+      ...AGENT_OPTS,
+      pinnedIntentLabel: "Technical co-founder in Berlin",
+    });
+    expect(prompt).toContain("intent id: intent-42");
+    expect(prompt).toContain("Technical co-founder in Berlin");
+  });
+
+  it("omits the section entirely for the unscoped DM", () => {
+    const prompt = buildNegotiatorSystemContent(makeCtx(), AGENT_OPTS);
+    expect(prompt).not.toContain("## Pinned signal");
+    // A stray label without an intent scope must not leak into the prompt.
+    const withLabel = buildNegotiatorSystemContent(makeCtx(), { ...AGENT_OPTS, pinnedIntentLabel: "Stray" });
+    expect(withLabel).not.toContain("Stray");
+  });
+
+  it("ignores network scope (no pinned-signal section)", () => {
+    const networkCtx = makeCtx({ scopeType: "network", scopeId: "net-1" } as Partial<ResolvedToolContext>);
+    const prompt = buildNegotiatorSystemContent(networkCtx, AGENT_OPTS);
+    expect(prompt).not.toContain("## Pinned signal");
+  });
+});
+
 // ─── Tool scoping ────────────────────────────────────────────────────────────
 
 /** Representative orchestrator registry (superset of the negotiator allowlist). */
@@ -196,6 +233,7 @@ describe("filterNegotiatorTools", () => {
 
   it("keeps the P4.5 capability groups (signals, knowledge writes, joins, contacts)", () => {
     for (const allowed of [
+      "read_pending_questions",
       "create_intent",
       "update_intent",
       "delete_intent",

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -16,6 +16,18 @@ const NEGOTIATOR_PERSONA = 'negotiator';
  */
 const NEGOTIATOR_SCOPE = { scopeType: 'persona', scopeId: NEGOTIATOR_PERSONA } as const;
 
+/**
+ * Registry scope_type for intent-pinned negotiator sessions (P4.2/IND-403).
+ * Keying the `chat_session_scopes` unique index as ('negotiator-intent',
+ * intentId) makes the negotiator's per-intent session distinct from the
+ * orchestrator's ('intent', intentId) session for the same user — persona is
+ * part of the key without a migration. Like 'persona', this value never
+ * appears in the `ChatScopeType` envelope: conversation_metadata still says
+ * scopeType 'intent' so scope-driven behavior (graph seeding, session load)
+ * is identical to any intent-scoped session.
+ */
+const NEGOTIATOR_INTENT_SCOPE_TYPE = 'negotiator-intent';
+
 export class ConversationDatabaseAdapter {
   /**
    * Retrieve a single user_context row (global when networkId is null), or null.
@@ -1517,6 +1529,77 @@ export class ConversationDatabaseAdapter {
         userId: data.userId,
         scopeType: NEGOTIATOR_SCOPE.scopeType,
         scopeId: NEGOTIATOR_SCOPE.scopeId,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+  }
+
+  /**
+   * Find the user's negotiator session pinned to a specific intent, if any
+   * (P4.2/IND-403).
+   */
+  async getNegotiatorIntentChatSession(userId: string, intentId: string): Promise<ChatSession | null> {
+    const normalizedIntentId = intentId.trim();
+    if (!normalizedIntentId) return null;
+    const [row] = await db
+      .select({ conversationId: schema.chatSessionScopes.conversationId })
+      .from(schema.chatSessionScopes)
+      .where(
+        and(
+          eq(schema.chatSessionScopes.userId, userId),
+          eq(schema.chatSessionScopes.scopeType, NEGOTIATOR_INTENT_SCOPE_TYPE),
+          eq(schema.chatSessionScopes.scopeId, normalizedIntentId),
+        ),
+      )
+      .limit(1);
+    return row ? this.getChatSession(row.conversationId) : null;
+  }
+
+  /**
+   * Create a negotiator session pinned to one of the user's intents
+   * (one per user+intent, P4.2/IND-403).
+   *
+   * Same transaction shape as {@link createNegotiatorChatSession}, but the
+   * registry row is keyed ('negotiator-intent', intentId) and the
+   * conversation metadata carries the canonical intent scope so the session
+   * behaves like any intent-scoped chat (graph seeding, scope echo on load)
+   * while staying a distinct conversation from the orchestrator's session
+   * for the same intent.
+   */
+  async createNegotiatorIntentChatSession(data: {
+    id: string;
+    userId: string;
+    intentId: string;
+    title?: string;
+  }): Promise<void> {
+    const now = new Date();
+    const intentId = data.intentId.trim();
+    await db.transaction(async (tx) => {
+      await tx.insert(schema.conversations).values({
+        id: data.id,
+        persona: NEGOTIATOR_PERSONA,
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      await tx.insert(schema.conversationParticipants).values([
+        { conversationId: data.id, participantId: data.userId, participantType: 'user' as const },
+        { conversationId: data.id, participantId: SYSTEM_AGENT_ID, participantType: 'agent' as const },
+      ]);
+
+      const meta: ChatConversationMeta = { scopeType: 'intent', scopeId: intentId };
+      if (data.title) meta.title = data.title;
+      await tx.insert(schema.conversationMetadata).values({
+        conversationId: data.id,
+        metadata: meta,
+      });
+
+      await tx.insert(schema.chatSessionScopes).values({
+        conversationId: data.id,
+        userId: data.userId,
+        scopeType: NEGOTIATOR_INTENT_SCOPE_TYPE,
+        scopeId: intentId,
         createdAt: now,
         updatedAt: now,
       });

--- a/services/api/src/controllers/chat.controller.ts
+++ b/services/api/src/controllers/chat.controller.ts
@@ -92,6 +92,11 @@ function getSuggestionGenerator(): SuggestionGenerator {
   return suggestionGeneratorInstance;
 }
 
+/** Optional body for POST /chat/negotiator/session (P4.2 intent pinning). */
+const negotiatorSessionBodySchema = z.object({
+  intentId: z.string().min(1).nullish(),
+});
+
 const resolveSessionBodySchema = z.object({
   scopeType: z.enum(['intent']),
   scopeId: z.string().min(1),
@@ -229,29 +234,37 @@ export class ChatController {
     const requestedScope = normalizeChatScope(body);
     if (requestedScope instanceof Response) return requestedScope;
 
+    // Captured by validateScope when an intent scope validates — used to pin
+    // the signal by name in the negotiator prompt (P4.2) without re-fetching.
+    let pinnedIntentLabel: string | undefined;
+
     const validateScope = async (scope: ChatScope | undefined) => {
       if (!scope) return undefined;
-      const validation = scope.scopeType === 'network'
-        ? await chatSessionService.validateIndexScope(user.id, scope.scopeId)
-        : await chatSessionService.validateIntentScope(user.id, scope.scopeId);
-      if (!validation.ok) {
-        return Response.json(
-          { error: validation.error },
-          { status: validation.status },
-        );
+      if (scope.scopeType === 'network') {
+        const validation = await chatSessionService.validateIndexScope(user.id, scope.scopeId);
+        if (!validation.ok) {
+          return Response.json({ error: validation.error }, { status: validation.status });
+        }
+        return undefined;
       }
+      const validation = await chatSessionService.validateIntentScope(user.id, scope.scopeId);
+      if (!validation.ok) {
+        return Response.json({ error: validation.error }, { status: validation.status });
+      }
+      pinnedIntentLabel = validation.title;
       return undefined;
     };
 
-    // Negotiator persona routing (P4.1): flag-gated, never scoped. Checked
-    // before scope validation — both rejections are cheap and unambiguous.
+    // Negotiator persona routing (P4.1): flag-gated. Intent scope is allowed
+    // (P4.2 pinned-signal sessions); network scope is not. Checked before
+    // scope validation — both rejections are cheap and unambiguous.
     const requestedPersona = body.persona ?? undefined;
     if (requestedPersona === NEGOTIATOR_PERSONA_ID) {
       if (!isNegotiatorChatEnabled()) {
         return Response.json({ error: "Not found" }, { status: 404 });
       }
-      if (requestedScope) {
-        return Response.json({ error: "Negotiator chat cannot be scoped" }, { status: 400 });
+      if (requestedScope?.scopeType === 'network') {
+        return Response.json({ error: "Negotiator chat cannot be network-scoped" }, { status: 400 });
       }
     }
 
@@ -267,7 +280,10 @@ export class ChatController {
       if (!negotiatorAgent) {
         return Response.json({ error: "Negotiator agent not available" }, { status: 404 });
       }
-      const resolved = await chatSessionService.resolveNegotiatorSession(user.id, negotiatorAgent.name);
+      // Intent scope → the per-intent pinned session (P4.2); otherwise the DM.
+      const resolved = requestedScope?.scopeType === 'intent'
+        ? await chatSessionService.resolveNegotiatorIntentSession(user.id, requestedScope.scopeId)
+        : await chatSessionService.resolveNegotiatorSession(user.id, negotiatorAgent.name);
       if ('error' in resolved) {
         return Response.json({ error: resolved.error }, { status: resolved.status });
       }
@@ -304,8 +320,15 @@ export class ChatController {
         if (!isNegotiatorChatEnabled()) {
           return Response.json({ error: "Not found" }, { status: 404 });
         }
-        if (requestedScope) {
-          return Response.json({ error: "Negotiator chat cannot be scoped" }, { status: 400 });
+        if (requestedScope?.scopeType === 'network') {
+          return Response.json({ error: "Negotiator chat cannot be network-scoped" }, { status: 400 });
+        }
+        // Negotiator sessions are born with their scope (or born as the
+        // unscoped DM) — they are never re-scoped after the fact. A scope
+        // request against the DM would otherwise fall through to the generic
+        // updateSessionScope path and corrupt the persona keying.
+        if (requestedScope && !sessionScope(loadedSession)) {
+          return Response.json({ error: "Negotiator DM cannot be scoped" }, { status: 400 });
         }
       } else if (requestedPersona === NEGOTIATOR_PERSONA_ID) {
         return Response.json({ error: "Session persona mismatch" }, { status: 409 });
@@ -334,7 +357,12 @@ export class ChatController {
     // Capture for closure
     const sessionId = currentSessionId;
     const factory = sessionPersona === NEGOTIATOR_PERSONA_ID && negotiatorAgent
-      ? chatSessionService.getNegotiatorGraphFactory(negotiatorAgent)
+      ? chatSessionService.getNegotiatorGraphFactory(
+          negotiatorAgent,
+          effectiveScope?.scopeType === 'intent' && pinnedIntentLabel
+            ? { label: pinnedIntentLabel }
+            : undefined,
+        )
       : chatSessionService.getGraphFactory();
     const useCheckpointer = body.useCheckpointer ?? true;
     const runId = crypto.randomUUID();
@@ -646,9 +674,26 @@ export class ChatController {
    */
   @Post("/negotiator/session")
   @UseGuards(RateLimit('write'), AuthGuard)
-  async negotiatorSession(_req: Request, user: AuthenticatedUser) {
+  async negotiatorSession(req: Request, user: AuthenticatedUser) {
     if (!isNegotiatorChatEnabled()) {
       return Response.json({ error: "Not found" }, { status: 404 });
+    }
+
+    // Body is optional (the sidebar posts none). `intentId` selects the
+    // per-intent pinned session (P4.2) instead of the DM.
+    let intentId: string | undefined;
+    try {
+      const raw: unknown = await req.json();
+      const parsed = negotiatorSessionBodySchema.safeParse(raw);
+      if (!parsed.success) {
+        return Response.json(
+          { error: "Invalid request body. Expected { intentId?: string }" },
+          { status: 400 },
+        );
+      }
+      intentId = parsed.data.intentId?.trim() || undefined;
+    } catch {
+      // No body / empty body — DM variant.
     }
 
     const agent = await resolveNegotiatorAgent(user.id);
@@ -656,7 +701,9 @@ export class ChatController {
       return Response.json({ error: "Negotiator agent not available" }, { status: 404 });
     }
 
-    const result = await chatSessionService.resolveNegotiatorSession(user.id, agent.name);
+    const result = intentId
+      ? await chatSessionService.resolveNegotiatorIntentSession(user.id, intentId)
+      : await chatSessionService.resolveNegotiatorSession(user.id, agent.name);
     if ('error' in result) {
       return Response.json({ error: result.error }, { status: result.status });
     }

--- a/services/api/src/controllers/tests/chat.negotiator.spec.ts
+++ b/services/api/src/controllers/tests/chat.negotiator.spec.ts
@@ -26,7 +26,7 @@ import { UserDatabaseAdapter, conversationDatabaseAdapter } from "../../adapters
 import { chatSessionService } from "../../services/chat.service";
 import type { ChatGraphFactory, ChatPersonaConfig } from "@indexnetwork/protocol";
 import db from "../../lib/drizzle/drizzle";
-import { agents } from "../../schemas/database.schema";
+import { agents, intents } from "../../schemas/database.schema";
 import type { AuthenticatedUser } from "../../guards/auth.guard";
 
 const EMAIL = "test-chat-negotiator@example.com";
@@ -41,7 +41,10 @@ describe("Negotiator chat persona (IND-402)", () => {
   /** Personas captured whenever the controller derives a persona factory. */
   const capturedPersonas: ChatPersonaConfig[] = [];
   /** Inputs captured from streamChatEventsWithContext calls. */
-  const capturedStreamInputs: Array<{ userId: string; sessionId: string; message: string }> = [];
+  const capturedStreamInputs: Array<{ userId: string; sessionId: string; message: string; scopeType?: string; scopeId?: string }> = [];
+  /** Intent owned by the test user (IND-403 pinning). */
+  let testIntentId: string;
+  const INTENT_PAYLOAD = "Looking for a technical co-founder in Berlin";
 
   const stubFactory = {
     withPersona(persona: ChatPersonaConfig) {
@@ -62,8 +65,13 @@ describe("Negotiator chat persona (IND-402)", () => {
     name: "Test Negotiator User",
   });
 
-  const negotiatorSessionReq = () =>
-    new Request("http://localhost/chat/negotiator/session", { method: "POST" });
+  const negotiatorSessionReq = (body?: Record<string, unknown>) =>
+    new Request("http://localhost/chat/negotiator/session", {
+      method: "POST",
+      ...(body
+        ? { headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) }
+        : {}),
+    });
 
   const streamReq = (body: Record<string, unknown>) =>
     new Request("http://localhost/chat/stream", {
@@ -87,6 +95,13 @@ describe("Negotiator chat persona (IND-402)", () => {
     });
     testUserId = user.id;
 
+    const [intent] = await db.insert(intents).values({
+      payload: INTENT_PAYLOAD,
+      summary: INTENT_PAYLOAD,
+      userId: testUserId,
+    }).returning({ id: intents.id });
+    testIntentId = intent.id;
+
     chatSessionService.setFactory(stubFactory);
     controller = new ChatController();
   });
@@ -99,6 +114,7 @@ describe("Negotiator chat persona (IND-402)", () => {
       await conversationDatabaseAdapter.deleteChatSession(sessionId).catch(() => {});
     }
     if (testUserId) {
+      await db.delete(intents).where(eq(intents.userId, testUserId));
       await db.delete(agents).where(eq(agents.ownerId, testUserId));
       await userAdapter.deleteById(testUserId);
     }
@@ -270,7 +286,7 @@ describe("Negotiator chat persona (IND-402)", () => {
 
   // ── Guardrails ─────────────────────────────────────────────────────────────
 
-  test("negotiator chat cannot be scoped", async () => {
+  test("negotiator chat cannot be network-scoped", async () => {
     process.env.NEGOTIATOR_CHAT_ENABLED = 'true';
     const res = await controller.messageStream(
       streamReq({
@@ -283,7 +299,157 @@ describe("Negotiator chat persona (IND-402)", () => {
     );
     expect(res.status).toBe(400);
     const data = (await res.json()) as { error: string };
-    expect(data.error).toContain("cannot be scoped");
+    expect(data.error).toContain("cannot be network-scoped");
+  }, 60000);
+
+  // ── Intent-pinned sessions (P4.2 / IND-403) ───────────────────────────
+
+  test("intent-pinned get-or-create is idempotent and distinct from the DM and the orchestrator intent session", async () => {
+    process.env.NEGOTIATOR_CHAT_ENABLED = 'true';
+
+    const first = await controller.negotiatorSession(negotiatorSessionReq({ intentId: testIntentId }), mockUser());
+    expect(first.status).toBe(200);
+    const firstData = (await first.json()) as {
+      session: { id: string; persona: string; title: string | null; scopeType: string | null; scopeId: string | null };
+      created: boolean;
+    };
+    createdSessionIds.push(firstData.session.id);
+
+    expect(firstData.created).toBe(true);
+    expect(firstData.session.persona).toBe("negotiator");
+    // The pinned session carries the canonical intent scope…
+    expect(firstData.session.scopeType).toBe("intent");
+    expect(firstData.session.scopeId).toBe(testIntentId);
+    // …and is titled after the signal, not the agent.
+    expect(firstData.session.title).toBe(INTENT_PAYLOAD);
+
+    // Idempotent.
+    const second = await controller.negotiatorSession(negotiatorSessionReq({ intentId: testIntentId }), mockUser());
+    const secondData = (await second.json()) as { session: { id: string }; created: boolean };
+    expect(secondData.created).toBe(false);
+    expect(secondData.session.id).toBe(firstData.session.id);
+
+    // Distinct from the unscoped DM.
+    const dm = await conversationDatabaseAdapter.getNegotiatorChatSession(testUserId);
+    expect(dm?.id).not.toBe(firstData.session.id);
+
+    // Keying spec: the orchestrator's session for the SAME (user, intent) is a
+    // different conversation — persona is part of the key.
+    const orchestrator = await chatSessionService.resolveSessionForScope(testUserId, {
+      scopeType: "intent",
+      scopeId: testIntentId,
+    });
+    if ('error' in orchestrator) throw new Error(orchestrator.error);
+    createdSessionIds.push(orchestrator.session.id);
+    expect(orchestrator.session.id).not.toBe(firstData.session.id);
+    expect(orchestrator.session.persona).toBe("orchestrator");
+    expect(orchestrator.session.scopeType).toBe("intent");
+  }, 60000);
+
+  test("streaming persona=negotiator with intent scope resolves the pinned session and seeds the scope + prompt pin", async () => {
+    process.env.NEGOTIATOR_CHAT_ENABLED = 'true';
+    capturedPersonas.length = 0;
+    capturedStreamInputs.length = 0;
+
+    const res = await controller.messageStream(
+      streamReq({
+        message: "What's happening with this signal?",
+        persona: "negotiator",
+        scopeType: "intent",
+        scopeId: testIntentId,
+      }),
+      mockUser(),
+    );
+    expect(res.status).toBe(200);
+    await res.text();
+
+    const pinned = (await conversationDatabaseAdapter.getNegotiatorIntentChatSession(testUserId, testIntentId))!;
+    expect(res.headers.get("X-Session-Id")).toBe(pinned.id);
+
+    // Negotiator persona factory with the intent scope threaded to the graph.
+    expect(capturedPersonas.length).toBe(1);
+    expect(capturedPersonas[0].id).toBe("negotiator");
+    expect(capturedStreamInputs.length).toBe(1);
+    expect(capturedStreamInputs[0].scopeType).toBe("intent");
+    expect(capturedStreamInputs[0].scopeId).toBe(testIntentId);
+
+    // The prompt pins the signal (id + human-readable label) when built with
+    // an intent-scoped context.
+    const prompt = capturedPersonas[0].buildSystemContent(
+      {
+        userId: testUserId,
+        userName: "Test Negotiator User",
+        userEmail: EMAIL,
+        user: { id: testUserId },
+        userProfile: null,
+        userNetworks: [],
+        scopeType: "intent",
+        scopeId: testIntentId,
+      } as never,
+      { iteration: 1 } as never,
+    );
+    expect(prompt).toContain("## Pinned signal");
+    expect(prompt).toContain(testIntentId);
+    expect(prompt).toContain(INTENT_PAYLOAD);
+  }, 60000);
+
+  test("streaming the pinned session by sessionId alone inherits the intent scope and negotiator persona", async () => {
+    process.env.NEGOTIATOR_CHAT_ENABLED = 'true';
+    capturedPersonas.length = 0;
+    capturedStreamInputs.length = 0;
+
+    const pinned = (await conversationDatabaseAdapter.getNegotiatorIntentChatSession(testUserId, testIntentId))!;
+    const res = await controller.messageStream(
+      streamReq({ message: "Any progress?", sessionId: pinned.id }),
+      mockUser(),
+    );
+    expect(res.status).toBe(200);
+    await res.text();
+
+    expect(capturedPersonas.length).toBe(1);
+    expect(capturedPersonas[0].id).toBe("negotiator");
+    expect(capturedStreamInputs[0].scopeType).toBe("intent");
+    expect(capturedStreamInputs[0].scopeId).toBe(testIntentId);
+  }, 60000);
+
+  test("the unscoped DM cannot be scoped after the fact", async () => {
+    process.env.NEGOTIATOR_CHAT_ENABLED = 'true';
+    const dm = (await conversationDatabaseAdapter.getNegotiatorChatSession(testUserId))!;
+
+    const res = await controller.messageStream(
+      streamReq({ message: "hello", sessionId: dm.id, scopeType: "intent", scopeId: testIntentId }),
+      mockUser(),
+    );
+    expect(res.status).toBe(400);
+    const data = (await res.json()) as { error: string };
+    expect(data.error).toContain("DM cannot be scoped");
+  }, 60000);
+
+  test("intent-pinned session for a nonexistent intent is a 404; ?persona=negotiator lists DM and pinned sessions distinguishably", async () => {
+    process.env.NEGOTIATOR_CHAT_ENABLED = 'true';
+
+    const missing = await controller.negotiatorSession(
+      negotiatorSessionReq({ intentId: crypto.randomUUID() }),
+      mockUser(),
+    );
+    expect(missing.status).toBe(404);
+
+    // The sidebar finds the DM among negotiator sessions by its null scope.
+    const listed = await controller.getSessions(
+      new Request("http://localhost/chat/sessions?persona=negotiator"),
+      mockUser(),
+    );
+    const listedData = (await listed.json()) as { sessions: Array<{ id: string; scopeType: string | null }> };
+    const dm = (await conversationDatabaseAdapter.getNegotiatorChatSession(testUserId))!;
+    const pinned = (await conversationDatabaseAdapter.getNegotiatorIntentChatSession(testUserId, testIntentId))!;
+    const byId = new Map(listedData.sessions.map((s) => [s.id, s.scopeType]));
+    expect(byId.get(dm.id)).toBeNull();
+    expect(byId.get(pinned.id)).toBe("intent");
+
+    // And the pinned session stays out of default history like the DM.
+    const defaults = await controller.getSessions(new Request("http://localhost/chat/sessions"), mockUser());
+    const defaultData = (await defaults.json()) as { sessions: Array<{ id: string }> };
+    expect(defaultData.sessions.map((s) => s.id)).not.toContain(pinned.id);
   }, 60000);
 
   test("persona=negotiator with an orchestrator session is a 409 mismatch", async () => {

--- a/services/api/src/services/chat.service.ts
+++ b/services/api/src/services/chat.service.ts
@@ -252,6 +252,56 @@ export class ChatSessionService {
     }
   }
 
+  /**
+   * Resolve or create the user's negotiator session pinned to one of their
+   * intents (P4.2/IND-403). One session per (user, intent, negotiator
+   * persona): keyed in `chat_session_scopes` as ('negotiator-intent',
+   * intentId), so it never collides with the orchestrator's ('intent',
+   * intentId) session for the same intent. Race-safe via the unique index
+   * (concurrent creates re-read on 23505).
+   *
+   * @param userId - The client user (must own the intent)
+   * @param intentId - The intent to pin
+   * @returns The session plus the validated intent title (for prompt pinning)
+   */
+  async resolveNegotiatorIntentSession(
+    userId: string,
+    intentId: string,
+  ): Promise<
+    | { session: NonNullable<Awaited<ReturnType<ChatSessionService['getSession']>>>; created: boolean; intentTitle: string }
+    | { error: string; status: 400 | 403 | 404 | 500 }
+  > {
+    const normalizedIntentId = intentId.trim();
+    if (!normalizedIntentId) {
+      return { error: 'intentId is required', status: 400 as const };
+    }
+
+    const validation = await this.validateIntentScope(userId, normalizedIntentId);
+    if (!validation.ok) return validation;
+
+    const existing = await this.db.getNegotiatorIntentChatSession(userId, normalizedIntentId);
+    if (existing) return { session: existing, created: false, intentTitle: validation.title };
+
+    try {
+      const id = crypto.randomUUID();
+      await this.db.createNegotiatorIntentChatSession({
+        id,
+        userId,
+        intentId: normalizedIntentId,
+        title: validation.title,
+      });
+      const session = await this.getSession(id, userId);
+      if (!session) return { error: 'Failed to create negotiator session', status: 500 as const };
+      return { session, created: true, intentTitle: validation.title };
+    } catch (err) {
+      if (this.isUniqueViolation(err)) {
+        const raced = await this.db.getNegotiatorIntentChatSession(userId, normalizedIntentId);
+        if (raced) return { session: raced, created: false, intentTitle: validation.title };
+      }
+      throw err;
+    }
+  }
+
   private isUniqueViolation(err: unknown): boolean {
     return typeof err === 'object' && err !== null && 'code' in err && (err as { code?: unknown }).code === '23505';
   }
@@ -475,12 +525,19 @@ export class ChatSessionService {
    * factory; only prompt/toolset/loop behaviors differ.
    *
    * @param agent - Identity from the user's `type='personal'` agent row
+   * @param pinnedIntent - Optional pinned-signal label for intent-scoped
+   *                       sessions (P4.2); rendered in the prompt's pinned
+   *                       signal section
    */
-  getNegotiatorGraphFactory(agent: { name: string; description?: string | null }): ChatGraphFactory {
+  getNegotiatorGraphFactory(
+    agent: { name: string; description?: string | null },
+    pinnedIntent?: { label?: string },
+  ): ChatGraphFactory {
     return this.factory.withPersona(
       createNegotiatorPersona({
         agentName: agent.name,
         ...(agent.description?.trim() ? { agentDescription: agent.description } : {}),
+        ...(pinnedIntent?.label?.trim() ? { pinnedIntentLabel: pinnedIntent.label.trim() } : {}),
       }),
     );
   }


### PR DESCRIPTION
## Summary

P4.2 of the Client-Advocate Protocol (IND-395): the same negotiator chat, opened from an intent — the intent is **pinned as context, not a sandbox**. The intent page's static questions block becomes a chat window to the user's personal negotiator.

Closes IND-403.

## Backend

### Session keying — persona is part of the key (the ⚠️ from the issue)
Intent-scoped sessions were keyed one-per-(user, intent) via `chat_session_scopes`; without persona in the key, the negotiator embed would have reused the orchestrator's intent chat. Following the `('persona','negotiator')` registry pattern from P4.1, the negotiator's per-intent session is keyed **`('negotiator-intent', intentId)`** — distinct from the orchestrator's `('intent', intentId)` row under the same unique index. Zero migration, race-safe (23505 → re-read). The conversation row still carries `persona='negotiator'` and canonical metadata scope `('intent', intentId)`, so graph seeding and session load behave like any intent-scoped chat.

### Endpoints
- `POST /chat/negotiator/session` now accepts optional `{ intentId }` → get-or-create the pinned session (owner-validated; title = the signal text). No body → the DM, unchanged.
- `POST /chat/stream`: `persona=negotiator` + `scopeType:'intent'` resolves the pinned session; network scope stays rejected; **the unscoped DM can never be scoped after the fact** (guards the generic `updateSessionScope` path that would corrupt persona keying).
- Loaded pinned sessions inherit their intent scope → threaded to the graph (`streamChatEventsWithContext` scope envelope), so `list_opportunities` / `read_pending_questions` self-clamp to the signal.

### Prompt + toolset
- `negotiator.prompt.ts`: new **Pinned signal** section when the resolved context carries intent scope — surface the signal's open questions early, report matches/negotiations grown out of it, propose `update_intent`/premise on restatement (human-confirmed), and explicitly "a focus, not a wall" (the persona can still reference the client's other knowledge).
- Pinned label (validated intent title) threaded from scope validation into the persona options — no extra fetch.
- `read_pending_questions` added to the allowlist (34 tools now); the tool already clamps itself to the focused intent scope.

### Deferred (blocked by IND-396)
"Negotiations originated from this intent via `initiatorUserId`" seeding — until P1.1 stamps initiators, negotiation awareness flows via intent-scoped opportunities → `get_negotiation`, which the pin section directs.

## Web

- **`IntentNegotiatorChat`** (new): replaces the static questions block on `/i/:intentId` behind the backend-surfaced `features.negotiatorChat` flag (bootstrap: `POST /chat/negotiator/session {intentId}` → `loadSession` into the shared `AIChatContext`; streaming, proposal cards, opportunity cards reuse existing chat components). Pending intent questions render as the chat's **opening turns** — answered through the existing `questionsService.answer` pipeline (the questions UI is replaced, not the pipeline). Runtime bootstrap failure → instant fallback to the questions block.
- **Sidebar fix**: the pinned Personal Agent entry now resolves the **unscoped** DM (`sessions.find(s => !s.scopeType)`) — intent-pinned sessions also carry `persona=negotiator` and would otherwise hijack the entry.
- History exclusion is automatic: pinned sessions ride the existing `excludePersona` filter.

## Deployability

- No migration, no new env var — rides `NEGOTIATOR_CHAT_ENABLED` (currently **on** on dev → live at merge).
- Flag off: endpoints 404, intent page renders the questions block unchanged.
- Rollback = unset flag; pinned-session data stays, unreachable from UI.

## Tests

- Protocol `negotiator.persona.spec.ts` — 18 pass (pinned-signal section with/without label, DM/network-scope omission, allowlist).
- API `chat.negotiator.spec.ts` — 16 pass, DB-backed: keying (negotiator-intent ≠ orchestrator-intent ≠ DM for the same user+intent), idempotency, stream routing (persona+scope resolve, sessionId-only inheritance, DM-scoping 400, network-scope 400, nonexistent intent 404), `?persona=negotiator` listing distinguishes DM (null scope) from pinned sessions.
- Web — 14 pass across `intent-negotiator-chat` (bootstrap/opening questions/send/unavailable/unmount), `intent-page-negotiator` (flag gating + runtime fallback), `sidebar-negotiator` (DM lookup skips pinned sessions). Remaining web failures identical on clean dev (known routes-symlink + DecisionQuestions baseline).
- Builds: protocol ✓, api tsc ✓, web vite ✓; eslint: 0 errors, no new warnings.

## Post-merge smoke (dev, flag already on)

1. Open an intent page → the Questions panel becomes **Personal Agent** with a chat window; open questions render as cards at the top.
2. Ask "what's happening with this signal?" → grounded, signal-scoped answer.
3. Answer a question card → persists via the existing pipeline (question disappears, refinement enqueued).
4. Sidebar Personal Agent entry still opens the **DM**, not the intent session; neither appears in History.
