### PR TITLE
feat: screen enforcement + screened_out outcome — P2.2 (IND-399)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -116,9 +116,10 @@ OPENROUTER_API_KEY=your-openrouter-api-key
 # NEGOTIATION_PROTOCOL_VERSION=v1          # Protocol version stamped on NEW negotiations: v1 (legacy) | v2 (seat rules:
                                            # initiator outreach/counter/question/withdraw, counterparty accept/decline/counter/question).
                                            # In-flight conversations inherit their stamped version; flipping this only affects fresh negotiations.
-# NEGOTIATION_SCREEN_MODE=off              # Outreach screen gate (P2.1): off (default, no LLM call) | shadow (decide + record on
-                                           # task metadata.screenDecision, never blocks) | enforce (reserved for P2.2; runs as shadow
-                                           # with a warning until enforcement lands). Fresh negotiations only; continuations never screen.
+# NEGOTIATION_SCREEN_MODE=off              # Outreach screen gate (P2.1/P2.2): off (default, no LLM call) | shadow (decide + record on
+                                           # task metadata.screenDecision, never blocks) | enforce (P2.2: a pass blocks before the first
+                                           # turn — outcome reason "screened_out", opportunity quietly rejected, zero counterparty
+                                           # involvement; failed screens still fail open). Fresh negotiations only; continuations never screen.
 # NEGOTIATION_ASK_USER_ENABLED=false       # ask_user client-consult pause (P3.2): when true, v2 negotiators may pause mid-negotiation
                                            # to ask their OWN client a question (task -> input_required, question via the
                                            # negotiation_inflight preset, 24h answer window, resume on answer or conservative

