### PR TITLE
feat: reflection jobs — reflect + chat_reflect memory write path (IND-406)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -124,6 +124,11 @@ OPENROUTER_API_KEY=your-openrouter-api-key
                                            # negotiation_inflight preset, 24h answer window, resume on answer or conservative
                                            # no-disclosure default on expiry). Default off = today's behavior byte-for-byte.
 # NEGOTIATION_ASK_USER_WINDOW_MS=86400000  # Answer window for a paused ask_user negotiation, in ms (default: 24h). Shorten on dev
+# NEGOTIATOR_MEMORY_WRITE_ENABLED=false    # Negotiator memory write path (P5.2): when true, finished negotiations and idle
+                                           # negotiator DMs are distilled into negotiator_memories, and ask_user answers are
+                                           # recorded as disclosure rules. Default off; keep off in prod until memory
+                                           # inspection (P5.4) ships. Nothing reads memories yet (P5.3).
+# NEGOTIATOR_CHAT_REFLECT_DELAY_MS=900000  # Idle window after the last negotiator-DM turn before chat reflection fires (default: 15m).
                                            # to exercise the expiry path.
 
 # Per-turn LLM round-trip cap for IndexNegotiator, in ms (default: 15000).

--- a/docs/domain/negotiation.md
+++ b/docs/domain/negotiation.md
@@ -148,6 +148,10 @@ The finalization logic examines the negotiation history to determine the outcome
 
 When an opportunity is produced, the final roles are derived from the last two turns (the accept turn and the preceding turn). Each side's `suggestedRoles.ownUser` from their respective last turns becomes the agreed role for that user.
 
+### Reflection (memory write path, flag-gated)
+
+When `NEGOTIATOR_MEMORY_WRITE_ENABLED=true`, the finalize node fire-and-forgets a `reflect` job (via the injected `reflectEnqueue` callback — same pattern as `questionerEnqueue`). The `negotiation-reflect` queue worker replays the turn history from **both sides' perspectives** and distills ≤ 3 private `negotiator_memories` entries per side (playbooks, disclosure rules, counterparty dossiers, thresholds), each citing the evidencing turn indexes in its `sourceRefs`. Reflection failure never affects the outcome — the negotiation finalized before the job runs. Two companion write paths: negotiator-DM turns debounce-schedule a `chat_reflect` job that distills the client's stated preferences once the session goes idle, and `ask_user` answers are recorded immediately as high-confidence disclosure rules (an answer is already a distilled policy). Anti-poisoning: per-kind entry caps with lowest-confidence eviction, one dossier per (agent, subject) with reinforce-on-repeat, and a daily confidence-decay cron. Nothing reads these memories yet (P5.3).
+
 ---
 
 ## Seed Assessment

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -164,6 +164,8 @@ export type { NegotiationDigest } from "./negotiation/insight.generator.js";
 export { IndexNegotiator } from "./negotiation/negotiation.agent.js";
 export { NegotiationScreener, configuredScreenMode, ScreenDecisionSchema, NEGOTIATION_SCREEN_MODES } from "./negotiation/negotiation.screen.js";
 export type { ScreenDecision, ScreenDecisionRecord, NegotiationScreenMode, NegotiationScreenerInput } from "./negotiation/negotiation.screen.js";
+export { NegotiationReflector, DistilledMemorySchema, ReflectionResultSchema, MAX_DISTILLED_MEMORIES, NEGOTIATOR_MEMORY_KINDS } from "./negotiation/negotiation.reflect.js";
+export type { DistilledMemory, DistilledMemoryKind, ReflectionResult, ReflectionTranscriptEntry, NegotiationReflectionInput, ChatReflectionInput, NegotiationReflectJobData, ReflectEnqueueFn } from "./negotiation/negotiation.reflect.js";
 export type { NegotiationAgentInput } from "./negotiation/negotiation.agent.js";
 export { QuestionerAgent } from "./questioner/questioner.agent.js";
 export type { QuestionerAgentConfig } from "./questioner/questioner.agent.js";

--- a/packages/protocol/src/negotiation/negotiation.graph.ts
+++ b/packages/protocol/src/negotiation/negotiation.graph.ts
@@ -12,6 +12,7 @@ import { NegotiationScreener, configuredScreenMode, type ScreenDecision, type Sc
 import type { NegotiationSeat, NegotiationProtocolVersion } from "../shared/schemas/negotiation-state.schema.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import type { QuestionerEnqueueFn } from "../questioner/questioner.types.js";
+import type { ReflectEnqueueFn } from "./negotiation.reflect.js";
 
 const logger = protocolLogger("NegotiationGraph");
 const initLog = protocolLogger("NegotiationGraph:Init");
@@ -58,10 +59,11 @@ export class NegotiationGraphFactory {
     private dispatcher: AgentDispatcher,
     private timeoutQueue?: NegotiationTimeoutQueue,
     private questionerEnqueue?: QuestionerEnqueueFn,
+    private reflectEnqueue?: ReflectEnqueueFn,
   ) {}
 
   createGraph() {
-    const { database, dispatcher, timeoutQueue, questionerEnqueue } = this;
+    const { database, dispatcher, timeoutQueue, questionerEnqueue, reflectEnqueue } = this;
     const systemAgent = new IndexNegotiator();
     const screener = new NegotiationScreener();
 
@@ -764,6 +766,35 @@ export class NegotiationGraphFactory {
             },
           }),
         });
+      }
+
+      // Enqueue post-negotiation reflection (P5.2 memory write path) — fire
+      // and forget: a reflection failure must never affect the outcome. Only
+      // sessions that actually exchanged turns teach anything; init/turn
+      // errors with turnCount 0 are skipped.
+      if (reflectEnqueue && state.turnCount > 0) {
+        reflectEnqueue({
+          negotiationId: state.taskId,
+          conversationId: state.conversationId,
+          ...(state.opportunityId && { opportunityId: state.opportunityId }),
+          sourceUser: {
+            id: state.sourceUser.id,
+            ...(state.sourceUser.profile.name && { name: state.sourceUser.profile.name }),
+            ...(state.sourceUser.profile.bio && { bio: state.sourceUser.profile.bio }),
+          },
+          candidateUser: {
+            id: state.candidateUser.id,
+            ...(state.candidateUser.profile.name && { name: state.candidateUser.profile.name }),
+            ...(state.candidateUser.profile.bio && { bio: state.candidateUser.profile.bio }),
+          },
+          initiatorUserId: state.initiatorUserId ?? state.sourceUser.id,
+          outcome: { hasOpportunity, reasoning: outcome.reasoning, turnCount: state.turnCount },
+        }).catch((err) =>
+          finalizeLog.error('Failed to enqueue negotiation reflection', {
+            taskId: state.taskId,
+            error: err,
+          })
+        );
       }
 
       // Enqueue question generation for stalled/capped negotiations (not accepted or explicitly rejected).

