### PR TITLE
feat: ask_user action — pause, 24h window, resume (IND-401)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,6 +119,12 @@ OPENROUTER_API_KEY=your-openrouter-api-key
 # NEGOTIATION_SCREEN_MODE=off              # Outreach screen gate (P2.1): off (default, no LLM call) | shadow (decide + record on
                                            # task metadata.screenDecision, never blocks) | enforce (reserved for P2.2; runs as shadow
                                            # with a warning until enforcement lands). Fresh negotiations only; continuations never screen.
+# NEGOTIATION_ASK_USER_ENABLED=false       # ask_user client-consult pause (P3.2): when true, v2 negotiators may pause mid-negotiation
+                                           # to ask their OWN client a question (task -> input_required, question via the
+                                           # negotiation_inflight preset, 24h answer window, resume on answer or conservative
+                                           # no-disclosure default on expiry). Default off = today's behavior byte-for-byte.
+# NEGOTIATION_ASK_USER_WINDOW_MS=86400000  # Answer window for a paused ask_user negotiation, in ms (default: 24h). Shorten on dev
+                                           # to exercise the expiry path.
 
 # Per-turn LLM round-trip cap for IndexNegotiator, in ms (default: 15000).
 # Bounds individual negotiator calls so a single slow upstream tail can't blow

