### PR TITLE
feat: pending question inbox in negotiator chat (IND-404)

### DIFF
--- a/apps/web/src/components/ChatContent.tsx
+++ b/apps/web/src/components/ChatContent.tsx
@@ -68,6 +68,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
     loadSession,
     sessionId,
     sessionTitle,
+    sessionPersona,
     suggestions: contextSuggestions,
     chatScope,
     setChatScope,
@@ -206,7 +207,10 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
 
   // Fetch conversation-linked questions on session load. In intent-scoped
   // sessions, also include pending questions derived from that selected intent,
-  // its opportunities, and their negotiations.
+  // its opportunities, and their negotiations. In the negotiator DM (persona
+  // 'negotiator', no intent pin), include the client's full question inbox —
+  // the same noConversation set the /questions page shows (P4.3/IND-404).
+  const isNegotiatorDm = sessionPersona === "negotiator" && chatScope?.type !== "intent";
   useEffect(() => {
     if (!sessionId) {
       setInjectedQuestions([]);
@@ -215,7 +219,9 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
     let active = true;
     const scopeQuestionPromise = chatScope?.type === "intent"
       ? questionsService.getPending({ scopeType: "intent", scopeId: chatScope.id })
-      : Promise.resolve([] as PendingQuestion[]);
+      : isNegotiatorDm
+        ? questionsService.getPending({ noConversation: true })
+        : Promise.resolve([] as PendingQuestion[]);
     Promise.all([
       questionsService.getByConversation(sessionId),
       scopeQuestionPromise,
@@ -228,7 +234,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
       setInjectedQuestions([...deduped.values()]);
     }).catch(() => {});
     return () => { active = false; };
-  }, [sessionId, questionsService, chatScope]);
+  }, [sessionId, questionsService, chatScope, isNegotiatorDm]);
 
   // Merge live ask_user_question cards (streamed via the user_question SSE
   // event) into the inline injected-questions list at render time. The
@@ -1325,11 +1331,18 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
               </div>
             ))}
             {injectedByMessageId.has(null) && (
-              <InjectedQuestions
-                questions={injectedByMessageId.get(null)!}
-                onAnswer={handleInjectedAnswer}
-                onDismiss={handleInjectedDismiss}
-              />
+              <div data-testid={isNegotiatorDm ? "negotiator-question-inbox" : undefined}>
+                {isNegotiatorDm && (
+                  <p className="text-xs font-medium uppercase tracking-wide text-gray-500 mt-4 mb-2">
+                    Open questions for you
+                  </p>
+                )}
+                <InjectedQuestions
+                  questions={injectedByMessageId.get(null)!}
+                  onAnswer={handleInjectedAnswer}
+                  onDismiss={handleInjectedDismiss}
+                />
+              </div>
             )}
             <div ref={scrollRef} />
           </div>

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -294,6 +294,16 @@ export default function Sidebar() {
           >
             <BotMessageSquare className="w-5 h-5" />
             <span className="flex-1 text-left truncate">{negotiatorLabel}</span>
+            {/* Pending question inbox count (IND-404) — the DM surfaces the
+                same open questions the Questions page lists. */}
+            {pendingQuestionsCount > 0 && (
+              <span
+                data-testid="negotiator-question-badge"
+                className="bg-[#041729] text-white text-xs px-2 py-0.5 rounded-full min-w-[20px] text-center"
+              >
+                {pendingQuestionsCount > 99 ? '99+' : pendingQuestionsCount}
+              </span>
+            )}
           </button>
         )}
 

