### PR TITLE
feat(web+api): intent page UX overhaul — 6/4 full-height workspace, eager loading, skeletons, chat bootstrap race fix

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -3,28 +3,17 @@
 @import url('https://fonts.googleapis.com/css2?family=Public+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&display=swap');
 @import "tailwindcss";
 
-:root {
-  --foreground-rgb: 0, 0, 0;
-  --background-start-rgb: 214, 219, 220;
-  --background-end-rgb: 255, 255, 255;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --foreground-rgb: 255, 255, 255;
-    --background-start-rgb: 0, 0, 0;
-    --background-end-rgb: 0, 0, 0;
-  }
-}
-
 @layer base {
   html {
     @apply scroll-smooth;
     overscroll-behavior: none;
+    /* The app is light-only: pin the UA color scheme so form controls,
+       scrollbars, and inherited colors never follow the OS dark mode. */
+    color-scheme: light;
   }
   
   body {
-    @apply text-gray-900 dark:text-gray-100;
+    @apply text-gray-900;
     font-family: 'Public Sans', -apple-system, BlinkMacSystemFont, sans-serif;
     background-color: #FDFDFD;
     overscroll-behavior: none;
@@ -48,7 +37,7 @@
 
 @layer components {
   .btn-primary {
-    @apply px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors dark:bg-blue-500 dark:hover:bg-blue-600;
+    @apply px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors;
   }
   
   .btn-secondary {
@@ -57,7 +46,7 @@
   }
   
   .card {
-    @apply bg-white dark:bg-gray-800 rounded-lg shadow-md p-6;
+    @apply bg-white rounded-lg shadow-md p-6;
   }
 
   .input {

--- a/apps/web/src/app/i/[intentId]/page.tsx
+++ b/apps/web/src/app/i/[intentId]/page.tsx
@@ -100,7 +100,7 @@ function StatPill({
       aria-pressed={active}
       onClick={onSelect}
       className={cn(
-        "inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-colors",
+        "inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors",
         active
           ? "bg-[#041729] text-white"
           : "text-gray-500 hover:bg-gray-100 hover:text-gray-700",
@@ -136,9 +136,9 @@ function Panel({
   className?: string;
 }) {
   return (
-    <section className={className}>
-      <div className="mb-4">
-        <h3 className="flex items-center gap-2 text-base font-bold tracking-[0.2em] text-[#3D3D3D] font-ibm-plex-mono">
+    <section className={cn("flex min-h-0 flex-col", className)}>
+      <div className="mb-2.5 shrink-0">
+        <h3 className="flex items-center gap-2 text-sm font-bold tracking-[0.2em] text-[#3D3D3D] font-ibm-plex-mono">
           <span>
             {title}
             {count !== undefined && ` (${count})`}
@@ -146,7 +146,7 @@ function Panel({
           {media}
         </h3>
         {description && (
-          <p className="mt-1.5 text-sm text-gray-500">{description}</p>
+          <p className="mt-1 text-xs text-gray-500">{description}</p>
         )}
       </div>
       {children}
@@ -341,12 +341,12 @@ export default function IntentDetailPage() {
   return (
     <ClientLayout>
       {inviteModalElement}
-      <div className="px-10 lg:px-16 py-6">
-        <ContentContainer size="xwide">
+      <div className="flex min-h-0 flex-1 flex-col px-6 py-4 lg:px-10">
+        <ContentContainer size="xwide" className="flex w-full min-h-0 flex-1 flex-col">
           <button
             type="button"
             onClick={() => navigate("/")}
-            className="mb-4 inline-flex items-center gap-1 text-sm text-gray-600 hover:text-black transition-colors"
+            className="mb-3 inline-flex shrink-0 items-center gap-1 text-sm text-gray-600 hover:text-black transition-colors"
             aria-label="Back to home"
           >
             <ChevronLeft className="h-4 w-4" />
@@ -363,9 +363,9 @@ export default function IntentDetailPage() {
             </div>
           ) : (
             <>
-              <div className="mb-6 rounded-lg border border-gray-200 bg-white p-5">
+              <div className="mb-4 shrink-0 rounded-lg border border-gray-200 bg-white p-4">
                 <div className="flex items-start justify-between gap-4">
-                  <h1 className="text-base font-bold text-black font-ibm-plex-mono leading-snug">
+                  <h1 className="text-sm font-bold text-black font-ibm-plex-mono leading-snug">
                     {title}
                   </h1>
                   <div className="flex shrink-0 items-center gap-0.5">
@@ -387,7 +387,7 @@ export default function IntentDetailPage() {
                     />
                   </div>
                 </div>
-                <div className="mt-2.5 flex items-center gap-2 text-xs text-gray-500 font-ibm-plex-mono">
+                <div className="mt-2 flex items-center gap-2 text-xs text-gray-500 font-ibm-plex-mono">
                   <span className="inline-flex items-center gap-1.5 rounded border border-green-300 px-1.5 py-0.5 font-medium lowercase tracking-wide text-green-600">
                     <span className="relative flex h-1.5 w-1.5">
                       <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-75" />
@@ -399,7 +399,7 @@ export default function IntentDetailPage() {
                 </div>
 
                 {showRefine && (
-                  <div className="mt-4 flex items-center gap-2">
+                  <div className="mt-3 flex items-center gap-2">
                     <input
                       type="text"
                       value={refineText}
@@ -424,13 +424,12 @@ export default function IntentDetailPage() {
                 )}
               </div>
 
-              <div className="grid grid-cols-1 lg:grid-cols-5 gap-8 items-start">
+              <div className="grid min-h-0 flex-1 grid-cols-1 gap-6 lg:grid-cols-10 lg:grid-rows-[minmax(0,1fr)]">
                 {negotiatorChatEnabled && intentId ? (
                   <Panel
                     title="Personal Agent"
-                    count={questions.length}
-                    description="Chat with your negotiator about this signal."
-                    className="lg:col-span-2"
+                    description="Your negotiator, scoped to this intent — ask what it's doing, steer it, or answer its follow-ups."
+                    className="lg:col-span-6"
                   >
                     <IntentNegotiatorChat
                       key={intentId}
@@ -451,19 +450,21 @@ export default function IntentDetailPage() {
                     title="Questions"
                     count={questions.length}
                     description="Answer pending follow-ups for this intent."
-                    className="lg:col-span-2"
+                    className="lg:col-span-6"
                   >
-                    {questions.length === 0 ? (
-                      <div className="text-sm text-gray-500 font-ibm-plex-mono py-8 text-center border border-dashed border-gray-200 rounded-lg">
-                        No pending questions right now.
-                      </div>
-                    ) : (
-                      <InjectedQuestions
-                        questions={questions}
-                        onAnswer={handleAnswer}
-                        onDismiss={handleDismiss}
-                      />
-                    )}
+                    <div className="min-h-0 flex-1 lg:overflow-y-auto lg:pr-1">
+                      {questions.length === 0 ? (
+                        <div className="text-sm text-gray-500 font-ibm-plex-mono py-8 text-center border border-dashed border-gray-200 rounded-lg">
+                          No pending questions right now.
+                        </div>
+                      ) : (
+                        <InjectedQuestions
+                          questions={questions}
+                          onAnswer={handleAnswer}
+                          onDismiss={handleDismiss}
+                        />
+                      )}
+                    </div>
                   </Panel>
                 )}
 
@@ -479,9 +480,9 @@ export default function IntentDetailPage() {
                       className="h-6 w-auto object-contain"
                     />
                   }
-                  className="lg:col-span-3"
+                  className="lg:col-span-4"
                 >
-                  <div className="mb-4 flex flex-wrap gap-2">
+                  <div className="mb-3 flex shrink-0 flex-wrap gap-1.5">
                     {RADAR_BUCKETS.map((bucket) => (
                       <StatPill
                         key={bucket.key}
@@ -492,6 +493,7 @@ export default function IntentDetailPage() {
                       />
                     ))}
                   </div>
+                  <div className="min-h-0 flex-1 lg:overflow-y-auto lg:pr-1">
                   {opportunitiesLoading ? (
                     <div className="flex justify-center py-8">
                       <Loader2 className="h-5 w-5 animate-spin text-gray-400" />
@@ -518,6 +520,7 @@ export default function IntentDetailPage() {
                       ))}
                     </div>
                   )}
+                  </div>
                 </Panel>
               </div>
             </>

--- a/apps/web/src/app/i/[intentId]/page.tsx
+++ b/apps/web/src/app/i/[intentId]/page.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router";
-import { ChevronLeft, Loader2, Pause, Pencil, Trash2 } from "lucide-react";
+import { ChevronLeft, Pause, Pencil, Trash2 } from "lucide-react";
 
 import ClientLayout from "@/components/ClientLayout";
 import { ContentContainer } from "@/components/layout";
-import OpportunityCard from "@/components/chat/OpportunityCardInChat";
+import OpportunityCard, { OpportunitySkeleton } from "@/components/chat/OpportunityCardInChat";
 import { InjectedQuestions } from "@/components/InjectedQuestions/InjectedQuestions";
 import IntentNegotiatorChat from "@/components/IntentNegotiatorChat";
 import { useAuthContext } from "@/contexts/AuthContext";
@@ -353,17 +353,22 @@ export default function IntentDetailPage() {
             Back
           </button>
 
-          {intentLoading ? (
-            <div className="flex justify-center py-12">
-              <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
-            </div>
-          ) : !intent ? (
+          {!intentLoading && !intent ? (
             <div className="text-sm text-gray-500 font-ibm-plex-mono py-12 text-center border border-dashed border-gray-200 rounded-lg">
               Intent not found
             </div>
           ) : (
             <>
+              {/* Header card: skeleton while the intent loads — the workspace
+                  below renders (and fetches) immediately, in parallel. */}
               <div className="mb-4 shrink-0 rounded-lg border border-gray-200 bg-white p-4">
+                {intentLoading ? (
+                  <div className="animate-pulse space-y-3" data-testid="intent-header-skeleton">
+                    <div className="h-4 w-2/3 rounded bg-gray-200" />
+                    <div className="h-3.5 w-52 rounded bg-gray-200" />
+                  </div>
+                ) : (
+                  <>
                 <div className="flex items-start justify-between gap-4">
                   <h1 className="text-sm font-bold text-black font-ibm-plex-mono leading-snug">
                     {title}
@@ -421,6 +426,8 @@ export default function IntentDetailPage() {
                       {refining ? "Refining..." : "Refine"}
                     </button>
                   </div>
+                )}
+                  </>
                 )}
               </div>
 
@@ -495,8 +502,9 @@ export default function IntentDetailPage() {
                   </div>
                   <div className="min-h-0 flex-1 lg:overflow-y-auto lg:pr-1">
                   {opportunitiesLoading ? (
-                    <div className="flex justify-center py-8">
-                      <Loader2 className="h-5 w-5 animate-spin text-gray-400" />
+                    <div className="space-y-3" data-testid="radar-skeleton">
+                      <OpportunitySkeleton />
+                      <OpportunitySkeleton />
                     </div>
                   ) : visibleOpportunities.length === 0 ? (
                     <div className="text-sm text-gray-500 font-ibm-plex-mono py-8 text-center border border-dashed border-gray-200 rounded-lg">

--- a/apps/web/src/app/i/[intentId]/page.tsx
+++ b/apps/web/src/app/i/[intentId]/page.tsx
@@ -415,7 +415,7 @@ export default function IntentDetailPage() {
                       placeholder="Refine this signal..."
                       disabled={refining}
                       autoFocus
-                      className="flex-1 text-sm bg-[#FCFCFC] border border-[#E9E9E9] rounded-full px-4 py-2 focus:outline-none focus:ring-2 focus:ring-[#4091BB]/30"
+                      className="flex-1 text-sm text-gray-900 placeholder:text-gray-400 bg-[#FCFCFC] border border-[#E9E9E9] rounded-full px-4 py-2 focus:outline-none focus:ring-2 focus:ring-[#4091BB]/30"
                     />
                     <button
                       type="button"

--- a/apps/web/src/app/i/[intentId]/page.tsx
+++ b/apps/web/src/app/i/[intentId]/page.tsx
@@ -346,7 +346,7 @@ export default function IntentDetailPage() {
           <button
             type="button"
             onClick={() => navigate("/")}
-            className="mb-3 inline-flex shrink-0 items-center gap-1 text-sm text-gray-600 hover:text-black transition-colors"
+            className="mb-3 inline-flex shrink-0 items-center gap-1 self-start text-sm text-gray-600 hover:text-black transition-colors"
             aria-label="Back to home"
           >
             <ChevronLeft className="h-4 w-4" />

--- a/apps/web/src/components/AuthModal.tsx
+++ b/apps/web/src/components/AuthModal.tsx
@@ -24,22 +24,44 @@ export default function AuthModal({ isOpen, onClose, callbackURL }: AuthModalPro
   const [error, setError] = useState<string | null>(null);
   const [socialProviders, setSocialProviders] = useState<string[]>([]);
   const [emailPasswordEnabled, setEmailPasswordEnabled] = useState(false);
+  const [providersStatus, setProvidersStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+  const [providersRetryKey, setProvidersRetryKey] = useState(0);
   const [isSignUp, setIsSignUp] = useState(false);
 
   useEffect(() => {
     if (!isOpen) return;
     ensureLandingFonts();
-    fetch(`${API_BASE}/auth/providers`)
-      .then((r) => r.json())
-      .then((data: { providers?: string[]; emailPassword?: boolean }) => {
-        setSocialProviders(data.providers ?? []);
-        setEmailPasswordEnabled(data.emailPassword ?? false);
-      })
-      .catch(() => {
-        setSocialProviders([]);
-        setEmailPasswordEnabled(false);
-      });
-  }, [isOpen]);
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const load = (attempt: number) => {
+      setProvidersStatus('loading');
+      fetch(`${API_BASE}/auth/providers`)
+        .then((r) => {
+          if (!r.ok) throw new Error(`providers request failed: ${r.status}`);
+          return r.json();
+        })
+        .then((data: { providers?: string[]; emailPassword?: boolean }) => {
+          if (cancelled) return;
+          setSocialProviders(data.providers ?? []);
+          setEmailPasswordEnabled(data.emailPassword ?? false);
+          setProvidersStatus('ready');
+        })
+        .catch(() => {
+          if (cancelled) return;
+          // Retry twice with backoff — covers transient API restarts (bun --watch).
+          if (attempt < 2) {
+            timer = setTimeout(() => load(attempt + 1), 1000 * (attempt + 1));
+          } else {
+            setProvidersStatus('error');
+          }
+        });
+    };
+    load(0);
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [isOpen, providersRetryKey]);
 
   if (!isOpen) return null;
 
@@ -179,6 +201,19 @@ export default function AuthModal({ isOpen, onClose, callbackURL }: AuthModalPro
             <p className="av-lede">
               Write what you want — let the network bring people to you.
             </p>
+
+            {providersStatus === 'error' && (
+              <p className="av-note">
+                Couldn&apos;t load all sign-in options.{' '}
+                <button
+                  type="button"
+                  className="av-link"
+                  onClick={() => setProvidersRetryKey((k) => k + 1)}
+                >
+                  Retry
+                </button>
+              </p>
+            )}
 
             {hasGoogle && (
               <button

--- a/apps/web/src/components/ChatSidebar.tsx
+++ b/apps/web/src/components/ChatSidebar.tsx
@@ -52,7 +52,10 @@ export default function ChatSidebar() {
   const { user } = useAuthContext();
   const { conversations, negotiations, refreshConversations, refreshNegotiations, hideConversation } = useConversation();
 
-  const [loading, setLoading] = useState(true);
+  // Background revalidation flag. The ConversationProvider prefetches both
+  // lists on auth, so cached data renders immediately; this only gates the
+  // empty state (skeleton vs "No messages yet") on a genuinely cold cache.
+  const [refreshing, setRefreshing] = useState(true);
   const [chatMenuOpen, setChatMenuOpen] = useState<string | null>(null);
   const [mode, setMode] = useState<'h2h' | 'a2a'>('h2h');
   const chatMenuRef = useRef<HTMLDivElement>(null);
@@ -61,7 +64,7 @@ export default function ChatSidebar() {
     if (!user?.id) return;
     let cancelled = false;
     Promise.all([refreshConversations(), refreshNegotiations()]).finally(() => {
-      if (!cancelled) setLoading(false);
+      if (!cancelled) setRefreshing(false);
     });
     return () => { cancelled = true; };
   }, [user?.id, refreshConversations, refreshNegotiations]);
@@ -150,8 +153,19 @@ export default function ChatSidebar() {
             Negotiations
           </button>
         </div>
-        {loading ? (
-          <div className="text-sm text-gray-400">Loading...</div>
+        {recentChats.length === 0 && refreshing ? (
+          /* Cold cache — conversation-row skeletons while the first fetch lands. */
+          <div className="space-y-1" data-testid="chat-sidebar-skeleton" aria-hidden="true">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-3 py-2 px-2 -mx-2 animate-pulse">
+                <div className="h-7 w-7 rounded-full bg-gray-200 shrink-0" />
+                <div className="min-w-0 flex-1 space-y-1.5">
+                  <div className="h-3.5 w-2/3 rounded bg-gray-200" />
+                  <div className="h-3 w-11/12 rounded bg-gray-200" />
+                </div>
+              </div>
+            ))}
+          </div>
         ) : recentChats.length === 0 ? (
           <div className="text-sm text-gray-400">No messages yet</div>
         ) : (

--- a/apps/web/src/components/ClientWrapper.tsx
+++ b/apps/web/src/components/ClientWrapper.tsx
@@ -1,6 +1,7 @@
 import { PropsWithChildren, Suspense, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router';
 import { useLocation } from 'react-router';
+import { PanelLeftClose, PanelLeftOpen } from 'lucide-react';
 import Header from "@/components/Header";
 import Sidebar from "@/components/Sidebar";
 import ChatSidebar from "@/components/ChatSidebar";
@@ -14,9 +15,19 @@ export default function ClientWrapper({ children }: PropsWithChildren) {
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   const { isAuthenticated } = useAuthContext();
 
+  // Intent detail pages open with the sidebar collapsed to give the two-column
+  // workspace the full width; the floating toggle brings it back. Leaving the
+  // intent page restores the expanded sidebar.
+  const isIntentDetail = useMemo(() => pathname?.startsWith('/i/') ?? false, [pathname]);
+  const [desktopSidebarCollapsed, setDesktopSidebarCollapsed] = useState(isIntentDetail);
+
   useEffect(() => {
     setMobileSidebarOpen(false);
   }, [pathname]);
+
+  useEffect(() => {
+    setDesktopSidebarCollapsed(isIntentDetail);
+  }, [isIntentDetail]);
 
   const appRoutes = ['/', '/d', '/i', '/u', '/networks', '/mynetwork', '/chat', '/settings', '/agents', '/agent', '/questions'];
   const publicRoutes = ['/c', '/l', '/index'];
@@ -93,12 +104,16 @@ export default function ClientWrapper({ children }: PropsWithChildren) {
                   id="app-sidebar"
                   className={`
                     fixed inset-y-0 left-0 z-50 w-64 bg-white border-r border-gray-200
-                    transform transition-transform duration-200 ease-in-out
-                    lg:translate-x-0 lg:relative lg:z-auto
+                    transform transition-[transform,width] duration-200 ease-in-out
+                    lg:relative lg:z-auto lg:translate-x-0
                     ${mobileSidebarOpen ? 'translate-x-0' : '-translate-x-full'}
+                    ${desktopSidebarCollapsed ? 'lg:w-0 lg:overflow-hidden lg:border-r-0' : 'lg:w-64'}
                   `}
                 >
-                  <Sidebar />
+                  {/* Fixed-width inner wrapper so content doesn't reflow while the width animates. */}
+                  <div className="h-full w-64">
+                    <Sidebar />
+                  </div>
                 </aside>
 
                 {/* Secondary sidebar for chat - only on messages view */}
@@ -129,6 +144,23 @@ export default function ClientWrapper({ children }: PropsWithChildren) {
                       <path d="M3 6h18M3 12h18M3 18h18" />
                     </svg>
                   </button>
+
+                  {/* Desktop sidebar toggle - only where the sidebar auto-collapses (intent pages) */}
+                  {isIntentDetail && (
+                    <button
+                      type="button"
+                      onClick={() => setDesktopSidebarCollapsed((v) => !v)}
+                      title={desktopSidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+                      aria-label={desktopSidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+                      className="hidden lg:inline-flex absolute top-4 left-2 z-30 p-1 rounded-md text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+                    >
+                      {desktopSidebarCollapsed ? (
+                        <PanelLeftOpen className="h-5 w-5" />
+                      ) : (
+                        <PanelLeftClose className="h-5 w-5" />
+                      )}
+                    </button>
+                  )}
                   
                   {/* Scrollable content area */}
                   <main className="flex-1 overflow-y-auto flex flex-col">

--- a/apps/web/src/components/IntentNegotiatorChat.tsx
+++ b/apps/web/src/components/IntentNegotiatorChat.tsx
@@ -254,7 +254,7 @@ export default function IntentNegotiatorChat({
           placeholder={placeholder}
           disabled={!ready}
           data-testid="negotiator-chat-input"
-          className="flex-1 rounded-full border border-[#E9E9E9] bg-[#FCFCFC] px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#4091BB]/30 disabled:opacity-60"
+          className="flex-1 rounded-full border border-[#E9E9E9] bg-[#FCFCFC] px-4 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#4091BB]/30 disabled:opacity-60"
         />
         {isLoading && sessionId ? (
           <button

--- a/apps/web/src/components/IntentNegotiatorChat.tsx
+++ b/apps/web/src/components/IntentNegotiatorChat.tsx
@@ -149,8 +149,11 @@ export default function IntentNegotiatorChat({
   const placeholder = agentName ? `Message ${agentName}…` : "Message your negotiator…";
 
   return (
-    <div className="flex h-[520px] flex-col" data-testid="intent-negotiator-chat">
-      <div className="flex-1 space-y-4 overflow-y-auto pr-1">
+    <div
+      className="flex h-[520px] flex-col lg:h-auto lg:min-h-0 lg:flex-1"
+      data-testid="intent-negotiator-chat"
+    >
+      <div className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1">
         {!ready ? (
           <div className="flex justify-center py-10">
             <Loader2 className="h-5 w-5 animate-spin text-gray-400" />
@@ -161,8 +164,9 @@ export default function IntentNegotiatorChat({
               <div className="flex items-start gap-2 text-sm text-gray-600 font-ibm-plex-mono">
                 <BotMessageSquare className="mt-0.5 h-4 w-4 shrink-0 text-gray-400" />
                 <p>
-                  This is your direct line to {agentName ?? "your negotiator"} about this signal —
-                  ask what's happening, refine what you're looking for, or answer follow-ups here.
+                  This is your direct line to {agentName ?? "your negotiator"} about this intent —
+                  ask who it found, why, what it's waiting on, or tell it how to negotiate on your
+                  behalf.
                 </p>
               </div>
             )}
@@ -170,7 +174,7 @@ export default function IntentNegotiatorChat({
             {questions.length > 0 && (
               <div data-testid="negotiator-opening-questions">
                 <p className="mb-2 text-xs uppercase tracking-wider text-gray-500 font-ibm-plex-mono">
-                  Open questions for this signal
+                  Your negotiator needs your input
                 </p>
                 <InjectedQuestions
                   questions={questions}
@@ -221,7 +225,7 @@ export default function IntentNegotiatorChat({
         <div ref={scrollRef} />
       </div>
 
-      <div className="mt-3 flex items-center gap-2 border-t border-gray-100 pt-3">
+      <div className="mt-2 flex shrink-0 items-center gap-2 border-t border-gray-100 pt-2">
         <input
           type="text"
           value={input}

--- a/apps/web/src/components/IntentNegotiatorChat.tsx
+++ b/apps/web/src/components/IntentNegotiatorChat.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { ArrowUp, BotMessageSquare, Loader2, Square } from "lucide-react";
+import { ArrowUp, BotMessageSquare, Square } from "lucide-react";
 
 import { useAIChat } from "@/contexts/AIChatContext";
 import { InjectedQuestions } from "@/components/InjectedQuestions/InjectedQuestions";
@@ -155,8 +155,23 @@ export default function IntentNegotiatorChat({
     >
       <div className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1">
         {!ready ? (
-          <div className="flex justify-center py-10">
-            <Loader2 className="h-5 w-5 animate-spin text-gray-400" />
+          /* Conversation-shaped skeleton while the session bootstraps. */
+          <div className="animate-pulse space-y-4 pt-1" data-testid="negotiator-chat-skeleton" aria-hidden="true">
+            <div className="flex justify-end">
+              <div className="h-9 w-2/5 rounded-2xl rounded-br-md bg-gray-200" />
+            </div>
+            <div className="space-y-2">
+              <div className="h-3 w-11/12 rounded bg-gray-200" />
+              <div className="h-3 w-4/5 rounded bg-gray-200" />
+              <div className="h-3 w-2/3 rounded bg-gray-200" />
+            </div>
+            <div className="flex justify-end">
+              <div className="h-9 w-1/3 rounded-2xl rounded-br-md bg-gray-200" />
+            </div>
+            <div className="space-y-2">
+              <div className="h-3 w-3/4 rounded bg-gray-200" />
+              <div className="h-3 w-1/2 rounded bg-gray-200" />
+            </div>
           </div>
         ) : (
           <>

--- a/apps/web/tests/intent-page-negotiator.test.tsx
+++ b/apps/web/tests/intent-page-negotiator.test.tsx
@@ -145,7 +145,7 @@ describe('Intent page — negotiator chat gating', () => {
     await screen.findByText('Looking for a technical co-founder');
     await screen.findByTestId('intent-negotiator-chat-stub');
     expect(screen.queryByTestId('injected-questions')).toBeNull();
-    expect(screen.getByText(/^Personal Agent \(/)).toBeInTheDocument();
+    expect(screen.getByText(/^Personal Agent$/)).toBeInTheDocument();
     expect(screen.queryByText(/^Questions \(/)).toBeNull();
   });
 

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -151,16 +151,64 @@ export class ConversationDatabaseAdapter {
       hiddenAtByConv.set(r.conversationId, r.hiddenAt);
     }
 
-    const convs = await db
-      .select()
-      .from(schema.conversations)
-      .where(inArray(schema.conversations.id, ids))
-      .orderBy(sql`${schema.conversations.lastMessageAt} DESC NULLS LAST`);
-
-    const allParticipants = await db
-      .select()
-      .from(schema.conversationParticipants)
-      .where(inArray(schema.conversationParticipants.conversationId, ids));
+    // Everything below only needs `ids` — run the lookups in one parallel
+    // wave instead of sequential round trips; this method is on the chat
+    // sidebar's critical path (GET /conversations and /conversations/negotiations).
+    const [convs, allParticipants, negotiatorRow, claimRows, lastMessages, allMeta] = await Promise.all([
+      db
+        .select()
+        .from(schema.conversations)
+        .where(inArray(schema.conversations.id, ids))
+        .orderBy(sql`${schema.conversations.lastMessageAt} DESC NULLS LAST`),
+      db
+        .select()
+        .from(schema.conversationParticipants)
+        .where(inArray(schema.conversationParticipants.conversationId, ids)),
+      // System negotiator name — fallback label when no personal agent drove a
+      // side. Well-known UUID from agent.database.adapter.ts SYSTEM_AGENT_IDS.
+      db
+        .select({ name: schema.agents.name })
+        .from(schema.agents)
+        .where(eq(schema.agents.id, '00000000-0000-0000-0000-000000000002'))
+        .limit(1),
+      // The *actual* agent that drove each user's side. For polling-backed
+      // turns, tasks.claimed_by_agent_id is the personal agent that picked the
+      // turn up. Deterministic ordering: most recent claim per owner wins.
+      db
+        .select({
+          conversationId: schema.tasks.conversationId,
+          agentId: schema.tasks.claimedByAgentId,
+          agentName: schema.agents.name,
+          agentType: schema.agents.type,
+          ownerId: schema.agents.ownerId,
+          avatar: schema.users.avatar,
+        })
+        .from(schema.tasks)
+        .innerJoin(schema.agents, eq(schema.agents.id, schema.tasks.claimedByAgentId))
+        .leftJoin(schema.users, eq(schema.users.id, schema.agents.ownerId))
+        .where(
+          and(
+            inArray(schema.tasks.conversationId, ids),
+            eq(schema.agents.type, 'external'),
+          ),
+        )
+        .orderBy(desc(schema.tasks.claimedAt), asc(schema.agents.id)),
+      // Last message per conversation via DISTINCT ON.
+      db
+        .selectDistinctOn([schema.messages.conversationId], {
+          conversationId: schema.messages.conversationId,
+          parts: schema.messages.parts,
+          senderId: schema.messages.senderId,
+          createdAt: schema.messages.createdAt,
+        })
+        .from(schema.messages)
+        .where(inArray(schema.messages.conversationId, ids))
+        .orderBy(schema.messages.conversationId, desc(schema.messages.createdAt)),
+      db
+        .select()
+        .from(schema.conversationMetadata)
+        .where(inArray(schema.conversationMetadata.conversationId, ids)),
+    ]);
 
     // Resolve user names/avatars for participants
     const userIds = [...new Set(allParticipants.filter(p => p.participantType === 'user').map(p => p.participantId))];
@@ -182,56 +230,18 @@ export class ConversationDatabaseAdapter {
       }
     }
 
-    // Resolve the system negotiator agent name (used as the fallback label when no
-    // personal agent drove any turn on a user's side). Well-known UUID from
-    // agent.database.adapter.ts SYSTEM_AGENT_IDS.negotiator.
-    let systemNegotiatorName = 'Index Negotiator';
-    const negotiatorRow = await db
-      .select({ name: schema.agents.name })
-      .from(schema.agents)
-      .where(eq(schema.agents.id, '00000000-0000-0000-0000-000000000002'))
-      .limit(1);
-    if (negotiatorRow.length > 0) {
-      systemNegotiatorName = negotiatorRow[0].name;
-    }
+    const systemNegotiatorName = negotiatorRow.length > 0 ? negotiatorRow[0].name : 'Index Negotiator';
 
-    // Resolve the *actual* agent that drove each user's side. For polling-backed turns,
-    // tasks.claimed_by_agent_id is set to the personal agent that picked the turn up.
-    // Fall back to the system negotiator when no claim exists (sync system-driven turns).
-    // Map: conversationId → (ownerUserId → agent { id, name, avatar })
+    // Map: conversationId → (ownerUserId → agent { name, avatar })
     const claimedAgentByConv = new Map<string, Map<string, { name: string; avatar: string | null }>>();
-    if (ids.length > 0) {
-      const claimRows = await db
-        .select({
-          conversationId: schema.tasks.conversationId,
-          agentId: schema.tasks.claimedByAgentId,
-          agentName: schema.agents.name,
-          agentType: schema.agents.type,
-          ownerId: schema.agents.ownerId,
-          avatar: schema.users.avatar,
-        })
-        .from(schema.tasks)
-        .innerJoin(schema.agents, eq(schema.agents.id, schema.tasks.claimedByAgentId))
-        .leftJoin(schema.users, eq(schema.users.id, schema.agents.ownerId))
-        .where(
-          and(
-            inArray(schema.tasks.conversationId, ids),
-            eq(schema.agents.type, 'external'),
-          ),
-        )
-        // Deterministic ordering so that if a conversation ever has claims
-        // from multiple external (poller) agents for the same owner, the displayed
-        // agent name is stable across requests. Most recent claim wins.
-        .orderBy(desc(schema.tasks.claimedAt), asc(schema.agents.id));
-      for (const r of claimRows) {
-        if (!r.ownerId) continue;
-        const convMap = claimedAgentByConv.get(r.conversationId) ?? new Map();
-        // First row wins after deterministic ordering — most recent claim per owner.
-        if (!convMap.has(r.ownerId)) {
-          convMap.set(r.ownerId, { name: r.agentName, avatar: r.avatar });
-        }
-        claimedAgentByConv.set(r.conversationId, convMap);
+    for (const r of claimRows) {
+      if (!r.ownerId) continue;
+      const convMap = claimedAgentByConv.get(r.conversationId) ?? new Map();
+      // First row wins after deterministic ordering — most recent claim per owner.
+      if (!convMap.has(r.ownerId)) {
+        convMap.set(r.ownerId, { name: r.agentName, avatar: r.avatar });
       }
+      claimedAgentByConv.set(r.conversationId, convMap);
     }
 
     const participantsByConv = new Map<string, ResolvedParticipant[]>();
@@ -260,38 +270,16 @@ export class ConversationDatabaseAdapter {
       participantsByConv.set(p.conversationId, list);
     }
 
-    // Fetch last message per conversation efficiently using DISTINCT ON
     const lastMessageByConv = new Map<string, { parts: unknown[]; senderId: string; createdAt: Date }>();
-    if (ids.length > 0) {
-      const lastMessages = await db
-        .selectDistinctOn([schema.messages.conversationId], {
-          conversationId: schema.messages.conversationId,
-          parts: schema.messages.parts,
-          senderId: schema.messages.senderId,
-          createdAt: schema.messages.createdAt,
-        })
-        .from(schema.messages)
-        .where(inArray(schema.messages.conversationId, ids))
-        .orderBy(schema.messages.conversationId, desc(schema.messages.createdAt));
-
-      for (const r of lastMessages) {
-        const hiddenAt = hiddenAtByConv.get(r.conversationId);
-        if (hiddenAt && r.createdAt <= hiddenAt) continue;
-        lastMessageByConv.set(r.conversationId, {
-          parts: r.parts as unknown[],
-          senderId: r.senderId,
-          createdAt: r.createdAt,
-        });
-      }
+    for (const r of lastMessages) {
+      const hiddenAt = hiddenAtByConv.get(r.conversationId);
+      if (hiddenAt && r.createdAt <= hiddenAt) continue;
+      lastMessageByConv.set(r.conversationId, {
+        parts: r.parts as unknown[],
+        senderId: r.senderId,
+        createdAt: r.createdAt,
+      });
     }
-
-    // Fetch metadata per conversation
-    const allMeta = ids.length > 0
-      ? await db
-          .select()
-          .from(schema.conversationMetadata)
-          .where(inArray(schema.conversationMetadata.conversationId, ids))
-      : [];
 
     const metaByConv = new Map<string, Record<string, unknown>>();
     for (const m of allMeta) {

--- a/services/api/src/services/chat.service.ts
+++ b/services/api/src/services/chat.service.ts
@@ -304,8 +304,19 @@ export class ChatSessionService {
     }
   }
 
+  /**
+   * True when the error (or any error in its `cause` chain) is a Postgres
+   * unique violation. Drizzle wraps driver errors in `DrizzleQueryError`
+   * with the pg error on `cause`, so checking only the top level misses the
+   * 23505 and turns a benign create race into a 500.
+   */
   private isUniqueViolation(err: unknown): boolean {
-    return typeof err === 'object' && err !== null && 'code' in err && (err as { code?: unknown }).code === '23505';
+    let current: unknown = err;
+    for (let depth = 0; current !== null && typeof current === 'object' && depth < 5; depth++) {
+      if ((current as { code?: unknown }).code === '23505') return true;
+      current = (current as { cause?: unknown }).cause;
+    }
+    return false;
   }
 
   /**

--- a/services/api/src/services/opportunity-delivery.service.ts
+++ b/services/api/src/services/opportunity-delivery.service.ts
@@ -300,9 +300,15 @@ export class OpportunityDeliveryService {
         deliveredAt: new Date(),
       });
     } catch (err) {
-      // Postgres unique_violation (23505) — a concurrent call already committed this delivery.
-      if ((err as { code?: string }).code === '23505') {
-        return 'already_delivered';
+      // Postgres unique_violation (23505) — a concurrent call already committed
+      // this delivery. Drizzle wraps the pg error in DrizzleQueryError, so walk
+      // the `cause` chain rather than checking only the top-level error.
+      let current: unknown = err;
+      for (let depth = 0; current !== null && typeof current === 'object' && depth < 5; depth++) {
+        if ((current as { code?: unknown }).code === '23505') {
+          return 'already_delivered';
+        }
+        current = (current as { cause?: unknown }).cause;
       }
       throw err;
     }

--- a/services/api/src/services/tests/chat.service.spec.ts
+++ b/services/api/src/services/tests/chat.service.spec.ts
@@ -49,6 +49,15 @@ mock.module("../../adapters/database.adapter", () => ({
   ChatDatabaseAdapter: class {
     getNetwork = mock(() => Promise.resolve(null));
     isNetworkMember = mock(() => Promise.resolve(false));
+    getIntent = mock(() =>
+      Promise.resolve({
+        id: "intent-001",
+        userId: "user-001",
+        summary: "Find a co-founder",
+        payload: "",
+        archivedAt: null,
+      }),
+    );
   },
 }));
 mock.module("../../adapters/embedder.adapter", () => ({
@@ -117,6 +126,53 @@ function createMockDb(overrides: Partial<MockDb> = {}): MockDb {
 }
 
 // ─── createSession ────────────────────────────────────────────────────────────
+
+describe("ChatSessionService.resolveNegotiatorIntentSession", () => {
+  it("recovers the raced session when create hits a Drizzle-wrapped 23505", async () => {
+    // Drizzle wraps the pg error in DrizzleQueryError with the real error on
+    // `cause` — the unique-violation detection must walk the cause chain, or a
+    // benign create race (e.g. React StrictMode double-bootstrap) becomes a 500.
+    const session = makeSession();
+    const wrapped = new Error('Failed query: insert into "chat_session_scopes" (...)');
+    (wrapped as { cause?: unknown }).cause = Object.assign(
+      new Error("duplicate key value violates unique constraint"),
+      { code: "23505" },
+    );
+
+    let scopeLookups = 0;
+    const db = createMockDb({
+      getNegotiatorIntentChatSession: mock(() => {
+        scopeLookups += 1;
+        // First lookup: no session yet. Post-conflict re-read: the winner's row.
+        return Promise.resolve(scopeLookups === 1 ? null : session);
+      }),
+      createNegotiatorIntentChatSession: mock(() => Promise.reject(wrapped)),
+      getChatSession: mock(() => Promise.resolve(session)),
+    });
+    const svc = new ChatSessionService(db as unknown as ConversationDatabaseAdapter);
+
+    const res = await svc.resolveNegotiatorIntentSession("user-001", "intent-001");
+
+    if ("error" in res) throw new Error(`expected session, got error: ${res.error}`);
+    expect(res.session.id).toBe(SESSION_ID);
+    expect(res.created).toBe(false);
+    expect(scopeLookups).toBe(2);
+  });
+
+  it("still rethrows non-unique-violation errors", async () => {
+    const db = createMockDb({
+      getNegotiatorIntentChatSession: mock(() => Promise.resolve(null)),
+      createNegotiatorIntentChatSession: mock(() =>
+        Promise.reject(new Error("connection refused")),
+      ),
+    });
+    const svc = new ChatSessionService(db as unknown as ConversationDatabaseAdapter);
+
+    expect(svc.resolveNegotiatorIntentSession("user-001", "intent-001")).rejects.toThrow(
+      "connection refused",
+    );
+  });
+});
 
 describe("ChatSessionService.createSession", () => {
   it("returns a UUID and persists the session", async () => {


### PR DESCRIPTION
## Intent page & chat surfaces — UX/perf round

Iterative UX pass on the intent detail page and chat surfaces, plus the backend fixes the pass surfaced.

### Intent page (`/i/:intentId`)
- **6/10 vs 4/10 split** — negotiator chat takes the wide column (was 2/5 vs 3/5 with chat narrow)
- **Full-height workspace**: columns fill the viewport on `lg`; chat message list and radar list scroll internally, header/pills/input stay pinned; compact chrome (smaller header card, panel titles, pills, paddings)
- **Conversation-first reframe**: "Personal Agent" panel is a conversation scoped to the intent, not a question inbox — question count dropped from the title, copy rewritten, pending questions framed as the negotiator asking for input
- **Sidebar auto-collapse**: entering an intent page collapses the app sidebar (animated width) to give the workspace the full window; floating PanelLeft toggle (desktop, intent pages only) re-expands/collapses; leaving restores. Mobile hamburger untouched
- **Eager loading**: the workspace renders immediately — chat session bootstrap runs in parallel with intent/questions/radar fetches (was a 3-step waterfall gated on `getIntent`)
- **Skeleton loaders** instead of spinners: header pulse lines, radar `OpportunitySkeleton` cards, conversation-shaped chat skeleton
- Explicit input text colors (chat + refine inputs)

### ChatSidebar (Messages view)
- Renders the provider's **prefetched** conversations/negotiations instantly — the mount fetch is a background revalidate (previously hid warm cached data behind "Loading..." until its own round trip finished)
- Cold cache shows conversation-row skeletons instead of "Loading..."

### AuthModal
- Surface provider-fetch failures: non-ok treated as failure, 2 retries with backoff for API restarts, inline notice + manual Retry, no setState after close

### Global
- `globals.css`: removed leftover dark-mode boilerplate (the site has no dark theme) and pinned `color-scheme: light` — fixes near-invisible input text for dark-mode-OS users app-wide (Tailwind preflight `color: inherit` + `dark:text-gray-100` on body)

### API
- **`getConversationsForUser`**: 7 sequential Neon round trips collapsed into 3 waves (`Promise.all`) — serves `/conversations` and `/conversations/negotiations` on the sidebar's critical path; same queries, same results, ~2-3× faster cold
- **`chat.service` unique-violation detection walks the error `cause` chain**: Drizzle wraps pg errors in `DrizzleQueryError`, so the designed-for 23505 create-race recovery never fired — React StrictMode's double-bootstrap turned into a 500 and a sticky "chat unavailable" fallback on the intent page. Same latent fix in `opportunity-delivery.confirmDelivery`
- Regression tests: Drizzle-wrapped 23505 race recovers the winner's session (`created: false`, re-read pinned); non-unique errors still rethrow

## Tests
- `chat.service.spec` 27/27 (2 new)
- `conversation.database.adapter.spec` 12/12 (live DB, parallelized query path)
- Web: `intent-page-negotiator` 3/3 (the previously flaky bootstrap-fallback test now passes deterministically thanks to eager mount), `intent-negotiator-chat` 6/6, `sidebar-negotiator` 7/7
- Web `tsc` at the 59-error pre-existing baseline; no errors in touched files

## Risk / rollback
- No migrations, no new env flags, no protocol changes
- Behavior-visible changes are all web UI; API changes are query parallelization (result-identical) and error-classification fixes (strictly widens recovery paths)
