### PR TITLE
feat: negotiation screen node in shadow mode (IND-398)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -116,6 +116,9 @@ OPENROUTER_API_KEY=your-openrouter-api-key
 # NEGOTIATION_PROTOCOL_VERSION=v1          # Protocol version stamped on NEW negotiations: v1 (legacy) | v2 (seat rules:
                                            # initiator outreach/counter/question/withdraw, counterparty accept/decline/counter/question).
                                            # In-flight conversations inherit their stamped version; flipping this only affects fresh negotiations.
+# NEGOTIATION_SCREEN_MODE=off              # Outreach screen gate (P2.1): off (default, no LLM call) | shadow (decide + record on
+                                           # task metadata.screenDecision, never blocks) | enforce (reserved for P2.2; runs as shadow
+                                           # with a warning until enforcement lands). Fresh negotiations only; continuations never screen.
 
 # Per-turn LLM round-trip cap for IndexNegotiator, in ms (default: 15000).
 # Bounds individual negotiator calls so a single slow upstream tail can't blow

--- a/docs/domain/negotiation.md
+++ b/docs/domain/negotiation.md
@@ -76,9 +76,22 @@ Each turn produces a structured assessment:
   - `otherUser`: agent, patient, or peer
 - **message** *(optional)*: Free-form text accompanying the action
 
+### Screen gate (shadow)
+
+Between init and the first turn, **fresh negotiations only** (continuations skip it) pass through an outreach gate: one structured LLM call from the reaching client's perspective deciding `reach_out | pass` — is this match worth the client's name before any turn is exchanged? Inputs: the client's intents + discovery query, the counterparty's `user_contexts` paragraph + active intents, and the seed assessment.
+
+Controlled by `NEGOTIATION_SCREEN_MODE`:
+
+- `off` *(code default)* — node skipped entirely; no LLM call, no telemetry.
+- `shadow` — the decision is recorded (`tasks.metadata.screenDecision`, a `negotiation_screen` trace event, and a log line) but **never blocks**: every negotiation proceeds to its first turn. Used to measure pass rates against observed reject rates before enforcement.
+- `enforce` — reserved; until enforcement lands it runs identically to `shadow` with a warning (by the time the screen runs, init has already created the task and flipped the opportunity to `negotiating`, so a blocking `pass` needs its own quiet/correct path).
+
+A screen failure (LLM error/timeout) **fails open**: the negotiation proceeds as `reach_out` with `failedOpen: true` recorded, so failed screens are excluded from pass-rate queries.
+
 ### Flow
 
 1. **Init**: An opportunity is created with `negotiating` status. A conversation and task are created in the A2A system to track the negotiation.
+1a. **Screen** *(fresh negotiations, `NEGOTIATION_SCREEN_MODE` ≠ `off`)*: the reaching client's gate records `reach_out | pass` on task metadata; in shadow mode the flow always continues.
 2. **Initiating agent's turn**: The agent presents the case (action: propose)
 3. **Responding agent's turn**: The agent evaluates and responds (accept, reject, counter, or question)
 4. **Alternation**: If the responding agent countered or asked a question, the other agent responds; turns alternate until resolution

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -162,6 +162,8 @@ export { LensInferrer } from "./shared/hyde/lens.inferrer.js";
 export { NegotiationInsightsGenerator } from "./negotiation/insight.generator.js";
 export type { NegotiationDigest } from "./negotiation/insight.generator.js";
 export { IndexNegotiator } from "./negotiation/negotiation.agent.js";
+export { NegotiationScreener, configuredScreenMode, ScreenDecisionSchema, NEGOTIATION_SCREEN_MODES } from "./negotiation/negotiation.screen.js";
+export type { ScreenDecision, ScreenDecisionRecord, NegotiationScreenMode, NegotiationScreenerInput } from "./negotiation/negotiation.screen.js";
 export type { NegotiationAgentInput } from "./negotiation/negotiation.agent.js";
 export { QuestionerAgent } from "./questioner/questioner.agent.js";
 export type { QuestionerAgentConfig } from "./questioner/questioner.agent.js";

--- a/packages/protocol/src/negotiation/negotiation.graph.ts
+++ b/packages/protocol/src/negotiation/negotiation.graph.ts
@@ -8,12 +8,14 @@ import type { AgentDispatcher, NegotiationTurnPayload } from "../shared/interfac
 import { NegotiationGraphState, type NegotiationTurn, type NegotiationOutcome, type UserNegotiationContext, type SeedAssessment, type NegotiationGraphLike } from "./negotiation.state.js";
 import { IndexNegotiator } from "./negotiation.agent.js";
 import { allowedActionsFor, configuredProtocolVersion, fallbackActionFor, isRejectLikeAction, isTerminalAction, readProtocolVersion, rejectActionFor } from "./negotiation.protocol.js";
+import { NegotiationScreener, configuredScreenMode, type ScreenDecision, type ScreenDecisionRecord } from "./negotiation.screen.js";
 import type { NegotiationSeat, NegotiationProtocolVersion } from "../shared/schemas/negotiation-state.schema.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import type { QuestionerEnqueueFn } from "../questioner/questioner.types.js";
 
 const logger = protocolLogger("NegotiationGraph");
 const initLog = protocolLogger("NegotiationGraph:Init");
+const screenNodeLog = protocolLogger("NegotiationGraph:Screen");
 const turnLog = protocolLogger("NegotiationGraph:Turn");
 const finalizeLog = protocolLogger("NegotiationGraph:Finalize");
 const negotiateCandidatesLog = protocolLogger("NegotiationGraph:negotiateCandidates");