--- a/apps/web/src/contexts/AIChatContext.tsx
+++ b/apps/web/src/contexts/AIChatContext.tsx
@@ -151,6 +151,8 @@ interface AIChatContextType {
   messages: ChatMessage[];
   sessionId: string | null;
   sessionTitle: string | null;
+  /** Persona driving the loaded session's agent loop (e.g. 'negotiator'). Null until a session is loaded. */
+  sessionPersona: string | null;
   setSessionId: (id: string | null) => void;
   /** The network bound to the current session (persisted). Null if no network scope. */
   sessionNetworkId: string | null;
@@ -294,6 +296,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [sessionTitle, setSessionTitle] = useState<string | null>(null);
+  const [sessionPersona, setSessionPersona] = useState<string | null>(null);
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const { refetchSessions } = useAIChatSessions();
@@ -1037,6 +1040,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
     setLiveQuestions([]);
     setSessionId(null);
     setSessionTitle(null);
+    setSessionPersona(null);
     setSessionScope(null); // Clear session-bound scope so new chat can use UI selection
     setSessionNetworkId(null); // Clear session-bound network so new chat can use UI selection
     if (abortStream && abortControllerRef.current) {
@@ -1058,6 +1062,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
         session: {
           id: string;
           title?: string | null;
+          persona?: string | null;
           networkId?: string | null;
           scopeType?: "network" | "intent" | null;
           scopeId?: string | null;
@@ -1087,6 +1092,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
       }>("/chat/session", { sessionId: id });
       setSessionId(data.session.id);
       setSessionTitle(data.session.title?.trim() ?? null);
+      setSessionPersona(data.session.persona ?? null);
       setSuggestions([]); // Session load does not return suggestions; next response will
       // Load the session's bound scope - this is the persisted scope for this conversation.
       const loadedScope: ChatScope = data.session.scopeType && data.session.scopeId
@@ -1155,6 +1161,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
         messages,
         sessionId,
         sessionTitle,
+        sessionPersona,
         setSessionId,
         sessionNetworkId,
         chatScope,

--- a/apps/web/tests/negotiator-dm-inbox.test.tsx
+++ b/apps/web/tests/negotiator-dm-inbox.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * Negotiator DM question inbox (P4.3 / IND-404).
+ *
+ * ChatContent surfaces the client's full pending-question inbox
+ * (GET /questions?status=pending&noConversation=true) when the loaded session
+ * runs the negotiator persona without an intent pin. Orchestrator sessions
+ * keep the existing behavior (conversation-linked questions only).
+ */
+import { screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import ChatContent from '@/components/ChatContent';
+import { renderWithRouter } from '@/test/test-utils';
+import type { PendingQuestion } from '@/services/questions';
+
+const mocks = vi.hoisted(() => {
+  const questionsService = {
+    getPending: vi.fn(),
+    getByConversation: vi.fn(),
+    answer: vi.fn(),
+    dismiss: vi.fn(),
+  };
+  const chat = {
+    messages: [] as Array<Record<string, unknown>>,
+    isLoading: false,
+    stopStream: vi.fn(),
+    sendMessage: vi.fn(),
+    clearChat: vi.fn(),
+    loadSession: vi.fn().mockResolvedValue(undefined),
+    sessionId: null as string | null,
+    sessionTitle: null as string | null,
+    sessionPersona: null as string | null,
+    suggestions: null,
+    chatScope: null as Record<string, unknown> | null,
+    setChatScope: vi.fn(),
+    setScopeNetworkId: vi.fn(),
+    sessionNetworkId: null,
+    updateSessionTitle: vi.fn(),
+    pendingQueue: [] as unknown[],
+    cancelQueuedMessage: vi.fn(),
+    submitMidStreamMessage: vi.fn(),
+    liveQuestions: [] as unknown[],
+  };
+  return {
+    questionsService,
+    chat,
+    apiClient: { get: vi.fn(), post: vi.fn().mockResolvedValue({}), patch: vi.fn(), delete: vi.fn() },
+  };
+});
+
+vi.mock('@/lib/api', () => ({
+  apiClient: mocks.apiClient,
+  useAuthenticatedAPI: () => mocks.apiClient,
+}));
+
+vi.mock('@/contexts/AIChatContext', () => ({
+  useAIChat: () => mocks.chat,
+}));
+
+vi.mock('@/contexts/APIContext', () => {
+  const noopService = new Proxy({}, { get: () => vi.fn().mockResolvedValue([]) });
+  return {
+    useOpportunities: () => noopService,
+    useQuestionsService: () => mocks.questionsService,
+    useNetworks: () => noopService,
+  };
+});
+
+vi.mock('@/services/v2/upload.service', () => ({
+  useUploadServiceV2: () => new Proxy({}, { get: () => vi.fn().mockResolvedValue([]) }),
+}));
+
+vi.mock('@/contexts/NotificationContext', () => ({
+  useNotifications: () => ({ success: vi.fn(), error: vi.fn(), addNotification: vi.fn() }),
+}));
+
+vi.mock('@/contexts/IndexFilterContext', () => ({
+  useNetworkFilter: () => ({ selectedNetworkIds: [], setSelectedNetworkIds: vi.fn() }),
+}));
+
+vi.mock('@/contexts/IndexesContext', () => ({
+  useNetworksState: () => ({ indexes: [], refreshIndexes: vi.fn(), addIndex: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useGmailConnect', () => ({
+  useGmailConnect: () => ({ OAuthLink: () => null }),
+}));
+
+vi.mock('@/hooks/useSuggestions', () => ({
+  useSuggestions: () => ({ suggestions: [] }),
+}));
+
+vi.mock('@/hooks/useOpportunityActions', () => ({
+  useOpportunityActions: () => ({
+    opportunityStatusMap: {},
+    setOpportunityStatusMap: vi.fn(),
+    opportunityActionLoading: {},
+    handleOpportunityAction: vi.fn(),
+    handleStreamingDraftStartChat: vi.fn(),
+    inviteModalElement: null,
+  }),
+}));
+
+vi.mock('@/components/InjectedQuestions/InjectedQuestions', () => ({
+  InjectedQuestions: ({ questions }: { questions: PendingQuestion[] }) => (
+    <div data-testid="injected-questions">
+      {questions.map((q) => (
+        <div key={q.id}>{q.payload?.title ?? q.id}</div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('@/components/chat/AssistantMessageContent', () => ({
+  default: ({ content }: { content: string }) => <div>{content}</div>,
+  parseAllBlocks: () => [],
+}));
+
+vi.mock('@/components/chat/ToolCallsDisplay', () => ({ ToolCallsDisplay: () => null }));
+vi.mock('@/components/chat/InlineDiscoveryCard', () => ({ default: () => null }));
+vi.mock('@/components/chat/OpportunityCardInChat', () => ({
+  default: () => null,
+  OpportunitySkeleton: () => null,
+}));
+vi.mock('@/components/chat/SuggestionChips', () => ({ SuggestionChips: () => null }));
+vi.mock('@/components/DecisionQuestions', () => ({ DecisionQuestions: () => null }));
+vi.mock('@/components/IntentList', () => ({ default: () => null }));
+vi.mock('@/components/DebugCopyButton', () => ({ DebugCopyButton: () => null }));
+vi.mock('@/components/MentionsInput', () => ({
+  MentionsTextInput: () => <textarea data-testid="chat-input" />,
+}));
+vi.mock('react-markdown', () => ({ default: ({ children }: { children: string }) => <div>{children}</div> }));
+vi.mock('remark-gfm', () => ({ default: () => null }));
+
+const INBOX_QUESTION = {
+  id: 'q-inbox-1',
+  detection: { mode: 'negotiation', sourceType: 'opportunity', sourceId: 'opp-1' },
+  actors: [],
+  payload: {
+    title: 'Timeline check',
+    prompt: 'When could you start?',
+    options: [],
+    multiSelect: false,
+  },
+  status: 'pending',
+  answer: null,
+  expiresAt: null,
+  createdAt: new Date().toISOString(),
+  conversationId: null,
+} as unknown as PendingQuestion;
+
+describe('Negotiator DM question inbox (IND-404)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.chat.sessionId = 'dm-session-1';
+    mocks.chat.sessionPersona = null;
+    mocks.chat.chatScope = null;
+    mocks.questionsService.getByConversation.mockResolvedValue([]);
+    mocks.questionsService.getPending.mockResolvedValue([INBOX_QUESTION]);
+    mocks.apiClient.post.mockResolvedValue({ intents: [] });
+  });
+
+  test('negotiator DM fetches the full inbox and renders it as question cards', async () => {
+    mocks.chat.sessionPersona = 'negotiator';
+
+    renderWithRouter(<ChatContent sessionIdParam="dm-session-1" />);
+
+    await waitFor(() =>
+      expect(mocks.questionsService.getPending).toHaveBeenCalledWith({ noConversation: true })
+    );
+    await screen.findByText('Timeline check');
+    expect(screen.getByTestId('negotiator-question-inbox')).toBeInTheDocument();
+    expect(screen.getByText('Open questions for you')).toBeInTheDocument();
+  });
+
+  test('orchestrator sessions do not fetch the global inbox', async () => {
+    mocks.chat.sessionPersona = 'orchestrator';
+
+    renderWithRouter(<ChatContent sessionIdParam="dm-session-1" />);
+
+    await waitFor(() =>
+      expect(mocks.questionsService.getByConversation).toHaveBeenCalledWith('dm-session-1')
+    );
+    expect(mocks.questionsService.getPending).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('negotiator-question-inbox')).toBeNull();
+  });
+
+  test('intent-pinned negotiator sessions keep the intent-scope query (no global inbox)', async () => {
+    mocks.chat.sessionPersona = 'negotiator';
+    mocks.chat.chatScope = { type: 'intent', id: 'intent-42' };
+
+    renderWithRouter(<ChatContent sessionIdParam="dm-session-1" />);
+
+    await waitFor(() =>
+      expect(mocks.questionsService.getPending).toHaveBeenCalledWith({ scopeType: 'intent', scopeId: 'intent-42' })
+    );
+    expect(mocks.questionsService.getPending).not.toHaveBeenCalledWith({ noConversation: true });
+    expect(screen.queryByTestId('negotiator-question-inbox')).toBeNull();
+  });
+});

--- a/apps/web/tests/sidebar-negotiator.test.tsx
+++ b/apps/web/tests/sidebar-negotiator.test.tsx
@@ -26,6 +26,7 @@ const mocks = vi.hoisted(() => {
       user: null as Record<string, unknown> | null,
       features: null as Record<string, unknown> | null,
     },
+    questionsState: { count: 0 },
   };
 });
 
@@ -90,7 +91,7 @@ vi.mock('@/contexts/NotificationContext', () => ({
 }));
 
 vi.mock('@/contexts/QuestionsContext', () => ({
-  useQuestions: () => ({ count: 0 }),
+  useQuestions: () => ({ count: mocks.questionsState.count }),
 }));
 
 vi.mock('@/components/modals/CreateIndexModal', () => ({
@@ -146,6 +147,7 @@ describe('Sidebar pinned Personal Agent entry', () => {
     vi.clearAllMocks();
     mocks.authState.user = aliceUser;
     mocks.authState.features = null;
+    mocks.questionsState.count = 0;
     mockSessions({});
   });
 
@@ -218,6 +220,37 @@ describe('Sidebar pinned Personal Agent entry', () => {
       expect(screen.getByTestId('location')).toHaveTextContent('/d/neg-dm-1')
     );
     expect(mocks.apiClient.post).not.toHaveBeenCalled();
+  });
+
+  test('pending-question badge renders on the entry when the inbox has open questions (IND-404)', async () => {
+    mocks.authState.features = { negotiatorChat: true };
+    mocks.questionsState.count = 3;
+    mockSessions({
+      negotiator: [{ id: 'neg-session-1', title: "Alice's Negotiator", networkId: null, createdAt: '', updatedAt: '' }],
+    });
+
+    renderSidebar();
+
+    await screen.findByText("Alice's Negotiator");
+    expect(screen.getByTestId('negotiator-question-badge')).toHaveTextContent('3');
+  });
+
+  test('badge caps at 99+ and disappears at zero (IND-404)', async () => {
+    mocks.authState.features = { negotiatorChat: true };
+    mocks.questionsState.count = 120;
+    mockSessions({
+      negotiator: [{ id: 'neg-session-1', title: "Alice's Negotiator", networkId: null, createdAt: '', updatedAt: '' }],
+    });
+
+    const { unmount } = renderSidebar();
+    await screen.findByText("Alice's Negotiator");
+    expect(screen.getByTestId('negotiator-question-badge')).toHaveTextContent('99+');
+    unmount();
+
+    mocks.questionsState.count = 0;
+    renderSidebar();
+    await screen.findByText("Alice's Negotiator");
+    expect(screen.queryByTestId('negotiator-question-badge')).toBeNull();
   });
 
   test('negotiator session never renders in the history list', async () => {

--- a/packages/protocol/src/chat/negotiator.persona.ts
+++ b/packages/protocol/src/chat/negotiator.persona.ts
@@ -46,8 +46,11 @@ export const NEGOTIATOR_TOOL_NAMES = [
   "update_opportunity",
   // Pending questions — the system's open questions for the client. Added for
   // intent-pinned sessions (P4.2/IND-403); the tool clamps itself to the
-  // focused intent scope when one is set.
+  // focused intent scope when one is set. answer_pending_question (P4.3/IND-404)
+  // records the client's explicit answers through the same pipeline the
+  // question cards use.
   "read_pending_questions",
+  "answer_pending_question",
   // Signals — the input surface of signal-based discovery (P4.5)
   "read_intents",
   "create_intent",

--- a/packages/protocol/src/chat/negotiator.prompt.ts
+++ b/packages/protocol/src/chat/negotiator.prompt.ts
@@ -43,10 +43,26 @@ function buildPinnedSignalSection(intentId: string, label?: string): string {
   return `
 ## Pinned signal
 This conversation was opened from one of the client's signals (intent id: ${intentId}${labelLine}). Treat it as the working focus of this chat:
-- Open questions listed by read_pending_questions here are this signal's open questions — surface them early and work through them conversationally; the client answers them via the question cards shown in this chat.
+- Open questions listed by read_pending_questions here are this signal's open questions — surface them early and work through them conversationally. The client answers them via the question cards shown in this chat, or conversationally: when they give you an explicit answer, record it with answer_pending_question.
 - list_opportunities and read_pending_questions are automatically restricted to this signal in this session; use them to report matches, negotiations, and follow-ups that grew out of it.
 - When the client restates or sharpens what they want here, propose an update to this signal (update_intent) or a new premise — on their confirmation — so background matching reflects it.
 - This is a focus, not a wall: you may still read the client's profile, premises, and other signals when the conversation needs the fuller picture, and general questions about their negotiations remain fair game.`;
+}
+
+/**
+ * Renders the question-inbox section for the unscoped DM (P4.3/IND-404).
+ * The DM is the client's primary surface for the system's open questions:
+ * signal refinements, negotiation follow-ups, profile gaps. Cards render in
+ * the chat; conversational answers are recorded via answer_pending_question.
+ */
+function buildQuestionInboxSection(): string {
+  return `
+## Client question inbox
+The system collects open questions for your client (signal refinements, negotiation follow-ups, profile gaps), and this chat is the primary place they get handled. Question cards also render directly in this chat.
+- Early in a conversation — or whenever the client asks what needs their attention — call read_pending_questions and surface what is open, briefly and in plain language.
+- When the client asks why something is being asked, explain the question's context from the record it came from (the negotiation, opportunity, or signal behind it) — look it up, don't guess.
+- When the client answers a question conversationally, record it with answer_pending_question — pass exactly what they said (their chosen options and/or their own words), never an answer you inferred. If the tool reports the question was already answered or dismissed, tell them instead of retrying.
+- Never pressure the client to answer; the questions keep for later and remain available in the app's Questions page.`;
 }
 
 /**
@@ -75,9 +91,11 @@ export function buildNegotiatorSystemContent(
     ? `\n${opts.agentDescription.trim()}\n`
     : "";
   const pinnedIntentId = focusedIntentId(ctx);
+  // Pinned sessions clamp the question tools to the signal and carry their own
+  // question guidance; the unscoped DM gets the full inbox instead.
   const pinnedSignalSection = pinnedIntentId
     ? buildPinnedSignalSection(pinnedIntentId, opts.pinnedIntentLabel)
-    : "";
+    : buildQuestionInboxSection();
 
   return `You are ${opts.agentName}, the personal negotiator agent working for ${ctx.userName}.
 ${descriptionLine}
@@ -120,6 +138,7 @@ ${profileContext}
 | **respond_to_negotiation** | negotiationId, ... | Act on a negotiation — ONLY on explicit client instruction |
 | **list_opportunities** | — | List the client's actionable opportunities |
 | **read_pending_questions** | limit? | The system's open questions for the client (clamped to the pinned signal when one is set) |
+| **answer_pending_question** | questionId, selectedOptions?, freeText? | Record the client's explicit answer to a pending question — ONLY with an answer they actually gave |
 | **update_opportunity** | opportunityId, status | Accept/pass an opportunity — ONLY on explicit client instruction |
 | **read_intents** / **search_intents** | — / query | The client's active signals (what they're looking for) |
 | **create_intent** | description, networkId? | Draft a new signal — returns a proposal card the client approves in the UI |

--- a/packages/protocol/src/chat/tests/negotiator.persona.spec.ts
+++ b/packages/protocol/src/chat/tests/negotiator.persona.spec.ts
@@ -158,6 +158,27 @@ describe("buildNegotiatorSystemContent — pinned signal (intent scope)", () => 
   });
 });
 
+// ─── Question inbox (P4.3 / IND-404) ─────────────────────────────────────────
+
+describe("buildNegotiatorSystemContent — client question inbox (DM)", () => {
+  it("renders the inbox section for the unscoped DM", () => {
+    const prompt = buildNegotiatorSystemContent(makeCtx(), AGENT_OPTS);
+    expect(prompt).toContain("## Client question inbox");
+    expect(prompt).toContain("answer_pending_question");
+    // Explicit-answer contract: never record inferred answers.
+    expect(prompt).toContain("never an answer you inferred");
+  });
+
+  it("does not render the inbox section in intent-pinned sessions (pin guidance replaces it)", () => {
+    const scopedCtx = makeCtx({ scopeType: "intent", scopeId: "intent-42" } as Partial<ResolvedToolContext>);
+    const prompt = buildNegotiatorSystemContent(scopedCtx, AGENT_OPTS);
+    expect(prompt).not.toContain("## Client question inbox");
+    expect(prompt).toContain("## Pinned signal");
+    // The pin section still teaches conversational answering.
+    expect(prompt).toContain("answer_pending_question");
+  });
+});
+
 // ─── Tool scoping ────────────────────────────────────────────────────────────
 
 /** Representative orchestrator registry (superset of the negotiator allowlist). */
@@ -219,6 +240,7 @@ const ORCHESTRATOR_REGISTRY_NAMES = [
   "update_premise",
   "retract_premise",
   "read_pending_questions",
+  "answer_pending_question",
   "ask_user_question",
 ];
 
@@ -234,6 +256,7 @@ describe("filterNegotiatorTools", () => {
   it("keeps the P4.5 capability groups (signals, knowledge writes, joins, contacts)", () => {
     for (const allowed of [
       "read_pending_questions",
+      "answer_pending_question",
       "create_intent",
       "update_intent",
       "delete_intent",

--- a/packages/protocol/src/questioner/questioner.tools.ts
+++ b/packages/protocol/src/questioner/questioner.tools.ts
@@ -34,8 +34,9 @@ function stripInternalActors(question: PendingQuestionSummary): Omit<PendingQues
  * block mirroring the network-tools convention.
  *
  * @param defineTool - Tool factory provided by the composition root.
- * @param deps       - Shared tool dependencies; `findPendingQuestions` is optional
- *                     and the tool fails gracefully when absent.
+ * @param deps       - Shared tool dependencies; `findPendingQuestions` and
+ *                     `answerPendingQuestion` are optional and the tools fail
+ *                     gracefully when absent.
  */
 export function createQuestionerTools(defineTool: DefineTool, deps: ToolDeps) {
   const readPendingQuestions = defineTool({
@@ -127,5 +128,88 @@ export function createQuestionerTools(defineTool: DefineTool, deps: ToolDeps) {
     },
   });
 
-  return [readPendingQuestions] as const;
+  const answerPendingQuestion = defineTool({
+    name: "answer_pending_question",
+    description:
+      "Records the client's explicit answer to one of their pending questions (from " +
+      "read_pending_questions) through the standard answer pipeline — the same one the " +
+      "question cards in the app use. Downstream effects (signal refinement, negotiation " +
+      "context, profile enrichment) fire exactly as if the client answered the card.\n\n" +
+      "**Use ONLY with an answer the client explicitly gave in this conversation.** Never " +
+      "infer, summarize, or invent an answer on their behalf. Pass the client's chosen " +
+      "option labels in `selectedOptions` and/or their own words in `freeText`.\n\n" +
+      "**Returns:** `answered: true` on success. If the question was already answered, " +
+      "dismissed, or expired, the tool reports that — tell the client instead of retrying.",
+    querySchema: z.object({
+      questionId: z.string().min(1).describe("Id of the pending question being answered (from read_pending_questions)."),
+      selectedOptions: z
+        .array(z.string().min(1))
+        .max(10)
+        .optional()
+        .describe("Option labels the client explicitly chose, when the question has options."),
+      freeText: z
+        .string()
+        .max(2000)
+        .optional()
+        .describe("The client's answer in their own words, for free-form answers or an 'other' option."),
+    }),
+    handler: async ({ context, query }) => {
+      if (!deps.answerPendingQuestion || !deps.findPendingQuestions) {
+        return error("Question answering is not available.");
+      }
+
+      // Client-surface action: network-scoped agent keys act inside one
+      // community and must not settle the user's global question inbox
+      // (same leak class as the SELF_OWNED_MODES clamp above).
+      if (focusedNetworkId(context)) {
+        return error("Answering questions is not available for network-scoped agents.");
+      }
+
+      const selectedOptions = (query.selectedOptions ?? []).map((option) => option.trim()).filter(Boolean);
+      const freeText = query.freeText?.trim();
+      if (selectedOptions.length === 0 && !freeText) {
+        return error(
+          "No answer provided. Pass the client's explicit answer via selectedOptions and/or freeText — never answer on their behalf.",
+        );
+      }
+
+      const scopedIntentId = focusedIntentId(context);
+      try {
+        // Visibility check under the same clamps as read_pending_questions:
+        // an intent-pinned session may only answer questions it can list.
+        const pending = await deps.findPendingQuestions(context.userId, {
+          ...(scopedIntentId ? { scopeType: 'intent' as const, scopeId: scopedIntentId } : {}),
+        });
+        const target = pending.find((q) => q.id === query.questionId);
+        if (!target) {
+          return error(
+            "Question not found among the client's pending questions — it may already be answered or dismissed. Re-check with read_pending_questions.",
+          );
+        }
+
+        const answered = await deps.answerPendingQuestion(context.userId, query.questionId, {
+          selectedOptions,
+          ...(freeText ? { freeText } : {}),
+        });
+        if (!answered) {
+          return error("The question was already answered or dismissed — nothing was recorded.");
+        }
+
+        return success({
+          answered: true,
+          question: { id: target.id, title: target.title, prompt: target.prompt },
+          recordedAnswer: { selectedOptions, ...(freeText ? { freeText } : {}) },
+        });
+      } catch (err) {
+        deps.reportToolError?.(err, {
+          operation: "answer-pending-question",
+          toolName: "answer_pending_question",
+          userId: context.userId,
+        });
+        return error("Failed to record the answer.");
+      }
+    },
+  });
+
+  return [readPendingQuestions, answerPendingQuestion] as const;
 }

--- a/packages/protocol/src/questioner/tests/questioner.tools.spec.ts
+++ b/packages/protocol/src/questioner/tests/questioner.tools.spec.ts
@@ -50,10 +50,12 @@ const mockQuestion: PendingQuestionSummary = {
 
 function makeDeps(overrides?: {
   findPendingQuestions?: ((userId: string, filters?: CapturedFilters) => Promise<PendingQuestionSummary[]>) | undefined;
+  answerPendingQuestion?: ((userId: string, questionId: string, answer: { selectedOptions: string[]; freeText?: string }) => Promise<boolean>) | undefined;
   reportToolError?: (error: unknown, report: Record<string, unknown>) => void;
 }) {
   return {
     findPendingQuestions: overrides?.findPendingQuestions,
+    answerPendingQuestion: overrides?.answerPendingQuestion,
     reportToolError: overrides?.reportToolError,
   } as never;
 }
@@ -199,6 +201,126 @@ describe("createQuestionerTools", () => {
       expect(reports).toHaveLength(1);
       expect(reports[0].toolName).toBe("read_pending_questions");
       expect(reports[0].operation).toBe("read-pending-questions");
+    });
+  });
+
+  describe("answer_pending_question (P4.3/IND-404)", () => {
+    type AnswerCall = { userId: string; questionId: string; answer: { selectedOptions: string[]; freeText?: string } };
+
+    function makeAnswerDeps(opts?: {
+      pending?: PendingQuestionSummary[];
+      answered?: boolean;
+      reportToolError?: (error: unknown, report: Record<string, unknown>) => void;
+    }) {
+      const calls: AnswerCall[] = [];
+      const capturedFilters: CapturedFilters[] = [];
+      const deps = makeDeps({
+        findPendingQuestions: async (_userId, filters) => {
+          capturedFilters.push(filters);
+          return opts?.pending ?? [mockQuestion];
+        },
+        answerPendingQuestion: async (uid, questionId, answer) => {
+          calls.push({ userId: uid, questionId, answer });
+          return opts?.answered ?? true;
+        },
+        reportToolError: opts?.reportToolError,
+      });
+      return { deps, calls, capturedFilters };
+    }
+
+    it("records the client's explicit answer through the pipeline", async () => {
+      const { defineTool, call } = makeDefineTool();
+      const { deps, calls } = makeAnswerDeps();
+      createQuestionerTools(defineTool as never, deps);
+      const result = await call("answer_pending_question", {
+        questionId: "q-0001",
+        selectedOptions: ["Co-building"],
+        freeText: "ideally something climate-adjacent",
+      }) as { success: boolean; data: { answered: boolean; question: { id: string } } };
+      expect(result.success).toBe(true);
+      expect(result.data.answered).toBe(true);
+      expect(result.data.question.id).toBe("q-0001");
+      expect(calls).toEqual([{
+        userId,
+        questionId: "q-0001",
+        answer: { selectedOptions: ["Co-building"], freeText: "ideally something climate-adjacent" },
+      }]);
+    });
+
+    it("rejects an empty answer (never answers on the client's behalf)", async () => {
+      const { defineTool, call } = makeDefineTool();
+      const { deps, calls } = makeAnswerDeps();
+      createQuestionerTools(defineTool as never, deps);
+      const result = await call("answer_pending_question", {
+        questionId: "q-0001",
+        selectedOptions: ["  "],
+      }) as { success: boolean; error: string };
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("No answer provided");
+      expect(calls).toHaveLength(0);
+    });
+
+    it("refuses network-scoped agents", async () => {
+      const { defineTool, call } = makeDefineTool();
+      const { deps, calls } = makeAnswerDeps();
+      createQuestionerTools(defineTool as never, deps);
+      const scoped = makeContext({ networkId: 'net-0001', scopeType: 'network', scopeId: 'net-0001', indexName: 'Edge Esmeralda' });
+      const result = await call("answer_pending_question", { questionId: "q-0001", freeText: "hi" }, scoped) as { success: boolean; error: string };
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("network-scoped");
+      expect(calls).toHaveLength(0);
+    });
+
+    it("clamps the visibility check to the pinned intent in intent-scoped sessions", async () => {
+      const { defineTool, call } = makeDefineTool();
+      const { deps, capturedFilters } = makeAnswerDeps();
+      createQuestionerTools(defineTool as never, deps);
+      const scoped = makeContext({ scopeType: 'intent', scopeId: 'intent-42' });
+      const result = await call("answer_pending_question", { questionId: "q-0001", freeText: "answer" }, scoped) as { success: boolean };
+      expect(result.success).toBe(true);
+      expect(capturedFilters[0]).toEqual({ scopeType: 'intent', scopeId: 'intent-42' });
+    });
+
+    it("errors when the question is not among the client's pending questions", async () => {
+      const { defineTool, call } = makeDefineTool();
+      const { deps, calls } = makeAnswerDeps({ pending: [] });
+      createQuestionerTools(defineTool as never, deps);
+      const result = await call("answer_pending_question", { questionId: "q-gone", freeText: "answer" }) as { success: boolean; error: string };
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("not found among the client's pending questions");
+      expect(calls).toHaveLength(0);
+    });
+
+    it("surfaces the already-answered race as an error, not a success", async () => {
+      const { defineTool, call } = makeDefineTool();
+      const { deps } = makeAnswerDeps({ answered: false });
+      createQuestionerTools(defineTool as never, deps);
+      const result = await call("answer_pending_question", { questionId: "q-0001", freeText: "answer" }) as { success: boolean; error: string };
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("already answered or dismissed");
+    });
+
+    it("returns an error when the answer dep is absent", async () => {
+      const { defineTool, call } = makeDefineTool();
+      createQuestionerTools(defineTool as never, makeDeps({ findPendingQuestions: async () => [mockQuestion] }));
+      const result = await call("answer_pending_question", { questionId: "q-0001", freeText: "answer" }) as { success: boolean; error: string };
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("not available");
+    });
+
+    it("reports and surfaces an error when the pipeline throws", async () => {
+      const { defineTool, call } = makeDefineTool();
+      const reports: Array<Record<string, unknown>> = [];
+      createQuestionerTools(defineTool as never, makeDeps({
+        findPendingQuestions: async () => [mockQuestion],
+        answerPendingQuestion: async () => { throw new Error("db down"); },
+        reportToolError: (_err, report) => { reports.push(report); },
+      }));
+      const result = await call("answer_pending_question", { questionId: "q-0001", freeText: "answer" }) as { success: boolean; error: string };
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Failed to record the answer");
+      expect(reports).toHaveLength(1);
+      expect(reports[0].toolName).toBe("answer_pending_question");
     });
   });
 });

--- a/packages/protocol/src/shared/agent/tool.helpers.ts
+++ b/packages/protocol/src/shared/agent/tool.helpers.ts
@@ -194,6 +194,18 @@ export interface ToolContext {
       limit?: number;
     },
   ) => Promise<PendingQuestionSummary[]>;
+  /**
+   * Record the client's explicit answer to a pending question through the
+   * host's question-answer pipeline (atomic pending→answered flip + answered
+   * events). Returns false when the question is not pending for this user
+   * (already answered/dismissed, expired, or not theirs). Injected by the
+   * composition root — absent when question delivery is disabled.
+   */
+  answerPendingQuestion?: (
+    userId: string,
+    questionId: string,
+    answer: { selectedOptions: string[]; freeText?: string },
+  ) => Promise<boolean>;
   /** Negotiation-digest summarizer. Optional; consumers fall back to deterministic digests. */
   negotiationSummary?: NegotiationSummaryReader;
   /**
@@ -545,6 +557,17 @@ export interface ToolDeps {
       limit?: number;
     },
   ) => Promise<PendingQuestionSummary[]>;
+  /**
+   * Record the client's explicit answer to a pending question through the
+   * host's question-answer pipeline (atomic pending→answered flip + answered
+   * events). Returns false when the question is not pending for this user.
+   * Injected by the composition root — absent when question delivery is disabled.
+   */
+  answerPendingQuestion?: (
+    userId: string,
+    questionId: string,
+    answer: { selectedOptions: string[]; freeText?: string },
+  ) => Promise<boolean>;
   /** Negotiation-digest summarizer. Optional; consumers fall back to deterministic digests. */
   negotiationSummary?: NegotiationSummaryReader;
   /**

--- a/services/api/src/controllers/tests/question.inbox.spec.ts
+++ b/services/api/src/controllers/tests/question.inbox.spec.ts
@@ -1,0 +1,202 @@
+/**
+ * P4.3 pending question inbox (IND-404) — API-layer integration tests.
+ *
+ * Covers the acceptance criteria that live in the API layer:
+ * - an open (pending) question is visible through the DM-inbox query the
+ *   negotiator chat surface uses (noConversation, all modes)
+ * - the answer_pending_question host dep (ToolService wiring) records answers
+ *   through the standard pipeline: atomic pending→answered flip + the
+ *   QuestionEvents.onAnswered mode dispatch
+ * - the double-answer race is guarded at every entry surface: the second
+ *   answer returns false at the adapter and 404 at the REST endpoint the
+ *   question cards use
+ *
+ * Uses the real database adapters against the test DB.
+ */
+import { config } from "dotenv";
+config({ path: '.env.test', override: true });
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from "bun:test";
+import { eq } from "drizzle-orm/sql";
+import { QuestionController } from "../question.controller";
+import { QuestionerAdapter, type AdapterPersistableQuestion } from "../../adapters/questioner.adapter";
+import { UserDatabaseAdapter } from "../../adapters/database.adapter";
+import { questionService } from "../../services/question.service";
+import { QuestionEvents } from "../../events/question.event";
+import db from "../../lib/drizzle/drizzle";
+import { questions } from "../../schemas/database.schema";
+import type { AuthenticatedUser } from "../../guards/auth.guard";
+
+const EMAIL = "test-question-inbox@example.com";
+
+describe("Pending question inbox (IND-404)", () => {
+  const userAdapter = new UserDatabaseAdapter();
+  const questionerAdapter = new QuestionerAdapter(db);
+  const controller = new QuestionController();
+  let testUserId: string;
+  const createdQuestionIds: string[] = [];
+  let answeredEvents: Array<{ questionId: string; mode: string; sourceId: string }> = [];
+  const prevOnAnswered = QuestionEvents.onAnswered;
+
+  const mockUser = (): AuthenticatedUser => ({
+    id: testUserId,
+    email: EMAIL,
+    name: "Test Inbox User",
+  });
+
+  /** Persist a pending question for the test user and track it for cleanup. */
+  async function persistQuestion(overrides?: Partial<AdapterPersistableQuestion>): Promise<string> {
+    const batch: AdapterPersistableQuestion[] = [{
+      detection: {
+        mode: 'negotiation',
+        sourceType: 'opportunity',
+        sourceId: crypto.randomUUID(),
+        timestamp: new Date().toISOString(),
+      },
+      actors: [{ userId: testUserId, role: 'subject' }],
+      payload: {
+        title: "Timeline check",
+        prompt: "The counterparty asked about your timeline — when could you start?",
+        options: [
+          { label: "Within a month", description: "Ready to move quickly" },
+          { label: "Later this year", description: "Not before Q4" },
+        ],
+        multiSelect: false,
+      },
+      strategy: 'surface_missing_detail',
+      ...overrides,
+    }];
+    const [id] = await questionerAdapter.persist(batch);
+    createdQuestionIds.push(id);
+    return id;
+  }
+
+  const answerReq = (body: Record<string, unknown>) =>
+    new Request("http://localhost/questions/x/answer", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+  beforeAll(async () => {
+    const existingUser = await userAdapter.findByEmail(EMAIL);
+    if (existingUser) await userAdapter.deleteByEmail(EMAIL);
+    const user = await userAdapter.create({ email: EMAIL, name: "Test Inbox User" });
+    testUserId = user.id;
+
+    QuestionEvents.onAnswered = (payload) => {
+      answeredEvents.push({ questionId: payload.questionId, mode: payload.mode, sourceId: payload.sourceId });
+    };
+  });
+
+  afterAll(async () => {
+    QuestionEvents.onAnswered = prevOnAnswered;
+    for (const id of createdQuestionIds) {
+      await db.delete(questions).where(eq(questions.id, id)).catch(() => {});
+    }
+    if (testUserId) await userAdapter.deleteById(testUserId);
+  });
+
+  beforeEach(() => {
+    answeredEvents = [];
+  });
+
+  // ── DM inbox visibility ────────────────────────────────────────────────
+
+  test("a pending question appears in the DM-inbox query (noConversation, all modes)", async () => {
+    const questionId = await persistQuestion();
+
+    // The negotiator DM surface queries the same way the global inbox does:
+    // pending, not bound to a conversation, no mode clamp.
+    const pending = await questionService.findPending(testUserId, { noConversation: true });
+    const ids = pending.map((q) => q.id);
+    expect(ids).toContain(questionId);
+    const row = pending.find((q) => q.id === questionId)!;
+    expect(row.detection.mode).toBe('negotiation');
+    expect(row.status).toBe('pending');
+  });
+
+  test("conversation-bound questions stay out of the DM inbox", async () => {
+    const questionId = await persistQuestion({
+      detection: {
+        mode: 'chat',
+        sourceType: 'conversation',
+        sourceId: 'session-1',
+        timestamp: new Date().toISOString(),
+      },
+      conversationId: crypto.randomUUID(),
+    });
+    const pending = await questionService.findPending(testUserId, { noConversation: true });
+    expect(pending.map((q) => q.id)).not.toContain(questionId);
+  });
+
+  // ── answer pipeline through the tool-host dep shape ────────────────────
+
+  test("answering flips pending→answered and fires the onAnswered mode dispatch", async () => {
+    const questionId = await persistQuestion();
+
+    // Exactly what ToolService.answerPendingQuestion does for the
+    // answer_pending_question tool.
+    const answered = await questionerAdapter.answer(questionId, testUserId, {
+      selectedOptions: ["Within a month"],
+      freeText: "assuming the contract closes",
+      answeredBy: testUserId,
+      answeredAt: new Date().toISOString(),
+    });
+    expect(answered).toBe(true);
+
+    expect(answeredEvents).toHaveLength(1);
+    expect(answeredEvents[0].questionId).toBe(questionId);
+    expect(answeredEvents[0].mode).toBe('negotiation');
+
+    const [row] = await db.select().from(questions).where(eq(questions.id, questionId));
+    expect(row.status).toBe('answered');
+    expect(row.answer?.selectedOptions).toEqual(["Within a month"]);
+    expect(row.answer?.freeText).toBe("assuming the contract closes");
+
+    // No longer pending anywhere.
+    const pending = await questionService.findPending(testUserId, { noConversation: true });
+    expect(pending.map((q) => q.id)).not.toContain(questionId);
+  });
+
+  test("double-answer race: the second answer is refused and fires no second event", async () => {
+    const questionId = await persistQuestion();
+    const answer = {
+      selectedOptions: ["Later this year"],
+      answeredBy: testUserId,
+      answeredAt: new Date().toISOString(),
+    };
+
+    expect(await questionerAdapter.answer(questionId, testUserId, answer)).toBe(true);
+    expect(await questionerAdapter.answer(questionId, testUserId, answer)).toBe(false);
+    expect(answeredEvents).toHaveLength(1);
+  });
+
+  test("another user cannot answer the client's question", async () => {
+    const questionId = await persistQuestion();
+    const answered = await questionerAdapter.answer(questionId, crypto.randomUUID(), {
+      selectedOptions: ["Within a month"],
+      answeredBy: 'someone-else',
+      answeredAt: new Date().toISOString(),
+    });
+    expect(answered).toBe(false);
+    expect(answeredEvents).toHaveLength(0);
+  });
+
+  // ── REST entry (the path the question cards use) ───────────────────────
+
+  test("REST double answer: 200 then 404 (card-path regression)", async () => {
+    const questionId = await persistQuestion();
+    const body = { selectedOptions: ["Within a month"] };
+
+    const first = await controller.answer(answerReq(body), mockUser(), { id: questionId });
+    expect(first.status).toBe(200);
+    const firstJson = await first.json() as { success: boolean; resumed: boolean };
+    expect(firstJson.success).toBe(true);
+    expect(firstJson.resumed).toBe(false);
+
+    const second = await controller.answer(answerReq(body), mockUser(), { id: questionId });
+    expect(second.status).toBe(404);
+    expect(answeredEvents).toHaveLength(1);
+  });
+});

--- a/services/api/src/services/tool.service.ts
+++ b/services/api/src/services/tool.service.ts
@@ -96,6 +96,19 @@ export class ToolService {
           })),
         }));
       },
+      // P4.3/IND-404: conversational answers from the negotiator chat ride the
+      // exact pipeline the question cards use — atomic pending→answered flip in
+      // the adapter, then QuestionEvents.onAnswered mode dispatch.
+      answerPendingQuestion: async (
+        userId: string,
+        questionId: string,
+        answer: { selectedOptions: string[]; freeText?: string },
+      ) => questionerAdapter.answer(questionId, userId, {
+        selectedOptions: answer.selectedOptions,
+        ...(answer.freeText ? { freeText: answer.freeText } : {}),
+        answeredBy: userId,
+        answeredAt: new Date().toISOString(),
+      }),
       graphs,
     };
   }


### PR DESCRIPTION
## Summary

P4.3 (IND-404): the negotiator chat becomes the primary surface for the client's open questions. Pending questions render as cards in the negotiator DM, the persona can read and record answers conversationally through the exact pipeline the cards use, and the sidebar Personal Agent entry carries the pending-question count.

Linear: [IND-404](https://linear.app/indexnetwork/issue/IND-404/p43-pending-ask-user-inbox-in-negotiator-chat) (parent [IND-395](https://linear.app/indexnetwork/issue/IND-395))

## What changed

### Protocol (`packages/protocol`)
- **New `answer_pending_question` tool** (`questioner.tools.ts`): records the client's explicit answer via the host's answer pipeline — same atomic `pending→answered` flip + `QuestionEvents.onAnswered` mode dispatch the question cards trigger. Guards:
  - refuses an empty answer ("never answer on the client's behalf")
  - refuses network-scoped agent keys (same leak class as the `SELF_OWNED_MODES` clamp)
  - visibility check under the same clamps as `read_pending_questions` (intent-pinned sessions can only answer questions they can list)
  - the already-answered race surfaces as an error, not a success
- **Negotiator allowlist 34 → 35 tools** (`negotiator.persona.ts`).
- **Prompt** (`negotiator.prompt.ts`): the unscoped DM gets a `## Client question inbox` section (surface open questions early, explain a question's context from the record it came from, record only explicit answers, never pressure). The pinned-signal section now teaches conversational answering too.

### API (`services/api`)
- `ToolService` wires `answerPendingQuestion` → `QuestionerAdapter.answer` (fires the existing `onAnswered` mode dispatch: negotiation answers land in `opportunity.metadata.userAnswers` and are picked up by the next `respond_to_negotiation`; intent answers enqueue refinement; etc.).
- The MCP registry (`mcp.controller.ts`) is deliberately **not** wired — external agent keys cannot settle the user's inbox (tool fails closed there).
- No migrations. No new endpoints.

### Web (`apps/web`)
- `AIChatContext` exposes `sessionPersona` (already returned by `POST /chat/session`; cleared on `clearChat`).
- `ChatContent`: negotiator DM sessions (persona `negotiator`, no intent pin) additionally fetch the full pending inbox (`GET /questions?status=pending&noConversation=true` — the same set the `/questions` page shows) and render it through the existing injected-questions machinery under an "Open questions for you" header. Answer/dismiss ride the existing card handlers (`POST /questions/:id/answer|dismiss`).
- Sidebar: the pinned Personal Agent entry shows the pending-question count badge (reuses `QuestionsContext`, same style as the Questions entry).

## Honest deltas from the issue text (predates the audit)

- **"tasks in `input_required`"** — `input_required` is a task state that is never written anywhere; the real inbox is `questions.status='pending'` (including `negotiation`-mode questions generated for stalled/capped/timed-out negotiations). Implemented against the questions table.
- **"timer cancelled → negotiation resumes"** — no timer is attached to questions (the 5-min negotiation park timer is counterparty-response machinery, cancelled by `respond_to_negotiation`, unrelated to questions). Negotiation-mode answers store context consumed by the next negotiation turn — that is the existing pipeline, and this PR routes conversational answers through it unchanged.
- **"live delivery to an active session"** — no SSE/presence registry exists (per-turn streams only), so push delivery at question-creation time is not possible without new infra. Delivery is pull-based: inbox fetch on DM open + sidebar badge (30s poll via `QuestionsContext`). `QuestionEvents.onCreated` remains the seam for a future push path. The async `/questions` queue is untouched as the fallback surface (AC).

## Tests

- protocol: `questioner.tools.spec.ts` 8 new specs for the answer tool; `negotiator.persona.spec.ts` inbox-section + allowlist specs — 95 pass across questioner + persona suites
- api: new DB-backed `question.inbox.spec.ts` (6): DM-inbox visibility (`noConversation`), conversation-bound exclusion, pipeline event dispatch, double-answer race at adapter + REST entry (200 → 404), cross-user answer refusal; `chat.negotiator.spec.ts` 16/16
- web: new `negotiator-dm-inbox.test.tsx` (3): DM fetches + renders inbox, orchestrator sessions don't, intent-pinned sessions keep the intent-scope query; `sidebar-negotiator.test.tsx` 7/7 incl. badge + 99+ cap
- builds: protocol tsc ✓, api tsc ✓, web vite ✓; eslint 0 errors (warnings = dev baseline)

## Rollout / rollback

- Additive; no flags added — the surfaces are already gated by `NEGOTIATOR_CHAT_ENABLED` (flag off → no negotiator chat, no badge, `/questions` unchanged).
- Rollback = revert; no data shape changes.
