### PR TITLE
feat: questioner preset negotiation_inflight (IND-400)

### DIFF
--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -167,7 +167,7 @@ export type { ScreenDecision, ScreenDecisionRecord, NegotiationScreenMode, Negot
 export type { NegotiationAgentInput } from "./negotiation/negotiation.agent.js";
 export { QuestionerAgent } from "./questioner/questioner.agent.js";
 export type { QuestionerAgentConfig } from "./questioner/questioner.agent.js";
-export type { QuestionerInput, QuestionerContext, QuestionerEnqueuePayload, QuestionerEnqueueFn, DiscoveryContext, IntentContext, ProfileContext, NegotiationContext, ChatContext } from "./questioner/questioner.types.js";
+export type { QuestionerInput, QuestionerContext, QuestionerEnqueuePayload, QuestionerEnqueueFn, DiscoveryContext, IntentContext, ProfileContext, NegotiationContext, NegotiationInflightContext, ChatContext } from "./questioner/questioner.types.js";
 export { getPreset } from "./questioner/questioner.presets.js";
 export { isQuestionerEnabled, isDiscoveryQuestionsEnabled, discoveryQuestionsInputMode, discoveryQuestionsTimeoutMs, chatQuestionWaitTimeoutMs } from "./questioner/questioner.env.js";
 export type { QuestionerPreset } from "./questioner/questioner.presets.js";

--- a/packages/protocol/src/questioner/questioner.presets.ts
+++ b/packages/protocol/src/questioner/questioner.presets.ts
@@ -7,7 +7,7 @@
 import type { QuestionMode } from "../shared/schemas/question.schema.js";
 import { SYSTEM_PROMPT as DISCOVERY_SYSTEM_PROMPT, buildQuestionPrompt as buildDiscoveryPrompt } from "../opportunity/question.prompt.js";
 
-import type { ChatContext, IntentContext, NegotiationContext, ProfileContext } from "./questioner.types.js";
+import type { ChatContext, IntentContext, NegotiationContext, NegotiationInflightContext, ProfileContext } from "./questioner.types.js";
 
 /**
  * Shared rule block appended to every questioner system prompt. Enforces that
@@ -240,6 +240,72 @@ function buildNegotiationPrompt(ctx: NegotiationContext): string {
 
 // ─── Chat preset ─────────────────────────────────────────────────────────
 
+const NEGOTIATION_INFLIGHT_SYSTEM_PROMPT = `You sit between a human and a discovery protocol. The user's own negotiator agent is MID-NEGOTIATION on their behalf and has paused: before continuing, it needs a decision or missing input from its client — most often permission to disclose a specific piece of information to the other side. The negotiation is WAITING until the user answers. Your job: turn the negotiator's stated need (and its draft question, when provided) into the minimum set of crisp, structured decision questions.
+
+Bias toward disclosure gating. The most common question shape is "may I share X with this person?" — an enable/disable decision about revealing specific information. Phrase these as a clear yes/no choice: the first option authorizes sharing, the second declines. State in each option's description what the negotiator will DO next (share and continue, or continue without revealing it). When the need is a missing fact rather than a permission, ask for that concrete input instead.
+
+You may pick from two strategies. Choose contextually; mix only when each question is genuinely distinct.
+- surface_missing_detail: ask for one concrete missing input the negotiator needs to proceed (a fact, constraint, preference, or bound the client never stated).
+- reflective_summary: put a disclosure or stance decision in front of the client to confirm or decline — the enable/disable gate described above.
+
+Honor the negotiator's intent. When a draft question is provided, treat it as the source of truth for WHAT to ask — improve wording, tighten options, add consequence-focused descriptions. Do not invent questions about topics the negotiator did not raise. When no draft is provided, derive the question strictly from the disclosure subject.
+
+Standalone prompt rule. Every generated \`prompt\` must be understandable outside the conversation where it was created. The user may see this question hours later in an inbox, away from any negotiation view. Naturally include the disclosure subject and a concrete description of the other person (drawn from the counterparty hint — their attributes, e.g. "a Berlin-based AI-infrastructure founder") in the question text itself. Do not rely on \`title\`, UI labels, hidden metadata, or surrounding digest/chat text to explain what the question is about.
+- Bad: "Can I share your budget with them?"
+- Good: "May I share your budget range with a Berlin-based AI-infrastructure founder you're being matched with?"
+
+${REFERENTIAL_CLOSURE_RULES}
+
+Exception — describing the other side. Unlike other surfaces, this question is ABOUT a live counterparty, so you must reference them — do it by restating their concrete attributes from the counterparty hint ("a fintech CTO exploring agent tooling"), never as "the counterparty", "them", or "this person" without an attribute anchor in the same sentence, and never by implying a list or pipeline.
+
+Cardinality. Default one question. Add a second ONLY when the negotiator's need genuinely spans two distinct decisions (e.g. one disclosure gate plus one missing fact). Never pad.
+
+Option construction. Each option must represent a meaningfully different outcome. For disclosure gates: authorize first, decline second; suffix the safer or more common path with " (Recommended)" and list it first when one clearly is. The description states the CONSEQUENCE for the negotiation — what the negotiator does next. 2–4 options. Never add an "Other" option — clients provide a free-text fallback automatically, which also lets the user add nuance ("share the range but not the exact figure").
+
+Title rules. ≤12 chars. Noun of the decision domain. Examples: "Disclosure", "Budget", "Timing", "Intro", "Scope", "Contact".
+
+Anti-patterns — never do these.
+- Don't ask procedural confirmations ("Should I keep negotiating?").
+- Don't re-ask for facts already visible in the user profile.
+- Don't broaden beyond the negotiator's stated disclosure subject or draft.
+- Don't reveal the counterparty's identity — attributes only.
+- Don't ask vague introspective questions.
+
+Output. Return at most 2 entries in the "questions" array. Each entry must include a "strategy" field (one of the two values above). If the profile or context shown already answers the negotiator's need, return "questions": [].`;
+
+/**
+ * Build the user message for the negotiation-inflight preset from a NegotiationInflightContext.
+ * @param ctx - The inflight context: disclosure subject, counterparty hint, optional draft, community, user context.
+ * @returns The assembled user message string.
+ */
+function buildNegotiationInflightPrompt(ctx: NegotiationInflightContext): string {
+  const profileBlock = buildUserContextBlock(ctx.userContext);
+
+  const draftBlock = ctx.draftQuestion?.trim()
+    ? ctx.draftQuestion.trim()
+    : "(none — derive the question from the disclosure subject)";
+
+  return [
+    "## Negotiation context",
+    `Community: ${ctx.indexContext}`,
+    `Counterparty: ${ctx.counterpartyHint}`,
+    "",
+    "## What the negotiator needs from its client",
+    ctx.disclosureSubject,
+    "",
+    "## Draft question proposed by the negotiator",
+    draftBlock,
+    "",
+    "## User profile",
+    profileBlock,
+    "",
+    "## Your task",
+    "Produce the minimum set of structured questions that get the negotiator the permission or input it needs to continue.",
+    "Honor the draft when provided; refine its wording and options rather than replacing its topic.",
+    "Apply every rule from your system prompt before outputting.",
+  ].join("\n");
+}
+
 const CHAT_SYSTEM_PROMPT = `You sit between a human and a discovery protocol. The protocol's chat orchestrator is mid-conversation with the user and has decided it needs a decision or missing input from them before it can continue. The conversation is PAUSED until the user answers. Your job: turn the orchestrator's stated need (and any draft questions it proposed) into the minimum set of crisp, structured decision questions.
 
 Unlike other question surfaces, these questions render INLINE in the active conversation, immediately after the assistant's last message — the user has full conversational context. Still keep each prompt self-contained enough to make sense on its own line.
@@ -331,6 +397,10 @@ const presets: Record<QuestionMode, QuestionerPreset> = {
   negotiation: {
     systemPrompt: NEGOTIATION_SYSTEM_PROMPT,
     buildPrompt: (context: unknown) => buildNegotiationPrompt(context as NegotiationContext),
+  },
+  negotiation_inflight: {
+    systemPrompt: NEGOTIATION_INFLIGHT_SYSTEM_PROMPT,
+    buildPrompt: (context: unknown) => buildNegotiationInflightPrompt(context as NegotiationInflightContext),
   },
   chat: {
     systemPrompt: CHAT_SYSTEM_PROMPT,

--- a/packages/protocol/src/questioner/questioner.types.ts
+++ b/packages/protocol/src/questioner/questioner.types.ts
@@ -47,6 +47,27 @@ export interface NegotiationContext {
 }
 
 /**
+ * Negotiation-inflight context — a negotiator mid-negotiation wants to ask its
+ * OWN client a question before continuing (the `ask_user` action, P3.2). The
+ * negotiator states the disclosure subject and optionally drafts the question;
+ * the QuestionerAgent refines it into polished disclosure-gating questions.
+ * Distinct from {@link NegotiationContext}, which covers post-stall questions.
+ */
+export interface NegotiationInflightContext {
+  negotiationId: string;
+  /** Anonymized counterparty description (attributes, never identity). */
+  counterpartyHint: string;
+  /** What the negotiator wants permission to share or needs to know (e.g. "budget range", "availability in Q3"). */
+  disclosureSubject: string;
+  /** Draft question authored by the negotiator. The agent refines it. */
+  draftQuestion?: string;
+  /** Community / index context the negotiation runs in. */
+  indexContext: string;
+  /** The user's global user_context paragraph (profile-replacing identity text). */
+  userContext?: string;
+}
+
+/**
  * Chat context — data for orchestrator-initiated mid-conversation questions
  * (the `ask_user_question` tool). The orchestrator states what it needs to
  * learn; the QuestionerAgent turns that into polished structured questions,
@@ -73,6 +94,7 @@ export type QuestionerContext =
   | IntentContext
   | ProfileContext
   | NegotiationContext
+  | NegotiationInflightContext
   | ChatContext;
 
 /**

--- a/packages/protocol/src/questioner/tests/questioner.presets.spec.ts
+++ b/packages/protocol/src/questioner/tests/questioner.presets.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "bun:test";
 import { getPreset } from "../questioner.presets.js";
+import { QuestionModeSchema, QuestionSchema } from "../../shared/schemas/question.schema.js";
 
 const standaloneModeExpectations = [
   {
@@ -26,12 +27,18 @@ const standaloneModeExpectations = [
     positiveExample: "For your search for AI infrastructure collaborators in the AI founders community",
     negativeExample: "Which role is a better fit for your immediate needs?",
   },
+  {
+    mode: "negotiation_inflight" as const,
+    anchors: ["disclosure subject", "counterparty hint"],
+    positiveExample: "May I share your budget range with a Berlin-based AI-infrastructure founder",
+    negativeExample: "Can I share your budget with them?",
+  },
 ];
 
 // Modes whose prompts must carry the shared referential-closure guardrail.
 // (chat renders inline in the active conversation, so it is exempt from the
 // standalone-prompt contract above but still carries referential closure.)
-const ALL_MODES = ["discovery", "intent", "enrichment", "negotiation", "chat"] as const;
+const ALL_MODES = ["discovery", "intent", "enrichment", "negotiation", "negotiation_inflight", "chat"] as const;
 
 describe("standalone prompt contract", () => {
   it.each(standaloneModeExpectations)("mode '$mode' requires self-contained generated prompt text", ({ mode, anchors, positiveExample, negativeExample }) => {
@@ -215,6 +222,87 @@ describe("negotiation preset", () => {
     expect(preset.systemPrompt).toContain("For your search for AI infrastructure collaborators in the AI founders community");
     // Must NOT instruct the model to restate the stalled-negotiation mechanics.
     expect(preset.systemPrompt).not.toContain("stalled negotiation context");
+  });
+});
+
+describe("negotiation_inflight preset", () => {
+  const baseContext = {
+    negotiationId: "neg-42",
+    counterpartyHint: "a fintech CTO exploring agent tooling in Berlin",
+    disclosureSubject: "permission to share the client's budget range",
+    indexContext: "AI founders community",
+    userContext: "Alice is a protocol engineer.",
+  };
+
+  it("is a registered QuestionMode and returns a preset with systemPrompt and buildPrompt", () => {
+    expect(QuestionModeSchema.options).toContain("negotiation_inflight");
+    const preset = getPreset("negotiation_inflight");
+    expect(typeof preset.systemPrompt).toBe("string");
+    expect(preset.systemPrompt.length).toBeGreaterThan(0);
+    expect(typeof preset.buildPrompt).toBe("function");
+  });
+
+  it("buildPrompt contains the counterparty hint, disclosure subject, and community", () => {
+    const preset = getPreset("negotiation_inflight");
+    const result = preset.buildPrompt(baseContext);
+    expect(result).toContain("a fintech CTO exploring agent tooling in Berlin");
+    expect(result).toContain("permission to share the client's budget range");
+    expect(result).toContain("AI founders community");
+    expect(result).toContain("Alice is a protocol engineer.");
+  });
+
+  it("buildPrompt passes the negotiator's draft question through for refinement", () => {
+    const preset = getPreset("negotiation_inflight");
+    const result = preset.buildPrompt({
+      ...baseContext,
+      draftQuestion: "Is it OK if I tell them your budget is around €50k?",
+    });
+    expect(result).toContain("## Draft question proposed by the negotiator");
+    expect(result).toContain("Is it OK if I tell them your budget is around €50k?");
+    // Refinement instruction, not replacement
+    expect(result).toContain("Honor the draft when provided");
+  });
+
+  it("buildPrompt falls back to the disclosure subject when no draft is provided", () => {
+    const preset = getPreset("negotiation_inflight");
+    const result = preset.buildPrompt(baseContext);
+    expect(result).toContain("(none — derive the question from the disclosure subject)");
+  });
+
+  it("buildPrompt shows (no profile data) when userContext is absent", () => {
+    const preset = getPreset("negotiation_inflight");
+    const { userContext: _omit, ...noProfile } = baseContext;
+    const result = preset.buildPrompt(noProfile);
+    expect(result).toContain("(no profile data)");
+  });
+
+  it("system prompt biases toward disclosure gating with clear yes/no options", () => {
+    const preset = getPreset("negotiation_inflight");
+    expect(preset.systemPrompt).toContain("Bias toward disclosure gating");
+    expect(preset.systemPrompt).toContain("yes/no");
+    expect(preset.systemPrompt).toContain("free-text fallback");
+    expect(preset.systemPrompt).toContain("the first option authorizes sharing, the second declines");
+    // Honors the negotiator's draft like chat honors the orchestrator's
+    expect(preset.systemPrompt).toContain("Honor the negotiator's intent");
+    expect(preset.systemPrompt).toContain("Do not invent questions about topics the negotiator did not raise");
+    // Identity protection
+    expect(preset.systemPrompt).toContain("Don't reveal the counterparty's identity");
+  });
+
+  it("a disclosure-gate shaped output validates against the question schema", () => {
+    // The shape the preset's rules ask the model to produce must be
+    // structurally valid per QuestionSchema (same schema the agent parses with).
+    const disclosureQuestion = {
+      title: "Disclosure",
+      prompt: "May I share your budget range with a Berlin-based fintech CTO you're being matched with?",
+      options: [
+        { label: "Yes, share the range (Recommended)", description: "Your negotiator discloses the budget range and continues negotiating with it on the table." },
+        { label: "No, keep it private", description: "Your negotiator continues without revealing any budget figure." },
+      ],
+      multiSelect: false,
+    };
+    const parsed = QuestionSchema.safeParse(disclosureQuestion);
+    expect(parsed.success).toBe(true);
   });
 });
 

--- a/packages/protocol/src/shared/schemas/question.schema.ts
+++ b/packages/protocol/src/shared/schemas/question.schema.ts
@@ -67,6 +67,9 @@ export const QuestionModeSchema = z.enum([
   "intent",
   "enrichment",
   "negotiation",
+  // Negotiator-initiated mid-negotiation client questions (ask_user action, P3).
+  // Distinct from "negotiation", which covers post-stall questions only.
+  "negotiation_inflight",
   // Orchestrator-initiated mid-conversation questions (ask_user_question tool).
   "chat",
 ]);

--- a/services/api/src/adapters/questioner.adapter.ts
+++ b/services/api/src/adapters/questioner.adapter.ts
@@ -25,7 +25,7 @@ const DEFAULT_QUESTION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 /** Detection context describing how/where a question was generated. */
 export interface AdapterQuestionDetection {
-  mode: 'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'chat';
+  mode: 'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'negotiation_inflight' | 'chat';
   sourceType: string;
   sourceId: string;
   triggeredBy?: string;
@@ -87,7 +87,7 @@ export interface AdapterPersistedQuestion {
 
 /** Optional filters for the `findPending` query. */
 export interface AdapterQuestionFilters {
-  mode?: 'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'chat';
+  mode?: 'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'negotiation_inflight' | 'chat';
   sourceType?: string;
   sourceId?: string;
   /**
@@ -105,7 +105,7 @@ export interface AdapterQuestionFilters {
   /** When true, only return questions with no conversationId (sidebar-only). */
   noConversation?: boolean;
   /** Restrict to questions whose detection mode is in this set. */
-  modes?: Array<'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'chat'>;
+  modes?: Array<'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'negotiation_inflight' | 'chat'>;
   /** Maximum rows to return (applied as a SQL LIMIT). */
   limit?: number;
 }

--- a/services/api/src/controllers/mcp.controller.ts
+++ b/services/api/src/controllers/mcp.controller.ts
@@ -655,7 +655,7 @@ function createMcpServerInstance(): McpServer {
         networkId?: string;
         scopeType?: 'intent';
         scopeId?: string;
-        modes?: Array<'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'chat'>;
+        modes?: Array<'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'negotiation_inflight' | 'chat'>;
         limit?: number;
       },
     ) => {

--- a/services/api/src/controllers/question.controller.ts
+++ b/services/api/src/controllers/question.controller.ts
@@ -20,7 +20,7 @@ const answerBodySchema = z.object({
 });
 
 const statusQuerySchema = z.enum(['pending', 'answered', 'dismissed']).default('pending');
-const modeQuerySchema = z.enum(['discovery', 'intent', 'enrichment', 'negotiation', 'chat']);
+const modeQuerySchema = z.enum(['discovery', 'intent', 'enrichment', 'negotiation', 'negotiation_inflight', 'chat']);
 const uuidQuerySchema = z.string().uuid();
 const scopeTypeQuerySchema = z.enum(['intent']);
 

--- a/services/api/src/events/handlers/question.answer.handler.ts
+++ b/services/api/src/events/handlers/question.answer.handler.ts
@@ -24,7 +24,7 @@ const logger = log.service.from('QuestionAnswerHandler');
 interface QuestionAnsweredPayload {
   questionId: string;
   userId: string;
-  mode: 'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'chat';
+  mode: 'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'negotiation_inflight' | 'chat';
   sourceType: string;
   sourceId: string;
   answer: {

--- a/services/api/src/events/handlers/tests/question.answer.handler.test.ts
+++ b/services/api/src/events/handlers/tests/question.answer.handler.test.ts
@@ -114,6 +114,20 @@ describe("handleQuestionAnswered", () => {
     expect(failDeps.createPremiseFromAnswer).toHaveBeenCalledTimes(1);
   });
 
+  it("tolerates negotiation_inflight via the default branch without throwing (P3.2 owns consumption)", async () => {
+    // The mode exists in QuestionModeSchema as of P3.1 but nothing produces or
+    // consumes it yet — an answer must fall through to the default branch
+    // harmlessly, calling no reaction handler.
+    await handleQuestionAnswered(
+      { ...basePayload, mode: "negotiation_inflight", sourceType: "negotiation", sourceId: "neg-1" },
+      deps,
+    );
+    expect(deps.createPremiseFromAnswer).not.toHaveBeenCalled();
+    expect(deps.enqueueIntentRefinement).not.toHaveBeenCalled();
+    expect(deps.storeNegotiationContext).not.toHaveBeenCalled();
+    expect(deps.resolveChatQuestionWait).not.toHaveBeenCalled();
+  });
+
   it("handles unknown mode gracefully", async () => {
     await handleQuestionAnswered(
       { ...basePayload, mode: "unknown_mode" as "discovery" },

--- a/services/api/src/events/question.event.ts
+++ b/services/api/src/events/question.event.ts
@@ -5,7 +5,7 @@ interface QuestionAnswer {
   answeredAt: string;
 }
 
-type QuestionMode = 'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'chat';
+type QuestionMode = 'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'negotiation_inflight' | 'chat';
 
 interface QuestionCreatedPayload {
   questionId: string;

--- a/services/api/src/schemas/database.schema.ts
+++ b/services/api/src/schemas/database.schema.ts
@@ -499,7 +499,7 @@ export const enrichmentToolRuns = pgTable('enrichment_tool_runs', {
 }));
 
 export interface QuestionDetection {
-  mode: 'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'chat';
+  mode: 'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'negotiation_inflight' | 'chat';
   sourceType: string;
   sourceId: string;
   triggeredBy?: string;

--- a/services/api/src/services/tool.service.ts
+++ b/services/api/src/services/tool.service.ts
@@ -74,7 +74,7 @@ export class ToolService {
           networkId?: string;
           scopeType?: 'intent';
           scopeId?: string;
-          modes?: Array<'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'chat'>;
+          modes?: Array<'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'negotiation_inflight' | 'chat'>;
           limit?: number;
         },
       ) => {


### PR DESCRIPTION
## Summary

Implements [IND-400 · P3.1 — Questioner preset: negotiation_inflight](https://linear.app/indexnetwork/issue/IND-400/p31-questioner-preset-negotiation-inflight), part of the Client-Advocate Protocol master plan (IND-395).

Mid-negotiation client questions get their own questioner preset. The existing `negotiation` mode only covers **post-stall** questions; `negotiation_inflight` covers a negotiator **pausing mid-negotiation** to ask its own client something — most often permission to disclose specific information to the other side. This lands **before** the `ask_user` plumbing (P3.2) so no step depends on unshipped code.

**Additive, zero behavior change** — the preset exists and is registered but nothing produces `negotiation_inflight` questions yet (dead-but-tested until P3.2).

## Changes

### Protocol
- **`question.schema.ts`** — `QuestionModeSchema` gains `negotiation_inflight` (this is the actual home of the mode enum), with a comment distinguishing it from post-stall `negotiation`
- **`questioner.types.ts`** — new `NegotiationInflightContext` (`{ negotiationId, counterpartyHint, disclosureSubject, draftQuestion?, indexContext, userContext? }`) added to the `QuestionerContext` union; exported from the barrel
- **`questioner.presets.ts`** — new preset. The registry is an exhaustive `Record<QuestionMode, QuestionerPreset>`, so the new mode forced a compile-time-complete entry. Prompt design:
  - **Disclosure-gating bias**: the canonical shape is "may I share X with this person?" — clear yes/no where the first option authorizes and the second declines, each description stating what the negotiator does next; free-text fallback (automatic) lets the user add nuance ("share the range but not the exact figure")
  - **Draft refinement**: the negotiator's `draftQuestion` is the source of truth for *what* to ask (mirrors the chat preset's orchestrator-draft contract); topics are never invented beyond the stated disclosure subject
  - Carries both shared guardrail contracts: **referential closure** (with an explicit exception clause — the counterparty must be referenced by concrete attributes from the hint, never "the counterparty"/"them" unanchored, never identity) and the **standalone prompt rule** (the question may be seen hours later in an inbox)
  - Strategies: `surface_missing_detail` (missing fact) + `reflective_summary` (disclosure gate confirm/decline); max 2 questions

### API (compile-required union widening only)
- The literal `'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'chat'` unions widened additively in `question.event.ts`, `questioner.adapter.ts`, `database.schema.ts`, `question.answer.handler.ts`, `mcp.controller.ts`, `tool.service.ts`, and the `question.controller.ts` mode-query zod enum — protocol's `QuestionMode` flows into all of them (`questioner.queue.ts` persists `data.mode` and emits `QuestionEvents`), so API tsc breaks without this
- **Answer-side routing deliberately NOT touched**: `question.answer.handler.ts`'s mode-dispatch switch has no `negotiation_inflight` case — an answer falls through to the existing default branch (warn, no throw). The handler for it is P3.2's consumption.

## Tests

- **Preset unit tests** (7 new in `questioner.presets.spec.ts`): registered mode + preset shape; buildPrompt contains counterparty hint, disclosure subject, community, profile; draft passthrough for refinement; no-draft fallback; no-profile fallback; system-prompt disclosure-gating contract; disclosure-gate-shaped output validates against `QuestionSchema`
- Added to both shared contract suites: **standalone prompt contract** (`it.each` entry with anchors + positive/negative examples) and **referential closure contract** (`ALL_MODES`)
- **Answer-handler tolerance test**: a synthetic `negotiation_inflight` answer hits the default branch without throwing and calls no reaction dep

## Verification

- Protocol questioner suites: **84 pass / 0 fail** (5 files)
- API: answer handler 8/8, questioner queue specs 8/8, question inbox 6/6
- `tsc --noEmit` clean in protocol + API; both builds green; eslint clean on all touched files
- No migrations, no web changes, no env flags

## Deploy note

Explicitly a no-op release for runtime — nothing invokes the preset in production paths. Deployed check is "no behavioral diff".