--- a/packages/protocol/src/negotiation/negotiation.reflect.ts
+++ b/packages/protocol/src/negotiation/negotiation.reflect.ts
@@ -1,0 +1,241 @@
+import { z } from "zod";
+
+import { createStructuredModel } from "../shared/agent/model.config.js";
+import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
+import { protocolLogger } from "../shared/observability/protocol.logger.js";
+
+const reflectLog = protocolLogger("NegotiationReflector");
+
+/**
+ * Memory kinds a reflection pass may distill (P5.1 `negotiator_memories.kind`).
+ * Plain text at the DB level (55P04 lesson) — adding kinds is code-only.
+ */
+export const NEGOTIATOR_MEMORY_KINDS = [
+  "playbook",
+  "disclosure_rule",
+  "counterparty_dossier",
+  "threshold",
+] as const;
+
+export type DistilledMemoryKind = (typeof NEGOTIATOR_MEMORY_KINDS)[number];
+
+/** Hard ceiling on entries distilled per reflection pass (per side). */
+export const MAX_DISTILLED_MEMORIES = 3;
+
+/**
+ * One distilled memory entry as produced by the reflection LLM. The caller
+ * owns persistence: it resolves `aboutCounterparty` to a `subjectUserId`,
+ * computes the embedding, and attaches provenance `sourceRefs`.
+ */
+export const DistilledMemorySchema = z.object({
+  kind: z.enum(NEGOTIATOR_MEMORY_KINDS),
+  /** Self-contained operational statement, useful without the transcript. */
+  content: z.string().min(1),
+  /** Evidence strength, 0..1. Explicit client statements score high. */
+  confidence: z.number().min(0).max(1),
+  /**
+   * True when the entry is about the counterparty (kind should be
+   * `counterparty_dossier`); false for client-side rules and playbooks.
+   */
+  aboutCounterparty: z.boolean(),
+  /** Turn indexes (0-based, into the provided transcript) evidencing this entry. */
+  turnIndexes: z.array(z.number().int().min(0)).default([]),
+});
+
+export type DistilledMemory = z.infer<typeof DistilledMemorySchema>;
+
+export const ReflectionResultSchema = z.object({
+  memories: z.array(DistilledMemorySchema).max(MAX_DISTILLED_MEMORIES),
+});
+
+export type ReflectionResult = z.infer<typeof ReflectionResultSchema>;
+
+/** A transcript row projected into the reflecting client's perspective. */
+export interface ReflectionTranscriptEntry {
+  index: number;
+  speaker: "client" | "counterparty";
+  action: string;
+  message?: string;
+  reasoning?: string;
+}
+
+export interface NegotiationReflectionInput {
+  /** The user whose negotiator is reflecting (memories land on their agent). */
+  clientUser: { id: string; name?: string; bio?: string };
+  counterpartyUser: { id: string; name?: string; bio?: string };
+  /** The client's seat in this negotiation. */
+  seat: "initiator" | "counterparty";
+  outcome: { hasOpportunity: boolean; reasoning: string; turnCount: number };
+  transcript: ReflectionTranscriptEntry[];
+  /** Network prompt for context (optional). */
+  indexContext?: string;
+}
+
+export interface ChatReflectionInput {
+  clientUser: { id: string; name?: string };
+  /** The negotiator DM messages, oldest first. */
+  messages: Array<{ role: "user" | "assistant"; content: string }>;
+}
+
+/**
+ * Payload the finalize node hands to the injected {@link ReflectEnqueueFn}.
+ * Carries user display context so the reflect worker never re-loads profiles;
+ * turn history is loaded from the conversation by the worker (payloads stay
+ * small in Redis).
+ */
+export interface NegotiationReflectJobData {
+  negotiationId: string;
+  conversationId: string;
+  opportunityId?: string;
+  sourceUser: { id: string; name?: string; bio?: string };
+  candidateUser: { id: string; name?: string; bio?: string };
+  initiatorUserId: string;
+  outcome: { hasOpportunity: boolean; reasoning: string; turnCount: number };
+}
+
+/**
+ * Injected enqueue callback for post-negotiation reflection (P5.2). The
+ * protocol package has no BullMQ access — services/api wires this at its
+ * composition roots, exactly like `QuestionerEnqueueFn`. Called fire-and-
+ * forget from the finalize node: a reflection failure must never affect the
+ * negotiation outcome.
+ */
+export type ReflectEnqueueFn = (job: NegotiationReflectJobData) => Promise<void>;
+
+const NEGOTIATION_SYSTEM_PROMPT = `You are the private post-negotiation reflection process for {clientName}'s negotiator agent. The negotiation is over; your job is to distill AT MOST ${MAX_DISTILLED_MEMORIES} durable operational memory entries that will make {clientName}'s negotiator better in FUTURE negotiations. These memories are private to {clientName}'s agent — the counterparty never sees them.
+
+Memory kinds:
+- "playbook": a tactic or pattern that worked or failed (e.g. "Opening with the specific shared-interest angle got engagement; generic intros stalled").
+- "disclosure_rule": what {clientName} is or is not willing to share/commit (only when the transcript actually evidences it).
+- "counterparty_dossier": a durable fact about the counterparty useful in future dealings with THEM specifically (set aboutCounterparty=true).
+- "threshold": a concrete boundary observed (e.g. minimum scope, timing constraints, deal-breakers).
+
+Rules:
+- Record ONLY what future negotiations need. No summaries, no play-by-play, no identity facts about {clientName} (their profile already covers those).
+- Every entry MUST cite the transcript turn indexes that evidence it in turnIndexes.
+- Each content string must be self-contained and actionable without the transcript.
+- Set confidence by evidence strength: explicit statements ≈ 0.8-0.9, inferred patterns ≈ 0.4-0.6.
+- aboutCounterparty=true ONLY for counterparty_dossier entries.
+- Return an empty memories array when nothing durable was learned — most short or failed negotiations teach nothing. Do not force entries.`;
+
+const CHAT_SYSTEM_PROMPT = `You are the private reflection process for {clientName}'s negotiator agent, reviewing a direct chat between {clientName} (the client) and their negotiator. Distill AT MOST ${MAX_DISTILLED_MEMORIES} durable operational memory entries capturing the client's STATED preferences, corrections, and instructions.
+
+Memory kinds:
+- "playbook": how the client wants negotiations approached (style, priorities).
+- "disclosure_rule": what the client said they will or won't share/commit.
+- "threshold": concrete boundaries the client stated (rates, scope, timing, deal-breakers).
+
+Rules:
+- Only distill what the CLIENT stated or clearly confirmed — never invent preferences from the negotiator's own suggestions.
+- Do NOT produce counterparty_dossier entries; this is a client-side conversation. Always set aboutCounterparty=false.
+- Each content string must be self-contained and actionable.
+- turnIndexes cite 0-based indexes into the provided message list.
+- Set confidence by how explicit the client was (direct instruction ≈ 0.9, implied preference ≈ 0.5).
+- Return an empty memories array when the chat contains no durable guidance — casual Q&A usually doesn't.`;
+
+const DEFAULT_REFLECT_TIMEOUT_MS = 20_000;
+
+export interface NegotiationReflectorConfig {
+  /** Hard ceiling on the reflection LLM round-trip, in ms (default 20000). */
+  timeoutMs?: number;
+}
+
+/**
+ * The memory distiller (P5.2). One structured LLM call per reflection pass,
+ * producing ≤ {@link MAX_DISTILLED_MEMORIES} private memory entries for one
+ * client's negotiator. Throws on LLM/validation failure — callers (the reflect
+ * queue worker) own the swallow-and-log policy, since reflection must never
+ * affect a negotiation outcome.
+ */
+export class NegotiationReflector {
+  private readonly timeoutMs: number;
+
+  constructor(config?: NegotiationReflectorConfig) {
+    this.timeoutMs = config?.timeoutMs && Number.isFinite(config.timeoutMs) && config.timeoutMs > 0
+      ? config.timeoutMs
+      : DEFAULT_REFLECT_TIMEOUT_MS;
+  }
+
+  /**
+   * Distill memories from a finished negotiation, from one side's perspective.
+   * @throws When the LLM call times out or returns schema-invalid output.
+   */
+  async reflectNegotiation(input: NegotiationReflectionInput): Promise<DistilledMemory[]> {
+    const clientName = input.clientUser.name ?? "the client";
+    const counterpartyName = input.counterpartyUser.name ?? "the counterparty";
+
+    const systemPrompt = NEGOTIATION_SYSTEM_PROMPT.replace(/{clientName}/g, clientName);
+
+    const transcriptText = input.transcript.length > 0
+      ? input.transcript.map((t) => {
+          const who = t.speaker === "client" ? `${clientName}'s negotiator` : `${counterpartyName}'s negotiator`;
+          const parts = [`[${t.index}] ${who} → ${t.action}`];
+          if (t.message) parts.push(`message: ${t.message}`);
+          if (t.reasoning) parts.push(`reasoning: ${t.reasoning}`);
+          return parts.join("\n  ");
+        }).join("\n")
+      : "(no turns)";
+
+    const userMessage = `CLIENT: ${clientName}${input.clientUser.bio ? ` — ${input.clientUser.bio}` : ""}
+SEAT: ${input.seat === "initiator" ? "initiator (client's negotiator reached out)" : "counterparty (client's negotiator was reached)"}
+COUNTERPARTY: ${counterpartyName}${input.counterpartyUser.bio ? ` — ${input.counterpartyUser.bio}` : ""}
+${input.indexContext ? `NETWORK CONTEXT: ${input.indexContext}\n` : ""}
+OUTCOME: ${input.outcome.hasOpportunity ? "accepted" : "not accepted"} after ${input.outcome.turnCount} turn(s) — ${input.outcome.reasoning}
+
+TRANSCRIPT:
+${transcriptText}
+
+Distill the durable memories (or return an empty array).`;
+
+    return this.distill(systemPrompt, userMessage);
+  }
+
+  /**
+   * Distill stated preferences/corrections from a client ↔ negotiator chat.
+   * @throws When the LLM call times out or returns schema-invalid output.
+   */
+  async reflectChat(input: ChatReflectionInput): Promise<DistilledMemory[]> {
+    const clientName = input.clientUser.name ?? "the client";
+    const systemPrompt = CHAT_SYSTEM_PROMPT.replace(/{clientName}/g, clientName);
+
+    const chatText = input.messages
+      .map((m, i) => `[${i}] ${m.role === "user" ? clientName : "negotiator"}: ${m.content}`)
+      .join("\n");
+
+    const userMessage = `CHAT between ${clientName} and their negotiator (oldest first):
+${chatText}
+
+Distill the client's durable guidance (or return an empty array).`;
+
+    return this.distill(systemPrompt, userMessage);
+  }
+
+  private async distill(systemPrompt: string, userMessage: string): Promise<DistilledMemory[]> {
+    const model = createStructuredModel("negotiationReflector", ReflectionResultSchema, { name: "negotiation_reflector" });
+
+    const result = await this.callModel(model, [
+      { role: "system", content: systemPrompt },
+      { role: "user", content: userMessage },
+    ]);
+
+    const parsed = ReflectionResultSchema.safeParse(result);
+    if (!parsed.success) {
+      reflectLog.warn("Reflection output failed schema validation", {
+        issues: parsed.error.issues.map((i) => i.message).slice(0, 3),
+      });
+      throw new Error(`Reflection failed validation: ${parsed.error.issues[0]?.message ?? "unknown"}`);
+    }
+    return parsed.data.memories.slice(0, MAX_DISTILLED_MEMORIES);
+  }
+
+  /**
+   * Raw structured-model round trip. Split out as a seam so tests can drive
+   * the schema-validation path without a live provider.
+   */
+  protected async callModel(
+    model: ReturnType<typeof createStructuredModel>,
+    chatMessages: Array<{ role: string; content: string }>,
+  ): Promise<unknown> {
+    return invokeWithAbortSignal(model, chatMessages, AbortSignal.timeout(this.timeoutMs));
+  }
+}

