### PR TITLE
feat(web+api): negotiator memory surfaces, intent-scoped memory filter, Personal Agent naming pass

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -134,6 +134,10 @@ OPENROUTER_API_KEY=your-openrouter-api-key
                                            # the screen gate, turn prompts, polling pickup payloads, and the negotiator DM
                                            # persona. Disclosure rules are hard prompt constraints; the rest are advisory
                                            # hints. Default off = prompts byte-identical to the pre-P5.3 build.
+# NEGOTIATOR_CHAT_ENABLED=false            # Negotiator persona chat surface (P4.1/IND-402): POST /chat/negotiator/session and
+                                           # negotiator-persona streaming on /chat/stream; surfaced to the web app as
+                                           # features.negotiatorChat on GET /auth/me (gates the intent-page Personal Agent
+                                           # chat and the pinned sidebar entry). Must be exactly "true" to enable.
                                            # to exercise the expiry path.
 
 # Per-turn LLM round-trip cap for IndexNegotiator, in ms (default: 15000).
@@ -267,13 +271,6 @@ S3_SECRET_ACCESS_KEY=your-secret-access-key
 # Read/remove of existing contacts and opportunity-acceptance contact links are
 # unaffected. DISABLED WHEN UNSET — must be exactly "true" to enable.
 CONTACTS_ENABLED=false
-
-# Negotiator chat feature flag (P4.1 / IND-402).
-# Gates the negotiator persona chat surface: POST /chat/negotiator/session and
-# negotiator-persona streaming on /chat/stream. Also surfaced to the web app as
-# features.negotiatorChat on GET /auth/me. DISABLED WHEN UNSET — must be exactly
-# "true" to enable.
-NEGOTIATOR_CHAT_ENABLED=false
 
 ########################################
 # 11. Telegram Bot

--- a/apps/web/src/app/agent/page.tsx
+++ b/apps/web/src/app/agent/page.tsx
@@ -3,6 +3,8 @@ import { useNavigate, useParams } from "react-router";
 import * as Tabs from "@radix-ui/react-tabs";
 import { Loader2, Sparkles, ArrowUp, Handshake, Clock, TrendingUp } from "lucide-react";
 import { useAuthContext } from "@/contexts/AuthContext";
+import { useAuthenticatedAPI } from "@/lib/api";
+import { negotiatorMemoriesPath, type NegotiatorMemoriesResponse } from "@/services/negotiatorMemories";
 import { useUsers } from "@/contexts/APIContext";
 import UserAvatar from "@/components/UserAvatar";
 import NegotiationHistory from "@/components/NegotiationHistory";
@@ -240,7 +242,28 @@ export default function AgentPage() {
   const navigate = useNavigate();
   const { tab } = useParams<{ tab?: string }>();
   const { user, isAuthenticated, isLoading: authLoading } = useAuthContext();
+  const api = useAuthenticatedAPI();
   const [feedback, setFeedback] = useState("");
+  // Lightweight count for the Memory tab badge — the panel refetches its own
+  // full list when opened; this only signals "there's something to review".
+  const [memoryCount, setMemoryCount] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!user?.id) return;
+    let cancelled = false;
+    api
+      .get<NegotiatorMemoriesResponse>(negotiatorMemoriesPath(user.id))
+      .then((res) => {
+        if (!cancelled) setMemoryCount(res.memories.length);
+      })
+      .catch(() => {
+        /* badge is best-effort */
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user?.id]);
 
   const activeTab: TabValue = VALID_TABS.includes(tab as TabValue)
     ? (tab as TabValue)