@@ -43,6 +45,7 @@ export class NegotiationGraphFactory {
   createGraph() {
     const { database, dispatcher, timeoutQueue, questionerEnqueue } = this;
     const systemAgent = new IndexNegotiator();
+    const screener = new NegotiationScreener();
 
     const initNode = async (state: typeof NegotiationGraphState.State) => {
       try {
@@ -199,6 +202,108 @@ export class NegotiationGraphFactory {
       } catch (err) {
         return { error: `Init failed: ${err instanceof Error ? err.message : String(err)}` };
       }
+    };
+
+    /**
+     * Screen node (P2.1) — the outreach gate. Runs between init and the first
+     * turn on FRESH negotiations only (routing skips it on continuations and
+     * when NEGOTIATION_SCREEN_MODE=off). The reaching client's negotiator
+     * decides whether the match is worth its client's name; in shadow mode the
+     * decision is recorded (task metadata + trace event + log line) but never
+     * blocks — the negotiation always proceeds to the first turn. `enforce`
+     * runs identically until P2.2 lands enforcement (by the time this node
+     * runs, init has already created the task and flipped the opportunity to
+     * `negotiating` — P2.2 owns making a blocking `pass` quiet/correct).
+     */
+    const screenNode = async (state: typeof NegotiationGraphState.State) => {
+      const traceEmitter = requestContext.getStore()?.traceEmitter;
+      const emitWide = (event: Record<string, unknown>) =>
+        (traceEmitter as ((e: Record<string, unknown>) => void) | undefined)?.(event);
+
+      const mode = configuredScreenMode();
+      if (mode === "enforce") {
+        screenNodeLog.warn("NEGOTIATION_SCREEN_MODE=enforce requested but enforcement lands in P2.2; running shadow", {
+          taskId: state.taskId,
+        });
+      }
+
+      const start = Date.now();
+      // The client is the initiator seat's user — the side whose negotiator is
+      // reaching out. Fresh runs stamp initiatorUserId in init; fall back to
+      // sourceUser (what the stamp defaults to anyway).
+      const initiatorId = state.initiatorUserId ?? state.sourceUser.id;
+      const clientIsSource = initiatorId !== state.candidateUser.id;
+      const clientUser = clientIsSource ? state.sourceUser : state.candidateUser;
+      const counterpartyUser = clientIsSource ? state.candidateUser : state.sourceUser;
+
+      let decision: ScreenDecision;
+      let failedOpen = false;
+      let screenError: string | undefined;
+      try {
+        const counterpartyContext = (await database.getUserContext(counterpartyUser.id, null).catch(() => null))?.text ?? "";
+        decision = await screener.invoke({
+          clientUser,
+          counterpartyUser,
+          ...(counterpartyContext && { counterpartyContext }),
+          // discoveryQuery belongs to the discovery session's source user; only
+          // meaningful for the client when the client holds the source side.
+          ...(clientIsSource && state.discoveryQuery && { discoveryQuery: state.discoveryQuery }),
+          seedAssessment: state.seedAssessment,
+          indexContext: state.indexContext,
+        });
+      } catch (err) {
+        // Fail open: a screen failure must never block a negotiation.
+        failedOpen = true;
+        screenError = err instanceof Error ? err.message : String(err);
+        screenNodeLog.warn("Screen failed; proceeding open (reach_out)", {
+          taskId: state.taskId,
+          opportunityId: state.opportunityId || undefined,
+          error: screenError,
+        });
+        decision = {
+          decision: "reach_out",
+          reasoning: `screen_error: ${screenError}`,
+          evidence: { counterpartyPremiseFit: "", intentAlignment: "" },
+        };
+      }
+
+      const durationMs = Date.now() - start;
+      const record: ScreenDecisionRecord = {
+        ...decision,
+        mode,
+        ...(failedOpen && { failedOpen, error: screenError }),
+        screenedAt: new Date().toISOString(),
+        durationMs,
+      };
+
+      await database.setTaskScreenDecision?.(state.taskId, record as unknown as Record<string, unknown>).catch((err) => {
+        screenNodeLog.error("Failed to persist screen decision", { taskId: state.taskId, error: err });
+      });
+
+      screenNodeLog.info("negotiation_screen", {
+        taskId: state.taskId,
+        opportunityId: state.opportunityId || undefined,
+        decision: decision.decision,
+        mode,
+        failedOpen,
+        durationMs,
+      });
+
+      if (state.opportunityId) {
+        emitWide({
+          type: "negotiation_screen",
+          opportunityId: state.opportunityId,
+          negotiationConversationId: state.conversationId,
+          decision: decision.decision,
+          reasoning: decision.reasoning,
+          mode,
+          failedOpen,
+          durationMs,
+        });
+      }
+
+      // Shadow (and pre-P2.2 enforce): always proceed to the first turn.
+      return { screenDecision: record };
     };
 
     const turnNode = async (state: typeof NegotiationGraphState.State) => {
@@ -525,6 +630,7 @@ export class NegotiationGraphFactory {
 
     const workflow = new StateGraph(NegotiationGraphState)
       .addNode("init", initNode)
+      .addNode("screen", screenNode)
       .addNode("turn", turnNode)
       .addNode("finalize", finalizeNode)
       .addConditionalEdges("turn", evaluateNode, {
@@ -532,8 +638,13 @@ export class NegotiationGraphFactory {
         finalize: "finalize",
       })
       .addConditionalEdges("init", (state: typeof NegotiationGraphState.State) => {
-        return state.error ? "finalize" : "turn";
-      }, { turn: "turn", finalize: "finalize" })
+        if (state.error) return "finalize";
+        // Screen gate: fresh negotiations only (continuations already passed
+        // the gate when the dialogue opened); off disables the node entirely.
+        if (!state.isContinuation && configuredScreenMode() !== "off") return "screen";
+        return "turn";
+      }, { screen: "screen", turn: "turn", finalize: "finalize" })
+      .addEdge("screen", "turn")
       .addEdge("__start__", "init")
       .addEdge("finalize", "__end__");
 

--- a/packages/protocol/src/negotiation/negotiation.screen.ts
+++ b/packages/protocol/src/negotiation/negotiation.screen.ts
@@ -1,0 +1,190 @@
+import { z } from "zod";
+
+import { createStructuredModel } from "../shared/agent/model.config.js";
+import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
+import type { UserNegotiationContext, SeedAssessment } from "../shared/schemas/negotiation-state.schema.js";
+import { protocolLogger } from "../shared/observability/protocol.logger.js";
+
+const screenLog = protocolLogger("NegotiationScreener");
+
+/**
+ * Screen-gate modes (P2.1 — client-advocate protocol).
+ *
+ * - `off` — the screen node is skipped entirely; no LLM call, no telemetry.
+ * - `shadow` — the screen decision is made and recorded (task metadata +
+ *   trace event + log line) but NEVER blocks: every fresh negotiation still
+ *   proceeds to the first turn. Used to measure pass rates against observed
+ *   reject rates before enforcement.
+ * - `enforce` — reserved for P2.2. Until enforcement lands, `enforce` runs
+ *   identically to `shadow` (decision recorded, negotiation proceeds) and the
+ *   screen node logs a warning that enforcement is not yet implemented.
+ */
+export const NEGOTIATION_SCREEN_MODES = ["off", "shadow", "enforce"] as const;
+
+export type NegotiationScreenMode = (typeof NEGOTIATION_SCREEN_MODES)[number];
+
+/**
+ * Resolve the screen mode from `NEGOTIATION_SCREEN_MODE`.
+ *
+ * Defaults to `off` when unset or unrecognized — the screen gate is an
+ * explicit opt-in flip (same operational pattern as
+ * `NEGOTIATION_PROTOCOL_VERSION` / `NEGOTIATOR_CHAT_ENABLED`): code ships
+ * inert, the environment turns it on.
+ */
+export function configuredScreenMode(): NegotiationScreenMode {
+  const raw = process.env.NEGOTIATION_SCREEN_MODE;
+  if (raw === "shadow" || raw === "enforce" || raw === "off") return raw;
+  return "off";
+}
+
+/**
+ * Structured screen decision — the outreach gate's verdict on whether this
+ * match is worth the client's name before any turn is exchanged.
+ */
+export const ScreenDecisionSchema = z.object({
+  decision: z.enum(["reach_out", "pass"]),
+  reasoning: z.string(),
+  /** Suggested opening angle for the outreach turn (only when reaching out). */
+  outreachAngle: z.string().nullable().optional(),
+  evidence: z.object({
+    /** How well the counterparty's context/premises fit the client's need. */
+    counterpartyPremiseFit: z.string(),
+    /** How the client's intents align with what the counterparty seeks. */
+    intentAlignment: z.string(),
+    /** Prior-negotiation memory signals. Wired in P5.3 — always absent today. */
+    memoryHints: z.string().nullable().optional(),
+  }),
+});
+
+export type ScreenDecision = z.infer<typeof ScreenDecisionSchema>;
+
+/**
+ * The record persisted to `tasks.metadata.screenDecision` and returned into
+ * graph state. Extends the LLM decision with operational context so pass-rate
+ * queries can group by mode and exclude failed-open rows.
+ */
+export interface ScreenDecisionRecord extends ScreenDecision {
+  mode: NegotiationScreenMode;
+  /** True when the screen LLM call failed and the gate defaulted open. */
+  failedOpen?: boolean;
+  /** Error message when `failedOpen` is set. */
+  error?: string;
+  screenedAt: string;
+  durationMs: number;
+}
+
+export interface NegotiationScreenerInput {
+  /** The client — the user whose negotiator is deciding whether to reach out. */
+  clientUser: UserNegotiationContext;
+  /** The counterparty the client's negotiator would be reaching out to. */
+  counterpartyUser: UserNegotiationContext;
+  /** The counterparty's `user_contexts` paragraph (empty string when absent). */
+  counterpartyContext?: string;
+  /** The explicit search query that triggered discovery (if any). */
+  discoveryQuery?: string;
+  seedAssessment: Omit<SeedAssessment, "actors">;
+  indexContext: { networkId: string; prompt?: string };
+}
+
+const SYSTEM_PROMPT = `You are the outreach gate for {clientName}'s negotiator agent on a discovery network. Before any negotiation turn is exchanged, you decide whether this match is worth reaching out to on {clientName}'s behalf — their name and attention are spent with every outreach.
+
+Network context: {networkContext}
+
+Decide:
+- "reach_out" when the counterparty plausibly serves {clientName}'s stated needs and a concrete, honest opening case can be made. When reaching out, set outreachAngle to the strongest specific angle for the opening message.
+- "pass" when the match is generic, one-sided, or rests on vague overlap that would waste both parties' attention.
+
+Rules:
+{queryRule}
+- Judge concrete intent alignment, not topical adjacency.
+- Fill evidence.counterpartyPremiseFit with what (if anything) in the counterparty's context actually fits, and evidence.intentAlignment with how the intents line up. Be specific; cite the strongest signal either way.
+- Do NOT reference internal system details like scores, pre-screens, or evaluator outputs in reasoning that could be shown to users.`;
+
+const QUERY_RULE = `- {clientName} explicitly searched for "{discoveryQuery}". This query is the PRIMARY criterion: if the counterparty does not satisfy it, pass — background intents cannot rescue a query mismatch.`;
+const NO_QUERY_RULE = `- No explicit search query: judge against {clientName}'s active intents.`;
+
+const DEFAULT_SCREEN_TIMEOUT_MS = 15_000;
+
+export interface NegotiationScreenerConfig {
+  /** Hard ceiling on the screen LLM round-trip, in ms (default 15000). */
+  timeoutMs?: number;
+}
+
+/**
+ * The outreach gate (P2.1). One structured LLM call deciding
+ * `reach_out | pass` for a fresh negotiation, from the reaching client's
+ * perspective. Throws on LLM/validation failure — the screen graph node owns
+ * the fail-open policy (a failed screen never blocks the negotiation).
+ */
+export class NegotiationScreener {
+  private readonly timeoutMs: number;
+
+  constructor(config?: NegotiationScreenerConfig) {
+    this.timeoutMs = config?.timeoutMs && Number.isFinite(config.timeoutMs) && config.timeoutMs > 0
+      ? config.timeoutMs
+      : DEFAULT_SCREEN_TIMEOUT_MS;
+  }
+
+  /**
+   * Produce a screen decision for a fresh match.
+   * @throws When the LLM call times out or returns schema-invalid output.
+   */
+  async invoke(input: NegotiationScreenerInput): Promise<ScreenDecision> {
+    const model = createStructuredModel("negotiationScreener", ScreenDecisionSchema, { name: "negotiation_screener" });
+
+    const clientName = input.clientUser.profile.name ?? "your client";
+    const counterpartyName = input.counterpartyUser.profile.name ?? "the counterparty";
+    const networkContext = input.indexContext.prompt || "General discovery";
+    const queryRule = (input.discoveryQuery ? QUERY_RULE : NO_QUERY_RULE)
+      .replace(/{clientName}/g, clientName)
+      .replace(/{discoveryQuery}/g, input.discoveryQuery ?? "");
+
+    const systemPrompt = SYSTEM_PROMPT
+      .replace(/{clientName}/g, clientName)
+      .replace("{networkContext}", networkContext)
+      .replace("{queryRule}", queryRule);
+
+    const formatIntents = (intents: UserNegotiationContext["intents"]): string =>
+      intents.length > 0 ? intents.map((i) => `- ${i.title}: ${i.description}`).join("\n") : "- (none)";
+
+    const userMessage = `YOUR CLIENT (${clientName}):
+Bio: ${input.clientUser.profile.bio ?? "N/A"}
+${input.discoveryQuery ? `Search query: "${input.discoveryQuery}"\nBackground intents (secondary to the query):` : "Active intents:"}
+${formatIntents(input.clientUser.intents)}
+
+COUNTERPARTY (${counterpartyName}):
+Bio: ${input.counterpartyUser.profile.bio ?? "N/A"}
+${input.counterpartyContext ? `Context: ${input.counterpartyContext}\n` : ""}Active intents:
+${formatIntents(input.counterpartyUser.intents)}
+
+Why this match was suggested: ${input.seedAssessment.reasoning}
+
+Decide whether reaching out serves ${clientName}.`;
+
+    const chatMessages = [
+      { role: "system", content: systemPrompt },
+      { role: "user", content: userMessage },
+    ];
+
+    const result = await this.callModel(model, chatMessages);
+    const parsed = ScreenDecisionSchema.safeParse(result);
+    if (!parsed.success) {
+      screenLog.warn("Screen output failed schema validation", {
+        issues: parsed.error.issues.map((i) => i.message).slice(0, 3),
+      });
+      throw new Error(`Screen decision failed validation: ${parsed.error.issues[0]?.message ?? "unknown"}`);
+    }
+    return parsed.data;
+  }
+
+  /**
+   * Raw structured-model round trip. Split out as a seam so tests can drive
+   * the schema-validation and fail-open paths without a live provider.
+   */
+  protected async callModel(
+    model: ReturnType<typeof createStructuredModel>,
+    chatMessages: Array<{ role: string; content: string }>,
+  ): Promise<unknown> {
+    return invokeWithAbortSignal(model, chatMessages, AbortSignal.timeout(this.timeoutMs));
+  }
+}

--- a/packages/protocol/src/negotiation/negotiation.state.ts
+++ b/packages/protocol/src/negotiation/negotiation.state.ts
@@ -1,6 +1,7 @@
 import { Annotation } from "@langchain/langgraph";
 import { z } from "zod";
 import type { NegotiationUserAnswer } from "../shared/interfaces/database.interface.js";
+import type { ScreenDecisionRecord } from "./negotiation.screen.js";
 import { NEGOTIATION_ACTIONS, type NegotiationProtocolVersion } from "../shared/schemas/negotiation-state.schema.js";
 
 /**
@@ -155,6 +156,16 @@ export const NegotiationGraphState = Annotation.Root({
   protocolVersion: Annotation<NegotiationProtocolVersion>({
     reducer: (curr, next) => next ?? curr,
     default: () => "v1" as const,
+  }),
+
+  /**
+   * Screen-gate decision for this fresh run (P2.1 shadow mode). Written by the
+   * screen node; null when the gate is off, on continuations, or before the
+   * node runs. Mirrors `tasks.metadata.screenDecision`.
+   */
+  screenDecision: Annotation<ScreenDecisionRecord | null>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => null,
   }),
 
   /** Whether this run is continuing a prior conversation with the same pair. */

--- a/packages/protocol/src/negotiation/tests/negotiation.screen-routing.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.screen-routing.spec.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+import { NegotiationGraphFactory } from "../negotiation.graph.js";
+import { NegotiationGraphState } from "../negotiation.state.js";
+import { IndexNegotiator, type NegotiationAgentInput } from "../negotiation.agent.js";
+import { NegotiationScreener, type NegotiationScreenerInput, type ScreenDecision } from "../negotiation.screen.js";
+import { requestContext } from "../../shared/observability/request-context.js";
+import type { NegotiationTurn } from "../negotiation.state.js";
+
+/**
+ * IND-398 — screen node routing + shadow semantics (graph level).
+ *
+ * Pins:
+ * - off (default): screen node skipped entirely — no screener call, no
+ *   metadata write,
+ * - shadow: fresh runs screen exactly once, decision persisted to
+ *   metadata.screenDecision, negotiation always proceeds (even on `pass`),
+ * - continuations never screen (even in shadow),
+ * - screen failure fails OPEN: negotiation proceeds, failedOpen recorded,
+ * - enforce (pre-P2.2): runs identically to shadow, mode recorded truthfully,
+ * - `negotiation_screen` trace event emitted when an opportunityId is present,
+ * - screener inputs: client = initiator side, counterparty context fetched,
+ *   discoveryQuery forwarded for source-side clients.
+ */
+
+type FakeMessage = {
+  id: string;
+  senderId: string;
+  role: "agent";
+  parts: unknown[];
+  createdAt: Date;
+};
+
+function priorMsg(senderUserId: string, action: string, idx: number): FakeMessage {
+  return {
+    id: `prior-${idx}`,
+    senderId: `agent:${senderUserId}`,
+    role: "agent",
+    parts: [{ kind: "data", data: { action, assessment: { reasoning: "r", suggestedRoles: { ownUser: "peer", otherUser: "peer" } }, message: null } }],
+    createdAt: new Date(Date.now() - (100 - idx) * 1000),
+  };
+}
+
+function mkStubs(opts?: {
+  priorMessages?: FakeMessage[];
+  userContextText?: string;
+  omitSetTaskScreenDecision?: boolean;
+}) {
+  const createdMessages: Array<{ senderId: string; parts: Array<{ kind: string; data: NegotiationTurn }> }> = [];
+  const screenWrites: Array<{ taskId: string; record: Record<string, unknown> }> = [];
+  const userContextLookups: string[] = [];
+  const database = {
+    getOrCreateDM: async () => ({ id: "conv-1" }),
+    createTask: async (conversationId: string) => ({ id: "task-new", conversationId, state: "submitted" }),
+    updateOpportunityStatus: async () => {},
+    createMessage: async (p: { senderId: string; parts: Array<{ kind: string; data: NegotiationTurn }> }) => {
+      createdMessages.push(p);
+      return { id: `msg-${createdMessages.length}`, senderId: p.senderId, parts: p.parts, createdAt: new Date() };
+    },
+    updateTaskState: async () => {},
+    createArtifact: async () => {},
+    setTaskTurnContext: async () => {},
+    ...(opts?.omitSetTaskScreenDecision ? {} : {
+      setTaskScreenDecision: async (taskId: string, record: Record<string, unknown>) => {
+        screenWrites.push({ taskId, record });
+      },
+    }),
+    getMessagesForConversation: async () => opts?.priorMessages ?? [],
+    getOpportunityUserAnswers: async () => [],
+    getNegotiationTaskForOpportunity: async () => null,
+    getLatestNegotiationTaskForConversation: async () => null,
+    getUserContext: async (userId: string) => {
+      userContextLookups.push(userId);
+      return opts?.userContextText != null ? { text: opts.userContextText } : null;
+    },
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[0];
+
+  const dispatcher = {
+    hasExternalAgent: async () => false,
+    dispatch: async () => ({ handled: false, reason: "no_agent" }),
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[1];
+
+  return { database, dispatcher, createdMessages, screenWrites, userContextLookups };
+}
+
+async function runGraph(stubs: ReturnType<typeof mkStubs>, input: Record<string, unknown> = {}) {
+  const graph = new NegotiationGraphFactory(stubs.database, stubs.dispatcher).createGraph();
+  return graph.invoke({
+    sourceUser: { id: "u-src", intents: [], profile: { name: "Alice" } },
+    candidateUser: { id: "u-cand", intents: [], profile: { name: "Bob" } },
+    indexContext: { networkId: "net-1", prompt: "" },
+    seedAssessment: { reasoning: "complementary", valencyRole: "peer" },
+    maxTurns: 1,
+    ...input,
+  } as Partial<typeof NegotiationGraphState.State>);
+}
+
+const screenerInputs: NegotiationScreenerInput[] = [];
+let screenerResult: ScreenDecision | (() => ScreenDecision) = {
+  decision: "reach_out",
+  reasoning: "solid fit",
+  outreachAngle: "shared ML focus",
+  evidence: { counterpartyPremiseFit: "fits", intentAlignment: "aligned" },
+};
+let screenerError: Error | null = null;
+
+describe("negotiation graph — screen node routing (IND-398)", () => {
+  let origScreenerInvoke: typeof NegotiationScreener.prototype.invoke;
+  let origAgentInvoke: typeof IndexNegotiator.prototype.invoke;
+  const origEnv = process.env.NEGOTIATION_SCREEN_MODE;
+
+  beforeAll(() => {
+    origScreenerInvoke = NegotiationScreener.prototype.invoke;
+    NegotiationScreener.prototype.invoke = async function (input: NegotiationScreenerInput) {
+      screenerInputs.push(input);
+      if (screenerError) throw screenerError;
+      return typeof screenerResult === "function" ? screenerResult() : screenerResult;
+    };
+    origAgentInvoke = IndexNegotiator.prototype.invoke;
+    IndexNegotiator.prototype.invoke = async function (input: NegotiationAgentInput) {
+      return {
+        action: (input.isFinalTurn ? "accept" : "propose") as NegotiationTurn["action"],
+        assessment: { reasoning: "stub", suggestedRoles: { ownUser: "peer" as const, otherUser: "peer" as const } },
+        message: null,
+      };
+    };
+  });
+
+  afterAll(() => {
+    NegotiationScreener.prototype.invoke = origScreenerInvoke;
+    IndexNegotiator.prototype.invoke = origAgentInvoke;
+  });
+
+  beforeEach(() => {
+    screenerInputs.length = 0;
+    screenerError = null;
+    screenerResult = {
+      decision: "reach_out",
+      reasoning: "solid fit",
+      outreachAngle: "shared ML focus",
+      evidence: { counterpartyPremiseFit: "fits", intentAlignment: "aligned" },
+    };
+    delete process.env.NEGOTIATION_SCREEN_MODE;
+  });
+
+  afterEach(() => {
+    if (origEnv === undefined) delete process.env.NEGOTIATION_SCREEN_MODE;
+    else process.env.NEGOTIATION_SCREEN_MODE = origEnv;
+  });
+
+  it("off (default): screen node is skipped — no screener call, no metadata write", async () => {
+    const stubs = mkStubs();
+    const result = await runGraph(stubs);
+
+    expect(screenerInputs.length).toBe(0);
+    expect(stubs.screenWrites.length).toBe(0);
+    expect(result.outcome).not.toBeNull();
+  });
+
+  it("shadow: fresh run screens once, persists the decision, and proceeds to turns", async () => {
+    process.env.NEGOTIATION_SCREEN_MODE = "shadow";
+    const stubs = mkStubs({ userContextText: "Bob builds ML systems." });
+
+    const result = await runGraph(stubs);
+
+    expect(screenerInputs.length).toBe(1);
+    expect(stubs.screenWrites.length).toBe(1);
+    expect(stubs.screenWrites[0].taskId).toBe("task-new");
+    expect(stubs.screenWrites[0].record.decision).toBe("reach_out");
+    expect(stubs.screenWrites[0].record.mode).toBe("shadow");
+    expect(stubs.screenWrites[0].record.failedOpen).toBeUndefined();
+    expect(typeof stubs.screenWrites[0].record.screenedAt).toBe("string");
+    // Negotiation ran normally after the screen
+    expect(stubs.createdMessages.length).toBeGreaterThanOrEqual(1);
+    expect(result.outcome).not.toBeNull();
+  });
+
+  it("shadow: a `pass` decision NEVER blocks — negotiation still proceeds", async () => {
+    process.env.NEGOTIATION_SCREEN_MODE = "shadow";
+    screenerResult = {
+      decision: "pass",
+      reasoning: "vague overlap",
+      evidence: { counterpartyPremiseFit: "weak", intentAlignment: "none" },
+    };
+    const stubs = mkStubs();
+
+    const result = await runGraph(stubs);
+
+    expect(stubs.screenWrites[0].record.decision).toBe("pass");
+    expect(stubs.createdMessages.length).toBeGreaterThanOrEqual(1);
+    expect(result.outcome).not.toBeNull();
+  });
+
+  it("shadow: continuations never screen", async () => {
+    process.env.NEGOTIATION_SCREEN_MODE = "shadow";
+    const stubs = mkStubs({
+      priorMessages: [priorMsg("u-src", "propose", 0), priorMsg("u-cand", "counter", 1)],
+    });
+
+    const result = await runGraph(stubs);
+
+    expect(screenerInputs.length).toBe(0);
+    expect(stubs.screenWrites.length).toBe(0);
+    expect(result.outcome).not.toBeNull();
+  });
+
+  it("shadow: screen failure fails OPEN — proceeds with failedOpen reach_out recorded", async () => {
+    process.env.NEGOTIATION_SCREEN_MODE = "shadow";
+    screenerError = new Error("provider timeout");
+    const stubs = mkStubs();
+
+    const result = await runGraph(stubs);
+
+    expect(stubs.screenWrites.length).toBe(1);
+    expect(stubs.screenWrites[0].record.decision).toBe("reach_out");
+    expect(stubs.screenWrites[0].record.failedOpen).toBe(true);
+    expect(String(stubs.screenWrites[0].record.error)).toContain("provider timeout");
+    expect(stubs.createdMessages.length).toBeGreaterThanOrEqual(1);
+    expect(result.outcome).not.toBeNull();
+  });
+
+  it("enforce (pre-P2.2): runs identically to shadow — proceeds, mode recorded truthfully", async () => {
+    process.env.NEGOTIATION_SCREEN_MODE = "enforce";
+    screenerResult = {
+      decision: "pass",
+      reasoning: "not worth the client's name",
+      evidence: { counterpartyPremiseFit: "weak", intentAlignment: "none" },
+    };
+    const stubs = mkStubs();
+
+    const result = await runGraph(stubs);
+
+    expect(stubs.screenWrites[0].record.mode).toBe("enforce");
+    expect(stubs.screenWrites[0].record.decision).toBe("pass");
+    // Enforcement lands in P2.2 — until then even a pass proceeds.
+    expect(stubs.createdMessages.length).toBeGreaterThanOrEqual(1);
+    expect(result.outcome).not.toBeNull();
+  });
+
+  it("emits a negotiation_screen trace event when an opportunityId is present", async () => {
+    process.env.NEGOTIATION_SCREEN_MODE = "shadow";
+    const stubs = mkStubs();
+    const events: Array<Record<string, unknown>> = [];
+
+    await requestContext.run(
+      { traceEmitter: ((e: Record<string, unknown>) => { events.push(e); }) as never },
+      () => runGraph(stubs, { opportunityId: "opp-1" }),
+    );
+
+    const screenEvents = events.filter((e) => e.type === "negotiation_screen");
+    expect(screenEvents.length).toBe(1);
+    expect(screenEvents[0].opportunityId).toBe("opp-1");
+    expect(screenEvents[0].decision).toBe("reach_out");
+    expect(screenEvents[0].mode).toBe("shadow");
+    expect(screenEvents[0].failedOpen).toBe(false);
+    expect(typeof screenEvents[0].durationMs).toBe("number");
+  });
+
+  it("screener inputs: client = source (initiator), counterparty context fetched, discoveryQuery forwarded", async () => {
+    process.env.NEGOTIATION_SCREEN_MODE = "shadow";
+    const stubs = mkStubs({ userContextText: "Bob builds ML systems." });
+
+    await runGraph(stubs, { discoveryQuery: "ML engineers" });
+
+    expect(screenerInputs.length).toBe(1);
+    expect(screenerInputs[0].clientUser.id).toBe("u-src");
+    expect(screenerInputs[0].counterpartyUser.id).toBe("u-cand");
+    expect(screenerInputs[0].counterpartyContext).toBe("Bob builds ML systems.");
+    expect(screenerInputs[0].discoveryQuery).toBe("ML engineers");
+    expect(stubs.userContextLookups).toContain("u-cand");
+  });
+
+  it("tolerates a database without setTaskScreenDecision (optional method) — still proceeds", async () => {
+    process.env.NEGOTIATION_SCREEN_MODE = "shadow";
+    const stubs = mkStubs({ omitSetTaskScreenDecision: true });
+
+    const result = await runGraph(stubs);
+
+    expect(screenerInputs.length).toBe(1);
+    expect(stubs.createdMessages.length).toBeGreaterThanOrEqual(1);
+    expect(result.outcome).not.toBeNull();
+  });
+});

--- a/packages/protocol/src/negotiation/tests/negotiation.screen.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.screen.spec.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { NegotiationScreener, ScreenDecisionSchema, configuredScreenMode, NEGOTIATION_SCREEN_MODES, type NegotiationScreenerInput } from "../negotiation.screen.js";
+
+/**
+ * IND-398 — screener unit behavior.
+ *
+ * Pins:
+ * - env parsing: off is the code default (flag-flip pattern), invalid values
+ *   coerce to off, all three modes parse,
+ * - decision schema shape (evidence required, outreachAngle/memoryHints optional),
+ * - invoke: valid model output returned as-is; schema-invalid output throws
+ *   (the graph node owns fail-open),
+ * - prompt assembly: discovery query becomes the PRIMARY criterion rule;
+ *   counterparty context paragraph and both intent sets are included.
+ */
+
+const origEnv = process.env.NEGOTIATION_SCREEN_MODE;
+
+afterAll(() => {
+  if (origEnv === undefined) delete process.env.NEGOTIATION_SCREEN_MODE;
+  else process.env.NEGOTIATION_SCREEN_MODE = origEnv;
+});
+
+describe("configuredScreenMode", () => {
+  beforeEach(() => {
+    delete process.env.NEGOTIATION_SCREEN_MODE;
+  });
+
+  it("defaults to off when unset", () => {
+    expect(configuredScreenMode()).toBe("off");
+  });
+
+  it("parses every documented mode", () => {
+    for (const mode of NEGOTIATION_SCREEN_MODES) {
+      process.env.NEGOTIATION_SCREEN_MODE = mode;
+      expect(configuredScreenMode()).toBe(mode);
+    }
+  });
+
+  it("coerces unrecognized values to off", () => {
+    process.env.NEGOTIATION_SCREEN_MODE = "loud";
+    expect(configuredScreenMode()).toBe("off");
+    process.env.NEGOTIATION_SCREEN_MODE = "";
+    expect(configuredScreenMode()).toBe("off");
+  });
+});
+
+describe("ScreenDecisionSchema", () => {
+  it("accepts a full decision", () => {
+    const parsed = ScreenDecisionSchema.safeParse({
+      decision: "reach_out",
+      reasoning: "strong fit",
+      outreachAngle: "shared ML focus",
+      evidence: { counterpartyPremiseFit: "fits", intentAlignment: "aligned", memoryHints: null },
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("accepts a minimal pass (no outreachAngle, no memoryHints)", () => {
+    const parsed = ScreenDecisionSchema.safeParse({
+      decision: "pass",
+      reasoning: "vague overlap",
+      evidence: { counterpartyPremiseFit: "weak", intentAlignment: "none" },
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects unknown decisions and missing evidence", () => {
+    expect(ScreenDecisionSchema.safeParse({
+      decision: "maybe",
+      reasoning: "x",
+      evidence: { counterpartyPremiseFit: "", intentAlignment: "" },
+    }).success).toBe(false);
+    expect(ScreenDecisionSchema.safeParse({
+      decision: "pass",
+      reasoning: "x",
+    }).success).toBe(false);
+  });
+});
+
+/** Screener with the model round-trip stubbed via the protected seam. */
+class SeamScreener extends NegotiationScreener {
+  public capturedMessages: Array<{ role: string; content: string }> = [];
+  constructor(private output: unknown) {
+    super();
+  }
+  protected override async callModel(
+    _model: unknown,
+    chatMessages: Array<{ role: string; content: string }>,
+  ): Promise<unknown> {
+    this.capturedMessages = chatMessages;
+    return this.output;
+  }
+}
+
+const baseInput: NegotiationScreenerInput = {
+  clientUser: {
+    id: "u-client",
+    intents: [{ id: "i1", title: "Find ML engineer", description: "Need ML expertise", confidence: 0.9 }],
+    profile: { name: "Alice", bio: "PM building AI startup" },
+  },
+  counterpartyUser: {
+    id: "u-counter",
+    intents: [{ id: "i2", title: "Seeking PM co-founder", description: "Wants product partner", confidence: 0.8 }],
+    profile: { name: "Bob", bio: "Senior ML engineer" },
+  },
+  counterpartyContext: "Bob has shipped three recommendation systems.",
+  seedAssessment: { reasoning: "complementary skills", valencyRole: "peer" },
+  indexContext: { networkId: "net-1", prompt: "AI startup co-founders" },
+};
+
+describe("NegotiationScreener.invoke", () => {
+  it("returns the parsed decision on valid model output", async () => {
+    const screener = new SeamScreener({
+      decision: "reach_out",
+      reasoning: "clear complementary fit",
+      outreachAngle: "co-founder search",
+      evidence: { counterpartyPremiseFit: "ships ML", intentAlignment: "PM seeks ML, ML seeks PM" },
+    });
+
+    const decision = await screener.invoke(baseInput);
+
+    expect(decision.decision).toBe("reach_out");
+    expect(decision.outreachAngle).toBe("co-founder search");
+  });
+
+  it("throws on schema-invalid model output (graph node owns fail-open)", async () => {
+    const screener = new SeamScreener({ decision: "shrug", reasoning: 42 });
+    await expect(screener.invoke(baseInput)).rejects.toThrow(/failed validation/);
+  });
+
+  it("includes counterparty context, both intent sets, and the seed reasoning in the prompt", async () => {
+    const screener = new SeamScreener({
+      decision: "pass",
+      reasoning: "r",
+      evidence: { counterpartyPremiseFit: "", intentAlignment: "" },
+    });
+    await screener.invoke(baseInput);
+
+    const user = screener.capturedMessages.find((m) => m.role === "user")!.content;
+    expect(user).toContain("Bob has shipped three recommendation systems.");
+    expect(user).toContain("Find ML engineer");
+    expect(user).toContain("Seeking PM co-founder");
+    expect(user).toContain("complementary skills");
+    const system = screener.capturedMessages.find((m) => m.role === "system")!.content;
+    expect(system).toContain("Alice");
+    expect(system).toContain("AI startup co-founders");
+    // No query → intents are the criterion
+    expect(system).toContain("No explicit search query");
+  });
+
+  it("promotes an explicit discovery query to the PRIMARY criterion", async () => {
+    const screener = new SeamScreener({
+      decision: "pass",
+      reasoning: "r",
+      evidence: { counterpartyPremiseFit: "", intentAlignment: "" },
+    });
+    await screener.invoke({ ...baseInput, discoveryQuery: "ML engineers" });
+
+    const system = screener.capturedMessages.find((m) => m.role === "system")!.content;
+    expect(system).toContain('searched for "ML engineers"');
+    expect(system).toContain("PRIMARY criterion");
+    const user = screener.capturedMessages.find((m) => m.role === "user")!.content;
+    expect(user).toContain('Search query: "ML engineers"');
+  });
+});

--- a/packages/protocol/src/shared/agent/model.config.ts
+++ b/packages/protocol/src/shared/agent/model.config.ts
@@ -44,6 +44,7 @@ function getModelConfig(config?: ModelConfig) {
     opportunityEvaluator: { model: "google/gemini-2.5-flash" },
     opportunityPresenter: { model: "google/gemini-2.5-flash" },
     negotiator:           { model: "google/gemini-2.5-flash" },
+    negotiationScreener:  { model: "google/gemini-2.5-flash", temperature: 0.2, maxTokens: 1024 },
     homeCategorizer:      { model: "google/gemini-2.5-flash" },
     suggestionGenerator:  { model: "google/gemini-2.5-flash", temperature: 0.4, maxTokens: 512 },
     chatTitleGenerator:   { model: "google/gemini-2.5-flash", temperature: 0.3, maxTokens: 32 },

--- a/packages/protocol/src/shared/interfaces/database.interface.ts
+++ b/packages/protocol/src/shared/interfaces/database.interface.ts
@@ -2230,6 +2230,16 @@ export interface NegotiationQueries {
   setTaskTurnContext(taskId: string, turnContext: Record<string, unknown>): Promise<void>;
 
   /**
+   * Merges a screen-gate decision (P2.1 shadow mode) into
+   * `metadata.screenDecision`, leaving other metadata keys intact. Optional so
+   * existing fakes/wireups remain valid; when absent the screen node logs the
+   * decision and proceeds without persisting.
+   * @param taskId - Task whose metadata to enrich
+   * @param screenDecision - ScreenDecisionRecord (decision, evidence, mode, timing)
+   */
+  setTaskScreenDecision?(taskId: string, screenDecision: Record<string, unknown>): Promise<void>;
+
+  /**
    * Returns the most-recently-created task whose metadata carries
    * `type: 'negotiation'` and `opportunityId: <id>`. Returns null if no
    * negotiation has been started for that opportunity yet.

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -737,6 +737,24 @@ export class ConversationDatabaseAdapter {
   }
 
   /**
+   * Merges a screen-gate decision (P2.1 shadow mode) into the task's metadata
+   * JSONB under the `screenDecision` key, preserving other metadata keys.
+   * Sibling of {@link setTaskTurnContext}.
+   *
+   * @param taskId - Task to update
+   * @param screenDecision - ScreenDecisionRecord (decision, evidence, mode, timing)
+   */
+  async setTaskScreenDecision(taskId: string, screenDecision: Record<string, unknown>): Promise<void> {
+    await db
+      .update(schema.tasks)
+      .set({
+        metadata: sql`COALESCE(${schema.tasks.metadata}, '{}'::jsonb) || jsonb_build_object('screenDecision', ${JSON.stringify(screenDecision)}::jsonb)`,
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.tasks.id, taskId));
+  }
+
+  /**
    * Retrieves a task by ID.
    * @param taskId - Task ID
    * @returns The task, or null if not found

--- a/services/api/src/startup.env.ts
+++ b/services/api/src/startup.env.ts
@@ -106,6 +106,7 @@ const envSchema = z.object({
   NEGOTIATION_MAX_TURNS_CHAT: optionalInt,
   NEGOTIATION_MAX_TURNS_AMBIENT: optionalInt,
   NEGOTIATOR_TURN_TIMEOUT_MS: optionalInt,
+  NEGOTIATION_SCREEN_MODE: z.union([z.literal(''), z.enum(['off', 'shadow', 'enforce'])]).optional(),
   QUESTIONER_ENABLED: optionalBoolean,
 
   // 9. MCP / tool runtime

--- a/services/api/tests/negotiation.e2e.spec.ts
+++ b/services/api/tests/negotiation.e2e.spec.ts
@@ -2,7 +2,8 @@ import { config } from "dotenv";
 config({ path: ".env.test", override: true });
 
 import { describe, it, expect } from "bun:test";
-import { NegotiationGraphFactory } from "@indexnetwork/protocol";
+import { randomUUID } from "node:crypto";
+import { NegotiationGraphFactory, requestContext } from "@indexnetwork/protocol";
 import type { NegotiationGraphDatabase } from "@indexnetwork/protocol";
 import { conversationDatabaseAdapter } from "../src/adapters/database.adapter";
 
@@ -28,7 +29,19 @@ describe("Negotiation E2E", () => {
     const sourceId = `e2e-source-${Date.now()}`;
     const candidateId = `e2e-candidate-${Date.now()}`;
 
-    const result = await graph.invoke({
+    // IND-398: run this fresh negotiation with the screen gate in shadow mode
+    // and a trace collector, so the screenDecision metadata + negotiation_screen
+    // trace event can be asserted below. Random UUID: the opportunity row does
+    // not exist, so status flips update 0 rows (already .catch-guarded).
+    const origScreenMode = process.env.NEGOTIATION_SCREEN_MODE;
+    process.env.NEGOTIATION_SCREEN_MODE = "shadow";
+    const opportunityId = randomUUID();
+    const traceEvents: Array<Record<string, unknown>> = [];
+
+    const result = await requestContext.run(
+      { traceEmitter: ((e: Record<string, unknown>) => { traceEvents.push(e); }) as never },
+      () => graph.invoke({
+        opportunityId,
       sourceUser: {
         id: sourceId,
         intents: [{ id: "i1", title: "Looking for ML engineer", description: "Need ML expertise for recommendation system", confidence: 0.9 }],
@@ -42,6 +55,10 @@ describe("Negotiation E2E", () => {
       indexContext: { networkId: "e2e-index", prompt: "AI startup co-founders" },
       seedAssessment: { reasoning: "Complementary skills", valencyRole: "Peer" },
       maxTurns: 4,
+      }),
+    ).finally(() => {
+      if (origScreenMode === undefined) delete process.env.NEGOTIATION_SCREEN_MODE;
+      else process.env.NEGOTIATION_SCREEN_MODE = origScreenMode;
     });
 
     // Verify outcome exists
@@ -63,6 +80,20 @@ describe("Negotiation E2E", () => {
     expect(metadata.sourceUserId).toBe(sourceId);
     // IND-397: fresh tasks are version-stamped (v1 unless env opts into v2).
     expect(metadata.protocolVersion).toBe(process.env.NEGOTIATION_PROTOCOL_VERSION === "v2" ? "v2" : "v1");
+
+    // IND-398: shadow screen ran before the first turn — decision persisted on
+    // task metadata and surfaced as a negotiation_screen trace event, and the
+    // negotiation proceeded regardless of the verdict.
+    const screen = metadata.screenDecision as Record<string, unknown> | undefined;
+    expect(screen).toBeTruthy();
+    expect(["reach_out", "pass"]).toContain(screen!.decision);
+    expect(screen!.mode).toBe("shadow");
+    expect(typeof (screen!.evidence as Record<string, unknown>).intentAlignment).toBe("string");
+
+    const screenEvents = traceEvents.filter((e) => e.type === "negotiation_screen");
+    expect(screenEvents.length).toBe(1);
+    expect(screenEvents[0].opportunityId).toBe(opportunityId);
+    expect(["reach_out", "pass"]).toContain(screenEvents[0].decision);
   }, 120_000);
 
   it("runs a full v2 negotiation: seat-scoped actions, counterparty-only accept (IND-397)", async () => {


### PR DESCRIPTION
Implements [IND-398 · P2.1 Screen node — shadow mode](https://linear.app/indexnetwork/issue/IND-398/p21-screen-node-shadow-mode) — the outreach gate of the client-advocate protocol, shipped in shadow: it decides and records, never blocks, so pass rates can be measured against observed reject rates before P2.2 enforces.

## What

**New `screen` graph node between `init` and the first `turn`, fresh negotiations only.** The reaching client's negotiator makes one structured LLM decision — `reach_out | pass` — on whether this match is worth its client's name before any turn is exchanged. Continuations never screen (routing keys on the `isContinuation` already computed in `initNode`).

- **New module `negotiation.screen.ts`**: `ScreenDecisionSchema` (`{ decision: reach_out|pass, reasoning, outreachAngle?, evidence: { counterpartyPremiseFit, intentAlignment, memoryHints? } }` — `memoryHints` wired in P5.3), `NegotiationScreener` (structured LLM call, 15 s cap, protected `callModel` test seam), `configuredScreenMode()`, `NEGOTIATION_SCREEN_MODES`. Inputs: client intents + discovery query, counterparty `user_contexts` paragraph + active intents, seed assessment.
- **Graph**: conditional edge `init → screen | turn | finalize`; screen node resolves client/counterparty from the **initiator seat** (`initiatorUserId`, IND-396 stamp), records the decision, and always proceeds (`screen → turn`).
- **Telemetry**: decision persisted to `tasks.metadata.screenDecision` via new adapter method `setTaskScreenDecision` (sibling of `setTaskTurnContext`, JSONB merge; optional on the interface so existing fakes stay valid); `negotiation_screen` trace event (when an opportunityId is present); `NegotiationGraph:Screen` log line (the Railway-visible surface for ambient runs).
- **Fail-open**: LLM error/timeout → proceed as `reach_out` with `failedOpen: true` + `error` recorded, so failed screens are excludable from pass-rate queries.
- **Env `NEGOTIATION_SCREEN_MODE = off | shadow | enforce`** (validated in `startup.env.ts`, documented in `.env.example` + `docs/domain/negotiation.md`). `enforce` runs identically to shadow with a warning until P2.2 lands enforcement (by the time screen runs, init has already created the task and flipped the opportunity to `negotiating` — P2.2 owns making a blocking pass quiet/correct, as recorded on the issue).

## Honest delta from the issue

The issue says default `shadow`; **the code default is `off`** — same flag-flip pattern as `NEGOTIATION_PROTOCOL_VERSION` / `NEGOTIATOR_CHAT_ENABLED`. Default-shadow would add a live LLM call to every fresh negotiation in every existing test suite and on deploy day; default-off ships the node inert, dev flips `NEGOTIATION_SCREEN_MODE=shadow` via Railway (single-switch rollback), and the shadow-mode intent is realized operationally.

## Tests (AC coverage)

- **Routing spec** (`negotiation.screen-routing.spec.ts`, 9 graph-level): off skips the node (no screener call, no metadata write); shadow screens exactly once, persists, and proceeds — **even on `pass`**; continuations never screen; screen failure fails open with `failedOpen: true` recorded; enforce proceeds pre-P2.2 with mode recorded truthfully; `negotiation_screen` trace event emitted; screener inputs pinned (client = initiator side, counterparty context fetched, discoveryQuery forwarded); tolerates databases without the optional `setTaskScreenDecision`.
- **Unit spec** (`negotiation.screen.spec.ts`, 10): env parsing (default off, invalid → off), decision schema, valid output returned / invalid output throws (graph owns fail-open), prompt assembly (query becomes PRIMARY criterion; counterparty paragraph + both intent sets included).
- **e2e** (real LLM + real Postgres): fresh negotiation under shadow — `metadata.screenDecision` present with `decision ∈ {reach_out, pass}`, `mode: shadow`, evidence populated; exactly one `negotiation_screen` trace event with the right opportunityId; negotiation proceeded to normal completion. 2/2 pass.

## Verification

- protocol `tsc` + build, api `tsc` + build green; eslint 0 errors
- protocol negotiation+opportunity: 833 pass; only failures are the two documented clean-dev baseline flakes (`MCP run coalescing` — confirmed failing identically on clean dev root — and the real-LLM `discoveryQuery priority` spec)
- API suites green per-file: negotiation-polling.seat 8, timeout.shared.seat 5, timeout.queue 8, claim-timeout.queue 7, negotiation.graph 4, from-intent 12, from-enrichment 11, from-introducer 11, conversation adapter 11, opportunity.negotiation 1
- No migrations, no new tables, no web changes. With `NEGOTIATION_SCREEN_MODE` unset, behavior is byte-identical to dev today.

## Deploy plan

1. Merge (inert — screen mode defaults off).
2. Flip `NEGOTIATION_SCREEN_MODE=shadow` on dev protocol (Railway).
3. Pass-rate query over `metadata.screenDecision` documented on the Linear issue — feeds the P2.2 enforce decision.