--- a/packages/protocol/src/negotiation/tests/negotiation.reflect.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.reflect.spec.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+
+import { NegotiationGraphFactory } from "../negotiation.graph.js";
+import { IndexNegotiator } from "../negotiation.agent.js";
+import { NegotiationReflector, MAX_DISTILLED_MEMORIES } from "../negotiation.reflect.js";
+import type { NegotiationReflectJobData, ReflectionResult } from "../negotiation.reflect.js";
+
+/**
+ * IND-406 — reflection jobs (memory write path).
+ *
+ * Pins:
+ * - the finalize node enqueues a reflect job with full payload when
+ *   `reflectEnqueue` is injected and turns were exchanged,
+ * - a rejecting `reflectEnqueue` never affects the negotiation outcome
+ *   (fire-and-forget), and an absent one leaves behavior unchanged,
+ * - `NegotiationReflector` validates LLM output against the schema (throws on
+ *   invalid, caps at MAX_DISTILLED_MEMORIES) and projects transcripts into
+ *   the prompt from the client's perspective.
+ */
+
+// ─── Reflector (distiller) ───────────────────────────────────────────────────
+
+class StubReflector extends NegotiationReflector {
+  public capturedMessages: Array<{ role: string; content: string }> = [];
+  constructor(private result: unknown) {
+    super();
+  }
+  protected override async callModel(
+    _model: unknown,
+    chatMessages: Array<{ role: string; content: string }>,
+  ): Promise<unknown> {
+    this.capturedMessages = chatMessages;
+    return this.result;
+  }
+}
+
+const validResult: ReflectionResult = {
+  memories: [
+    {
+      kind: "playbook",
+      content: "Opening with the shared-conference angle got immediate engagement.",
+      confidence: 0.6,
+      aboutCounterparty: false,
+      turnIndexes: [0, 1],
+    },
+    {
+      kind: "counterparty_dossier",
+      content: "Bob prefers async collaboration and is timezone-constrained to CET.",
+      confidence: 0.8,
+      aboutCounterparty: true,
+      turnIndexes: [2],
+    },
+  ],
+};
+
+const reflectionInput = {
+  clientUser: { id: "u-alice", name: "Alice", bio: "founder" },
+  counterpartyUser: { id: "u-bob", name: "Bob" },
+  seat: "initiator" as const,
+  outcome: { hasOpportunity: true, reasoning: "aligned on scope", turnCount: 3 },
+  transcript: [
+    { index: 0, speaker: "client" as const, action: "outreach", message: "hello from the conference" },
+    { index: 1, speaker: "counterparty" as const, action: "question", message: "which track?" },
+    { index: 2, speaker: "counterparty" as const, action: "accept", reasoning: "async works, CET" },
+  ],
+};
+
+describe("NegotiationReflector", () => {
+  it("parses valid distillation output", async () => {
+    const reflector = new StubReflector(validResult);
+    const memories = await reflector.reflectNegotiation(reflectionInput);
+
+    expect(memories.length).toBe(2);
+    expect(memories[0].kind).toBe("playbook");
+    expect(memories[1].aboutCounterparty).toBe(true);
+    expect(memories[1].turnIndexes).toEqual([2]);
+  });
+
+  it("projects the transcript into the prompt from the client's perspective", async () => {
+    const reflector = new StubReflector(validResult);
+    await reflector.reflectNegotiation(reflectionInput);
+
+    const userMessage = reflector.capturedMessages.find((m) => m.role === "user")?.content ?? "";
+    expect(userMessage).toContain("Alice's negotiator → outreach");
+    expect(userMessage).toContain("Bob's negotiator → question");
+    expect(userMessage).toContain("SEAT: initiator");
+    expect(userMessage).toContain("accepted after 3 turn(s)");
+
+    const systemMessage = reflector.capturedMessages.find((m) => m.role === "system")?.content ?? "";
+    expect(systemMessage).toContain("Alice");
+    expect(systemMessage).toContain(`AT MOST ${MAX_DISTILLED_MEMORIES}`);
+  });
+
+  it("throws on schema-invalid output (confidence out of range)", async () => {
+    const reflector = new StubReflector({
+      memories: [{ kind: "playbook", content: "x", confidence: 3, aboutCounterparty: false, turnIndexes: [] }],
+    });
+    await expect(reflector.reflectNegotiation(reflectionInput)).rejects.toThrow(/validation/i);
+  });
+
+  it("throws when more than the max entries are returned", async () => {
+    const entry = validResult.memories[0];
+    const reflector = new StubReflector({ memories: [entry, entry, entry, entry] });
+    await expect(reflector.reflectNegotiation(reflectionInput)).rejects.toThrow();
+  });
+
+  it("accepts an empty memories array (nothing durable learned)", async () => {
+    const reflector = new StubReflector({ memories: [] });
+    const memories = await reflector.reflectNegotiation(reflectionInput);
+    expect(memories).toEqual([]);
+  });
+
+  it("reflectChat distills from the client-negotiator DM", async () => {
+    const reflector = new StubReflector({
+      memories: [{
+        kind: "disclosure_rule",
+        content: "Never share the client's day rate before a scope call.",
+        confidence: 0.9,
+        aboutCounterparty: false,
+        turnIndexes: [0],
+      }],
+    });
+    const memories = await reflector.reflectChat({
+      clientUser: { id: "u-alice", name: "Alice" },
+      messages: [
+        { role: "user", content: "never share my day rate before a scope call" },
+        { role: "assistant", content: "understood" },
+      ],
+    });
+
+    expect(memories.length).toBe(1);
+    expect(memories[0].kind).toBe("disclosure_rule");
+    const userMessage = reflector.capturedMessages.find((m) => m.role === "user")?.content ?? "";
+    expect(userMessage).toContain("[0] Alice: never share my day rate");
+    const systemMessage = reflector.capturedMessages.find((m) => m.role === "system")?.content ?? "";
+    expect(systemMessage).toContain("counterparty_dossier");
+  });
+});
+
+// ─── Graph finalize → reflectEnqueue ─────────────────────────────────────────
+
+function mkStubs() {
+  const database = {
+    createConversation: async () => ({ id: "conv-1" }),
+    getOrCreateDM: async () => ({ id: "conv-1" }),
+    createTask: async (conversationId: string, metadata: Record<string, unknown>) =>
+      ({ id: "task-1", conversationId, state: "submitted", metadata }),
+    updateOpportunityStatus: async () => {},
+    createMessage: async (p: { senderId: string; parts: unknown[] }) => ({
+      id: "msg-1", senderId: p.senderId, parts: p.parts, createdAt: new Date(),
+    }),
+    updateTaskState: async () => {},
+    createArtifact: async () => {},
+    setTaskTurnContext: async () => {},
+    getMessagesForConversation: async () => [],
+    getOpportunityUserAnswers: async () => [],
+    getNegotiationTaskForOpportunity: async () => null,
+    getLatestNegotiationTaskForConversation: async () => null,
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[0];
+
+  const dispatcher = {
+    hasExternalAgent: async () => false,
+    dispatch: async () => ({ handled: false, reason: "no_agent" }),
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[1];
+
+  return { database, dispatcher };
+}
+
+const graphInput = {
+  sourceUser: { id: "u-src", intents: [], profile: { name: "Alice", bio: "founder" } },
+  candidateUser: { id: "u-cand", intents: [], profile: { name: "Bob" } },
+  indexContext: { networkId: "net-1", prompt: "" },
+  seedAssessment: { reasoning: "x", valencyRole: "peer" },
+  opportunityId: "opp-1",
+  maxTurns: 2,
+};
+
+describe("negotiation graph — finalize reflect enqueue (IND-406)", () => {
+  let origInvoke: typeof IndexNegotiator.prototype.invoke;
+
+  beforeAll(() => {
+    origInvoke = IndexNegotiator.prototype.invoke;
+    IndexNegotiator.prototype.invoke = async function () {
+      return {
+        action: "accept" as const,
+        assessment: {
+          reasoning: "stub",
+          suggestedRoles: { ownUser: "agent" as const, otherUser: "patient" as const },
+        },
+        message: "deal",
+      };
+    };
+  });
+
+  afterAll(() => {
+    IndexNegotiator.prototype.invoke = origInvoke;
+  });
+
+  it("enqueues a reflect job with the full payload after finalize", async () => {
+    const stubs = mkStubs();
+    const jobs: NegotiationReflectJobData[] = [];
+    const graph = new NegotiationGraphFactory(
+      stubs.database,
+      stubs.dispatcher,
+      undefined,
+      undefined,
+      async (job) => { jobs.push(job); },
+    ).createGraph();
+
+    const result = await graph.invoke(graphInput);
+
+    expect(result.outcome?.hasOpportunity).toBe(true);
+    expect(jobs.length).toBe(1);
+    expect(jobs[0]).toMatchObject({
+      negotiationId: "task-1",
+      conversationId: "conv-1",
+      opportunityId: "opp-1",
+      sourceUser: { id: "u-src", name: "Alice", bio: "founder" },
+      candidateUser: { id: "u-cand", name: "Bob" },
+      initiatorUserId: "u-src",
+      outcome: { hasOpportunity: true, turnCount: 2 },
+    });
+  });
+
+  it("a rejecting reflectEnqueue never affects the negotiation outcome", async () => {
+    const stubs = mkStubs();
+    const graph = new NegotiationGraphFactory(
+      stubs.database,
+      stubs.dispatcher,
+      undefined,
+      undefined,
+      async () => { throw new Error("redis down"); },
+    ).createGraph();
+
+    const result = await graph.invoke(graphInput);
+
+    expect(result.error).toBeFalsy();
+    expect(result.outcome?.hasOpportunity).toBe(true);
+    expect(result.outcome?.turnCount).toBe(2);
+  });
+
+  it("graph without reflectEnqueue behaves as today (optional dep)", async () => {
+    const stubs = mkStubs();
+    const graph = new NegotiationGraphFactory(stubs.database, stubs.dispatcher).createGraph();
+
+    const result = await graph.invoke(graphInput);
+
+    expect(result.error).toBeFalsy();
+    expect(result.outcome?.hasOpportunity).toBe(true);
+  });
+});

--- a/packages/protocol/src/shared/agent/model.config.ts
+++ b/packages/protocol/src/shared/agent/model.config.ts
@@ -45,6 +45,7 @@ function getModelConfig(config?: ModelConfig) {
     opportunityPresenter: { model: "google/gemini-2.5-flash" },
     negotiator:           { model: "google/gemini-2.5-flash" },
     negotiationScreener:  { model: "google/gemini-2.5-flash", temperature: 0.2, maxTokens: 1024 },
+    negotiationReflector: { model: "google/gemini-2.5-flash", temperature: 0.3, maxTokens: 2048 },
     homeCategorizer:      { model: "google/gemini-2.5-flash" },
     suggestionGenerator:  { model: "google/gemini-2.5-flash", temperature: 0.4, maxTokens: 512 },
     chatTitleGenerator:   { model: "google/gemini-2.5-flash", temperature: 0.3, maxTokens: 32 },

--- a/services/api/src/adapters/negotiator-memory.database.adapter.ts
+++ b/services/api/src/adapters/negotiator-memory.database.adapter.ts
@@ -17,7 +17,7 @@
  * vectors — it never calls the embedding API itself.
  */
 
-import { and, desc, eq, isNotNull, sql } from 'drizzle-orm/sql';
+import { and, desc, eq, isNotNull, lt, sql } from 'drizzle-orm/sql';
 
 import db from '../lib/drizzle/drizzle';
 import * as schema from '../schemas/database.schema';
@@ -222,6 +222,32 @@ export class NegotiatorMemoryDatabaseAdapter {
       .limit(query.limit ?? 5);
 
     return rows.map((r) => ({ ...r.memory, similarity: r.similarity }));
+  }
+
+  /**
+   * Maintenance-only bulk confidence decay (P5.2 anti-poisoning schedule).
+   * Multiplies confidence by `factor` for rows whose updatedAt is older than
+   * `olderThanMs`, then deletes rows whose confidence fell below
+   * `deleteBelow`. Deliberately unscoped — this is the cron maintenance path
+   * across all owners, not a user read surface. Decay does NOT bump
+   * updatedAt: stale rows keep decaying daily until reinforced (which bumps
+   * updatedAt via update) or they fall below the floor and are removed.
+   */
+  async decayAll(opts: { factor: number; olderThanMs: number; deleteBelow: number }): Promise<{ decayed: number; deleted: number }> {
+    const cutoff = new Date(Date.now() - opts.olderThanMs);
+    const decayedRows = await db
+      .update(schema.negotiatorMemories)
+      .set({ confidence: sql`${schema.negotiatorMemories.confidence} * ${opts.factor}` })
+      .where(lt(schema.negotiatorMemories.updatedAt, cutoff))
+      .returning({ id: schema.negotiatorMemories.id });
+    const deletedRows = await db
+      .delete(schema.negotiatorMemories)
+      .where(lt(schema.negotiatorMemories.confidence, opts.deleteBelow))
+      .returning({ id: schema.negotiatorMemories.id });
+    if (decayedRows.length > 0 || deletedRows.length > 0) {
+      logger.info('Negotiator memory decay pass', { decayed: decayedRows.length, deleted: deletedRows.length });
+    }
+    return { decayed: decayedRows.length, deleted: deletedRows.length };
   }
 }
 

--- a/services/api/src/adapters/tests/negotiator-memory.database.spec.ts
+++ b/services/api/src/adapters/tests/negotiator-memory.database.spec.ts
@@ -254,6 +254,42 @@ describe('NegotiatorMemoryDatabaseAdapter', () => {
     expect(orphan).toBeUndefined();
   });
 
+  it('decayAll: decays stale rows and deletes below the floor (fresh rows untouched)', async () => {
+    // NOTE: decayAll is deliberately global (the cron maintenance path), and
+    // .env.test points at the shared dev DB — so this test uses the mild
+    // production-like factor (0.99) and a floor (0.001) low enough that no
+    // realistic real row is deleted by a re-run.
+    const stale = await adapter.create({
+      agentId, userId: ownerId, kind: 'playbook', content: `stale playbook ${run}`, confidence: 0.5,
+    });
+    const nearFloor = await adapter.create({
+      agentId, userId: ownerId, kind: 'playbook', content: `near-floor playbook ${run}`, confidence: 0.0005,
+    });
+    const fresh = await adapter.create({
+      agentId, userId: ownerId, kind: 'playbook', content: `fresh playbook ${run}`, confidence: 0.5,
+    });
+    // Backdate the stale rows past the decay window; `fresh` keeps its defaultNow().
+    const backdated = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    await db.update(schema.negotiatorMemories)
+      .set({ updatedAt: backdated })
+      .where(inArray(schema.negotiatorMemories.id, [stale.id, nearFloor.id]));
+
+    const result = await adapter.decayAll({ factor: 0.99, olderThanMs: 7 * 24 * 60 * 60 * 1000, deleteBelow: 0.001 });
+
+    expect(result.decayed).toBeGreaterThanOrEqual(2);
+    expect(result.deleted).toBeGreaterThanOrEqual(1);
+
+    const staleAfter = await adapter.getById(stale.id, ownerId);
+    expect(staleAfter?.confidence).toBeCloseTo(0.495); // 0.5 * 0.99, above the floor
+    const nearFloorAfter = await adapter.getById(nearFloor.id, ownerId);
+    expect(nearFloorAfter).toBeNull(); // 0.0005 * 0.99 < 0.001 → deleted
+    const freshAfter = await adapter.getById(fresh.id, ownerId);
+    expect(freshAfter?.confidence).toBeCloseTo(0.5); // untouched
+
+    await adapter.delete(stale.id, ownerId);
+    await adapter.delete(fresh.id, ownerId);
+  });
+
   it('cascades: deleting the subject user removes dossiers about them', async () => {
     const tempSubject = await createUser('subject-cascade');
     const dossier = await adapter.create({

--- a/services/api/src/controllers/chat.controller.ts
+++ b/services/api/src/controllers/chat.controller.ts
@@ -9,6 +9,7 @@ import { chatSessionService } from "../services/chat.service";
 import { fileService } from "../services/file.service";
 import { agentService } from "../services/agent.service";
 import { isNegotiatorChatEnabled } from "../lib/negotiator-feature";
+import { negotiationReflectQueue } from "../queues/negotiations/reflect.queue";
 import { SuggestionGenerator, ChatInterruptClassifier, NEGOTIATOR_PERSONA_ID } from '@indexnetwork/protocol';
 import { createDoneEvent, createErrorEvent, createStatusEvent, createSteerOrQueueEvent, formatSSEEvent, type DebugMetaDiscoveryQuestions } from "../types/chat-streaming.types";
 import { emitChatInterrupt, onChatInterrupt } from '../lib/chat-interrupt.events';
@@ -537,6 +538,15 @@ export class ChatController {
               routingDecision,
               subgraphResults,
             });
+          }
+
+          // Negotiator DM turns debounce-schedule a chat reflection (P5.2):
+          // the job fires once the session has been idle for the delay window,
+          // distilling stated preferences into negotiator memories. No-op when
+          // NEGOTIATOR_MEMORY_WRITE_ENABLED is off; never blocks the stream.
+          if (sessionPersona === NEGOTIATOR_PERSONA_ID && fullResponse) {
+            negotiationReflectQueue.scheduleChatReflect({ sessionId, userId: user.id })
+              .catch((err) => logger.error("Failed to schedule negotiator chat reflection", { sessionId, error: err }));
           }
 
           // Persist debug metadata (non-blocking for user experience)

--- a/services/api/src/controllers/mcp.controller.ts
+++ b/services/api/src/controllers/mcp.controller.ts
@@ -42,6 +42,7 @@ import { IntegrationService } from '../services/integration.service';
 import { opportunityDeliveryService } from '../services/opportunity-delivery.service';
 import { userService } from '../services/user.service';
 import { negotiationTimeoutQueue } from '../queues/negotiations/timeout.queue';
+import { reflectEnqueueIfEnabled } from '../queues/negotiations/reflect.queue';
 import { signConnectToken } from '../services/connect-token.service';
 import type { ConnectLinkKind } from '../services/connect-link.service';
 import { mintConnectLink as mintConnectLinkSvc, buildConnectShortUrl } from '../services/connect-link.service';
@@ -192,6 +193,8 @@ function getOrCompileGraphs(): ToolDeps['graphs'] {
     protocolDeps.agentDispatcher!,
     protocolDeps.negotiationTimeoutQueue,
     qEnqueue,
+    // Finished negotiations enqueue memory distillation (P5.2, flag-gated).
+    reflectEnqueueIfEnabled(),
   ).createGraph();
   const opportunityGraph = new OpportunityGraphFactory(
     database, embedder, compiledHydeGraph,

--- a/services/api/src/events/handlers/question.answer.negotiation-inflight.ts
+++ b/services/api/src/events/handlers/question.answer.negotiation-inflight.ts
@@ -39,6 +39,19 @@ export interface InflightResumeDeps {
   closeTask: (taskId: string, reason: string) => Promise<void>;
   /** Enqueue the run-existing continuation. */
   enqueueResume: (opportunityId: string, userId: string) => Promise<void>;
+  /**
+   * Optional P5.2 hook: record the client's answer as an immediate
+   * `disclosure_rule` negotiator memory (the answer is already a distilled
+   * policy). Fire-and-forget — a memory-write failure must never affect the
+   * resume. Absent → behaves exactly as before.
+   */
+  recordDisclosureRule?: (input: {
+    userId: string;
+    opportunityId: string;
+    questionId: string;
+    selectedOptions: string[];
+    freeText?: string;
+  }) => Promise<void>;
 }
 
 export function resumeInflightNegotiationFactory(deps: InflightResumeDeps) {
@@ -52,6 +65,15 @@ export function resumeInflightNegotiationFactory(deps: InflightResumeDeps) {
     // 1. Store the answer first — even if the resume below short-circuits,
     //    the context enrichment must not be lost.
     await deps.storeNegotiationContext(input);
+
+    // 1b. Memory write path (P5.2): an ask_user answer is already a distilled
+    //     disclosure policy — record it immediately, fire-and-forget.
+    deps.recordDisclosureRule?.(input).catch((err) => {
+      logger.warn('Failed to record disclosure rule from ask_user answer', {
+        questionId: input.questionId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
 
     // 2. Find the paused task.
     const task = await deps.getNegotiationTaskForOpportunity(input.opportunityId);

--- a/services/api/src/events/handlers/tests/question.answer.negotiation-inflight.test.ts
+++ b/services/api/src/events/handlers/tests/question.answer.negotiation-inflight.test.ts
@@ -85,4 +85,39 @@ describe("resumeInflightNegotiationFactory", () => {
     expect(deps.closeTask).toHaveBeenCalledWith("task-1", "ask_user_answered");
     expect(deps.enqueueResume).toHaveBeenCalledWith("opp-1", "u-1");
   });
+
+  // ─── P5.2 (IND-406): disclosure_rule memory hook ──────────────────────────
+
+  it("records the answer as a disclosure rule when the hook is wired (even without a paused task)", async () => {
+    const recordDisclosureRule = mock(async () => {});
+    deps = makeDeps({
+      getNegotiationTaskForOpportunity: mock(async () => null),
+      recordDisclosureRule,
+    });
+    const resume = resumeInflightNegotiationFactory(deps);
+    await resume(input);
+
+    expect(recordDisclosureRule).toHaveBeenCalledWith(input);
+  });
+
+  it("a rejecting disclosure-rule hook never affects the resume (fire-and-forget)", async () => {
+    deps = makeDeps({
+      recordDisclosureRule: mock(async () => { throw new Error("memory write failed"); }),
+    });
+    const resume = resumeInflightNegotiationFactory(deps);
+    await resume(input);
+    // Let the fire-and-forget rejection settle so its .catch runs inside the test.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(deps.closeTask).toHaveBeenCalledWith("task-1", "ask_user_answered");
+    expect(deps.enqueueResume).toHaveBeenCalledWith("opp-1", "u-1");
+  });
+
+  it("absent hook → behavior unchanged (optional dep)", async () => {
+    const resume = resumeInflightNegotiationFactory(deps);
+    await resume(input);
+
+    expect(deps.storeNegotiationContext).toHaveBeenCalledTimes(1);
+    expect(deps.enqueueResume).toHaveBeenCalledWith("opp-1", "u-1");
+  });
 });

--- a/services/api/src/main.ts
+++ b/services/api/src/main.ts
@@ -62,6 +62,8 @@ import { emailQueue } from './queues/email.queue';
 import { enrichmentQueue } from './queues/enrichment.queue';
 import { negotiationTimeoutQueue } from './queues/negotiations/timeout.queue';
 import { negotiationClaimTimeoutQueue } from './queues/negotiations/claim-timeout.queue';
+import { negotiationReflectQueue, reflectEnqueueIfEnabled } from './queues/negotiations/reflect.queue';
+import { negotiatorMemoryWriteService } from './services/negotiator-memory.service';
 import { integrationSyncQueue } from './queues/integration.queue';
 import { questionerQueue, questionerEnqueueIfEnabled } from './queues/questioner.queue';
 import { NetworkMembershipEvents } from './events/network_membership.event';
@@ -124,6 +126,9 @@ const backgroundNegotiationGraph = new NegotiationGraphFactory(
   // source user (mode='negotiation', sourceType='opportunity') so the intent
   // page can surface what would unblock the next attempt.
   questionerEnqueueIfEnabled(),
+  // Finished negotiations enqueue memory distillation for both sides (P5.2,
+  // gated on NEGOTIATOR_MEMORY_WRITE_ENABLED).
+  reflectEnqueueIfEnabled(),
 ).createGraph();
 fromIntentQueue.setRuntimeDeps({
   negotiationGraph: backgroundNegotiationGraph,
@@ -289,6 +294,18 @@ const questionAnswerDeps = {
     enqueueResume: async (opportunityId, userId) => {
       await negotiationRunExistingQueue.addJob({ opportunityId, userId });
     },
+    // P5.2: the answer is already a distilled disclosure policy — record it
+    // as a negotiator memory (no-op while NEGOTIATOR_MEMORY_WRITE_ENABLED is off).
+    recordDisclosureRule: async ({ userId, questionId, selectedOptions, freeText }) => {
+      const question = await answerQuestionerAdapter.getById(questionId).catch(() => null);
+      await negotiatorMemoryWriteService.recordDisclosureRuleFromAnswer({
+        userId,
+        questionId,
+        ...(question?.payload.prompt && { questionPrompt: question.payload.prompt }),
+        selectedOptions,
+        ...(freeText !== undefined && { freeText }),
+      });
+    },
   }),
   resolveChatQuestionWait: ({ questionId, answer }: {
     questionId: string;
@@ -328,6 +345,8 @@ hydeQueue.startCrons();
 emailQueue.startWorker();
 negotiationTimeoutQueue.startWorker();
 negotiationClaimTimeoutQueue.startWorker();
+negotiationReflectQueue.startWorker();
+negotiationReflectQueue.startCrons();
 integrationSyncQueue.startWorker();
 if (isQuestionerEnabled()) {
   questionerQueue.startWorker();

--- a/services/api/src/queues/negotiations/reflect.queue.ts
+++ b/services/api/src/queues/negotiations/reflect.queue.ts
@@ -1,0 +1,320 @@
+/**
+ * Negotiation reflection queue (P5.2 / IND-406) — the memory write path.
+ *
+ * Two job kinds:
+ * - `reflect`: enqueued by the negotiation graph's finalize node (via the
+ *   injected `ReflectEnqueueFn` — the protocol package has no BullMQ access).
+ *   Replays the finished negotiation's turn history from BOTH sides and
+ *   distills ≤ 3 private memory entries per side via `NegotiationReflector`.
+ * - `chat_reflect`: debounce-scheduled after each negotiator-DM turn; fires
+ *   once the session has been idle for the debounce window ("session end"),
+ *   distilling the client's stated preferences/corrections.
+ *
+ * Write-only: nothing reads `negotiator_memories` yet (P5.3). Every write
+ * funnels through `NegotiatorMemoryWriteService` (flag gate, caps, dossier
+ * upsert). Job failures never affect negotiation outcomes — the negotiation
+ * finalized before the job runs, and the graph enqueues fire-and-forget.
+ *
+ * A daily cron runs the confidence-decay pass (anti-poisoning schedule).
+ */
+
+import { Job } from 'bullmq';
+import cron from 'node-cron';
+
+import { NegotiationReflector, NEGOTIATOR_PERSONA_ID } from '@indexnetwork/protocol';
+import type { NegotiationReflectJobData, ReflectEnqueueFn, ReflectionTranscriptEntry, DistilledMemory } from '@indexnetwork/protocol';
+
+import { log } from '../../lib/log';
+import { QueueFactory } from '../../lib/bullmq/bullmq';
+import { conversationDatabaseAdapter } from '../../adapters/database.adapter';
+import { chatSessionService } from '../../services/chat.service';
+import { negotiatorMemoryWriteService, isNegotiatorMemoryWriteEnabled, type NegotiatorMemoryWriteService } from '../../services/negotiator-memory.service';
+
+/** BullMQ queue name for reflection jobs. */
+export const QUEUE_NAME = 'negotiation-reflect';
+
+/** Idle window after the last negotiator-DM turn before chat_reflect fires. */
+const DEFAULT_CHAT_REFLECT_DELAY_MS = 15 * 60 * 1000;
+
+function chatReflectDelayMs(): number {
+  const raw = Number(process.env.NEGOTIATOR_CHAT_REFLECT_DELAY_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_CHAT_REFLECT_DELAY_MS;
+}
+
+export type ReflectJobData = NegotiationReflectJobData;
+
+export interface ChatReflectJobData {
+  sessionId: string;
+  userId: string;
+}
+
+type ReflectQueueJobData = ReflectJobData | ChatReflectJobData;
+
+/** Optional deps for testing — abstractions only, no real DB/LLM/Redis. */
+export interface ReflectQueueDeps {
+  conversations?: {
+    getMessagesForConversation: (conversationId: string) => Promise<Array<{
+      id: string;
+      senderId: string;
+      parts: unknown[];
+      createdAt: Date;
+    }>>;
+  };
+  chat?: {
+    getSession: (sessionId: string, userId: string) => Promise<{ persona: string } | null>;
+    getSessionMessages: (sessionId: string, limit?: number) => Promise<Array<{ role: 'user' | 'assistant' | 'system'; content: string }>>;
+  };
+  reflector?: Pick<NegotiationReflector, 'reflectNegotiation' | 'reflectChat'>;
+  writer?: Pick<NegotiatorMemoryWriteService, 'writeDistilledMemories' | 'runConfidenceDecay'>;
+}
+
+/**
+ * Reflection queue: BullMQ queue + worker + cron in one class. Workers are
+ * started only by the protocol server via {@link startWorker}; the decay cron
+ * via {@link startCrons}.
+ */
+export class NegotiationReflectQueue {
+  static readonly QUEUE_NAME = QUEUE_NAME;
+
+  readonly queue = QueueFactory.createQueue<ReflectQueueJobData>(QUEUE_NAME);
+
+  private readonly logger = log.job.from('NegotiationReflectJob');
+  private readonly queueLogger = log.queue.from('NegotiationReflectQueue');
+  private readonly deps: ReflectQueueDeps | undefined;
+  private reflector: Pick<NegotiationReflector, 'reflectNegotiation' | 'reflectChat'> | null;
+  private worker: ReturnType<typeof QueueFactory.createWorker<ReflectQueueJobData>> | null = null;
+  private cronStarted = false;
+
+  constructor(deps?: ReflectQueueDeps) {
+    this.deps = deps;
+    this.reflector = deps?.reflector ?? null; // lazy — created on first job (defers OPENROUTER key need)
+  }
+
+  private getReflector(): Pick<NegotiationReflector, 'reflectNegotiation' | 'reflectChat'> {
+    if (!this.reflector) this.reflector = new NegotiationReflector();
+    return this.reflector;
+  }
+
+  private getWriter(): Pick<NegotiatorMemoryWriteService, 'writeDistilledMemories' | 'runConfidenceDecay'> {
+    return this.deps?.writer ?? negotiatorMemoryWriteService;
+  }
+
+  /** Enqueue a post-negotiation reflection job. */
+  async addReflectJob(data: ReflectJobData): Promise<void> {
+    await this.queue.add('reflect', data, { jobId: `reflect-${data.negotiationId}` });
+  }
+
+  /**
+   * Debounce-schedule a chat reflection for a negotiator DM: each call
+   * replaces any pending delayed job for the session, so the job only fires
+   * after the session has been idle for the full delay window — the closest
+   * observable "session end" for an open-ended DM surface. No-op when the
+   * write flag is off (avoids Redis churn for a job that would skip anyway).
+   */
+  async scheduleChatReflect(data: ChatReflectJobData): Promise<void> {
+    if (!isNegotiatorMemoryWriteEnabled()) return;
+    const jobId = `chat-reflect-${data.sessionId}`;
+    await this.queue.remove(jobId).catch(() => { /* not present or already active — fine */ });
+    await this.queue.add('chat_reflect', data, { jobId, delay: chatReflectDelayMs() });
+  }
+
+  /** Run a job handler (worker path and tests with injected deps). */
+  async processJob(name: string, data: ReflectQueueJobData): Promise<void> {
+    switch (name) {
+      case 'reflect':
+        await this.handleReflect(data as ReflectJobData);
+        break;
+      case 'chat_reflect':
+        await this.handleChatReflect(data as ChatReflectJobData);
+        break;
+      default:
+        this.queueLogger.warn('Unknown job name', { name });
+    }
+  }
+
+  /** Start the BullMQ worker. Idempotent; protocol server only. */
+  startWorker(): void {
+    if (this.worker) return;
+    const processor = async (job: Job<ReflectQueueJobData>) => {
+      this.queueLogger.info('Processing job', { jobId: job.id, jobName: job.name });
+      await this.processJob(job.name, job.data);
+    };
+    this.worker = QueueFactory.createWorker<ReflectQueueJobData>(QUEUE_NAME, processor);
+  }
+
+  /**
+   * Start the daily confidence-decay cron (04:40, after the HyDE maintenance
+   * window). Runs regardless of the write flag — decay is maintenance of
+   * existing rows and no-ops on an empty table.
+   */
+  startCrons(): void {
+    if (this.cronStarted) return;
+    this.cronStarted = true;
+    cron.schedule('40 4 * * *', () => {
+      this.getWriter().runConfidenceDecay()
+        .then(({ decayed, deleted }) => {
+          if (decayed > 0 || deleted > 0) this.logger.info('Confidence decay pass complete', { decayed, deleted });
+        })
+        .catch((err) => this.logger.error('Confidence decay cron failed', { error: err }));
+    });
+  }
+
+  /** Gracefully close the worker and queue connections. */
+  async close(): Promise<void> {
+    if (this.worker) {
+      await this.worker.close();
+      this.worker = null;
+    }
+    await this.queue.close();
+  }
+
+  // ─── reflect ──────────────────────────────────────────────────────────────
+
+  private async handleReflect(data: ReflectJobData): Promise<void> {
+    if (!isNegotiatorMemoryWriteEnabled()) {
+      this.logger.info('Memory writes disabled; skipping reflection', { negotiationId: data.negotiationId });
+      return;
+    }
+
+    const conversations: NonNullable<ReflectQueueDeps['conversations']> =
+      this.deps?.conversations ?? conversationDatabaseAdapter;
+    const messages = await conversations.getMessagesForConversation(data.conversationId);
+
+    // Extract turn data parts (same projection the graph uses).
+    const turns = messages
+      .map((m) => {
+        const dataPart = (m.parts as Array<{ kind?: string; data?: { action?: string; message?: string; assessment?: { reasoning?: string } } }>)
+          .find((p) => p.kind === 'data');
+        return dataPart?.data ? { senderId: m.senderId, turn: dataPart.data } : null;
+      })
+      .filter((t): t is NonNullable<typeof t> => t !== null);
+
+    if (turns.length === 0) {
+      this.logger.info('No turns to reflect on', { negotiationId: data.negotiationId });
+      return;
+    }
+
+    // Each side's negotiator learns independently: run the distiller once per
+    // user, projecting the shared transcript into that side's perspective.
+    // One side failing must not cost the other its memories.
+    const sides = [
+      { user: data.sourceUser, other: data.candidateUser },
+      { user: data.candidateUser, other: data.sourceUser },
+    ];
+
+    for (const { user, other } of sides) {
+      try {
+        const transcript: ReflectionTranscriptEntry[] = turns.map((t, index) => ({
+          index,
+          speaker: t.senderId === `agent:${user.id}` ? 'client' as const : 'counterparty' as const,
+          action: t.turn.action ?? 'unknown',
+          ...(t.turn.message && { message: t.turn.message }),
+          ...(t.turn.assessment?.reasoning && { reasoning: t.turn.assessment.reasoning }),
+        }));
+
+        const entries = await this.getReflector().reflectNegotiation({
+          clientUser: user,
+          counterpartyUser: other,
+          seat: user.id === data.initiatorUserId ? 'initiator' : 'counterparty',
+          outcome: data.outcome,
+          transcript,
+        });
+
+        const { written, skipped } = await this.getWriter().writeDistilledMemories({
+          userId: user.id,
+          counterpartyUserId: other.id,
+          entries,
+          sourceRef: { type: 'negotiation', id: data.negotiationId },
+        });
+
+        this.logger.info('Negotiation reflection side complete', {
+          negotiationId: data.negotiationId,
+          userId: user.id,
+          distilled: entries.length,
+          written,
+          skipped,
+        });
+      } catch (err) {
+        this.logger.error('Negotiation reflection side failed', {
+          negotiationId: data.negotiationId,
+          userId: user.id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+
+  // ─── chat_reflect ─────────────────────────────────────────────────────────
+
+  private async handleChatReflect(data: ChatReflectJobData): Promise<void> {
+    if (!isNegotiatorMemoryWriteEnabled()) {
+      this.logger.info('Memory writes disabled; skipping chat reflection', { sessionId: data.sessionId });
+      return;
+    }
+
+    const chat = this.deps?.chat ?? chatSessionService;
+
+    // Ownership + persona guard: only the client's own negotiator DM is
+    // reflected — orchestrator chats teach the negotiator nothing.
+    const session = await chat.getSession(data.sessionId, data.userId);
+    if (!session || session.persona !== NEGOTIATOR_PERSONA_ID) {
+      this.logger.info('Not a negotiator session; skipping chat reflection', {
+        sessionId: data.sessionId,
+        persona: session?.persona ?? 'none',
+      });
+      return;
+    }
+
+    const raw = await chat.getSessionMessages(data.sessionId, 60);
+    const messages = raw
+      .filter((m): m is typeof m & { role: 'user' | 'assistant' } => m.role === 'user' || m.role === 'assistant')
+      .map((m) => ({ role: m.role, content: m.content }))
+      .filter((m) => m.content.trim().length > 0);
+
+    if (!messages.some((m) => m.role === 'user')) {
+      this.logger.info('No client messages in session; skipping chat reflection', { sessionId: data.sessionId });
+      return;
+    }
+
+    const entries = await this.getReflector().reflectChat({
+      clientUser: { id: data.userId },
+      messages,
+    });
+
+    // Chat scope has no counterparty: dossiers cannot be attributed to a
+    // subject here, so any that slip through the prompt are dropped.
+    const clientSideEntries: DistilledMemory[] = entries.filter((e) => e.kind !== 'counterparty_dossier');
+
+    const { written, skipped } = await this.getWriter().writeDistilledMemories({
+      userId: data.userId,
+      entries: clientSideEntries,
+      sourceRef: { type: 'chat', id: data.sessionId },
+    });
+
+    this.logger.info('Chat reflection complete', {
+      sessionId: data.sessionId,
+      userId: data.userId,
+      distilled: entries.length,
+      written,
+      skipped,
+    });
+  }
+}
+
+/** Singleton reflect queue instance. */
+export const negotiationReflectQueue = new NegotiationReflectQueue();
+
+/**
+ * Returns the reflect enqueue callback when memory writes are enabled
+ * (`NEGOTIATOR_MEMORY_WRITE_ENABLED=true`), or `undefined` otherwise.
+ *
+ * Use at every negotiation-graph composition site (main.ts background graph,
+ * negotiation/tool services, MCP composition root) — mirrors
+ * `questionerEnqueueIfEnabled` so no path silently drops reflection.
+ */
+export function reflectEnqueueIfEnabled(): ReflectEnqueueFn | undefined {
+  if (!isNegotiatorMemoryWriteEnabled()) return undefined;
+  return async (job) => {
+    await negotiationReflectQueue.addReflectJob(job);
+  };
+}

--- a/services/api/src/queues/tests/reflect.queue.spec.ts
+++ b/services/api/src/queues/tests/reflect.queue.spec.ts
@@ -1,0 +1,239 @@
+/**
+ * IND-406 — NegotiationReflectQueue job handlers (unit tests, deps injected).
+ *
+ * Pins:
+ * - `reflect`: flag off → distiller never invoked; flag on → BOTH sides get a
+ *   reflection pass with perspective-projected transcripts and correct seat
+ *   attribution; one side failing never costs the other its memories,
+ * - `chat_reflect`: ownership/persona guard (only the negotiator DM reflects),
+ *   counterparty_dossier entries are dropped (no subject in chat scope),
+ *   sessions without client messages are skipped.
+ */
+process.env.DATABASE_URL = process.env.DATABASE_URL ?? 'postgresql://unused:unused@localhost:5432/unused';
+process.env.OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY ?? 'test-key';
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+import { NEGOTIATOR_PERSONA_ID } from '@indexnetwork/protocol';
+import type { NegotiationReflectionInput, ChatReflectionInput, DistilledMemory } from '@indexnetwork/protocol';
+
+import { NegotiationReflectQueue, type ReflectJobData } from '../negotiations/reflect.queue';
+
+const origFlag = process.env.NEGOTIATOR_MEMORY_WRITE_ENABLED;
+
+function turnMessage(senderUserId: string, action: string, message?: string): {
+  id: string; senderId: string; parts: unknown[]; createdAt: Date;
+} {
+  return {
+    id: `msg-${action}-${senderUserId}`,
+    senderId: `agent:${senderUserId}`,
+    parts: [{ kind: 'data', data: { action, ...(message && { message }), assessment: { reasoning: `${action} reasoning` } } }],
+    createdAt: new Date(),
+  };
+}
+
+const reflectJob: ReflectJobData = {
+  negotiationId: 'neg-1',
+  conversationId: 'conv-1',
+  opportunityId: 'opp-1',
+  sourceUser: { id: 'u-alice', name: 'Alice' },
+  candidateUser: { id: 'u-bob', name: 'Bob' },
+  initiatorUserId: 'u-alice',
+  outcome: { hasOpportunity: true, reasoning: 'aligned', turnCount: 2 },
+};
+
+const distilled: DistilledMemory[] = [{
+  kind: 'playbook',
+  content: 'x',
+  confidence: 0.5,
+  aboutCounterparty: false,
+  turnIndexes: [0],
+}];
+
+function mkQueue(opts?: {
+  reflectNegotiation?: (input: NegotiationReflectionInput) => Promise<DistilledMemory[]>;
+  reflectChat?: (input: ChatReflectionInput) => Promise<DistilledMemory[]>;
+  session?: { persona: string } | null;
+  chatMessages?: Array<{ role: 'user' | 'assistant' | 'system'; content: string }>;
+}) {
+  const reflectCalls: NegotiationReflectionInput[] = [];
+  const chatCalls: ChatReflectionInput[] = [];
+  const writes: Array<Record<string, unknown>> = [];
+
+  const queue = new NegotiationReflectQueue({
+    conversations: {
+      getMessagesForConversation: async () => [
+        turnMessage('u-alice', 'outreach', 'hello'),
+        turnMessage('u-bob', 'accept', 'deal'),
+      ],
+    },
+    chat: {
+      getSession: async () => opts?.session === undefined ? { persona: NEGOTIATOR_PERSONA_ID } : opts.session,
+      getSessionMessages: async () => opts?.chatMessages ?? [
+        { role: 'user', content: 'never share my rate' },
+        { role: 'assistant', content: 'understood' },
+      ],
+    },
+    reflector: {
+      reflectNegotiation: mock(async (input: NegotiationReflectionInput) => {
+        reflectCalls.push(input);
+        return opts?.reflectNegotiation ? opts.reflectNegotiation(input) : distilled;
+      }),
+      reflectChat: mock(async (input: ChatReflectionInput) => {
+        chatCalls.push(input);
+        return opts?.reflectChat ? opts.reflectChat(input) : distilled;
+      }),
+    },
+    writer: {
+      writeDistilledMemories: mock(async (input: Record<string, unknown>) => {
+        writes.push(input);
+        return { written: (input.entries as unknown[]).length, skipped: 0 };
+      }) as never,
+      runConfidenceDecay: mock(async () => ({ decayed: 0, deleted: 0 })),
+    },
+  });
+
+  return { queue, reflectCalls, chatCalls, writes };
+}
+
+describe('NegotiationReflectQueue', () => {
+  const queues: NegotiationReflectQueue[] = [];
+
+  beforeEach(() => {
+    process.env.NEGOTIATOR_MEMORY_WRITE_ENABLED = 'true';
+  });
+
+  afterEach(async () => {
+    if (origFlag === undefined) delete process.env.NEGOTIATOR_MEMORY_WRITE_ENABLED;
+    else process.env.NEGOTIATOR_MEMORY_WRITE_ENABLED = origFlag;
+    await Promise.all(queues.splice(0).map((q) => q.close().catch(() => undefined)));
+  });
+
+  describe('reflect', () => {
+    it('flag off → distiller never invoked, zero writes', async () => {
+      delete process.env.NEGOTIATOR_MEMORY_WRITE_ENABLED;
+      const { queue, reflectCalls, writes } = mkQueue();
+      queues.push(queue);
+
+      await queue.processJob('reflect', reflectJob);
+
+      expect(reflectCalls.length).toBe(0);
+      expect(writes.length).toBe(0);
+    });
+
+    it('runs one perspective-projected pass per side with correct seat attribution', async () => {
+      const { queue, reflectCalls, writes } = mkQueue();
+      queues.push(queue);
+
+      await queue.processJob('reflect', reflectJob);
+
+      expect(reflectCalls.length).toBe(2);
+
+      // Alice's pass: she spoke turn 0, holds the initiator seat.
+      const alicePass = reflectCalls.find((c) => c.clientUser.id === 'u-alice')!;
+      expect(alicePass.seat).toBe('initiator');
+      expect(alicePass.counterpartyUser.id).toBe('u-bob');
+      expect(alicePass.transcript).toEqual([
+        { index: 0, speaker: 'client', action: 'outreach', message: 'hello', reasoning: 'outreach reasoning' },
+        { index: 1, speaker: 'counterparty', action: 'accept', message: 'deal', reasoning: 'accept reasoning' },
+      ]);
+
+      // Bob's pass: same transcript, flipped perspective, counterparty seat.
+      const bobPass = reflectCalls.find((c) => c.clientUser.id === 'u-bob')!;
+      expect(bobPass.seat).toBe('counterparty');
+      expect(bobPass.transcript[0].speaker).toBe('counterparty');
+      expect(bobPass.transcript[1].speaker).toBe('client');
+
+      // Both sides write with negotiation provenance and the counterparty as dossier subject.
+      expect(writes.length).toBe(2);
+      expect(writes[0]).toMatchObject({
+        userId: 'u-alice',
+        counterpartyUserId: 'u-bob',
+        sourceRef: { type: 'negotiation', id: 'neg-1' },
+      });
+      expect(writes[1]).toMatchObject({ userId: 'u-bob', counterpartyUserId: 'u-alice' });
+    });
+
+    it('one side failing never costs the other its memories', async () => {
+      const { queue, writes } = mkQueue({
+        reflectNegotiation: async (input) => {
+          if (input.clientUser.id === 'u-alice') throw new Error('LLM timeout');
+          return distilled;
+        },
+      });
+      queues.push(queue);
+
+      await queue.processJob('reflect', reflectJob);
+
+      expect(writes.length).toBe(1);
+      expect(writes[0]).toMatchObject({ userId: 'u-bob' });
+    });
+  });
+
+  describe('chat_reflect', () => {
+    const chatJob = { sessionId: 'sess-1', userId: 'u-alice' };
+
+    it('flag off → skipped entirely', async () => {
+      delete process.env.NEGOTIATOR_MEMORY_WRITE_ENABLED;
+      const { queue, chatCalls } = mkQueue();
+      queues.push(queue);
+
+      await queue.processJob('chat_reflect', chatJob);
+      expect(chatCalls.length).toBe(0);
+    });
+
+    it('non-negotiator persona → skipped (guard)', async () => {
+      const { queue, chatCalls, writes } = mkQueue({ session: { persona: 'orchestrator' } });
+      queues.push(queue);
+
+      await queue.processJob('chat_reflect', chatJob);
+      expect(chatCalls.length).toBe(0);
+      expect(writes.length).toBe(0);
+    });
+
+    it('missing/unowned session → skipped (guard)', async () => {
+      const { queue, chatCalls } = mkQueue({ session: null });
+      queues.push(queue);
+
+      await queue.processJob('chat_reflect', chatJob);
+      expect(chatCalls.length).toBe(0);
+    });
+
+    it('no client messages → skipped', async () => {
+      const { queue, chatCalls } = mkQueue({
+        chatMessages: [{ role: 'assistant', content: 'hello, I am your negotiator' }],
+      });
+      queues.push(queue);
+
+      await queue.processJob('chat_reflect', chatJob);
+      expect(chatCalls.length).toBe(0);
+    });
+
+    it('distills the DM and writes with chat provenance; dossiers are dropped', async () => {
+      const { queue, chatCalls, writes } = mkQueue({
+        reflectChat: async () => [
+          { kind: 'disclosure_rule', content: 'never share rate', confidence: 0.9, aboutCounterparty: false, turnIndexes: [0] },
+          { kind: 'counterparty_dossier', content: 'should be dropped', confidence: 0.5, aboutCounterparty: true, turnIndexes: [] },
+        ],
+      });
+      queues.push(queue);
+
+      await queue.processJob('chat_reflect', chatJob);
+
+      expect(chatCalls.length).toBe(1);
+      expect(chatCalls[0].messages).toEqual([
+        { role: 'user', content: 'never share my rate' },
+        { role: 'assistant', content: 'understood' },
+      ]);
+
+      expect(writes.length).toBe(1);
+      const entries = writes[0].entries as DistilledMemory[];
+      expect(entries.length).toBe(1);
+      expect(entries[0].kind).toBe('disclosure_rule');
+      expect(writes[0]).toMatchObject({
+        userId: 'u-alice',
+        sourceRef: { type: 'chat', id: 'sess-1' },
+      });
+    });
+  });
+});

--- a/services/api/src/schemas/database.schema.ts
+++ b/services/api/src/schemas/database.schema.ts
@@ -742,6 +742,8 @@ export type NegotiatorMemoryKind = 'playbook' | 'disclosure_rule' | 'counterpart
 export interface NegotiatorMemorySourceRef {
   type: 'negotiation' | 'question_answer' | 'chat' | 'manual';
   id: string;
+  /** For negotiation refs: 0-based turn indexes evidencing the memory. */
+  turnIndexes?: number[];
 }
 
 /**

--- a/services/api/src/services/negotiation.service.ts
+++ b/services/api/src/services/negotiation.service.ts
@@ -4,6 +4,7 @@ import { ChatDatabaseAdapter, conversationDatabaseAdapter } from '../adapters/da
 import { NegotiationGraphFactory } from '@indexnetwork/protocol';
 import type { UserNegotiationContext, AgentDispatcher } from '@indexnetwork/protocol';
 import { questionerEnqueueIfEnabled } from '../queues/questioner.queue';
+import { reflectEnqueueIfEnabled } from '../queues/negotiations/reflect.queue';
 
 const logger = log.service.from('NegotiationService');
 
@@ -41,6 +42,8 @@ export class NegotiationService {
       undefined,
       // Stalled negotiations enqueue follow-up questions for the source user.
       questionerEnqueueIfEnabled(),
+      // Finished negotiations enqueue memory distillation (P5.2, flag-gated).
+      reflectEnqueueIfEnabled(),
     ).createGraph();
 
     logger.info('Starting discovery negotiation', { sourceUserId, candidateUserId });

--- a/services/api/src/services/negotiator-memory.service.ts
+++ b/services/api/src/services/negotiator-memory.service.ts
@@ -1,0 +1,282 @@
+/**
+ * Negotiator memory write service (P5.2 / IND-406).
+ *
+ * The single choke point for every `negotiator_memories` write: the reflect
+ * queue (post-negotiation + chat distillation) and the ask_user answer path
+ * (immediate disclosure_rule) both land here. Owns the anti-poisoning policy:
+ *
+ * - **Flag gate**: `NEGOTIATOR_MEMORY_WRITE_ENABLED` (default OFF — code
+ *   ships inert, the environment turns it on; off in prod until P5.4
+ *   inspection ships so users can see memory before it accumulates).
+ * - **Per-kind entry caps** per negotiator: at cap, the lowest-confidence
+ *   (oldest first) entry is evicted to make room.
+ * - **Dossier upsert**: one dossier per (agent, subject) — repeat encounters
+ *   reinforce (content refresh + confidence bump + provenance append) instead
+ *   of duplicating.
+ * - **Confidence decay schedule**: cron-driven bulk decay of stale rows via
+ *   the adapter; rows below the floor are removed.
+ *
+ * Leak-guard unchanged from IND-405: this service only WRITES; no read path
+ * is exposed to discovery, user contexts, or counterparty-visible surfaces.
+ */
+
+import type { DistilledMemory } from '@indexnetwork/protocol';
+
+import { log } from '../lib/log';
+import { agentDatabaseAdapter } from '../adapters/agent.database.adapter';
+import { embedderAdapter } from '../adapters/embedder.adapter';
+import { negotiatorMemoryDatabaseAdapter, type NegotiatorMemoryDatabaseAdapter } from '../adapters/negotiator-memory.database.adapter';
+import type { NegotiatorMemoryKind, NegotiatorMemorySourceRef } from '../schemas/database.schema';
+
+const logger = log.service.from('NegotiatorMemoryWrite');
+
+/** Write-path flag. Default off; flipped per environment (dev first). */
+export function isNegotiatorMemoryWriteEnabled(): boolean {
+  return process.env.NEGOTIATOR_MEMORY_WRITE_ENABLED === 'true';
+}
+
+/** Per-kind entry caps per negotiator agent (anti-poisoning). */
+export const NEGOTIATOR_MEMORY_KIND_CAPS: Record<NegotiatorMemoryKind, number> = {
+  playbook: 25,
+  disclosure_rule: 50,
+  counterparty_dossier: 200,
+  threshold: 15,
+};
+
+/** Confidence bump when a dossier is reinforced by a new encounter. */
+const REINFORCE_BUMP = 0.1;
+/** Max provenance refs kept per row (oldest dropped first). */
+const MAX_SOURCE_REFS = 10;
+/** Daily decay multiplier for rows not updated within {@link DECAY_AFTER_MS}. */
+const DECAY_FACTOR = 0.99;
+const DECAY_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
+/** Rows decaying below this confidence floor are deleted. */
+const DECAY_DELETE_BELOW = 0.05;
+
+type MemoryAdapterSurface = Pick<
+  NegotiatorMemoryDatabaseAdapter,
+  'create' | 'list' | 'update' | 'delete' | 'decayAll'
+>;
+
+export interface NegotiatorMemoryWriteDeps {
+  memories?: MemoryAdapterSurface;
+  /** Embed a content string (2000-dim premise space); null on failure. */
+  embed?: (text: string) => Promise<number[] | null>;
+  /** Resolve the user's personal negotiator agent id (provisioning if missing). */
+  resolveNegotiatorAgentId?: (userId: string) => Promise<string | null>;
+}
+
+export interface WriteDistilledInput {
+  /** The client whose negotiator learns. */
+  userId: string;
+  entries: DistilledMemory[];
+  /** Provenance attached to every written row (turnIndexes merged per entry). */
+  sourceRef: NegotiatorMemorySourceRef;
+  /** Subject for `counterparty_dossier` entries; dossiers are skipped without it. */
+  counterpartyUserId?: string;
+}
+
+export class NegotiatorMemoryWriteService {
+  private readonly memories: MemoryAdapterSurface;
+  private readonly embed: (text: string) => Promise<number[] | null>;
+  private readonly resolveNegotiatorAgentId: (userId: string) => Promise<string | null>;
+
+  constructor(deps?: NegotiatorMemoryWriteDeps) {
+    this.memories = deps?.memories ?? negotiatorMemoryDatabaseAdapter;
+    this.embed = deps?.embed ?? (async (text) => {
+      try {
+        const vector = await embedderAdapter.generate(text);
+        return vector as number[];
+      } catch (err) {
+        logger.warn('Embedding failed for negotiator memory; storing without vector', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return null;
+      }
+    });
+    this.resolveNegotiatorAgentId = deps?.resolveNegotiatorAgentId ?? (async (userId) =>
+      // Same resolution agentService.getNegotiatorAgent uses — idempotent
+      // provision of the user's type='personal' negotiator row (IND-410).
+      agentDatabaseAdapter.ensureNegotiatorAgent(userId));
+  }
+
+  /**
+   * Persist a batch of distilled memories for one client's negotiator,
+   * applying caps and dossier upsert. Returns write counters (never throws
+   * for individual entry failures — callers are fire-and-forget paths).
+   */
+  async writeDistilledMemories(input: WriteDistilledInput): Promise<{ written: number; skipped: number }> {
+    if (!isNegotiatorMemoryWriteEnabled()) {
+      return { written: 0, skipped: input.entries.length };
+    }
+    if (input.entries.length === 0) return { written: 0, skipped: 0 };
+
+    const agentId = await this.resolveNegotiatorAgentId(input.userId);
+    if (!agentId) {
+      logger.warn('No personal negotiator agent for user; skipping memory write', { userId: input.userId });
+      return { written: 0, skipped: input.entries.length };
+    }
+
+    let written = 0;
+    let skipped = 0;
+
+    for (const entry of input.entries) {
+      try {
+        const isDossier = entry.kind === 'counterparty_dossier';
+        if (isDossier && !input.counterpartyUserId) {
+          skipped++;
+          continue;
+        }
+
+        const ref: NegotiatorMemorySourceRef = {
+          ...input.sourceRef,
+          ...(entry.turnIndexes.length > 0 && { turnIndexes: entry.turnIndexes }),
+        };
+
+        if (isDossier) {
+          await this.upsertDossier(agentId, input.userId, input.counterpartyUserId!, entry, ref);
+        } else {
+          await this.enforceKindCap(agentId, input.userId, entry.kind);
+          const embedding = await this.embed(entry.content);
+          await this.memories.create({
+            agentId,
+            userId: input.userId,
+            kind: entry.kind,
+            content: entry.content,
+            confidence: entry.confidence,
+            ...(embedding && { embedding }),
+            sourceRefs: [ref],
+          });
+        }
+        written++;
+      } catch (err) {
+        skipped++;
+        logger.error('Failed to write negotiator memory entry', {
+          userId: input.userId,
+          kind: entry.kind,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    if (written > 0) {
+      logger.info('Negotiator memories written', {
+        userId: input.userId,
+        agentId,
+        written,
+        skipped,
+        sourceType: input.sourceRef.type,
+        sourceId: input.sourceRef.id,
+      });
+    }
+    return { written, skipped };
+  }
+
+  /**
+   * Record an `ask_user` answer as an immediate disclosure_rule memory (the
+   * answer is already a distilled policy — no LLM pass needed). High
+   * confidence: this is the client speaking directly.
+   */
+  async recordDisclosureRuleFromAnswer(input: {
+    userId: string;
+    questionId: string;
+    questionPrompt?: string;
+    selectedOptions: string[];
+    freeText?: string;
+  }): Promise<void> {
+    if (!isNegotiatorMemoryWriteEnabled()) return;
+
+    const answerText = [input.selectedOptions.join('; '), input.freeText?.trim()]
+      .filter(Boolean)
+      .join(' — ');
+    if (!answerText) return;
+
+    const subject = input.questionPrompt?.trim() || 'a mid-negotiation disclosure decision';
+    const content = `Client guidance on "${subject}": ${answerText}`;
+
+    await this.writeDistilledMemories({
+      userId: input.userId,
+      entries: [{
+        kind: 'disclosure_rule',
+        content,
+        confidence: 0.9,
+        aboutCounterparty: false,
+        turnIndexes: [],
+      }],
+      sourceRef: { type: 'question_answer', id: input.questionId },
+    });
+  }
+
+  /**
+   * Run one confidence-decay pass (cron path). Independent of the write flag:
+   * decay is maintenance of existing rows and no-ops on an empty table.
+   */
+  async runConfidenceDecay(): Promise<{ decayed: number; deleted: number }> {
+    return this.memories.decayAll({
+      factor: DECAY_FACTOR,
+      olderThanMs: DECAY_AFTER_MS,
+      deleteBelow: DECAY_DELETE_BELOW,
+    });
+  }
+
+  /** One dossier per (agent, subject): reinforce, don't duplicate. */
+  private async upsertDossier(
+    agentId: string,
+    userId: string,
+    subjectUserId: string,
+    entry: DistilledMemory,
+    ref: NegotiatorMemorySourceRef,
+  ): Promise<void> {
+    const [existing] = await this.memories.list(agentId, userId, {
+      kind: 'counterparty_dossier',
+      subjectUserId,
+      limit: 1,
+    });
+
+    if (existing) {
+      const embedding = await this.embed(entry.content);
+      await this.memories.update(existing.id, userId, {
+        content: entry.content,
+        ...(embedding && { embedding }),
+        confidence: Math.min(1, Math.max(existing.confidence, entry.confidence) + REINFORCE_BUMP),
+        sourceRefs: [...existing.sourceRefs.slice(-(MAX_SOURCE_REFS - 1)), ref],
+      });
+      return;
+    }
+
+    await this.enforceKindCap(agentId, userId, 'counterparty_dossier');
+    const embedding = await this.embed(entry.content);
+    await this.memories.create({
+      agentId,
+      userId,
+      kind: 'counterparty_dossier',
+      content: entry.content,
+      subjectUserId,
+      confidence: entry.confidence,
+      ...(embedding && { embedding }),
+      sourceRefs: [ref],
+    });
+  }
+
+  /**
+   * Evict lowest-confidence (oldest-first tie-break) entries when the kind is
+   * at cap, leaving room for exactly one new row.
+   */
+  private async enforceKindCap(agentId: string, userId: string, kind: NegotiatorMemoryKind): Promise<void> {
+    const cap = NEGOTIATOR_MEMORY_KIND_CAPS[kind];
+    const rows = await this.memories.list(agentId, userId, { kind, limit: cap + 16 });
+    if (rows.length < cap) return;
+
+    const evictable = [...rows].sort((a, b) =>
+      a.confidence !== b.confidence
+        ? a.confidence - b.confidence
+        : new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+    const toEvict = evictable.slice(0, rows.length - cap + 1);
+    for (const row of toEvict) {
+      await this.memories.delete(row.id, userId);
+      logger.info('Evicted negotiator memory at kind cap', { agentId, kind, evictedId: row.id, confidence: row.confidence });
+    }
+  }
+}
+
+export const negotiatorMemoryWriteService = new NegotiatorMemoryWriteService();

--- a/services/api/src/services/tests/negotiator-memory.service.spec.ts
+++ b/services/api/src/services/tests/negotiator-memory.service.spec.ts
@@ -1,0 +1,321 @@
+/**
+ * IND-406 — NegotiatorMemoryWriteService anti-poisoning policy (pure unit
+ * tests, all deps injected).
+ *
+ * Pins:
+ * - flag off → zero writes (adapter never touched),
+ * - per-kind caps: at cap, lowest-confidence (oldest first) rows are evicted,
+ * - dossier upsert: one dossier per (agent, subject) — reinforce (confidence
+ *   bump + provenance append), don't duplicate,
+ * - ask_user answer → immediate high-confidence disclosure_rule,
+ * - embedding failure degrades to an embeddingless row (content preserved),
+ * - decay pass delegates to the adapter with the schedule constants.
+ */
+process.env.DATABASE_URL = process.env.DATABASE_URL ?? 'postgresql://unused:unused@localhost:5432/unused';
+process.env.OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY ?? 'test-key';
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+import { NegotiatorMemoryWriteService, NEGOTIATOR_MEMORY_KIND_CAPS, isNegotiatorMemoryWriteEnabled } from '../negotiator-memory.service';
+import type { NegotiatorMemory } from '../../schemas/database.schema';
+
+const origFlag = process.env.NEGOTIATOR_MEMORY_WRITE_ENABLED;
+
+function mkRow(partial: Partial<NegotiatorMemory>): NegotiatorMemory {
+  return {
+    id: 'mem-1',
+    agentId: 'agent-1',
+    userId: 'u-1',
+    kind: 'playbook',
+    subjectUserId: null,
+    content: 'x',
+    embedding: null,
+    sourceRefs: [],
+    confidence: 0.5,
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+    ...partial,
+  } as NegotiatorMemory;
+}
+
+function mkService(overrides?: {
+  listRows?: NegotiatorMemory[];
+  embedding?: number[] | null;
+  agentId?: string | null;
+}) {
+  const created: unknown[] = [];
+  const updated: Array<{ id: string; patch: unknown }> = [];
+  const deleted: string[] = [];
+  const decayCalls: unknown[] = [];
+
+  const memories = {
+    create: mock(async (input: unknown) => { created.push(input); return mkRow({}); }),
+    list: mock(async () => overrides?.listRows ?? []),
+    update: mock(async (id: string, _userId: string, patch: unknown) => { updated.push({ id, patch }); return mkRow({ id }); }),
+    delete: mock(async (id: string) => { deleted.push(id); return true; }),
+    decayAll: mock(async (opts: unknown) => { decayCalls.push(opts); return { decayed: 2, deleted: 1 }; }),
+  };
+
+  const service = new NegotiatorMemoryWriteService({
+    memories: memories as never,
+    embed: async () => overrides?.embedding === undefined ? [0.1, 0.2] : overrides.embedding,
+    resolveNegotiatorAgentId: async () => overrides?.agentId === undefined ? 'agent-1' : overrides.agentId,
+  });
+
+  return { service, memories, created, updated, deleted, decayCalls };
+}
+
+const playbookEntry = {
+  kind: 'playbook' as const,
+  content: 'Lead with the specific shared-interest angle.',
+  confidence: 0.6,
+  aboutCounterparty: false,
+  turnIndexes: [0, 2],
+};
+
+const dossierEntry = {
+  kind: 'counterparty_dossier' as const,
+  content: 'Bob is CET-constrained and prefers async.',
+  confidence: 0.7,
+  aboutCounterparty: true,
+  turnIndexes: [3],
+};
+
+describe('NegotiatorMemoryWriteService', () => {
+  beforeEach(() => {
+    process.env.NEGOTIATOR_MEMORY_WRITE_ENABLED = 'true';
+  });
+
+  afterEach(() => {
+    if (origFlag === undefined) delete process.env.NEGOTIATOR_MEMORY_WRITE_ENABLED;
+    else process.env.NEGOTIATOR_MEMORY_WRITE_ENABLED = origFlag;
+  });
+
+  it('flag off → zero writes, adapter never touched', async () => {
+    delete process.env.NEGOTIATOR_MEMORY_WRITE_ENABLED;
+    expect(isNegotiatorMemoryWriteEnabled()).toBe(false);
+
+    const { service, memories } = mkService();
+    const result = await service.writeDistilledMemories({
+      userId: 'u-1',
+      entries: [playbookEntry],
+      sourceRef: { type: 'negotiation', id: 'neg-1' },
+    });
+
+    expect(result).toEqual({ written: 0, skipped: 1 });
+    expect(memories.create).not.toHaveBeenCalled();
+    expect(memories.list).not.toHaveBeenCalled();
+  });
+
+  it('writes an entry with embedding and provenance (turnIndexes merged into the ref)', async () => {
+    const { service, created } = mkService();
+    const result = await service.writeDistilledMemories({
+      userId: 'u-1',
+      entries: [playbookEntry],
+      sourceRef: { type: 'negotiation', id: 'neg-1' },
+    });
+
+    expect(result).toEqual({ written: 1, skipped: 0 });
+    expect(created.length).toBe(1);
+    expect(created[0]).toMatchObject({
+      agentId: 'agent-1',
+      userId: 'u-1',
+      kind: 'playbook',
+      confidence: 0.6,
+      embedding: [0.1, 0.2],
+      sourceRefs: [{ type: 'negotiation', id: 'neg-1', turnIndexes: [0, 2] }],
+    });
+  });
+
+  it('embedding failure degrades to an embeddingless row (content preserved)', async () => {
+    const { service, created } = mkService({ embedding: null });
+    await service.writeDistilledMemories({
+      userId: 'u-1',
+      entries: [playbookEntry],
+      sourceRef: { type: 'negotiation', id: 'neg-1' },
+    });
+
+    expect(created.length).toBe(1);
+    expect((created[0] as { embedding?: unknown }).embedding).toBeUndefined();
+    expect((created[0] as { content: string }).content).toBe(playbookEntry.content);
+  });
+
+  it('no personal negotiator agent → all entries skipped', async () => {
+    const { service, memories } = mkService({ agentId: null });
+    const result = await service.writeDistilledMemories({
+      userId: 'u-ghost',
+      entries: [playbookEntry],
+      sourceRef: { type: 'negotiation', id: 'neg-1' },
+    });
+
+    expect(result).toEqual({ written: 0, skipped: 1 });
+    expect(memories.create).not.toHaveBeenCalled();
+  });
+
+  it('dossier without counterpartyUserId is skipped (no subject to attribute)', async () => {
+    const { service, memories } = mkService();
+    const result = await service.writeDistilledMemories({
+      userId: 'u-1',
+      entries: [dossierEntry],
+      sourceRef: { type: 'chat', id: 'sess-1' },
+    });
+
+    expect(result).toEqual({ written: 0, skipped: 1 });
+    expect(memories.create).not.toHaveBeenCalled();
+  });
+
+  it('dossier upsert: existing dossier is reinforced, not duplicated', async () => {
+    const existing = mkRow({
+      id: 'dossier-1',
+      kind: 'counterparty_dossier',
+      subjectUserId: 'u-bob',
+      confidence: 0.5,
+      sourceRefs: [{ type: 'negotiation', id: 'neg-0' }],
+    });
+    const { service, memories, created, updated } = mkService({ listRows: [existing] });
+
+    const result = await service.writeDistilledMemories({
+      userId: 'u-1',
+      counterpartyUserId: 'u-bob',
+      entries: [dossierEntry],
+      sourceRef: { type: 'negotiation', id: 'neg-1' },
+    });
+
+    expect(result).toEqual({ written: 1, skipped: 0 });
+    expect(memories.create).not.toHaveBeenCalled();
+    expect(updated.length).toBe(1);
+    expect(updated[0].id).toBe('dossier-1');
+    const patch = updated[0].patch as { confidence: number; sourceRefs: unknown[]; content: string };
+    // reinforce: max(existing 0.5, entry 0.7) + 0.1
+    expect(patch.confidence).toBeCloseTo(0.8);
+    expect(patch.content).toBe(dossierEntry.content);
+    expect(patch.sourceRefs).toEqual([
+      { type: 'negotiation', id: 'neg-0' },
+      { type: 'negotiation', id: 'neg-1', turnIndexes: [3] },
+    ]);
+    expect(created.length).toBe(0);
+  });
+
+  it('fresh dossier (no existing row for subject) is created with the subject', async () => {
+    const { service, created } = mkService({ listRows: [] });
+    await service.writeDistilledMemories({
+      userId: 'u-1',
+      counterpartyUserId: 'u-bob',
+      entries: [dossierEntry],
+      sourceRef: { type: 'negotiation', id: 'neg-1' },
+    });
+
+    expect(created.length).toBe(1);
+    expect(created[0]).toMatchObject({ kind: 'counterparty_dossier', subjectUserId: 'u-bob' });
+  });
+
+  it('kind cap: at cap, the lowest-confidence oldest row is evicted to make room', async () => {
+    const cap = NEGOTIATOR_MEMORY_KIND_CAPS.threshold;
+    const rows = Array.from({ length: cap }, (_, i) => mkRow({
+      id: `thr-${i}`,
+      kind: 'threshold',
+      confidence: i === 3 ? 0.1 : 0.5 + (i % 4) * 0.1,
+      createdAt: new Date(2026, 0, 1 + i),
+    }));
+    const { service, deleted, created } = mkService({ listRows: rows });
+
+    await service.writeDistilledMemories({
+      userId: 'u-1',
+      entries: [{ ...playbookEntry, kind: 'threshold' as const }],
+      sourceRef: { type: 'negotiation', id: 'neg-1' },
+    });
+
+    expect(deleted).toEqual(['thr-3']); // lowest confidence
+    expect(created.length).toBe(1);
+  });
+
+  it('under cap → no eviction', async () => {
+    const rows = [mkRow({ id: 'thr-0', kind: 'threshold' })];
+    const { service, deleted, created } = mkService({ listRows: rows });
+
+    await service.writeDistilledMemories({
+      userId: 'u-1',
+      entries: [{ ...playbookEntry, kind: 'threshold' as const }],
+      sourceRef: { type: 'negotiation', id: 'neg-1' },
+    });
+
+    expect(deleted).toEqual([]);
+    expect(created.length).toBe(1);
+  });
+
+  it('one failing entry does not sink the batch', async () => {
+    const { service, created, memories } = mkService();
+    let call = 0;
+    memories.create.mockImplementation(async (input: unknown) => {
+      call++;
+      if (call === 1) throw new Error('db hiccup');
+      created.push(input);
+      return mkRow({});
+    });
+
+    const result = await service.writeDistilledMemories({
+      userId: 'u-1',
+      entries: [playbookEntry, { ...playbookEntry, content: 'second' }],
+      sourceRef: { type: 'negotiation', id: 'neg-1' },
+    });
+
+    expect(result).toEqual({ written: 1, skipped: 1 });
+    expect(created.length).toBe(1);
+  });
+
+  it('recordDisclosureRuleFromAnswer → immediate high-confidence disclosure_rule', async () => {
+    const { service, created } = mkService();
+    await service.recordDisclosureRuleFromAnswer({
+      userId: 'u-1',
+      questionId: 'q-1',
+      questionPrompt: 'Share your day rate with Bob?',
+      selectedOptions: ['Yes, share it'],
+      freeText: 'but only the range',
+    });
+
+    expect(created.length).toBe(1);
+    expect(created[0]).toMatchObject({
+      kind: 'disclosure_rule',
+      confidence: 0.9,
+      sourceRefs: [{ type: 'question_answer', id: 'q-1' }],
+    });
+    const content = (created[0] as { content: string }).content;
+    expect(content).toContain('Share your day rate with Bob?');
+    expect(content).toContain('Yes, share it');
+    expect(content).toContain('but only the range');
+  });
+
+  it('recordDisclosureRuleFromAnswer no-ops when the flag is off', async () => {
+    delete process.env.NEGOTIATOR_MEMORY_WRITE_ENABLED;
+    const { service, memories } = mkService();
+    await service.recordDisclosureRuleFromAnswer({
+      userId: 'u-1',
+      questionId: 'q-1',
+      selectedOptions: ['Yes'],
+    });
+    expect(memories.create).not.toHaveBeenCalled();
+  });
+
+  it('recordDisclosureRuleFromAnswer no-ops on an empty answer', async () => {
+    const { service, memories } = mkService();
+    await service.recordDisclosureRuleFromAnswer({
+      userId: 'u-1',
+      questionId: 'q-1',
+      selectedOptions: [],
+    });
+    expect(memories.create).not.toHaveBeenCalled();
+  });
+
+  it('runConfidenceDecay delegates to the adapter with the schedule constants', async () => {
+    const { service, decayCalls } = mkService();
+    const result = await service.runConfidenceDecay();
+
+    expect(result).toEqual({ decayed: 2, deleted: 1 });
+    expect(decayCalls.length).toBe(1);
+    expect(decayCalls[0]).toMatchObject({
+      factor: 0.99,
+      olderThanMs: 7 * 24 * 60 * 60 * 1000,
+      deleteBelow: 0.05,
+    });
+  });
+});

--- a/services/api/src/services/tool.service.ts
+++ b/services/api/src/services/tool.service.ts
@@ -15,6 +15,7 @@ import type { AgentDispatcher } from '@indexnetwork/protocol';
 import type { HydeGraphDatabase, PremiseGraphDatabase, ToolDeps, ContactServiceAdapter, IntegrationAdapter, PendingQuestionSummary } from '@indexnetwork/protocol';
 import { intentQueue } from '../queues/intent.queue';
 import { questionerEnqueueIfEnabled } from '../queues/questioner.queue';
+import { reflectEnqueueIfEnabled } from '../queues/negotiations/reflect.queue';
 import { enrichUserProfile } from '../lib/parallel/parallel';
 import { QuestionerAdapter } from '../adapters/questioner.adapter';
 import db from '../lib/drizzle/drizzle';
@@ -257,6 +258,8 @@ export class ToolService {
       undefined,
       // Stalled negotiations enqueue follow-up questions for the source user.
       questionerEnqueueIfEnabled(),
+      // Finished negotiations enqueue memory distillation (P5.2, flag-gated).
+      reflectEnqueueIfEnabled(),
     ).createGraph();
     const opportunityGraph = new OpportunityGraphFactory(
       database,

--- a/services/api/src/startup.env.ts
+++ b/services/api/src/startup.env.ts
@@ -109,6 +109,8 @@ const envSchema = z.object({
   NEGOTIATION_SCREEN_MODE: z.union([z.literal(''), z.enum(['off', 'shadow', 'enforce'])]).optional(),
   NEGOTIATION_ASK_USER_ENABLED: optionalBoolean,
   NEGOTIATION_ASK_USER_WINDOW_MS: optionalInt,
+  NEGOTIATOR_MEMORY_WRITE_ENABLED: optionalBoolean,
+  NEGOTIATOR_CHAT_REFLECT_DELAY_MS: optionalInt,
   QUESTIONER_ENABLED: optionalBoolean,
 
   // 9. MCP / tool runtime


### PR DESCRIPTION
## Summary

P5.2 of the client-advocate protocol ([IND-406](https://linear.app/indexnetwork/issue/IND-406/p52-reflection-jobs-reflect-chat-reflect-memory-write-path), parent [IND-395](https://linear.app/indexnetwork/issue/IND-395)): the **memory write path** onto the `negotiator_memories` store shipped in #1107. Write-only — nothing reads memory yet (P5.3) — so this deploys risk-free behind `NEGOTIATOR_MEMORY_WRITE_ENABLED` (default **off**).

## What's in the box

### `negotiation-reflect` queue (`services/api/src/queues/negotiations/reflect.queue.ts`)
- **`reflect`**: enqueued by the graph's finalize node via a new **injected `reflectEnqueue` callback** (protocol has no BullMQ access — exact `questionerEnqueue` pattern). The worker replays the turn history from **both sides' perspectives** and runs the distiller once per user: each side's negotiator learns independently, with correct seat attribution (`initiatorUserId`, never parity) and perspective-projected transcripts. One side failing never costs the other its memories.
- **`chat_reflect`**: negotiator-DM turns **debounce-schedule** the job (remove + re-add with delay, `NEGOTIATOR_CHAT_REFLECT_DELAY_MS`, default 15 m) — it fires once the session has been idle for the window, the closest observable "session end" for an open-ended DM. Guards: session ownership + `negotiator` persona; `counterparty_dossier` entries dropped (no subject in chat scope).
- Daily **confidence-decay cron** (04:40): stale rows (untouched > 7 d) decay ×0.99/day; rows below 0.05 are removed.

### `NegotiationReflector` distiller (`packages/protocol/src/negotiation/negotiation.reflect.ts`)
One structured LLM call per pass, ≤ **3** entries (schema-enforced), kinds `playbook | disclosure_rule | counterparty_dossier | threshold`, **mandatory turn-index provenance** merged into `sourceRefs`. Explicit "return empty when nothing durable was learned" instruction. Throws on invalid output — the queue worker owns swallow-and-log.

### Graph change (`negotiation.graph.ts`)
`reflectEnqueue` as a 5th **optional** constructor dep; finalize fire-and-forgets with `.catch` — reflection failure never affects the outcome. Wired at all four composition roots (main.ts background graph, negotiation.service, tool.service, mcp.controller) via `reflectEnqueueIfEnabled()`.

### Direct write: ask_user answers → disclosure rules
`resumeInflightNegotiationFactory` gains an optional `recordDisclosureRule` hook (fire-and-forget, never affects the resume): the client's answer is already a distilled policy, recorded immediately at confidence 0.9 with `question_answer` provenance.

### Anti-poisoning (`services/api/src/services/negotiator-memory.service.ts`)
Single choke point for every memory write: flag gate, per-kind caps (playbook 25 / disclosure_rule 50 / dossier 200 / threshold 15) with lowest-confidence-oldest eviction, **one dossier per (agent, subject)** upsert (content refresh + confidence reinforce + provenance append, capped at 10 refs), embedding-failure degradation to embeddingless rows (content preserved).

## Acceptance criteria

- ✅ finalize → reflect job → rows with valid sourceRefs (graph spec + queue spec); job failure never affects the outcome (explicit rejecting-enqueue test); graph without `reflectEnqueue` behaves as today (optional-dep test)
- ✅ Entry caps + dossier upsert + confidence decay unit-tested (14 service specs + DB-backed `decayAll` spec)
- ✅ ask_user answer → immediate disclosure_rule row (handler + service specs)
- ✅ Flag off → zero writes, suites green (pinned at every layer: enqueue helper, queue handlers, write service)
- ⏳ Deployed check (dev) after merge + flag flip: run a negotiation end-to-end, see distilled rows with evidence refs

## Testing

- `packages/protocol` — `negotiation.reflect.spec.ts` **9/9** (distiller schema/prompt/caps + graph finalize enqueue trio); adjacent `initiator`/`seat-rules`/`screen-routing` suites green
- `services/api` — `negotiator-memory.service.spec.ts` **14/14**, `reflect.queue.spec.ts` **8/8**, `question.answer.negotiation-inflight.test.ts` **7/7** (3 new), DB-backed `negotiator-memory.database.spec.ts` **10/10** (new `decayAll` case, dev-DB-safe parameters)
- Builds + eslint clean (protocol, api); adjacent `question.answer.handler` / `questioner-enqueue-if-enabled` / `adapter-interface-alignment` / `timeout` / `claim-timeout` suites green

## Rollout

1. Merge → deploys inert (flag off in every environment).
2. Flip `NEGOTIATOR_MEMORY_WRITE_ENABLED=true` on dev; watch `negotiator_memories` rows appear after negotiations finalize.
3. Keep **off in prod** until P5.4 (memory inspection) ships — users must be able to see memory before it accumulates.

Rollback: unset the flag — single switch, write path goes dark, no schema changes in this PR.