@@ -269,7 +292,7 @@ export default function AgentPage() {
       <div className="px-6 lg:px-8 py-6 pb-32 flex-1">
         <ContentContainer>
           <h1 className="text-2xl font-bold text-black font-ibm-plex-mono mb-6">
-            Agent
+            Personal Agent
           </h1>
 
           <Tabs.Root value={activeTab} onValueChange={setActiveTab}>
@@ -291,6 +314,14 @@ export default function AgentPage() {
                 className="px-4 py-2 text-sm text-gray-600 border-b-2 border-transparent data-[state=active]:border-black data-[state=active]:text-black data-[state=active]:font-bold"
               >
                 Memory
+                {memoryCount !== null && memoryCount > 0 && (
+                  <span
+                    data-testid="memory-tab-count"
+                    className="ml-1.5 inline-block rounded-full bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-600 align-middle"
+                  >
+                    {memoryCount}
+                  </span>
+                )}
               </Tabs.Trigger>
             </Tabs.List>
 

--- a/apps/web/src/app/i/[intentId]/page.tsx
+++ b/apps/web/src/app/i/[intentId]/page.tsx
@@ -1,11 +1,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router";
-import { ChevronLeft, Pause, Pencil, Trash2 } from "lucide-react";
+import { Brain, ChevronLeft, Pause, Pencil, Trash2 } from "lucide-react";
+import { Link } from "react-router";
 
 import ClientLayout from "@/components/ClientLayout";
 import { ContentContainer } from "@/components/layout";
 import OpportunityCard, { OpportunitySkeleton } from "@/components/chat/OpportunityCardInChat";
 import { InjectedQuestions } from "@/components/InjectedQuestions/InjectedQuestions";
+import IntentMemoryStrip from "@/components/IntentMemoryStrip";
 import IntentNegotiatorChat from "@/components/IntentNegotiatorChat";
 import { useAuthContext } from "@/contexts/AuthContext";
 import { useIntents, useOpportunities, useQuestionsService } from "@/contexts/APIContext";
@@ -125,6 +127,7 @@ function Panel({
   count,
   description,
   media,
+  action,
   children,
   className,
 }: {
@@ -132,6 +135,8 @@ function Panel({
   count?: number;
   description?: string;
   media?: React.ReactNode;
+  /** Right-aligned header affordance (e.g. a link to a related surface). */
+  action?: React.ReactNode;
   children: React.ReactNode;
   className?: string;
 }) {
@@ -144,6 +149,7 @@ function Panel({
             {count !== undefined && ` (${count})`}
           </span>
           {media}
+          {action && <span className="ml-auto">{action}</span>}
         </h3>
         {description && (
           <p className="mt-1 text-xs text-gray-500">{description}</p>
@@ -166,7 +172,7 @@ export default function IntentDetailPage() {
   const opportunitiesService = useOpportunities();
   const questionsService = useQuestionsService();
   const { error: showError } = useNotifications();
-  const { features } = useAuthContext();
+  const { user, features } = useAuthContext();
 
   const [intent, setIntent] = useState<
     Awaited<ReturnType<typeof intentsService.getIntent>> | null
@@ -435,9 +441,22 @@ export default function IntentDetailPage() {
                 {negotiatorChatEnabled && intentId ? (
                   <Panel
                     title="Personal Agent"
-                    description="Your negotiator, scoped to this intent — ask what it's doing, steer it, or answer its follow-ups."
+                    description="Your Personal Agent, scoped to this intent — ask what it's doing, steer it, or answer its follow-ups."
+                    action={
+                      <Link
+                        to="/agent/memory"
+                        data-testid="intent-agent-memory-link"
+                        className="inline-flex items-center gap-1 text-[11px] font-medium normal-case tracking-normal text-gray-400 hover:text-gray-700"
+                      >
+                        <Brain className="h-3.5 w-3.5" />
+                        Memory
+                      </Link>
+                    }
                     className="lg:col-span-6"
                   >
+                    {user?.id && (
+                      <IntentMemoryStrip intentId={intentId} userId={user.id} />
+                    )}
                     <IntentNegotiatorChat
                       key={intentId}
                       intentId={intentId}

--- a/apps/web/src/components/IntentMemoryStrip.tsx
+++ b/apps/web/src/components/IntentMemoryStrip.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useState } from 'react';
+import { Brain, ChevronDown, ChevronRight } from 'lucide-react';
+import { Link } from 'react-router';
+
+import { useAuthenticatedAPI } from '@/lib/api';
+import { negotiatorMemoriesPath, type NegotiatorMemoriesResponse, type NegotiatorMemory, type NegotiatorMemoryKind } from '@/services/negotiatorMemories';
+
+/**
+ * "What your agent has learned here" — the intent-scoped slice of the
+ * negotiator's memory (memories whose source negotiations ran for this
+ * intent). Renders nothing while loading, on error, or when the intent has
+ * produced no memories yet: the strip is evidence, not chrome.
+ *
+ * Full inspection/editing lives at /agent/memory (P5.4); this is a read-only
+ * window with a link there.
+ */
+
+const KIND_LABELS: Record<NegotiatorMemoryKind, string> = {
+  disclosure_rule: 'Disclosure rule',
+  threshold: 'Threshold',
+  playbook: 'Playbook',
+  counterparty_dossier: 'Counterparty note',
+};
+
+const MAX_ROWS = 5;
+
+export default function IntentMemoryStrip({
+  intentId,
+  userId,
+}: {
+  intentId: string;
+  userId: string;
+}) {
+  const api = useAuthenticatedAPI();
+  const [memories, setMemories] = useState<NegotiatorMemory[]>([]);
+  const [expanded, setExpanded] = useState(false);
+
+  useEffect(() => {
+    if (!userId || !intentId) return;
+    let cancelled = false;
+    api
+      .get<NegotiatorMemoriesResponse>(negotiatorMemoriesPath(userId, { intentId }))
+      .then((res) => {
+        if (!cancelled) setMemories(res.memories);
+      })
+      .catch(() => {
+        /* best-effort — the strip simply stays hidden */
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userId, intentId]);
+
+  if (memories.length === 0) return null;
+
+  return (
+    <div
+      data-testid="intent-memory-strip"
+      className="mb-3 shrink-0 rounded-lg border border-gray-100 bg-gray-50/60 px-3 py-2"
+    >
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        className="flex w-full items-center gap-1.5 text-left text-xs font-medium text-gray-600 hover:text-gray-900"
+      >
+        {expanded ? (
+          <ChevronDown className="h-3.5 w-3.5 shrink-0 text-gray-400" />
+        ) : (
+          <ChevronRight className="h-3.5 w-3.5 shrink-0 text-gray-400" />
+        )}
+        <Brain className="h-3.5 w-3.5 shrink-0 text-gray-400" />
+        <span>
+          What your agent has learned here ({memories.length})
+        </span>
+      </button>
+
+      {expanded && (
+        <div className="mt-2 space-y-1.5 pl-5">
+          {memories.slice(0, MAX_ROWS).map((m) => (
+            <div key={m.id} className="flex items-start gap-2 text-xs text-gray-700">
+              <span className="mt-px shrink-0 rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-gray-500">
+                {KIND_LABELS[m.kind]}
+              </span>
+              <p className="line-clamp-2 leading-relaxed">{m.content}</p>
+            </div>
+          ))}
+          <Link
+            to="/agent/memory"
+            className="inline-block pt-0.5 text-[11px] font-medium text-gray-500 underline-offset-2 hover:text-gray-900 hover:underline"
+          >
+            Review or edit in Memory →
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/IntentNegotiatorChat.tsx
+++ b/apps/web/src/components/IntentNegotiatorChat.tsx
@@ -146,7 +146,7 @@ export default function IntentNegotiatorChat({
     [proposalIntentMap],
   );
 
-  const placeholder = agentName ? `Message ${agentName}…` : "Message your negotiator…";
+  const placeholder = agentName ? `Message ${agentName}…` : "Message your Personal Agent…";
 
   return (
     <div
@@ -179,7 +179,7 @@ export default function IntentNegotiatorChat({
               <div className="flex items-start gap-2 text-sm text-gray-600 font-ibm-plex-mono">
                 <BotMessageSquare className="mt-0.5 h-4 w-4 shrink-0 text-gray-400" />
                 <p>
-                  This is your direct line to {agentName ?? "your negotiator"} about this intent —
+                  This is your direct line to {agentName ?? "your Personal Agent"} about this intent —
                   ask who it found, why, what it's waiting on, or tell it how to negotiate on your
                   behalf.
                 </p>
@@ -189,7 +189,7 @@ export default function IntentNegotiatorChat({
             {questions.length > 0 && (
               <div data-testid="negotiator-opening-questions">
                 <p className="mb-2 text-xs uppercase tracking-wider text-gray-500 font-ibm-plex-mono">
-                  Your negotiator needs your input
+                  Your Personal Agent needs your input
                 </p>
                 <InjectedQuestions
                   questions={questions}

--- a/apps/web/src/components/NegotiatorMemoryPanel.tsx
+++ b/apps/web/src/components/NegotiatorMemoryPanel.tsx
@@ -25,19 +25,19 @@ const KIND_META: Record<NegotiatorMemoryKind, { title: string; description: stri
   disclosure_rule: {
     title: 'Disclosure rules',
     description:
-      'What your negotiator may or may not share. These are binding in every negotiation until you edit or delete them.',
+      'What your Personal Agent may or may not share. These are binding in every negotiation until you edit or delete them.',
   },
   threshold: {
     title: 'Thresholds',
-    description: 'Hard limits and reservation points your negotiator holds to.',
+    description: 'Hard limits and reservation points your Personal Agent holds to.',
   },
   playbook: {
     title: 'Playbooks',
-    description: 'Tactics your negotiator has learned work for you.',
+    description: 'Tactics your Personal Agent has learned work for you.',
   },
   counterparty_dossier: {
     title: 'Counterparty notes',
-    description: 'What your negotiator has learned about people it negotiated with.',
+    description: 'What your Personal Agent has learned about people it negotiated with.',
   },
 };
 
@@ -158,7 +158,7 @@ export default function NegotiatorMemoryPanel({ userId }: { userId: string }) {
       setMemories(res.memories);
       setError(null);
     } catch {
-      setError('Failed to load your negotiator’s memory.');
+      setError('Failed to load your Personal Agent’s memory.');
     } finally {
       setLoading(false);
     }
@@ -203,7 +203,7 @@ export default function NegotiatorMemoryPanel({ userId }: { userId: string }) {
     return (
       <div className="flex flex-col items-center justify-center py-20 text-center">
         <Brain className="w-10 h-10 text-gray-300 mb-3" />
-        <p className="text-sm text-gray-500">Your negotiator hasn’t learned anything yet</p>
+        <p className="text-sm text-gray-500">Your Personal Agent hasn’t learned anything yet</p>
         <p className="text-xs text-gray-400 mt-1 max-w-sm">
           As it negotiates for you — and as you give it standing rules in chat (“never share my
           budget”) — everything it remembers shows up here for you to review, edit, or delete.

--- a/apps/web/src/components/PendingQuestions/QuestionGroup.tsx
+++ b/apps/web/src/components/PendingQuestions/QuestionGroup.tsx
@@ -8,7 +8,7 @@ import type { AnswerBody } from '@/services/questions';
 export function groupLabel(sourceType: string, mode: string): string {
   if (sourceType === 'opportunity' && mode === 'discovery') return 'About your opportunities';
   if (sourceType === 'opportunity' && mode === 'negotiation') return 'About a negotiation';
-  if (sourceType === 'opportunity' && mode === 'negotiation_inflight') return 'Your negotiator needs your input';
+  if (sourceType === 'opportunity' && mode === 'negotiation_inflight') return 'Your Personal Agent needs your input';
   if (sourceType === 'intent') return 'About your signal';
   if (sourceType === 'profile') return 'About you';
   return 'Questions';

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useRef, useCallback } from 'react';
 import { useNavigate, useLocation } from 'react-router';
 import { Link } from 'react-router';
-import { Compass, MessagesSquare, ChevronDown, Settings, LogOut, History, Network, Bot, BotMessageSquare, CircleHelp } from 'lucide-react';
+import { Compass, MessagesSquare, ChevronDown, Settings, LogOut, History, Network, Bot, BotMessageSquare, Brain, CircleHelp } from 'lucide-react';
 import { useAuthContext } from '@/contexts/AuthContext';
 import { useNetworkFilter } from '@/contexts/IndexFilterContext';
 import { useAIChatSessions } from '@/contexts/AIChatSessionsContext';
@@ -194,8 +194,9 @@ export default function Sidebar() {
     }
   };
 
-  const negotiatorLabel = negotiatorSession?.title
-    || (user?.name ? `${user.name.split(' ')[0]}'s Negotiator` : 'Personal Agent');
+  // Canonical branding: the pinned entry is "Personal Agent" unless the
+  // session carries the agent's real name (e.g. "Ada's Negotiator").
+  const negotiatorLabel = negotiatorSession?.title || 'Personal Agent';
 
   // Fetch AI chat sessions (cookie-based auth; credentials sent automatically)
   useEffect(() => {
@@ -283,13 +284,16 @@ export default function Sidebar() {
             pinned surface, not a history entry (backend excludes it from
             /chat/sessions). */}
         {negotiatorEnabled && (
+          <div
+            className={`group flex items-center rounded-md transition-colors ${
+              isNegotiatorView ? 'bg-gray-100' : 'hover:bg-gray-50'
+            }`}
+          >
           <button
             onClick={handleNegotiatorClick}
             disabled={openingNegotiator}
-            className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-md text-sm transition-colors ${
-              isNegotiatorView
-                ? 'bg-gray-100 text-black font-bold'
-                : 'text-black font-medium hover:bg-gray-50'
+            className={`min-w-0 flex-1 flex items-center gap-3 px-3 py-2.5 rounded-md text-sm text-black ${
+              isNegotiatorView ? 'font-bold' : 'font-medium'
             } ${openingNegotiator ? 'opacity-50 cursor-wait' : ''}`}
           >
             <BotMessageSquare className="w-5 h-5" />
@@ -305,6 +309,17 @@ export default function Sidebar() {
               </span>
             )}
           </button>
+          {/* Memory shortcut — everything the agent remembers is inspectable
+              at /agent/memory (P5.4); revealed on hover to keep the row calm. */}
+          <button
+            onClick={() => navigate('/agent/memory')}
+            aria-label="Personal Agent memory"
+            data-testid="negotiator-memory-link"
+            className="p-1.5 mr-1.5 rounded text-gray-400 opacity-0 group-hover:opacity-100 focus:opacity-100 hover:text-black transition-opacity"
+          >
+            <Brain className="w-4 h-4" />
+          </button>
+          </div>
         )}
 
         {/* History menu item with submenu */}

--- a/apps/web/src/components/chat/OpportunityCardInChat.tsx
+++ b/apps/web/src/components/chat/OpportunityCardInChat.tsx
@@ -443,9 +443,9 @@ export default function OpportunityCard({
       {/* Main Text (Personalized Summary) — shimmer while the presenter text is still being generated */}
       {card.presentationPending ? (
         <div className="space-y-2 animate-pulse" aria-hidden="true">
-          <div className="h-4 w-full bg-gray-100 rounded-sm" />
-          <div className="h-4 w-[85%] bg-gray-100 rounded-sm" />
-          <div className="h-4 w-[55%] bg-gray-100 rounded-sm" />
+          <div className="h-4 w-full bg-gray-200 rounded-sm" />
+          <div className="h-4 w-[85%] bg-gray-200 rounded-sm" />
+          <div className="h-4 w-[55%] bg-gray-200 rounded-sm" />
         </div>
       ) : (
         <div className="text-[14px] text-[#3D3D3D] leading-relaxed [&_a]:text-[#4091BB] [&_a]:underline [&_a]:underline-offset-1">

--- a/apps/web/src/services/negotiatorMemories.ts
+++ b/apps/web/src/services/negotiatorMemories.ts
@@ -42,8 +42,10 @@ export interface UpdateNegotiatorMemoryBody {
   confidence?: number;
 }
 
-export const negotiatorMemoriesPath = (userId: string) =>
-  `/users/${userId}/negotiator/memories`;
+export const negotiatorMemoriesPath = (userId: string, opts?: { intentId?: string }) =>
+  opts?.intentId
+    ? `/users/${userId}/negotiator/memories?intentId=${encodeURIComponent(opts.intentId)}`
+    : `/users/${userId}/negotiator/memories`;
 
 export const negotiatorMemoryPath = (userId: string, memoryId: string) =>
   `/users/${userId}/negotiator/memories/${memoryId}`;

--- a/apps/web/tests/intent-memory-strip.test.tsx
+++ b/apps/web/tests/intent-memory-strip.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * IntentMemoryStrip — the intent-scoped "What your agent has learned here"
+ * window on the intent page. Verifies: fetch is intent-scoped, the strip is
+ * hidden when there is nothing to show (empty or fetch failure), and
+ * expanding reveals rows plus the link to the full memory panel.
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import IntentMemoryStrip from '@/components/IntentMemoryStrip';
+import type { NegotiatorMemory } from '@/services/negotiatorMemories';
+
+const mocks = vi.hoisted(() => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/api', () => ({
+  apiClient: mocks.apiClient,
+  useAuthenticatedAPI: () => mocks.apiClient,
+}));
+
+const mkMemory = (partial: Partial<NegotiatorMemory>): NegotiatorMemory => ({
+  id: 'mem-1',
+  kind: 'playbook',
+  content: 'Open with the shared-interest angle.',
+  confidence: 0.6,
+  subjectUser: null,
+  sourceRefs: [],
+  createdAt: '2026-07-01T00:00:00.000Z',
+  updatedAt: '2026-07-01T00:00:00.000Z',
+  ...partial,
+});
+
+const renderStrip = () =>
+  render(
+    <MemoryRouter>
+      <IntentMemoryStrip intentId="intent-1" userId="u-1" />
+    </MemoryRouter>,
+  );
+
+describe('IntentMemoryStrip', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('fetches intent-scoped memories and expands to rows with a link to the full panel', async () => {
+    mocks.apiClient.get.mockResolvedValue({
+      memories: [
+        mkMemory({ id: 'mem-a', kind: 'threshold', content: 'Minimum rate is $150/h.' }),
+        mkMemory({ id: 'mem-b', kind: 'playbook', content: 'Lead with the timeline question.' }),
+      ],
+    });
+
+    renderStrip();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('intent-memory-strip')).toBeInTheDocument());
+    expect(mocks.apiClient.get).toHaveBeenCalledWith(
+      '/users/u-1/negotiator/memories?intentId=intent-1',
+    );
+    expect(screen.getByText('What your agent has learned here (2)')).toBeInTheDocument();
+
+    // Collapsed by default — content hidden until expanded.
+    expect(screen.queryByText('Minimum rate is $150/h.')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('What your agent has learned here (2)'));
+    expect(screen.getByText('Minimum rate is $150/h.')).toBeInTheDocument();
+    expect(screen.getByText('Threshold')).toBeInTheDocument();
+    expect(screen.getByText('Lead with the timeline question.')).toBeInTheDocument();
+
+    const link = screen.getByRole('link', { name: /Review or edit in Memory/ });
+    expect(link).toHaveAttribute('href', '/agent/memory');
+  });
+
+  test('renders nothing when the intent has produced no memories', async () => {
+    mocks.apiClient.get.mockResolvedValue({ memories: [] });
+
+    renderStrip();
+
+    await waitFor(() => expect(mocks.apiClient.get).toHaveBeenCalled());
+    expect(screen.queryByTestId('intent-memory-strip')).not.toBeInTheDocument();
+  });
+
+  test('renders nothing when the fetch fails (best-effort surface)', async () => {
+    mocks.apiClient.get.mockRejectedValue(new Error('boom'));
+
+    renderStrip();
+
+    await waitFor(() => expect(mocks.apiClient.get).toHaveBeenCalled());
+    expect(screen.queryByTestId('intent-memory-strip')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/negotiator-memory-panel.test.tsx
+++ b/apps/web/tests/negotiator-memory-panel.test.tsx
@@ -112,6 +112,6 @@ describe('NegotiatorMemoryPanel', () => {
     mocks.apiClient.get.mockResolvedValue({ memories: [] });
     render(<NegotiatorMemoryPanel userId="u-1" />);
     await waitFor(() =>
-      expect(screen.getByText('Your negotiator hasn’t learned anything yet')).toBeInTheDocument());
+      expect(screen.getByText('Your Personal Agent hasn’t learned anything yet')).toBeInTheDocument());
   });
 });

--- a/apps/web/tests/sidebar-negotiator.test.tsx
+++ b/apps/web/tests/sidebar-negotiator.test.tsx
@@ -161,7 +161,7 @@ describe('Sidebar pinned Personal Agent entry', () => {
     expect(mocks.apiClient.get).not.toHaveBeenCalledWith('/chat/sessions?persona=negotiator');
   });
 
-  test('flag on, no session yet → entry visible with derived label; click get-or-creates and navigates', async () => {
+  test('flag on, no session yet → entry visible with canonical label; click get-or-creates and navigates', async () => {
     mocks.authState.features = { negotiatorChat: true };
     mocks.apiClient.post.mockResolvedValue({
       session: { id: 'neg-session-1', title: "Alice's Negotiator" },
@@ -171,7 +171,9 @@ describe('Sidebar pinned Personal Agent entry', () => {
 
     renderSidebar();
 
-    const entry = await screen.findByText("Alice's Negotiator");
+    // Canonical branding until the session (which carries the agent's real
+    // name) resolves.
+    const entry = await screen.findByText('Personal Agent');
     fireEvent.click(entry);
 
     await waitFor(() =>
@@ -180,6 +182,21 @@ describe('Sidebar pinned Personal Agent entry', () => {
     await waitFor(() =>
       expect(screen.getByTestId('location')).toHaveTextContent('/d/neg-session-1')
     );
+  });
+
+  test('memory shortcut on the pinned entry navigates to /agent/memory', async () => {
+    mocks.authState.features = { negotiatorChat: true };
+
+    renderSidebar();
+
+    const link = await screen.findByTestId('negotiator-memory-link');
+    fireEvent.click(link);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('location')).toHaveTextContent('/agent/memory')
+    );
+    // The memory shortcut must not bootstrap a chat session.
+    expect(mocks.apiClient.post).not.toHaveBeenCalled();
   });
 
   test('flag on, existing session → label from session title; click navigates without POST', async () => {

--- a/services/api/src/adapters/negotiator-memory.database.adapter.ts
+++ b/services/api/src/adapters/negotiator-memory.database.adapter.ts
@@ -55,6 +55,15 @@ export interface ListNegotiatorMemoriesFilter {
   kind?: NegotiatorMemoryKind;
   subjectUserId?: string;
   limit?: number;
+  /**
+   * Only memories learned from negotiations that ran for this intent: a
+   * source ref of type 'negotiation' whose task's opportunity involves the
+   * intent — either as the triggering intent or as the owner's actor intent.
+   * Owner-scoped by construction (the actor match keys on the memory's own
+   * userId), so it can never widen the row set beyond the (agentId, userId)
+   * scope — it only narrows it.
+   */
+  intentId?: string;
 }
 
 export interface SimilarNegotiatorMemoriesQuery {
@@ -145,6 +154,23 @@ export class NegotiatorMemoryDatabaseAdapter {
       eq(schema.negotiatorMemories.userId, userId),
       ...(filter.kind ? [eq(schema.negotiatorMemories.kind, filter.kind)] : []),
       ...(filter.subjectUserId ? [eq(schema.negotiatorMemories.subjectUserId, filter.subjectUserId)] : []),
+      ...(filter.intentId
+        ? [sql`EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(${schema.negotiatorMemories.sourceRefs}) AS src_ref
+            JOIN ${schema.tasks} ON ${schema.tasks.id} = src_ref->>'id'
+            JOIN ${schema.opportunities} ON ${schema.opportunities.id} = ${schema.tasks.metadata}->>'opportunityId'
+            WHERE src_ref->>'type' = 'negotiation'
+              AND (
+                ${schema.opportunities.detection}->>'triggeredBy' = ${filter.intentId}
+                OR EXISTS (
+                  SELECT 1 FROM jsonb_array_elements(${schema.opportunities.actors}) AS actor
+                  WHERE actor->>'userId' = ${schema.negotiatorMemories.userId}
+                    AND actor->>'intent' = ${filter.intentId}
+                )
+              )
+          )`]
+        : []),
     ];
     return db
       .select()

--- a/services/api/src/adapters/tests/negotiator-memory.database.spec.ts
+++ b/services/api/src/adapters/tests/negotiator-memory.database.spec.ts
@@ -192,6 +192,80 @@ describe('NegotiatorMemoryDatabaseAdapter', () => {
     await adapter.delete(b.id, ownerId);
   }, 15000);
 
+  it('filters by intentId via negotiation source refs — triggeredBy and owner-actor paths, no cross-user widening', async () => {
+    const intentA = randomUUID();
+    const intentB = randomUUID();
+    const networkId = randomUUID();
+
+    // Fixture graph: memory → sourceRef(negotiation task) → opportunity → intent.
+    const [conversation] = await db.insert(schema.conversations).values({}).returning({ id: schema.conversations.id });
+
+    const [oppA] = await db.insert(schema.opportunities).values({
+      // Path 1: the opportunity's triggering intent. The stranger actor on
+      // intentB must NOT widen intentB's results to this opportunity.
+      detection: { source: 'opportunity_graph', triggeredBy: intentA, timestamp: new Date().toISOString() },
+      actors: [{ networkId, userId: strangerId, intent: intentB, role: 'peer' }],
+      interpretation: { category: 'test', reasoning: 'test', confidence: 0.9 },
+      context: {},
+      confidence: '0.9',
+    }).returning({ id: schema.opportunities.id });
+
+    const [oppB] = await db.insert(schema.opportunities).values({
+      // Path 2: the memory owner's own actor intent.
+      detection: { source: 'opportunity_graph', timestamp: new Date().toISOString() },
+      actors: [{ networkId, userId: ownerId, intent: intentB, role: 'peer' }],
+      interpretation: { category: 'test', reasoning: 'test', confidence: 0.9 },
+      context: {},
+      confidence: '0.9',
+    }).returning({ id: schema.opportunities.id });
+
+    const [taskA] = await db.insert(schema.tasks).values({
+      conversationId: conversation.id,
+      metadata: { type: 'negotiation', opportunityId: oppA.id },
+    }).returning({ id: schema.tasks.id });
+    const [taskB] = await db.insert(schema.tasks).values({
+      conversationId: conversation.id,
+      metadata: { type: 'negotiation', opportunityId: oppB.id },
+    }).returning({ id: schema.tasks.id });
+
+    const memA = await adapter.create({
+      agentId, userId: ownerId, kind: 'playbook',
+      content: 'learned from intent A negotiation',
+      sourceRefs: [{ type: 'negotiation', id: taskA.id, turnIndexes: [3] }],
+    });
+    const memB = await adapter.create({
+      agentId, userId: ownerId, kind: 'threshold',
+      content: 'learned from intent B negotiation',
+      sourceRefs: [{ type: 'negotiation', id: taskB.id }],
+    });
+    const memNoRefs = await adapter.create({
+      agentId, userId: ownerId, kind: 'playbook',
+      content: 'standing rule with no negotiation provenance',
+    });
+
+    try {
+      const forA = await adapter.list(agentId, ownerId, { intentId: intentA });
+      expect(forA.map((m) => m.id)).toEqual([memA.id]);
+
+      const forB = await adapter.list(agentId, ownerId, { intentId: intentB });
+      expect(forB.map((m) => m.id)).toEqual([memB.id]);
+
+      // Unknown intent → empty; unfiltered list still sees everything.
+      expect(await adapter.list(agentId, ownerId, { intentId: randomUUID() })).toHaveLength(0);
+      const all = await adapter.list(agentId, ownerId);
+      expect(all.map((m) => m.id)).toEqual(expect.arrayContaining([memA.id, memB.id, memNoRefs.id]));
+
+      // Composable with kind.
+      expect((await adapter.list(agentId, ownerId, { intentId: intentB, kind: 'playbook' }))).toHaveLength(0);
+    } finally {
+      await adapter.delete(memA.id, ownerId);
+      await adapter.delete(memB.id, ownerId);
+      await adapter.delete(memNoRefs.id, ownerId);
+      await db.delete(schema.conversations).where(eq(schema.conversations.id, conversation.id));
+      await db.delete(schema.opportunities).where(inArray(schema.opportunities.id, [oppA.id, oppB.id]));
+    }
+  }, 20000);
+
   it('returns top-k by cosine similarity, scoped to the agent', async () => {
     const exact = await adapter.create({
       agentId, userId: ownerId, kind: 'playbook',

--- a/services/api/src/controllers/user.controller.ts
+++ b/services/api/src/controllers/user.controller.ts
@@ -436,7 +436,8 @@ export class UserController {
 
   /**
    * GET /users/:userId/negotiator/memories — list the user's negotiator's
-   * private memory (P5.4). Optional `?kind=` filter.
+   * private memory (P5.4). Optional `?kind=` and `?intentId=` filters
+   * (intentId narrows to memories learned from that intent's negotiations).
    *
    * Strict self-only — stricter than the neighbor negotiations route, which
    * permits other viewers with mutual filtering. Negotiator memories are
@@ -455,11 +456,17 @@ export class UserController {
     if (kindParam && !NEGOTIATOR_MEMORY_KINDS.includes(kindParam as never)) {
       return Response.json({ error: `Invalid kind: "${kindParam}". Use one of: ${NEGOTIATOR_MEMORY_KINDS.join(', ')}` }, { status: 400 });
     }
+    const intentIdParam = url.searchParams.get('intentId')?.trim() || undefined;
 
     try {
       const rows = await negotiatorMemoryInspectionService.list(
         params.userId,
-        kindParam ? { kind: kindParam as NegotiatorMemoryKind } : undefined,
+        kindParam || intentIdParam
+          ? {
+            ...(kindParam ? { kind: kindParam as NegotiatorMemoryKind } : {}),
+            ...(intentIdParam ? { intentId: intentIdParam } : {}),
+          }
+          : undefined,
       );
 
       const subjectIds = [...new Set(rows.map((r) => r.subjectUserId).filter((id): id is string => !!id))];

--- a/services/api/src/services/negotiator-memory-inspection.service.ts
+++ b/services/api/src/services/negotiator-memory-inspection.service.ts
@@ -73,13 +73,19 @@ export class NegotiatorMemoryInspectionService {
 
   /**
    * List the user's own negotiator memories, newest first, optionally
-   * filtered by kind. Returns [] when the user has no negotiator agent.
+   * filtered by kind and/or by the intent whose negotiations produced them
+   * (source-ref → task → opportunity → intent; see the adapter filter).
+   * Returns [] when the user has no negotiator agent.
    */
-  async list(userId: string, filter?: { kind?: NegotiatorMemoryKind }): Promise<NegotiatorMemory[]> {
+  async list(
+    userId: string,
+    filter?: { kind?: NegotiatorMemoryKind; intentId?: string },
+  ): Promise<NegotiatorMemory[]> {
     const agentId = await this.resolveNegotiatorAgentId(userId);
     if (!agentId) return [];
     return this.memories.list(agentId, userId, {
       ...(filter?.kind ? { kind: filter.kind } : {}),
+      ...(filter?.intentId ? { intentId: filter.intentId } : {}),
       limit: LIST_LIMIT,
     });
   }


### PR DESCRIPTION
## Why

Verification round on the negotiator memory pipeline (P5.1–P5.4) plus a frontend consistency audit after the intent-page UX overhaul (#1115).

**Memory pipeline verified live on dev** before this PR: reflect jobs write after negotiations close (36 memories / 9 agents, source refs + turn indexes), retrieval injects into negotiation prompts (adapter log lines). What was missing is *surface*: the `/agent` → Memory tab existed but nothing pointed at it, and the agent was named three different ways across the UI.

## What

### Memory discoverability & intent scoping
- **API**: `GET /users/:userId/negotiator/memories?intentId=` — memories learned from that intent's negotiations. Resolution: `source_refs` (type `negotiation`, id = task id) → `tasks.metadata->>'opportunityId'` → opportunity matching `detection->>'triggeredBy' = intentId` **or** an actor entry with the *memory owner's* userId + intent. The actor match keys on the memory's own `user_id`, so the filter can only narrow the owner-scoped row set — no cross-user widening.
- **`IntentMemoryStrip`** (new): collapsible "What your agent has learned here (n)" inside the intent page's Personal Agent panel. Hidden while loading, on error, or when empty — evidence, not chrome. Expands to kind-chipped rows + link to `/agent/memory`.
- **Shortcuts**: header `Memory` link on the Personal Agent panel; hover Brain button on the pinned sidebar entry (`/agent/memory`); count badge on the `/agent` Memory tab.

### Consistency fixes (from the audit)
- **Naming**: "Personal Agent" is now the canonical brand wherever the agent's real name is unavailable — sidebar fallback label (was `"{First}'s Negotiator"`), chat placeholder, panel copy, memory panel copy, question group header, `/agent` page title. Real agent names (session titles) still show where they exist.
- **Skeleton**: `OpportunityCardInChat` narrative shimmer `bg-gray-100` → `bg-gray-200` (house skeleton tone; gray-100 is nearly invisible on white).

## Testing
- **API**: adapter spec 11/11 live-DB, including new `intentId` filter test covering both linkage paths (triggeredBy + owner actor), unknown-intent → empty, kind composition, and a stranger-actor fixture proving no cross-user widening. Controller 7/7, service 23/23. `bun run build` green.
- **Web**: 27/27 across sidebar / intent-page / intent-chat / memory-panel / new intent-memory-strip suites; `tsc` at the 59-error baseline; build green. Full-suite failures (routes.test.tsx, DecisionQuestions 12) reproduced on clean dev — pre-existing baseline.

No migrations, no new flags, no protocol changes. The `?intentId=` param is additive; strict self-only authorization on the endpoint is unchanged.