--- a/apps/web/src/components/PendingQuestions/QuestionGroup.tsx
+++ b/apps/web/src/components/PendingQuestions/QuestionGroup.tsx
@@ -8,6 +8,7 @@ import type { AnswerBody } from '@/services/questions';
 export function groupLabel(sourceType: string, mode: string): string {
   if (sourceType === 'opportunity' && mode === 'discovery') return 'About your opportunities';
   if (sourceType === 'opportunity' && mode === 'negotiation') return 'About a negotiation';
+  if (sourceType === 'opportunity' && mode === 'negotiation_inflight') return 'Your negotiator needs your input';
   if (sourceType === 'intent') return 'About your signal';
   if (sourceType === 'profile') return 'About you';
   return 'Questions';

--- a/apps/web/src/components/chat/ToolCallsDisplay.tsx
+++ b/apps/web/src/components/chat/ToolCallsDisplay.tsx
@@ -381,7 +381,7 @@ interface GraphNode {
 export interface NegotiationTurnRow {
   turnIndex: number;
   actor: "source" | "candidate";
-  action: "propose" | "accept" | "reject" | "counter" | "question" | "outreach" | "withdraw" | "decline";
+  action: "propose" | "accept" | "reject" | "counter" | "question" | "outreach" | "withdraw" | "decline" | "ask_user";
   reasoning?: string;
   message?: string;
   suggestedRoles?: { ownUser?: string; otherUser?: string };

--- a/apps/web/src/contexts/AIChatContext.tsx
+++ b/apps/web/src/contexts/AIChatContext.tsx
@@ -95,7 +95,7 @@ export interface TraceEvent {
   startedAt?: number;
   turnIndex?: number;
   actor?: "source" | "candidate";
-  action?: "propose" | "accept" | "reject" | "counter" | "question" | "outreach" | "withdraw" | "decline";
+  action?: "propose" | "accept" | "reject" | "counter" | "question" | "outreach" | "withdraw" | "decline" | "ask_user";
   reasoning?: string;
   message?: string;
   suggestedRoles?: { ownUser?: string; otherUser?: string };

--- a/apps/web/src/services/questions.ts
+++ b/apps/web/src/services/questions.ts
@@ -15,7 +15,7 @@ export interface QuestionPayload {
 }
 
 export interface QuestionDetection {
-  mode: 'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'chat';
+  mode: 'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'negotiation_inflight' | 'chat';
   sourceType: string;
   sourceId: string;
   triggeredBy?: string;

--- a/docs/domain/negotiation.md
+++ b/docs/domain/negotiation.md
@@ -88,6 +88,20 @@ Controlled by `NEGOTIATION_SCREEN_MODE`:
 
 A screen failure (LLM error/timeout) **fails open**: the negotiation proceeds as `reach_out` with `failedOpen: true` recorded, so failed screens are excluded from pass-rate queries.
 
+### Client consultation (`ask_user`, flag-gated)
+
+With `NEGOTIATION_ASK_USER_ENABLED=true`, v2 negotiators gain one extra non-final action per seat: **`ask_user`** — pause the negotiation to consult **their own client** (not the counterparty; `question` covers that). The turn carries `askUser: { disclosureSubject, draftQuestion }`.
+
+Flow: the `ask_user` turn is persisted → the task transitions to `input_required` (an A2A state previously unused by negotiations) → the draft is refined by the questioner's `negotiation_inflight` preset and delivered through the pending-questions UI → a **24 h answer window** is armed (`NEGOTIATION_ASK_USER_WINDOW_MS` overridable). The graph exits at the turn boundary, so chat-triggered runs never block a stream on a question — the resume is always an async continuation.
+
+- **Answer in time**: the answer lands on the opportunity's `metadata.userAnswers`, the timer is cancelled, the paused task is closed (`canceled`, superseded), and a `negotiation-run-existing` continuation resumes the dialogue. The asker speaks again (an `ask_user` turn does not pass the floor) with the answer in its context.
+- **Window expires**: the negotiation resumes with a **conservative default** — a synthetic `userAnswers` entry records that the client did not answer and instructs no disclosure/commitment on the subject. Negotiations always terminate.
+- **Lock**: while a task is `input_required` it holds the conversation lock for the full answer window (+1 h slack), not the usual 5-minute freshness — ambient rediscovery cannot start a fresh negotiation past the pause.
+- **Rationing**: at most **one client consultation per negotiation per side**, checked against the full turn history (continuations count prior sessions). Opening turns and final-cap turns never offer the action.
+- The 5-min park/claim timeout machinery ignores paused tasks: those workers only act on `waiting_for_agent`/`claimed` states.
+
+The action is only offered when the full pause loop is wired (questioner enabled, answer-window timer available, an opportunity to resume against); it is not accepted from the external polling `respond` surface — polling agents have their own channel to their user.
+
 ### Flow
 
 1. **Init**: An opportunity is created with `negotiating` status. A conversation and task are created in the A2A system to track the negotiation.
@@ -95,7 +109,7 @@ A screen failure (LLM error/timeout) **fails open**: the negotiation proceeds as
 2. **Initiating agent's turn**: The agent presents the case (action: propose)
 3. **Responding agent's turn**: The agent evaluates and responds (accept, reject, counter, or question)
 4. **Alternation**: If the responding agent countered or asked a question, the other agent responds; turns alternate until resolution
-5. **Finalize**: When a terminal action occurs or the turn cap is reached, the outcome is computed and the opportunity status is updated accordingly
+5. **Finalize**: When a terminal action occurs or the turn cap is reached, the outcome is computed and the opportunity status is updated accordingly. An `ask_user` pause exits before finalization — the task stays `input_required` until the client answers or the window expires, then the dialogue resumes as a continuation.
 
 ### Turn cap
 

--- a/packages/protocol/src/chat/chat-streaming.types.ts
+++ b/packages/protocol/src/chat/chat-streaming.types.ts
@@ -505,7 +505,7 @@ export interface NegotiationTurnEvent extends ChatStreamEventBase {
   negotiationConversationId: string;
   turnIndex: number;
   actor: "source" | "candidate";
-  action: "propose" | "accept" | "reject" | "counter" | "question" | "outreach" | "withdraw" | "decline";
+  action: "propose" | "accept" | "reject" | "counter" | "question" | "outreach" | "withdraw" | "decline" | "ask_user";
   reasoning?: string;
   message?: string;
   suggestedRoles?: { ownUser?: string; otherUser?: string };

--- a/packages/protocol/src/chat/chat.agent.ts
+++ b/packages/protocol/src/chat/chat.agent.ts
@@ -107,7 +107,7 @@ export type AgentStreamEvent =
       negotiationConversationId: string;
       turnIndex: number;
       actor: "source" | "candidate";
-      action: "propose" | "accept" | "reject" | "counter" | "question" | "outreach" | "withdraw" | "decline";
+      action: "propose" | "accept" | "reject" | "counter" | "question" | "outreach" | "withdraw" | "decline" | "ask_user";
       reasoning?: string;
       message?: string;
       suggestedRoles?: { ownUser?: string; otherUser?: string };

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -86,7 +86,7 @@ export type {
   UpdateUserEnrichmentRunInput, PreviewUserEnrichmentRunInput,
   EnrichmentRunRecord, EnrichmentRunStatus, EnrichmentRunOperation,
 } from "./shared/interfaces/enrichment-run.interface.js";
-export type { NegotiationTimeoutQueue } from "./shared/interfaces/negotiation-events.interface.js";
+export type { NegotiationTimeoutQueue, AskUserExpiryPayload } from "./shared/interfaces/negotiation-events.interface.js";
 export type { AgentDispatcher, AgentDispatchResult, NegotiationTurnPayload } from "./shared/interfaces/agent-dispatcher.interface.js";
 export type { AgentRecord, AgentTransportRecord, AgentPermissionRecord, AgentWithRelations, CreateAgentInput, CreateTransportInput, GrantPermissionInput, AgentDatabase } from './shared/interfaces/agent.interface.js';
 export { SYSTEM_AGENT_IDS } from './shared/interfaces/agent.interface.js';
@@ -216,8 +216,8 @@ export type { ElicitResultLike, ElicitInputFn, DispatchElicitationsParams } from
 // @experimental — internal graph-state shapes; may change in a minor release.
 
 export type { UserNegotiationContext, NegotiationTurn, NegotiationOutcome, SeedAssessment } from "./shared/schemas/negotiation-state.schema.js";
-export { NEGOTIATION_ACTIONS } from "./shared/schemas/negotiation-state.schema.js";
-export type { NegotiationAction, NegotiationSeat, NegotiationProtocolVersion } from "./shared/schemas/negotiation-state.schema.js";
+export { NEGOTIATION_ACTIONS, AskUserPayloadSchema } from "./shared/schemas/negotiation-state.schema.js";
+export type { NegotiationAction, NegotiationSeat, NegotiationProtocolVersion, AskUserPayload } from "./shared/schemas/negotiation-state.schema.js";
 export type { NegotiationGraphLike } from "./negotiation/negotiation.state.js";
 
 // ─── Negotiation seat rules (v2 client-advocate protocol) ───────────────────
@@ -227,6 +227,8 @@ export {
   CounterpartyTurnSchema,
   FinalInitiatorTurnSchema,
   FinalCounterpartyTurnSchema,
+  InitiatorAskUserTurnSchema,
+  CounterpartyAskUserTurnSchema,
   allowedActionsFor,
   turnSchemaFor,
   isTerminalAction,
@@ -235,6 +237,10 @@ export {
   rejectActionFor,
   readProtocolVersion,
   configuredProtocolVersion,
+  configuredAskUserEnabled,
+  askUserAnswerWindowMs,
+  DEFAULT_ASK_USER_WINDOW_MS,
+  ASK_USER_LOCK_SLACK_MS,
   resolveSeat,
   seatViolationMessage,
 } from "./negotiation/negotiation.protocol.js";

--- a/packages/protocol/src/negotiation/negotiation.agent.ts
+++ b/packages/protocol/src/negotiation/negotiation.agent.ts
@@ -39,6 +39,14 @@ const V2_INITIATOR_RULES = `- You hold the INITIATING seat: your user's side sur
   - "question" if you need a specific clarification from the counterparty
   - "withdraw" if the match does not serve {userName}'s needs`;
 
+/**
+ * v2 client-consult pause rule (P3.2). Appended to either seat's rules only
+ * when the caller granted `canAskUser` — the action never appears in the
+ * prompt (or the schema) otherwise.
+ */
+const ASK_USER_RULE = `
+- "ask_user" if you need {userName}'s OWN input before you can proceed — typically permission to disclose something sensitive (budget, availability, private details) or a fact only they know. This PAUSES the negotiation until they answer (up to 24h), so use it only when proceeding without their input would risk over-disclosure or a wrong call. You get AT MOST ONE client consultation per negotiation — spend it well. Set askUser: { disclosureSubject: what you need permission for or need to know, draftQuestion: the question in your words }. Use "question" (not "ask_user") when the clarification should come from the other side.`;
+
 /** v2 counterparty seat: receiving stance — acceptance is this seat's decision alone. */
 const V2_COUNTERPARTY_RULES = `- You hold the RECEIVING seat: the other side reached out to {userName}. Whether to accept is YOUR seat's decision alone.
 - Evaluate the initiator's arguments. Either:
@@ -74,6 +82,15 @@ export interface NegotiationAgentInput {
    * `v1` (default) keeps the legacy symmetric vocabulary and prompt.
    */
   protocolVersion?: NegotiationProtocolVersion;
+  /**
+   * Whether the `ask_user` client-consult pause (P3.2) is available on this
+   * turn. The caller (negotiation graph) grants it only when the feature flag
+   * is on, the pause loop is fully wired (questioner + answer-window timer +
+   * opportunity to resume against), the turn is v2 non-final and non-opening,
+   * and this side has not already consumed its one client question for the
+   * negotiation. When true, the seat schema and prompt gain the action.
+   */
+  canAskUser?: boolean;
 }
 
 export interface IndexNegotiatorConfig {
@@ -137,18 +154,19 @@ export class IndexNegotiator {
     const version: NegotiationProtocolVersion = input.protocolVersion ?? "v1";
     const seat: NegotiationSeat = input.seat ?? (input.isDiscoverer ? "initiator" : "counterparty");
     const isFinalTurn = input.isFinalTurn ?? false;
+    const canAskUser = input.canAskUser === true && version === "v2" && !isFinalTurn;
     const schema = turnSchemaFor(version, seat, isFinalTurn, {
       system: SystemNegotiationTurnSchema,
       final: FinalNegotiationTurnSchema,
-    });
+    }, { askUser: canAskUser });
     const model = createStructuredModel("negotiator", schema, { name: "index_negotiator" });
 
     const userName = input.ownUser.profile.name ?? "your user";
     const role = input.seedAssessment.valencyRole || "peer";
     const networkContext = input.indexContext.prompt || "General discovery";
-    const actionRules = version === "v2"
+    const actionRules = (version === "v2"
       ? (seat === "initiator" ? V2_INITIATOR_RULES : V2_COUNTERPARTY_RULES)
-      : V1_ACTION_RULES;
+      : V1_ACTION_RULES) + (canAskUser ? ASK_USER_RULE : "");
     const finalTurnInstruction = input.isFinalTurn
       ? (version === "v2"
           ? (seat === "initiator"

--- a/packages/protocol/src/negotiation/negotiation.graph.ts
+++ b/packages/protocol/src/negotiation/negotiation.graph.ts
@@ -7,7 +7,7 @@ import type { NegotiationTimeoutQueue } from "../shared/interfaces/negotiation-e
 import type { AgentDispatcher, NegotiationTurnPayload } from "../shared/interfaces/agent-dispatcher.interface.js";
 import { NegotiationGraphState, type NegotiationTurn, type NegotiationOutcome, type UserNegotiationContext, type SeedAssessment, type NegotiationGraphLike } from "./negotiation.state.js";
 import { IndexNegotiator } from "./negotiation.agent.js";
-import { allowedActionsFor, configuredProtocolVersion, fallbackActionFor, isRejectLikeAction, isTerminalAction, readProtocolVersion, rejectActionFor } from "./negotiation.protocol.js";
+import { ASK_USER_LOCK_SLACK_MS, allowedActionsFor, askUserAnswerWindowMs, configuredAskUserEnabled, configuredProtocolVersion, fallbackActionFor, isRejectLikeAction, isTerminalAction, readProtocolVersion, rejectActionFor } from "./negotiation.protocol.js";
 import { NegotiationScreener, configuredScreenMode, type ScreenDecision, type ScreenDecisionRecord } from "./negotiation.screen.js";
 import type { NegotiationSeat, NegotiationProtocolVersion } from "../shared/schemas/negotiation-state.schema.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
@@ -28,6 +28,24 @@ function turnsFromMessages(messages: Array<{ parts: unknown[] }>): NegotiationTu
       return dataPart?.data as NegotiationTurn;
     })
     .filter(Boolean);
+}
+
+/**
+ * Whether `userId`'s side has already spent its one `ask_user` client
+ * consultation in this conversation (P3.2 rationing: max one per negotiation
+ * per side, checked against the full message history so continuations count
+ * prior sessions' consultations too).
+ */
+function hasPriorAskUser(
+  messages: Array<{ senderId: string; parts: unknown[] }>,
+  userId: string,
+): boolean {
+  const sender = `agent:${userId}`;
+  return messages.some((m) => {
+    if (m.senderId !== sender) return false;
+    const dataPart = (m.parts as Array<{ kind?: string; data?: { action?: string } }>).find((p) => p.kind === "data");
+    return dataPart?.data?.action === "ask_user";
+  });
 }
 
 /**
@@ -58,8 +76,18 @@ export class NegotiationGraphFactory {
         const priorMessages = await database.getMessagesForConversation(conversation.id);
 
         const activeStates = ['submitted', 'working', 'input_required', 'waiting_for_agent', 'claimed'];
-        const isActiveAndFresh = (t: { state: string; updatedAt: Date }) =>
-          activeStates.includes(t.state) && (Date.now() - new Date(t.updatedAt).getTime()) < 5 * 60 * 1000;
+        const isActiveAndFresh = (t: { state: string; updatedAt: Date }) => {
+          if (!activeStates.includes(t.state)) return false;
+          // State-aware freshness (IND-401): an `input_required` task is an
+          // ask_user pause — it holds the conversation lock for its full answer
+          // window (+ slack for the expiry worker), not the 5-min turn window.
+          // Otherwise ambient rediscovery / chat negotiate_existing would start
+          // a fresh negotiation right past the pause after 5 minutes.
+          const freshnessMs = t.state === 'input_required'
+            ? askUserAnswerWindowMs() + ASK_USER_LOCK_SLACK_MS
+            : 5 * 60 * 1000;
+          return (Date.now() - new Date(t.updatedAt).getTime()) < freshnessMs;
+        };
 
         const priorTask = state.opportunityId
           ? await database.getNegotiationTaskForOpportunity(state.opportunityId)
@@ -79,11 +107,20 @@ export class NegotiationGraphFactory {
 
         const isContinuation = priorTurns.length > 0;
 
-        // Determine currentSpeaker from last prior message
+        // Determine currentSpeaker from last prior message. An `ask_user` last
+        // turn does NOT pass the floor: the sender paused to consult its own
+        // client, so on resume the same side speaks again — now armed with the
+        // client's answer (or its recorded absence). Flipping here would hand
+        // the turn to the counterparty, who has nothing to respond to.
         let currentSpeaker: 'source' | 'candidate' = 'source';
         if (isContinuation && priorMessages.length > 0) {
-          const lastSender = priorMessages[priorMessages.length - 1].senderId;
-          currentSpeaker = lastSender === agentIdA ? 'candidate' : 'source';
+          const lastMessage = priorMessages[priorMessages.length - 1];
+          const lastAction = turnsFromMessages([lastMessage])[0]?.action;
+          if (lastAction === 'ask_user') {
+            currentSpeaker = lastMessage.senderId === agentIdA ? 'source' : 'candidate';
+          } else {
+            currentSpeaker = lastMessage.senderId === agentIdA ? 'candidate' : 'source';
+          }
         }
 
         // Determine scenario-based maxTurns
@@ -336,6 +373,23 @@ export class NegotiationGraphFactory {
           ? 'initiator'
           : 'counterparty';
 
+        // ask_user availability (P3.2): flag on, full pause loop wired
+        // (questioner + answer-window timer + an opportunity to resume
+        // against), v2 non-final non-opening turn, and this side's one client
+        // consultation not yet spent (rationing). Chat-triggered runs get no
+        // special casing — the pause exits the graph at the turn boundary, so
+        // the stream never blocks on a question; the resume is always an async
+        // continuation.
+        const askUserAvailable =
+          version === 'v2'
+          && !isFinalTurn
+          && configuredAskUserEnabled()
+          && !!questionerEnqueue
+          && !!timeoutQueue?.enqueueAskUserExpiry
+          && !!state.opportunityId
+          && !(state.turnCount === 0 && !state.isContinuation)
+          && !hasPriorAskUser(state.messages, ownUser.id);
+
         const payload: NegotiationTurnPayload = {
           negotiationId: state.taskId,
           ownUser,
@@ -347,7 +401,7 @@ export class NegotiationGraphFactory {
           isDiscoverer: isSource,
           seat,
           protocolVersion: version,
-          allowedActions: [...allowedActionsFor(version, seat, isFinalTurn)],
+          allowedActions: [...allowedActionsFor(version, seat, isFinalTurn, { askUser: askUserAvailable })],
           ...(state.discoveryQuery && isSource && { discoveryQuery: state.discoveryQuery }),
         };
 
@@ -362,7 +416,7 @@ export class NegotiationGraphFactory {
           // the conservative fallback — the polling/respond surfaces reject
           // these with a 400, but locally-dispatched turns land here directly.
           turn = dispatchResult.turn;
-          if (version === 'v2' && !allowedActionsFor(version, seat, isFinalTurn).includes(turn.action)) {
+          if (version === 'v2' && !allowedActionsFor(version, seat, isFinalTurn, { askUser: askUserAvailable }).includes(turn.action)) {
             turnLog.warn('Personal agent returned out-of-seat action, coercing to conservative fallback', {
               action: turn.action, seat, isFinalTurn,
             });
@@ -403,6 +457,7 @@ export class NegotiationGraphFactory {
             ...(state.discoveryQuery && isSource && { discoveryQuery: state.discoveryQuery }),
             isContinuation: state.isContinuation,
             ...(state.userAnswers.length > 0 && { userAnswers: state.userAnswers }),
+            ...(askUserAvailable && { canAskUser: true }),
           });
         }
 
@@ -420,6 +475,17 @@ export class NegotiationGraphFactory {
           }
         }
 
+        // Safety net: an ask_user that slipped past availability gating (e.g. a
+        // locally-dispatched agent ignoring allowedActions, or rationing already
+        // spent) is coerced to the conservative fallback BEFORE persisting — a
+        // pause we cannot resume must never enter the turn history.
+        if (turn.action === 'ask_user' && !askUserAvailable) {
+          turnLog.warn('ask_user emitted while unavailable, coercing to conservative fallback', {
+            seat, isFinalTurn, taskId: state.taskId,
+          });
+          turn = { ...turn, action: fallbackActionFor(version, seat, isFinalTurn) };
+        }
+
         const parts = [{ kind: "data" as const, data: turn }];
         const message = await database.createMessage({
           conversationId: state.conversationId,
@@ -428,6 +494,96 @@ export class NegotiationGraphFactory {
           parts,
           taskId: state.taskId,
         });
+
+        // ─── ask_user pause (P3.2) ────────────────────────────────────────────
+        // The negotiator consults its OWN client: persist the turn (done above),
+        // park the full turn context, arm the answer-window timer, enqueue the
+        // question through the negotiation_inflight preset, then suspend the
+        // task as input_required. The graph exits at this turn boundary exactly
+        // like the waiting_for_agent suspend; the answer (or window expiry)
+        // resumes via the run-existing continuation path.
+        if (turn.action === 'ask_user') {
+          const disclosureSubject = turn.askUser?.disclosureSubject?.trim()
+            || turn.message
+            || turn.assessment.reasoning;
+          const draftQuestion = turn.askUser?.draftQuestion ?? turn.message ?? undefined;
+
+          await database.setTaskTurnContext(state.taskId, {
+            sourceUser: state.sourceUser,
+            candidateUser: state.candidateUser,
+            indexContext: state.indexContext,
+            seedAssessment: state.seedAssessment,
+            ...(isSource && state.discoveryQuery && { discoveryQuery: state.discoveryQuery }),
+          });
+
+          // Arm the timer BEFORE flipping state: a timer against a task that
+          // never reaches input_required no-ops harmlessly at fire time, while
+          // an input_required task without a timer would strand until the lock
+          // slack expires.
+          const windowMs = askUserAnswerWindowMs();
+          await timeoutQueue!.enqueueAskUserExpiry!(state.taskId, {
+            opportunityId: state.opportunityId,
+            userId: ownUser.id,
+            disclosureSubject,
+          }, windowMs);
+
+          // Counterparty referenced by attributes, never identity — the
+          // negotiation_inflight preset's referential-closure contract.
+          const counterpartyHint = [
+            otherUser.profile.bio,
+            otherUser.profile.location,
+            otherUser.profile.skills?.length ? `skills: ${otherUser.profile.skills.join(', ')}` : undefined,
+          ].filter(Boolean).join('; ') || 'a potential match on the network';
+          const userContext = (await database.getUserContext(ownUser.id, null).catch(() => null))?.text ?? '';
+
+          await questionerEnqueue!({
+            mode: 'negotiation_inflight',
+            userId: ownUser.id,
+            sourceType: 'opportunity',
+            sourceId: state.opportunityId,
+            context: {
+              negotiationId: state.taskId,
+              counterpartyHint,
+              disclosureSubject,
+              ...(draftQuestion && { draftQuestion }),
+              indexContext: state.indexContext.prompt,
+              ...(userContext && { userContext }),
+            },
+          });
+
+          await database.updateTaskState(state.taskId, 'input_required');
+
+          turnLog.info('negotiation_ask_user_pause', {
+            taskId: state.taskId,
+            opportunityId: state.opportunityId,
+            seat,
+            askingUserId: ownUser.id,
+            windowMs,
+          });
+          traceEmitter?.({ type: "agent_end", name: agentName, durationMs: Date.now() - agentStart, summary: "ask_user" });
+          emitWide({
+            type: 'negotiation_ask_user',
+            opportunityId: state.opportunityId,
+            negotiationConversationId: state.conversationId,
+            turnIndex: state.turnCount,
+            actor: isSource ? 'source' : 'candidate',
+            disclosureSubject,
+            windowMs,
+          });
+
+          return {
+            messages: [{
+              id: message.id,
+              senderId: message.senderId,
+              role: "agent" as const,
+              parts: message.parts,
+              createdAt: message.createdAt,
+            }],
+            turnCount: state.turnCount + 1,
+            lastTurn: turn,
+            status: 'input_required' as const,
+          };
+        }
 
         await database.updateTaskState(state.taskId, "working");
 
@@ -478,6 +634,7 @@ export class NegotiationGraphFactory {
 
     const evaluateNode = (state: typeof NegotiationGraphState.State): string => {
       if (state.status === 'waiting_for_agent') return "finalize";
+      if (state.status === 'input_required') return "finalize";
       if (state.error) return "finalize";
       if (!state.lastTurn) return "finalize";
       // Terminal actions: accept (v1+v2), reject (v1), withdraw/decline (v2)
@@ -498,6 +655,21 @@ export class NegotiationGraphFactory {
             type: "negotiation_outcome",
             opportunityId: state.opportunityId,
             outcome: "waiting_for_agent",
+            turnCount: state.turnCount,
+            isContinuation: state.isContinuation,
+          });
+        }
+        return {};
+      }
+
+      // ask_user pause: no outcome, no completed state — the task stays
+      // input_required until the client answers or the window expires.
+      if (state.status === 'input_required') {
+        if (state.opportunityId) {
+          emitWide({
+            type: "negotiation_outcome",
+            opportunityId: state.opportunityId,
+            outcome: "input_required",
             turnCount: state.turnCount,
             isContinuation: state.isContinuation,
           });

--- a/packages/protocol/src/negotiation/negotiation.protocol.ts
+++ b/packages/protocol/src/negotiation/negotiation.protocol.ts
@@ -19,6 +19,7 @@
  */
 import { z } from "zod";
 
+import { AskUserPayloadSchema } from "../shared/schemas/negotiation-state.schema.js";
 import type { NegotiationAction, NegotiationSeat, NegotiationProtocolVersion } from "../shared/schemas/negotiation-state.schema.js";
 
 // ─── Shared assessment fragment ──────────────────────────────────────────────
@@ -36,6 +37,8 @@ function turnSchema<T extends [NegotiationAction, ...NegotiationAction[]]>(actio
     action: z.enum(actions),
     assessment: AssessmentSchema,
     message: z.string().nullable().optional(),
+    /** Present when action is `ask_user` (v2, P3.2). */
+    askUser: AskUserPayloadSchema.nullable().optional(),
   });
 }
 
@@ -53,6 +56,17 @@ export const FinalInitiatorTurnSchema = turnSchema(["withdraw", "counter"]);
 /** Counterparty seat, final allowed turn: must decide. */
 export const FinalCounterpartyTurnSchema = turnSchema(["accept", "decline"]);
 
+// ─── v2 ask_user variants (P3.2, flag-gated) ────────────────────────────────
+// Non-final turns only: the final-cap turn must decide, never pause. Selected
+// via the `opts.askUser` parameter on allowedActionsFor/turnSchemaFor — the
+// base schemas above stay byte-identical for every existing caller.
+
+/** Initiator seat, non-final turn, with the client-consult pause available. */
+export const InitiatorAskUserTurnSchema = turnSchema(["outreach", "counter", "question", "withdraw", "ask_user"]);
+
+/** Counterparty seat, non-final turn, with the client-consult pause available. */
+export const CounterpartyAskUserTurnSchema = turnSchema(["accept", "decline", "counter", "question", "ask_user"]);
+
 // ─── Action vocabulary per version + seat ────────────────────────────────────
 
 const V1_ACTIONS: readonly NegotiationAction[] = ["propose", "accept", "reject", "counter", "question"];
@@ -61,6 +75,8 @@ const V2_INITIATOR_ACTIONS: readonly NegotiationAction[] = ["outreach", "counter
 const V2_COUNTERPARTY_ACTIONS: readonly NegotiationAction[] = ["accept", "decline", "counter", "question"];
 const V2_FINAL_INITIATOR_ACTIONS: readonly NegotiationAction[] = ["withdraw", "counter"];
 const V2_FINAL_COUNTERPARTY_ACTIONS: readonly NegotiationAction[] = ["accept", "decline"];
+const V2_INITIATOR_ASK_USER_ACTIONS: readonly NegotiationAction[] = [...V2_INITIATOR_ACTIONS, "ask_user"];
+const V2_COUNTERPARTY_ASK_USER_ACTIONS: readonly NegotiationAction[] = [...V2_COUNTERPARTY_ACTIONS, "ask_user"];
 
 /**
  * The set of actions a given seat may submit under a given protocol version.
@@ -72,10 +88,14 @@ export function allowedActionsFor(
   version: NegotiationProtocolVersion,
   seat: NegotiationSeat,
   isFinalTurn = false,
+  opts?: AskUserOpts,
 ): readonly NegotiationAction[] {
   if (version !== "v2") return isFinalTurn ? V1_FINAL_ACTIONS : V1_ACTIONS;
-  if (seat === "initiator") return isFinalTurn ? V2_FINAL_INITIATOR_ACTIONS : V2_INITIATOR_ACTIONS;
-  return isFinalTurn ? V2_FINAL_COUNTERPARTY_ACTIONS : V2_COUNTERPARTY_ACTIONS;
+  const askUser = opts?.askUser === true && !isFinalTurn;
+  if (seat === "initiator") {
+    return isFinalTurn ? V2_FINAL_INITIATOR_ACTIONS : (askUser ? V2_INITIATOR_ASK_USER_ACTIONS : V2_INITIATOR_ACTIONS);
+  }
+  return isFinalTurn ? V2_FINAL_COUNTERPARTY_ACTIONS : (askUser ? V2_COUNTERPARTY_ASK_USER_ACTIONS : V2_COUNTERPARTY_ACTIONS);
 }
 
 /**
@@ -92,10 +112,27 @@ export function turnSchemaFor(
   seat: NegotiationSeat,
   isFinalTurn: boolean,
   v1Schemas: { system: z.ZodTypeAny; final: z.ZodTypeAny },
+  opts?: AskUserOpts,
 ): z.ZodTypeAny {
   if (version !== "v2") return isFinalTurn ? v1Schemas.final : v1Schemas.system;
-  if (seat === "initiator") return isFinalTurn ? FinalInitiatorTurnSchema : InitiatorTurnSchema;
-  return isFinalTurn ? FinalCounterpartyTurnSchema : CounterpartyTurnSchema;
+  const askUser = opts?.askUser === true && !isFinalTurn;
+  if (seat === "initiator") {
+    return isFinalTurn ? FinalInitiatorTurnSchema : (askUser ? InitiatorAskUserTurnSchema : InitiatorTurnSchema);
+  }
+  return isFinalTurn ? FinalCounterpartyTurnSchema : (askUser ? CounterpartyAskUserTurnSchema : CounterpartyTurnSchema);
+}
+
+/**
+ * Opt-in extension of the seat vocabulary with the `ask_user` client-consult
+ * pause (P3.2). Never granted on final-cap turns (the final turn must decide)
+ * and never under v1. Callers pass `{ askUser: true }` only when the full
+ * pause loop is available on their surface: the ask-user feature flag is on,
+ * a questioner enqueue and an answer-window timer are wired, the negotiation
+ * has an opportunity to resume against, and the acting side has not already
+ * consumed its one client question for this negotiation (rationing).
+ */
+export interface AskUserOpts {
+  askUser?: boolean;
 }
 
 // ─── Action semantics (version-independent) ──────────────────────────────────
@@ -160,6 +197,41 @@ export function readProtocolVersion(
 export function configuredProtocolVersion(): NegotiationProtocolVersion {
   return process.env.NEGOTIATION_PROTOCOL_VERSION === "v2" ? "v2" : "v1";
 }
+
+/**
+ * Whether the `ask_user` client-consult pause (P3.2) is enabled, from the
+ * `NEGOTIATION_ASK_USER_ENABLED` env switch. Defaults to off — the deployment
+ * is byte-for-byte unchanged until the flag is flipped, and rolling back is
+ * the same single switch.
+ */
+export function configuredAskUserEnabled(): boolean {
+  return process.env.NEGOTIATION_ASK_USER_ENABLED === "true";
+}
+
+/** Default answer window for a paused `ask_user` negotiation: 24 hours. */
+export const DEFAULT_ASK_USER_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Answer window for a paused `ask_user` negotiation, in ms. Overridable via
+ * `NEGOTIATION_ASK_USER_WINDOW_MS` (dev/e2e use shorter windows to exercise
+ * the expiry path); invalid or non-positive values fall back to 24 h.
+ */
+export function askUserAnswerWindowMs(): number {
+  const raw = process.env.NEGOTIATION_ASK_USER_WINDOW_MS;
+  if (raw) {
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return DEFAULT_ASK_USER_WINDOW_MS;
+}
+
+/**
+ * Slack added on top of the answer window when deciding whether a paused
+ * (`input_required`) task still holds the conversation lock. Covers expiry
+ * worker delay: the lock must outlive the timer slightly, so ambient
+ * rediscovery cannot slip in between window expiry and the worker's resume.
+ */
+export const ASK_USER_LOCK_SLACK_MS = 60 * 60 * 1000;
 
 /**
  * Resolve the seat of `userId` on a negotiation task.

--- a/packages/protocol/src/negotiation/negotiation.state.ts
+++ b/packages/protocol/src/negotiation/negotiation.state.ts
@@ -2,7 +2,7 @@ import { Annotation } from "@langchain/langgraph";
 import { z } from "zod";
 import type { NegotiationUserAnswer } from "../shared/interfaces/database.interface.js";
 import type { ScreenDecisionRecord } from "./negotiation.screen.js";
-import { NEGOTIATION_ACTIONS, type NegotiationProtocolVersion } from "../shared/schemas/negotiation-state.schema.js";
+import { AskUserPayloadSchema, NEGOTIATION_ACTIONS, type NegotiationProtocolVersion } from "../shared/schemas/negotiation-state.schema.js";
 
 /**
  * Zod schema for a single negotiation turn (DataPart payload in A2A message).
@@ -19,6 +19,8 @@ export const NegotiationTurnSchema = z.object({
     }),
   }),
   message: z.string().nullable().optional(),
+  /** Present when action is `ask_user` (v2, P3.2). */
+  askUser: AskUserPayloadSchema.nullable().optional(),
 });
 
 /** Restricted v1 turn schema for the system agent (no question action). */
@@ -222,9 +224,11 @@ export const NegotiationGraphState = Annotation.Root({
    * Graph status.
    * - `active` — agents are exchanging turns (default)
    * - `waiting_for_agent` — graph suspended; awaiting external agent response or timeout
+   * - `input_required` — graph suspended on an `ask_user` pause; awaiting the
+   *   negotiator's own client (answer or 24 h window expiry resumes it)
    * - `completed` — negotiation finalized (accept/reject/turn-cap/timeout)
    */
-  status: Annotation<'active' | 'waiting_for_agent' | 'completed'>({
+  status: Annotation<'active' | 'waiting_for_agent' | 'input_required' | 'completed'>({
     reducer: (curr, next) => next ?? curr,
     default: () => 'active' as const,
   }),

--- a/packages/protocol/src/negotiation/tests/negotiation.agent.ask-user.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.agent.ask-user.spec.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "bun:test";
+import { IndexNegotiator } from "../negotiation.agent.js";
+import type { NegotiationAgentInput } from "../negotiation.agent.js";
+
+/**
+ * IND-401 — IndexNegotiator `canAskUser` contract.
+ *
+ * Uses the `callModel` seam (no live provider): the subclass captures the
+ * system prompt and feeds scripted outputs into the validate loop, pinning:
+ * - the ask_user rule appears in the prompt ONLY when canAskUser is granted,
+ * - the schema accepts an ask_user turn (with payload) only when granted,
+ * - without the grant an ask_user output is schema-invalid → conservative
+ *   fallback after the retry,
+ * - v1 and final turns never gain the action even with canAskUser set.
+ */
+
+class CapturingNegotiator extends IndexNegotiator {
+  calls = 0;
+  systemPrompts: string[] = [];
+  constructor(private outputs: unknown[]) {
+    super({ turnTimeoutMs: 1000 });
+  }
+  protected override async callModel(
+    _model: unknown,
+    chatMessages: Array<{ role: string; content: string }>,
+  ): Promise<unknown> {
+    this.systemPrompts.push(chatMessages[0].content);
+    const out = this.outputs[Math.min(this.calls, this.outputs.length - 1)];
+    this.calls += 1;
+    return out;
+  }
+}
+
+const baseInput: NegotiationAgentInput = {
+  ownUser: { id: "u-init", intents: [], profile: { name: "Alice" } },
+  otherUser: { id: "u-cp", intents: [], profile: { name: "Bob" } },
+  indexContext: { networkId: "net-1", prompt: "" },
+  seedAssessment: { reasoning: "seed", valencyRole: "peer" },
+  history: [{ action: "counter", assessment: { reasoning: "r", suggestedRoles: { ownUser: "peer", otherUser: "peer" } }, message: null }],
+  seat: "initiator",
+  protocolVersion: "v2",
+};
+
+const askUserOutput = {
+  action: "ask_user",
+  assessment: { reasoning: "need permission", suggestedRoles: { ownUser: "peer", otherUser: "peer" } },
+  message: null,
+  askUser: { disclosureSubject: "budget range", draftQuestion: "Share your budget?" },
+};
+
+function validTurn(action: string) {
+  return {
+    action,
+    assessment: { reasoning: "ok", suggestedRoles: { ownUser: "peer", otherUser: "peer" } },
+    message: null,
+  };
+}
+
+describe("IndexNegotiator — canAskUser (IND-401)", () => {
+  it("accepts an ask_user turn with payload when granted, and the prompt carries the rule", async () => {
+    const agent = new CapturingNegotiator([askUserOutput]);
+    const turn = await agent.invoke({ ...baseInput, canAskUser: true });
+    expect(turn.action).toBe("ask_user");
+    expect(turn.askUser?.disclosureSubject).toBe("budget range");
+    expect(agent.calls).toBe(1);
+    expect(agent.systemPrompts[0]).toContain('"ask_user"');
+    expect(agent.systemPrompts[0]).toContain("AT MOST ONE client consultation");
+    // The {userName} placeholder inside the rule is substituted.
+    expect(agent.systemPrompts[0]).toContain("Alice's OWN input");
+  });
+
+  it("counterparty seat gains the same rule when granted", async () => {
+    const agent = new CapturingNegotiator([askUserOutput]);
+    const turn = await agent.invoke({ ...baseInput, seat: "counterparty", canAskUser: true });
+    expect(turn.action).toBe("ask_user");
+    expect(agent.systemPrompts[0]).toContain('"ask_user"');
+  });
+
+  it("without the grant, ask_user output is schema-invalid → retry → conservative fallback", async () => {
+    const agent = new CapturingNegotiator([askUserOutput, askUserOutput]);
+    const turn = await agent.invoke(baseInput);
+    expect(turn.action).toBe("counter");
+    expect(agent.calls).toBe(2);
+    expect(agent.systemPrompts[0]).not.toContain("ask_user");
+  });
+
+  it("v1 never gains the action even with canAskUser set", async () => {
+    const agent = new CapturingNegotiator([askUserOutput, validTurn("counter")]);
+    const turn = await agent.invoke({ ...baseInput, protocolVersion: "v1", seat: "initiator", canAskUser: true });
+    expect(turn.action).toBe("counter");
+    expect(agent.systemPrompts[0]).not.toContain("ask_user");
+  });
+
+  it("final turns never gain the action even with canAskUser set", async () => {
+    const agent = new CapturingNegotiator([askUserOutput, validTurn("withdraw")]);
+    const turn = await agent.invoke({ ...baseInput, isFinalTurn: true, canAskUser: true });
+    expect(turn.action).toBe("withdraw");
+    expect(agent.systemPrompts[0]).not.toContain('"ask_user"');
+  });
+});

--- a/packages/protocol/src/negotiation/tests/negotiation.ask-user.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.ask-user.spec.ts
@@ -1,0 +1,460 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+import { NegotiationGraphFactory } from "../negotiation.graph.js";
+import { NegotiationGraphState } from "../negotiation.state.js";
+import { IndexNegotiator, type NegotiationAgentInput } from "../negotiation.agent.js";
+import { allowedActionsFor, turnSchemaFor, configuredAskUserEnabled, askUserAnswerWindowMs, DEFAULT_ASK_USER_WINDOW_MS, ASK_USER_LOCK_SLACK_MS, InitiatorTurnSchema, CounterpartyTurnSchema, InitiatorAskUserTurnSchema, CounterpartyAskUserTurnSchema } from "../negotiation.protocol.js";
+import { SystemNegotiationTurnSchema, FinalNegotiationTurnSchema } from "../negotiation.state.js";
+import type { NegotiationTurn } from "../negotiation.state.js";
+import type { QuestionerEnqueuePayload } from "../../questioner/questioner.types.js";
+
+/**
+ * IND-401 — `ask_user` client-consult pause (P3.2).
+ *
+ * Pins:
+ * - vocabulary: ask_user is opt-in per surface ({ askUser: true }), v2
+ *   non-final only; base schemas stay byte-identical,
+ * - graph pause loop: ask_user turn → message persisted → turn context parked
+ *   → answer-window timer armed → negotiation_inflight question enqueued →
+ *   task input_required → graph exits without an outcome,
+ * - availability gating: flag, wiring (questioner + timer + opportunityId),
+ *   opening turn, final turn, and per-side rationing,
+ * - coercion: an unavailable ask_user never enters the turn history,
+ * - lock-gate extension: input_required tasks hold the conversation lock for
+ *   the full answer window, not the 5-min turn freshness,
+ * - resume floor: an ask_user last turn does not pass the floor — the asker
+ *   speaks again on the continuation.
+ */
+
+// ─── Vocabulary + schema (pure) ──────────────────────────────────────────────
+
+const askUserTurn: NegotiationTurn = {
+  action: "ask_user",
+  assessment: { reasoning: "need client input", suggestedRoles: { ownUser: "peer", otherUser: "peer" } },
+  message: "May I share your budget range?",
+  askUser: { disclosureSubject: "budget range", draftQuestion: "Can I tell them your budget range?" },
+};
+
+describe("ask_user vocabulary + seat schemas", () => {
+  it("is excluded everywhere by default (no opts)", () => {
+    expect(allowedActionsFor("v2", "initiator")).not.toContain("ask_user");
+    expect(allowedActionsFor("v2", "counterparty")).not.toContain("ask_user");
+    expect(allowedActionsFor("v1", "initiator")).not.toContain("ask_user");
+  });
+
+  it("is granted per surface via opts.askUser, v2 non-final only", () => {
+    expect(allowedActionsFor("v2", "initiator", false, { askUser: true })).toContain("ask_user");
+    expect(allowedActionsFor("v2", "counterparty", false, { askUser: true })).toContain("ask_user");
+    // Final-cap turns must decide, never pause.
+    expect(allowedActionsFor("v2", "initiator", true, { askUser: true })).not.toContain("ask_user");
+    expect(allowedActionsFor("v2", "counterparty", true, { askUser: true })).not.toContain("ask_user");
+    // v1 has no ask_user regardless.
+    expect(allowedActionsFor("v1", "initiator", false, { askUser: true })).not.toContain("ask_user");
+  });
+
+  it("keeps the base v2 vocabularies byte-identical", () => {
+    expect([...allowedActionsFor("v2", "initiator")]).toEqual(["outreach", "counter", "question", "withdraw"]);
+    expect([...allowedActionsFor("v2", "counterparty")]).toEqual(["accept", "decline", "counter", "question"]);
+  });
+
+  it("turnSchemaFor selects the ask_user schema variants only when granted", () => {
+    const v1Schemas = { system: SystemNegotiationTurnSchema, final: FinalNegotiationTurnSchema };
+    expect(turnSchemaFor("v2", "initiator", false, v1Schemas, { askUser: true })).toBe(InitiatorAskUserTurnSchema);
+    expect(turnSchemaFor("v2", "counterparty", false, v1Schemas, { askUser: true })).toBe(CounterpartyAskUserTurnSchema);
+    expect(turnSchemaFor("v2", "initiator", false, v1Schemas)).toBe(InitiatorTurnSchema);
+    expect(turnSchemaFor("v2", "counterparty", false, v1Schemas)).toBe(CounterpartyTurnSchema);
+    // Final turns never get the variant.
+    expect(turnSchemaFor("v2", "initiator", true, v1Schemas, { askUser: true })).not.toBe(InitiatorAskUserTurnSchema);
+  });
+
+  it("ask_user variants parse an ask_user turn with payload; base schemas reject it", () => {
+    expect(InitiatorAskUserTurnSchema.safeParse(askUserTurn).success).toBe(true);
+    expect(CounterpartyAskUserTurnSchema.safeParse(askUserTurn).success).toBe(true);
+    expect(InitiatorTurnSchema.safeParse(askUserTurn).success).toBe(false);
+    expect(CounterpartyTurnSchema.safeParse(askUserTurn).success).toBe(false);
+  });
+
+  it("env helpers: flag defaults off; window defaults 24h and accepts overrides", () => {
+    const origEnabled = process.env.NEGOTIATION_ASK_USER_ENABLED;
+    const origWindow = process.env.NEGOTIATION_ASK_USER_WINDOW_MS;
+    try {
+      delete process.env.NEGOTIATION_ASK_USER_ENABLED;
+      delete process.env.NEGOTIATION_ASK_USER_WINDOW_MS;
+      expect(configuredAskUserEnabled()).toBe(false);
+      expect(askUserAnswerWindowMs()).toBe(DEFAULT_ASK_USER_WINDOW_MS);
+      process.env.NEGOTIATION_ASK_USER_ENABLED = "true";
+      expect(configuredAskUserEnabled()).toBe(true);
+      process.env.NEGOTIATION_ASK_USER_WINDOW_MS = "60000";
+      expect(askUserAnswerWindowMs()).toBe(60_000);
+      process.env.NEGOTIATION_ASK_USER_WINDOW_MS = "-5";
+      expect(askUserAnswerWindowMs()).toBe(DEFAULT_ASK_USER_WINDOW_MS);
+    } finally {
+      if (origEnabled === undefined) delete process.env.NEGOTIATION_ASK_USER_ENABLED; else process.env.NEGOTIATION_ASK_USER_ENABLED = origEnabled;
+      if (origWindow === undefined) delete process.env.NEGOTIATION_ASK_USER_WINDOW_MS; else process.env.NEGOTIATION_ASK_USER_WINDOW_MS = origWindow;
+    }
+  });
+});
+
+// ─── Graph harness ───────────────────────────────────────────────────────────
+
+type FakeMessage = {
+  id: string;
+  senderId: string;
+  role: "agent";
+  parts: unknown[];
+  createdAt: Date;
+};
+
+function priorMsg(senderUserId: string, action: string, idx: number): FakeMessage {
+  return {
+    id: `prior-${idx}`,
+    senderId: `agent:${senderUserId}`,
+    role: "agent",
+    parts: [{ kind: "data", data: { action, assessment: { reasoning: "r", suggestedRoles: { ownUser: "peer", otherUser: "peer" } }, message: null } }],
+    createdAt: new Date(Date.now() - (100 - idx) * 1000),
+  };
+}
+
+/** Prior task metadata pinning the conversation to v2 with u-src as initiator. */
+const V2_PRIOR_TASK = {
+  id: "task-prior",
+  conversationId: "conv-1",
+  state: "completed",
+  metadata: { type: "negotiation", protocolVersion: "v2", initiatorUserId: "u-src", sourceUserId: "u-src", candidateUserId: "u-cand" },
+  createdAt: new Date(Date.now() - 3_600_000),
+  updatedAt: new Date(Date.now() - 3_600_000),
+};
+
+function mkStubs(opts?: {
+  priorMessages?: FakeMessage[];
+  priorTask?: Record<string, unknown> | null;
+}) {
+  const createdMessages: Array<{ senderId: string; parts: Array<{ kind: string; data: NegotiationTurn }> }> = [];
+  const stateWrites: Array<{ taskId: string; state: string }> = [];
+  const turnContextWrites: Array<{ taskId: string }> = [];
+  const database = {
+    getOrCreateDM: async () => ({ id: "conv-1" }),
+    createTask: async (conversationId: string) => ({ id: "task-new", conversationId, state: "submitted" }),
+    updateOpportunityStatus: async () => {},
+    createMessage: async (p: { senderId: string; parts: Array<{ kind: string; data: NegotiationTurn }> }) => {
+      createdMessages.push(p);
+      return { id: `msg-${createdMessages.length}`, senderId: p.senderId, parts: p.parts, createdAt: new Date() };
+    },
+    updateTaskState: async (taskId: string, state: string) => {
+      stateWrites.push({ taskId, state });
+    },
+    createArtifact: async () => {},
+    setTaskTurnContext: async (taskId: string) => {
+      turnContextWrites.push({ taskId });
+    },
+    getMessagesForConversation: async () => opts?.priorMessages ?? [],
+    getOpportunityUserAnswers: async () => [],
+    getNegotiationTaskForOpportunity: async () => (opts?.priorTask === undefined ? V2_PRIOR_TASK : opts.priorTask),
+    getLatestNegotiationTaskForConversation: async () => null,
+    getUserContext: async () => ({ text: "Alice builds AI startups" }),
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[0];
+
+  const dispatcher = {
+    hasExternalAgent: async () => false,
+    dispatch: async () => ({ handled: false, reason: "no_agent" }),
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[1];
+
+  const expiryArms: Array<{ negotiationId: string; payload: Record<string, unknown>; delayMs: number }> = [];
+  const timeoutQueue = {
+    enqueueTimeout: async () => "job-1",
+    cancelTimeout: async () => {},
+    enqueueAskUserExpiry: async (negotiationId: string, payload: Record<string, unknown>, delayMs: number) => {
+      expiryArms.push({ negotiationId, payload, delayMs });
+      return "askuser-job-1";
+    },
+    cancelAskUserExpiry: async () => {},
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[2];
+
+  const questionerEnqueues: QuestionerEnqueuePayload[] = [];
+  const questionerEnqueue = async (input: QuestionerEnqueuePayload) => {
+    questionerEnqueues.push(input);
+  };
+
+  return { database, dispatcher, timeoutQueue, questionerEnqueue, createdMessages, stateWrites, turnContextWrites, expiryArms, questionerEnqueues };
+}
+
+async function runGraph(
+  stubs: ReturnType<typeof mkStubs>,
+  input: Record<string, unknown> = {},
+  opts?: { omitTimeoutQueue?: boolean; omitQuestioner?: boolean },
+) {
+  const graph = new NegotiationGraphFactory(
+    stubs.database,
+    stubs.dispatcher,
+    opts?.omitTimeoutQueue ? undefined : stubs.timeoutQueue,
+    opts?.omitQuestioner ? undefined : stubs.questionerEnqueue,
+  ).createGraph();
+  return graph.invoke({
+    sourceUser: { id: "u-src", intents: [], profile: { name: "Alice", bio: "PM", skills: ["product"] } },
+    candidateUser: { id: "u-cand", intents: [], profile: { name: "Bob", bio: "ML engineer", location: "Berlin", skills: ["ml"] } },
+    indexContext: { networkId: "net-1", prompt: "AI startup network" },
+    seedAssessment: { reasoning: "complementary", valencyRole: "peer" },
+    opportunityId: "opp-1",
+    maxTurns: 4,
+    ...input,
+  } as Partial<typeof NegotiationGraphState.State>);
+}
+
+// Scripted system-agent turns + captured inputs.
+let agentInputs: NegotiationAgentInput[] = [];
+let agentScript: NegotiationTurn[] = [];
+
+const declineTurn: NegotiationTurn = {
+  action: "decline",
+  assessment: { reasoning: "not a fit", suggestedRoles: { ownUser: "peer", otherUser: "peer" } },
+  message: null,
+};
+
+describe("negotiation graph — ask_user pause (IND-401)", () => {
+  let origAgentInvoke: typeof IndexNegotiator.prototype.invoke;
+  const origFlag = process.env.NEGOTIATION_ASK_USER_ENABLED;
+  const origWindow = process.env.NEGOTIATION_ASK_USER_WINDOW_MS;
+
+  beforeAll(() => {
+    origAgentInvoke = IndexNegotiator.prototype.invoke;
+    IndexNegotiator.prototype.invoke = async function (input: NegotiationAgentInput) {
+      agentInputs.push(input);
+      const turn = agentScript.shift();
+      if (!turn) throw new Error("agent script exhausted");
+      return turn;
+    };
+  });
+
+  afterAll(() => {
+    IndexNegotiator.prototype.invoke = origAgentInvoke;
+  });
+
+  beforeEach(() => {
+    agentInputs = [];
+    agentScript = [];
+    process.env.NEGOTIATION_ASK_USER_ENABLED = "true";
+    delete process.env.NEGOTIATION_ASK_USER_WINDOW_MS;
+  });
+
+  afterEach(() => {
+    if (origFlag === undefined) delete process.env.NEGOTIATION_ASK_USER_ENABLED; else process.env.NEGOTIATION_ASK_USER_ENABLED = origFlag;
+    if (origWindow === undefined) delete process.env.NEGOTIATION_ASK_USER_WINDOW_MS; else process.env.NEGOTIATION_ASK_USER_WINDOW_MS = origWindow;
+  });
+
+  /** Continuation where the source (u-src, initiator) speaks next. */
+  const continuationMessages = [priorMsg("u-src", "outreach", 0), priorMsg("u-cand", "counter", 1)];
+
+  it("pauses the full loop: message + turn context + timer + question + input_required, no outcome", async () => {
+    const stubs = mkStubs({ priorMessages: continuationMessages });
+    agentScript = [askUserTurn];
+
+    const result = await runGraph(stubs);
+
+    // Turn persisted with the ask_user action.
+    expect(stubs.createdMessages).toHaveLength(1);
+    expect(stubs.createdMessages[0].parts[0].data.action).toBe("ask_user");
+    expect(stubs.createdMessages[0].senderId).toBe("agent:u-src");
+
+    // Turn context parked for pickup/resume.
+    expect(stubs.turnContextWrites).toEqual([{ taskId: "task-new" }]);
+
+    // Answer-window timer armed with resume coordinates + default window.
+    expect(stubs.expiryArms).toHaveLength(1);
+    expect(stubs.expiryArms[0].negotiationId).toBe("task-new");
+    expect(stubs.expiryArms[0].payload).toEqual({
+      opportunityId: "opp-1",
+      userId: "u-src",
+      disclosureSubject: "budget range",
+    });
+    expect(stubs.expiryArms[0].delayMs).toBe(DEFAULT_ASK_USER_WINDOW_MS);
+
+    // Question enqueued through the negotiation_inflight preset for the
+    // asker's OWN client, counterparty referenced by attributes.
+    expect(stubs.questionerEnqueues).toHaveLength(1);
+    const q = stubs.questionerEnqueues[0];
+    expect(q.mode).toBe("negotiation_inflight");
+    expect(q.userId).toBe("u-src");
+    expect(q.sourceType).toBe("opportunity");
+    expect(q.sourceId).toBe("opp-1");
+    const ctx = q.context as Record<string, unknown>;
+    expect(ctx.negotiationId).toBe("task-new");
+    expect(ctx.disclosureSubject).toBe("budget range");
+    expect(ctx.draftQuestion).toBe("Can I tell them your budget range?");
+    expect(ctx.counterpartyHint).toContain("ML engineer");
+    expect(ctx.counterpartyHint).not.toContain("Bob");
+    expect(ctx.indexContext).toBe("AI startup network");
+    expect(ctx.userContext).toBe("Alice builds AI startups");
+
+    // Task suspended as input_required; no completed transition, no outcome.
+    expect(stubs.stateWrites).toContainEqual({ taskId: "task-new", state: "input_required" });
+    expect(stubs.stateWrites.map((w) => w.state)).not.toContain("completed");
+    expect(result.outcome).toBeNull();
+  });
+
+  it("respects the env window override when arming the timer", async () => {
+    process.env.NEGOTIATION_ASK_USER_WINDOW_MS = "120000";
+    const stubs = mkStubs({ priorMessages: continuationMessages });
+    agentScript = [askUserTurn];
+    await runGraph(stubs);
+    expect(stubs.expiryArms[0].delayMs).toBe(120_000);
+  });
+
+  it("grants canAskUser to the agent when the loop is fully wired", async () => {
+    const stubs = mkStubs({ priorMessages: continuationMessages });
+    agentScript = [askUserTurn];
+    await runGraph(stubs);
+    expect(agentInputs[0].canAskUser).toBe(true);
+  });
+
+  it.each([
+    ["flag off", { env: "false" }],
+    ["questioner missing", { omitQuestioner: true }],
+    ["timer missing", { omitTimeoutQueue: true }],
+    ["no opportunityId", { noOpportunity: true }],
+  ] as Array<[string, { env?: string; omitQuestioner?: boolean; omitTimeoutQueue?: boolean; noOpportunity?: boolean }]>)(
+    "withholds canAskUser when %s",
+    async (_label, cfg) => {
+      if (cfg.env) process.env.NEGOTIATION_ASK_USER_ENABLED = cfg.env;
+      const stubs = mkStubs({ priorMessages: continuationMessages });
+      agentScript = [declineTurn];
+      await runGraph(
+        stubs,
+        cfg.noOpportunity ? { opportunityId: "" } : {},
+        { omitQuestioner: cfg.omitQuestioner, omitTimeoutQueue: cfg.omitTimeoutQueue },
+      );
+      expect(agentInputs[0].canAskUser).toBeUndefined();
+    },
+  );
+
+  it("withholds canAskUser on the opening turn of a fresh negotiation", async () => {
+    const stubs = mkStubs({ priorMessages: [], priorTask: null });
+    const origVersion = process.env.NEGOTIATION_PROTOCOL_VERSION;
+    process.env.NEGOTIATION_PROTOCOL_VERSION = "v2";
+    try {
+      agentScript = [
+        { ...declineTurn, action: "outreach" },
+        declineTurn,
+      ];
+      await runGraph(stubs);
+      expect(agentInputs[0].canAskUser).toBeUndefined();
+      // Subsequent turn (turnCount > 0) regains it.
+      expect(agentInputs[1].canAskUser).toBe(true);
+    } finally {
+      if (origVersion === undefined) delete process.env.NEGOTIATION_PROTOCOL_VERSION; else process.env.NEGOTIATION_PROTOCOL_VERSION = origVersion;
+    }
+  });
+
+  it("rations: a side that already consumed ask_user does not get it again (prior sessions count)", async () => {
+    const stubs = mkStubs({
+      priorMessages: [
+        priorMsg("u-src", "outreach", 0),
+        priorMsg("u-cand", "counter", 1),
+        priorMsg("u-src", "ask_user", 2),
+        priorMsg("u-src", "counter", 3),
+      ],
+    });
+    // Last sender u-src (counter) → candidate speaks; give the candidate a
+    // decline so the run terminates after one turn.
+    agentScript = [declineTurn];
+    await runGraph(stubs);
+    // u-cand has NOT consumed its consultation — it still gets the option.
+    expect(agentInputs[0].canAskUser).toBe(true);
+
+    // Now the source side speaks (candidate countered): no second consultation.
+    const stubs2 = mkStubs({
+      priorMessages: [
+        priorMsg("u-src", "outreach", 0),
+        priorMsg("u-src", "ask_user", 1),
+        priorMsg("u-cand", "counter", 2),
+      ],
+    });
+    agentInputs = [];
+    agentScript = [{ ...declineTurn, action: "withdraw" }];
+    await runGraph(stubs2);
+    expect(agentInputs[0].canAskUser).toBeUndefined();
+  });
+
+  it("coerces an unavailable ask_user to the conservative fallback before persisting", async () => {
+    process.env.NEGOTIATION_ASK_USER_ENABLED = "false";
+    const stubs = mkStubs({ priorMessages: continuationMessages });
+    // Script: agent emits ask_user anyway (schema would prevent this for the
+    // system agent; this pins the safety net for dispatched turns), then the
+    // counterparty declines to terminate.
+    agentScript = [askUserTurn, declineTurn];
+    await runGraph(stubs);
+    expect(stubs.createdMessages[0].parts[0].data.action).toBe("counter");
+    expect(stubs.questionerEnqueues).toHaveLength(0);
+    expect(stubs.expiryArms).toHaveLength(0);
+    expect(stubs.stateWrites.map((w) => w.state)).not.toContain("input_required");
+  });
+
+  it("lock gate: an input_required task older than 5 min still holds the conversation lock", async () => {
+    const stubs = mkStubs({
+      priorMessages: continuationMessages,
+      priorTask: {
+        ...V2_PRIOR_TASK,
+        state: "input_required",
+        updatedAt: new Date(Date.now() - 10 * 60 * 1000), // 10 min — stale under the old 5-min rule
+      },
+    });
+    agentScript = [declineTurn];
+    const result = await runGraph(stubs);
+    expect(result.error).toBe("busy");
+    expect(stubs.createdMessages).toHaveLength(0);
+  });
+
+  it("lock gate: an input_required task past window+slack releases the lock", async () => {
+    const stubs = mkStubs({
+      priorMessages: continuationMessages,
+      priorTask: {
+        ...V2_PRIOR_TASK,
+        state: "input_required",
+        updatedAt: new Date(Date.now() - DEFAULT_ASK_USER_WINDOW_MS - ASK_USER_LOCK_SLACK_MS - 60_000),
+      },
+    });
+    agentScript = [declineTurn];
+    const result = await runGraph(stubs);
+    expect(result.error).not.toBe("busy");
+    expect(stubs.createdMessages).toHaveLength(1);
+  });
+
+  it("lock gate: a working task older than 5 min does NOT hold the lock (unchanged)", async () => {
+    const stubs = mkStubs({
+      priorMessages: continuationMessages,
+      priorTask: {
+        ...V2_PRIOR_TASK,
+        state: "working",
+        updatedAt: new Date(Date.now() - 10 * 60 * 1000),
+      },
+    });
+    agentScript = [declineTurn];
+    const result = await runGraph(stubs);
+    expect(result.error).not.toBe("busy");
+  });
+
+  it("resume floor: an ask_user last turn does not pass the floor — the asker speaks again", async () => {
+    const stubs = mkStubs({
+      priorMessages: [
+        priorMsg("u-src", "outreach", 0),
+        priorMsg("u-cand", "counter", 1),
+        priorMsg("u-src", "ask_user", 2),
+      ],
+    });
+    agentScript = [{ ...declineTurn, action: "withdraw" }];
+    await runGraph(stubs);
+    // Without the floor rule the last sender (u-src) would hand the turn to
+    // u-cand; with it, u-src resumes as the speaker.
+    expect(agentInputs[0].ownUser.id).toBe("u-src");
+  });
+
+  it("resume floor: a non-ask_user last turn still flips the speaker (unchanged)", async () => {
+    const stubs = mkStubs({
+      priorMessages: [
+        priorMsg("u-src", "outreach", 0),
+        priorMsg("u-cand", "counter", 1),
+      ],
+    });
+    agentScript = [{ ...declineTurn, action: "withdraw" }];
+    await runGraph(stubs);
+    expect(agentInputs[0].ownUser.id).toBe("u-src");
+  });
+});

--- a/packages/protocol/src/opportunity/question.prompt.ts
+++ b/packages/protocol/src/opportunity/question.prompt.ts
@@ -16,7 +16,7 @@ export type NegotiationRole = "agent" | "patient" | "peer";
 
 /** One turn within a negotiation. */
 export interface DiscoveryTurn {
-  action: "propose" | "accept" | "reject" | "counter" | "question" | "outreach" | "withdraw" | "decline";
+  action: "propose" | "accept" | "reject" | "counter" | "question" | "outreach" | "withdraw" | "decline" | "ask_user";
   reasoning: string;
   suggestedRoles: { ownUser: NegotiationRole; otherUser: NegotiationRole };
 }

--- a/packages/protocol/src/shared/interfaces/negotiation-events.interface.ts
+++ b/packages/protocol/src/shared/interfaces/negotiation-events.interface.ts
@@ -24,4 +24,41 @@ export interface NegotiationTimeoutQueue {
    * @param negotiationId - The negotiation task ID
    */
   cancelTimeout(negotiationId: string): Promise<void>;
+
+  /**
+   * Arm the answer-window timer for an `ask_user` pause (P3.2). Fires after
+   * `delayMs` (typically 24 h); the worker resumes the negotiation with a
+   * conservative no-disclosure default when the task is still
+   * `input_required`, and no-ops otherwise (stale job).
+   *
+   * Optional so fakes and pre-P3.2 implementations stay valid; the graph only
+   * offers `ask_user` when this method is present.
+   *
+   * @param negotiationId - The paused negotiation task ID
+   * @param payload - Resume coordinates + observability context
+   * @param delayMs - Delay before the expiry fires
+   * @returns The job ID for cancellation
+   */
+  enqueueAskUserExpiry?(
+    negotiationId: string,
+    payload: AskUserExpiryPayload,
+    delayMs: number,
+  ): Promise<string>;
+
+  /**
+   * Cancel a pending ask_user answer-window timer (the client answered in
+   * time, or the negotiation reached a terminal state another way).
+   * @param negotiationId - The paused negotiation task ID
+   */
+  cancelAskUserExpiry?(negotiationId: string): Promise<void>;
+}
+
+/** Payload carried by an ask_user answer-window expiry job. */
+export interface AskUserExpiryPayload {
+  /** Opportunity to resume via the run-existing continuation path. */
+  opportunityId: string;
+  /** The asking side's client (the user who was asked and did not answer). */
+  userId: string;
+  /** What the negotiator wanted permission to share / needed to know. */
+  disclosureSubject: string;
 }

--- a/packages/protocol/src/shared/schemas/discovery-question.schema.ts
+++ b/packages/protocol/src/shared/schemas/discovery-question.schema.ts
@@ -14,7 +14,7 @@ export const NegotiationRoleSchema = z.enum(["agent", "patient", "peer"]);
 export type NegotiationRole = z.infer<typeof NegotiationRoleSchema>;
 
 export const DiscoveryTurnSchema = z.object({
-  action: z.enum(["propose", "accept", "reject", "counter", "question", "outreach", "withdraw", "decline"]),
+  action: z.enum(["propose", "accept", "reject", "counter", "question", "outreach", "withdraw", "decline", "ask_user"]),
   reasoning: z.string(),
   suggestedRoles: z.object({
     ownUser: NegotiationRoleSchema,

--- a/packages/protocol/src/shared/schemas/negotiation-state.schema.ts
+++ b/packages/protocol/src/shared/schemas/negotiation-state.schema.ts
@@ -20,6 +20,7 @@ import { z } from "zod";
 export const NEGOTIATION_ACTIONS = [
   "propose", "accept", "reject", "counter", "question",
   "outreach", "withdraw", "decline",
+  "ask_user",
 ] as const;
 export type NegotiationAction = (typeof NEGOTIATION_ACTIONS)[number];
 
@@ -28,6 +29,19 @@ export type NegotiationSeat = "initiator" | "counterparty";
 
 /** Negotiation protocol version stamped on task metadata. */
 export type NegotiationProtocolVersion = "v1" | "v2";
+
+/**
+ * Payload for the v2 `ask_user` action (P3.2): the negotiator pauses the
+ * negotiation to consult its OWN client. `disclosureSubject` states what the
+ * negotiator wants permission to share or needs to know; `draftQuestion` is
+ * the negotiator's own phrasing, refined by the questioner's
+ * `negotiation_inflight` preset before delivery.
+ */
+export const AskUserPayloadSchema = z.object({
+  disclosureSubject: z.string(),
+  draftQuestion: z.string().nullable().optional(),
+});
+export type AskUserPayload = z.infer<typeof AskUserPayloadSchema>;
 
 export const NegotiationTurnSchema = z.object({
   action: z.enum(NEGOTIATION_ACTIONS),
@@ -39,6 +53,8 @@ export const NegotiationTurnSchema = z.object({
     }),
   }),
   message: z.string().nullable().optional(),
+  /** Present when action is `ask_user` (v2, P3.2). */
+  askUser: AskUserPayloadSchema.nullable().optional(),
 });
 export type NegotiationTurn = z.infer<typeof NegotiationTurnSchema>;
 

--- a/services/api/src/controllers/agent.controller.ts
+++ b/services/api/src/controllers/agent.controller.ts
@@ -64,7 +64,7 @@ const confirmOpportunityDeliveredSchema = z.object({
 // Accepts the union of v1 + v2 action vocabularies; the polling service
 // enforces the per-task version + seat subset (wrong-seat action → 400).
 const respondNegotiationSchema = z.object({
-  action: z.enum(['propose', 'accept', 'reject', 'counter', 'question', 'outreach', 'withdraw', 'decline']),
+  action: z.enum(['propose', 'accept', 'reject', 'counter', 'question', 'outreach', 'withdraw', 'decline', 'ask_user']),
   message: z.string().nullable().optional(),
   assessment: z.object({
     reasoning: z.string(),

--- a/services/api/src/events/handlers/question.answer.handler.ts
+++ b/services/api/src/events/handlers/question.answer.handler.ts
@@ -11,6 +11,9 @@
  * - profile:   create a premise from the answer → triggers profile regen
  * - intent:    enqueue intent refinement with the new context
  * - negotiation: store answer as context for the next negotiation turn
+ * - negotiation_inflight: store answer, cancel the 24h answer-window timer,
+ *              close the paused input_required task, resume the negotiation
+ *              via the run-existing continuation (P3.2 ask_user loop)
  * - chat:      resolve the in-memory wait bus so a blocked ask_user_question
  *              tool call resumes the paused chat turn with the answer
  */
@@ -56,6 +59,19 @@ export interface QuestionAnswerHandlerDeps {
 
   /** Store the answer as negotiation context for the next turn. */
   storeNegotiationContext: (input: {
+    userId: string;
+    opportunityId: string;
+    questionId: string;
+    selectedOptions: string[];
+    freeText?: string;
+  }) => Promise<void>;
+
+  /**
+   * Resume a negotiation paused on an `ask_user` client consultation:
+   * store the answer, cancel the answer-window timer, close the paused
+   * task, and enqueue the run-existing continuation.
+   */
+  resumeInflightNegotiation: (input: {
     userId: string;
     opportunityId: string;
     questionId: string;
@@ -115,6 +131,16 @@ export async function handleQuestionAnswered(
 
       case 'negotiation':
         await deps.storeNegotiationContext({
+          userId,
+          opportunityId: sourceId,
+          questionId,
+          selectedOptions: answer.selectedOptions,
+          freeText: answer.freeText,
+        });
+        break;
+
+      case 'negotiation_inflight':
+        await deps.resumeInflightNegotiation({
           userId,
           opportunityId: sourceId,
           questionId,

--- a/services/api/src/events/handlers/question.answer.negotiation-inflight.ts
+++ b/services/api/src/events/handlers/question.answer.negotiation-inflight.ts
@@ -1,0 +1,91 @@
+/**
+ * Negotiation-inflight answer handler (P3.2 resume path): a negotiator paused
+ * mid-negotiation with `ask_user` to consult its own client, and the client
+ * answered.
+ *
+ * Flow: store the answer on the opportunity (same channel the resuming
+ * negotiator reads via `userAnswers`) → cancel the 24 h answer-window timer →
+ * terminally close the paused `input_required` task (the resume session
+ * creates a fresh task inheriting seat + protocol version from its metadata)
+ * → enqueue the existing `negotiation-run-existing` continuation.
+ *
+ * When no paused task exists (window already expired and the expiry worker
+ * resumed with the conservative default, or the negotiation terminated some
+ * other way), the answer is still stored — it enriches any future session —
+ * but no resume is enqueued.
+ */
+
+import { log } from '../../lib/log';
+
+const logger = log.service.from('QuestionAnswerNegotiationInflight');
+
+export interface InflightResumeDeps {
+  /** Store the answer as negotiation context (shared with the `negotiation` mode handler). */
+  storeNegotiationContext: (input: {
+    userId: string;
+    opportunityId: string;
+    questionId: string;
+    selectedOptions: string[];
+    freeText?: string;
+  }) => Promise<void>;
+  /** Latest negotiation task attached to the opportunity. */
+  getNegotiationTaskForOpportunity: (opportunityId: string) => Promise<{
+    id: string;
+    state: string;
+  } | null>;
+  /** Cancel the pending ask_user answer-window timer. */
+  cancelAskUserExpiry: (negotiationId: string) => Promise<void>;
+  /** Terminally transition the paused task. */
+  closeTask: (taskId: string, reason: string) => Promise<void>;
+  /** Enqueue the run-existing continuation. */
+  enqueueResume: (opportunityId: string, userId: string) => Promise<void>;
+}
+
+export function resumeInflightNegotiationFactory(deps: InflightResumeDeps) {
+  return async (input: {
+    userId: string;
+    opportunityId: string;
+    questionId: string;
+    selectedOptions: string[];
+    freeText?: string;
+  }): Promise<void> => {
+    // 1. Store the answer first — even if the resume below short-circuits,
+    //    the context enrichment must not be lost.
+    await deps.storeNegotiationContext(input);
+
+    // 2. Find the paused task.
+    const task = await deps.getNegotiationTaskForOpportunity(input.opportunityId);
+    if (!task || task.state !== 'input_required') {
+      logger.info('No paused negotiation task for answered inflight question — answer stored, no resume', {
+        opportunityId: input.opportunityId,
+        questionId: input.questionId,
+        taskState: task?.state ?? 'none',
+      });
+      return;
+    }
+
+    // 3. Cancel the answer-window timer (the client answered in time).
+    await deps.cancelAskUserExpiry(task.id).catch((err) => {
+      // Non-fatal: a leftover timer no-ops at fire time because the task will
+      // no longer be input_required.
+      logger.warn('Failed to cancel ask-user expiry timer', {
+        negotiationId: task.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+
+    // 4. Terminally close the paused task so the resume session's init node
+    //    sees no lock and creates the continuation task.
+    await deps.closeTask(task.id, 'ask_user_answered');
+
+    // 5. Resume.
+    await deps.enqueueResume(input.opportunityId, input.userId);
+
+    logger.info('Paused negotiation resumed with client answer', {
+      negotiationId: task.id,
+      opportunityId: input.opportunityId,
+      questionId: input.questionId,
+      userId: input.userId,
+    });
+  };
+}

--- a/services/api/src/events/handlers/tests/question.answer.handler.test.ts
+++ b/services/api/src/events/handlers/tests/question.answer.handler.test.ts
@@ -6,6 +6,7 @@ function makeDeps(overrides?: Partial<QuestionAnswerHandlerDeps>): QuestionAnswe
     createPremiseFromAnswer: mock(async () => {}),
     enqueueIntentRefinement: mock(async () => {}),
     storeNegotiationContext: mock(async () => {}),
+    resumeInflightNegotiation: mock(async () => {}),
     resolveChatQuestionWait: mock(() => {}),
     ...overrides,
   };
@@ -114,18 +115,33 @@ describe("handleQuestionAnswered", () => {
     expect(failDeps.createPremiseFromAnswer).toHaveBeenCalledTimes(1);
   });
 
-  it("tolerates negotiation_inflight via the default branch without throwing (P3.2 owns consumption)", async () => {
-    // The mode exists in QuestionModeSchema as of P3.1 but nothing produces or
-    // consumes it yet — an answer must fall through to the default branch
-    // harmlessly, calling no reaction handler.
+  it("routes negotiation_inflight to resumeInflightNegotiation (P3.2 resume path)", async () => {
+    // P3.1 shipped the mode with a default-branch tolerance; P3.2 (IND-401)
+    // owns consumption: the answer resumes the paused negotiation.
     await handleQuestionAnswered(
-      { ...basePayload, mode: "negotiation_inflight", sourceType: "negotiation", sourceId: "neg-1" },
+      { ...basePayload, mode: "negotiation_inflight", sourceType: "opportunity", sourceId: "opp-1", answer: { ...basePayload.answer, freeText: "yes, share it" } },
       deps,
     );
-    expect(deps.createPremiseFromAnswer).not.toHaveBeenCalled();
-    expect(deps.enqueueIntentRefinement).not.toHaveBeenCalled();
+    expect(deps.resumeInflightNegotiation).toHaveBeenCalledTimes(1);
+    const call = (deps.resumeInflightNegotiation as ReturnType<typeof mock>).mock.calls[0];
+    expect(call[0]).toEqual({
+      userId: "u-1",
+      opportunityId: "opp-1",
+      questionId: "q-1",
+      selectedOptions: ["Option A"],
+      freeText: "yes, share it",
+    });
     expect(deps.storeNegotiationContext).not.toHaveBeenCalled();
     expect(deps.resolveChatQuestionWait).not.toHaveBeenCalled();
+  });
+
+  it("resumeInflightNegotiation failure is caught, not thrown", async () => {
+    deps = makeDeps({ resumeInflightNegotiation: mock(async () => { throw new Error("boom"); }) });
+    await handleQuestionAnswered(
+      { ...basePayload, mode: "negotiation_inflight", sourceType: "opportunity", sourceId: "opp-1" },
+      deps,
+    );
+    expect(deps.resumeInflightNegotiation).toHaveBeenCalledTimes(1);
   });
 
   it("handles unknown mode gracefully", async () => {

--- a/services/api/src/events/handlers/tests/question.answer.negotiation-inflight.test.ts
+++ b/services/api/src/events/handlers/tests/question.answer.negotiation-inflight.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { resumeInflightNegotiationFactory, type InflightResumeDeps } from "../question.answer.negotiation-inflight";
+
+/**
+ * IND-401 — negotiation_inflight answer → resume path.
+ *
+ * Pins:
+ * - answer stored first, always (even when no paused task exists),
+ * - paused (input_required) task: timer cancelled → task closed → resume
+ *   enqueued, in that order,
+ * - no task / non-paused task: answer stored, nothing else touched,
+ * - timer-cancel failure is non-fatal (task still closed, resume still runs).
+ */
+
+function makeDeps(overrides?: Partial<InflightResumeDeps>): InflightResumeDeps {
+  return {
+    storeNegotiationContext: mock(async () => {}),
+    getNegotiationTaskForOpportunity: mock(async () => ({ id: "task-1", state: "input_required" })),
+    cancelAskUserExpiry: mock(async () => {}),
+    closeTask: mock(async () => {}),
+    enqueueResume: mock(async () => {}),
+    ...overrides,
+  };
+}
+
+const input = {
+  userId: "u-1",
+  opportunityId: "opp-1",
+  questionId: "q-1",
+  selectedOptions: ["Yes, share it"],
+  freeText: "but only the range",
+};
+
+describe("resumeInflightNegotiationFactory", () => {
+  let deps: InflightResumeDeps;
+
+  beforeEach(() => {
+    deps = makeDeps();
+  });
+
+  it("stores the answer, cancels the timer, closes the paused task, and enqueues the resume", async () => {
+    const calls: string[] = [];
+    deps = makeDeps({
+      storeNegotiationContext: mock(async () => { calls.push("store"); }),
+      cancelAskUserExpiry: mock(async () => { calls.push("cancel"); }),
+      closeTask: mock(async () => { calls.push("close"); }),
+      enqueueResume: mock(async () => { calls.push("resume"); }),
+    });
+    const resume = resumeInflightNegotiationFactory(deps);
+    await resume(input);
+
+    expect(deps.storeNegotiationContext).toHaveBeenCalledWith(input);
+    expect(deps.cancelAskUserExpiry).toHaveBeenCalledWith("task-1");
+    expect(deps.closeTask).toHaveBeenCalledWith("task-1", "ask_user_answered");
+    expect(deps.enqueueResume).toHaveBeenCalledWith("opp-1", "u-1");
+    expect(calls).toEqual(["store", "cancel", "close", "resume"]);
+  });
+
+  it("stores the answer but skips the resume when no task exists", async () => {
+    deps = makeDeps({ getNegotiationTaskForOpportunity: mock(async () => null) });
+    const resume = resumeInflightNegotiationFactory(deps);
+    await resume(input);
+
+    expect(deps.storeNegotiationContext).toHaveBeenCalledTimes(1);
+    expect(deps.cancelAskUserExpiry).not.toHaveBeenCalled();
+    expect(deps.closeTask).not.toHaveBeenCalled();
+    expect(deps.enqueueResume).not.toHaveBeenCalled();
+  });
+
+  it("stores the answer but skips the resume when the task is not paused (expiry already resumed it)", async () => {
+    deps = makeDeps({ getNegotiationTaskForOpportunity: mock(async () => ({ id: "task-1", state: "canceled" })) });
+    const resume = resumeInflightNegotiationFactory(deps);
+    await resume(input);
+
+    expect(deps.storeNegotiationContext).toHaveBeenCalledTimes(1);
+    expect(deps.closeTask).not.toHaveBeenCalled();
+    expect(deps.enqueueResume).not.toHaveBeenCalled();
+  });
+
+  it("a timer-cancel failure is non-fatal: task still closed, resume still enqueued", async () => {
+    deps = makeDeps({ cancelAskUserExpiry: mock(async () => { throw new Error("redis down"); }) });
+    const resume = resumeInflightNegotiationFactory(deps);
+    await resume(input);
+
+    expect(deps.closeTask).toHaveBeenCalledWith("task-1", "ask_user_answered");
+    expect(deps.enqueueResume).toHaveBeenCalledWith("opp-1", "u-1");
+  });
+});

--- a/services/api/src/main.ts
+++ b/services/api/src/main.ts
@@ -73,6 +73,7 @@ import { emitChatQuestionResolution } from './lib/chat-question.events';
 import { createPremiseFromAnswerFactory } from './events/handlers/question.answer.enrichment';
 import { enqueueIntentRefinementFactory } from './events/handlers/question.answer.intent';
 import { storeNegotiationContextFactory } from './events/handlers/question.answer.negotiation';
+import { resumeInflightNegotiationFactory } from './events/handlers/question.answer.negotiation-inflight';
 import { QuestionerAdapter } from './adapters/questioner.adapter';
 import db from './lib/drizzle/drizzle';
 import { premiseQueue } from './queues/premise.queue';
@@ -225,6 +226,24 @@ const answerQuestionerAdapter = new QuestionerAdapter(db);
 // re-embedding, persistence, and HyDE regeneration.
 const answerIntentGraph = new IntentGraphFactory(chatDatabaseAdapter, embedderAdapter, intentQueue).createGraph();
 
+// Shared by the `negotiation` (post-stall) and `negotiation_inflight`
+// (ask_user pause) answer reactions — both store the answer on the
+// opportunity's metadata.userAnswers channel.
+const storeNegotiationContext = storeNegotiationContextFactory({
+  getOpportunity: async (opportunityId) => {
+    const opp = await chatDatabaseAdapter.getOpportunity(opportunityId);
+    if (!opp) return null;
+    return {
+      id: opp.id,
+      status: opp.status,
+      metadata: (opp.metadata ?? {}) as Record<string, unknown>,
+    };
+  },
+  updateOpportunityMetadata: async (opportunityId, metadata) => {
+    await chatDatabaseAdapter.updateOpportunityMetadata(opportunityId, metadata);
+  },
+});
+
 const questionAnswerDeps = {
   createPremiseFromAnswer: createPremiseFromAnswerFactory({
     runPremiseLifecycle: async (input) => profileAnswerPremiseGraph.invoke(input),
@@ -258,18 +277,17 @@ const questionAnswerDeps = {
       };
     },
   }),
-  storeNegotiationContext: storeNegotiationContextFactory({
-    getOpportunity: async (opportunityId) => {
-      const opp = await chatDatabaseAdapter.getOpportunity(opportunityId);
-      if (!opp) return null;
-      return {
-        id: opp.id,
-        status: opp.status,
-        metadata: (opp.metadata ?? {}) as Record<string, unknown>,
-      };
+  storeNegotiationContext,
+  resumeInflightNegotiation: resumeInflightNegotiationFactory({
+    storeNegotiationContext,
+    getNegotiationTaskForOpportunity: (opportunityId) =>
+      conversationDatabaseAdapter.getNegotiationTaskForOpportunity(opportunityId),
+    cancelAskUserExpiry: (negotiationId) => negotiationTimeoutQueue.cancelAskUserExpiry(negotiationId),
+    closeTask: async (taskId, reason) => {
+      await conversationDatabaseAdapter.updateTaskState(taskId, 'canceled', { reason });
     },
-    updateOpportunityMetadata: async (opportunityId, metadata) => {
-      await chatDatabaseAdapter.updateOpportunityMetadata(opportunityId, metadata);
+    enqueueResume: async (opportunityId, userId) => {
+      await negotiationRunExistingQueue.addJob({ opportunityId, userId });
     },
   }),
   resolveChatQuestionWait: ({ questionId, answer }: {

--- a/services/api/src/queues/negotiations/timeout.queue.ts
+++ b/services/api/src/queues/negotiations/timeout.queue.ts
@@ -1,9 +1,12 @@
 import { Job } from 'bullmq';
+import { eq, and, sql } from 'drizzle-orm/sql';
 import { log } from '../../lib/log';
 import { QueueFactory } from '../../lib/bullmq/bullmq';
-import { conversationDatabaseAdapter } from '../../adapters/database.adapter';
+import db from '../../lib/drizzle/drizzle';
+import { questions } from '../../schemas/database.schema';
+import { conversationDatabaseAdapter, ChatDatabaseAdapter } from '../../adapters/database.adapter';
 import { AMBIENT_PARK_WINDOW_MS } from '@indexnetwork/protocol';
-import type { NegotiationGraphDatabase } from '@indexnetwork/protocol';
+import type { NegotiationGraphDatabase, AskUserExpiryPayload } from '@indexnetwork/protocol';
 
 import { runTimeoutFallback, type NegotiationTaskMeta } from './timeout.shared';
 
@@ -16,9 +19,23 @@ export interface NegotiationTimeoutJobData {
   turnNumber: number;
 }
 
+/** Payload for an ask_user answer-window expiry job (P3.2). */
+export interface AskUserExpiryJobData extends AskUserExpiryPayload {
+  negotiationId: string;
+}
+
+/** Union of job payloads carried on the negotiation-timeout queue. */
+export type NegotiationTimeoutQueueJobData = NegotiationTimeoutJobData | AskUserExpiryJobData;
+
 /** Optional deps for testing. */
 export interface NegotiationTimeoutQueueDeps {
   database?: NegotiationGraphDatabase;
+  /** Append a synthetic conservative answer to opportunity metadata (ask_user expiry). */
+  storeExpiryAnswer?: (opportunityId: string, disclosureSubject: string) => Promise<void>;
+  /** Dismiss pending negotiation_inflight question rows for an opportunity. */
+  dismissInflightQuestions?: (opportunityId: string) => Promise<void>;
+  /** Enqueue the resume continuation after an expiry. */
+  enqueueResume?: (opportunityId: string, userId: string) => Promise<void>;
 }
 
 /**
@@ -36,12 +53,12 @@ export interface NegotiationTimeoutQueueDeps {
 export class NegotiationTimeoutQueue {
   static readonly QUEUE_NAME = QUEUE_NAME;
 
-  readonly queue = QueueFactory.createQueue<NegotiationTimeoutJobData>(QUEUE_NAME);
+  readonly queue = QueueFactory.createQueue<NegotiationTimeoutQueueJobData>(QUEUE_NAME);
 
   private readonly logger = log.job.from('NegotiationTimeoutJob');
   private readonly queueLogger = log.queue.from('NegotiationTimeoutQueue');
   private readonly deps: NegotiationTimeoutQueueDeps | undefined;
-  private worker: ReturnType<typeof QueueFactory.createWorker<NegotiationTimeoutJobData>> | null = null;
+  private worker: ReturnType<typeof QueueFactory.createWorker<NegotiationTimeoutQueueJobData>> | null = null;
 
   constructor(deps?: NegotiationTimeoutQueueDeps) {
     this.deps = deps;
@@ -106,12 +123,67 @@ export class NegotiationTimeoutQueue {
   }
 
   /**
+   * Arm the answer-window timer for an `ask_user` pause (P3.2). Delayed job
+   * on this same queue under its own jobId namespace — it never collides with
+   * the park-window timer for the same negotiation.
+   */
+  async enqueueAskUserExpiry(negotiationId: string, payload: AskUserExpiryPayload, delayMs: number): Promise<string> {
+    const jobId = `neg-askuser-${negotiationId}`;
+
+    try {
+      const existing = await this.queue.getJob(jobId);
+      if (existing) {
+        await existing.remove();
+      }
+    } catch {
+      // Job may not exist, ignore
+    }
+
+    const job = await this.queue.add('ask_user_expiry', { negotiationId, ...payload }, {
+      jobId,
+      delay: delayMs,
+      attempts: 3,
+      backoff: { type: 'exponential', delay: 5000 },
+      removeOnComplete: { age: 24 * 3600 },
+      removeOnFail: { age: 7 * 24 * 3600 },
+    });
+
+    this.logger.info('Ask-user expiry armed', { negotiationId, delayMs, jobId: job.id });
+    return job.id ?? jobId;
+  }
+
+  /**
+   * Cancel a pending ask_user answer-window timer (client answered in time).
+   */
+  async cancelAskUserExpiry(negotiationId: string): Promise<void> {
+    const jobId = `neg-askuser-${negotiationId}`;
+    try {
+      const job = await this.queue.getJob(jobId);
+      if (job) {
+        const state = await job.getState();
+        if (state === 'delayed' || state === 'waiting') {
+          await job.remove();
+          this.logger.info('Ask-user expiry cancelled', { negotiationId, jobId });
+        }
+      }
+    } catch (err) {
+      this.logger.warn('Failed to cancel ask-user expiry', {
+        negotiationId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
    * Process a timeout job. Exported for testing.
    */
-  async processJob(name: string, data: NegotiationTimeoutJobData): Promise<void> {
+  async processJob(name: string, data: NegotiationTimeoutQueueJobData): Promise<void> {
     switch (name) {
       case 'negotiation_timeout':
-        await this.handleTimeout(data);
+        await this.handleTimeout(data as NegotiationTimeoutJobData);
+        break;
+      case 'ask_user_expiry':
+        await this.handleAskUserExpiry(data as AskUserExpiryJobData);
         break;
       default:
         this.queueLogger.warn('Unknown job name', { name });
@@ -124,12 +196,12 @@ export class NegotiationTimeoutQueue {
   startWorker(): void {
     if (this.worker) return;
 
-    const processor = async (job: Job<NegotiationTimeoutJobData>) => {
+    const processor = async (job: Job<NegotiationTimeoutQueueJobData>) => {
       this.queueLogger.info('Processing job', { jobId: job.id, jobName: job.name });
       await this.processJob(job.name, job.data);
     };
 
-    this.worker = QueueFactory.createWorker<NegotiationTimeoutJobData>(QUEUE_NAME, processor);
+    this.worker = QueueFactory.createWorker<NegotiationTimeoutQueueJobData>(QUEUE_NAME, processor);
   }
 
   /**
@@ -206,6 +278,105 @@ export class NegotiationTimeoutQueue {
       },
     });
   }
+
+  /**
+   * Handle an ask_user answer-window expiry (P3.2): the client never answered.
+   * Resume the negotiation with the conservative default — do not disclose —
+   * recorded as a synthetic user answer so the resuming negotiator sees the
+   * non-answer in its context. No-ops when the task already left
+   * `input_required` (the answer arrived and the resume path won the race, or
+   * the negotiation terminated another way).
+   */
+  private async handleAskUserExpiry(data: AskUserExpiryJobData): Promise<void> {
+    const { negotiationId, opportunityId, userId, disclosureSubject } = data;
+    const database = this.deps?.database ?? conversationDatabaseAdapter;
+
+    const task = await database.getTask(negotiationId);
+    if (!task) {
+      this.logger.warn('Task not found, skipping ask-user expiry', { negotiationId });
+      return;
+    }
+    if (task.state !== 'input_required') {
+      this.logger.info('Task no longer input_required, skipping ask-user expiry (stale job)', {
+        negotiationId,
+        currentState: task.state,
+      });
+      return;
+    }
+
+    // 1. Record the conservative default as a synthetic answer on the
+    //    opportunity so the resuming session's userAnswers context carries it.
+    const storeExpiryAnswer = this.deps?.storeExpiryAnswer ?? defaultStoreExpiryAnswer;
+    await storeExpiryAnswer(opportunityId, disclosureSubject).catch((err) => {
+      this.logger.error('Failed to store conservative expiry answer', { negotiationId, opportunityId, error: err });
+    });
+
+    // 2. Dismiss the now-moot pending question row(s) so the inbox stops asking.
+    const dismissInflight = this.deps?.dismissInflightQuestions ?? defaultDismissInflightQuestions;
+    await dismissInflight(opportunityId).catch((err) => {
+      this.logger.warn('Failed to dismiss expired inflight questions', { opportunityId, error: err });
+    });
+
+    // 3. Terminally close the paused task — the resume session creates a fresh
+    //    task that inherits seat + protocol version from this one's metadata.
+    await database.updateTaskState(negotiationId, 'canceled', { reason: 'ask_user_window_expired' });
+
+    // 4. Resume via the existing continuation path. Lazy import: keeps this
+    //    module free of a static run-existing dependency (circular-import and
+    //    barrel-mock hazard — run-existing pulls OpportunityGraphFactory from
+    //    the protocol barrel at module scope).
+    const enqueueResume = this.deps?.enqueueResume
+      ?? (async (oid: string, uid: string) => {
+        const { negotiationRunExistingQueue } = await import('./run-existing.queue');
+        await negotiationRunExistingQueue.addJob({ opportunityId: oid, userId: uid });
+      });
+    await enqueueResume(opportunityId, userId);
+
+    this.logger.info('Ask-user window expired; negotiation resumed with conservative default', {
+      negotiationId,
+      opportunityId,
+      userId,
+    });
+  }
+}
+
+/**
+ * Default expiry-answer store: appends a synthetic `userAnswers` entry to the
+ * opportunity metadata. The resuming IndexNegotiator renders it under
+ * "additional context (provided between sessions)".
+ */
+async function defaultStoreExpiryAnswer(opportunityId: string, disclosureSubject: string): Promise<void> {
+  const chatDb = new ChatDatabaseAdapter();
+  const opportunity = await chatDb.getOpportunity(opportunityId);
+  if (!opportunity) return;
+  const metadata = (opportunity.metadata ?? {}) as Record<string, unknown>;
+  const existing = Array.isArray(metadata.userAnswers) ? metadata.userAnswers : [];
+  await chatDb.updateOpportunityMetadata(opportunityId, {
+    ...metadata,
+    userAnswers: [
+      ...existing,
+      {
+        questionId: `ask-user-expired-${opportunityId}`,
+        selectedOptions: [],
+        freeText: `(no response) The client did not answer the negotiator's question about "${disclosureSubject}" within the allowed window. Conservative default applies: do NOT disclose or commit on this subject; proceed without it.`,
+        answeredAt: new Date().toISOString(),
+      },
+    ],
+  });
+}
+
+/** Default dismissal: pending negotiation_inflight rows for the opportunity. */
+async function defaultDismissInflightQuestions(opportunityId: string): Promise<void> {
+  await db
+    .update(questions)
+    .set({ status: 'dismissed' })
+    .where(
+      and(
+        eq(questions.status, 'pending'),
+        sql`${questions.detection}->>'mode' = 'negotiation_inflight'`,
+        sql`${questions.detection}->>'sourceId' = ${opportunityId}`,
+      ),
+    );
 }
 
 /** Singleton negotiation timeout queue instance. */

--- a/services/api/src/queues/tests/timeout.queue.spec.ts
+++ b/services/api/src/queues/tests/timeout.queue.spec.ts
@@ -152,3 +152,74 @@ describe('NegotiationTimeoutQueue.handleTimeout', () => {
     expect(db.updateOpportunityStatus).toHaveBeenCalledWith('opp-1', 'stalled');
   });
 });
