### PR TITLE
feat: seat-scoped turn schemas + counterparty-only accept (IND-397)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,6 +113,9 @@ OPENROUTER_API_KEY=your-openrouter-api-key
 # PREMISE_DEDUP_SIMILARITY=                 # Premise dedup similarity threshold, 0..1 (protocol runtime)
 # NEGOTIATION_MAX_TURNS_CHAT=4
 # NEGOTIATION_MAX_TURNS_AMBIENT=6
+# NEGOTIATION_PROTOCOL_VERSION=v1          # Protocol version stamped on NEW negotiations: v1 (legacy) | v2 (seat rules:
+                                           # initiator outreach/counter/question/withdraw, counterparty accept/decline/counter/question).
+                                           # In-flight conversations inherit their stamped version; flipping this only affects fresh negotiations.
 
 # Per-turn LLM round-trip cap for IndexNegotiator, in ms (default: 15000).
 # Bounds individual negotiator calls so a single slow upstream tail can't blow

--- a/apps/web/src/components/ChatSidebar.tsx
+++ b/apps/web/src/components/ChatSidebar.tsx
@@ -89,7 +89,7 @@ export default function ChatSidebar() {
       const lastAction = dataPart?.data?.action;
       const negotiationStatus: NegotiationStatus = lastAction === 'accept'
         ? 'accepted'
-        : lastAction === 'reject'
+        : (lastAction === 'reject' || lastAction === 'withdraw' || lastAction === 'decline')
           ? 'rejected'
           : lastAction
             ? 'in_progress'

--- a/apps/web/src/components/chat/ToolCallsDisplay.tsx
+++ b/apps/web/src/components/chat/ToolCallsDisplay.tsx
@@ -381,7 +381,7 @@ interface GraphNode {
 export interface NegotiationTurnRow {
   turnIndex: number;
   actor: "source" | "candidate";
-  action: "propose" | "accept" | "reject" | "counter" | "question";
+  action: "propose" | "accept" | "reject" | "counter" | "question" | "outreach" | "withdraw" | "decline";
   reasoning?: string;
   message?: string;
   suggestedRoles?: { ownUser?: string; otherUser?: string };

--- a/apps/web/src/contexts/AIChatContext.tsx
+++ b/apps/web/src/contexts/AIChatContext.tsx
@@ -95,7 +95,7 @@ export interface TraceEvent {
   startedAt?: number;
   turnIndex?: number;
   actor?: "source" | "candidate";
-  action?: "propose" | "accept" | "reject" | "counter" | "question";
+  action?: "propose" | "accept" | "reject" | "counter" | "question" | "outreach" | "withdraw" | "decline";
   reasoning?: string;
   message?: string;
   suggestedRoles?: { ownUser?: string; otherUser?: string };

--- a/docs/domain/negotiation.md
+++ b/docs/domain/negotiation.md
@@ -39,16 +39,28 @@ On the first turn, the initiating side presents the match case. On subsequent tu
 
 Negotiation proceeds in alternating turns.
 
-### Actions
+### Protocol versions
 
-Each turn produces one of five actions:
+Each negotiation task carries a `protocolVersion` (`v1` | `v2`) in its metadata. The version is **inherited, never re-stamped**: continuations copy the version from the prior task on the conversation, so an in-flight v1 conversation stays v1 even after the environment moves to v2. Only genuinely fresh negotiations stamp from the `NEGOTIATION_PROTOCOL_VERSION` env switch (default `v1`); rollback is the same single switch.
+
+Under **v2 (client-advocate seat rules)** the action vocabulary is scoped by seat, keyed on `metadata.initiatorUserId` (the rigid stamp from discovery time — never turn parity):
+
+- **Initiator seat** (`outreach | counter | question | withdraw`): the side that surfaced the match. It reaches out and may walk away, but it can **never accept** — this is schema-enforced, not prompt-enforced.
+- **Counterparty seat** (`accept | decline | counter | question`): the receiving side. Acceptance is this seat's decision alone.
+- **Final turn**: initiator `withdraw | counter`; counterparty `accept | decline` (must decide).
+
+Outcome mapping is version-independent: `accept` → `pending`, `reject`/`withdraw`/`decline` → `rejected`, turn cap → `stalled`.
+
+### Actions (v1)
+
+Each v1 turn produces one of five actions:
 
 | Action | When used |
 |---|---|
-| **propose** | First turn only. The initiating agent presents the match case. |
+| **propose** | First turn only. The initiating agent presents the match case. (v2: **outreach**, initiator seat only.) |
 | **counter** | The agent partially agrees but has specific objections. States what is missing or weak. |
-| **accept** | The agent is convinced the match genuinely benefits their user. |
-| **reject** | The agent concludes the match does not serve their user's needs. |
+| **accept** | The agent is convinced the match genuinely benefits their user. (v2: counterparty seat only.) |
+| **reject** | The agent concludes the match does not serve their user's needs. (v2: split into **withdraw** for the initiator / **decline** for the counterparty.) |
 | **question** | Personal agents only. A clarifying question for the other party. Routes the same as counter (non-terminal, awaits response). |
 
 Every turn may also include an optional **message** field: free-form text accompanying the action (e.g. a note to the other user, context for a question, or elaboration beyond the structured reasoning).
@@ -57,7 +69,7 @@ Every turn may also include an optional **message** field: free-form text accomp
 
 Each turn produces a structured assessment:
 
-- **action**: The action taken this turn (`propose`, `counter`, `accept`, `reject`, or `question`)
+- **action**: The action taken this turn (v1: `propose`, `counter`, `accept`, `reject`, `question`; v2: `outreach`, `counter`, `question`, `withdraw` for the initiator / `accept`, `decline`, `counter`, `question` for the counterparty)
 - **assessment.reasoning**: Why the agent took this action
 - **assessment.suggestedRoles**: What roles each user should play
   - `ownUser`: agent, patient, or peer
@@ -90,8 +102,8 @@ If the cap is reached without accept or reject, the opportunity transitions to `
 
 The finalization logic examines the negotiation history to determine the outcome:
 
-- **Has opportunity**: The last action was "accept". The opportunity transitions to `pending` (awaiting human acceptance via the UI).
-- **Rejected**: The last action was "reject". The opportunity transitions to `rejected`.
+- **Has opportunity**: The last action was "accept". The opportunity transitions to `pending` (awaiting human acceptance via the UI). Under v2 only the counterparty seat can produce this action.
+- **Rejected**: The last action was "reject" (v1) or "withdraw"/"decline" (v2). The opportunity transitions to `rejected`.
 - **Turn cap**: The maximum turns were exhausted. The opportunity transitions to `stalled`; `reason: "turn_cap"`.
 - **Timeout**: 24 hours elapsed without resolution (personal-vs-personal only). The opportunity transitions to `stalled`; `reason: "timeout"`.
 
@@ -131,9 +143,9 @@ When a negotiation graph reaches a turn the system cannot resolve synchronously 
 ### Parked-turn lifecycle
 
 1. The negotiation graph writes the turn into `tasks.state = 'waiting_for_agent'` and enqueues a 24-hour fallback timeout.
-2. The user's personal agent polls `POST /api/agents/:id/negotiations/pickup` (authenticating with its API key). The backend atomically CAS's the oldest pending task for the caller's user from `waiting_for_agent` to `claimed`, cancels the 24-hour fallback, and enqueues a 6-hour claim timeout. The agent receives the turn number, deadline, counterparty action, full turn history, and the projected own/other user context.
+2. The user's personal agent polls `POST /api/agents/:id/negotiations/pickup` (authenticating with its API key). The backend atomically CAS's the oldest pending task for the caller's user from `waiting_for_agent` to `claimed`, cancels the 24-hour fallback, and enqueues a 6-hour claim timeout. The agent receives the turn number, deadline, counterparty action, full turn history, the projected own/other user context, and — since v2 — the caller's `seat`, the task's `protocolVersion`, and the `allowedActions` for that seat.
 3. The agent deliberates and submits its decision via `POST /api/agents/:id/negotiations/:negotiationId/respond` with `{ action, message?, assessment: { reasoning, suggestedRoles } }`. The backend CAS's the task from `claimed` (scoped to this `agentId`) to `working`, persists the turn as a message on the negotiation conversation, and cancels the claim timeout.
-4. If the action is `accept`, `reject`, or pushes the turn count over the cap, the task is completed and an outcome artifact is written. Otherwise the task returns to `waiting_for_agent` and a fresh 24-hour fallback is enqueued for the counterparty.
+4. The submitted action is validated against the caller's seat + the task's protocol version before any state changes — an out-of-seat action (e.g. a v2 initiator submitting `accept`) returns HTTP 400 and leaves the claim intact for a retry. If the action is terminal (`accept`, `reject`, `withdraw`, `decline`) or pushes the turn count over the cap, the task is completed and an outcome artifact is written. Otherwise the task returns to `waiting_for_agent` and a fresh 24-hour fallback is enqueued for the counterparty.
 5. If a pickup is not followed by a `respond` within 6 hours, the claim expires and the task returns to `waiting_for_agent` for another pickup attempt. If no agent claims within 24 hours of first parking, the in-process system `Index Negotiator` takes the turn instead.
 
 Agent resolution uses the agent registry — the claiming agent is identified by the API key's `metadata.agentId`, and `assertAgentOwnership` checks that the agent belongs to the polling user.
@@ -200,7 +212,7 @@ Called by a personal agent to submit a turn response.
 
 **Input fields:**
 - `negotiationId`: The negotiation to respond to
-- `action`: One of `propose`, `counter`, `accept`, `reject`, `question`
+- `action`: One of `propose`, `counter`, `accept`, `reject`, `question` (v1) or the caller's seat vocabulary under v2 (`outreach`/`counter`/`question`/`withdraw` for the initiator, `accept`/`decline`/`counter`/`question` for the counterparty) — `get_negotiation` announces `seat`, `protocolVersion`, and `allowedActions`
 - `reasoning`: Why the agent took this action
 - `suggestedRoles`: Role suggestions for own user and other user
 - `message` *(optional)*: Free-form text accompanying the action

--- a/packages/protocol/src/chat/chat-streaming.types.ts
+++ b/packages/protocol/src/chat/chat-streaming.types.ts
@@ -505,7 +505,7 @@ export interface NegotiationTurnEvent extends ChatStreamEventBase {
   negotiationConversationId: string;
   turnIndex: number;
   actor: "source" | "candidate";
-  action: "propose" | "accept" | "reject" | "counter" | "question";
+  action: "propose" | "accept" | "reject" | "counter" | "question" | "outreach" | "withdraw" | "decline";
   reasoning?: string;
   message?: string;
   suggestedRoles?: { ownUser?: string; otherUser?: string };

--- a/packages/protocol/src/chat/chat.agent.ts
+++ b/packages/protocol/src/chat/chat.agent.ts
@@ -107,7 +107,7 @@ export type AgentStreamEvent =
       negotiationConversationId: string;
       turnIndex: number;
       actor: "source" | "candidate";
-      action: "propose" | "accept" | "reject" | "counter" | "question";
+      action: "propose" | "accept" | "reject" | "counter" | "question" | "outreach" | "withdraw" | "decline";
       reasoning?: string;
       message?: string;
       suggestedRoles?: { ownUser?: string; otherUser?: string };

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -214,7 +214,28 @@ export type { ElicitResultLike, ElicitInputFn, DispatchElicitationsParams } from
 // @experimental — internal graph-state shapes; may change in a minor release.
 
 export type { UserNegotiationContext, NegotiationTurn, NegotiationOutcome, SeedAssessment } from "./shared/schemas/negotiation-state.schema.js";
+export { NEGOTIATION_ACTIONS } from "./shared/schemas/negotiation-state.schema.js";
+export type { NegotiationAction, NegotiationSeat, NegotiationProtocolVersion } from "./shared/schemas/negotiation-state.schema.js";
 export type { NegotiationGraphLike } from "./negotiation/negotiation.state.js";
+
+// ─── Negotiation seat rules (v2 client-advocate protocol) ───────────────────
+
+export {
+  InitiatorTurnSchema,
+  CounterpartyTurnSchema,
+  FinalInitiatorTurnSchema,
+  FinalCounterpartyTurnSchema,
+  allowedActionsFor,
+  turnSchemaFor,
+  isTerminalAction,
+  isRejectLikeAction,
+  fallbackActionFor,
+  rejectActionFor,
+  readProtocolVersion,
+  configuredProtocolVersion,
+  resolveSeat,
+  seatViolationMessage,
+} from "./negotiation/negotiation.protocol.js";
 
 // ─── Streamers ────────────────────────────────────────────────────────────────
 

--- a/packages/protocol/src/negotiation/negotiation.agent.ts
+++ b/packages/protocol/src/negotiation/negotiation.agent.ts
@@ -1,7 +1,12 @@
 import { createStructuredModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 import { SystemNegotiationTurnSchema, FinalNegotiationTurnSchema, type NegotiationTurn, type UserNegotiationContext, type SeedAssessment } from "./negotiation.state.js";
+import { turnSchemaFor, fallbackActionFor } from "./negotiation.protocol.js";
+import type { NegotiationSeat, NegotiationProtocolVersion } from "../shared/schemas/negotiation-state.schema.js";
 import type { NegotiationUserAnswer } from "../shared/interfaces/database.interface.js";
+import { protocolLogger } from "../shared/observability/protocol.logger.js";
+
+const agentLog = protocolLogger("IndexNegotiator");
 
 const SYSTEM_PROMPT = `You are the Index Negotiator, an AI agent acting on behalf of {userName}. You represent their interests in a bilateral negotiation about a potential connection on a discovery network.
 
@@ -13,15 +18,35 @@ Network context: {networkContext}
 Your job: Evaluate whether this connection genuinely serves {userName}'s interests given their role. Argue their case honestly — acknowledge weaknesses, but advocate for genuine fit.
 
 Rules:
-- On the FIRST turn: Propose the connection case. Explain why it would benefit both parties. Set action to "propose".
-- On SUBSEQUENT turns: Evaluate the other agent's arguments. Either:
-  - "counter" if you have specific objections but see potential
-  - "accept" if the match genuinely benefits {userName}
-  - "reject" if the match does not serve {userName}'s needs
+{actionRules}
 - Focus on concrete intent alignment, not vague overlap.
 - Do NOT reference internal system details like scores, pre-screens, or evaluator outputs.
 - suggestedRoles: "agent" = can help, "patient" = seeks help, "peer" = mutual benefit.
 {finalTurnInstruction}`;
+
+/** v1 action rules — byte-identical to the pre-seat-rules prompt. */
+const V1_ACTION_RULES = `- On the FIRST turn: Propose the connection case. Explain why it would benefit both parties. Set action to "propose".
+- On SUBSEQUENT turns: Evaluate the other agent's arguments. Either:
+  - "counter" if you have specific objections but see potential
+  - "accept" if the match genuinely benefits {userName}
+  - "reject" if the match does not serve {userName}'s needs`;
+
+/** v2 initiator seat: reaching stance — accept is structurally unavailable. */
+const V2_INITIATOR_RULES = `- You hold the INITIATING seat: your user's side surfaced this match and you are reaching out. Only the counterparty may accept — "accept" is NOT available to you.
+- On the FIRST turn: Make the outreach case. Explain why the connection would benefit both parties. Set action to "outreach".
+- On SUBSEQUENT turns: Evaluate the counterparty's arguments. Either:
+  - "counter" if you have specific objections but see potential
+  - "question" if you need a specific clarification from the counterparty
+  - "withdraw" if the match does not serve {userName}'s needs`;
+
+/** v2 counterparty seat: receiving stance — acceptance is this seat's decision alone. */
+const V2_COUNTERPARTY_RULES = `- You hold the RECEIVING seat: the other side reached out to {userName}. Whether to accept is YOUR seat's decision alone.
+- Evaluate the initiator's arguments. Either:
+  - "accept" if the match genuinely benefits {userName}
+  - "decline" if the match does not serve {userName}'s needs
+  - "counter" if you have specific objections but see potential
+  - "question" if you need a specific clarification from the initiator
+- Never use "outreach" — you are responding, not reaching out.`;
 
 export interface NegotiationAgentInput {
   ownUser: UserNegotiationContext;
@@ -38,6 +63,17 @@ export interface NegotiationAgentInput {
   isContinuation?: boolean;
   /** User answers collected by the questioner between negotiation sessions. */
   userAnswers?: NegotiationUserAnswer[];
+  /**
+   * The acting user's seat under the v2 client-advocate protocol. Selects the
+   * seat-scoped turn schema and prompt stance when `protocolVersion` is `v2`.
+   * Ignored under v1. Defaults from `isDiscoverer` when omitted.
+   */
+  seat?: NegotiationSeat;
+  /**
+   * Negotiation protocol version for this task (inherited, never re-stamped).
+   * `v1` (default) keeps the legacy symmetric vocabulary and prompt.
+   */
+  protocolVersion?: NegotiationProtocolVersion;
 }
 
 export interface IndexNegotiatorConfig {
@@ -98,14 +134,27 @@ export class IndexNegotiator {
    * @throws If the per-turn timeout fires before the LLM responds.
    */
   async invoke(input: NegotiationAgentInput): Promise<NegotiationTurn> {
-    const schema = input.isFinalTurn ? FinalNegotiationTurnSchema : SystemNegotiationTurnSchema;
+    const version: NegotiationProtocolVersion = input.protocolVersion ?? "v1";
+    const seat: NegotiationSeat = input.seat ?? (input.isDiscoverer ? "initiator" : "counterparty");
+    const isFinalTurn = input.isFinalTurn ?? false;
+    const schema = turnSchemaFor(version, seat, isFinalTurn, {
+      system: SystemNegotiationTurnSchema,
+      final: FinalNegotiationTurnSchema,
+    });
     const model = createStructuredModel("negotiator", schema, { name: "index_negotiator" });
 
     const userName = input.ownUser.profile.name ?? "your user";
     const role = input.seedAssessment.valencyRole || "peer";
     const networkContext = input.indexContext.prompt || "General discovery";
+    const actionRules = version === "v2"
+      ? (seat === "initiator" ? V2_INITIATOR_RULES : V2_COUNTERPARTY_RULES)
+      : V1_ACTION_RULES;
     const finalTurnInstruction = input.isFinalTurn
-      ? "\n\nIMPORTANT: This is your FINAL turn. You MUST choose either 'accept' or 'reject'. No counter is allowed."
+      ? (version === "v2"
+          ? (seat === "initiator"
+              ? "\n\nIMPORTANT: This is your FINAL turn. You MUST choose either 'withdraw' or 'counter'. Accept is not available to your seat."
+              : "\n\nIMPORTANT: This is your FINAL turn. You MUST choose either 'accept' or 'decline'. No counter is allowed.")
+          : "\n\nIMPORTANT: This is your FINAL turn. You MUST choose either 'accept' or 'reject'. No counter is allowed.")
       : "";
 
     const otherName = input.otherUser.profile.name ?? "the other user";
@@ -122,6 +171,7 @@ QUERY PRIORITY RULE: This search query is the PRIMARY criterion for this negotia
       : '';
 
     const systemPrompt = SYSTEM_PROMPT
+      .replace("{actionRules}", actionRules)
       .replace(/{userName}/g, userName)
       .replace("{discoveryContext}", discoveryContext)
       .replace("{discoveryQueryContext}", discoveryQueryContext)
@@ -179,17 +229,51 @@ ${input.otherUser.intents.map((i) => `- ${i.title}: ${i.description}`).join("\n"
 
 Why this match was suggested: ${input.seedAssessment.reasoning}${input.isContinuation ? continuationContext : historyText}${userAnswersContext}
 ${discoveryQueryReminder}
-${input.history.length === 0 && !input.isContinuation ? "This is the opening turn. Propose the connection case." : "Evaluate the latest arguments and respond."}`;
+${input.history.length === 0 && !input.isContinuation ? (version === "v2" && seat === "initiator" ? "This is the opening turn. Make the outreach case." : "This is the opening turn. Propose the connection case.") : "Evaluate the latest arguments and respond."}`;
 
-    const result = await invokeWithAbortSignal(
-      model,
-      [
-        { role: "system", content: systemPrompt },
-        { role: "user", content: userMessage },
-      ],
-      AbortSignal.timeout(this.turnTimeoutMs),
-    );
+    const chatMessages = [
+      { role: "system", content: systemPrompt },
+      { role: "user", content: userMessage },
+    ];
 
-    return result as NegotiationTurn;
+    // Structured output is schema-constrained, but providers can still emit
+    // out-of-vocabulary actions. Validate; retry once; then fall back to the
+    // conservative seat-valid action instead of poisoning the turn history.
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const result = await this.callModel(model, chatMessages);
+      const parsed = schema.safeParse(result);
+      if (parsed.success) return parsed.data as NegotiationTurn;
+      agentLog.warn("Negotiator output failed seat-schema validation", {
+        attempt: attempt + 1,
+        seat,
+        version,
+        isFinalTurn,
+        issues: parsed.error.issues.map((i) => i.message).slice(0, 3),
+      });
+    }
+
+    const fallbackAction = fallbackActionFor(version, seat, isFinalTurn);
+    agentLog.warn("Negotiator output invalid after retry; using conservative fallback", {
+      seat, version, isFinalTurn, fallbackAction,
+    });
+    return {
+      action: fallbackAction,
+      assessment: {
+        reasoning: "Agent produced an invalid response; conservative fallback applied.",
+        suggestedRoles: { ownUser: "peer", otherUser: "peer" },
+      },
+      message: null,
+    };
+  }
+
+  /**
+   * Raw structured-model round trip. Split out as a seam so tests can drive
+   * the validate→retry→fallback loop without a live provider.
+   */
+  protected async callModel(
+    model: ReturnType<typeof createStructuredModel>,
+    chatMessages: Array<{ role: string; content: string }>,
+  ): Promise<unknown> {
+    return invokeWithAbortSignal(model, chatMessages, AbortSignal.timeout(this.turnTimeoutMs));
   }
 }

--- a/packages/protocol/src/negotiation/negotiation.graph.ts
+++ b/packages/protocol/src/negotiation/negotiation.graph.ts
@@ -7,6 +7,8 @@ import type { NegotiationTimeoutQueue } from "../shared/interfaces/negotiation-e
 import type { AgentDispatcher, NegotiationTurnPayload } from "../shared/interfaces/agent-dispatcher.interface.js";
 import { NegotiationGraphState, type NegotiationTurn, type NegotiationOutcome, type UserNegotiationContext, type SeedAssessment, type NegotiationGraphLike } from "./negotiation.state.js";
 import { IndexNegotiator } from "./negotiation.agent.js";
+import { allowedActionsFor, configuredProtocolVersion, fallbackActionFor, isRejectLikeAction, isTerminalAction, readProtocolVersion, rejectActionFor } from "./negotiation.protocol.js";
+import type { NegotiationSeat, NegotiationProtocolVersion } from "../shared/schemas/negotiation-state.schema.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import type { QuestionerEnqueueFn } from "../questioner/questioner.types.js";
 
@@ -108,9 +110,13 @@ export class NegotiationGraphFactory {
           return typeof v === 'string' && v.length > 0 ? v : null;
         };
         let initiatorUserId = readInitiator(priorTask?.metadata) ?? state.initiatorUserId ?? state.sourceUser.id;
+        // Conversation-scoped prior task: reused for both the initiator tie-break
+        // (only when active+fresh) and protocol-version inheritance (any prior
+        // task on the conversation pins the version).
+        const convTask = (!readInitiator(priorTask?.metadata) || !readProtocolVersion(priorTask?.metadata))
+          ? await database.getLatestNegotiationTaskForConversation?.(conversation.id).catch(() => null)
+          : null;
         if (!readInitiator(priorTask?.metadata)) {
-          const convTask = await database.getLatestNegotiationTaskForConversation?.(conversation.id)
-            .catch(() => null);
           if (convTask && convTask.id !== priorTask?.id && isActiveAndFresh(convTask)) {
             const convInitiator = readInitiator(convTask.metadata);
             if (convInitiator) {
@@ -124,10 +130,28 @@ export class NegotiationGraphFactory {
           }
         }
 
+        // --- Protocol version: inherited, never re-stamped ---
+        // Every session (including continuations) creates a new task row, so a
+        // naïve "stamp from env at init" would flip a v1 conversation to v2
+        // mid-flight. Rule: any prior negotiation task on this conversation pins
+        // the version (absent field on a genuine prior = pre-v2 task = v1);
+        // prior turns without a readable task also grandfather to v1; only
+        // genuinely fresh negotiations stamp from NEGOTIATION_PROTOCOL_VERSION.
+        let protocolVersion: NegotiationProtocolVersion;
+        const priorVersionSource = priorTask ?? convTask;
+        if (priorVersionSource) {
+          protocolVersion = readProtocolVersion(priorVersionSource.metadata) ?? 'v1';
+        } else if (isContinuation) {
+          protocolVersion = 'v1';
+        } else {
+          protocolVersion = configuredProtocolVersion();
+        }
+
         const task = await database.createTask(conversation.id, {
           type: 'negotiation',
           sourceUserId: state.sourceUser.id,
           initiatorUserId,
+          protocolVersion,
           candidateUserId: state.candidateUser.id,
           networkId: state.indexContext.networkId,
           ...(state.opportunityId && { opportunityId: state.opportunityId }),
@@ -167,6 +191,7 @@ export class NegotiationGraphFactory {
           maxTurns,
           isContinuation,
           initiatorUserId,
+          protocolVersion,
           priorTurnCount: priorTurns.length,
           ...(userAnswers.length > 0 && { userAnswers }),
           ...(seedMessages.length > 0 && { messages: seedMessages }),
@@ -198,6 +223,14 @@ export class NegotiationGraphFactory {
         const maxTurns = state.maxTurns ?? 0;
         const isFinalTurn = maxTurns > 0 && (state.turnCount + 1) >= maxTurns;
 
+        // Seat attribution keys on initiatorUserId (rigid v2 stamp), never on
+        // parity or source/candidate position — under the conversation-scoped
+        // tie-break this run's source may hold the counterparty seat.
+        const version = state.protocolVersion ?? 'v1';
+        const seat: NegotiationSeat = ownUser.id === (state.initiatorUserId ?? state.sourceUser.id)
+          ? 'initiator'
+          : 'counterparty';
+
         const payload: NegotiationTurnPayload = {
           negotiationId: state.taskId,
           ownUser,
@@ -207,6 +240,9 @@ export class NegotiationGraphFactory {
           history,
           isFinalTurn,
           isDiscoverer: isSource,
+          seat,
+          protocolVersion: version,
+          allowedActions: [...allowedActionsFor(version, seat, isFinalTurn)],
           ...(state.discoveryQuery && isSource && { discoveryQuery: state.discoveryQuery }),
         };
 
@@ -217,8 +253,16 @@ export class NegotiationGraphFactory {
         let turn: NegotiationTurn;
 
         if (dispatchResult.handled) {
-          // Personal agent responded
+          // Personal agent responded. Under v2, coerce out-of-seat actions to
+          // the conservative fallback — the polling/respond surfaces reject
+          // these with a 400, but locally-dispatched turns land here directly.
           turn = dispatchResult.turn;
+          if (version === 'v2' && !allowedActionsFor(version, seat, isFinalTurn).includes(turn.action)) {
+            turnLog.warn('Personal agent returned out-of-seat action, coercing to conservative fallback', {
+              action: turn.action, seat, isFinalTurn,
+            });
+            turn = { ...turn, action: fallbackActionFor(version, seat, isFinalTurn) };
+          }
         } else if (dispatchResult.reason === 'waiting') {
           // Long timeout — graph suspends. Persist the full turn context so the
           // polling agent (and MCP consumers via get_negotiation) reconstruct
@@ -249,6 +293,8 @@ export class NegotiationGraphFactory {
             history,
             isFinalTurn,
             isDiscoverer: isSource,
+            seat,
+            protocolVersion: version,
             ...(state.discoveryQuery && isSource && { discoveryQuery: state.discoveryQuery }),
             isContinuation: state.isContinuation,
             ...(state.userAnswers.length > 0 && { userAnswers: state.userAnswers }),
@@ -257,10 +303,16 @@ export class NegotiationGraphFactory {
 
         traceEmitter?.({ type: "agent_end", name: agentName, durationMs: Date.now() - agentStart, summary: `${turn.action}` });
 
-        // First turn must be "propose" (unless continuing a prior conversation)
-        if (state.turnCount === 0 && !state.isContinuation && turn.action !== "propose") {
-          turnLog.warn("Agent returned unexpected action on turn 0, forcing to propose", { action: turn.action });
-          turn.action = "propose";
+        // First turn must open the negotiation (unless continuing a prior
+        // conversation): v1 → "propose"; v2 initiator → "outreach". A v2 turn-0
+        // speaker holding the counterparty seat (tie-break inheritance) is left
+        // unforced — it is responding, not opening.
+        if (state.turnCount === 0 && !state.isContinuation) {
+          const openingAction = version === 'v2' ? 'outreach' : 'propose';
+          if ((version !== 'v2' || seat === 'initiator') && turn.action !== openingAction) {
+            turnLog.warn(`Agent returned unexpected action on turn 0, forcing to ${openingAction}`, { action: turn.action });
+            turn.action = openingAction;
+          }
         }
 
         const parts = [{ kind: "data" as const, data: turn }];
@@ -305,9 +357,12 @@ export class NegotiationGraphFactory {
         const errMsg = err instanceof Error ? err.message : String(err);
         turnLog.error("Agent invocation failed", { error: errMsg, stack: err instanceof Error ? err.stack : undefined, turnCount: state.turnCount });
         traceEmitter?.({ type: "agent_end", name: agentName, durationMs: Date.now() - agentStart, summary: `error: ${errMsg}` });
+        const errorSeat: NegotiationSeat = (state.currentSpeaker === 'source' ? state.sourceUser.id : state.candidateUser.id) === (state.initiatorUserId ?? state.sourceUser.id)
+          ? 'initiator'
+          : 'counterparty';
         return {
           lastTurn: {
-            action: "reject" as const,
+            action: rejectActionFor(state.protocolVersion ?? 'v1', errorSeat),
             assessment: { reasoning: `Agent error: ${errMsg}`, suggestedRoles: { ownUser: "peer" as const, otherUser: "peer" as const } },
           },
           turnCount: state.turnCount + 1,
@@ -320,8 +375,8 @@ export class NegotiationGraphFactory {
       if (state.status === 'waiting_for_agent') return "finalize";
       if (state.error) return "finalize";
       if (!state.lastTurn) return "finalize";
-      if (state.lastTurn.action === "accept") return "finalize";
-      if (state.lastTurn.action === "reject") return "finalize";
+      // Terminal actions: accept (v1+v2), reject (v1), withdraw/decline (v2)
+      if (isTerminalAction(state.lastTurn.action)) return "finalize";
       // question routes same as counter — next turn
       if ((state.maxTurns ?? 0) > 0 && state.turnCount >= state.maxTurns!) return "finalize";
       return "turn";
@@ -349,7 +404,7 @@ export class NegotiationGraphFactory {
 
       const lastTurn = state.lastTurn;
       const hasOpportunity = lastTurn?.action === "accept";
-      const atCap = (state.maxTurns ?? 0) > 0 && state.turnCount >= state.maxTurns! && lastTurn?.action !== "accept" && lastTurn?.action !== "reject";
+      const atCap = (state.maxTurns ?? 0) > 0 && state.turnCount >= state.maxTurns! && !isTerminalAction(lastTurn?.action);
 
       let agreedRoles: NegotiationOutcome["agreedRoles"] = [];
       if (hasOpportunity && history.length >= 2) {
@@ -395,7 +450,7 @@ export class NegotiationGraphFactory {
         if (state.opportunityId) {
           const nextStatus = lastTurn?.action === 'accept'
             ? 'pending'
-            : lastTurn?.action === 'reject'
+            : isRejectLikeAction(lastTurn?.action)
               ? 'rejected'
               : 'stalled';
           await database.updateOpportunityStatus(state.opportunityId, nextStatus).catch((err) => {
@@ -414,8 +469,6 @@ export class NegotiationGraphFactory {
             ? "turn_cap"
             : state.error && /timeout/i.test(state.error)
             ? "timed_out"
-            : lastTurn?.action === "reject"
-            ? "rejected_stalled"
             : "rejected_stalled";
 
         emitWide({
@@ -438,7 +491,7 @@ export class NegotiationGraphFactory {
 
       // Enqueue question generation for stalled/capped negotiations (not accepted or explicitly rejected).
       // Require turnCount > 0 so early init/turn errors don't enqueue with empty context.
-      if (!hasOpportunity && lastTurn?.action !== 'reject' && state.turnCount > 0 && state.opportunityId && questionerEnqueue) {
+      if (!hasOpportunity && !isRejectLikeAction(lastTurn?.action) && state.turnCount > 0 && state.opportunityId && questionerEnqueue) {
         const stallReason: 'turn_cap' | 'timeout' | 'stalled' = atCap
           ? 'turn_cap'
           : (state.error && /timeout/i.test(state.error))

--- a/packages/protocol/src/negotiation/negotiation.protocol.ts
+++ b/packages/protocol/src/negotiation/negotiation.protocol.ts
@@ -1,0 +1,194 @@
+/**
+ * Seat-scoped negotiation protocol rules (v2 client-advocate protocol).
+ *
+ * v2 fixes exactly one initiating seat per match (`metadata.initiatorUserId`,
+ * stamped at discovery time — IND-396) and makes consent asymmetric:
+ * **accept can only come from the counterparty seat**, schema-enforced.
+ *
+ * Vocabulary per seat (v2):
+ * - initiator:     `outreach | counter | question | withdraw`  (no accept)
+ * - counterparty:  `accept | decline | counter | question`
+ * - final turn:    initiator `withdraw | counter`; counterparty `accept | decline`
+ *
+ * v1 tasks keep the legacy vocabulary (`propose | accept | reject | counter |
+ * question`) — the version is inherited per conversation, never re-stamped, so
+ * in-flight v1 negotiations are grandfathered untouched.
+ *
+ * Outcome mapping is version-independent: `accept` → opportunity `pending`,
+ * `reject`/`withdraw`/`decline` → `rejected`, turn-cap → `stalled`.
+ */
+import { z } from "zod";
+
+import type { NegotiationAction, NegotiationSeat, NegotiationProtocolVersion } from "../shared/schemas/negotiation-state.schema.js";
+
+// ─── Shared assessment fragment ──────────────────────────────────────────────
+
+const AssessmentSchema = z.object({
+  reasoning: z.string(),
+  suggestedRoles: z.object({
+    ownUser: z.enum(["agent", "patient", "peer"]),
+    otherUser: z.enum(["agent", "patient", "peer"]),
+  }),
+});
+
+function turnSchema<T extends [NegotiationAction, ...NegotiationAction[]]>(actions: T) {
+  return z.object({
+    action: z.enum(actions),
+    assessment: AssessmentSchema,
+    message: z.string().nullable().optional(),
+  });
+}
+
+// ─── v2 seat-scoped turn schemas ─────────────────────────────────────────────
+
+/** Initiator seat, non-final turn: may reach out, push back, ask, or walk away — never accept. */
+export const InitiatorTurnSchema = turnSchema(["outreach", "counter", "question", "withdraw"]);
+
+/** Counterparty seat, non-final turn: the only seat that can accept. */
+export const CounterpartyTurnSchema = turnSchema(["accept", "decline", "counter", "question"]);
+
+/** Initiator seat, final allowed turn: commit to walking away or leave the door open. */
+export const FinalInitiatorTurnSchema = turnSchema(["withdraw", "counter"]);
+
+/** Counterparty seat, final allowed turn: must decide. */
+export const FinalCounterpartyTurnSchema = turnSchema(["accept", "decline"]);
+
+// ─── Action vocabulary per version + seat ────────────────────────────────────
+
+const V1_ACTIONS: readonly NegotiationAction[] = ["propose", "accept", "reject", "counter", "question"];
+const V1_FINAL_ACTIONS: readonly NegotiationAction[] = ["accept", "reject"];
+const V2_INITIATOR_ACTIONS: readonly NegotiationAction[] = ["outreach", "counter", "question", "withdraw"];
+const V2_COUNTERPARTY_ACTIONS: readonly NegotiationAction[] = ["accept", "decline", "counter", "question"];
+const V2_FINAL_INITIATOR_ACTIONS: readonly NegotiationAction[] = ["withdraw", "counter"];
+const V2_FINAL_COUNTERPARTY_ACTIONS: readonly NegotiationAction[] = ["accept", "decline"];
+
+/**
+ * The set of actions a given seat may submit under a given protocol version.
+ *
+ * v1 ignores the seat entirely (legacy symmetric vocabulary) so pre-v2
+ * negotiations behave exactly as before.
+ */
+export function allowedActionsFor(
+  version: NegotiationProtocolVersion,
+  seat: NegotiationSeat,
+  isFinalTurn = false,
+): readonly NegotiationAction[] {
+  if (version !== "v2") return isFinalTurn ? V1_FINAL_ACTIONS : V1_ACTIONS;
+  if (seat === "initiator") return isFinalTurn ? V2_FINAL_INITIATOR_ACTIONS : V2_INITIATOR_ACTIONS;
+  return isFinalTurn ? V2_FINAL_COUNTERPARTY_ACTIONS : V2_COUNTERPARTY_ACTIONS;
+}
+
+/**
+ * Zod turn schema for a system-agent turn, selected by version + seat +
+ * final-turn flag. v1 returns the legacy schemas (seat-agnostic); v2 returns
+ * the seat-scoped schemas above, making an initiator `accept` structurally
+ * impossible rather than prompt-discouraged.
+ *
+ * The v1 legacy schemas are passed in by the caller (they live in
+ * `negotiation.state.ts`) to keep this module free of a state-module import.
+ */
+export function turnSchemaFor(
+  version: NegotiationProtocolVersion,
+  seat: NegotiationSeat,
+  isFinalTurn: boolean,
+  v1Schemas: { system: z.ZodTypeAny; final: z.ZodTypeAny },
+): z.ZodTypeAny {
+  if (version !== "v2") return isFinalTurn ? v1Schemas.final : v1Schemas.system;
+  if (seat === "initiator") return isFinalTurn ? FinalInitiatorTurnSchema : InitiatorTurnSchema;
+  return isFinalTurn ? FinalCounterpartyTurnSchema : CounterpartyTurnSchema;
+}
+
+// ─── Action semantics (version-independent) ──────────────────────────────────
+
+/** Terminal actions end the negotiation immediately. */
+export function isTerminalAction(action: string | undefined | null): boolean {
+  return action === "accept" || action === "reject" || action === "withdraw" || action === "decline";
+}
+
+/** Reject-like actions map the opportunity to `rejected` (v1 reject, v2 withdraw/decline). */
+export function isRejectLikeAction(action: string | undefined | null): boolean {
+  return action === "reject" || action === "withdraw" || action === "decline";
+}
+
+/**
+ * Conservative action when an agent produced schema-invalid output (after the
+ * retry) or an internal error needs a seat-valid terminal placeholder.
+ *
+ * Non-final turns fall back to `counter` (keeps the dialogue open — the AC's
+ * "conservative counter"). Final turns must decide: v1 → `reject`, v2
+ * counterparty → `decline`, v2 initiator → `counter` is still legal on the
+ * final turn so it stays `counter` (finalizes as turn-cap/stalled).
+ */
+export function fallbackActionFor(
+  version: NegotiationProtocolVersion,
+  seat: NegotiationSeat,
+  isFinalTurn: boolean,
+): NegotiationAction {
+  if (!isFinalTurn) return "counter";
+  if (version !== "v2") return "reject";
+  return seat === "counterparty" ? "decline" : "counter";
+}
+
+/** Seat-appropriate reject-like action for error paths. */
+export function rejectActionFor(
+  version: NegotiationProtocolVersion,
+  seat: NegotiationSeat,
+): NegotiationAction {
+  if (version !== "v2") return "reject";
+  return seat === "initiator" ? "withdraw" : "decline";
+}
+
+// ─── Metadata readers ────────────────────────────────────────────────────────
+
+/**
+ * Read the protocol version off task metadata. Returns null when the task
+ * predates version stamping (treat as v1 at the call site when the task is a
+ * genuine prior; fresh tasks stamp from {@link configuredProtocolVersion}).
+ */
+export function readProtocolVersion(
+  metadata: { protocolVersion?: unknown } | null | undefined,
+): NegotiationProtocolVersion | null {
+  const v = metadata?.protocolVersion;
+  return v === "v2" ? "v2" : v === "v1" ? "v1" : null;
+}
+
+/**
+ * Protocol version for genuinely fresh negotiations, from the
+ * `NEGOTIATION_PROTOCOL_VERSION` env switch. Defaults to `v1` when unset —
+ * v2 is opt-in per environment, and rolling back is the same single switch.
+ */
+export function configuredProtocolVersion(): NegotiationProtocolVersion {
+  return process.env.NEGOTIATION_PROTOCOL_VERSION === "v2" ? "v2" : "v1";
+}
+
+/**
+ * Resolve the seat of `userId` on a negotiation task.
+ *
+ * Keys on `metadata.initiatorUserId` (the rigid v2 stamp), **never on turn
+ * parity** — continuations can start with either side speaking first, so
+ * parity misattributes seats across sessions. Pre-stamp tasks fall back to
+ * `sourceUserId` (the discovery-session opener), which is what the stamp
+ * defaults to anyway.
+ */
+export function resolveSeat(
+  userId: string,
+  metadata: { initiatorUserId?: unknown; sourceUserId?: unknown } | null | undefined,
+): NegotiationSeat {
+  const initiator =
+    typeof metadata?.initiatorUserId === "string" && metadata.initiatorUserId.length > 0
+      ? metadata.initiatorUserId
+      : typeof metadata?.sourceUserId === "string"
+        ? metadata.sourceUserId
+        : undefined;
+  return initiator === userId ? "initiator" : "counterparty";
+}
+
+/** Human-readable seat-violation message shared by respond surfaces. */
+export function seatViolationMessage(
+  action: string,
+  seat: NegotiationSeat,
+  version: NegotiationProtocolVersion,
+): string {
+  const allowed = allowedActionsFor(version, seat).join(", ");
+  return `Action "${action}" is not allowed for your seat (${seat}) under negotiation protocol ${version}. Allowed actions: ${allowed}.`;
+}

--- a/packages/protocol/src/negotiation/negotiation.state.ts
+++ b/packages/protocol/src/negotiation/negotiation.state.ts
@@ -1,10 +1,15 @@
 import { Annotation } from "@langchain/langgraph";
 import { z } from "zod";
 import type { NegotiationUserAnswer } from "../shared/interfaces/database.interface.js";
+import { NEGOTIATION_ACTIONS, type NegotiationProtocolVersion } from "../shared/schemas/negotiation-state.schema.js";
 
-/** Zod schema for a single negotiation turn (DataPart payload in A2A message). */
+/**
+ * Zod schema for a single negotiation turn (DataPart payload in A2A message).
+ * Accepts the full v1+v2 action union — which subset is valid for a given turn
+ * is enforced by the seat-scoped schemas in `negotiation.protocol.ts`.
+ */
 export const NegotiationTurnSchema = z.object({
-  action: z.enum(["propose", "accept", "reject", "counter", "question"]),
+  action: z.enum(NEGOTIATION_ACTIONS),
   assessment: z.object({
     reasoning: z.string(),
     suggestedRoles: z.object({
@@ -15,7 +20,7 @@ export const NegotiationTurnSchema = z.object({
   message: z.string().nullable().optional(),
 });
 
-/** Restricted turn schema for the system agent (no question action). */
+/** Restricted v1 turn schema for the system agent (no question action). */
 export const SystemNegotiationTurnSchema = z.object({
   action: z.enum(["propose", "accept", "reject", "counter"]),
   assessment: z.object({
@@ -28,7 +33,7 @@ export const SystemNegotiationTurnSchema = z.object({
   message: z.string().nullable().optional(),
 });
 
-/** Turn schema for system agent's final allowed turn (must decide). */
+/** v1 turn schema for system agent's final allowed turn (must decide). */
 export const FinalNegotiationTurnSchema = z.object({
   action: z.enum(["accept", "reject"]),
   assessment: z.object({
@@ -141,6 +146,17 @@ export const NegotiationGraphState = Annotation.Root({
     reducer: (curr, next) => next ?? curr,
     default: () => undefined,
   }),
+  /**
+   * Negotiation protocol version for this session's task. Resolved by the
+   * init node: inherited from the prior task on the conversation when one
+   * exists (never re-stamped — a v1 conversation stays v1 mid-flight), else
+   * stamped from `NEGOTIATION_PROTOCOL_VERSION` for genuinely fresh runs.
+   */
+  protocolVersion: Annotation<NegotiationProtocolVersion>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => "v1" as const,
+  }),
+
   /** Whether this run is continuing a prior conversation with the same pair. */
   isContinuation: Annotation<boolean>({
     reducer: (curr, next) => next ?? curr,

--- a/packages/protocol/src/negotiation/negotiation.tools.ts
+++ b/packages/protocol/src/negotiation/negotiation.tools.ts
@@ -4,6 +4,8 @@ import type { DefineTool, ToolDeps } from '../shared/agent/tool.helpers.js';
 import { success, error } from '../shared/agent/tool.helpers.js';
 import { IndexNegotiator } from './negotiation.agent.js';
 import type { NegotiationTurn, UserNegotiationContext, SeedAssessment, NegotiationOutcome } from './negotiation.state.js';
+import { allowedActionsFor, isTerminalAction, readProtocolVersion, rejectActionFor, resolveSeat, seatViolationMessage } from './negotiation.protocol.js';
+import { NEGOTIATION_ACTIONS } from '../shared/schemas/negotiation-state.schema.js';
 import type { NegotiationTurnPayload } from '../shared/interfaces/agent-dispatcher.interface.js';
 import { protocolLogger } from '../shared/observability/protocol.logger.js';
 import { focusedNetworkId } from '../shared/agent/tool.scope.js';
@@ -134,9 +136,14 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
             ? ((lastMessage.parts as Array<{ kind?: string; data?: unknown }>)?.find(p => p.kind === 'data')?.data as { action?: string; assessment?: { reasoning?: string }; message?: string | null } | undefined)
             : undefined;
 
-          // Determine whose turn it is based on message count (alternating source/candidate)
+          // Determine whose turn it is from the last message's sender — not
+          // parity, which misattributes across continuation sessions. Rows
+          // without senderId (legacy) fall back to parity.
           const turnCount = messages.length;
-          const currentSpeaker = turnCount % 2 === 0 ? 'source' : 'candidate';
+          const lastSenderId = turnCount > 0 ? messages[turnCount - 1].senderId : null;
+          const currentSpeaker = lastSenderId
+            ? (lastSenderId === `agent:${meta.sourceUserId}` ? 'candidate' : 'source')
+            : (turnCount % 2 === 0 ? 'source' : 'candidate');
 
           // Map task state to tool status
           const status = task.state === 'working' ? 'active'
@@ -170,7 +177,9 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
           const recentMessages = messages.slice(-RECENT_TURNS_LIMIT);
           const recentTurns = recentMessages.map((m, sliceIdx) => {
             const absoluteIdx = messages.length - recentMessages.length + sliceIdx;
-            const speaker = absoluteIdx % 2 === 0 ? 'source' : 'candidate';
+            const speaker = m.senderId
+              ? (m.senderId === `agent:${meta.sourceUserId}` ? 'source' : 'candidate')
+              : (absoluteIdx % 2 === 0 ? 'source' : 'candidate');
             const td = ((m.parts as Array<{ kind?: string; data?: unknown }>)?.find(p => p.kind === 'data')?.data as { action?: string; message?: string | null } | undefined);
             return {
               turnNumber: absoluteIdx + 1,
@@ -258,6 +267,8 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
         const meta = task.metadata as {
           sourceUserId?: string;
           candidateUserId?: string;
+          initiatorUserId?: string;
+          protocolVersion?: string;
           type?: string;
           maxTurns?: number;
           opportunityId?: string;
@@ -326,7 +337,8 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
           negotiationDatabase.getArtifactsForTask(task.id),
         ]);
 
-        // Parse turns from messages
+        // Parse turns from messages (speaker from senderId, not parity —
+        // continuations can start with either side speaking first)
         const turns = messages.map((m, idx) => {
           const dataPart = (m.parts as Array<{ kind?: string; data?: unknown }>)?.find(p => p.kind === 'data');
           const turnData = dataPart?.data as {
@@ -336,7 +348,9 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
           } | undefined;
 
           const turnNumber = idx + 1;
-          const speaker = turnNumber % 2 === 1 ? 'source' : 'candidate';
+          const speaker = m.senderId
+            ? (m.senderId === `agent:${meta.sourceUserId}` ? 'source' : 'candidate')
+            : (turnNumber % 2 === 1 ? 'source' : 'candidate');
 
           return {
             turnNumber,
@@ -356,9 +370,13 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
           ? (outcomeArtifact.parts as Array<{ kind?: string; data?: unknown }>)?.find(p => p.kind === 'data')?.data
           : null;
 
-        // Determine whose turn it is
+        // Determine whose turn it is (last sender's counterpart, not parity;
+        // rows without senderId fall back to parity)
         const turnCount = messages.length;
-        const currentSpeaker = turnCount % 2 === 0 ? 'source' : 'candidate';
+        const lastSenderId = turnCount > 0 ? messages[turnCount - 1].senderId : null;
+        const currentSpeaker = lastSenderId
+          ? (lastSenderId === `agent:${meta.sourceUserId}` ? 'candidate' : 'source')
+          : (turnCount % 2 === 0 ? 'source' : 'candidate');
 
         const status = task.state === 'working' ? 'active'
           : task.state === 'waiting_for_agent' ? 'waiting_for_agent'
@@ -371,11 +389,19 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
         const isContinuation = meta.isContinuation ?? false;
         const priorTurnCount = meta.priorTurnCount ?? 0;
 
+        // Seat + protocol version (v2 client-advocate): announce the caller's
+        // seat and the actions it may submit so agents don't guess.
+        const protocolVersion = readProtocolVersion(meta) ?? 'v1';
+        const seat = resolveSeat(context.userId, meta);
+
         return success({
           id: task.id,
           conversationId: task.conversationId,
           status,
           role: isSource ? 'source' : 'candidate',
+          seat,
+          protocolVersion,
+          allowedActions: allowedActionsFor(protocolVersion, seat),
           counterpartyId: counterpartyId ?? 'unknown',
           turnCount,
           isUsersTurn,
@@ -402,22 +428,25 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
       'by accepting, rejecting, countering, or asking a clarifying question.\n\n' +
       '**Turn-based model:** Negotiations alternate between source and candidate agents. When the graph yields with ' +
       '`waiting_for_agent` status, the user whose turn it is can respond.\n\n' +
-      '**Valid actions:**\n' +
-      '- `accept` — Accept the current proposal. The negotiation will be finalized as an opportunity.\n' +
-      '- `reject` — Reject the current proposal. The negotiation will end without creating an opportunity.\n' +
-      '- `counter` — Counter the proposal with a message (message is required). The negotiation will continue.\n' +
-      '- `question` — Ask the counterparty a clarifying question (message is required). The negotiation will continue.\n\n' +
-      '**What happens after:** Accept/reject finalizes the negotiation immediately. Counter/question continues the negotiation — ' +
-      'if the counterparty has an agent, the negotiation yields again; otherwise the AI agent responds inline.\n\n' +
+      '**Valid actions depend on the negotiation protocol version and your seat** — call get_negotiation first: ' +
+      'its `seat`, `protocolVersion`, and `allowedActions` fields tell you exactly what you may submit.\n\n' +
+      '**v1 negotiations (legacy):** `propose | accept | reject | counter | question` — on the first turn the action MUST be `propose`.\n\n' +
+      '**v2 negotiations (client-advocate seat rules):**\n' +
+      '- Initiator seat (`outreach | counter | question | withdraw`): you reached out — you can NEVER accept. ' +
+      '`outreach` opens the negotiation; `withdraw` ends it without an opportunity.\n' +
+      '- Counterparty seat (`accept | decline | counter | question`): only your seat can `accept` (finalizes an opportunity); ' +
+      '`decline` ends the negotiation without one.\n\n' +
+      '- `counter` — Counter with a message (message is required). The negotiation continues.\n' +
+      '- `question` — Ask the other side a clarifying question (message is required). The negotiation continues.\n\n' +
+      '**What happens after:** Terminal actions (accept/reject/withdraw/decline) finalize the negotiation immediately. ' +
+      'Counter/question continues — if the counterparty has an agent, the negotiation yields again; otherwise the AI agent responds inline.\n\n' +
       '**Silent-subagent response contract.** In negotiation-turn mode, submit exactly ONE call to this tool ' +
-      'per dispatch with the action (propose | counter | accept | reject | question) and the assessment ' +
-      '(reasoning + suggestedRoles). If the decision is ambiguous, pick the most conservative action — usually ' +
-      '`counter` with specific objections, or `reject` with clear reasoning. On the first turn of a negotiation ' +
-      '(turnCount === 0) the action MUST be `propose`. Do not ask the user clarifying questions; you are ' +
-      'authorized to act on their behalf within the scope granted to your agent.',
+      'per dispatch with an action from your seat\'s allowed set and the assessment (reasoning + suggestedRoles). ' +
+      'If the decision is ambiguous, pick the most conservative action — usually `counter` with specific objections. ' +
+      'Do not ask the user clarifying questions; you are authorized to act on their behalf within the scope granted to your agent.',
     querySchema: z.object({
       negotiationId: z.string().describe('The negotiation task ID to respond to.'),
-      action: z.enum(['propose', 'accept', 'reject', 'counter', 'question']).describe('The response action. On the first turn (turnCount === 0) this MUST be "propose".'),
+      action: z.enum(NEGOTIATION_ACTIONS).describe('The response action. Must be within your seat\'s allowedActions (see get_negotiation). v1 first turn MUST be "propose"; v2 initiator first turn MUST be "outreach".'),
       reasoning: z.string().describe('Why you are taking this action — your assessment of the opportunity.'),
       suggestedRoles: z.object({
         ownUser: z.enum(['agent', 'patient', 'peer']).describe('Suggested role for your user in this opportunity.'),
@@ -435,6 +464,8 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
         const meta = task.metadata as {
           sourceUserId?: string;
           candidateUserId?: string;
+          initiatorUserId?: string;
+          protocolVersion?: string;
           type?: string;
           maxTurns?: number;
           networkId?: string;
@@ -466,15 +497,32 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
           return error('Access denied: you are not a party to this negotiation.');
         }
 
-        // Determine whose turn it is
+        // Seat + version validation (v2 client-advocate): the submitted action
+        // must be within the caller's seat vocabulary. v1 tasks accept the
+        // legacy vocabulary unchanged (grandfathered).
+        const protocolVersion = readProtocolVersion(meta) ?? 'v1';
+        const seat = resolveSeat(context.userId, meta);
+        if (!allowedActionsFor(protocolVersion, seat).includes(query.action)) {
+          return error(seatViolationMessage(query.action, seat, protocolVersion));
+        }
+
+        // Determine whose turn it is from the last message's sender — not
+        // parity, which misattributes across continuation sessions. Rows
+        // without senderId (legacy) fall back to the parity heuristic.
         const messages = await negotiationDatabase.getMessagesForConversation(task.conversationId);
         const turnCount = messages.length;
-        const currentSpeaker = turnCount % 2 === 0 ? 'source' : 'candidate';
-        const isUsersTurn = (isSource && currentSpeaker === 'source') || (!isSource && currentSpeaker === 'candidate');
+        const lastSenderId = turnCount > 0 ? messages[turnCount - 1].senderId : null;
+        const paritySpeaker = turnCount % 2 === 0 ? 'source' : 'candidate';
+        const isUsersTurn = lastSenderId
+          ? lastSenderId !== `agent:${context.userId}`
+          : ((isSource && paritySpeaker === 'source') || (!isSource && paritySpeaker === 'candidate'));
 
         if (!isUsersTurn) {
           return error('It is not your turn to respond in this negotiation.');
         }
+
+        // The caller is the current speaker (verified above).
+        const currentSpeaker: 'source' | 'candidate' = isSource ? 'source' : 'candidate';
 
         // Validate counter/question has a message
         if ((query.action === 'counter' || query.action === 'question') && !query.message?.trim()) {
@@ -507,8 +555,8 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
 
         const newTurnCount = turnCount + 1;
 
-        // ── Handle accept/reject: finalize immediately ──
-        if (query.action === 'accept' || query.action === 'reject') {
+        // ── Handle terminal actions (accept / reject / withdraw / decline): finalize immediately ──
+        if (isTerminalAction(query.action)) {
           const allMessages = [...messages, { id: turnMessage.id, senderId: turnMessage.senderId, role: turnMessage.role, parts: turnMessage.parts as unknown[], createdAt: turnMessage.createdAt }];
           const history: NegotiationTurn[] = turnsFromMessages(allMessages);
 
@@ -526,7 +574,11 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
           return success({
             message: query.action === 'accept'
               ? 'Negotiation accepted. An opportunity has been created.'
-              : 'Negotiation rejected.',
+              : query.action === 'withdraw'
+                ? 'Negotiation withdrawn.'
+                : query.action === 'decline'
+                  ? 'Negotiation declined.'
+                  : 'Negotiation rejected.',
             negotiationId: task.id,
             action: query.action,
             turnNumber: newTurnCount,
@@ -564,6 +616,7 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
         // ── Counter/question under max turns: dispatch to counterparty's agent ──
         const counterpartyUserId = isSource ? meta.candidateUserId! : meta.sourceUserId!;
         const counterpartySpeaker = isSource ? 'candidate' : 'source';
+        const counterpartySeat = resolveSeat(counterpartyUserId, meta);
 
         // Build the current turn history for dispatcher payload
         const allMessagesWithTurn = [...messages, { id: turnMessage.id, senderId: turnMessage.senderId, role: turnMessage.role, parts: turnMessage.parts as unknown[], createdAt: turnMessage.createdAt }];
@@ -584,6 +637,9 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
           history: historyForDispatch,
           isFinalTurn,
           isDiscoverer: false,
+          seat: counterpartySeat,
+          protocolVersion,
+          allowedActions: [...allowedActionsFor(protocolVersion, counterpartySeat, isFinalTurn)],
         };
 
         const scope = { action: 'negotiation.respond', scopeType: 'negotiation', scopeId: task.id };
@@ -600,7 +656,7 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
           }
 
           return success({
-            message: `${query.action === 'question' ? 'Question' : query.action === 'propose' ? 'Proposal' : 'Counter-proposal'} submitted. Waiting for counterparty response.`,
+            message: `${query.action === 'question' ? 'Question' : query.action === 'propose' ? 'Proposal' : query.action === 'outreach' ? 'Outreach' : 'Counter-proposal'} submitted. Waiting for counterparty response.`,
             negotiationId: task.id,
             action: query.action,
             turnNumber: newTurnCount,
@@ -631,6 +687,8 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
               seedAssessment,
               history: historyForDispatch,
               isFinalTurn,
+              seat: counterpartySeat,
+              protocolVersion,
             });
           } catch (err) {
             const errMsg = err instanceof Error ? err.message : String(err);
@@ -648,7 +706,7 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
               error: errMsg,
             });
             aiTurn = {
-              action: 'reject',
+              action: rejectActionFor(protocolVersion, counterpartySeat),
               assessment: {
                 reasoning: isTimeout
                   ? 'Negotiator response timed out.'
@@ -672,7 +730,7 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
         const finalTurnCount = newTurnCount + 1;
 
         // Evaluate response
-        if (aiTurn.action === 'accept' || aiTurn.action === 'reject') {
+        if (isTerminalAction(aiTurn.action)) {
           const fullHistory = [...historyForDispatch, aiTurn];
           const outcome = buildNegotiationOutcome(fullHistory, finalTurnCount, aiTurn.action, meta.sourceUserId!, meta.candidateUserId!, counterpartySpeaker === 'source' ? 'candidate' : 'source');
 
@@ -727,6 +785,9 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
           history: [...historyForDispatch, aiTurn],
           isFinalTurn: finalTurnCount + 1 >= maxTurns,
           isDiscoverer: true,
+          seat,
+          protocolVersion,
+          allowedActions: [...allowedActionsFor(protocolVersion, seat, finalTurnCount + 1 >= maxTurns)],
         };
 
         const userDispatchResult = await deps.agentDispatcher?.dispatch(context.userId, scope, userDispatchPayload, { timeoutMs });
@@ -781,7 +842,7 @@ export function createNegotiationTools(defineTool: DefineTool, deps: ToolDeps) {
 
           const userTurnCount = finalTurnCount + 1;
 
-          if (userAgentTurn.action === 'accept' || userAgentTurn.action === 'reject') {
+          if (isTerminalAction(userAgentTurn.action)) {
             const fullHistory = [...historyForDispatch, aiTurn, userAgentTurn];
             const userSpeaker = isSource ? 'source' : 'candidate';
             const outcome = buildNegotiationOutcome(fullHistory, userTurnCount, userAgentTurn.action, meta.sourceUserId!, meta.candidateUserId!, userSpeaker === 'source' ? 'candidate' : 'source');
@@ -883,7 +944,8 @@ function buildNegotiationOutcome(
   currentSpeaker: string,
 ): NegotiationOutcome {
   const hasOpportunity = lastAction === 'accept';
-  const atCap = lastAction === 'counter';
+  // Non-terminal last action at finalization means the turn cap was hit.
+  const atCap = !isTerminalAction(lastAction);
 
   let agreedRoles: NegotiationOutcome['agreedRoles'] = [];
   if (hasOpportunity && history.length >= 2) {

--- a/packages/protocol/src/negotiation/tests/negotiation.agent.retry.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.agent.retry.spec.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "bun:test";
+import { IndexNegotiator } from "../negotiation.agent.js";
+import type { NegotiationAgentInput } from "../negotiation.agent.js";
+
+/**
+ * IND-397 — system-agent invalid output: retry once, then conservative fallback.
+ *
+ * Uses the `callModel` seam so no live provider is involved: the subclass
+ * feeds scripted raw model outputs into the validate→retry→fallback loop.
+ */
+
+class ScriptedNegotiator extends IndexNegotiator {
+  calls = 0;
+  constructor(private outputs: unknown[]) {
+    super({ turnTimeoutMs: 1000 });
+  }
+  protected override async callModel(): Promise<unknown> {
+    const out = this.outputs[Math.min(this.calls, this.outputs.length - 1)];
+    this.calls += 1;
+    return out;
+  }
+}
+
+const baseInput: NegotiationAgentInput = {
+  ownUser: { id: "u-init", intents: [], profile: { name: "Alice" } },
+  otherUser: { id: "u-cp", intents: [], profile: { name: "Bob" } },
+  indexContext: { networkId: "net-1", prompt: "" },
+  seedAssessment: { reasoning: "seed", valencyRole: "peer" },
+  history: [],
+  seat: "initiator",
+  protocolVersion: "v2",
+};
+
+function validTurn(action: string) {
+  return {
+    action,
+    assessment: { reasoning: "ok", suggestedRoles: { ownUser: "peer", otherUser: "peer" } },
+    message: null,
+  };
+}
+
+describe("IndexNegotiator — seat-schema validation with retry + fallback (IND-397)", () => {
+  it("valid seat output passes through on the first attempt", async () => {
+    const agent = new ScriptedNegotiator([validTurn("outreach")]);
+    const turn = await agent.invoke(baseInput);
+    expect(turn.action).toBe("outreach");
+    expect(agent.calls).toBe(1);
+  });
+
+  it("initiator accept (schema-impossible) retries once, then succeeds on a valid retry", async () => {
+    const agent = new ScriptedNegotiator([validTurn("accept"), validTurn("counter")]);
+    const turn = await agent.invoke(baseInput);
+    expect(turn.action).toBe("counter");
+    expect(agent.calls).toBe(2);
+  });
+
+  it("invalid output twice falls back to conservative counter (initiator, non-final)", async () => {
+    const agent = new ScriptedNegotiator([validTurn("accept"), validTurn("accept")]);
+    const turn = await agent.invoke(baseInput);
+    expect(turn.action).toBe("counter");
+    expect(agent.calls).toBe(2);
+    expect(turn.assessment.reasoning).toContain("conservative fallback");
+  });
+
+  it("counterparty final turn falls back to decline (must decide)", async () => {
+    const agent = new ScriptedNegotiator([validTurn("counter"), validTurn("counter")]);
+    const turn = await agent.invoke({
+      ...baseInput,
+      seat: "counterparty",
+      isFinalTurn: true,
+    });
+    expect(turn.action).toBe("decline");
+  });
+
+  it("v1 output is validated against the legacy schema (propose valid, outreach invalid)", async () => {
+    const v1Input: NegotiationAgentInput = { ...baseInput, seat: undefined, protocolVersion: "v1" };
+    const okAgent = new ScriptedNegotiator([validTurn("propose")]);
+    expect((await okAgent.invoke(v1Input)).action).toBe("propose");
+
+    const badAgent = new ScriptedNegotiator([validTurn("outreach"), validTurn("outreach")]);
+    const fallback = await badAgent.invoke(v1Input);
+    expect(fallback.action).toBe("counter");
+    expect(badAgent.calls).toBe(2);
+  });
+});

--- a/packages/protocol/src/negotiation/tests/negotiation.protocol.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.protocol.spec.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { InitiatorTurnSchema, CounterpartyTurnSchema, FinalInitiatorTurnSchema, FinalCounterpartyTurnSchema, allowedActionsFor, turnSchemaFor, isTerminalAction, isRejectLikeAction, fallbackActionFor, rejectActionFor, readProtocolVersion, configuredProtocolVersion, resolveSeat, seatViolationMessage } from "../negotiation.protocol.js";
+import { SystemNegotiationTurnSchema, FinalNegotiationTurnSchema } from "../negotiation.state.js";
+
+/**
+ * IND-397 — seat-scoped turn schemas + counterparty-only accept.
+ * Pure unit coverage for the protocol-rules module: the consent asymmetry is
+ * schema-enforced, not prompt-enforced.
+ */
+
+const assessment = {
+  reasoning: "r",
+  suggestedRoles: { ownUser: "peer", otherUser: "peer" },
+};
+
+function turn(action: string) {
+  return { action, assessment, message: null };
+}
+
+describe("v2 seat-scoped schemas — consent asymmetry", () => {
+  it("initiator accept is structurally impossible", () => {
+    expect(InitiatorTurnSchema.safeParse(turn("accept")).success).toBe(false);
+    expect(FinalInitiatorTurnSchema.safeParse(turn("accept")).success).toBe(false);
+  });
+
+  it("initiator vocabulary: outreach | counter | question | withdraw", () => {
+    for (const a of ["outreach", "counter", "question", "withdraw"]) {
+      expect(InitiatorTurnSchema.safeParse(turn(a)).success).toBe(true);
+    }
+    for (const a of ["accept", "decline", "propose", "reject"]) {
+      expect(InitiatorTurnSchema.safeParse(turn(a)).success).toBe(false);
+    }
+  });
+
+  it("counterparty vocabulary: accept | decline | counter | question", () => {
+    for (const a of ["accept", "decline", "counter", "question"]) {
+      expect(CounterpartyTurnSchema.safeParse(turn(a)).success).toBe(true);
+    }
+    for (const a of ["outreach", "withdraw", "propose", "reject"]) {
+      expect(CounterpartyTurnSchema.safeParse(turn(a)).success).toBe(false);
+    }
+  });
+
+  it("final turns: counterparty must decide (accept|decline); initiator may withdraw|counter", () => {
+    expect(FinalCounterpartyTurnSchema.safeParse(turn("accept")).success).toBe(true);
+    expect(FinalCounterpartyTurnSchema.safeParse(turn("decline")).success).toBe(true);
+    expect(FinalCounterpartyTurnSchema.safeParse(turn("counter")).success).toBe(false);
+    expect(FinalInitiatorTurnSchema.safeParse(turn("withdraw")).success).toBe(true);
+    expect(FinalInitiatorTurnSchema.safeParse(turn("counter")).success).toBe(true);
+    expect(FinalInitiatorTurnSchema.safeParse(turn("question")).success).toBe(false);
+  });
+});
+
+describe("allowedActionsFor", () => {
+  it("v1 ignores seat (legacy symmetric vocabulary)", () => {
+    expect(allowedActionsFor("v1", "initiator")).toEqual(["propose", "accept", "reject", "counter", "question"]);
+    expect(allowedActionsFor("v1", "counterparty")).toEqual(["propose", "accept", "reject", "counter", "question"]);
+    expect(allowedActionsFor("v1", "counterparty", true)).toEqual(["accept", "reject"]);
+  });
+
+  it("v2 scopes by seat, and final turns narrow further", () => {
+    expect(allowedActionsFor("v2", "initiator")).toEqual(["outreach", "counter", "question", "withdraw"]);
+    expect(allowedActionsFor("v2", "counterparty")).toEqual(["accept", "decline", "counter", "question"]);
+    expect(allowedActionsFor("v2", "initiator", true)).toEqual(["withdraw", "counter"]);
+    expect(allowedActionsFor("v2", "counterparty", true)).toEqual(["accept", "decline"]);
+  });
+
+  it("v2 initiator can never accept in any turn position", () => {
+    expect(allowedActionsFor("v2", "initiator")).not.toContain("accept");
+    expect(allowedActionsFor("v2", "initiator", true)).not.toContain("accept");
+  });
+});
+
+describe("turnSchemaFor", () => {
+  const v1 = { system: SystemNegotiationTurnSchema, final: FinalNegotiationTurnSchema };
+
+  it("v1 returns the legacy schemas regardless of seat", () => {
+    expect(turnSchemaFor("v1", "initiator", false, v1)).toBe(SystemNegotiationTurnSchema);
+    expect(turnSchemaFor("v1", "counterparty", false, v1)).toBe(SystemNegotiationTurnSchema);
+    expect(turnSchemaFor("v1", "initiator", true, v1)).toBe(FinalNegotiationTurnSchema);
+  });
+
+  it("v2 returns the seat-scoped schemas", () => {
+    expect(turnSchemaFor("v2", "initiator", false, v1)).toBe(InitiatorTurnSchema);
+    expect(turnSchemaFor("v2", "counterparty", false, v1)).toBe(CounterpartyTurnSchema);
+    expect(turnSchemaFor("v2", "initiator", true, v1)).toBe(FinalInitiatorTurnSchema);
+    expect(turnSchemaFor("v2", "counterparty", true, v1)).toBe(FinalCounterpartyTurnSchema);
+  });
+});
+
+describe("action semantics", () => {
+  it("terminal actions: accept, reject, withdraw, decline", () => {
+    for (const a of ["accept", "reject", "withdraw", "decline"]) expect(isTerminalAction(a)).toBe(true);
+    for (const a of ["propose", "outreach", "counter", "question", undefined, null]) expect(isTerminalAction(a)).toBe(false);
+  });
+
+  it("reject-like actions map to rejected: reject, withdraw, decline (not accept)", () => {
+    for (const a of ["reject", "withdraw", "decline"]) expect(isRejectLikeAction(a)).toBe(true);
+    for (const a of ["accept", "counter", "question", "outreach", "propose"]) expect(isRejectLikeAction(a)).toBe(false);
+  });
+
+  it("fallback is conservative counter; final turns must decide per seat", () => {
+    expect(fallbackActionFor("v1", "initiator", false)).toBe("counter");
+    expect(fallbackActionFor("v2", "counterparty", false)).toBe("counter");
+    expect(fallbackActionFor("v1", "counterparty", true)).toBe("reject");
+    expect(fallbackActionFor("v2", "counterparty", true)).toBe("decline");
+    expect(fallbackActionFor("v2", "initiator", true)).toBe("counter");
+  });
+
+  it("rejectActionFor is seat-appropriate under v2", () => {
+    expect(rejectActionFor("v1", "initiator")).toBe("reject");
+    expect(rejectActionFor("v2", "initiator")).toBe("withdraw");
+    expect(rejectActionFor("v2", "counterparty")).toBe("decline");
+  });
+});
+
+describe("metadata readers", () => {
+  const origEnv = process.env.NEGOTIATION_PROTOCOL_VERSION;
+  afterEach(() => {
+    if (origEnv === undefined) delete process.env.NEGOTIATION_PROTOCOL_VERSION;
+    else process.env.NEGOTIATION_PROTOCOL_VERSION = origEnv;
+  });
+
+  it("readProtocolVersion: v1/v2 pass through; absent or junk → null", () => {
+    expect(readProtocolVersion({ protocolVersion: "v2" })).toBe("v2");
+    expect(readProtocolVersion({ protocolVersion: "v1" })).toBe("v1");
+    expect(readProtocolVersion({})).toBeNull();
+    expect(readProtocolVersion({ protocolVersion: "v3" })).toBeNull();
+    expect(readProtocolVersion(null)).toBeNull();
+  });
+
+  it("configuredProtocolVersion: env switch, defaults v1", () => {
+    delete process.env.NEGOTIATION_PROTOCOL_VERSION;
+    expect(configuredProtocolVersion()).toBe("v1");
+    process.env.NEGOTIATION_PROTOCOL_VERSION = "v2";
+    expect(configuredProtocolVersion()).toBe("v2");
+    process.env.NEGOTIATION_PROTOCOL_VERSION = "nonsense";
+    expect(configuredProtocolVersion()).toBe("v1");
+  });
+
+  it("resolveSeat keys on initiatorUserId, falling back to sourceUserId (never parity)", () => {
+    expect(resolveSeat("u-a", { initiatorUserId: "u-a", sourceUserId: "u-b" })).toBe("initiator");
+    expect(resolveSeat("u-b", { initiatorUserId: "u-a", sourceUserId: "u-b" })).toBe("counterparty");
+    // Pre-stamp task: sourceUserId is the fallback seat anchor
+    expect(resolveSeat("u-a", { sourceUserId: "u-a" })).toBe("initiator");
+    expect(resolveSeat("u-b", { sourceUserId: "u-a" })).toBe("counterparty");
+    // Empty-string stamp is ignored
+    expect(resolveSeat("u-a", { initiatorUserId: "", sourceUserId: "u-a" })).toBe("initiator");
+  });
+
+  it("seatViolationMessage names the action, seat, version, and allowed set", () => {
+    const msg = seatViolationMessage("accept", "initiator", "v2");
+    expect(msg).toContain('"accept"');
+    expect(msg).toContain("initiator");
+    expect(msg).toContain("v2");
+    expect(msg).toContain("outreach, counter, question, withdraw");
+  });
+});

--- a/packages/protocol/src/negotiation/tests/negotiation.seat-rules.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.seat-rules.spec.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+import { NegotiationGraphFactory } from "../negotiation.graph.js";
+import { NegotiationGraphState } from "../negotiation.state.js";
+import { IndexNegotiator, type NegotiationAgentInput } from "../negotiation.agent.js";
+import type { NegotiationTurn } from "../negotiation.state.js";
+
+/**
+ * IND-397 — seat-scoped turn schemas + counterparty-only accept (graph level).
+ *
+ * Pins:
+ * - protocolVersion stamping for fresh runs (env switch) and inheritance for
+ *   continuations (a v1 conversation stays v1 mid-flight even with env=v2),
+ * - turn-0 opening action per version (v1 propose, v2 initiator outreach),
+ * - seat + version propagation into the system agent and dispatch payload,
+ * - v2 coercion of out-of-seat personal-agent turns (initiator accept →
+ *   conservative counter),
+ * - counterparty accept finalizing normally under v2.
+ */
+
+type TaskRecord = {
+  id: string;
+  conversationId: string;
+  state: string;
+  metadata: Record<string, unknown> | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type FakeMessage = {
+  id: string;
+  senderId: string;
+  role: "agent";
+  parts: unknown[];
+  createdAt: Date;
+};
+
+function priorMsg(senderUserId: string, action: string, idx: number): FakeMessage {
+  return {
+    id: `prior-${idx}`,
+    senderId: `agent:${senderUserId}`,
+    role: "agent",
+    parts: [{ kind: "data", data: { action, assessment: { reasoning: "r", suggestedRoles: { ownUser: "peer", otherUser: "peer" } }, message: null } }],
+    createdAt: new Date(Date.now() - (100 - idx) * 1000),
+  };
+}
+
+function mkStubs(opts?: {
+  priorOpportunityTask?: TaskRecord | null;
+  conversationTask?: TaskRecord | null;
+  priorMessages?: FakeMessage[];
+  dispatch?: (userId: string) => Promise<unknown>;
+}) {
+  const createdTasks: Array<{ conversationId: string; metadata: Record<string, unknown> }> = [];
+  const createdMessages: Array<{ senderId: string; parts: Array<{ kind: string; data: NegotiationTurn }> }> = [];
+  const database = {
+    createConversation: async () => ({ id: "conv-1" }),
+    getOrCreateDM: async () => ({ id: "conv-1" }),
+    createTask: async (conversationId: string, metadata: Record<string, unknown>) => {
+      createdTasks.push({ conversationId, metadata });
+      return { id: "task-new", conversationId, state: "submitted" };
+    },
+    updateOpportunityStatus: async () => {},
+    createMessage: async (p: { senderId: string; parts: Array<{ kind: string; data: NegotiationTurn }> }) => {
+      createdMessages.push(p);
+      return { id: `msg-${createdMessages.length}`, senderId: p.senderId, parts: p.parts, createdAt: new Date() };
+    },
+    updateTaskState: async () => {},
+    createArtifact: async () => {},
+    setTaskTurnContext: async () => {},
+    getMessagesForConversation: async () => opts?.priorMessages ?? [],
+    getOpportunityUserAnswers: async () => [],
+    getNegotiationTaskForOpportunity: async () => opts?.priorOpportunityTask ?? null,
+    getLatestNegotiationTaskForConversation: async () => opts?.conversationTask ?? null,
+    getUserContext: async () => null,
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[0];
+
+  const dispatcher = {
+    hasExternalAgent: async () => false,
+    dispatch: async (userId: string) =>
+      opts?.dispatch ? opts.dispatch(userId) : { handled: false, reason: "no_agent" },
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[1];
+
+  return { database, dispatcher, createdTasks, createdMessages };
+}
+
+function mkTask(partial: Partial<TaskRecord>): TaskRecord {
+  return {
+    id: "task-prior",
+    conversationId: "conv-1",
+    state: "completed",
+    metadata: null,
+    createdAt: new Date(Date.now() - 60 * 60 * 1000),
+    updatedAt: new Date(Date.now() - 60 * 60 * 1000),
+    ...partial,
+  };
+}
+
+async function runGraph(stubs: ReturnType<typeof mkStubs>, input: Record<string, unknown>) {
+  const graph = new NegotiationGraphFactory(stubs.database, stubs.dispatcher).createGraph();
+  return graph.invoke({
+    sourceUser: { id: "u-src", intents: [], profile: { name: "Alice" } },
+    candidateUser: { id: "u-cand", intents: [], profile: { name: "Bob" } },
+    indexContext: { networkId: "net-1", prompt: "" },
+    seedAssessment: { reasoning: "x", valencyRole: "peer" },
+    maxTurns: 1,
+    ...input,
+  } as Partial<typeof NegotiationGraphState.State>);
+}
+
+const agentInputs: NegotiationAgentInput[] = [];
+let stubAction: string | ((input: NegotiationAgentInput) => string) = "counter";
+
+describe("negotiation graph — seat rules + protocol version (IND-397)", () => {
+  let origInvoke: typeof IndexNegotiator.prototype.invoke;
+  const origEnv = process.env.NEGOTIATION_PROTOCOL_VERSION;
+
+  beforeAll(() => {
+    origInvoke = IndexNegotiator.prototype.invoke;
+    IndexNegotiator.prototype.invoke = async function (input: NegotiationAgentInput) {
+      agentInputs.push(input);
+      const action = typeof stubAction === "function" ? stubAction(input) : stubAction;
+      return {
+        action: action as NegotiationTurn["action"],
+        assessment: { reasoning: "stub", suggestedRoles: { ownUser: "peer" as const, otherUser: "peer" as const } },
+        message: null,
+      };
+    };
+  });
+
+  afterAll(() => {
+    IndexNegotiator.prototype.invoke = origInvoke;
+  });
+
+  beforeEach(() => {
+    agentInputs.length = 0;
+    stubAction = "counter";
+    delete process.env.NEGOTIATION_PROTOCOL_VERSION;
+  });
+
+  afterEach(() => {
+    if (origEnv === undefined) delete process.env.NEGOTIATION_PROTOCOL_VERSION;
+    else process.env.NEGOTIATION_PROTOCOL_VERSION = origEnv;
+  });
+
+  it("fresh run with env=v2: stamps protocolVersion v2 and forces turn 0 to outreach", async () => {
+    process.env.NEGOTIATION_PROTOCOL_VERSION = "v2";
+    const stubs = mkStubs();
+    stubAction = "counter"; // out-of-position opening — must be forced
+
+    await runGraph(stubs, { opportunityId: "opp-1" });
+
+    expect(stubs.createdTasks[0].metadata.protocolVersion).toBe("v2");
+    expect(stubs.createdMessages[0].parts[0].data.action).toBe("outreach");
+    // System agent got the initiator seat + v2 version
+    expect(agentInputs[0].seat).toBe("initiator");
+    expect(agentInputs[0].protocolVersion).toBe("v2");
+  });
+
+  it("fresh run without env: stays v1 and forces turn 0 to propose (legacy unchanged)", async () => {
+    const stubs = mkStubs();
+    stubAction = "counter";
+
+    await runGraph(stubs, { opportunityId: "opp-1" });
+
+    expect(stubs.createdTasks[0].metadata.protocolVersion).toBe("v1");
+    expect(stubs.createdMessages[0].parts[0].data.action).toBe("propose");
+    expect(agentInputs[0].protocolVersion).toBe("v1");
+  });
+
+  it("version inheritance: continuation of a v1 conversation stays v1 even with env=v2", async () => {
+    process.env.NEGOTIATION_PROTOCOL_VERSION = "v2";
+    const stubs = mkStubs({
+      priorOpportunityTask: mkTask({
+        metadata: { type: "negotiation", initiatorUserId: "u-src", sourceUserId: "u-src", protocolVersion: "v1" },
+      }),
+      priorMessages: [priorMsg("u-src", "propose", 0), priorMsg("u-cand", "counter", 1)],
+    });
+    stubAction = "counter";
+
+    await runGraph(stubs, { opportunityId: "opp-1" });
+
+    expect(stubs.createdTasks[0].metadata.protocolVersion).toBe("v1");
+    expect(agentInputs[0].protocolVersion).toBe("v1");
+  });
+
+  it("version inheritance: prior task without a version field grandfathers to v1 under env=v2", async () => {
+    process.env.NEGOTIATION_PROTOCOL_VERSION = "v2";
+    const stubs = mkStubs({
+      priorOpportunityTask: mkTask({
+        metadata: { type: "negotiation", initiatorUserId: "u-src", sourceUserId: "u-src" }, // pre-v2 task
+      }),
+      priorMessages: [priorMsg("u-src", "propose", 0)],
+    });
+
+    await runGraph(stubs, { opportunityId: "opp-1" });
+
+    expect(stubs.createdTasks[0].metadata.protocolVersion).toBe("v1");
+  });
+
+  it("version inheritance: prior conversation turns without any readable task grandfather to v1", async () => {
+    process.env.NEGOTIATION_PROTOCOL_VERSION = "v2";
+    const stubs = mkStubs({
+      priorMessages: [priorMsg("u-src", "propose", 0), priorMsg("u-cand", "counter", 1)],
+    });
+
+    await runGraph(stubs, { opportunityId: "opp-1" });
+
+    expect(stubs.createdTasks[0].metadata.protocolVersion).toBe("v1");
+  });
+
+  it("version inheritance: a v2 conversation stays v2 even after env rollback to v1", async () => {
+    process.env.NEGOTIATION_PROTOCOL_VERSION = "v1";
+    const stubs = mkStubs({
+      priorOpportunityTask: mkTask({
+        metadata: { type: "negotiation", initiatorUserId: "u-src", sourceUserId: "u-src", protocolVersion: "v2" },
+      }),
+      priorMessages: [priorMsg("u-src", "outreach", 0)],
+    });
+
+    await runGraph(stubs, { opportunityId: "opp-1" });
+
+    expect(stubs.createdTasks[0].metadata.protocolVersion).toBe("v2");
+    expect(agentInputs[0].protocolVersion).toBe("v2");
+  });
+
+  it("v2 continuation: counterparty seat is derived from initiatorUserId, not speaking order", async () => {
+    process.env.NEGOTIATION_PROTOCOL_VERSION = "v2";
+    // Prior session: initiator u-src spoke last → this session opens with the
+    // candidate (u-cand) speaking. u-cand holds the counterparty seat.
+    const stubs = mkStubs({
+      priorOpportunityTask: mkTask({
+        metadata: { type: "negotiation", initiatorUserId: "u-src", sourceUserId: "u-src", protocolVersion: "v2" },
+      }),
+      priorMessages: [priorMsg("u-src", "outreach", 0)],
+    });
+    stubAction = "accept";
+
+    const result = await runGraph(stubs, { opportunityId: "opp-1", maxTurns: 6 });
+
+    expect(agentInputs[0].seat).toBe("counterparty");
+    expect(stubs.createdMessages[0].parts[0].data.action).toBe("accept");
+    expect((result as { outcome: { hasOpportunity: boolean } }).outcome?.hasOpportunity).toBe(true);
+  });
+
+  it("v2: personal-agent accept from the initiator seat is coerced to conservative counter", async () => {
+    process.env.NEGOTIATION_PROTOCOL_VERSION = "v2";
+    // Prior session: counterparty (u-cand) spoke last → initiator (u-src)
+    // speaks next. Its personal agent tries to accept — out of seat.
+    const stubs = mkStubs({
+      priorOpportunityTask: mkTask({
+        metadata: { type: "negotiation", initiatorUserId: "u-src", sourceUserId: "u-src", protocolVersion: "v2" },
+      }),
+      priorMessages: [priorMsg("u-src", "outreach", 0), priorMsg("u-cand", "counter", 1)],
+      dispatch: async () => ({
+        handled: true,
+        turn: {
+          action: "accept",
+          assessment: { reasoning: "rogue", suggestedRoles: { ownUser: "peer", otherUser: "peer" } },
+          message: null,
+        },
+      }),
+    });
+
+    await runGraph(stubs, { opportunityId: "opp-1", maxTurns: 1 });
+
+    expect(stubs.createdMessages[0].parts[0].data.action).toBe("counter");
+    expect(stubs.createdMessages[0].senderId).toBe("agent:u-src");
+  });
+
+  it("v2: withdraw finalizes as rejected (reject-like), not stalled", async () => {
+    process.env.NEGOTIATION_PROTOCOL_VERSION = "v2";
+    const statusUpdates: string[] = [];
+    const stubs = mkStubs({
+      priorOpportunityTask: mkTask({
+        metadata: { type: "negotiation", initiatorUserId: "u-src", sourceUserId: "u-src", protocolVersion: "v2" },
+      }),
+      priorMessages: [priorMsg("u-src", "outreach", 0), priorMsg("u-cand", "counter", 1)],
+    });
+    (stubs.database as unknown as { updateOpportunityStatus: (id: string, s: string) => Promise<void> }).updateOpportunityStatus =
+      async (_id: string, s: string) => { statusUpdates.push(s); };
+    stubAction = "withdraw";
+
+    const result = await runGraph(stubs, { opportunityId: "opp-1", maxTurns: 6 });
+
+    expect((result as { outcome: { hasOpportunity: boolean } }).outcome?.hasOpportunity).toBe(false);
+    expect(statusUpdates).toContain("rejected");
+  });
+
+  it("v2 final turn: agent is invoked with isFinalTurn and the parked seat", async () => {
+    process.env.NEGOTIATION_PROTOCOL_VERSION = "v2";
+    const stubs = mkStubs();
+    stubAction = (input) => (input.isFinalTurn ? "decline" : "counter");
+
+    await runGraph(stubs, { opportunityId: "opp-1", maxTurns: 2 });
+
+    // Turn 0: initiator opening; Turn 1 (= maxTurns): final counterparty turn
+    expect(agentInputs.length).toBe(2);
+    expect(agentInputs[1].isFinalTurn).toBe(true);
+    expect(agentInputs[1].seat).toBe("counterparty");
+    expect(agentInputs[1].protocolVersion).toBe("v2");
+  });
+
+  it("dispatch payload announces seat, version, and allowedActions", async () => {
+    process.env.NEGOTIATION_PROTOCOL_VERSION = "v2";
+    const payloads: Array<Record<string, unknown>> = [];
+    const stubs = mkStubs({
+      dispatch: async () => ({ handled: false, reason: "no_agent" }),
+    });
+    (stubs.dispatcher as unknown as { dispatch: (u: string, s: unknown, p: Record<string, unknown>) => Promise<unknown> }).dispatch =
+      async (_u: string, _s: unknown, p: Record<string, unknown>) => { payloads.push(p); return { handled: false, reason: "no_agent" }; };
+
+    await runGraph(stubs, { opportunityId: "opp-1", maxTurns: 6 });
+
+    expect(payloads[0].seat).toBe("initiator");
+    expect(payloads[0].protocolVersion).toBe("v2");
+    expect(payloads[0].allowedActions).toEqual(["outreach", "counter", "question", "withdraw"]);
+  });
+});

--- a/packages/protocol/src/negotiation/tests/negotiation.tools.seat.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.tools.seat.spec.ts
@@ -1,0 +1,273 @@
+import { describe, expect, test } from "bun:test";
+import { z } from "zod";
+import { createNegotiationTools } from "../negotiation.tools.js";
+import type { ToolDeps, ResolvedToolContext } from "../../shared/agent/tool.helpers.js";
+
+/**
+ * IND-397 — respond_to_negotiation seat + version validation.
+ *
+ * v2 tasks: the submitted action must be within the caller's seat vocabulary
+ * (initiator can never accept). v1 tasks are grandfathered: the legacy
+ * vocabulary stays valid. get_negotiation announces seat/version/allowedActions.
+ */
+
+function makeContext(userId: string): ResolvedToolContext {
+  return {
+    userId,
+    user: { id: userId, name: "U", email: "u@test" } as never,
+    userProfile: null,
+    userNetworks: [],
+    isMcp: true,
+  } as unknown as ResolvedToolContext;
+}
+
+function captureTool(name: string, deps: Partial<ToolDeps>) {
+  let captured: { handler: (i: { context: ResolvedToolContext; query: unknown }) => Promise<string>; querySchema?: z.ZodType } | undefined;
+  const defineTool = (def: { name: string; handler: (...args: unknown[]) => unknown; querySchema?: z.ZodType }) => {
+    if (def.name === name) captured = def as typeof captured;
+    return def;
+  };
+  createNegotiationTools(defineTool as never, deps as ToolDeps);
+  return captured!;
+}
+
+function v2Task(initiatorUserId: string) {
+  return {
+    id: "task-1",
+    conversationId: "conv-1",
+    state: "waiting_for_agent",
+    metadata: {
+      type: "negotiation",
+      sourceUserId: "user-src",
+      candidateUserId: "user-cand",
+      initiatorUserId,
+      protocolVersion: "v2",
+      maxTurns: 6,
+    },
+    createdAt: new Date("2026-01-01"),
+    updatedAt: new Date("2026-01-02"),
+  };
+}
+
+function msgFrom(senderUserId: string, action: string) {
+  return {
+    id: "m-1",
+    senderId: `agent:${senderUserId}`,
+    role: "agent",
+    parts: [{ kind: "data", data: { action, assessment: { reasoning: "r", suggestedRoles: { ownUser: "peer", otherUser: "peer" } }, message: null } }],
+    createdAt: new Date(),
+  };
+}
+
+function makeDeps(task: unknown, messages: unknown[]) {
+  const createdMessages: Array<{ senderId: string; parts: Array<{ data: { action: string } }> }> = [];
+  return {
+    deps: {
+      negotiationDatabase: {
+        getTask: async () => task,
+        getMessagesForConversation: async () => messages,
+        createMessage: async (m: { senderId: string; parts: Array<{ data: { action: string } }> }) => {
+          createdMessages.push(m);
+          return { id: "msg-new", senderId: m.senderId, role: "agent", parts: m.parts, createdAt: new Date() };
+        },
+        updateTaskState: async () => {},
+        createArtifact: async () => {},
+        getArtifactsForTask: async () => [],
+      },
+      negotiationTimeoutQueue: { cancelTimeout: async () => {}, enqueueTimeout: async () => {} },
+      agentDispatcher: { dispatch: async () => ({ handled: false, reason: "waiting" }) },
+    } as Partial<ToolDeps>,
+    createdMessages,
+  };
+}
+
+const assessmentQuery = {
+  reasoning: "because",
+  suggestedRoles: { ownUser: "peer", otherUser: "peer" },
+};
+
+describe("respond_to_negotiation — v2 seat validation", () => {
+  test("initiator submitting accept is rejected with a seat-violation error", async () => {
+    // user-src is the initiator; counterparty (user-cand) spoke last → src's turn
+    const { deps } = makeDeps(v2Task("user-src"), [msgFrom("user-cand", "counter")]);
+    const tool = captureTool("respond_to_negotiation", deps);
+
+    const result = JSON.parse(await tool.handler({
+      context: makeContext("user-src"),
+      query: { negotiationId: "task-1", action: "accept", ...assessmentQuery },
+    }));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("not allowed for your seat (initiator)");
+    expect(result.error).toContain("outreach, counter, question, withdraw");
+  });
+
+  test("counterparty accept is allowed and finalizes with an opportunity", async () => {
+    // user-cand is counterparty; initiator (user-src) spoke last → cand's turn
+    const { deps, createdMessages } = makeDeps(v2Task("user-src"), [msgFrom("user-src", "outreach")]);
+    const tool = captureTool("respond_to_negotiation", deps);
+
+    const result = JSON.parse(await tool.handler({
+      context: makeContext("user-cand"),
+      query: { negotiationId: "task-1", action: "accept", ...assessmentQuery },
+    }));
+
+    expect(result.success).toBe(true);
+    expect(result.data.message).toContain("accepted");
+    expect(result.data.outcome.hasOpportunity).toBe(true);
+    expect(createdMessages[0].senderId).toBe("agent:user-cand");
+  });
+
+  test("initiator withdraw finalizes without an opportunity", async () => {
+    const { deps } = makeDeps(v2Task("user-src"), [msgFrom("user-cand", "counter")]);
+    const tool = captureTool("respond_to_negotiation", deps);
+
+    const result = JSON.parse(await tool.handler({
+      context: makeContext("user-src"),
+      query: { negotiationId: "task-1", action: "withdraw", ...assessmentQuery },
+    }));
+
+    expect(result.success).toBe(true);
+    expect(result.data.message).toContain("withdrawn");
+    expect(result.data.outcome.hasOpportunity).toBe(false);
+  });
+
+  test("counterparty decline finalizes without an opportunity", async () => {
+    const { deps } = makeDeps(v2Task("user-src"), [msgFrom("user-src", "outreach")]);
+    const tool = captureTool("respond_to_negotiation", deps);
+
+    const result = JSON.parse(await tool.handler({
+      context: makeContext("user-cand"),
+      query: { negotiationId: "task-1", action: "decline", ...assessmentQuery },
+    }));
+
+    expect(result.success).toBe(true);
+    expect(result.data.message).toContain("declined");
+    expect(result.data.outcome.hasOpportunity).toBe(false);
+  });
+
+  test("counterparty cannot outreach", async () => {
+    const { deps } = makeDeps(v2Task("user-src"), [msgFrom("user-src", "outreach")]);
+    const tool = captureTool("respond_to_negotiation", deps);
+
+    const result = JSON.parse(await tool.handler({
+      context: makeContext("user-cand"),
+      query: { negotiationId: "task-1", action: "outreach", ...assessmentQuery },
+    }));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("counterparty");
+  });
+
+  test("seat attribution ignores speaking order: counterparty speaking first still cannot accept as initiator", async () => {
+    // Continuation where the counterparty spoke first: 1 message from user-cand.
+    // Parity would call the next speaker "candidate"; senderId-based turn-taking
+    // correctly gives the turn to user-src, and seat still keys on the stamp.
+    const { deps, createdMessages } = makeDeps(v2Task("user-src"), [msgFrom("user-cand", "question")]);
+    const tool = captureTool("respond_to_negotiation", deps);
+
+    const violation = JSON.parse(await tool.handler({
+      context: makeContext("user-src"),
+      query: { negotiationId: "task-1", action: "accept", ...assessmentQuery },
+    }));
+    expect(violation.success).toBe(false);
+    expect(violation.error).toContain("initiator");
+
+    const ok = JSON.parse(await tool.handler({
+      context: makeContext("user-src"),
+      query: { negotiationId: "task-1", action: "counter", message: "adjusting", ...assessmentQuery },
+    }));
+    expect(ok.success).toBe(true);
+    expect(createdMessages[0].senderId).toBe("agent:user-src");
+  });
+});
+
+describe("respond_to_negotiation — v1 grandfathering", () => {
+  function v1Task() {
+    return {
+      id: "task-1",
+      conversationId: "conv-1",
+      state: "waiting_for_agent",
+      metadata: { type: "negotiation", sourceUserId: "user-src", candidateUserId: "user-cand", maxTurns: 6 },
+      createdAt: new Date("2026-01-01"),
+      updatedAt: new Date("2026-01-02"),
+    };
+  }
+
+  test("in-flight v1 task accepts legacy propose", async () => {
+    const { deps } = makeDeps(v1Task(), []);
+    const tool = captureTool("respond_to_negotiation", deps);
+
+    const result = JSON.parse(await tool.handler({
+      context: makeContext("user-src"),
+      query: { negotiationId: "task-1", action: "propose", ...assessmentQuery },
+    }));
+
+    expect(result.success).toBe(true);
+  });
+
+  test("in-flight v1 task accepts legacy reject (either party)", async () => {
+    const { deps } = makeDeps(v1Task(), [msgFrom("user-src", "propose")]);
+    const tool = captureTool("respond_to_negotiation", deps);
+
+    const result = JSON.parse(await tool.handler({
+      context: makeContext("user-cand"),
+      query: { negotiationId: "task-1", action: "reject", ...assessmentQuery },
+    }));
+
+    expect(result.success).toBe(true);
+    expect(result.data.message).toContain("rejected");
+  });
+
+  test("v1 task rejects the v2-only vocabulary", async () => {
+    const { deps } = makeDeps(v1Task(), [msgFrom("user-src", "propose")]);
+    const tool = captureTool("respond_to_negotiation", deps);
+
+    const result = JSON.parse(await tool.handler({
+      context: makeContext("user-cand"),
+      query: { negotiationId: "task-1", action: "decline", ...assessmentQuery },
+    }));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("v1");
+  });
+});
+
+describe("get_negotiation — seat announcement", () => {
+  test("returns seat, protocolVersion, and allowedActions for the caller", async () => {
+    const { deps } = makeDeps(v2Task("user-src"), [msgFrom("user-src", "outreach")]);
+    const tool = captureTool("get_negotiation", deps);
+
+    const asInitiator = JSON.parse(await tool.handler({
+      context: makeContext("user-src"),
+      query: { negotiationId: "task-1" },
+    }));
+    expect(asInitiator.data.seat).toBe("initiator");
+    expect(asInitiator.data.protocolVersion).toBe("v2");
+    expect(asInitiator.data.allowedActions).toEqual(["outreach", "counter", "question", "withdraw"]);
+    expect(asInitiator.data.isUsersTurn).toBe(false);
+
+    const asCounterparty = JSON.parse(await tool.handler({
+      context: makeContext("user-cand"),
+      query: { negotiationId: "task-1" },
+    }));
+    expect(asCounterparty.data.seat).toBe("counterparty");
+    expect(asCounterparty.data.allowedActions).toEqual(["accept", "decline", "counter", "question"]);
+    expect(asCounterparty.data.isUsersTurn).toBe(true);
+  });
+
+  test("v1 task announces the legacy vocabulary", async () => {
+    const { deps } = makeDeps(
+      { ...v2Task("user-src"), metadata: { type: "negotiation", sourceUserId: "user-src", candidateUserId: "user-cand" } },
+      [],
+    );
+    const tool = captureTool("get_negotiation", deps);
+
+    const result = JSON.parse(await tool.handler({
+      context: makeContext("user-src"),
+      query: { negotiationId: "task-1" },
+    }));
+    expect(result.data.protocolVersion).toBe("v1");
+    expect(result.data.allowedActions).toEqual(["propose", "accept", "reject", "counter", "question"]);
+  });
+});

--- a/packages/protocol/src/opportunity/question.prompt.ts
+++ b/packages/protocol/src/opportunity/question.prompt.ts
@@ -16,7 +16,7 @@ export type NegotiationRole = "agent" | "patient" | "peer";
 
 /** One turn within a negotiation. */
 export interface DiscoveryTurn {
-  action: "propose" | "accept" | "reject" | "counter" | "question";
+  action: "propose" | "accept" | "reject" | "counter" | "question" | "outreach" | "withdraw" | "decline";
   reasoning: string;
   suggestedRoles: { ownUser: NegotiationRole; otherUser: NegotiationRole };
 }

--- a/packages/protocol/src/shared/interfaces/agent-dispatcher.interface.ts
+++ b/packages/protocol/src/shared/interfaces/agent-dispatcher.interface.ts
@@ -21,6 +21,12 @@ export interface NegotiationTurnPayload {
   isDiscoverer: boolean;
   /** The explicit search query that triggered this discovery (if any). Takes priority over background intents. */
   discoveryQuery?: string;
+  /** The acting user's seat under the v2 client-advocate protocol (`initiator` | `counterparty`). */
+  seat?: string;
+  /** Negotiation protocol version for this task (`v1` | `v2`). */
+  protocolVersion?: string;
+  /** Actions the acting seat may submit on this turn (seat + version + final-turn scoped). */
+  allowedActions?: string[];
 }
 
 /** Result of a dispatch attempt. */

--- a/packages/protocol/src/shared/schemas/discovery-question.schema.ts
+++ b/packages/protocol/src/shared/schemas/discovery-question.schema.ts
@@ -14,7 +14,7 @@ export const NegotiationRoleSchema = z.enum(["agent", "patient", "peer"]);
 export type NegotiationRole = z.infer<typeof NegotiationRoleSchema>;
 
 export const DiscoveryTurnSchema = z.object({
-  action: z.enum(["propose", "accept", "reject", "counter", "question"]),
+  action: z.enum(["propose", "accept", "reject", "counter", "question", "outreach", "withdraw", "decline"]),
   reasoning: z.string(),
   suggestedRoles: z.object({
     ownUser: NegotiationRoleSchema,

--- a/packages/protocol/src/shared/schemas/negotiation-state.schema.ts
+++ b/packages/protocol/src/shared/schemas/negotiation-state.schema.ts
@@ -7,8 +7,30 @@ import { z } from "zod";
 
 // ─── Zod schemas (available for runtime validation) ───────────────────────────
 
+/**
+ * Union of every negotiation turn action across protocol versions.
+ *
+ * v1 vocabulary: `propose | accept | reject | counter | question`.
+ * v2 (client-advocate seat rules) renames `propose`→`outreach` and splits
+ * `reject` into `withdraw` (initiator seat) / `decline` (counterparty seat).
+ * Which subset is valid for a given turn depends on the task's
+ * `protocolVersion` and the acting user's seat — see
+ * `negotiation/negotiation.protocol.ts` for the seat-scoped schemas.
+ */
+export const NEGOTIATION_ACTIONS = [
+  "propose", "accept", "reject", "counter", "question",
+  "outreach", "withdraw", "decline",
+] as const;
+export type NegotiationAction = (typeof NEGOTIATION_ACTIONS)[number];
+
+/** Negotiation seat under the v2 client-advocate protocol. */
+export type NegotiationSeat = "initiator" | "counterparty";
+
+/** Negotiation protocol version stamped on task metadata. */
+export type NegotiationProtocolVersion = "v1" | "v2";
+
 export const NegotiationTurnSchema = z.object({
-  action: z.enum(["propose", "accept", "reject", "counter", "question"]),
+  action: z.enum(NEGOTIATION_ACTIONS),
   assessment: z.object({
     reasoning: z.string(),
     suggestedRoles: z.object({

--- a/services/api/src/controllers/agent.controller.ts
+++ b/services/api/src/controllers/agent.controller.ts
@@ -6,7 +6,7 @@ import { log } from '../lib/log';
 import { Controller, Delete, Get, Patch, Post, UseGuards } from '../lib/router/router.decorators';
 import { AgentTestMessageService } from '../services/agent-test-message.service';
 import { agentService } from '../services/agent.service';
-import { negotiationPollingService, NotFoundError, ConflictError, UnauthorizedError } from '../services/negotiation-polling.service';
+import { negotiationPollingService, NotFoundError, ConflictError, UnauthorizedError, SeatViolationError } from '../services/negotiation-polling.service';
 import { opportunityDeliveryService } from '../services/opportunity-delivery.service';
 
 const agentTestMessageService = new AgentTestMessageService();
@@ -61,8 +61,10 @@ const confirmOpportunityDeliveredSchema = z.object({
   reservationToken: z.string().min(1, 'reservationToken is required'),
 });
 
+// Accepts the union of v1 + v2 action vocabularies; the polling service
+// enforces the per-task version + seat subset (wrong-seat action → 400).
 const respondNegotiationSchema = z.object({
-  action: z.enum(['propose', 'accept', 'reject', 'counter', 'question']),
+  action: z.enum(['propose', 'accept', 'reject', 'counter', 'question', 'outreach', 'withdraw', 'decline']),
   message: z.string().nullable().optional(),
   assessment: z.object({
     reasoning: z.string(),
@@ -90,6 +92,7 @@ function parseErrorMessage(err: unknown): string {
 }
 
 function errorStatus(err: unknown, fallback = 400): number {
+  if (err instanceof SeatViolationError) return 400;
   if (err instanceof UnauthorizedError) return 403;
   if (err instanceof NotFoundError) return 404;
   if (err instanceof ConflictError) return 409;

--- a/services/api/src/queues/negotiations/timeout.shared.ts
+++ b/services/api/src/queues/negotiations/timeout.shared.ts
@@ -1,5 +1,5 @@
-import { IndexNegotiator } from '@indexnetwork/protocol';
-import type { NegotiationTurn, NegotiationOutcome, UserNegotiationContext, SeedAssessment, NegotiationGraphDatabase } from '@indexnetwork/protocol';
+import { IndexNegotiator, isRejectLikeAction, isTerminalAction, readProtocolVersion, resolveSeat } from '@indexnetwork/protocol';
+import type { NegotiationTurn, NegotiationOutcome, UserNegotiationContext, SeedAssessment, NegotiationGraphDatabase, NegotiationProtocolVersion } from '@indexnetwork/protocol';
 
 import { log } from '../../lib/log';
 
@@ -9,6 +9,10 @@ type TimeoutLogger = ReturnType<typeof log.job.from>;
 export interface NegotiationTaskMeta {
   sourceUserId?: string;
   candidateUserId?: string;
+  /** Rigid initiator seat, stamped at discovery time (v2 client-advocate). */
+  initiatorUserId?: string;
+  /** Negotiation protocol version; absent on pre-v2 tasks (treated as v1). */
+  protocolVersion?: string;
   type?: string;
   maxTurns?: number;
   opportunityId?: string;
@@ -37,7 +41,8 @@ export function buildNegotiationOutcome(
   currentSpeaker: string,
 ): NegotiationOutcome {
   const hasOpportunity = lastAction === 'accept';
-  const atCap = lastAction === 'counter';
+  // Non-terminal last action at finalization means the turn cap was hit.
+  const atCap = !isTerminalAction(lastAction);
 
   let agreedRoles: NegotiationOutcome['agreedRoles'] = [];
   if (hasOpportunity && history.length >= 2) {
@@ -82,7 +87,7 @@ export async function runTimeoutFallback(params: {
   taskId: string;
   conversationId: string;
   meta: NegotiationTaskMeta;
-  messages: Array<{ parts: unknown[] }>;
+  messages: Array<{ parts: unknown[]; senderId?: string }>;
   currentTurnCount: number;
   seedReasoning: string;
   maxTurns: number;
@@ -96,11 +101,24 @@ export async function runTimeoutFallback(params: {
     meta, messages, currentTurnCount, seedReasoning, maxTurns, fallbackLogExtra, rearm,
   } = params;
 
-  // Determine whose turn it is
-  const currentSpeaker = currentTurnCount % 2 === 0 ? 'source' : 'candidate';
+  // Determine whose turn it is from the last message's sender — not parity,
+  // which misattributes the parked seat across continuation sessions (a
+  // continuation can start with either side speaking first).
+  const lastSenderId = messages.length > 0 ? messages[messages.length - 1].senderId : undefined;
+  const currentSpeaker = lastSenderId
+    ? (lastSenderId === `agent:${meta.sourceUserId}` ? 'candidate' : 'source')
+    : (currentTurnCount % 2 === 0 ? 'source' : 'candidate');
   const isSource = currentSpeaker === 'source';
   const activeUserId = isSource ? meta.sourceUserId! : meta.candidateUserId!;
   const otherUserId = isSource ? meta.candidateUserId! : meta.sourceUserId!;
+
+  // Seat + version for the parked seat (v2 client-advocate): the system agent
+  // taking over this turn must use the seat-scoped schema — an initiator-seat
+  // fallback can never accept on the user's behalf. v1 tasks keep the legacy
+  // schema and the legacy non-final behavior (no isFinalTurn forcing).
+  const protocolVersion = (readProtocolVersion(meta) ?? 'v1') as NegotiationProtocolVersion;
+  const seat = resolveSeat(activeUserId, meta);
+  const isFinalTurn = protocolVersion === 'v2' && (currentTurnCount + 1) >= maxTurns;
 
   logger.info(labels.fallback, {
     negotiationId,
@@ -128,6 +146,9 @@ export async function runTimeoutFallback(params: {
     seedAssessment,
     history,
     isDiscoverer: isSource,
+    seat,
+    protocolVersion,
+    ...(isFinalTurn && { isFinalTurn }),
   });
 
   // Persist the AI turn
@@ -141,8 +162,8 @@ export async function runTimeoutFallback(params: {
 
   const newTurnCount = currentTurnCount + 1;
 
-  // Evaluate: accept/reject → finalize; counter at max → finalize; counter under max → continue
-  if (aiTurn.action === 'accept' || aiTurn.action === 'reject' || newTurnCount >= maxTurns) {
+  // Evaluate: terminal action → finalize; counter at max → finalize; counter under max → continue
+  if (isTerminalAction(aiTurn.action) || newTurnCount >= maxTurns) {
     const fullHistory = [...history, aiTurn];
     const nextSpeaker = currentSpeaker === 'source' ? 'candidate' : 'source';
     const outcome = buildNegotiationOutcome(fullHistory, newTurnCount, aiTurn.action, meta.sourceUserId!, meta.candidateUserId!, nextSpeaker);
@@ -156,13 +177,13 @@ export async function runTimeoutFallback(params: {
     });
 
     const outcomeStr = aiTurn.action === 'accept' ? 'accepted'
-      : aiTurn.action === 'reject' ? 'rejected'
+      : isRejectLikeAction(aiTurn.action) ? 'rejected'
       : 'turn_cap';
 
     const opportunityId = meta.opportunityId;
     if (opportunityId) {
       const nextStatus = aiTurn.action === 'accept' ? 'pending'
-        : aiTurn.action === 'reject' ? 'rejected'
+        : isRejectLikeAction(aiTurn.action) ? 'rejected'
         : 'stalled';
       await database.updateOpportunityStatus(opportunityId, nextStatus).catch((err: unknown) => {
         logger.error(labels.statusUpdateFailed, {

--- a/services/api/src/queues/tests/claim-timeout.queue.spec.ts
+++ b/services/api/src/queues/tests/claim-timeout.queue.spec.ts
@@ -59,6 +59,12 @@ mock.module('@indexnetwork/protocol', () => ({
     }
   },
   AMBIENT_PARK_WINDOW_MS: 1000,
+  // Pure seat-rule helpers (mirror the real implementations — timeout.shared
+  // imports these from the barrel, which this mock replaces wholesale).
+  isTerminalAction: (a) => a === 'accept' || a === 'reject' || a === 'withdraw' || a === 'decline',
+  isRejectLikeAction: (a) => a === 'reject' || a === 'withdraw' || a === 'decline',
+  readProtocolVersion: (m) => (m?.protocolVersion === 'v2' ? 'v2' : m?.protocolVersion === 'v1' ? 'v1' : null),
+  resolveSeat: (userId, m) => ((m?.initiatorUserId || m?.sourceUserId) === userId ? 'initiator' : 'counterparty'),
 }));
 
 afterAll(() => {

--- a/services/api/src/queues/tests/timeout.queue.spec.ts
+++ b/services/api/src/queues/tests/timeout.queue.spec.ts
@@ -36,6 +36,12 @@ mock.module('@indexnetwork/protocol', () => ({
     }
   },
   AMBIENT_PARK_WINDOW_MS: 1000,
+  // Pure seat-rule helpers (mirror the real implementations — timeout.shared
+  // imports these from the barrel, which this mock replaces wholesale).
+  isTerminalAction: (a) => a === 'accept' || a === 'reject' || a === 'withdraw' || a === 'decline',
+  isRejectLikeAction: (a) => a === 'reject' || a === 'withdraw' || a === 'decline',
+  readProtocolVersion: (m) => (m?.protocolVersion === 'v2' ? 'v2' : m?.protocolVersion === 'v1' ? 'v1' : null),
+  resolveSeat: (userId, m) => ((m?.initiatorUserId || m?.sourceUserId) === userId ? 'initiator' : 'counterparty'),
 }));
 
 afterAll(() => {

--- a/services/api/src/queues/tests/timeout.shared.seat.spec.ts
+++ b/services/api/src/queues/tests/timeout.shared.seat.spec.ts
@@ -1,0 +1,148 @@
+/**
+ * IND-397 — timeout fallback uses the parked seat's schema (v2 seat rules).
+ *
+ * When a parked turn times out and the system agent takes over, the agent must
+ * be invoked with the parked seat + the task's protocol version — an
+ * initiator-seat fallback can never accept on the user's behalf. Speaker
+ * attribution derives from the last message's sender, not turn parity.
+ * Hermetic: protocol barrel mocked (capturing IndexNegotiator), database faked.
+ */
+import { config } from 'dotenv';
+config({ path: '.env.test', override: true });
+process.env.OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY || 'test-key';
+
+import { describe, expect, it, mock, afterAll, beforeEach } from 'bun:test';
+
+let MOCK_TURN: Record<string, unknown> = {
+  action: 'counter',
+  assessment: { reasoning: 'ai', suggestedRoles: { ownUser: 'peer', otherUser: 'peer' } },
+};
+const invokeInputs: Array<Record<string, unknown>> = [];
+
+mock.module('@indexnetwork/protocol', () => ({
+  IndexNegotiator: class {
+    async invoke(input: Record<string, unknown>) {
+      invokeInputs.push(input);
+      return MOCK_TURN;
+    }
+  },
+  AMBIENT_PARK_WINDOW_MS: 1000,
+  isTerminalAction: (a: string) => a === 'accept' || a === 'reject' || a === 'withdraw' || a === 'decline',
+  isRejectLikeAction: (a: string) => a === 'reject' || a === 'withdraw' || a === 'decline',
+  readProtocolVersion: (m: { protocolVersion?: unknown } | null) =>
+    (m?.protocolVersion === 'v2' ? 'v2' : m?.protocolVersion === 'v1' ? 'v1' : null),
+  resolveSeat: (userId: string, m: { initiatorUserId?: string; sourceUserId?: string } | null) =>
+    ((m?.initiatorUserId || m?.sourceUserId) === userId ? 'initiator' : 'counterparty'),
+}));
+
+afterAll(() => {
+  mock.restore();
+});
+
+const { runTimeoutFallback } = await import('../negotiations/timeout.shared');
+const { log } = await import('../../lib/log');
+
+function makeDb() {
+  return {
+    getMessagesForConversation: mock(async () => []),
+    createMessage: mock(async () => ({ id: 'm-new' })),
+    updateTaskState: mock(async () => {}),
+    createArtifact: mock(async () => {}),
+    updateOpportunityStatus: mock(async () => {}),
+  };
+}
+
+const turnData = { action: 'counter', assessment: { reasoning: 'r', suggestedRoles: { ownUser: 'peer', otherUser: 'peer' } } };
+const msgFrom = (senderUserId: string) => ({ senderId: `agent:${senderUserId}`, parts: [{ kind: 'data', data: turnData }] });
+const legacyMsg = () => ({ parts: [{ kind: 'data', data: turnData }] });
+
+const labels = { fallback: 'f', finalized: 'z', statusUpdateFailed: 's' };
+
+function run(meta: Record<string, unknown>, messages: Array<Record<string, unknown>>, opts?: { maxTurns?: number }) {
+  const db = makeDb();
+  return {
+    db,
+    done: runTimeoutFallback({
+      database: db as never,
+      logger: log.job.from('TimeoutSharedSeatSpec'),
+      labels,
+      negotiationId: 'neg-1',
+      taskId: 'task-1',
+      conversationId: 'conv-1',
+      meta: meta as never,
+      messages: messages as never,
+      currentTurnCount: messages.length,
+      seedReasoning: 'seed',
+      maxTurns: opts?.maxTurns ?? 6,
+      rearm: async () => {},
+    }),
+  };
+}
+
+const v2Meta = {
+  type: 'negotiation',
+  sourceUserId: 'u-a',
+  candidateUserId: 'u-b',
+  initiatorUserId: 'u-a',
+  protocolVersion: 'v2',
+  opportunityId: 'opp-1',
+};
+
+beforeEach(() => {
+  invokeInputs.length = 0;
+  MOCK_TURN = { action: 'counter', assessment: { reasoning: 'ai', suggestedRoles: { ownUser: 'peer', otherUser: 'peer' } } };
+});
+
+describe('runTimeoutFallback — seat-scoped schema selection (IND-397)', () => {
+  it('v2: parked counterparty turn invokes the agent with counterparty seat + v2', async () => {
+    // Initiator (u-a) spoke last → the parked seat is u-b (counterparty).
+    const { done } = run(v2Meta, [msgFrom('u-a')]);
+    await done;
+
+    expect(invokeInputs[0].seat).toBe('counterparty');
+    expect(invokeInputs[0].protocolVersion).toBe('v2');
+  });
+
+  it('v2: counterparty-spoke-first continuation parks the initiator seat (parity would flip it)', async () => {
+    // One message from u-b → parity (odd count) would call the active speaker
+    // "candidate" (u-b); senderId-based attribution correctly parks u-a.
+    MOCK_TURN = { action: 'withdraw', assessment: { reasoning: 'not a fit', suggestedRoles: { ownUser: 'peer', otherUser: 'peer' } } };
+    const { db, done } = run(v2Meta, [msgFrom('u-b')]);
+    await done;
+
+    expect(invokeInputs[0].seat).toBe('initiator');
+    // The withdrawing turn is attributed to the initiator's agent
+    const created = (db.createMessage.mock.calls[0] as unknown[])[0] as { senderId: string };
+    expect(created.senderId).toBe('agent:u-a');
+    // withdraw is reject-like → opportunity rejected
+    const statusCall = (db.updateOpportunityStatus.mock.calls[0] as unknown[]) as [string, string];
+    expect(statusCall[1]).toBe('rejected');
+  });
+
+  it('v2: final allowed turn passes isFinalTurn so the final seat schema is selected', async () => {
+    MOCK_TURN = { action: 'decline', assessment: { reasoning: 'no', suggestedRoles: { ownUser: 'peer', otherUser: 'peer' } } };
+    const { done } = run(v2Meta, [msgFrom('u-a')], { maxTurns: 2 });
+    await done;
+
+    expect(invokeInputs[0].isFinalTurn).toBe(true);
+    expect(invokeInputs[0].seat).toBe('counterparty');
+  });
+
+  it('v1 tasks keep legacy behavior: v1 version, no final-turn forcing', async () => {
+    const v1Meta = { type: 'negotiation', sourceUserId: 'u-a', candidateUserId: 'u-b' };
+    const { done } = run(v1Meta, [legacyMsg()], { maxTurns: 2 });
+    await done;
+
+    expect(invokeInputs[0].protocolVersion).toBe('v1');
+    expect(invokeInputs[0].isFinalTurn).toBeUndefined();
+  });
+
+  it('legacy rows without senderId fall back to parity attribution', async () => {
+    const v1Meta = { type: 'negotiation', sourceUserId: 'u-a', candidateUserId: 'u-b' };
+    const { db, done } = run(v1Meta, [legacyMsg()]); // 1 message, no senderId → parity: candidate speaks
+    await done;
+
+    const created = (db.createMessage.mock.calls[0] as unknown[])[0] as { senderId: string };
+    expect(created.senderId).toBe('agent:u-b');
+  });
+});

--- a/services/api/src/services/negotiation-polling.service.ts
+++ b/services/api/src/services/negotiation-polling.service.ts
@@ -7,8 +7,8 @@ import { conversationDatabaseAdapter, ChatDatabaseAdapter } from '../adapters/da
 import { negotiationTimeoutQueue } from '../queues/negotiations/timeout.queue';
 import { negotiationClaimTimeoutQueue } from '../queues/negotiations/claim-timeout.queue';
 import { log } from '../lib/log';
-import type { NegotiationTurn, UserNegotiationContext, SeedAssessment } from '@indexnetwork/protocol';
-import { AMBIENT_PARK_WINDOW_MS } from '@indexnetwork/protocol';
+import type { NegotiationTurn, UserNegotiationContext, SeedAssessment, NegotiationAction, NegotiationSeat, NegotiationProtocolVersion } from '@indexnetwork/protocol';
+import { AMBIENT_PARK_WINDOW_MS, allowedActionsFor, isRejectLikeAction, isTerminalAction, readProtocolVersion, resolveSeat, seatViolationMessage } from '@indexnetwork/protocol';
 
 const logger = log.service.from('NegotiationPollingService');
 
@@ -37,6 +37,17 @@ export class UnauthorizedError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'UnauthorizedError';
+  }
+}
+
+/**
+ * Thrown when a submitted negotiation action is outside the caller's seat
+ * vocabulary for the task's protocol version. Maps to HTTP 400.
+ */
+export class SeatViolationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SeatViolationError';
   }
 }
 
@@ -82,6 +93,15 @@ export interface PickupResult {
     counterpartyAction: string;
   };
   /**
+   * The claiming user's seat under the task's negotiation protocol version
+   * (v2 client-advocate: `initiator` never accepts; only `counterparty` can).
+   */
+  seat: NegotiationSeat;
+  /** Negotiation protocol version stamped on the task (`v1` for pre-v2 tasks). */
+  protocolVersion: NegotiationProtocolVersion;
+  /** Actions the claiming seat may submit on this turn. */
+  allowedActions: NegotiationAction[];
+  /**
    * Full negotiation context, mirroring what the in-process system agent
    * receives as its `NegotiationAgentInput`. `ownUser`/`otherUser` are
    * projected to the claiming user's perspective. Populated on turns parked
@@ -99,7 +119,7 @@ export interface PickupResult {
 }
 
 export interface RespondInput {
-  action: 'propose' | 'accept' | 'reject' | 'counter' | 'question';
+  action: NegotiationAction;
   message?: string | null;
   assessment: {
     reasoning: string;
@@ -129,6 +149,10 @@ interface NegotiationTaskMetadata {
   type: 'negotiation';
   sourceUserId: string;
   candidateUserId: string;
+  /** Rigid initiator seat, stamped at discovery time (v2 client-advocate). */
+  initiatorUserId?: string;
+  /** Negotiation protocol version; absent on pre-v2 tasks (treated as v1). */
+  protocolVersion?: string;
   maxTurns?: number;
   opportunityId?: string;
   turnContext?: PersistedTurnContext;
@@ -300,7 +324,28 @@ export class NegotiationPollingService {
   ): Promise<{ success: true }> {
     await this.assertAgentOwnership(agentId, userId);
 
-    // 1. Atomically transition out of 'claimed' to 'working' with CAS on
+    // 1. Seat + version validation (v2 client-advocate protocol) — BEFORE the
+    //    CAS transition, so a rejected action leaves the claim intact and the
+    //    agent can retry with a valid one. The action must be within the
+    //    caller's seat vocabulary; seat attribution keys on
+    //    metadata.initiatorUserId — never on turn parity, which misattributes
+    //    seats when a continuation starts with the counterparty speaking first.
+    //    v1 tasks are grandfathered: the legacy vocabulary stays valid.
+    const preflight = await conversationDatabaseAdapter.getTask(negotiationId);
+    if (!preflight) {
+      throw new NotFoundError(`Negotiation ${negotiationId} not found`);
+    }
+    const preflightMeta = preflight.metadata as NegotiationTaskMetadata | null;
+    if (preflightMeta?.type !== 'negotiation') {
+      throw new NotFoundError(`Task ${negotiationId} is not a negotiation`);
+    }
+    const protocolVersion = (readProtocolVersion(preflightMeta) ?? 'v1') as NegotiationProtocolVersion;
+    const seat = resolveSeat(userId, preflightMeta);
+    if (!allowedActionsFor(protocolVersion, seat).includes(input.action)) {
+      throw new SeatViolationError(seatViolationMessage(input.action, seat, protocolVersion));
+    }
+
+    // 2. Atomically transition out of 'claimed' to 'working' with CAS on
     //    claimedByAgentId. This prevents the claim-timeout worker and respond
     //    from both observing 'claimed' and both appending a turn.
     const now = new Date();
@@ -338,19 +383,18 @@ export class NegotiationPollingService {
       throw new NotFoundError(`Task ${negotiationId} is not a negotiation`);
     }
 
-    // 2. Cancel 6h claim timeout (the CAS already fenced it off, but remove the
+    // 3. Cancel 6h claim timeout (the CAS already fenced it off, but remove the
     //    delayed job so it doesn't wake up and short-circuit on state mismatch).
     await negotiationClaimTimeoutQueue.cancelTimeout(negotiationId);
 
-    // 3. Determine current speaker
+    // 4. The caller IS the current speaker (they claimed the turn) — attribute
+    //    the message to them directly rather than deriving from turn parity.
     const messages = await conversationDatabaseAdapter.getMessagesForConversation(task.conversationId);
     const currentTurnCount = messages.length;
-    const currentSpeaker: 'source' | 'candidate' = currentTurnCount % 2 === 0 ? 'source' : 'candidate';
-    const senderId = currentSpeaker === 'source'
-      ? `agent:${meta.sourceUserId}`
-      : `agent:${meta.candidateUserId}`;
+    const currentSpeaker: 'source' | 'candidate' = meta.sourceUserId === userId ? 'source' : 'candidate';
+    const senderId = `agent:${userId}`;
 
-    // 4. Persist the turn as a message
+    // 5. Persist the turn as a message
     const turn: NegotiationTurn = {
       action: input.action,
       message: input.message ?? null,
@@ -368,8 +412,9 @@ export class NegotiationPollingService {
     const newTurnCount = currentTurnCount + 1;
     const maxTurns = meta.maxTurns ?? DEFAULT_MAX_TURNS;
 
-    // 5. Evaluate: accept/reject/maxTurns -> finalize, else -> waiting_for_agent + re-arm timeout
-    if (input.action === 'accept' || input.action === 'reject' || newTurnCount >= maxTurns) {
+    // 6. Evaluate: terminal action (accept/reject/withdraw/decline) or maxTurns
+    //    -> finalize, else -> waiting_for_agent + re-arm timeout
+    if (isTerminalAction(input.action) || newTurnCount >= maxTurns) {
       // Parse full history for outcome building
       const history = this.parseHistory(messages);
       const fullHistory = [...history, turn];
@@ -393,12 +438,12 @@ export class NegotiationPollingService {
       });
 
       const outcomeStr = input.action === 'accept' ? 'accepted'
-        : input.action === 'reject' ? 'rejected'
+        : isRejectLikeAction(input.action) ? 'rejected'
         : 'turn_cap';
 
       if (meta.opportunityId) {
         const nextStatus = input.action === 'accept' ? 'pending'
-          : input.action === 'reject' ? 'rejected'
+          : isRejectLikeAction(input.action) ? 'rejected'
           : 'stalled';
         await new ChatDatabaseAdapter().updateOpportunityStatus(meta.opportunityId, nextStatus).catch((err) => {
           logger.error('Failed to update opportunity status on finalization', {
@@ -505,7 +550,11 @@ export class NegotiationPollingService {
         (p) => p.kind === 'data',
       );
       const turnData = dp?.data;
-      const speaker: 'source' | 'candidate' = idx % 2 === 0 ? 'source' : 'candidate';
+      // Speaker from senderId, not parity — continuations can start with
+      // either side speaking first.
+      const speaker: 'source' | 'candidate' = m.senderId
+        ? (m.senderId === `agent:${meta.sourceUserId}` ? 'source' : 'candidate')
+        : (idx % 2 === 0 ? 'source' : 'candidate');
       return {
         turnNumber: idx,
         agent: speaker,
@@ -541,6 +590,11 @@ export class NegotiationPollingService {
       };
     }
 
+    // Announce the claiming user's seat + allowed actions (v2 client-advocate
+    // protocol) so agents don't have to guess the valid vocabulary.
+    const protocolVersion = (readProtocolVersion(meta) ?? 'v1') as NegotiationProtocolVersion;
+    const seat = resolveSeat(userId, meta);
+
     return {
       negotiationId: task.id,
       taskId: task.id,
@@ -551,6 +605,9 @@ export class NegotiationPollingService {
         history,
         counterpartyAction,
       },
+      seat,
+      protocolVersion,
+      allowedActions: [...allowedActionsFor(protocolVersion, seat)],
       context,
     };
   }
@@ -591,7 +648,8 @@ export class NegotiationPollingService {
     currentSpeaker: string,
   ): { hasOpportunity: boolean; agreedRoles: Array<{ userId: string; role: string }>; reasoning: string; turnCount: number; reason?: string } {
     const hasOpportunity = lastAction === 'accept';
-    const atCap = lastAction === 'counter';
+    // Non-terminal last action at finalization means the turn cap was hit.
+    const atCap = !isTerminalAction(lastAction);
 
     let agreedRoles: Array<{ userId: string; role: string }> = [];
     if (hasOpportunity && history.length >= 2) {

--- a/services/api/src/services/tests/negotiation-polling.seat.spec.ts
+++ b/services/api/src/services/tests/negotiation-polling.seat.spec.ts
@@ -1,0 +1,313 @@
+/**
+ * IND-397 — polling respond/pickup seat rules (DB-backed).
+ *
+ * Covers:
+ * - full v2 flow via respond: outreach → counter → counter → accept
+ *   (counterparty) → task completed + opportunity `pending`,
+ * - withdraw (initiator) → `rejected`; decline (counterparty) → `rejected`,
+ * - wrong-seat action → SeatViolationError (HTTP 400 via agent.controller),
+ *   with the claim left intact for a retry,
+ * - seat/turn attribution from senderId + initiator stamp, not parity
+ *   (continuation where the counterparty spoke first),
+ * - pickup announces seat, protocolVersion, and allowedActions,
+ * - v1 grandfathering: legacy propose/reject stay valid.
+ *
+ * Real Postgres via .env.test; BullMQ queues mocked (no Redis).
+ */
+import { config } from 'dotenv';
+config({ path: '.env.test', override: true });
+process.env.OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY || 'test-key';
+
+import { describe, it, expect, beforeAll, afterAll, mock } from 'bun:test';
+import { randomUUID } from 'crypto';
+
+mock.module('../../queues/negotiations/timeout.queue', () => ({
+  negotiationTimeoutQueue: { cancelTimeout: async () => {}, enqueueTimeout: async () => {} },
+}));
+mock.module('../../queues/negotiations/claim-timeout.queue', () => ({
+  negotiationClaimTimeoutQueue: { cancelTimeout: async () => {}, enqueueTimeout: async () => {} },
+}));
+
+const { negotiationPollingService, SeatViolationError, ConflictError } = await import('../negotiation-polling.service');
+const { conversationDatabaseAdapter } = await import('../../adapters/database.adapter');
+const { default: db } = await import('../../lib/drizzle/drizzle');
+const dbSchema = await import('../../schemas/database.schema');
+const convSchema = await import('../../schemas/conversation.schema');
+const { eq } = await import('drizzle-orm');
+
+afterAll(() => {
+  mock.restore();
+});
+
+let userA: string; // initiator
+let userB: string; // counterparty
+let agentA: string;
+let agentB: string;
+const cleanupConversations: string[] = [];
+const cleanupOpportunities: string[] = [];
+
+async function seedUser(name: string): Promise<string> {
+  const [u] = await db.insert(dbSchema.users)
+    .values({ email: `seat-spec-${randomUUID()}@test.local`, name })
+    .returning({ id: dbSchema.users.id });
+  return u.id;
+}
+
+async function seedAgent(ownerId: string): Promise<string> {
+  const [a] = await db.insert(dbSchema.agents)
+    .values({ ownerId, name: 'seat-spec-agent', type: 'external' })
+    .returning({ id: dbSchema.agents.id });
+  return a.id;
+}
+
+async function seedOpportunity(): Promise<string> {
+  const [o] = await db.insert(dbSchema.opportunities)
+    .values({
+      detection: { kind: 'test', summary: 'seat spec' } as never,
+      actors: [{ userId: userA, role: 'peer' }, { userId: userB, role: 'peer' }] as never,
+      interpretation: { reasoning: 'seat spec', category: 'test' } as never,
+      context: {} as never,
+      confidence: '0.9',
+      status: 'negotiating',
+    })
+    .returning({ id: dbSchema.opportunities.id });
+  cleanupOpportunities.push(o.id);
+  return o.id;
+}
+
+async function seedNegotiation(opts?: {
+  protocolVersion?: 'v1' | 'v2';
+  opportunityId?: string;
+  priorTurns?: Array<{ from: 'A' | 'B'; action: string }>;
+  maxTurns?: number;
+}): Promise<{ taskId: string; conversationId: string }> {
+  const conv = await conversationDatabaseAdapter.createConversation([
+    { participantId: `agent:${userA}`, participantType: 'agent' as const },
+    { participantId: `agent:${userB}`, participantType: 'agent' as const },
+  ]);
+  cleanupConversations.push(conv.id);
+
+  const task = await conversationDatabaseAdapter.createTask(conv.id, {
+    type: 'negotiation',
+    sourceUserId: userA,
+    candidateUserId: userB,
+    initiatorUserId: userA,
+    ...(opts?.protocolVersion && { protocolVersion: opts.protocolVersion }),
+    ...(opts?.opportunityId && { opportunityId: opts.opportunityId }),
+    maxTurns: opts?.maxTurns ?? 6,
+  });
+
+  for (const t of opts?.priorTurns ?? []) {
+    await conversationDatabaseAdapter.createMessage({
+      conversationId: conv.id,
+      senderId: `agent:${t.from === 'A' ? userA : userB}`,
+      role: 'agent',
+      parts: [{ kind: 'data', data: { action: t.action, assessment: { reasoning: 'r', suggestedRoles: { ownUser: 'peer', otherUser: 'peer' } }, message: null } }],
+      taskId: task.id,
+    });
+  }
+
+  await conversationDatabaseAdapter.updateTaskState(task.id, 'waiting_for_agent');
+  return { taskId: task.id, conversationId: conv.id };
+}
+
+async function getTaskState(taskId: string) {
+  const task = await conversationDatabaseAdapter.getTask(taskId);
+  return task?.state;
+}
+
+async function getOpportunityStatus(id: string): Promise<string | undefined> {
+  const [row] = await db.select({ status: dbSchema.opportunities.status })
+    .from(dbSchema.opportunities)
+    .where(eq(dbSchema.opportunities.id, id))
+    .limit(1);
+  return row?.status;
+}
+
+const respondInput = (action: string, message?: string) => ({
+  action: action as never,
+  message: message ?? null,
+  assessment: { reasoning: 'because', suggestedRoles: { ownUser: 'peer' as const, otherUser: 'peer' as const } },
+});
+
+/** Claim the parked turn for a specific user's agent (pickup is user-scoped). */
+async function claimFor(taskId: string, who: 'A' | 'B') {
+  // Force-claim the specific task to keep tests independent of other parked
+  // tasks these users may have from parallel test data.
+  const now = new Date();
+  const agentId = who === 'A' ? agentA : agentB;
+  const [claimed] = await db.update(convSchema.tasks)
+    .set({ state: 'claimed', claimedByAgentId: agentId, claimedAt: now, updatedAt: now })
+    .where(eq(convSchema.tasks.id, taskId))
+    .returning();
+  expect(claimed?.state).toBe('claimed');
+}
+
+beforeAll(async () => {
+  userA = await seedUser('Seat Spec Initiator');
+  userB = await seedUser('Seat Spec Counterparty');
+  agentA = await seedAgent(userA);
+  agentB = await seedAgent(userB);
+});
+
+afterAll(async () => {
+  for (const id of cleanupConversations) {
+    try { await conversationDatabaseAdapter.deleteConversation(id); } catch { /* ignore */ }
+  }
+  for (const id of cleanupOpportunities) {
+    try { await db.delete(dbSchema.opportunities).where(eq(dbSchema.opportunities.id, id)); } catch { /* ignore */ }
+  }
+  try { await db.delete(dbSchema.users).where(eq(dbSchema.users.id, userA)); } catch { /* ignore */ }
+  try { await db.delete(dbSchema.users).where(eq(dbSchema.users.id, userB)); } catch { /* ignore */ }
+});
+
+describe('pickup — seat announcement', () => {
+  it('announces seat, protocolVersion, and allowedActions for the claiming user', async () => {
+    const { taskId } = await seedNegotiation({ protocolVersion: 'v2' });
+    const result = await negotiationPollingService.pickup(agentA, userA);
+
+    expect(result).not.toBeNull();
+    expect(result!.taskId).toBe(taskId);
+    expect(result!.seat).toBe('initiator');
+    expect(result!.protocolVersion).toBe('v2');
+    expect(result!.allowedActions).toEqual(['outreach', 'counter', 'question', 'withdraw']);
+    expect(result!.allowedActions).not.toContain('accept');
+
+    // Idempotent repick returns the same announcement
+    const again = await negotiationPollingService.pickup(agentA, userA);
+    expect(again!.seat).toBe('initiator');
+
+    // Finish the flow so this task doesn't linger claimed
+    await negotiationPollingService.respond(agentA, userA, taskId, respondInput('withdraw'));
+    expect(await getTaskState(taskId)).toBe('completed');
+  }, 30_000);
+});
+
+describe('respond — v2 seat validation', () => {
+  it('initiator accept → SeatViolationError; claim stays intact and a valid retry succeeds', async () => {
+    const { taskId } = await seedNegotiation({ protocolVersion: 'v2' });
+    await claimFor(taskId, 'A');
+
+    expect(
+      negotiationPollingService.respond(agentA, userA, taskId, respondInput('accept')),
+    ).rejects.toThrow(SeatViolationError);
+
+    // The claim survives the violation — the agent can retry with a valid action
+    expect(await getTaskState(taskId)).toBe('claimed');
+    await negotiationPollingService.respond(agentA, userA, taskId, respondInput('outreach'));
+    expect(await getTaskState(taskId)).toBe('waiting_for_agent');
+  }, 30_000);
+
+  it('v2 vocabulary on a v1 task is rejected; legacy vocabulary passes (grandfather)', async () => {
+    const { taskId } = await seedNegotiation({}); // no protocolVersion → v1
+    await claimFor(taskId, 'A');
+
+    expect(
+      negotiationPollingService.respond(agentA, userA, taskId, respondInput('outreach')),
+    ).rejects.toThrow(SeatViolationError);
+
+    await negotiationPollingService.respond(agentA, userA, taskId, respondInput('propose'));
+    expect(await getTaskState(taskId)).toBe('waiting_for_agent');
+
+    // Legacy reject from the other side still finalizes
+    await claimFor(taskId, 'B');
+    await negotiationPollingService.respond(agentB, userB, taskId, respondInput('reject'));
+    expect(await getTaskState(taskId)).toBe('completed');
+  }, 30_000);
+});
+
+describe('respond — full v2 flows', () => {
+  it('outreach → counter → counter → accept (counterparty) → completed + opportunity pending', async () => {
+    const opportunityId = await seedOpportunity();
+    const { taskId, conversationId } = await seedNegotiation({ protocolVersion: 'v2', opportunityId });
+
+    await claimFor(taskId, 'A');
+    await negotiationPollingService.respond(agentA, userA, taskId, respondInput('outreach', 'let us connect'));
+
+    await claimFor(taskId, 'B');
+    await negotiationPollingService.respond(agentB, userB, taskId, respondInput('counter', 'tell me more'));
+
+    await claimFor(taskId, 'A');
+    await negotiationPollingService.respond(agentA, userA, taskId, respondInput('counter', 'here is more'));
+
+    await claimFor(taskId, 'B');
+    await negotiationPollingService.respond(agentB, userB, taskId, respondInput('accept'));
+
+    expect(await getTaskState(taskId)).toBe('completed');
+    expect(await getOpportunityStatus(opportunityId)).toBe('pending');
+
+    // Message attribution follows the actual speakers
+    const messages = await conversationDatabaseAdapter.getMessagesForConversation(conversationId);
+    expect(messages.map((m) => m.senderId)).toEqual([
+      `agent:${userA}`, `agent:${userB}`, `agent:${userA}`, `agent:${userB}`,
+    ]);
+
+    // Outcome artifact records the opportunity
+    const artifacts = await conversationDatabaseAdapter.getArtifactsForTask(taskId);
+    const outcome = (artifacts.find((a) => a.name === 'negotiation-outcome')?.parts as Array<{ data?: { hasOpportunity?: boolean } }>)?.find((p) => p.data)?.data;
+    expect(outcome?.hasOpportunity).toBe(true);
+  }, 60_000);
+
+  it('initiator withdraw → completed + opportunity rejected', async () => {
+    const opportunityId = await seedOpportunity();
+    const { taskId } = await seedNegotiation({
+      protocolVersion: 'v2',
+      opportunityId,
+      priorTurns: [{ from: 'A', action: 'outreach' }, { from: 'B', action: 'counter' }],
+    });
+
+    await claimFor(taskId, 'A');
+    await negotiationPollingService.respond(agentA, userA, taskId, respondInput('withdraw'));
+
+    expect(await getTaskState(taskId)).toBe('completed');
+    expect(await getOpportunityStatus(opportunityId)).toBe('rejected');
+  }, 30_000);
+
+  it('counterparty decline → completed + opportunity rejected', async () => {
+    const opportunityId = await seedOpportunity();
+    const { taskId } = await seedNegotiation({
+      protocolVersion: 'v2',
+      opportunityId,
+      priorTurns: [{ from: 'A', action: 'outreach' }],
+    });
+
+    await claimFor(taskId, 'B');
+    await negotiationPollingService.respond(agentB, userB, taskId, respondInput('decline'));
+
+    expect(await getTaskState(taskId)).toBe('completed');
+    expect(await getOpportunityStatus(opportunityId)).toBe('rejected');
+  }, 30_000);
+});
+
+describe('respond — seat attribution is parity-proof', () => {
+  it('continuation where the counterparty spoke first: initiator still cannot accept, and the turn is attributed to the actual caller', async () => {
+    // One prior message from B → odd count. Parity-based attribution would
+    // treat the next speaker as "candidate" (B) and stamp B's senderId on
+    // A's turn. senderId+stamp-based logic must reject accept (initiator
+    // seat) and attribute the turn to A.
+    const { taskId, conversationId } = await seedNegotiation({
+      protocolVersion: 'v2',
+      priorTurns: [{ from: 'B', action: 'question' }],
+    });
+
+    await claimFor(taskId, 'A');
+    expect(
+      negotiationPollingService.respond(agentA, userA, taskId, respondInput('accept')),
+    ).rejects.toThrow(SeatViolationError);
+
+    await negotiationPollingService.respond(agentA, userA, taskId, respondInput('counter', 'answering your question'));
+
+    const messages = await conversationDatabaseAdapter.getMessagesForConversation(conversationId);
+    expect(messages[messages.length - 1].senderId).toBe(`agent:${userA}`);
+  }, 30_000);
+});
+
+describe('respond — guards unchanged', () => {
+  it('responding without a claim still conflicts (seat preflight does not bypass the CAS)', async () => {
+    const { taskId } = await seedNegotiation({ protocolVersion: 'v2' });
+    // waiting_for_agent, never claimed
+    expect(
+      negotiationPollingService.respond(agentA, userA, taskId, respondInput('outreach')),
+    ).rejects.toThrow(ConflictError);
+  }, 30_000);
+});

--- a/services/api/src/types/chat-streaming.types.ts
+++ b/services/api/src/types/chat-streaming.types.ts
@@ -498,7 +498,7 @@ export interface NegotiationTurnEvent extends ChatStreamEventBase {
   negotiationConversationId: string;
   turnIndex: number;
   actor: "source" | "candidate";
-  action: "propose" | "accept" | "reject" | "counter" | "question";
+  action: "propose" | "accept" | "reject" | "counter" | "question" | "outreach" | "withdraw" | "decline";
   reasoning?: string;
   message?: string;
   suggestedRoles?: { ownUser?: string; otherUser?: string };

--- a/services/api/tests/negotiation.e2e.spec.ts
+++ b/services/api/tests/negotiation.e2e.spec.ts
@@ -22,14 +22,20 @@ describe("Negotiation E2E", () => {
     );
     const graph = factory.createGraph();
 
+    // Per-run unique ids: fixed ids accumulate DM history across runs, turning
+    // later runs into continuations that legitimately resolve in one turn and
+    // break the fresh-negotiation assertions below.
+    const sourceId = `e2e-source-${Date.now()}`;
+    const candidateId = `e2e-candidate-${Date.now()}`;
+
     const result = await graph.invoke({
       sourceUser: {
-        id: "e2e-source",
+        id: sourceId,
         intents: [{ id: "i1", title: "Looking for ML engineer", description: "Need ML expertise for recommendation system", confidence: 0.9 }],
         profile: { name: "Alice", bio: "Product manager building AI startup", skills: ["product management", "AI strategy"] },
       },
       candidateUser: {
-        id: "e2e-candidate",
+        id: candidateId,
         intents: [{ id: "i2", title: "Seeking PM co-founder", description: "ML engineer looking for product-minded co-founder", confidence: 0.85 }],
         profile: { name: "Bob", bio: "Senior ML engineer with 8 years experience", skills: ["machine learning", "PyTorch"] },
       },
@@ -53,7 +59,81 @@ describe("Negotiation E2E", () => {
     // IND-396: every new negotiation task carries the initiator seat stamp.
     const task = await conversationDatabaseAdapter.getTask(result.taskId);
     const metadata = (task?.metadata ?? {}) as Record<string, unknown>;
-    expect(metadata.initiatorUserId).toBe("e2e-source");
-    expect(metadata.sourceUserId).toBe("e2e-source");
+    expect(metadata.initiatorUserId).toBe(sourceId);
+    expect(metadata.sourceUserId).toBe(sourceId);
+    // IND-397: fresh tasks are version-stamped (v1 unless env opts into v2).
+    expect(metadata.protocolVersion).toBe(process.env.NEGOTIATION_PROTOCOL_VERSION === "v2" ? "v2" : "v1");
   }, 120_000);
+
+  it("runs a full v2 negotiation: seat-scoped actions, counterparty-only accept (IND-397)", async () => {
+    const origVersion = process.env.NEGOTIATION_PROTOCOL_VERSION;
+    process.env.NEGOTIATION_PROTOCOL_VERSION = "v2";
+    try {
+      const factory = new NegotiationGraphFactory(
+        conversationDatabaseAdapter as unknown as NegotiationGraphDatabase,
+        noopDispatcher,
+      );
+      const graph = factory.createGraph();
+
+      // Fresh user ids per run so the DM conversation has no prior turns
+      // (version stamping is inheritance-based).
+      const runTag = Date.now();
+      const initiatorId = `e2e-v2-init-${runTag}`;
+      const counterpartyId = `e2e-v2-cp-${runTag}`;
+
+      const result = await graph.invoke({
+        sourceUser: {
+          id: initiatorId,
+          intents: [{ id: "i1", title: "Looking for ML engineer", description: "Need ML expertise for recommendation system", confidence: 0.9 }],
+          profile: { name: "Alice", bio: "Product manager building AI startup", skills: ["product management", "AI strategy"] },
+        },
+        candidateUser: {
+          id: counterpartyId,
+          intents: [{ id: "i2", title: "Seeking PM co-founder", description: "ML engineer looking for product-minded co-founder", confidence: 0.85 }],
+          profile: { name: "Bob", bio: "Senior ML engineer with 8 years experience", skills: ["machine learning", "PyTorch"] },
+        },
+        indexContext: { networkId: "e2e-index", prompt: "AI startup co-founders" },
+        seedAssessment: { reasoning: "Complementary skills", valencyRole: "Peer" },
+        maxTurns: 4,
+        initiatorUserId: initiatorId,
+      });
+
+      expect(result.outcome).not.toBeNull();
+
+      // Version stamp on the task
+      const task = await conversationDatabaseAdapter.getTask(result.taskId);
+      const metadata = (task?.metadata ?? {}) as Record<string, unknown>;
+      expect(metadata.protocolVersion).toBe("v2");
+      expect(metadata.initiatorUserId).toBe(initiatorId);
+
+      // Seat rules on the wire: turn 0 is the initiator's outreach; the
+      // initiator never accepts; every action is v2 vocabulary.
+      const turns = result.messages.map((m) => {
+        const dp = (m.parts as Array<{ kind?: string; data?: { action?: string } }>).find((p) => p.kind === "data");
+        return { senderId: m.senderId, action: dp?.data?.action };
+      });
+      expect(turns.length).toBeGreaterThanOrEqual(2);
+      expect(turns[0].senderId).toBe(`agent:${initiatorId}`);
+      expect(turns[0].action).toBe("outreach");
+      const v2Vocabulary = ["outreach", "counter", "question", "withdraw", "accept", "decline"];
+      for (const t of turns) {
+        expect(v2Vocabulary).toContain(t.action ?? "");
+        if (t.senderId === `agent:${initiatorId}`) {
+          expect(t.action).not.toBe("accept");
+        } else {
+          expect(["accept", "decline", "counter", "question"]).toContain(t.action ?? "");
+        }
+      }
+
+      // Outcome consistency: an opportunity exists only when the counterparty accepted.
+      const lastTurn = turns[turns.length - 1];
+      if (result.outcome!.hasOpportunity) {
+        expect(lastTurn.action).toBe("accept");
+        expect(lastTurn.senderId).toBe(`agent:${counterpartyId}`);
+      }
+    } finally {
+      if (origVersion === undefined) delete process.env.NEGOTIATION_PROTOCOL_VERSION;
+      else process.env.NEGOTIATION_PROTOCOL_VERSION = origVersion;
+    }
+  }, 180_000);
 });


### PR DESCRIPTION
Closes IND-397 (P1.2 of the Client-Advocate Protocol, IND-395). Builds directly on the `initiatorUserId` stamp from IND-396 (#1102).

## What

The core consent asymmetry: **accept must come from the receiving seat, schema-enforced** — not prompt-enforced.

### New protocol-rules module (`negotiation.protocol.ts`)
- v2 seat-scoped Zod turn schemas: `InitiatorTurnSchema` (`outreach | counter | question | withdraw` — **no accept**), `CounterpartyTurnSchema` (`accept | decline | counter | question`), plus final-turn variants (initiator `withdraw | counter`; counterparty `accept | decline`).
- Helpers shared by every surface: `allowedActionsFor`, `turnSchemaFor`, `isTerminalAction`, `isRejectLikeAction`, `fallbackActionFor`, `rejectActionFor`, `resolveSeat`, `readProtocolVersion`, `configuredProtocolVersion`, `seatViolationMessage`. Exported from the protocol barrel.
- Action renames: `propose`→`outreach`; `reject` splits into `withdraw` (initiator) / `decline` (counterparty). Outcome mapping unchanged: `accept`→`pending`, withdraw/decline/reject→`rejected`, cap→`stalled`.

### `protocolVersion` (v1|v2): inherited, never re-stamped
- Init node: any prior negotiation task on the conversation pins the version (absent field on a genuine prior = pre-v2 = v1); prior turns without a readable task grandfather to v1; only genuinely fresh negotiations stamp from `NEGOTIATION_PROTOCOL_VERSION`.
- **Default is `v1`** — v2 is opt-in per environment; rollback is the same single env switch. (Honest delta from the issue's "new negotiations run v2": flag-flip pattern keeps every existing suite green and mirrors how `NEGOTIATOR_CHAT_ENABLED` shipped. Dev gets `NEGOTIATION_PROTOCOL_VERSION=v2` post-deploy.)

### Seat attribution keys on `initiatorUserId`, never parity
- Graph turn node: seat = acting user vs `state.initiatorUserId`.
- Polling `respond`: the caller **is** the speaker — `senderId = agent:{userId}`; parity-based `turnCount % 2` speaker derivation removed (it misattributed seats when a continuation starts with the counterparty speaking first).
- `timeout.shared` fallback workers + tools list/get/pickup history: speaker derived from message `senderId` (parity kept only as fallback for legacy senderId-less rows).

### Enforcement at every surface
- **System agent** (`IndexNegotiator`): selects the seat schema by version+seat+final-turn; v2 seat-aware prompts (reaching vs receiving stance); validates output, retries once, then falls back to conservative `counter` (final: counterparty `decline`). New `callModel` seam for hermetic tests.
- **Graph**: v2 turn-0 forced to `outreach` (initiator only); dispatched personal-agent turns with out-of-seat actions coerced to the conservative fallback; error-path turns use seat-appropriate reject actions.
- **Polling `respond`**: seat+version validation as a preflight **before** the claimed→working CAS — a violation returns 400 (`SeatViolationError`) and leaves the claim intact for a retry.
- **Pickup / `get_negotiation`**: announce the caller's `seat`, `protocolVersion`, and `allowedActions`.
- **`respond_to_negotiation` MCP tool**: same validation + updated description; v1 tasks keep the legacy vocabulary (grandfathered).
- **`agent.controller`**: respond schema widened to the v1+v2 union (service enforces the per-task subset).
- Timeout workers select the parked seat's schema; v2 passes `isFinalTurn` (v1 behavior untouched).

## Tests

- Protocol (new): `negotiation.protocol.spec.ts` (18 — schemas/helpers), `negotiation.seat-rules.spec.ts` (11 — graph stamping/inheritance/coercion/turn-0), `negotiation.agent.retry.spec.ts` (5 — retry-once-then-fallback), `negotiation.tools.seat.spec.ts` (10 — MCP respond validation + grandfather + seat announcement).
- API (new): `negotiation-polling.seat.spec.ts` (8, DB-backed — full deterministic v2 flows: outreach→counter→counter→accept→opportunity `pending`; withdraw→`rejected`; decline→`rejected`; wrong-seat → `SeatViolationError` with claim intact; parity-proof attribution; pickup announcement), `timeout.shared.seat.spec.ts` (5 — parked-seat schema selection).
- e2e extended: real-LLM v2 negotiation (turn 0 = initiator `outreach`, initiator never accepts, v2 vocabulary throughout, `protocolVersion: v2` persisted). Also fixed the pre-existing v1 e2e flake (fixed user ids accumulated DM history → continuations legitimately resolve in 1 turn; now per-run unique ids — confirmed failing identically on clean dev).
- Regressions: protocol negotiation+opportunity 816 pass (2 known clean-dev flakes, both verified: coalescing spec + discoveryQuery LLM spec passes solo); API negotiation/queue/adapter suites green per-file; timeout queue spec protocol-barrel mocks extended with the new helper exports; web vitest failures identical to clean-dev baseline (12, unrelated files).
- Builds: protocol tsc, API tsc, web vite build green; eslint 0 errors.

## Deploy / rollback

No migrations, no new tables. Ship → set `NEGOTIATION_PROTOCOL_VERSION=v2` on dev protocol → new negotiations run seat rules; in-flight v1 conversations are untouched by construction. Rollback = unset the env (v2 conversations already started keep their inherited version and remain valid — the respond enum accepts the union).
