### PR TITLE
feat: stamp initiatorUserId at every discovery origin (IND-396)

### DIFF
--- a/packages/protocol/src/chat/chat-streaming.types.ts
+++ b/packages/protocol/src/chat/chat-streaming.types.ts
@@ -484,6 +484,8 @@ export interface NegotiationSessionStartEvent extends ChatStreamEventBase {
   negotiationConversationId: string;
   sourceUserId: string;
   candidateUserId: string;
+  /** The user holding the initiating seat for this match (v2 stamp). */
+  initiatorUserId?: string;
   candidateName?: string;
   trigger: "orchestrator" | "ambient";
   startedAt: number;

--- a/packages/protocol/src/negotiation/negotiation.graph.ts
+++ b/packages/protocol/src/negotiation/negotiation.graph.ts
@@ -52,17 +52,14 @@ export class NegotiationGraphFactory {
         // --- Lock gate: check for an active task on this conversation ---
         const priorMessages = await database.getMessagesForConversation(conversation.id);
 
-        let isLocked = false;
-        if (state.opportunityId) {
-          const priorTask = await database.getNegotiationTaskForOpportunity(state.opportunityId);
-          if (priorTask) {
-            const activeStates = ['submitted', 'working', 'input_required', 'waiting_for_agent', 'claimed'];
-            const isFresh = (Date.now() - new Date(priorTask.updatedAt).getTime()) < 5 * 60 * 1000;
-            if (activeStates.includes(priorTask.state) && isFresh) {
-              isLocked = true;
-            }
-          }
-        }
+        const activeStates = ['submitted', 'working', 'input_required', 'waiting_for_agent', 'claimed'];
+        const isActiveAndFresh = (t: { state: string; updatedAt: Date }) =>
+          activeStates.includes(t.state) && (Date.now() - new Date(t.updatedAt).getTime()) < 5 * 60 * 1000;
+
+        const priorTask = state.opportunityId
+          ? await database.getNegotiationTaskForOpportunity(state.opportunityId)
+          : null;
+        const isLocked = !!priorTask && isActiveAndFresh(priorTask);
 
         if (isLocked) {
           initLog.info('Conversation locked by active task, returning busy', {
@@ -97,9 +94,40 @@ export class NegotiationGraphFactory {
           maxTurns = (sourceHasAgent && candidateHasAgent) ? 0 : ambientMax;
         }
 
+        // --- Initiator seat resolution (v2: rigid per match, stamped at discovery) ---
+        // 1. Continuations inherit from the prior task for the same opportunity —
+        //    never re-derive, so the seat cannot flip between sessions.
+        // 2. Conversation-scoped tie-break: if another negotiation on this DM is
+        //    active and fresh (symmetric concurrent start under a different
+        //    opportunityId — the opportunity-scoped lock above cannot see it),
+        //    the first created task keeps the seat; this run inherits its stamp.
+        // 3. Otherwise: explicit stamp from the caller, falling back to the
+        //    session's sourceUser (pre-stamp heuristic behavior, unchanged).
+        const readInitiator = (metadata: Record<string, unknown> | null | undefined): string | null => {
+          const v = metadata?.initiatorUserId;
+          return typeof v === 'string' && v.length > 0 ? v : null;
+        };
+        let initiatorUserId = readInitiator(priorTask?.metadata) ?? state.initiatorUserId ?? state.sourceUser.id;
+        if (!readInitiator(priorTask?.metadata)) {
+          const convTask = await database.getLatestNegotiationTaskForConversation?.(conversation.id)
+            .catch(() => null);
+          if (convTask && convTask.id !== priorTask?.id && isActiveAndFresh(convTask)) {
+            const convInitiator = readInitiator(convTask.metadata);
+            if (convInitiator) {
+              initLog.info('Conversation-scoped tie-break: inheriting initiator seat from concurrent task', {
+                conversationId: conversation.id,
+                winningTaskId: convTask.id,
+                initiatorUserId: convInitiator,
+              });
+              initiatorUserId = convInitiator;
+            }
+          }
+        }
+
         const task = await database.createTask(conversation.id, {
           type: 'negotiation',
           sourceUserId: state.sourceUser.id,
+          initiatorUserId,
           candidateUserId: state.candidateUser.id,
           networkId: state.indexContext.networkId,
           ...(state.opportunityId && { opportunityId: state.opportunityId }),
@@ -138,6 +166,7 @@ export class NegotiationGraphFactory {
           turnCount: 0,
           maxTurns,
           isContinuation,
+          initiatorUserId,
           priorTurnCount: priorTurns.length,
           ...(userAnswers.length > 0 && { userAnswers }),
           ...(seedMessages.length > 0 && { messages: seedMessages }),
@@ -518,9 +547,15 @@ export async function negotiateCandidates(
     timeoutMs?: number;
     onCandidateResolved?: OnNegotiationResolved;
     trigger?: "orchestrator" | "ambient";
+    /**
+     * Initiator seat for every candidate session in this fan-out (v2 stamp).
+     * Passed through to the negotiation graph, which may still override it by
+     * inheriting from a prior task on the same opportunity/conversation.
+     */
+    initiatorUserId?: string;
   },
 ): Promise<NegotiationResult[]> {
-  const { maxTurns, traceEmitter, indexContextOverrides, timeoutMs, onCandidateResolved, trigger } = opts ?? {};
+  const { maxTurns, traceEmitter, indexContextOverrides, timeoutMs, onCandidateResolved, trigger, initiatorUserId } = opts ?? {};
 
   // Local helper to emit events whose shape is wider than the declared
   // `TraceEmitter` union (mirrors the cast used in chat.agent at the relay sink
@@ -539,6 +574,7 @@ export async function negotiateCandidates(
           negotiationConversationId: "", // filled in on session_end
           sourceUserId: sourceUser.id,
           candidateUserId: candidate.userId,
+          initiatorUserId: initiatorUserId ?? sourceUser.id,
           ...(candidateName && { candidateName }),
           trigger: trigger ?? "ambient",
           startedAt: start,
@@ -561,6 +597,7 @@ export async function negotiateCandidates(
           },
           ...(candidate.discoveryQuery && { discoveryQuery: candidate.discoveryQuery }),
           ...(candidate.opportunityId && { opportunityId: candidate.opportunityId }),
+          ...(initiatorUserId && { initiatorUserId }),
           ...(maxTurns !== undefined && { maxTurns }),
           ...(timeoutMs !== undefined && { timeoutMs }),
         });

--- a/packages/protocol/src/negotiation/negotiation.state.ts
+++ b/packages/protocol/src/negotiation/negotiation.state.ts
@@ -82,6 +82,13 @@ export interface NegotiationGraphLike {
     opportunityId?: string;
     maxTurns?: number;
     timeoutMs?: number;
+    /**
+     * The user who holds the initiating seat for this match (v2 client-advocate
+     * protocol). Stamped into task metadata by the init node. When omitted, the
+     * init node resolves it: inherit from the prior task for the same
+     * opportunity → conversation-scoped tie-break → fall back to sourceUser.id.
+     */
+    initiatorUserId?: string;
   }): Promise<{
     outcome: NegotiationOutcome | null;
     messages?: NegotiationMessage[];
@@ -117,6 +124,16 @@ export const NegotiationGraphState = Annotation.Root({
   seedAssessment: Annotation<SeedAssessment>({
     reducer: (curr, next) => next ?? curr,
     default: () => ({ reasoning: "", valencyRole: "" }),
+  }),
+
+  /**
+   * Explicit initiator seat for this match (purely additive metadata — no seat
+   * rules attach to it yet). Resolution when unset happens in the init node;
+   * the resolved value is written back to state and into task metadata.
+   */
+  initiatorUserId: Annotation<string | undefined>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => undefined,
   }),
 
   /** The explicit search query that triggered discovery (if any). */

--- a/packages/protocol/src/negotiation/tests/negotiation.initiator.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.initiator.spec.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { NegotiationGraphFactory } from "../negotiation.graph.js";
+import { NegotiationGraphState } from "../negotiation.state.js";
+import { IndexNegotiator } from "../negotiation.agent.js";
+
+/**
+ * IND-396 — initiator seat stamping (v2 client-advocate protocol).
+ *
+ * Every negotiation task row is created in exactly one place (the init node),
+ * so these tests pin the resolution order of `metadata.initiatorUserId`:
+ *   1. inherit from the prior task for the same opportunity (continuations
+ *      never re-derive the seat),
+ *   2. conversation-scoped tie-break (symmetric concurrent starts),
+ *   3. explicit `initiatorUserId` on the invoke input,
+ *   4. fallback to sourceUser.id (pre-stamp behavior).
+ */
+
+type TaskRecord = {
+  id: string;
+  conversationId: string;
+  state: string;
+  metadata: Record<string, unknown> | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+function mkStubs(opts?: {
+  priorOpportunityTask?: TaskRecord | null;
+  conversationTask?: TaskRecord | null;
+  omitConversationLookup?: boolean;
+}) {
+  const createdTasks: Array<{ conversationId: string; metadata: Record<string, unknown> }> = [];
+  const database = {
+    createConversation: async () => ({ id: "conv-1" }),
+    getOrCreateDM: async () => ({ id: "conv-1" }),
+    createTask: async (conversationId: string, metadata: Record<string, unknown>) => {
+      createdTasks.push({ conversationId, metadata });
+      return { id: "task-new", conversationId, state: "submitted" };
+    },
+    updateOpportunityStatus: async () => {},
+    createMessage: async (p: { senderId: string; parts: unknown[] }) => ({
+      id: "msg-1", senderId: p.senderId, parts: p.parts, createdAt: new Date(),
+    }),
+    updateTaskState: async () => {},
+    createArtifact: async () => {},
+    setTaskTurnContext: async () => {},
+    getMessagesForConversation: async () => [],
+    getOpportunityUserAnswers: async () => [],
+    getNegotiationTaskForOpportunity: async () => opts?.priorOpportunityTask ?? null,
+    ...(opts?.omitConversationLookup
+      ? {}
+      : { getLatestNegotiationTaskForConversation: async () => opts?.conversationTask ?? null }),
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[0];
+
+  const dispatcher = {
+    hasExternalAgent: async () => false,
+    dispatch: async () => ({ handled: false, reason: "no-agent" }),
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[1];
+
+  return { database, dispatcher, createdTasks };
+}
+
+function mkTask(partial: Partial<TaskRecord>): TaskRecord {
+  return {
+    id: "task-prior",
+    conversationId: "conv-1",
+    state: "completed",
+    metadata: null,
+    createdAt: new Date(Date.now() - 60 * 60 * 1000),
+    updatedAt: new Date(Date.now() - 60 * 60 * 1000),
+    ...partial,
+  };
+}
+
+async function runGraph(
+  stubs: ReturnType<typeof mkStubs>,
+  input: Record<string, unknown>,
+) {
+  const graph = new NegotiationGraphFactory(stubs.database, stubs.dispatcher).createGraph();
+  return graph.invoke({
+    sourceUser: { id: "u-src", intents: [], profile: { name: "Alice" } },
+    candidateUser: { id: "u-cand", intents: [], profile: { name: "Bob" } },
+    indexContext: { networkId: "net-1", prompt: "" },
+    seedAssessment: { reasoning: "x", valencyRole: "peer" },
+    maxTurns: 1,
+    ...input,
+  } as Partial<typeof NegotiationGraphState.State>);
+}
+
+describe("negotiation graph — initiatorUserId stamping (IND-396)", () => {
+  let origInvoke: typeof IndexNegotiator.prototype.invoke;
+
+  beforeAll(() => {
+    origInvoke = IndexNegotiator.prototype.invoke;
+    IndexNegotiator.prototype.invoke = async function () {
+      return {
+        action: "accept" as const,
+        assessment: {
+          reasoning: "stub",
+          suggestedRoles: { ownUser: "agent" as const, otherUser: "patient" as const },
+        },
+        message: "deal",
+      };
+    };
+  });
+
+  afterAll(() => {
+    IndexNegotiator.prototype.invoke = origInvoke;
+  });
+
+  it("fresh run: stamps sourceUser.id when nothing else is available", async () => {
+    const stubs = mkStubs();
+    await runGraph(stubs, { opportunityId: "opp-1" });
+
+    expect(stubs.createdTasks.length).toBe(1);
+    expect(stubs.createdTasks[0].metadata.initiatorUserId).toBe("u-src");
+    expect(stubs.createdTasks[0].metadata.sourceUserId).toBe("u-src");
+  });
+
+  it("explicit stamp: invoke input initiatorUserId wins over the sourceUser fallback", async () => {
+    const stubs = mkStubs();
+    await runGraph(stubs, { opportunityId: "opp-1", initiatorUserId: "u-explicit" });
+
+    expect(stubs.createdTasks[0].metadata.initiatorUserId).toBe("u-explicit");
+  });
+
+  it("no-opportunity path (triggerDiscoveryNegotiation shape): explicit stamp still lands", async () => {
+    const stubs = mkStubs();
+    await runGraph(stubs, { initiatorUserId: "u-viewer" });
+
+    expect(stubs.createdTasks.length).toBe(1);
+    expect(stubs.createdTasks[0].metadata.initiatorUserId).toBe("u-viewer");
+    expect(stubs.createdTasks[0].metadata.opportunityId).toBeUndefined();
+  });
+
+  it("continuation inherits from the prior task even when the heuristic would flip the seat", async () => {
+    // Prior session was initiated by the *candidate* side of this run.
+    const stubs = mkStubs({
+      priorOpportunityTask: mkTask({
+        state: "completed",
+        metadata: { type: "negotiation", initiatorUserId: "u-cand", sourceUserId: "u-cand" },
+      }),
+    });
+    // This re-entry runs with u-src as sourceUser (the heuristic would pick u-src).
+    await runGraph(stubs, { opportunityId: "opp-1", initiatorUserId: "u-src" });
+
+    expect(stubs.createdTasks[0].metadata.initiatorUserId).toBe("u-cand");
+    expect(stubs.createdTasks[0].metadata.sourceUserId).toBe("u-src");
+  });
+
+  it("pre-stamp prior task: falls back to the session sourceUser (heuristic unchanged)", async () => {
+    const stubs = mkStubs({
+      priorOpportunityTask: mkTask({
+        state: "completed",
+        metadata: { type: "negotiation", sourceUserId: "u-cand" }, // no initiatorUserId
+      }),
+    });
+    await runGraph(stubs, { opportunityId: "opp-1" });
+
+    expect(stubs.createdTasks[0].metadata.initiatorUserId).toBe("u-src");
+  });
+
+  it("tie-break: concurrent symmetric start on the same conversation yields exactly one initiator", async () => {
+    // The counterparty's run (different opportunityId) already created an
+    // active, fresh task on this agent-pair DM — it won the seat.
+    const stubs = mkStubs({
+      conversationTask: mkTask({
+        id: "task-winner",
+        state: "working",
+        updatedAt: new Date(), // fresh
+        metadata: { type: "negotiation", initiatorUserId: "u-cand", sourceUserId: "u-cand", opportunityId: "opp-theirs" },
+      }),
+    });
+    await runGraph(stubs, { opportunityId: "opp-ours" });
+
+    // The losing run proceeds, but as counterparty: it inherits the winner's seat.
+    expect(stubs.createdTasks.length).toBe(1);
+    expect(stubs.createdTasks[0].metadata.initiatorUserId).toBe("u-cand");
+    expect(stubs.createdTasks[0].metadata.sourceUserId).toBe("u-src");
+  });
+
+  it("tie-break is inert for stale conversation tasks (asymmetric flows unchanged)", async () => {
+    const stubs = mkStubs({
+      conversationTask: mkTask({
+        id: "task-old",
+        state: "completed", // terminal — not a concurrent start
+        metadata: { type: "negotiation", initiatorUserId: "u-cand" },
+      }),
+    });
+    await runGraph(stubs, { opportunityId: "opp-ours" });
+
+    expect(stubs.createdTasks[0].metadata.initiatorUserId).toBe("u-src");
+  });
+
+  it("dep without getLatestNegotiationTaskForConversation (optional): stamps without crashing", async () => {
+    const stubs = mkStubs({ omitConversationLookup: true });
+    await runGraph(stubs, { opportunityId: "opp-1" });
+
+    expect(stubs.createdTasks[0].metadata.initiatorUserId).toBe("u-src");
+  });
+
+  it("emits initiatorUserId on negotiation_session_start via negotiateCandidates", async () => {
+    const { negotiateCandidates } = await import("../negotiation.graph.js");
+    const events: Array<Record<string, unknown>> = [];
+    const fakeGraph = {
+      invoke: async (input: Record<string, unknown>) => {
+        events.push({ type: "_invoke", initiatorUserId: input.initiatorUserId });
+        return { outcome: { hasOpportunity: false, reasoning: "", turnCount: 1 }, messages: [] };
+      },
+    };
+
+    await negotiateCandidates(
+      fakeGraph as never,
+      { id: "u-src", intents: [], profile: {} },
+      [{
+        userId: "u-cand",
+        opportunityId: "opp-1",
+        reasoning: "r",
+        valencyRole: "peer",
+        candidateUser: { id: "u-cand", intents: [], profile: {} },
+      }],
+      { networkId: "", prompt: "" },
+      { initiatorUserId: "u-initiator", traceEmitter: ((e: Record<string, unknown>) => events.push(e)) as never },
+    );
+
+    const start = events.find((e) => e.type === "negotiation_session_start");
+    expect(start?.initiatorUserId).toBe("u-initiator");
+    const invoked = events.find((e) => e.type === "_invoke");
+    expect(invoked?.initiatorUserId).toBe("u-initiator");
+  });
+});

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -2137,6 +2137,11 @@ export class OpportunityGraphFactory {
             indexContextOverrides: indexContextMap,
             timeoutMs,
             trigger: state.trigger === 'orchestrator' ? 'orchestrator' : 'ambient',
+            // v2 initiator stamp: every fresh-discovery origin resolves to the
+            // discovery user — querying user (chat/tool), intent owner
+            // (from-intent), enriched user (from-enrichment/discovery-run), or
+            // represented user (from-introducer, via onBehalfOfUserId).
+            initiatorUserId: discoveryUserId,
             onCandidateResolved },
         );
 
@@ -3510,6 +3515,10 @@ export class OpportunityGraphFactory {
           if (prompt) indexContextMap.set(candidate.networkId, prompt);
         }
 
+        // Deliberately no `initiatorUserId` here: re-entries inherit the stamp
+        // from the prior task's metadata inside the negotiation init node
+        // (continuations never re-derive the seat). The role heuristic above
+        // remains only as the fallback for pre-stamp tasks.
         const acceptedResults = await negotiateCandidates(
           this.negotiationGraph, sourceUser, [candidate],
           { networkId: '', prompt: '' },

--- a/packages/protocol/src/opportunity/tests/opportunity.graph.initiator.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.graph.initiator.spec.ts
@@ -1,0 +1,172 @@
+import { config } from "dotenv";
+config({ path: '.env.test', override: true });
+process.env.OPENROUTER_API_KEY ??= 'test';
+
+import { describe, test, expect } from 'bun:test';
+import { OpportunityGraphFactory } from '../opportunity.graph.js';
+import type { Id } from '../../types/common.types.js';
+import type { OpportunityGraphDatabase, OpportunityActor } from '../../shared/interfaces/database.interface.js';
+import type { Embedder } from '../../shared/interfaces/embedder.interface.js';
+import type { EvaluatedOpportunityWithActors } from '../opportunity.evaluator.js';
+
+/**
+ * IND-396 — the negotiate node stamps `initiatorUserId` for every fresh
+ * discovery origin. All origins resolve to `onBehalfOfUserId ?? userId`:
+ *   - chat/tool/MCP fan-out → querying user (userId)
+ *   - from-intent          → intent owner (userId)
+ *   - from-enrichment / discovery-run → surfaced user (userId)
+ *   - from-introducer      → represented user (onBehalfOfUserId)
+ * The stamp rides `negotiateCandidates` opts into the negotiation graph input.
+ */
+
+const dummyEmbedding = new Array(2000).fill(0.1);
+
+function makeFactory() {
+  const negotiationInputs: Array<Record<string, unknown>> = [];
+
+  const persistedOpp = {
+    id: 'opp-init-1',
+    detection: { source: 'auto' },
+    actors: [
+      { userId: 'u-source', role: 'patient', networkId: 'idx-1', intentId: null },
+      { userId: 'u-candidate', role: 'agent', networkId: 'idx-1', intentId: null },
+    ] satisfies OpportunityActor[],
+    interpretation: { reasoning: 'mock', confidence: 0.8 },
+    context: { conversationId: undefined },
+    confidence: '0.8',
+    status: 'negotiating' as const,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    expiresAt: null,
+  };
+
+  const mockDb = {
+    getProfile: async () => null,
+    createOpportunity: async () => persistedOpp,
+    opportunityExistsBetweenActors: async () => false,
+    findOpportunitiesByActors: async () => [],
+    getUserIndexIds: async () => (['idx-1'] as Id<'networks'>[]),
+    getNetworkMemberships: async () => [{
+      networkId: 'idx-1' as Id<'networks'>,
+      networkTitle: 'Test',
+      indexPrompt: null,
+      permissions: ['member'],
+      memberPrompt: null,
+      autoAssign: true,
+      isPersonal: false,
+      joinedAt: new Date(),
+    }],
+    getActiveIntents: async () => [{
+      id: 'intent-1' as Id<'intents'>,
+      payload: 'Looking for a co-founder',
+      summary: 'Co-founder',
+      createdAt: new Date(),
+    }],
+    getNetwork: async () => ({ id: 'idx-1', title: 'Test' }),
+    getNetworkMemberCount: async () => 2,
+    getNetworkIdsForIntent: async () => ['idx-1'],
+    getUser: async (id: string) => ({ id, name: 'Test User', email: 'test@example.com' }),
+    isNetworkMember: async () => true,
+    isIndexOwner: async () => false,
+    getOpportunity: async () => null,
+    getOpportunitiesForUser: async () => [],
+    updateOpportunityStatus: async () => null,
+    updateOpportunityActorApproval: async () => null,
+    getIntent: async () => null,
+    getIntentIndexScores: async () => [],
+    getNetworkMemberContext: async () => null,
+    getOrCreateDM: async () => ({ id: 'conv-1' }),
+    getNegotiationTaskForOpportunity: async () => null,
+    stampOpportunityActorAction: async () => null,
+    getPremisesForUser: async () => [],
+    searchPremisesBySimilarity: async () => [],
+  } as unknown as OpportunityGraphDatabase;
+
+  const mockEmbedder = {
+    generate: async () => dummyEmbedding,
+    search: async () => [],
+    searchWithHydeEmbeddings: async () => ([{
+      type: 'intent' as const,
+      id: 'intent-candidate' as Id<'intents'>,
+      userId: 'u-candidate',
+      score: 0.9,
+      matchedVia: 'mirror' as const,
+      networkId: 'idx-1',
+    }]),
+  } as unknown as Embedder;
+
+  const mockHyde = {
+    invoke: async () => ({
+      hydeEmbeddings: { mirror: dummyEmbedding, reciprocal: dummyEmbedding },
+    }),
+  };
+
+  const evaluatorResult: EvaluatedOpportunityWithActors[] = [{
+    reasoning: 'mock',
+    score: 88,
+    actors: [
+      { userId: 'u-source', role: 'patient' as const, intentId: null },
+      { userId: 'u-candidate', role: 'agent' as const, intentId: null },
+    ],
+  }];
+
+  const mockEvaluator = { invokeEntityBundle: async () => evaluatorResult };
+
+  const mockNegotiationGraph = {
+    invoke: async (input: Record<string, unknown>) => {
+      negotiationInputs.push(input);
+      return {
+        outcome: {
+          hasOpportunity: false,
+          agreedRoles: [],
+          reasoning: 'no deal',
+          turnCount: 1,
+        },
+        messages: [],
+      };
+    },
+  };
+
+  const factory = new OpportunityGraphFactory(
+    mockDb,
+    mockEmbedder,
+    mockHyde as never,
+    mockEvaluator,
+    async () => undefined,
+    mockNegotiationGraph as never,
+  );
+
+  return { factory, negotiationInputs };
+}
+
+describe('opportunity graph: negotiate node initiator stamp (IND-396)', () => {
+  test('fresh discovery: initiatorUserId = querying user (chat/tool/MCP, from-intent, from-enrichment)', async () => {
+    const { factory, negotiationInputs } = makeFactory();
+    const graph = factory.createGraph();
+
+    await graph.invoke({
+      userId: 'u-source' as Id<'users'>,
+      searchQuery: 'find me a co-founder',
+      options: {},
+    });
+
+    expect(negotiationInputs.length).toBeGreaterThanOrEqual(1);
+    expect(negotiationInputs[0].initiatorUserId).toBe('u-source');
+    expect((negotiationInputs[0].sourceUser as { id: string }).id).toBe('u-source');
+  });
+
+  test('introducer flow: initiatorUserId = represented user (onBehalfOfUserId), not the introducer', async () => {
+    const { factory, negotiationInputs } = makeFactory();
+    const graph = factory.createGraph();
+
+    await graph.invoke({
+      userId: 'u-introducer' as Id<'users'>,
+      onBehalfOfUserId: 'u-source' as Id<'users'>,
+      searchQuery: 'find me a co-founder',
+      options: {},
+    });
+
+    expect(negotiationInputs.length).toBeGreaterThanOrEqual(1);
+    expect(negotiationInputs[0].initiatorUserId).toBe('u-source');
+  });
+});

--- a/packages/protocol/src/shared/interfaces/database.interface.ts
+++ b/packages/protocol/src/shared/interfaces/database.interface.ts
@@ -2244,6 +2244,24 @@ export interface NegotiationQueries {
   } | null>;
 
   /**
+   * Returns the most-recently-created task whose metadata carries
+   * `type: 'negotiation'` on the given conversation, regardless of
+   * opportunityId or direction. Used by the init node's conversation-scoped
+   * tie-break: symmetric concurrent starts carry different opportunityIds, so
+   * the opportunity-scoped lookup above cannot see the competing task.
+   * Optional so existing fakes/wireups remain valid; when absent the
+   * tie-break is skipped (pre-stamp behavior).
+   */
+  getLatestNegotiationTaskForConversation?(conversationId: string): Promise<{
+    id: string;
+    conversationId: string;
+    state: string;
+    metadata: Record<string, unknown> | null;
+    createdAt: Date;
+    updatedAt: Date;
+  } | null>;
+
+  /**
    * Returns user answers collected by the questioner system for a given
    * opportunity. Reads `metadata.userAnswers` from the opportunities table.
    * Used by the negotiation graph to inject between-session context into

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -896,6 +896,49 @@ export class ConversationDatabaseAdapter {
   }
 
   /**
+   * Returns the most-recently-created negotiation task on a conversation,
+   * regardless of opportunityId or direction. Used by the negotiation init
+   * node's conversation-scoped initiator tie-break: symmetric concurrent
+   * starts carry different opportunityIds, so the opportunity-scoped lookup
+   * cannot see the competing task on the same agent-pair DM.
+   *
+   * @param conversationId - The agent-pair DM conversation id
+   * @returns The task record or null
+   */
+  async getLatestNegotiationTaskForConversation(conversationId: string): Promise<{
+    id: string;
+    conversationId: string;
+    state: string;
+    metadata: Record<string, unknown> | null;
+    createdAt: Date;
+    updatedAt: Date;
+  } | null> {
+    const rows = await db
+      .select()
+      .from(schema.tasks)
+      .where(
+        and(
+          eq(schema.tasks.conversationId, conversationId),
+          sql`${schema.tasks.metadata}->>'type' = 'negotiation'`,
+        ),
+      )
+      .orderBy(desc(schema.tasks.createdAt))
+      .limit(1);
+
+    const [row] = rows;
+    if (!row) return null;
+
+    return {
+      id: row.id,
+      conversationId: row.conversationId,
+      state: row.state as string,
+      metadata: (row.metadata as Record<string, unknown> | null) ?? null,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    };
+  }
+
+  /**
    * Returns user answers collected by the questioner for a given opportunity.
    * Reads `metadata.userAnswers` from the opportunities table.
    */

--- a/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
+++ b/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
@@ -80,6 +80,32 @@ describe('ConversationDatabaseAdapter', () => {
     }, 10000);
   });
 
+  describe('getLatestNegotiationTaskForConversation', () => {
+    it('returns the negotiation task, ignoring non-negotiation tasks, and null for fresh conversations', async () => {
+      const conv = await adapter.createConversation([
+        { participantId: 'agent:init-a', participantType: 'agent' as const },
+        { participantId: 'agent:init-b', participantType: 'agent' as const },
+      ]);
+      createdIds.push(conv.id);
+
+      expect(await adapter.getLatestNegotiationTaskForConversation(conv.id)).toBeNull();
+
+      // Non-negotiation task must not match.
+      await adapter.createTask(conv.id, { type: 'chat' });
+      expect(await adapter.getLatestNegotiationTaskForConversation(conv.id)).toBeNull();
+
+      const negotiationTask = await adapter.createTask(conv.id, {
+        type: 'negotiation',
+        sourceUserId: 'init-a',
+        initiatorUserId: 'init-a',
+      });
+
+      const found = await adapter.getLatestNegotiationTaskForConversation(conv.id);
+      expect(found?.id).toBe(negotiationTask.id);
+      expect(found?.metadata?.initiatorUserId).toBe('init-a');
+    }, 10000);
+  });
+
   describe('artifacts', () => {
     it('creates artifact linked to task', async () => {
       const task = await adapter.createTask(createdIds[0]);

--- a/services/api/src/services/negotiation.service.ts
+++ b/services/api/src/services/negotiation.service.ts
@@ -51,6 +51,10 @@ export class NegotiationService {
       indexContext: { networkId: '', prompt: '' },
       seedAssessment: { reasoning: 'Discovery negotiation', valencyRole: 'peer' },
       maxTurns: 4,
+      // v2 initiator stamp: explicit user-triggered negotiation — the viewer
+      // who requested it holds the initiating seat. This path has no
+      // opportunityId, so the stamp must ride the invoke input directly.
+      initiatorUserId: sourceUserId,
     });
 
     logger.info('Discovery negotiation completed', {

--- a/services/api/tests/negotiation.e2e.spec.ts
+++ b/services/api/tests/negotiation.e2e.spec.ts
@@ -49,5 +49,11 @@ describe("Negotiation E2E", () => {
     expect(result.conversationId).toBeTruthy();
     expect(result.taskId).toBeTruthy();
     expect(result.messages.length).toBeGreaterThanOrEqual(2);
+
+    // IND-396: every new negotiation task carries the initiator seat stamp.
+    const task = await conversationDatabaseAdapter.getTask(result.taskId);
+    const metadata = (task?.metadata ?? {}) as Record<string, unknown>;
+    expect(metadata.initiatorUserId).toBe("e2e-source");
+    expect(metadata.sourceUserId).toBe("e2e-source");
   }, 120_000);
 });

--- a/services/api/tests/negotiation.graph.spec.ts
+++ b/services/api/tests/negotiation.graph.spec.ts
@@ -92,3 +92,46 @@ describe("NegotiationGraph → opportunity status lifecycle (init)", () => {
     expect(initCall).toBeUndefined();
   }, 30_000);
 });
+
+describe("NegotiationGraph → initiatorUserId stamp (IND-396)", () => {
+  it("stamps metadata.initiatorUserId = sourceUser.id when not supplied", async () => {
+    const deps = createDeps();
+
+    const factory = new NegotiationGraphFactory(deps.database, deps.dispatcher);
+    const graph = factory.createGraph();
+    await graph.invoke({
+      sourceUser,
+      candidateUser,
+      indexContext: { networkId: "idx-1", prompt: "AI co-founders" },
+      seedAssessment: seed,
+      opportunityId: "opp-1",
+      maxTurns: 1,
+    });
+
+    const createTaskMock = deps.database.createTask as unknown as { mock: { calls: unknown[][] } };
+    expect(createTaskMock.mock.calls.length).toBe(1);
+    const metadata = createTaskMock.mock.calls[0][1] as Record<string, unknown>;
+    expect(metadata.initiatorUserId).toBe("user-source");
+    expect(metadata.sourceUserId).toBe("user-source");
+  }, 30_000);
+
+  it("stamps an explicit initiatorUserId (triggerDiscoveryNegotiation path, no opportunityId)", async () => {
+    const deps = createDeps();
+
+    const factory = new NegotiationGraphFactory(deps.database, deps.dispatcher);
+    const graph = factory.createGraph();
+    await graph.invoke({
+      sourceUser,
+      candidateUser,
+      indexContext: { networkId: "idx-1", prompt: "AI co-founders" },
+      seedAssessment: seed,
+      maxTurns: 1,
+      initiatorUserId: "user-viewer",
+    });
+
+    const createTaskMock = deps.database.createTask as unknown as { mock: { calls: unknown[][] } };
+    expect(createTaskMock.mock.calls.length).toBe(1);
+    const metadata = createTaskMock.mock.calls[0][1] as Record<string, unknown>;
+    expect(metadata.initiatorUserId).toBe("user-viewer");
+  }, 30_000);
+});


### PR DESCRIPTION
Closes IND-396 (P1.1 · Stamp initiatorUserId at every discovery origin) — first issue of the protocol-core track under IND-395.

## What

Every new negotiation task now carries `metadata.initiatorUserId`: the rigid initiating seat for the match, fixed at discovery time. **Purely additive metadata — zero behavior change, no migrations, no flags.**

### Resolution order (negotiation `initNode` — the single place task rows are created)

1. **Continuations inherit, never re-derive** — prior task for the same `opportunityId` carries the stamp → inherit it, even when the session's `sourceUser` (the actor-role heuristic in `negotiate_existing`) sits on the other side. The heuristic remains only as fallback for pre-stamp tasks.
2. **Conversation-scoped tie-break** — the existing lock gate is opportunity-scoped, so two concurrent symmetric starts (different `opportunityId`s, same agent-pair DM) previously both claimed the seat. Init now also consults the latest negotiation task on the conversation: if it's active and fresh, the first created task wins and this run inherits its stamp (proceeds as counterparty). Inert for asymmetric flows and stale/terminal tasks.
3. **Explicit stamp** on the invoke input (`NegotiationGraphLike.invoke` + `NegotiationGraphState` gained `initiatorUserId?`).
4. **Fallback**: `sourceUser.id` (pre-stamp behavior, unchanged).

### Origin coverage

All fresh-discovery origins resolve to `discoveryUserId = onBehalfOfUserId ?? userId`, which the opportunity graph `negotiate` node now passes as `initiatorUserId` through `negotiateCandidates`:

| Origin | Initiator |
|---|---|
| chat/tool-registry/MCP fan-out | querying user (`userId`) |
| `from-intent.queue` | intent owner (`userId`) |
| `from-enrichment.queue` / `discovery-run.queue` | user whose run surfaced the candidate (`userId`) |
| `from-introducer.queue` | represented user (`onBehalfOfUserId`) |
| `negotiation.service#triggerDiscoveryNegotiation` | requesting viewer (explicit, no `opportunityId` on this path) |
| re-entries (`run-existing`, `approve_introduction`) | inherited from prior task metadata at init — queue payloads unchanged |

`negotiation_session_start` trace events now carry `initiatorUserId` (typed on `NegotiationSessionStartEvent`).

### New dep

`getLatestNegotiationTaskForConversation?(conversationId)` — optional on `NegotiationQueries` (existing fakes/wireups stay valid; absent implementations skip the tie-break). Implemented in `ConversationDatabaseAdapter` (conversation-scoped, `metadata->>'type' = 'negotiation'`, latest first).

## Tests

- **protocol** `negotiation.initiator.spec.ts` (9): fresh stamp, explicit stamp, no-opportunity path, continuation inheritance vs heuristic flip, pre-stamp fallback, tie-break win/inert, optional-dep absence, session_start emission + graph input pass-through.
- **protocol** `opportunity.graph.initiator.spec.ts` (2): negotiate node stamps querying user; introducer flow stamps the represented user, not the introducer.
- **api** `negotiation.graph.spec.ts` (+2): `createTask` metadata assertions for derived + explicit stamps.
- **api** `conversation.database.adapter.spec.ts` (+1, DB-backed): new query filters non-negotiation tasks, null on fresh conversations.
- **api** `negotiation.e2e.spec.ts` extended: persisted task metadata contains `initiatorUserId` (ran green locally, 15.8s, real LLM + DB).
- Suites: protocol negotiation+opportunity 773 pass (1 pre-existing flake, present on clean dev); origin queue specs 44 pass; builds + tsc green; eslint 0 errors.

## Deployable increment

No behavior change; new tasks simply carry the stamp. The tie-break only affects truly concurrent symmetric starts — previously a latent double-initiation bug. Unblocks IND-403's deferred negotiation seeding and the seat-rule issues downstream.