+
+// ─── ask_user answer-window expiry (IND-401) ─────────────────────────────────
+
+function makeExpiryDeps(taskState: string | null) {
+  const task = taskState === null ? null : negTask({ state: taskState });
+  const { db } = makeDb(task, []);
+  const stored: Array<{ opportunityId: string; disclosureSubject: string }> = [];
+  const dismissed: string[] = [];
+  const resumed: Array<{ opportunityId: string; userId: string }> = [];
+  const q = new NegotiationTimeoutQueue({
+    database: db as never,
+    storeExpiryAnswer: async (opportunityId, disclosureSubject) => { stored.push({ opportunityId, disclosureSubject }); },
+    dismissInflightQuestions: async (opportunityId) => { dismissed.push(opportunityId); },
+    enqueueResume: async (opportunityId, userId) => { resumed.push({ opportunityId, userId }); },
+  });
+  return { q, db, stored, dismissed, resumed };
+}
+
+const expiryData = { negotiationId: 'task-1', opportunityId: 'opp-1', userId: 'u-src', disclosureSubject: 'budget range' };
+
+describe('NegotiationTimeoutQueue.handleAskUserExpiry', () => {
+  it('input_required: stores conservative answer, dismisses questions, cancels task, resumes', async () => {
+    const { q, db, stored, dismissed, resumed } = makeExpiryDeps('input_required');
+    await q.processJob('ask_user_expiry', expiryData);
+
+    expect(stored).toEqual([{ opportunityId: 'opp-1', disclosureSubject: 'budget range' }]);
+    expect(dismissed).toEqual(['opp-1']);
+    expect(db.updateTaskState).toHaveBeenCalledWith('task-1', 'canceled', { reason: 'ask_user_window_expired' });
+    expect(resumed).toEqual([{ opportunityId: 'opp-1', userId: 'u-src' }]);
+  });
+
+  it('no-ops when the task already left input_required (answer won the race)', async () => {
+    const { q, db, stored, resumed } = makeExpiryDeps('canceled');
+    await q.processJob('ask_user_expiry', expiryData);
+
+    expect(stored).toEqual([]);
+    expect(db.updateTaskState).not.toHaveBeenCalled();
+    expect(resumed).toEqual([]);
+  });
+
+  it('no-ops when the task is missing', async () => {
+    const { q, stored, resumed } = makeExpiryDeps(null);
+    await q.processJob('ask_user_expiry', expiryData);
+    expect(stored).toEqual([]);
+    expect(resumed).toEqual([]);
+  });
+
+  it('a store failure does not block the resume (negotiation must always terminate)', async () => {
+    const { db } = makeDb(negTask({ state: 'input_required' }), []);
+    const resumed: string[] = [];
+    const q = new NegotiationTimeoutQueue({
+      database: db as never,
+      storeExpiryAnswer: async () => { throw new Error('db down'); },
+      dismissInflightQuestions: async () => {},
+      enqueueResume: async (oid) => { resumed.push(oid); },
+    });
+    await q.processJob('ask_user_expiry', expiryData);
+    expect(db.updateTaskState).toHaveBeenCalledWith('task-1', 'canceled', { reason: 'ask_user_window_expired' });
+    expect(resumed).toEqual(['opp-1']);
+  });
+
+  it('enqueueAskUserExpiry adds a delayed job under its own jobId namespace', async () => {
+    const q = new NegotiationTimeoutQueue();
+    await q.enqueueAskUserExpiry('task-1', { opportunityId: 'opp-1', userId: 'u-src', disclosureSubject: 's' }, 86_400_000);
+    expect(mockAdd).toHaveBeenCalledWith(
+      'ask_user_expiry',
+      { negotiationId: 'task-1', opportunityId: 'opp-1', userId: 'u-src', disclosureSubject: 's' },
+      expect.objectContaining({ jobId: 'neg-askuser-task-1', delay: 86_400_000 }),
+    );
+  });
+});