--- a/apps/web/src/components/chat/ToolCallsDisplay.tsx
+++ b/apps/web/src/components/chat/ToolCallsDisplay.tsx
@@ -397,7 +397,7 @@ export interface NegotiationNode {
   startTimestamp: number;
   durationMs?: number;
   turns: NegotiationTurnRow[];
-  outcome?: "accepted" | "rejected_stalled" | "waiting_for_agent" | "timed_out" | "turn_cap";
+  outcome?: "accepted" | "rejected_stalled" | "waiting_for_agent" | "timed_out" | "turn_cap" | "screened_out";
   turnCount?: number;
   outcomeReasoning?: string;
   isRunning: boolean;
@@ -1160,7 +1160,7 @@ function NegotiationTree({ negotiations }: { negotiations: NegotiationNode[] }) 
               )}
               {n.isRunning ? (
                 <Loader2 className="w-2.5 h-2.5 text-gray-500 animate-spin flex-shrink-0" />
-              ) : n.outcome === "timed_out" || n.outcome === "rejected_stalled" || n.outcome === "turn_cap" ? (
+              ) : n.outcome === "timed_out" || n.outcome === "rejected_stalled" || n.outcome === "turn_cap" || n.outcome === "screened_out" ? (
                 <Square className="w-2.5 h-2.5 text-amber-600 fill-amber-600 flex-shrink-0" />
               ) : (
                 <MessagesSquare className="w-2.5 h-2.5 text-gray-800 flex-shrink-0" />

--- a/apps/web/src/contexts/AIChatContext.tsx
+++ b/apps/web/src/contexts/AIChatContext.tsx
@@ -99,7 +99,7 @@ export interface TraceEvent {
   reasoning?: string;
   message?: string;
   suggestedRoles?: { ownUser?: string; otherUser?: string };
-  outcome?: "accepted" | "rejected_stalled" | "waiting_for_agent" | "timed_out" | "turn_cap";
+  outcome?: "accepted" | "rejected_stalled" | "waiting_for_agent" | "timed_out" | "turn_cap" | "screened_out";
   turnCount?: number;
   agreedRoles?: { ownUser?: string; otherUser?: string };
 }

--- a/docs/domain/negotiation.md
+++ b/docs/domain/negotiation.md
@@ -76,7 +76,7 @@ Each turn produces a structured assessment:
   - `otherUser`: agent, patient, or peer
 - **message** *(optional)*: Free-form text accompanying the action
 
-### Screen gate (shadow)
+### Screen gate (shadow / enforce)
 
 Between init and the first turn, **fresh negotiations only** (continuations skip it) pass through an outreach gate: one structured LLM call from the reaching client's perspective deciding `reach_out | pass` — is this match worth the client's name before any turn is exchanged? Inputs: the client's intents + discovery query, the counterparty's `user_contexts` paragraph + active intents, and the seed assessment.
 
@@ -84,9 +84,11 @@ Controlled by `NEGOTIATION_SCREEN_MODE`:
 
 - `off` *(code default)* — node skipped entirely; no LLM call, no telemetry.
 - `shadow` — the decision is recorded (`tasks.metadata.screenDecision`, a `negotiation_screen` trace event, and a log line) but **never blocks**: every negotiation proceeds to its first turn. Used to measure pass rates against observed reject rates before enforcement.
-- `enforce` — reserved; until enforcement lands it runs identically to `shadow` with a warning (by the time the screen runs, init has already created the task and flipped the opportunity to `negotiating`, so a blocking `pass` needs its own quiet/correct path).
+- `enforce` *(P2.2)* — a `pass` blocks the negotiation **before the first turn**: the graph routes straight to finalize with outcome `reason: "screened_out"` — zero turns, zero counterparty involvement, zero notifications, no questioner, no reflection. Init had already flipped the opportunity to `negotiating`, so finalize quietly transitions it to `rejected` (hidden from default lists). `reach_out` proceeds normally.
 
-A screen failure (LLM error/timeout) **fails open**: the negotiation proceeds as `reach_out` with `failedOpen: true` recorded, so failed screens are excluded from pass-rate queries.
+A screen failure (LLM error/timeout) **fails open** in every mode (including enforce): the negotiation proceeds as `reach_out` with `failedOpen: true` recorded, so failed screens are excluded from pass-rate queries.
+
+**`screened_out` is the client's private gate decision, not a negotiation.** Presentation treats it as never-happened: the negotiation-context loader returns `null` for screened-out outcomes (so no card/feed/digest surface can frame it as "counterparty declined"), and the mutual-viewer negotiations list excludes screened-out rows — the counterparty never learns a gate decision was made. The owner still sees the row in their own negotiations list, and the summarizer/question-generator digests carry `outcomeReason: "screened_out"` with client-appropriate copy.
 
 ### Client consultation (`ask_user`, flag-gated)
 

--- a/packages/protocol/src/chat/chat-streaming.types.ts
+++ b/packages/protocol/src/chat/chat-streaming.types.ts
@@ -520,7 +520,8 @@ export interface NegotiationOutcomeEvent extends ChatStreamEventBase {
     | "rejected_stalled"
     | "waiting_for_agent"
     | "timed_out"
-    | "turn_cap";
+    | "turn_cap"
+    | "screened_out";
   turnCount: number;
   reasoning?: string;
   agreedRoles?: { ownUser?: string; otherUser?: string };

--- a/packages/protocol/src/chat/chat.agent.ts
+++ b/packages/protocol/src/chat/chat.agent.ts
@@ -121,7 +121,8 @@ export type AgentStreamEvent =
         | "rejected_stalled"
         | "waiting_for_agent"
         | "timed_out"
-        | "turn_cap";
+        | "turn_cap"
+        | "screened_out";
       turnCount: number;
       reasoning?: string;
       agreedRoles?: { ownUser?: string; otherUser?: string };

--- a/packages/protocol/src/negotiation/negotiation.graph.ts
+++ b/packages/protocol/src/negotiation/negotiation.graph.ts
@@ -287,10 +287,11 @@ export class NegotiationGraphFactory {
      * when NEGOTIATION_SCREEN_MODE=off). The reaching client's negotiator
      * decides whether the match is worth its client's name; in shadow mode the
      * decision is recorded (task metadata + trace event + log line) but never
-     * blocks — the negotiation always proceeds to the first turn. `enforce`
-     * runs identically until P2.2 lands enforcement (by the time this node
-     * runs, init has already created the task and flipped the opportunity to
-     * `negotiating` — P2.2 owns making a blocking `pass` quiet/correct).
+     * blocks — the negotiation always proceeds to the first turn. In enforce
+     * mode (P2.2) a `pass` routes straight to finalize: zero turns, zero
+     * counterparty involvement, outcome `reason: "screened_out"`, opportunity
+     * quietly `rejected` (init had already flipped it to `negotiating`).
+     * A failed screen still fails OPEN in every mode.
      */
     const screenNode = async (state: typeof NegotiationGraphState.State) => {
       const traceEmitter = requestContext.getStore()?.traceEmitter;
@@ -298,12 +299,6 @@ export class NegotiationGraphFactory {
         (traceEmitter as ((e: Record<string, unknown>) => void) | undefined)?.(event);
 
       const mode = configuredScreenMode();
-      if (mode === "enforce") {
-        screenNodeLog.warn("NEGOTIATION_SCREEN_MODE=enforce requested but enforcement lands in P2.2; running shadow", {
-          taskId: state.taskId,
-        });
-      }
-
       const start = Date.now();
       // The client is the initiator seat's user — the side whose negotiator is
       // reaching out. Fresh runs stamp initiatorUserId in init; fall back to
@@ -388,9 +383,21 @@ export class NegotiationGraphFactory {
         });
       }
 
-      // Shadow (and pre-P2.2 enforce): always proceed to the first turn.
+      // Routing happens on the conditional edge: shadow always proceeds to
+      // the first turn; enforce routes a (non-failed-open) pass to finalize.
       return { screenDecision: record, memoryBySide: { [clientSide]: clientMemory } };
     };
+
+    /**
+     * P2.2 — true when the screen gate blocked this negotiation: enforce mode,
+     * a genuine `pass` (never failed-open), before any turn was exchanged.
+     * Shadow-mode passes and fail-open records never block.
+     */
+    const isScreenBlocked = (state: typeof NegotiationGraphState.State): boolean =>
+      state.screenDecision?.mode === "enforce"
+      && state.screenDecision.decision === "pass"
+      && state.screenDecision.failedOpen !== true
+      && state.turnCount === 0;
 
     const turnNode = async (state: typeof NegotiationGraphState.State) => {
       const traceEmitter = requestContext.getStore()?.traceEmitter;
@@ -742,7 +749,10 @@ export class NegotiationGraphFactory {
 
       const lastTurn = state.lastTurn;
       const hasOpportunity = lastTurn?.action === "accept";
-      const atCap = (state.maxTurns ?? 0) > 0 && state.turnCount >= state.maxTurns! && !isTerminalAction(lastTurn?.action);
+      // P2.2: the client's own outreach gate declined before any turn — the
+      // negotiation never happened from the counterparty's perspective.
+      const screenedOut = isScreenBlocked(state);
+      const atCap = !screenedOut && (state.maxTurns ?? 0) > 0 && state.turnCount >= state.maxTurns! && !isTerminalAction(lastTurn?.action);
 
       let agreedRoles: NegotiationOutcome["agreedRoles"] = [];
       if (hasOpportunity && history.length >= 2) {
@@ -761,9 +771,15 @@ export class NegotiationGraphFactory {
       const outcome: NegotiationOutcome = {
         hasOpportunity,
         agreedRoles,
-        reasoning: lastTurn?.assessment.reasoning ?? "",
+        reasoning: screenedOut
+          ? (state.screenDecision?.reasoning ?? "")
+          : (lastTurn?.assessment.reasoning ?? ""),
         turnCount: state.turnCount,
-        ...(atCap && { reason: "turn_cap" as const }),
+        ...(screenedOut
+          ? { reason: "screened_out" as const }
+          : atCap
+            ? { reason: "turn_cap" as const }
+            : {}),
       };
 
       try {
@@ -781,14 +797,17 @@ export class NegotiationGraphFactory {
           isContinuation: state.isContinuation,
           turnsAdded: state.turnCount,
           priorTurnCount: state.priorTurnCount,
-          outcome: hasOpportunity ? 'accepted' : (atCap ? 'turn_cap' : (lastTurn?.action ?? 'unknown')),
+          outcome: hasOpportunity ? 'accepted' : screenedOut ? 'screened_out' : (atCap ? 'turn_cap' : (lastTurn?.action ?? 'unknown')),
           opportunityId: state.opportunityId || undefined,
         });
 
         if (state.opportunityId) {
+          // screened_out → 'rejected': quiet terminal status (hidden from
+          // default lists), never 'stalled' — with zero turns the generic
+          // mapping would misfile the client's own gate decision.
           const nextStatus = lastTurn?.action === 'accept'
             ? 'pending'
-            : isRejectLikeAction(lastTurn?.action)
+            : (screenedOut || isRejectLikeAction(lastTurn?.action))
               ? 'rejected'
               : 'stalled';
           await database.updateOpportunityStatus(state.opportunityId, nextStatus).catch((err) => {
@@ -800,9 +819,11 @@ export class NegotiationGraphFactory {
       }
 
       if (state.opportunityId) {
-        const emittedOutcome: "accepted" | "rejected_stalled" | "turn_cap" | "timed_out" =
+        const emittedOutcome: "accepted" | "rejected_stalled" | "turn_cap" | "timed_out" | "screened_out" =
           hasOpportunity
             ? "accepted"
+            : screenedOut
+            ? "screened_out"
             : atCap
             ? "turn_cap"
             : state.error && /timeout/i.test(state.error)
@@ -906,7 +927,10 @@ export class NegotiationGraphFactory {
         if (!state.isContinuation && configuredScreenMode() !== "off") return "screen";
         return "turn";
       }, { screen: "screen", turn: "turn", finalize: "finalize" })
-      .addEdge("screen", "turn")
+      // P2.2: enforce-mode pass → finalize (screened_out); everything else → turn.
+      .addConditionalEdges("screen", (state: typeof NegotiationGraphState.State) =>
+        isScreenBlocked(state) ? "finalize" : "turn",
+      { turn: "turn", finalize: "finalize" })
       .addEdge("__start__", "init")
       .addEdge("finalize", "__end__");
 

--- a/packages/protocol/src/negotiation/negotiation.screen.ts
+++ b/packages/protocol/src/negotiation/negotiation.screen.ts
@@ -16,9 +16,11 @@ const screenLog = protocolLogger("NegotiationScreener");
  *   trace event + log line) but NEVER blocks: every fresh negotiation still
  *   proceeds to the first turn. Used to measure pass rates against observed
  *   reject rates before enforcement.
- * - `enforce` — reserved for P2.2. Until enforcement lands, `enforce` runs
- *   identically to `shadow` (decision recorded, negotiation proceeds) and the
- *   screen node logs a warning that enforcement is not yet implemented.
+ * - `enforce` — (P2.2) a `pass` decision blocks the negotiation before the
+ *   first turn: the graph routes straight to finalize with outcome
+ *   `reason: "screened_out"` — zero turns, zero counterparty involvement,
+ *   zero notifications; the opportunity is quietly `rejected`. A failed
+ *   screen still fails OPEN (never blocks), and `reach_out` proceeds normally.
  */
 export const NEGOTIATION_SCREEN_MODES = ["off", "shadow", "enforce"] as const;
 

--- a/packages/protocol/src/negotiation/negotiation.state.ts
+++ b/packages/protocol/src/negotiation/negotiation.state.ts
@@ -61,7 +61,7 @@ export const NegotiationOutcomeSchema = z.object({
   })),
   reasoning: z.string(),
   turnCount: z.number(),
-  reason: z.enum(["turn_cap", "timeout"]).optional(),
+  reason: z.enum(["turn_cap", "timeout", "screened_out"]).optional(),
 });
 
 export type NegotiationOutcome = z.infer<typeof NegotiationOutcomeSchema>;

--- a/packages/protocol/src/negotiation/negotiation.summarizer.ts
+++ b/packages/protocol/src/negotiation/negotiation.summarizer.ts
@@ -26,7 +26,7 @@ Output requirements (ALL fields — set optional fields to null when not applica
 - counterpartyHint: copy the input field verbatim, truncated to ≤120 chars.
 - indexContext: copy the input field verbatim, truncated to ≤120 chars.
 - outcomeRole: "opportunity" when hasOpportunity=true, else "no-opportunity".
-- outcomeReason: when outcomeRole="no-opportunity", set to "turn_cap" / "timeout" if the input's reason matches; else "rejected" (if a turn explicitly rejected) or "stalled". When outcomeRole="opportunity", set to null.
+- outcomeReason: when outcomeRole="no-opportunity", set to "turn_cap" / "timeout" / "screened_out" if the input's reason matches; else "rejected" (if a turn explicitly rejected) or "stalled". When outcomeRole="opportunity", set to null. "screened_out" means the seeker's own agent chose not to reach out before any turn was exchanged — never describe it as the candidate declining or stalling.
 - keyTake: ONE sentence (≤180 chars). Describe the decisive moment, the alignment gap, or the recurring signal — anything a question generator could use to formulate a clarifying question. NOT a generic outcome restatement. Anchor in a concrete detail from the negotiation if possible (a role mismatch, a missing input the candidate flagged, a pivot one party suggested).
 - suggestedRoles: when both parties agreed on roles (the last turn's suggestedRoles), copy them from input. Otherwise set to null.
 
@@ -113,7 +113,7 @@ export function buildFallbackDigest(n: DiscoveryNegotiation): DiscoveryNegotiati
     outcomeRole,
     outcomeReason:
       outcomeRole === "no-opportunity"
-        ? ((n.outcome.reason ?? "stalled") as "turn_cap" | "timeout" | "stalled")
+        ? ((n.outcome.reason ?? "stalled") as "turn_cap" | "timeout" | "stalled" | "screened_out")
         : null,
     keyTake: keyTakeRaw.slice(0, 180),
     suggestedRoles:

--- a/packages/protocol/src/negotiation/tests/negotiation.screen-routing.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.screen-routing.spec.ts
@@ -16,7 +16,10 @@ import type { NegotiationTurn } from "../negotiation.state.js";
  *   metadata.screenDecision, negotiation always proceeds (even on `pass`),
  * - continuations never screen (even in shadow),
  * - screen failure fails OPEN: negotiation proceeds, failedOpen recorded,
- * - enforce (pre-P2.2): runs identically to shadow, mode recorded truthfully,
+ * - enforce (P2.2): a genuine `pass` blocks before the first turn — zero
+ *   messages, outcome reason `screened_out`, opportunity quietly `rejected`,
+ *   no questioner/reflect enqueue, distinct trace outcome; `reach_out` and
+ *   failed-open screens still proceed; shadow `pass` still never blocks,
  * - `negotiation_screen` trace event emitted when an opportunityId is present,
  * - screener inputs: client = initiator side, counterparty context fetched,
  *   discoveryQuery forwarded for source-side clients.
@@ -48,16 +51,25 @@ function mkStubs(opts?: {
   const createdMessages: Array<{ senderId: string; parts: Array<{ kind: string; data: NegotiationTurn }> }> = [];
   const screenWrites: Array<{ taskId: string; record: Record<string, unknown> }> = [];
   const userContextLookups: string[] = [];
+  const statusUpdates: Array<{ opportunityId: string; status: string }> = [];
+  const artifacts: Array<Record<string, unknown>> = [];
+  const taskStates: string[] = [];
   const database = {
     getOrCreateDM: async () => ({ id: "conv-1" }),
     createTask: async (conversationId: string) => ({ id: "task-new", conversationId, state: "submitted" }),
-    updateOpportunityStatus: async () => {},
+    updateOpportunityStatus: async (opportunityId: string, status: string) => {
+      statusUpdates.push({ opportunityId, status });
+    },
     createMessage: async (p: { senderId: string; parts: Array<{ kind: string; data: NegotiationTurn }> }) => {
       createdMessages.push(p);
       return { id: `msg-${createdMessages.length}`, senderId: p.senderId, parts: p.parts, createdAt: new Date() };
     },
-    updateTaskState: async () => {},
-    createArtifact: async () => {},
+    updateTaskState: async (_taskId: string, state: string) => {
+      taskStates.push(state);
+    },
+    createArtifact: async (a: Record<string, unknown>) => {
+      artifacts.push(a);
+    },
     setTaskTurnContext: async () => {},
     ...(opts?.omitSetTaskScreenDecision ? {} : {
       setTaskScreenDecision: async (taskId: string, record: Record<string, unknown>) => {
@@ -79,7 +91,7 @@ function mkStubs(opts?: {
     dispatch: async () => ({ handled: false, reason: "no_agent" }),
   } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[1];
 
-  return { database, dispatcher, createdMessages, screenWrites, userContextLookups };
+  return { database, dispatcher, createdMessages, screenWrites, userContextLookups, statusUpdates, artifacts, taskStates };
 }
 
 async function runGraph(stubs: ReturnType<typeof mkStubs>, input: Record<string, unknown> = {}) {
@@ -218,7 +230,7 @@ describe("negotiation graph — screen node routing (IND-398)", () => {
     expect(result.outcome).not.toBeNull();
   });
 
-  it("enforce (pre-P2.2): runs identically to shadow — proceeds, mode recorded truthfully", async () => {
+  it("enforce (P2.2): a `pass` blocks before the first turn — screened_out, zero messages, opportunity rejected", async () => {
     process.env.NEGOTIATION_SCREEN_MODE = "enforce";
     screenerResult = {
       decision: "pass",
@@ -227,13 +239,111 @@ describe("negotiation graph — screen node routing (IND-398)", () => {
     };
     const stubs = mkStubs();
 
-    const result = await runGraph(stubs);
+    const result = await runGraph(stubs, { opportunityId: "opp-1" });
 
+    // Decision recorded truthfully
     expect(stubs.screenWrites[0].record.mode).toBe("enforce");
     expect(stubs.screenWrites[0].record.decision).toBe("pass");
-    // Enforcement lands in P2.2 — until then even a pass proceeds.
+    // Zero turns — the counterparty is never involved
+    expect(stubs.createdMessages.length).toBe(0);
+    // Outcome artifact: rejected as screened_out, not stalled; screen reasoning carried
+    expect(result.outcome?.hasOpportunity).toBe(false);
+    expect(result.outcome?.reason).toBe("screened_out");
+    expect(result.outcome?.turnCount).toBe(0);
+    expect(result.outcome?.reasoning).toBe("not worth the client's name");
+    expect(stubs.taskStates).toContain("completed");
+    const artifactOutcome = (stubs.artifacts[0]?.parts as Array<{ data: Record<string, unknown> }>)[0]?.data;
+    expect(artifactOutcome?.reason).toBe("screened_out");
+    // Opportunity quietly rejected (init had flipped it to negotiating)
+    expect(stubs.statusUpdates).toEqual([
+      { opportunityId: "opp-1", status: "negotiating" },
+      { opportunityId: "opp-1", status: "rejected" },
+    ]);
+  });
+
+  it("enforce (P2.2): screened_out emits a distinct negotiation_outcome trace event and never enqueues questioner/reflect", async () => {
+    process.env.NEGOTIATION_SCREEN_MODE = "enforce";
+    screenerResult = {
+      decision: "pass",
+      reasoning: "generic overlap",
+      evidence: { counterpartyPremiseFit: "weak", intentAlignment: "none" },
+    };
+    const stubs = mkStubs();
+    const questionerCalls: unknown[] = [];
+    const reflectCalls: unknown[] = [];
+    const graph = new NegotiationGraphFactory(
+      stubs.database,
+      stubs.dispatcher,
+      undefined,
+      (async (job: unknown) => { questionerCalls.push(job); }) as never,
+      (async (job: unknown) => { reflectCalls.push(job); }) as never,
+    ).createGraph();
+    const events: Array<Record<string, unknown>> = [];
+
+    await requestContext.run(
+      { traceEmitter: ((e: Record<string, unknown>) => { events.push(e); }) as never },
+      () => graph.invoke({
+        sourceUser: { id: "u-src", intents: [], profile: { name: "Alice" } },
+        candidateUser: { id: "u-cand", intents: [], profile: { name: "Bob" } },
+        indexContext: { networkId: "net-1", prompt: "" },
+        seedAssessment: { reasoning: "complementary", valencyRole: "peer" },
+        maxTurns: 1,
+        opportunityId: "opp-1",
+      } as Partial<typeof NegotiationGraphState.State>),
+    );
+
+    const outcomeEvents = events.filter((e) => e.type === "negotiation_outcome");
+    expect(outcomeEvents.length).toBe(1);
+    expect(outcomeEvents[0].outcome).toBe("screened_out");
+    expect(outcomeEvents[0].turnCount).toBe(0);
+    // Zero downstream noise: no clarifying questions, no reflection
+    expect(questionerCalls.length).toBe(0);
+    expect(reflectCalls.length).toBe(0);
+  });
+
+  it("enforce (P2.2): `reach_out` proceeds to turns normally", async () => {
+    process.env.NEGOTIATION_SCREEN_MODE = "enforce";
+    const stubs = mkStubs();
+
+    const result = await runGraph(stubs);
+
+    expect(stubs.screenWrites[0].record.decision).toBe("reach_out");
     expect(stubs.createdMessages.length).toBeGreaterThanOrEqual(1);
     expect(result.outcome).not.toBeNull();
+    expect(result.outcome?.reason).not.toBe("screened_out");
+  });
+
+  it("enforce (P2.2): a failed screen still fails OPEN — negotiation proceeds", async () => {
+    process.env.NEGOTIATION_SCREEN_MODE = "enforce";
+    screenerError = new Error("provider exploded");
+    const stubs = mkStubs();
+
+    const result = await runGraph(stubs);
+
+    expect(stubs.screenWrites[0].record.failedOpen).toBe(true);
+    expect(stubs.createdMessages.length).toBeGreaterThanOrEqual(1);
+    expect(result.outcome).not.toBeNull();
+    expect(result.outcome?.reason).not.toBe("screened_out");
+  });
+
+  it("enforce (P2.2): continuations never screen — enforcement cannot touch in-flight dialogues", async () => {
+    process.env.NEGOTIATION_SCREEN_MODE = "enforce";
+    screenerResult = {
+      decision: "pass",
+      reasoning: "would block if it ran",
+      evidence: { counterpartyPremiseFit: "weak", intentAlignment: "none" },
+    };
+    const stubs = mkStubs({
+      priorMessages: [priorMsg("u-src", "propose", 0), priorMsg("u-cand", "counter", 1)],
+    });
+
+    const result = await runGraph(stubs);
+
+    expect(screenerInputs.length).toBe(0);
+    expect(stubs.screenWrites.length).toBe(0);
+    expect(stubs.createdMessages.length).toBeGreaterThanOrEqual(1);
+    expect(result.outcome).not.toBeNull();
+    expect(result.outcome?.reason).not.toBe("screened_out");
   });
 
   it("emits a negotiation_screen trace event when an opportunityId is present", async () => {

--- a/packages/protocol/src/negotiation/tests/negotiation.summarizer.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.summarizer.spec.ts
@@ -4,7 +4,7 @@ config({ path: '.env.test', override: true });
 
 import { describe, it, expect } from "bun:test";
 
-import { NegotiationSummarizer } from "../negotiation.summarizer.js";
+import { NegotiationSummarizer, buildFallbackDigest } from "../negotiation.summarizer.js";
 import type { DiscoveryNegotiation } from "../../opportunity/question.prompt.js";
 
 const summarizer = new NegotiationSummarizer();
@@ -48,6 +48,26 @@ const richNegotiation: DiscoveryNegotiation = {
     ],
   },
 };
+
+describe("buildFallbackDigest — screened_out passthrough (P2.2, pure)", () => {
+  it("preserves reason screened_out instead of coercing to stalled", () => {
+    const digest = buildFallbackDigest({
+      counterpartyId: "user-bob",
+      counterpartyHint: "AI infra founder, Berlin",
+      indexContext: "Builders network",
+      turns: [],
+      outcome: {
+        hasOpportunity: false,
+        reasoning: "Gate declined: generic overlap, no concrete angle.",
+        reason: "screened_out",
+      },
+    });
+
+    expect(digest.outcomeRole).toBe("no-opportunity");
+    expect(digest.outcomeReason).toBe("screened_out");
+    expect(digest.keyTake).toContain("Gate declined");
+  });
+});
 
 describe("NegotiationSummarizer", () => {
   it("returns a digest with clamped fields when the LLM call succeeds", async () => {

--- a/packages/protocol/src/opportunity/negotiation-context.loader.ts
+++ b/packages/protocol/src/opportunity/negotiation-context.loader.ts
@@ -12,6 +12,11 @@
  * For `pending`, `stalled`, `accepted`, and `rejected` opportunities, the
  * full transcript and outcome are included so the prompt can ground its
  * explanation in concrete turn content.
+ *
+ * Screened-out negotiations (P2.2 — the client's own outreach gate declined
+ * before any turn was exchanged) return null: presentation treats them as
+ * never-happened, so no card, feed, or digest surface can frame the client's
+ * private gate decision as a "counterparty declined" event.
  */
 
 import type { NegotiationGraphDatabase, OpportunityStatus } from '../shared/interfaces/database.interface.js';
@@ -91,6 +96,11 @@ export async function loadNegotiationContext(
 
   const artifacts = await db.getArtifactsForTask(task.id);
   const outcome = extractOutcome(artifacts);
+
+  // P2.2: screened_out is the client's private gate decision, not a negotiation.
+  if (outcome?.reason === 'screened_out') {
+    return null;
+  }
 
   return {
     status: opportunityStatus,

--- a/packages/protocol/src/opportunity/question.prompt.ts
+++ b/packages/protocol/src/opportunity/question.prompt.ts
@@ -27,7 +27,7 @@ export interface DiscoveryOutcome {
   reasoning: string;
   agreedRoles?: Array<{ userId: string; role: NegotiationRole }>;
   /** Why the negotiation stopped, when not by an explicit accept/reject. */
-  reason?: "turn_cap" | "timeout";
+  reason?: "turn_cap" | "timeout" | "screened_out";
 }
 
 /** One negotiation that ran during this discovery turn. */
@@ -235,6 +235,8 @@ function renderOutcomeReason(reason: DiscoveryNegotiationDigest["outcomeReason"]
       return "not enough mutual interest";
     case "stalled":
       return "stalled";
+    case "screened_out":
+      return "didn't look like a strong enough fit to pursue";
     case null:
       return "";
   }

--- a/packages/protocol/src/opportunity/tests/negotiation-context.loader.spec.ts
+++ b/packages/protocol/src/opportunity/tests/negotiation-context.loader.spec.ts
@@ -35,7 +35,7 @@ function turnMessage(
 
 function outcomeArtifact(
   hasOpportunity: boolean,
-  reason?: "turn_cap" | "timeout",
+  reason?: "turn_cap" | "timeout" | "screened_out",
 ): { id: string; name: string | null; parts: unknown[]; metadata: Record<string, unknown> | null } {
   const outcome: NegotiationOutcome = {
     hasOpportunity,
@@ -179,6 +179,25 @@ describe("loadNegotiationContext", () => {
     expect(result!.outcome?.reason).toBe("turn_cap");
     expect(result!.outcome?.hasOpportunity).toBe(false);
     expect(result!.turns).toHaveLength(3);
+  });
+
+  it("returns null for screened_out outcomes — presentation treats the client's gate decision as never-happened (P2.2)", async () => {
+    const db = buildDb({
+      getNegotiationTaskForOpportunity: async () => ({
+        id: "task-1",
+        conversationId: "conv-1",
+        state: "completed",
+        metadata: { type: "negotiation", opportunityId: OPPORTUNITY_ID, maxTurns: 6 },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }),
+      getMessagesForConversation: async () => [],
+      getArtifactsForTask: async () => [outcomeArtifact(false, "screened_out")],
+    });
+
+    const result = await loadNegotiationContext(db, OPPORTUNITY_ID, "rejected");
+
+    expect(result).toBeNull();
   });
 
   it("defaults turnCap to 0 when task metadata omits maxTurns", async () => {

--- a/packages/protocol/src/opportunity/tests/question.prompt.spec.ts
+++ b/packages/protocol/src/opportunity/tests/question.prompt.spec.ts
@@ -114,12 +114,23 @@ describe("buildQuestionPrompt", () => {
     expect(out).not.toContain("(no negotiations)");
   });
 
+
+
   it("redacts internal outcome reasons", () => {
     const out = buildQuestionPrompt(makeInput({
       negotiationDigests: [makeDigest({ outcomeReason: "turn_cap" })],
     }));
     expect(out).toContain("needed more detail");
     expect(out).not.toContain("turn_cap");
+  });
+
+  it("renders screened_out with user-facing copy and no protocol jargon (P2.2)", () => {
+    const out = buildQuestionPrompt(makeInput({
+      negotiationDigests: [makeDigest({ outcomeReason: "screened_out" })],
+    }));
+    expect(out).toContain("didn't look like a strong enough fit to pursue");
+    expect(out).not.toContain("screened_out");
+    expect(out).not.toContain("screen");
   });
 
   it("renders suggestedRoles as user-facing relationship signals", () => {

--- a/packages/protocol/src/shared/schemas/discovery-question.schema.ts
+++ b/packages/protocol/src/shared/schemas/discovery-question.schema.ts
@@ -30,7 +30,7 @@ export const DiscoveryOutcomeSchema = z.object({
     userId: z.string(),
     role: NegotiationRoleSchema,
   })).optional(),
-  reason: z.enum(["turn_cap", "timeout"]).optional(),
+  reason: z.enum(["turn_cap", "timeout", "screened_out"]).optional(),
 });
 export type DiscoveryOutcome = z.infer<typeof DiscoveryOutcomeSchema>;
 

--- a/packages/protocol/src/shared/schemas/negotiation-digest.schema.ts
+++ b/packages/protocol/src/shared/schemas/negotiation-digest.schema.ts
@@ -27,7 +27,7 @@ export const DiscoveryNegotiationDigestSchema = z.object({
   /** Whether the negotiation produced an opportunity. */
   outcomeRole: z.enum(["opportunity", "no-opportunity"]),
   /** When `outcomeRole === "no-opportunity"`, why the negotiation didn't yield one. Null otherwise. */
-  outcomeReason: z.enum(["turn_cap", "timeout", "rejected", "stalled"]).nullable(),
+  outcomeReason: z.enum(["turn_cap", "timeout", "rejected", "stalled", "screened_out"]).nullable(),
   /**
    * One-sentence (≤180 chars) summary of the decisive moment or pattern in
    * this negotiation. Written for the downstream question generator — should

--- a/packages/protocol/src/shared/schemas/negotiation-state.schema.ts
+++ b/packages/protocol/src/shared/schemas/negotiation-state.schema.ts
@@ -66,7 +66,7 @@ export const NegotiationOutcomeSchema = z.object({
   })),
   reasoning: z.string(),
   turnCount: z.number(),
-  reason: z.enum(["turn_cap", "timeout"]).optional(),
+  reason: z.enum(["turn_cap", "timeout", "screened_out"]).optional(),
 });
 export type NegotiationOutcome = z.infer<typeof NegotiationOutcomeSchema>;
 

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -1117,7 +1117,18 @@ export class ConversationDatabaseAdapter {
       ? sql`${schema.tasks.createdAt} >= ${opts.since.toISOString()}`
       : undefined;
 
-    const allFilters = [userFilter, resultFilter, sinceFilter].filter(Boolean);
+    // P2.2: screened_out negotiations are the owner's private outreach-gate
+    // decisions — zero turns, no counterparty involvement. They stay visible
+    // to the owner (self view) but are excluded from the mutual (non-self
+    // viewer) list so the counterparty never learns a gate decision was made.
+    const screenedOutFilter = opts?.mutualWithUserId
+      ? or(
+          isNull(schema.artifacts.id),
+          sql`coalesce(${schema.artifacts.parts}->0->'data'->>'reason', '') <> 'screened_out'`,
+        )
+      : undefined;
+
+    const allFilters = [userFilter, resultFilter, sinceFilter, screenedOutFilter].filter(Boolean);
     const combinedFilter = allFilters.length > 1 ? and(...allFilters) : allFilters[0];
 
     const rows = await db

--- a/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
+++ b/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
@@ -119,6 +119,71 @@ describe('ConversationDatabaseAdapter', () => {
     }, 10000);
   });
 
+  describe('getNegotiationsByUser — screened_out visibility (P2.2)', () => {
+    it('screened_out rows stay visible to the owner but are excluded from the mutual (non-self) view', async () => {
+      const run = Date.now();
+      const userA = `screen-owner-${run}`;
+      const userB = `screen-counterparty-${run}`;
+
+      const conv = await adapter.createConversation([
+        { participantId: `agent:${userA}`, participantType: 'agent' as const },
+        { participantId: `agent:${userB}`, participantType: 'agent' as const },
+      ]);
+      createdIds.push(conv.id);
+
+      // 1. A screened_out negotiation (zero turns, gate declined).
+      const screenedTask = await adapter.createTask(conv.id, {
+        type: 'negotiation',
+        sourceUserId: userA,
+        candidateUserId: userB,
+        initiatorUserId: userA,
+      });
+      await adapter.updateTaskState(screenedTask.id, 'completed');
+      await adapter.createArtifact({
+        taskId: screenedTask.id,
+        name: 'negotiation-outcome',
+        parts: [{ kind: 'data', data: { hasOpportunity: false, agreedRoles: [], reasoning: 'gate declined', turnCount: 0, reason: 'screened_out' } }],
+      });
+
+      // 2. A normally-rejected negotiation between the same pair.
+      const rejectedTask = await adapter.createTask(conv.id, {
+        type: 'negotiation',
+        sourceUserId: userA,
+        candidateUserId: userB,
+        initiatorUserId: userA,
+      });
+      await adapter.updateTaskState(rejectedTask.id, 'completed');
+      await adapter.createArtifact({
+        taskId: rejectedTask.id,
+        name: 'negotiation-outcome',
+        parts: [{ kind: 'data', data: { hasOpportunity: false, agreedRoles: [], reasoning: 'declined after turns', turnCount: 3 } }],
+      });
+
+      // 3. An in-progress negotiation (no artifact yet) — must survive the exclusion filter.
+      const inProgressTask = await adapter.createTask(conv.id, {
+        type: 'negotiation',
+        sourceUserId: userA,
+        candidateUserId: userB,
+        initiatorUserId: userA,
+      });
+
+      // Self view: the owner sees all three, including their own gate decision.
+      const selfRows = await adapter.getNegotiationsByUser(userA, { limit: 50 });
+      const selfIds = selfRows.map((r) => r.id);
+      expect(selfIds).toContain(screenedTask.id);
+      expect(selfIds).toContain(rejectedTask.id);
+      expect(selfIds).toContain(inProgressTask.id);
+
+      // Mutual view (counterparty viewing the owner's profile): the gate
+      // decision is invisible; real negotiations and in-flight rows remain.
+      const mutualRows = await adapter.getNegotiationsByUser(userA, { limit: 50, mutualWithUserId: userB });
+      const mutualIds = mutualRows.map((r) => r.id);
+      expect(mutualIds).not.toContain(screenedTask.id);
+      expect(mutualIds).toContain(rejectedTask.id);
+      expect(mutualIds).toContain(inProgressTask.id);
+    }, 30000);
+  });
+
   describe('hideConversation', () => {
     it('sets hiddenAt on participant', async () => {
       await adapter.hideConversation('test-user-1', createdIds[0]);

--- a/services/api/src/types/chat-streaming.types.ts
+++ b/services/api/src/types/chat-streaming.types.ts
@@ -513,7 +513,8 @@ export interface NegotiationOutcomeEvent extends ChatStreamEventBase {
     | "rejected_stalled"
     | "waiting_for_agent"
     | "timed_out"
-    | "turn_cap";
+    | "turn_cap"
+    | "screened_out";
   turnCount: number;
   reasoning?: string;
   agreedRoles?: { ownUser?: string; otherUser?: string };

--- a/services/api/tests/negotiation.e2e.spec.ts
+++ b/services/api/tests/negotiation.e2e.spec.ts
@@ -3,7 +3,7 @@ config({ path: ".env.test", override: true });
 
 import { describe, it, expect } from "bun:test";
 import { randomUUID } from "node:crypto";
-import { NegotiationGraphFactory, requestContext } from "@indexnetwork/protocol";
+import { NegotiationGraphFactory, NegotiationScreener, requestContext } from "@indexnetwork/protocol";
 import type { NegotiationGraphDatabase } from "@indexnetwork/protocol";
 import { conversationDatabaseAdapter } from "../src/adapters/database.adapter";
 
@@ -95,6 +95,77 @@ describe("Negotiation E2E", () => {
     expect(screenEvents[0].opportunityId).toBe(opportunityId);
     expect(["reach_out", "pass"]).toContain(screenEvents[0].decision);
   }, 120_000);
+
+  it("enforce + forced pass → screened_out: zero A2A messages, completed task, artifact reason screened_out (IND-399)", async () => {
+    const factory = new NegotiationGraphFactory(
+      conversationDatabaseAdapter as unknown as NegotiationGraphDatabase,
+      noopDispatcher,
+    );
+    const graph = factory.createGraph();
+
+    const sourceId = `e2e-screen-src-${Date.now()}`;
+    const candidateId = `e2e-screen-cand-${Date.now()}`;
+    const opportunityId = randomUUID();
+
+    // Force a deterministic `pass` — the real screen LLM verdict is not stable
+    // enough to gate an e2e on; enforcement mechanics are what's under test.
+    const origScreenMode = process.env.NEGOTIATION_SCREEN_MODE;
+    const origInvoke = NegotiationScreener.prototype.invoke;
+    process.env.NEGOTIATION_SCREEN_MODE = "enforce";
+    NegotiationScreener.prototype.invoke = async () => ({
+      decision: "pass",
+      reasoning: "e2e forced pass: generic overlap",
+      evidence: { counterpartyPremiseFit: "weak", intentAlignment: "none" },
+    });
+
+    const traceEvents: Array<Record<string, unknown>> = [];
+    try {
+      const result = await requestContext.run(
+        { traceEmitter: ((e: Record<string, unknown>) => { traceEvents.push(e); }) as never },
+        () => graph.invoke({
+          opportunityId,
+          sourceUser: { id: sourceId, intents: [], profile: { name: "Alice" } },
+          candidateUser: { id: candidateId, intents: [], profile: { name: "Bob" } },
+          indexContext: { networkId: "e2e-index", prompt: "AI startup co-founders" },
+          seedAssessment: { reasoning: "Vague overlap", valencyRole: "Peer" },
+          maxTurns: 4,
+        }),
+      );
+
+      // Outcome: rejected as screened_out with zero turns — never 'stalled'.
+      expect(result.outcome).not.toBeNull();
+      expect(result.outcome!.hasOpportunity).toBe(false);
+      expect(result.outcome!.reason).toBe("screened_out");
+      expect(result.outcome!.turnCount).toBe(0);
+      expect(result.outcome!.reasoning).toBe("e2e forced pass: generic overlap");
+
+      // Zero counterparty involvement: no A2A messages persisted.
+      const messages = await conversationDatabaseAdapter.getMessages(result.conversationId);
+      expect(messages.filter((m) => m.role === "agent").length).toBe(0);
+
+      // Task completed with the enforce decision on metadata…
+      const task = await conversationDatabaseAdapter.getTask(result.taskId);
+      expect(task?.state).toBe("completed");
+      const screen = (task?.metadata as Record<string, unknown>)?.screenDecision as Record<string, unknown>;
+      expect(screen.mode).toBe("enforce");
+      expect(screen.decision).toBe("pass");
+
+      // …and the outcome artifact carries reason screened_out (not stalled).
+      const artifacts = await conversationDatabaseAdapter.getArtifactsForTask(result.taskId);
+      const outcomeArtifact = artifacts.find((a) => a.name === "negotiation-outcome");
+      const data = (outcomeArtifact?.parts as Array<{ kind?: string; data?: Record<string, unknown> }>)?.find((p) => p.kind === "data")?.data;
+      expect(data?.reason).toBe("screened_out");
+
+      // Distinct trace outcome for observability.
+      const outcomeEvents = traceEvents.filter((e) => e.type === "negotiation_outcome");
+      expect(outcomeEvents.length).toBe(1);
+      expect(outcomeEvents[0].outcome).toBe("screened_out");
+    } finally {
+      NegotiationScreener.prototype.invoke = origInvoke;
+      if (origScreenMode === undefined) delete process.env.NEGOTIATION_SCREEN_MODE;
+      else process.env.NEGOTIATION_SCREEN_MODE = origScreenMode;
+    }
+  }, 60_000);
 
   it("runs a full v2 negotiation: seat-scoped actions, counterparty-only accept (IND-397)", async () => {
     const origVersion = process.env.NEGOTIATION_PROTOCOL_VERSION;


### PR DESCRIPTION
## P2.2 · Screen enforcement + `screened_out` outcome (IND-399)

Turns the outreach gate (P2.1) from an observer into an enforcer. In `NEGOTIATION_SCREEN_MODE=enforce`, a genuine screen `pass` now blocks the negotiation **before the first turn**: zero A2A messages, zero counterparty involvement, zero notifications, outcome `reason: "screened_out"`, opportunity quietly `rejected`.

**Deployable increment:** default stays `shadow` — merged behavior is byte-identical until the Railway env flip; rollback is flipping back.

### Graph (protocol)

- `screen → turn` fixed edge replaced with a conditional edge: `isScreenBlocked` (enforce mode + genuine `pass` + not failed-open + zero turns) routes to finalize; everything else proceeds. Shadow passes and failed-open screens **never** block; continuations never screen (enforcement cannot touch in-flight dialogues).
- Finalize gains an explicit screened_out branch: with zero turns the generic status mapping would misfile the outcome as `'stalled'` and emit `rejected_stalled`. Now: outcome `reason: "screened_out"` with the screen decision's reasoning carried, opportunity `negotiating → rejected`, distinct `negotiation_outcome` trace (`outcome: "screened_out"`), log label `screened_out`.
- Structural guard rails preserved (regression-tested): questioner and reflection enqueues both require `turnCount > 0` — a screened_out finalize enqueues neither.

### `reason` consumers (all of them)

- `NegotiationOutcomeSchema.reason` gains `"screened_out"` in **both** copies (`negotiation-state.schema.ts`, `negotiation.state.ts`) + `DiscoveryOutcomeSchema` + `DiscoveryNegotiationDigestSchema.outcomeReason`.
- Summarizer prompt maps `screened_out` explicitly ("the seeker's own agent chose not to reach out — never describe it as the candidate declining or stalling"); `buildFallbackDigest` passes it through instead of coercing to `"stalled"`.
- Question-generator renderer: exhaustive switch gains user-facing copy ("didn't look like a strong enough fit to pursue") — no protocol jargon leaks (pinned).
- Trace unions widened: protocol `chat-streaming.types` + `chat.agent`, API `chat-streaming.types`, web `AIChatContext` + `ToolCallsDisplay` (amber square, same as other non-outcomes).
- `buildOutcome` duplicates in `timeout.shared.ts` / `negotiation-polling.service.ts` untouched by design: they only ever produce `turn_cap`, and the widened schema is the shared source of truth.

### Presentation: screened_out is never-happened

Per the `opportunity-presentation-safety` skill:

- **Single choke point:** `negotiation-context.loader.ts` returns `null` for screened_out outcomes — no card, home-feed, digest, or MCP surface can frame the client's private gate decision as "counterparty declined". (Opportunity lands in `rejected`, which default lists already hide — IND-254.)
- **Mutual negotiations list:** `getNegotiationsByUser` with `mutualWithUserId` (the only non-self view) excludes screened_out rows — the counterparty never learns a gate decision was made. Self view keeps full visibility (it's the owner's own agent's decision); in-progress rows (null artifact) survive the filter.

### Tests

- **Graph routing spec (13):** enforce+pass → zero messages, screened_out artifact, `negotiating → rejected` status sequence, distinct trace event, no questioner/reflect; enforce+reach_out proceeds; enforce+failed-open proceeds; enforce+continuation never screens; shadow `pass` still never blocks (unchanged pre-P2.2 pins all green).
- **e2e (real DB adapter):** forced pass under enforce → zero A2A messages persisted, completed task with enforce decision on metadata, artifact `reason: screened_out`, distinct trace outcome. Existing shadow e2e untouched and green = shadow-behavior-identical AC.
- **Loader spec:** screened_out → `null` context.
- **Summarizer:** fallback digest preserves screened_out (no stalled coercion); prompt updated for the LLM path.
- **Question prompt spec:** screened_out renders user-facing copy, `screened_out`/`screen` never appear in the prompt.
- **Adapter spec (DB-backed):** owner sees screened_out rows; mutual viewer does not; rejected + in-progress rows unaffected.
- Full protocol negotiation suite 207/207; opportunity suite 683/684 (single failure = documented `MCP run coalescing` baseline flake on clean dev). API + protocol tsc clean; web tsc at the exact 59-error baseline.

### Rollout

1. Merge (shadow default — no behavior change).
2. Pre-flip analysis + threshold agreement on IND-399 (posted as issue comment).
3. Flip `NEGOTIATION_SCREEN_MODE=enforce` on dev → watch `screened_out` outcomes appear; flip back = instant rollback.

Closes IND-399.