--- a/services/api/src/startup.env.ts
+++ b/services/api/src/startup.env.ts
@@ -107,6 +107,8 @@ const envSchema = z.object({
   NEGOTIATION_MAX_TURNS_AMBIENT: optionalInt,
   NEGOTIATOR_TURN_TIMEOUT_MS: optionalInt,
   NEGOTIATION_SCREEN_MODE: z.union([z.literal(''), z.enum(['off', 'shadow', 'enforce'])]).optional(),
+  NEGOTIATION_ASK_USER_ENABLED: optionalBoolean,
+  NEGOTIATION_ASK_USER_WINDOW_MS: optionalInt,
   QUESTIONER_ENABLED: optionalBoolean,
 
   // 9. MCP / tool runtime

--- a/services/api/src/types/chat-streaming.types.ts
+++ b/services/api/src/types/chat-streaming.types.ts
@@ -498,7 +498,7 @@ export interface NegotiationTurnEvent extends ChatStreamEventBase {
   negotiationConversationId: string;
   turnIndex: number;
   actor: "source" | "candidate";
-  action: "propose" | "accept" | "reject" | "counter" | "question" | "outreach" | "withdraw" | "decline";
+  action: "propose" | "accept" | "reject" | "counter" | "question" | "outreach" | "withdraw" | "decline" | "ask_user";
   reasoning?: string;
   message?: string;
   suggestedRoles?: { ownUser?: string; otherUser?: string };

--- a/services/api/tests/negotiation.ask-user.e2e.spec.ts
+++ b/services/api/tests/negotiation.ask-user.e2e.spec.ts
@@ -1,0 +1,250 @@
+import { config } from "dotenv";
+config({ path: ".env.test", override: true });
+
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { NegotiationGraphFactory, negotiateCandidates } from "@indexnetwork/protocol";
+import type { NegotiationGraphDatabase, NegotiationTurn, QuestionerEnqueuePayload } from "@indexnetwork/protocol";
+import { conversationDatabaseAdapter } from "../src/adapters/database.adapter";
+import { resumeInflightNegotiationFactory } from "../src/events/handlers/question.answer.negotiation-inflight";
+
+// IND-401 — ask_user pause/resume loop against the real database (no LLM: all
+// turns come from a scripted dispatcher; the questioner + timers are
+// collectors). Requires DATABASE_URL in .env.test.
+//
+// Covers the e2e ACs:
+// - ask_user → task row input_required + question enqueued + timer armed,
+// - answer → timer cancelled, paused task terminally transitioned,
+//   continuation resumed with the ASKER holding the floor,
+// - graph invoke resolves at the pause (chat-trigger deferral: the stream
+//   never blocks on a question — the resume is always an async continuation).
+//
+// Run with: cd services/api && bun test tests/negotiation.ask-user.e2e.spec.ts
+
+const ENV_KEYS = ["NEGOTIATION_PROTOCOL_VERSION", "NEGOTIATION_ASK_USER_ENABLED", "NEGOTIATION_SCREEN_MODE"] as const;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeAll(() => {
+  for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+  process.env.NEGOTIATION_PROTOCOL_VERSION = "v2";
+  process.env.NEGOTIATION_ASK_USER_ENABLED = "true";
+  delete process.env.NEGOTIATION_SCREEN_MODE;
+});
+
+afterAll(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+});
+
+function turn(action: NegotiationTurn["action"], extra?: Partial<NegotiationTurn>): NegotiationTurn {
+  return {
+    action,
+    assessment: { reasoning: `${action} reasoning`, suggestedRoles: { ownUser: "peer", otherUser: "peer" } },
+    message: null,
+    ...extra,
+  };
+}
+
+/** Dispatcher that answers every turn from a per-user script. */
+function scriptedDispatcher(scripts: Record<string, NegotiationTurn[]>) {
+  const seen: Array<{ userId: string; allowedActions: string[] }> = [];
+  return {
+    seen,
+    hasExternalAgent: async () => false,
+    dispatch: async (userId: string, _scope: unknown, payload: { allowedActions: string[] }) => {
+      seen.push({ userId, allowedActions: payload.allowedActions });
+      const next = scripts[userId]?.shift();
+      if (!next) throw new Error(`no scripted turn for ${userId}`);
+      return { handled: true as const, turn: next };
+    },
+  };
+}
+
+function mkUser(id: string, name: string) {
+  return {
+    id,
+    intents: [{ id: `i-${id}`, title: "collaboration", description: "seeking collaborators", confidence: 0.9 }],
+    profile: { name, bio: `${name} bio`, skills: ["engineering"] },
+  };
+}
+
+describe("ask_user pause/resume E2E (IND-401)", () => {
+  it("pauses on ask_user, resumes on answer with the asker holding the floor", async () => {
+    const runId = Date.now();
+    const sourceId = `e2e-au-src-${runId}`;
+    const candidateId = `e2e-au-cand-${runId}`;
+    const opportunityId = randomUUID();
+
+    const timerArms: Array<{ negotiationId: string; payload: Record<string, unknown>; delayMs: number }> = [];
+    const timerCancels: string[] = [];
+    const timeoutQueue = {
+      enqueueTimeout: async () => "job",
+      cancelTimeout: async () => {},
+      enqueueAskUserExpiry: async (negotiationId: string, payload: Record<string, unknown>, delayMs: number) => {
+        timerArms.push({ negotiationId, payload, delayMs });
+        return "askuser-job";
+      },
+      cancelAskUserExpiry: async (negotiationId: string) => {
+        timerCancels.push(negotiationId);
+      },
+    };
+    const questions: QuestionerEnqueuePayload[] = [];
+
+    // ── Session 1: source opens, candidate pauses to consult its client ──
+    const dispatcher1 = scriptedDispatcher({
+      [sourceId]: [turn("outreach")],
+      [candidateId]: [turn("ask_user", {
+        askUser: { disclosureSubject: "availability this quarter", draftQuestion: "Can I share your Q3 availability?" },
+      })],
+    });
+    const graph1 = new NegotiationGraphFactory(
+      conversationDatabaseAdapter as unknown as NegotiationGraphDatabase,
+      dispatcher1 as never,
+      timeoutQueue as never,
+      async (input) => { questions.push(input); },
+    ).createGraph();
+
+    const invokeInput = {
+      sourceUser: mkUser(sourceId, "Alice"),
+      candidateUser: mkUser(candidateId, "Bob"),
+      indexContext: { networkId: `e2e-net-${runId}`, prompt: "collaboration network" },
+      seedAssessment: { reasoning: "complementary", valencyRole: "peer" },
+      opportunityId,
+      maxTurns: 6,
+      initiatorUserId: sourceId,
+    };
+
+    // The invoke resolves AT the pause — this is the chat-trigger deferral
+    // guarantee: no in-stream question, the resume is an async continuation.
+    const result1 = await graph1.invoke(invokeInput);
+    expect(result1.outcome).toBeNull();
+
+    // AC 1: task row is input_required; question + timer armed.
+    const paused = await conversationDatabaseAdapter.getNegotiationTaskForOpportunity(opportunityId);
+    expect(paused).not.toBeNull();
+    expect(paused!.state).toBe("input_required");
+    expect(timerArms).toHaveLength(1);
+    expect(timerArms[0].negotiationId).toBe(paused!.id);
+    expect(timerArms[0].payload.userId).toBe(candidateId);
+    expect(questions).toHaveLength(1);
+    expect(questions[0].mode).toBe("negotiation_inflight");
+    expect(questions[0].userId).toBe(candidateId);
+    expect(questions[0].sourceId).toBe(opportunityId);
+    // The dispatcher was offered ask_user on the candidate turn (v2 + flag).
+    expect(dispatcher1.seen[1].allowedActions).toContain("ask_user");
+
+    // ── Answer arrives: resume path ──
+    const resumes: Array<{ opportunityId: string; userId: string }> = [];
+    const resume = resumeInflightNegotiationFactory({
+      // Opportunity row does not exist in this harness — the store safely
+      // no-ops on a missing row; answer-visibility is covered by the
+      // negotiation-mode userAnswers unit path.
+      storeNegotiationContext: async () => {},
+      getNegotiationTaskForOpportunity: (oid) => conversationDatabaseAdapter.getNegotiationTaskForOpportunity(oid),
+      cancelAskUserExpiry: (nid) => timeoutQueue.cancelAskUserExpiry(nid),
+      closeTask: async (taskId, reason) => {
+        await conversationDatabaseAdapter.updateTaskState(taskId, "canceled", { reason });
+      },
+      enqueueResume: async (oid, uid) => { resumes.push({ opportunityId: oid, userId: uid }); },
+    });
+    await resume({
+      userId: candidateId,
+      opportunityId,
+      questionId: randomUUID(),
+      selectedOptions: ["Yes, share it"],
+      freeText: "mornings only",
+    });
+
+    // AC 2: timer cancelled, paused task terminally transitioned, resume enqueued.
+    expect(timerCancels).toEqual([paused!.id]);
+    const closed = await conversationDatabaseAdapter.getTask(paused!.id);
+    expect(closed!.state).toBe("canceled");
+    expect(resumes).toEqual([{ opportunityId, userId: candidateId }]);
+
+    // ── Session 2 (the continuation the resume job runs): the ASKER speaks ──
+    const dispatcher2 = scriptedDispatcher({
+      [candidateId]: [turn("decline")],
+    });
+    const graph2 = new NegotiationGraphFactory(
+      conversationDatabaseAdapter as unknown as NegotiationGraphDatabase,
+      dispatcher2 as never,
+      timeoutQueue as never,
+      async (input) => { questions.push(input); },
+    ).createGraph();
+    const result2 = await graph2.invoke(invokeInput);
+
+    // Resume floor: candidate (the asker) spoke, not the source.
+    expect(dispatcher2.seen[0].userId).toBe(candidateId);
+    // Rationing: the candidate's consultation is spent — not offered again.
+    expect(dispatcher2.seen[0].allowedActions).not.toContain("ask_user");
+    expect(result2.outcome).not.toBeNull();
+    expect(result2.outcome!.hasOpportunity).toBe(false);
+    expect((result2 as { isContinuation?: boolean }).isContinuation).toBe(true);
+
+    const final = await conversationDatabaseAdapter.getNegotiationTaskForOpportunity(opportunityId);
+    expect(final!.state).toBe("completed");
+  }, 30_000);
+
+  it("lock gate: a paused negotiation blocks a re-trigger on the same opportunity", async () => {
+    const runId = Date.now() + 1;
+    const sourceId = `e2e-au2-src-${runId}`;
+    const candidateId = `e2e-au2-cand-${runId}`;
+    const opportunityId = randomUUID();
+
+    const timeoutQueue = {
+      enqueueTimeout: async () => "job",
+      cancelTimeout: async () => {},
+      enqueueAskUserExpiry: async () => "askuser-job",
+      cancelAskUserExpiry: async () => {},
+    };
+    const dispatcher = scriptedDispatcher({
+      [sourceId]: [turn("outreach")],
+      [candidateId]: [turn("ask_user", { askUser: { disclosureSubject: "budget" } })],
+    });
+    const graph = new NegotiationGraphFactory(
+      conversationDatabaseAdapter as unknown as NegotiationGraphDatabase,
+      dispatcher as never,
+      timeoutQueue as never,
+      async () => {},
+    ).createGraph();
+
+    const invokeInput = {
+      sourceUser: mkUser(sourceId, "Ann"),
+      candidateUser: mkUser(candidateId, "Ben"),
+      indexContext: { networkId: `e2e-net2-${runId}`, prompt: "network" },
+      seedAssessment: { reasoning: "fit", valencyRole: "peer" },
+      opportunityId,
+      maxTurns: 6,
+      initiatorUserId: sourceId,
+    };
+    await graph.invoke(invokeInput);
+    const paused = await conversationDatabaseAdapter.getNegotiationTaskForOpportunity(opportunityId);
+    expect(paused!.state).toBe("input_required");
+
+    // Re-trigger on the same opportunity while paused → busy, no new turn.
+    const retrigger = await graph.invoke(invokeInput);
+    expect((retrigger as { error?: string }).error).toBe("busy");
+
+    // negotiateCandidates (the chat/ambient fan-out wrapper) also resolves
+    // without blocking and yields no acceptance against the paused state.
+    const results = await negotiateCandidates(
+      graph as never,
+      mkUser(sourceId, "Ann"),
+      [{
+        userId: candidateId,
+        reasoning: "fit",
+        valencyRole: "peer",
+        opportunityId,
+        candidateUser: mkUser(candidateId, "Ben"),
+      }],
+      { networkId: `e2e-net2-${runId}`, prompt: "network" },
+      { maxTurns: 6, trigger: "orchestrator", initiatorUserId: sourceId },
+    );
+    expect(results).toEqual([]);
+
+    // Cleanup so later dev runs don't inherit a 24h-locked task.
+    await conversationDatabaseAdapter.updateTaskState(paused!.id, "canceled", { reason: "e2e-cleanup" });
+  }, 30_000);
+});


### PR DESCRIPTION
## IND-401 · P3.2 — `ask_user` action: pause, 24h window, resume

Part of the Client-Advocate Protocol rollout ([IND-395](https://linear.app/indexnetwork/issue/IND-395)). Implements [IND-401](https://linear.app/indexnetwork/issue/IND-401).

v2 negotiators can now pause a negotiation to consult **their own client** — the negotiation equivalent of the chat `ask_user_question` pattern. Fully flag-gated: with `NEGOTIATION_ASK_USER_ENABLED` unset (default), the deployment is byte-for-byte today's behavior.

### The pause loop

1. A v2 negotiator (either seat, non-final, non-opening turn) emits `ask_user` with `askUser: { disclosureSubject, draftQuestion }`.
2. The turn is persisted, the full turn context is parked, the **24h answer-window timer** is armed (`ask_user_expiry` job type alongside `negotiation-timeout`, window overridable via `NEGOTIATION_ASK_USER_WINDOW_MS`), the draft is refined through the P3.1 `negotiation_inflight` questioner preset into the pending-questions UI, and the task transitions to **`input_required`** (existing A2A state, previously unused by negotiations).
3. The graph exits at the turn boundary — exactly like the `waiting_for_agent` suspend. **Chat-triggered runs never block a stream on a question**; the resume is always an async continuation.
4. **Answer** → answer stored on `opportunity.metadata.userAnswers`, timer cancelled, paused task terminally transitioned (`canceled`), `negotiation-run-existing` continuation enqueued. The **asker keeps the floor** (an `ask_user` turn does not pass it) and resumes with the answer in context.
5. **Expiry** → conservative default: a synthetic `userAnswers` entry records the non-answer and instructs no disclosure/commitment on the subject; pending inflight questions are dismissed; the negotiation resumes and always terminates.

### Key invariants

- **Lock-gate extension (critical)**: `input_required` tasks hold the conversation lock for the **full answer window + 1h slack**, not the 5-min turn freshness — ambient rediscovery / chat `negotiate_existing` cannot start a fresh negotiation past the pause. Covered by explicit unit + DB-backed e2e tests (both fail against the old 5-min rule).
- **Rationing**: max **one client consultation per negotiation per side**, checked against the full message history (continuations count prior sessions). Unavailable `ask_user` (rationing spent, flag off, loop unwired) is **coerced to the conservative fallback before persisting** — a pause we cannot resume never enters the turn history.
- **Availability gating**: the action is only offered (prompt + schema + `allowedActions`) when the full loop is wired: flag on, questioner enqueue present, answer-window timer present, an `opportunityId` to resume against, v2, non-final, non-opening turn.
- **Timeout machinery untouched**: park/claim timeout workers only act on `waiting_for_agent`/`claimed`; stale jobs firing against `input_required` no-op (pre-existing behavior, per the issue's audit).
- **Polling/MCP respond surfaces reject `ask_user`** (seat validation, existing `allowedActionsFor` default) — external polling agents have their own channel to their user; extending that surface is a natural follow-up if wanted.
- `NegotiationTimeoutQueue` interface gains **optional** `enqueueAskUserExpiry`/`cancelAskUserExpiry` — fakes and barrel mocks stay valid.

### Scope deltas vs. the issue

- Action literal unions widened additively across protocol/API/web (compile-driven, same pattern as the IND-400 `QuestionMode` widening): `question.prompt.ts`, `chat-streaming.types.ts` (×2), `chat.agent.ts`, `discovery-question.schema.ts`, `agent.controller.ts` zod enum, web `AIChatContext`/`ToolCallsDisplay`/`questions.ts` + a pending-questions group label ("Your negotiator needs your input").
- `docs/domain/negotiation.md` gains a "Client consultation" section.

### Tests

- **Protocol** (26 new): vocabulary/schema opt-in (base schemas byte-identical), full pause loop (message + turn context + timer + question payload + `input_required`, no outcome), env window override, `canAskUser` gating matrix (flag/questioner/timer/opportunityId/opening turn), per-side rationing incl. cross-session, coercion safety net, lock-gate extension (holds at 10min, releases past window+slack, `working` unchanged), resume floor, `IndexNegotiator` prompt/schema contract via the `callModel` seam.
- **API** (9 new): expiry worker (conservative answer + dismissal + cancel + resume; stale no-op; store-failure still resumes), resume factory (order-pinned store→cancel→close→resume; no-task and already-resumed short-circuits; cancel failure non-fatal), answer dispatch routing.
- **DB-backed e2e** (2): full pause→answer→resume loop against the real database (scripted dispatcher, no LLM) asserting task-row states, timer arms/cancels, question payload, resume floor and spent rationing on the continuation; paused-lock re-trigger guard incl. `negotiateCandidates` non-blocking resolution.
- Builds (protocol + api) green, eslint clean, web tsc baseline-identical to dev (59 pre-existing errors, none in touched files). Adjacent suites green: timeout queue 13/13, claim-timeout 7/7, run-existing 10/10, timeout-shared 5/5, polling-seat 8/8, answer handlers 17/17, questioner 84/84 + queue 8/8, question inbox 6/6, negotiation protocol suite 176/177 (1 known real-LLM baseline flake, green on re-runs).

### Rollout

1. Merge → deploy is a no-op (flag off).
2. Dev: set `NEGOTIATION_ASK_USER_ENABLED=true` (optionally `NEGOTIATION_ASK_USER_WINDOW_MS` low to exercise expiry).
3. Rollback = unset the flag. In-flight paused tasks still resume correctly (answer + expiry paths don't check the flag — only new pauses do).
