### PR TITLE
feat(protocol+api+web): pool_discovery questions — deterministic synthesis, budget, interview chaining (IND-418)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -338,6 +338,14 @@ QUESTIONER_ENABLED=false
 # of QUESTIONER_ENABLED. Values: off (default) | shadow.
 # POOL_QUESTIONS_MINING=off
 
+# P2 (IND-418): turn the top-VoI discriminator into a pool_discovery question
+# the Personal Agent asks on the intent page (chip options + "Both matter" +
+# evidence chip; interview-mode chaining on answer). "on" implies mining runs
+# even when POOL_QUESTIONS_MINING is off; the actual enqueue additionally
+# requires QUESTIONER_ENABLED=true. Budget: <=1 pending pool question and <=3
+# pending total per intent. Values: off (default) | on.
+# POOL_QUESTIONS_MODE=off
+
 ########################################
 # 14. MCP / Tool Runtime
 # Scope: [api+protocol]

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/app/i/[intentId]/page.tsx
+++ b/apps/web/src/app/i/[intentId]/page.tsx
@@ -181,6 +181,19 @@ export default function IntentDetailPage() {
   const [opportunities, setOpportunities] = useState<HomeViewCardItem[]>([]);
   const [opportunitiesLoading, setOpportunitiesLoading] = useState(true);
   const [questions, setQuestions] = useState<PendingQuestion[]>([]);
+  // Interview-mode chaining (IND-418): after a pool_discovery answer, the
+  // backend may synchronously persist a follow-up — show a typing indicator,
+  // refetch once, and append any new pool_discovery card.
+  const [questionChainPending, setQuestionChainPending] = useState(false);
+  /** Every question id ever displayed — so a chain refetch only appends new cards. */
+  const seenQuestionIdsRef = useRef<Set<string>>(new Set());
+  const chainTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (chainTimerRef.current) clearTimeout(chainTimerRef.current);
+    },
+    [],
+  );
   const [refineText, setRefineText] = useState("");
   const [refining, setRefining] = useState(false);
   const [showRefine, setShowRefine] = useState(false);
@@ -265,7 +278,9 @@ export default function IntentDetailPage() {
     questionsService
       .getPending({ scopeType: "intent", scopeId: intentId })
       .then((res) => {
-        if (active) setQuestions(res);
+        if (!active) return;
+        for (const q of res) seenQuestionIdsRef.current.add(q.id);
+        setQuestions(res);
       })
       .catch(() => {});
     void loadOpportunities();
@@ -304,10 +319,38 @@ export default function IntentDetailPage() {
 
   const handleAnswer = useCallback(
     async (questionId: string, body: AnswerBody) => {
+      const answered = questions.find((q) => q.id === questionId);
       await questionsService.answer(questionId, body);
       setQuestions((prev) => prev.filter((q) => q.id !== questionId));
+      // Chain once per answer: a pool_discovery answer may have synchronously
+      // produced a follow-up question — refetch shortly and append it.
+      if (answered?.detection?.mode === "pool_discovery" && intentId) {
+        setQuestionChainPending(true);
+        if (chainTimerRef.current) clearTimeout(chainTimerRef.current);
+        chainTimerRef.current = setTimeout(async () => {
+          try {
+            const refreshed = await questionsService.getPending({
+              scopeType: "intent",
+              scopeId: intentId,
+            });
+            const fresh = refreshed.filter(
+              (q) =>
+                q.detection?.mode === "pool_discovery" &&
+                !seenQuestionIdsRef.current.has(q.id),
+            );
+            for (const q of fresh) seenQuestionIdsRef.current.add(q.id);
+            if (fresh.length > 0) {
+              setQuestions((current) => [...current, ...fresh]);
+            }
+          } catch {
+            // Best-effort — the follow-up will surface on the next visit.
+          } finally {
+            setQuestionChainPending(false);
+          }
+        }, 1200);
+      }
     },
-    [questionsService],
+    [questions, questionsService, intentId],
   );
 
   const handleDismiss = useCallback(
@@ -442,6 +485,16 @@ export default function IntentDetailPage() {
                   <Panel
                     title="Personal Agent"
                     description="Your Personal Agent, scoped to this intent — ask what it's doing, steer it, or answer its follow-ups."
+                    media={
+                      questions.length > 0 ? (
+                        <span
+                          data-testid="intent-question-count"
+                          className="bg-[#041729] text-white text-xs px-2 py-0.5 rounded-full min-w-[20px] text-center font-sans normal-case tracking-normal"
+                        >
+                          {questions.length > 99 ? "99+" : questions.length}
+                        </span>
+                      ) : undefined
+                    }
                     action={
                       <Link
                         to="/agent/memory"
@@ -463,6 +516,7 @@ export default function IntentDetailPage() {
                       questions={questions}
                       onAnswerQuestion={handleAnswer}
                       onDismissQuestion={handleDismiss}
+                      questionChainPending={questionChainPending}
                       opportunityStatusMap={opportunityStatusMap}
                       opportunityActionLoading={opportunityActionLoading}
                       onOpportunityAction={(id, action, userId, role, name) =>
@@ -479,7 +533,7 @@ export default function IntentDetailPage() {
                     className="lg:col-span-6"
                   >
                     <div className="min-h-0 flex-1 lg:overflow-y-auto lg:pr-1">
-                      {questions.length === 0 ? (
+                      {questions.length === 0 && !questionChainPending ? (
                         <div className="text-sm text-gray-500 font-ibm-plex-mono py-8 text-center border border-dashed border-gray-200 rounded-lg">
                           No pending questions right now.
                         </div>
@@ -488,6 +542,7 @@ export default function IntentDetailPage() {
                           questions={questions}
                           onAnswer={handleAnswer}
                           onDismiss={handleDismiss}
+                          showTypingIndicator={questionChainPending}
                         />
                       )}
                     </div>

--- a/apps/web/src/components/DecisionQuestions/OptionRow.tsx
+++ b/apps/web/src/components/DecisionQuestions/OptionRow.tsx
@@ -12,6 +12,12 @@ interface OptionRowProps {
   checked: boolean;
   disabled?: boolean;
   onChange: (next: boolean) => void;
+  /**
+   * Render the label as the main line with the description as a muted
+   * sub-line (chip-style options with counts, e.g. pool discriminators).
+   * Default keeps the legacy single-line `description || label` rendering.
+   */
+  showSubline?: boolean;
 }
 
 /**
@@ -28,6 +34,7 @@ export function OptionRow({
   checked,
   disabled,
   onChange,
+  showSubline,
 }: OptionRowProps) {
   return (
     <label
@@ -73,11 +80,20 @@ export function OptionRow({
       </span>
       <span
         className={cn(
-          'text-sm leading-snug',
+          'flex min-w-0 flex-col text-sm leading-snug',
           checked ? 'font-medium text-gray-900' : 'text-gray-700',
         )}
       >
-        {description || label}
+        {showSubline ? (
+          <>
+            <span>{label}</span>
+            {description && description !== label && (
+              <span className="text-xs font-normal text-gray-500">{description}</span>
+            )}
+          </>
+        ) : (
+          description || label
+        )}
       </span>
     </label>
   );

--- a/apps/web/src/components/InjectedQuestions/InjectedQuestions.tsx
+++ b/apps/web/src/components/InjectedQuestions/InjectedQuestions.tsx
@@ -57,6 +57,16 @@ function InjectedQuestionCard({ question, onAnswer, onDismiss }: InjectedQuestio
 
   return (
     <div className="rounded-lg border border-gray-200 bg-white p-5">
+      {payload.evidence && (
+        <div className="mb-2">
+          <span
+            data-testid="question-evidence-chip"
+            className="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-500"
+          >
+            {`\u25CE ${payload.evidence}`}
+          </span>
+        </div>
+      )}
       <p className="text-[15px] font-semibold leading-snug text-gray-900">
         {payload.prompt}
       </p>
@@ -76,6 +86,7 @@ function InjectedQuestionCard({ question, onAnswer, onDismiss }: InjectedQuestio
             checked={selectedLabels.includes(opt.label)}
             disabled={submitting}
             onChange={(checked) => toggleSelection(opt.label, checked)}
+            showSubline={!payload.multiSelect}
           />
         ))}
         <OptionRow
@@ -126,14 +137,39 @@ function InjectedQuestionCard({ question, onAnswer, onDismiss }: InjectedQuestio
   );
 }
 
+/**
+ * Three-dot typing indicator shown while the agent may be preparing a
+ * follow-up pool-discovery question (interview-mode chaining, IND-418).
+ */
+function TypingDots() {
+  return (
+    <div
+      data-testid="question-chain-typing"
+      aria-label="Your agent is preparing a follow-up"
+      className="flex items-center gap-1 px-2 py-2"
+    >
+      <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-gray-400" />
+      <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-gray-400 [animation-delay:150ms]" />
+      <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-gray-400 [animation-delay:300ms]" />
+    </div>
+  );
+}
+
 interface InjectedQuestionsProps {
   questions: PendingQuestion[];
   onAnswer: (questionId: string, body: AnswerBody) => Promise<void>;
   onDismiss: (questionId: string) => Promise<void>;
+  /** Show a typing indicator below the cards (follow-up may be incoming). */
+  showTypingIndicator?: boolean;
 }
 
-export function InjectedQuestions({ questions, onAnswer, onDismiss }: InjectedQuestionsProps) {
-  if (questions.length === 0) return null;
+export function InjectedQuestions({
+  questions,
+  onAnswer,
+  onDismiss,
+  showTypingIndicator,
+}: InjectedQuestionsProps) {
+  if (questions.length === 0 && !showTypingIndicator) return null;
 
   return (
     <div className="flex flex-col gap-2">
@@ -145,6 +181,7 @@ export function InjectedQuestions({ questions, onAnswer, onDismiss }: InjectedQu
           onDismiss={onDismiss}
         />
       ))}
+      {showTypingIndicator && <TypingDots />}
     </div>
   );
 }

--- a/apps/web/src/components/IntentNegotiatorChat.tsx
+++ b/apps/web/src/components/IntentNegotiatorChat.tsx
@@ -19,6 +19,11 @@ export interface IntentNegotiatorChatProps {
   questions: PendingQuestion[];
   onAnswerQuestion: (questionId: string, body: AnswerBody) => Promise<void>;
   onDismissQuestion: (questionId: string) => Promise<void>;
+  /**
+   * A pool-discovery answer was just submitted and a chained follow-up may
+   * be incoming — render a typing indicator below the question cards.
+   */
+  questionChainPending?: boolean;
   /** Opportunity card plumbing shared with the page's Radar panel. */
   opportunityStatusMap: Record<string, string>;
   opportunityActionLoading: Record<string, boolean>;
@@ -51,6 +56,7 @@ export default function IntentNegotiatorChat({
   questions,
   onAnswerQuestion,
   onDismissQuestion,
+  questionChainPending,
   opportunityStatusMap,
   opportunityActionLoading,
   onOpportunityAction,
@@ -113,7 +119,7 @@ export default function IntentNegotiatorChat({
   // Follow the stream.
   useEffect(() => {
     scrollRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
-  }, [messages, questions.length, ready]);
+  }, [messages, questions.length, questionChainPending, ready]);
 
   const handleSend = useCallback(async () => {
     const text = input.trim();
@@ -186,7 +192,7 @@ export default function IntentNegotiatorChat({
               </div>
             )}
 
-            {questions.length > 0 && (
+            {(questions.length > 0 || questionChainPending) && (
               <div data-testid="negotiator-opening-questions">
                 <p className="mb-2 text-xs uppercase tracking-wider text-gray-500 font-ibm-plex-mono">
                   Your Personal Agent needs your input
@@ -195,6 +201,7 @@ export default function IntentNegotiatorChat({
                   questions={questions}
                   onAnswer={onAnswerQuestion}
                   onDismiss={onDismissQuestion}
+                  showTypingIndicator={questionChainPending}
                 />
               </div>
             )}

--- a/apps/web/src/services/questions.ts
+++ b/apps/web/src/services/questions.ts
@@ -12,10 +12,22 @@ export interface QuestionPayload {
   prompt: string;
   options: QuestionOption[];
   multiSelect: boolean;
+  /**
+   * Optional provenance line rendered as a muted chip above the prompt
+   * (e.g. "based on 18 people matching this intent"). Aggregate counts only.
+   */
+  evidence?: string;
 }
 
 export interface QuestionDetection {
-  mode: 'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'negotiation_inflight' | 'chat';
+  mode:
+    | 'discovery'
+    | 'intent'
+    | 'enrichment'
+    | 'negotiation'
+    | 'negotiation_inflight'
+    | 'chat'
+    | 'pool_discovery';
   sourceType: string;
   sourceId: string;
   triggeredBy?: string;

--- a/apps/web/tests/pool-discovery-questions.test.tsx
+++ b/apps/web/tests/pool-discovery-questions.test.tsx
@@ -1,0 +1,252 @@
+/**
+ * Pool discriminator questions on the intent page (IND-418).
+ *
+ * Covers the web half of pool_discovery questions:
+ * - evidence provenance chip on the question card (present/absent),
+ * - pending-question count badge in the Personal Agent panel header,
+ * - interview-mode chaining: after answering a pool_discovery question the
+ *   page refetches once and appends a newly returned follow-up card.
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import IntentDetailPage from '@/app/i/[intentId]/page';
+import { InjectedQuestions } from '@/components/InjectedQuestions/InjectedQuestions';
+import type { PendingQuestion } from '@/services/questions';
+
+const mocks = vi.hoisted(() => ({
+  authState: {
+    features: null as Record<string, unknown> | null,
+  },
+  questionsService: {
+    getPending: vi.fn(),
+    answer: vi.fn(),
+    dismiss: vi.fn(),
+  },
+  intentsService: {
+    getIntent: vi.fn(),
+    archiveIntent: vi.fn(),
+    refineIntent: vi.fn(),
+  },
+  opportunitiesService: {
+    getHomeView: vi.fn(),
+  },
+}));
+
+vi.mock('@/components/ClientLayout', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/chat/OpportunityCardInChat', () => ({
+  default: () => null,
+  OpportunitySkeleton: () => null,
+}));
+
+vi.mock('@/components/IntentMemoryStrip', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/components/IntentNegotiatorChat', () => ({
+  default: () => <div data-testid="intent-negotiator-chat-stub" />,
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuthContext: () => ({
+    isReady: true,
+    isLoading: false,
+    isAuthenticated: true,
+    user: { id: 'user-1', name: 'Alice Smith' },
+    features: mocks.authState.features,
+    userLoading: false,
+    error: null,
+    refetchUser: vi.fn(),
+    updateUser: vi.fn(),
+    openLoginModal: vi.fn(),
+    signOut: vi.fn(),
+  }),
+}));
+
+vi.mock('@/contexts/APIContext', () => ({
+  useIntents: () => mocks.intentsService,
+  useOpportunities: () => mocks.opportunitiesService,
+  useQuestionsService: () => mocks.questionsService,
+}));
+
+function primePageServices() {
+  mocks.intentsService.getIntent.mockResolvedValue({
+    id: 'intent-1',
+    payload: 'Looking for a technical co-founder',
+    summary: 'Looking for a technical co-founder',
+    createdAt: new Date().toISOString(),
+  });
+  mocks.opportunitiesService.getHomeView.mockResolvedValue({ sections: [] });
+}
+
+vi.mock('@/contexts/NotificationContext', () => ({
+  useNotifications: () => ({
+    success: vi.fn(),
+    error: vi.fn(),
+    addNotification: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useOpportunityActions', () => ({
+  useOpportunityActions: () => ({
+    opportunityStatusMap: {},
+    setOpportunityStatusMap: vi.fn(),
+    opportunityActionLoading: {},
+    handleOpportunityAction: vi.fn(),
+    handleStreamingDraftStartChat: vi.fn(),
+    inviteModalElement: null,
+  }),
+}));
+
+function makePoolQuestion(overrides: {
+  id: string;
+  prompt: string;
+  evidence?: string;
+}): PendingQuestion {
+  return {
+    id: overrides.id,
+    detection: {
+      mode: 'pool_discovery',
+      sourceType: 'intent',
+      sourceId: 'intent-1',
+      timestamp: new Date().toISOString(),
+    },
+    actors: [{ userId: 'user-1', role: 'subject' }],
+    payload: {
+      title: overrides.prompt,
+      prompt: overrides.prompt,
+      options: [
+        {
+          label: 'Prefer senior folks',
+          description: '8 of your 21 current matches lean this way',
+        },
+        {
+          label: 'Both matter',
+          description: 'Keep the pool broad',
+        },
+      ],
+      multiSelect: false,
+      ...(overrides.evidence ? { evidence: overrides.evidence } : {}),
+    },
+    status: 'pending',
+    answer: null,
+    expiresAt: null,
+    createdAt: new Date().toISOString(),
+    conversationId: null,
+  };
+}
+
+function renderIntentPage() {
+  return render(
+    <MemoryRouter initialEntries={['/i/intent-1']}>
+      <Routes>
+        <Route path="/i/:intentId" element={<IntentDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('pool_discovery questions — evidence chip', () => {
+  const noop = async () => {};
+
+  test('renders the muted provenance chip above the prompt when payload.evidence is present', () => {
+    const question = makePoolQuestion({
+      id: 'q-pool-1',
+      prompt: 'What matters more in a co-founder?',
+      evidence: 'based on 18 people matching this intent',
+    });
+    render(<InjectedQuestions questions={[question]} onAnswer={noop} onDismiss={noop} />);
+
+    const chip = screen.getByTestId('question-evidence-chip');
+    expect(chip).toHaveTextContent('◎ based on 18 people matching this intent');
+    // Muted styling — never the red/amber reserved for rejected/expired.
+    expect(chip.className).toContain('text-gray-500');
+    expect(chip.className).toContain('bg-gray-100');
+    // Option description renders as a sub-line for single-select options.
+    expect(screen.getByText('Prefer senior folks')).toBeInTheDocument();
+    expect(screen.getByText('8 of your 21 current matches lean this way')).toBeInTheDocument();
+  });
+
+  test('renders no chip when payload.evidence is absent', () => {
+    const question = makePoolQuestion({
+      id: 'q-pool-2',
+      prompt: 'What matters more in a co-founder?',
+    });
+    render(<InjectedQuestions questions={[question]} onAnswer={noop} onDismiss={noop} />);
+
+    expect(screen.queryByTestId('question-evidence-chip')).toBeNull();
+  });
+});
+
+describe('intent page — pending question count badge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    primePageServices();
+    mocks.authState.features = { negotiatorChat: true };
+  });
+
+  test('shows the pending count in the Personal Agent panel header', async () => {
+    mocks.questionsService.getPending.mockResolvedValue([
+      makePoolQuestion({ id: 'q-1', prompt: 'First?' }),
+      makePoolQuestion({ id: 'q-2', prompt: 'Second?' }),
+    ]);
+    renderIntentPage();
+
+    const badge = await screen.findByTestId('intent-question-count');
+    expect(badge).toHaveTextContent('2');
+  });
+
+  test('hides the badge when the pending count is 0', async () => {
+    mocks.questionsService.getPending.mockResolvedValue([]);
+    renderIntentPage();
+
+    await screen.findByTestId('intent-negotiator-chat-stub');
+    expect(screen.queryByTestId('intent-question-count')).toBeNull();
+  });
+});
+
+describe('intent page — interview-mode chaining', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    primePageServices();
+    // Flag off → the static Questions panel renders the real InjectedQuestions.
+    mocks.authState.features = null;
+    mocks.questionsService.answer.mockResolvedValue({ success: true });
+  });
+
+  test('after answering a pool_discovery question, refetches once and appends the follow-up', async () => {
+    const first = makePoolQuestion({ id: 'q-pool-1', prompt: 'What matters more in a co-founder?' });
+    const followUp = makePoolQuestion({ id: 'q-pool-2', prompt: 'Which stage do you prefer?' });
+    mocks.questionsService.getPending
+      .mockResolvedValueOnce([first])
+      .mockResolvedValue([followUp]);
+
+    const { container } = renderIntentPage();
+
+    await screen.findByText('What matters more in a co-founder?');
+
+    // Answer: pick an option and submit through the real card machinery.
+    const option = container.querySelector('input[value="Both matter"]') as HTMLInputElement;
+    fireEvent.click(option);
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() =>
+      expect(mocks.questionsService.answer).toHaveBeenCalledWith('q-pool-1', {
+        selectedOptions: ['Both matter'],
+      }),
+    );
+
+    // Typing indicator shows while the chained refetch is pending.
+    await screen.findByTestId('question-chain-typing');
+
+    // ~1.2s later the follow-up card is appended as a continuation.
+    await screen.findByText('Which stage do you prefer?', undefined, { timeout: 3000 });
+    expect(screen.queryByTestId('question-chain-typing')).toBeNull();
+    // Exactly one chain refetch (initial load + one after the answer).
+    expect(mocks.questionsService.getPending).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -182,7 +182,7 @@ export type { NegotiatorMemoryEntry, NegotiatorMemoryQuery, NegotiatorMemoryScop
 export type { NegotiationAgentInput } from "./negotiation/negotiation.agent.js";
 export { QuestionerAgent } from "./questioner/questioner.agent.js";
 export type { QuestionerAgentConfig } from "./questioner/questioner.agent.js";
-export type { QuestionerInput, QuestionerContext, QuestionerEnqueuePayload, QuestionerEnqueueFn, DiscoveryContext, IntentContext, ProfileContext, NegotiationContext, NegotiationInflightContext, ChatContext } from "./questioner/questioner.types.js";
+export type { QuestionerInput, QuestionerContext, QuestionerEnqueuePayload, QuestionerEnqueueFn, DiscoveryContext, IntentContext, ProfileContext, NegotiationContext, NegotiationInflightContext, ChatContext, PoolDiscoveryContext } from "./questioner/questioner.types.js";
 export { getPreset } from "./questioner/questioner.presets.js";
 export { isQuestionerEnabled, isDiscoveryQuestionsEnabled, discoveryQuestionsInputMode, discoveryQuestionsTimeoutMs, chatQuestionWaitTimeoutMs } from "./questioner/questioner.env.js";
 export type { QuestionerPreset } from "./questioner/questioner.presets.js";
@@ -191,8 +191,11 @@ export type { PoolDiscriminatorMinerConfig } from "./opportunity/discriminator/d
 export { runPoolDiscriminatorShadow } from "./opportunity/discriminator/discriminator.shadow.js";
 export type { DiscriminatorShadowInput } from "./opportunity/discriminator/discriminator.shadow.js";
 export { scoreDiscriminator, computeNovelty, cosineSimilarity } from "./opportunity/discriminator/discriminator.scorer.js";
-export { poolQuestionsMiningMode, POOL_DISCRIMINATOR_MIN_POOL_SIZE, POOL_DISCRIMINATOR_MAX_CANDIDATES, POOL_DISCRIMINATOR_MAX_PUBLIC_CONTEXT_CHARS } from "./opportunity/discriminator/discriminator.env.js";
-export type { PoolQuestionsMiningMode } from "./opportunity/discriminator/discriminator.env.js";
+export { poolQuestionsMiningMode, poolQuestionsMode, POOL_DISCRIMINATOR_MIN_POOL_SIZE, POOL_DISCRIMINATOR_MAX_CANDIDATES, POOL_DISCRIMINATOR_MAX_PUBLIC_CONTEXT_CHARS, POOL_QUESTION_MIN_VOI, POOL_QUESTION_MIN_EVIDENCE_RATE, POOL_QUESTION_MAX_DISCRIMINATORS, POOL_QUESTION_MAX_PENDING_PER_INTENT } from "./opportunity/discriminator/discriminator.env.js";
+export type { PoolQuestionsMiningMode, PoolQuestionsMode } from "./opportunity/discriminator/discriminator.env.js";
+export { synthesizePoolQuestion, selectQuestionDiscriminators, toQuestionDiscriminator, BOTH_MATTER_LABEL } from "./opportunity/discriminator/discriminator.question.js";
+export type { SynthesizePoolQuestionInput, SynthesizedPoolQuestion } from "./opportunity/discriminator/discriminator.question.js";
+export type { QuestionPoolAssignment, QuestionPoolDiscriminator, QuestionPoolSnapshot } from "./shared/schemas/question.schema.js";
 export type { PoolCandidate, DiscriminatorMiningInput, MinedDiscriminator, ScoredDiscriminator, VerifiedAssignment, DiscriminatorShadowResult } from "./opportunity/discriminator/discriminator.types.js";
 export { OpportunityEvaluator } from "./opportunity/opportunity.evaluator.js";
 export type { EvaluatorInput, OpportunityEvaluatorOptionsConstructor } from "./opportunity/opportunity.evaluator.js";

--- a/packages/protocol/src/opportunity/discriminator/discriminator.env.ts
+++ b/packages/protocol/src/opportunity/discriminator/discriminator.env.ts
@@ -21,6 +21,31 @@ export function poolQuestionsMiningMode(): PoolQuestionsMiningMode {
   return process.env.POOL_QUESTIONS_MINING?.trim() === "shadow" ? "shadow" : "off";
 }
 
+/** Question mode for pool discriminators (IND-418). */
+export type PoolQuestionsMode = "off" | "on";
+
+/**
+ * Current POOL_QUESTIONS_MODE (default off). When "on", the mining hook also
+ * enqueues a pool_discovery question for the top eligible discriminator
+ * (still subject to the QUESTIONER_ENABLED master gate and per-intent budget).
+ * "on" implies mining runs even when POOL_QUESTIONS_MINING is off.
+ */
+export function poolQuestionsMode(): PoolQuestionsMode {
+  return process.env.POOL_QUESTIONS_MODE?.trim() === "on" ? "on" : "off";
+}
+
+/** Minimum VoI for a discriminator to become (or chain) a question. */
+export const POOL_QUESTION_MIN_VOI = 0.2;
+
+/** Minimum evidence-verification rate for a discriminator to become a question. */
+export const POOL_QUESTION_MIN_EVIDENCE_RATE = 0.6;
+
+/** Max eligible discriminators carried per mining pass (asked + alternates). */
+export const POOL_QUESTION_MAX_DISCRIMINATORS = 3;
+
+/** Unattended budget: max pending questions of ANY mode per intent. */
+export const POOL_QUESTION_MAX_PENDING_PER_INTENT = 3;
+
 /**
  * k-anonymity floor: axes are only mined when the pool has at least this many
  * candidates, so no axis (or later, question option) can be traced back to a

--- a/packages/protocol/src/opportunity/discriminator/discriminator.question.ts
+++ b/packages/protocol/src/opportunity/discriminator/discriminator.question.ts
@@ -1,0 +1,131 @@
+/**
+ * Deterministic pool_discovery question synthesis (IND-418).
+ *
+ * A mined discriminator already carries everything a question needs: a label,
+ * a question seed, 2–3 sides, and verified per-candidate assignments. This
+ * module turns the top discriminator into a `Question` payload + server-side
+ * pool snapshot with ZERO generation-time LLM calls — the phrasing was
+ * produced (and evidence-verified) at mining time, so synthesis is pure,
+ * auditable, and cheap to re-run for interview-mode chaining.
+ */
+import type { Question, QuestionOption, QuestionPoolDiscriminator, QuestionPoolSnapshot } from "../../shared/schemas/question.schema.js";
+import { POOL_DISCRIMINATOR_MIN_POOL_SIZE, POOL_QUESTION_MAX_DISCRIMINATORS, POOL_QUESTION_MIN_EVIDENCE_RATE, POOL_QUESTION_MIN_VOI } from "./discriminator.env.js";
+import type { ScoredDiscriminator } from "./discriminator.types.js";
+
+/** Fixed option appended to every pool question — the no-preference escape. */
+export const BOTH_MATTER_LABEL = "Both matter";
+
+/** Max words in a chip-style option label (prototype voice: terse, glanceable). */
+const MAX_LABEL_WORDS = 5;
+
+/** Question title (≤12 chars, per QuestionSchema). */
+const POOL_QUESTION_TITLE = "Matches";
+
+/**
+ * Converts a scored discriminator into the compact snapshot form stored on
+ * the question row (verified assignments only; unknowns dropped).
+ */
+export function toQuestionDiscriminator(d: ScoredDiscriminator): QuestionPoolDiscriminator {
+  const sideCounts: Record<string, number> = {};
+  for (const side of d.sides) sideCounts[side] = 0;
+  const assignments: Array<{ opportunityId: string; side: string }> = [];
+  for (const a of d.assignments) {
+    if (a.side === null || !a.verified) continue;
+    if (!(a.side in sideCounts)) continue;
+    sideCounts[a.side] += 1;
+    assignments.push({ opportunityId: a.id, side: a.side });
+  }
+  return {
+    label: d.label,
+    questionSeed: d.questionSeed,
+    sides: d.sides,
+    sideCounts,
+    voi: d.voi,
+    evidenceRate: d.evidenceRate,
+    assignments,
+  };
+}
+
+/**
+ * Filters a mining pass down to question-eligible discriminators:
+ * VoI ≥ {@link POOL_QUESTION_MIN_VOI}, evidenceRate ≥
+ * {@link POOL_QUESTION_MIN_EVIDENCE_RATE}, capped at
+ * {@link POOL_QUESTION_MAX_DISCRIMINATORS}. Input is already VoI-sorted.
+ */
+export function selectQuestionDiscriminators(discriminators: ScoredDiscriminator[]): ScoredDiscriminator[] {
+  return discriminators
+    .filter((d) => d.voi >= POOL_QUESTION_MIN_VOI && d.evidenceRate >= POOL_QUESTION_MIN_EVIDENCE_RATE)
+    .slice(0, POOL_QUESTION_MAX_DISCRIMINATORS);
+}
+
+/** Truncates a side label to the chip word budget. */
+function chipLabel(side: string): string {
+  const words = side.trim().split(/\s+/);
+  return words.slice(0, MAX_LABEL_WORDS).join(" ");
+}
+
+/** Ensures the prompt reads as one question and fits the schema bounds. */
+function toPrompt(questionSeed: string): string {
+  let p = questionSeed.trim().replace(/\s+/g, " ");
+  if (!/[?]$/.test(p)) p = p.replace(/[.!]+$/, "") + "?";
+  return p.slice(0, 400);
+}
+
+/** Input for one question synthesis. */
+export interface SynthesizePoolQuestionInput {
+  /** The discriminator to ask about (already eligibility-filtered). */
+  discriminator: QuestionPoolDiscriminator;
+  /** Remaining ranked eligible discriminators (interview-mode chain stash). */
+  alternates: QuestionPoolDiscriminator[];
+  poolSize: number;
+  /** ISO-8601 timestamp of the mining pass. */
+  minedAt: string;
+  /** Discovery run id, when known. */
+  runId?: string;
+}
+
+/** Synthesized question: client payload + server-side snapshot. */
+export interface SynthesizedPoolQuestion {
+  payload: Question;
+  pool: QuestionPoolSnapshot;
+}
+
+/**
+ * Builds the pool_discovery question. Returns null when the pool is below
+ * the k-anonymity floor or the discriminator shape is unusable (guards are
+ * duplicated here so no caller can bypass them).
+ */
+export function synthesizePoolQuestion(input: SynthesizePoolQuestionInput): SynthesizedPoolQuestion | null {
+  const { discriminator: d, poolSize } = input;
+  if (poolSize < POOL_DISCRIMINATOR_MIN_POOL_SIZE) return null;
+  if (d.sides.length < 2 || d.sides.length > 3) return null;
+
+  const sideOptions: QuestionOption[] = d.sides.map((side) => ({
+    label: chipLabel(side),
+    description: `${d.sideCounts[side] ?? 0} of your ${poolSize} current matches lean this way`,
+  }));
+  const options: QuestionOption[] = [
+    ...sideOptions,
+    {
+      label: BOTH_MATTER_LABEL,
+      description: "No preference — keep the current ranking",
+    },
+  ];
+
+  return {
+    payload: {
+      title: POOL_QUESTION_TITLE,
+      prompt: toPrompt(d.questionSeed),
+      options,
+      multiSelect: false,
+      evidence: `based on ${poolSize} people matching this intent`,
+    },
+    pool: {
+      poolSize,
+      minedAt: input.minedAt,
+      ...(input.runId ? { runId: input.runId } : {}),
+      discriminator: d,
+      alternates: input.alternates,
+    },
+  };
+}

--- a/packages/protocol/src/opportunity/discriminator/discriminator.question.ts
+++ b/packages/protocol/src/opportunity/discriminator/discriminator.question.ts
@@ -64,9 +64,44 @@ function chipLabel(side: string): string {
   return words.slice(0, MAX_LABEL_WORDS).join(" ");
 }
 
-/** Ensures the prompt reads as one question and fits the schema bounds. */
-function toPrompt(questionSeed: string): string {
-  let p = questionSeed.trim().replace(/\s+/g, " ");
+/**
+ * Miner seeds are sometimes written from the intent owner's POV ("Do I
+ * prefer…"). The question is asked TO the owner, so normalize to second
+ * person. Conservative verb-pair map + bare pronoun/possessive swaps.
+ */
+function toSecondPerson(seed: string): string {
+  return seed
+    .replace(/\b(do|should|would|could|can|will) I\b/gi, (_, verb: string) => `${verb.toLowerCase()} you`)
+    .replace(/\bam I\b/gi, "are you")
+    .replace(/\bI\b/g, "you")
+    .replace(/\bmy\b/gi, "your");
+}
+
+/**
+ * A good discriminator prompt names BOTH sides so the chips read as a real
+ * choice. When the seed mentions fewer than two sides (e.g. "Do you prefer
+ * hands-on prototyping?"), fall back to a deterministic two-sided template.
+ */
+function mentionsSide(seed: string, side: string): boolean {
+  const lowerSeed = seed.toLowerCase();
+  return side
+    .toLowerCase()
+    .split(/[^a-z0-9-]+/)
+    .filter((w) => w.length > 3)
+    .some((w) => lowerSeed.includes(w));
+}
+
+/** Ensures the prompt reads as one second-person, two-sided question. */
+function toPrompt(questionSeed: string, sides: string[]): string {
+  let p = toSecondPerson(questionSeed.trim().replace(/\s+/g, " "));
+  const sidesMentioned = sides.filter((s) => mentionsSide(p, s)).length;
+  if (sidesMentioned < 2) {
+    const last = sides[sides.length - 1];
+    const head = sides.slice(0, -1).join(", ");
+    p = `Which matters more here: ${head} or ${last}`;
+  }
+  // Sentence-case the first character (template + normalization can lowercase it).
+  p = p.charAt(0).toUpperCase() + p.slice(1);
   if (!/[?]$/.test(p)) p = p.replace(/[.!]+$/, "") + "?";
   return p.slice(0, 400);
 }
@@ -115,7 +150,7 @@ export function synthesizePoolQuestion(input: SynthesizePoolQuestionInput): Synt
   return {
     payload: {
       title: POOL_QUESTION_TITLE,
-      prompt: toPrompt(d.questionSeed),
+      prompt: toPrompt(d.questionSeed, d.sides),
       options,
       multiSelect: false,
       evidence: `based on ${poolSize} people matching this intent`,

--- a/packages/protocol/src/opportunity/discriminator/tests/discriminator.question.spec.ts
+++ b/packages/protocol/src/opportunity/discriminator/tests/discriminator.question.spec.ts
@@ -123,8 +123,54 @@ describe("synthesizePoolQuestion", () => {
   it("normalizes trailing punctuation on the seed into a single question mark", () => {
     const out = synthesizePoolQuestion({
       ...base,
-      discriminator: questionDiscriminator({ questionSeed: "Which side matters most." }),
+      discriminator: questionDiscriminator({
+        questionSeed: "Do you want someone hands-on builder style, or advisor style.",
+      }),
     })!;
-    expect(out.payload.prompt).toBe("Which side matters most?");
+    expect(out.payload.prompt).toBe("Do you want someone hands-on builder style, or advisor style?");
+  });
+
+  it("rewrites first-person miner seeds into second person", () => {
+    const out = synthesizePoolQuestion({
+      ...base,
+      discriminator: questionDiscriminator({
+        questionSeed: "Do I prefer a hands-on builder, or am I open to an advisor for my intent",
+      }),
+    })!;
+    expect(out.payload.prompt).toBe(
+      "Do you prefer a hands-on builder, or are you open to an advisor for your intent?",
+    );
+  });
+
+  it("falls back to the two-sided template when the seed names fewer than two sides", () => {
+    const out = synthesizePoolQuestion({
+      ...base,
+      discriminator: questionDiscriminator({
+        questionSeed: "Do you prefer hands-on builders", // never mentions 'Advisor'
+      }),
+    })!;
+    expect(out.payload.prompt).toBe("Which matters more here: Hands-on builder or Advisor?");
+  });
+
+  it("uses the template with a comma list for 3-sided discriminators", () => {
+    const out = synthesizePoolQuestion({
+      ...base,
+      discriminator: questionDiscriminator({
+        sides: ["Builders", "Advisors", "Investors"],
+        sideCounts: { Builders: 5, Advisors: 4, Investors: 3 },
+        questionSeed: "What kind of person are you seeking",
+      }),
+    })!;
+    expect(out.payload.prompt).toBe("Which matters more here: Builders, Advisors or Investors?");
+  });
+
+  it("keeps a seed that already names both sides untouched apart from the question mark", () => {
+    const out = synthesizePoolQuestion({
+      ...base,
+      discriminator: questionDiscriminator({
+        questionSeed: "Are you looking for a hands-on builder or a strategic advisor",
+      }),
+    })!;
+    expect(out.payload.prompt).toBe("Are you looking for a hands-on builder or a strategic advisor?");
   });
 });

--- a/packages/protocol/src/opportunity/discriminator/tests/discriminator.question.spec.ts
+++ b/packages/protocol/src/opportunity/discriminator/tests/discriminator.question.spec.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "bun:test";
+
+import { QuestionSchema } from "../../../shared/schemas/question.schema.js";
+import type { QuestionPoolDiscriminator } from "../../../shared/schemas/question.schema.js";
+import { BOTH_MATTER_LABEL, selectQuestionDiscriminators, synthesizePoolQuestion, toQuestionDiscriminator } from "../discriminator.question.js";
+import type { ScoredDiscriminator } from "../discriminator.types.js";
+
+function scored(overrides: Partial<ScoredDiscriminator> = {}): ScoredDiscriminator {
+  return {
+    label: "Hands-on builders vs advisors",
+    questionSeed: "Do you want someone hands-on or advisory",
+    sides: ["Hands-on builder", "Advisor"],
+    assignments: [
+      { id: "opp-1", side: "Hands-on builder", evidence: "ev", verified: true },
+      { id: "opp-2", side: "Advisor", evidence: "ev", verified: true },
+      { id: "opp-3", side: "Advisor", evidence: "bad", verified: false },
+      { id: "opp-4", side: null, evidence: null, verified: false },
+    ],
+    evidenceRate: 0.9,
+    entropy: 0.9,
+    coverage: 0.8,
+    novelty: 0.7,
+    voi: 0.5,
+    ...overrides,
+  };
+}
+
+function questionDiscriminator(overrides: Partial<QuestionPoolDiscriminator> = {}): QuestionPoolDiscriminator {
+  return {
+    label: "Hands-on builders vs advisors",
+    questionSeed: "Do you want someone hands-on or advisory",
+    sides: ["Hands-on builder", "Advisor"],
+    sideCounts: { "Hands-on builder": 8, "Advisor": 6 },
+    voi: 0.5,
+    evidenceRate: 0.9,
+    assignments: [{ opportunityId: "opp-1", side: "Hands-on builder" }],
+    ...overrides,
+  };
+}
+
+describe("toQuestionDiscriminator", () => {
+  it("keeps only verified assignments and counts them per side", () => {
+    const d = toQuestionDiscriminator(scored());
+    expect(d.assignments).toEqual([
+      { opportunityId: "opp-1", side: "Hands-on builder" },
+      { opportunityId: "opp-2", side: "Advisor" },
+    ]);
+    expect(d.sideCounts).toEqual({ "Hands-on builder": 1, "Advisor": 1 });
+  });
+});
+
+describe("selectQuestionDiscriminators", () => {
+  it("filters by VoI and evidenceRate bars and caps the count", () => {
+    const eligible1 = scored({ label: "a", voi: 0.5, evidenceRate: 0.9 });
+    const lowVoi = scored({ label: "b", voi: 0.1, evidenceRate: 0.9 });
+    const lowEvidence = scored({ label: "c", voi: 0.5, evidenceRate: 0.3 });
+    const eligible2 = scored({ label: "d", voi: 0.3, evidenceRate: 0.7 });
+    const eligible3 = scored({ label: "e", voi: 0.25, evidenceRate: 0.61 });
+    const eligible4 = scored({ label: "f", voi: 0.21, evidenceRate: 0.99 });
+    const out = selectQuestionDiscriminators([eligible1, lowVoi, lowEvidence, eligible2, eligible3, eligible4]);
+    expect(out.map((d) => d.label)).toEqual(["a", "d", "e"]); // cap 3, bars enforced
+  });
+});
+
+describe("synthesizePoolQuestion", () => {
+  const base = {
+    discriminator: questionDiscriminator(),
+    alternates: [questionDiscriminator({ label: "alt-1" })],
+    poolSize: 21,
+    minedAt: "2026-07-14T14:00:00.000Z",
+    runId: "run-1",
+  };
+
+  it("produces a schema-valid question: sides as chip options + Both matter", () => {
+    const out = synthesizePoolQuestion(base);
+    expect(out).not.toBeNull();
+    const payload = out!.payload;
+    expect(() => QuestionSchema.parse(payload)).not.toThrow();
+    expect(payload.options.map((o) => o.label)).toEqual([
+      "Hands-on builder",
+      "Advisor",
+      BOTH_MATTER_LABEL,
+    ]);
+    expect(payload.options[0].description).toBe("8 of your 21 current matches lean this way");
+    expect(payload.options[1].description).toBe("6 of your 21 current matches lean this way");
+    expect(payload.multiSelect).toBe(false);
+    expect(payload.evidence).toBe("based on 21 people matching this intent");
+    expect(payload.prompt.endsWith("?")).toBe(true);
+  });
+
+  it("stashes the pool snapshot with alternates for chaining", () => {
+    const out = synthesizePoolQuestion(base)!;
+    expect(out.pool.poolSize).toBe(21);
+    expect(out.pool.runId).toBe("run-1");
+    expect(out.pool.discriminator.label).toBe("Hands-on builders vs advisors");
+    expect(out.pool.alternates.map((a) => a.label)).toEqual(["alt-1"]);
+  });
+
+  it("caps option labels at 5 words", () => {
+    const out = synthesizePoolQuestion({
+      ...base,
+      discriminator: questionDiscriminator({
+        sides: ["one two three four five six seven", "Advisor"],
+        sideCounts: { "one two three four five six seven": 3, "Advisor": 2 },
+      }),
+    })!;
+    expect(out.payload.options[0].label).toBe("one two three four five");
+  });
+
+  it("returns null below the k-anonymity pool floor", () => {
+    expect(synthesizePoolQuestion({ ...base, poolSize: 4 })).toBeNull();
+  });
+
+  it("returns null for degenerate side counts", () => {
+    expect(
+      synthesizePoolQuestion({
+        ...base,
+        discriminator: questionDiscriminator({ sides: ["only-one"] }),
+      }),
+    ).toBeNull();
+  });
+
+  it("normalizes trailing punctuation on the seed into a single question mark", () => {
+    const out = synthesizePoolQuestion({
+      ...base,
+      discriminator: questionDiscriminator({ questionSeed: "Which side matters most." }),
+    })!;
+    expect(out.payload.prompt).toBe("Which side matters most?");
+  });
+});

--- a/packages/protocol/src/questioner/questioner.presets.ts
+++ b/packages/protocol/src/questioner/questioner.presets.ts
@@ -380,7 +380,14 @@ function buildChatPrompt(ctx: ChatContext): string {
   ].join("\n");
 }
 
-const presets: Record<QuestionMode, QuestionerPreset> = {
+/**
+ * pool_discovery has NO preset by design: those questions are synthesized
+ * deterministically from mined discriminators (see
+ * `opportunity/discriminator/discriminator.question.ts`) and never reach the
+ * QuestionerAgent. `getPreset("pool_discovery")` therefore throws — the
+ * QuestionerQueue branches on the mode before invoking the agent.
+ */
+const presets: Partial<Record<QuestionMode, QuestionerPreset>> = {
   discovery: {
     systemPrompt: DISCOVERY_SYSTEM_PROMPT,
     buildPrompt: (context: unknown) =>

--- a/packages/protocol/src/questioner/questioner.types.ts
+++ b/packages/protocol/src/questioner/questioner.types.ts
@@ -7,7 +7,7 @@
  */
 import type { DiscoveryQuestionInput } from "../opportunity/question.prompt.js";
 import type { ToolScopeType } from "../shared/agent/tool.scope.js";
-import type { QuestionMode } from "../shared/schemas/question.schema.js";
+import type { QuestionMode, QuestionPoolDiscriminator } from "../shared/schemas/question.schema.js";
 
 // ─── Per-mode context types ─────────────────────────────────────────────────
 
@@ -88,6 +88,25 @@ export interface ChatContext {
   userContext?: string;
 }
 
+/**
+ * Pool-discovery context — mined discriminators from a discovery-run pool
+ * (IND-418). No generator LLM runs for this mode: the QuestionerQueue
+ * synthesizes the question deterministically from the top discriminator and
+ * stashes the rest as interview-mode alternates.
+ */
+export interface PoolDiscoveryContext {
+  intentId: string;
+  /** Intent payload (+ summary) used for the question's grounding. */
+  intentText: string;
+  poolSize: number;
+  /** Discovery run that produced the pool. */
+  runId?: string;
+  /** Eligible discriminators, VoI-descending (asked + chain alternates). */
+  discriminators: QuestionPoolDiscriminator[];
+  /** ISO-8601 timestamp of the mining pass. */
+  minedAt: string;
+}
+
 /** Discriminated union: mode selects the context shape. */
 export type QuestionerContext =
   | DiscoveryContext
@@ -95,7 +114,8 @@ export type QuestionerContext =
   | ProfileContext
   | NegotiationContext
   | NegotiationInflightContext
-  | ChatContext;
+  | ChatContext
+  | PoolDiscoveryContext;
 
 /**
  * Payload shape accepted by the questionerEnqueue callback. Covers all

--- a/packages/protocol/src/shared/schemas/question.schema.ts
+++ b/packages/protocol/src/shared/schemas/question.schema.ts
@@ -26,6 +26,12 @@ export const QuestionSchema = z.object({
   options: z.array(QuestionOptionSchema).min(2).max(4),
   /** True when options are not mutually exclusive (priorities, bundles). */
   multiSelect: z.boolean(),
+  /**
+   * Optional provenance line rendered as a muted chip above the prompt
+   * (e.g. "based on 18 people matching this intent"). Aggregate counts only —
+   * never individual identities (pool_discovery k-anonymity invariant).
+   */
+  evidence: z.string().min(1).max(160).optional(),
 });
 
 export const QuestionStrategySchema = z.enum([
@@ -72,7 +78,47 @@ export const QuestionModeSchema = z.enum([
   "negotiation_inflight",
   // Orchestrator-initiated mid-conversation questions (ask_user_question tool).
   "chat",
+  // Pool-discriminator questions mined from the intent's candidate pool
+  // (IND-418). Synthesized deterministically — no generator LLM call.
+  "pool_discovery",
 ]);
+
+/** One server-side candidate→side assignment (never serialized to clients). */
+export const QuestionPoolAssignmentSchema = z.object({
+  opportunityId: z.string().min(1),
+  side: z.string().min(1),
+});
+
+/**
+ * One mined discriminator carried inside a pool_discovery question's
+ * detection (the asked one plus ranked alternates for interview-mode
+ * chaining). INTERNAL — the read path strips `detection.pool` before any
+ * payload leaves the server.
+ */
+export const QuestionPoolDiscriminatorSchema = z.object({
+  label: z.string().min(1),
+  questionSeed: z.string().min(1),
+  sides: z.array(z.string().min(1)).min(2).max(3),
+  /** Verified-assignment count per side label. */
+  sideCounts: z.record(z.string(), z.number()),
+  voi: z.number(),
+  evidenceRate: z.number(),
+  /** Verified assignments only — the P3 re-rank input. */
+  assignments: z.array(QuestionPoolAssignmentSchema),
+});
+
+/** Pool snapshot stored on pool_discovery questions (server-side only). */
+export const QuestionPoolSnapshotSchema = z.object({
+  poolSize: z.number().int().min(0),
+  /** ISO-8601 timestamp of the mining pass. */
+  minedAt: z.string().min(1),
+  /** Discovery run that produced the pool, when known. */
+  runId: z.string().optional(),
+  /** The discriminator this question asks about. */
+  discriminator: QuestionPoolDiscriminatorSchema,
+  /** Remaining ranked discriminators for interview-mode chaining. */
+  alternates: z.array(QuestionPoolDiscriminatorSchema),
+});
 
 export const QuestionDetectionSchema = z.object({
   /** Which preset mode generated this question. */
@@ -87,6 +133,11 @@ export const QuestionDetectionSchema = z.object({
   timestamp: z.string().min(1),
   /** ID of the assistant message that triggered this question. Used by the frontend to anchor the question card inline. */
   messageId: z.string().optional(),
+  /**
+   * pool_discovery only: the mined pool snapshot (assignments + alternates).
+   * INTERNAL — stripped from every client-facing read (web + MCP).
+   */
+  pool: QuestionPoolSnapshotSchema.optional(),
 });
 
 export const QuestionActorSchema = z.object({
@@ -113,3 +164,6 @@ export type QuestionMode = z.infer<typeof QuestionModeSchema>;
 export type QuestionDetection = z.infer<typeof QuestionDetectionSchema>;
 export type QuestionActor = z.infer<typeof QuestionActorSchema>;
 export type QuestionAnswer = z.infer<typeof QuestionAnswerSchema>;
+export type QuestionPoolAssignment = z.infer<typeof QuestionPoolAssignmentSchema>;
+export type QuestionPoolDiscriminator = z.infer<typeof QuestionPoolDiscriminatorSchema>;
+export type QuestionPoolSnapshot = z.infer<typeof QuestionPoolSnapshotSchema>;

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/adapters/questioner.adapter.ts
+++ b/services/api/src/adapters/questioner.adapter.ts
@@ -23,15 +23,24 @@ const DEFAULT_QUESTION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 // ─── Local adapter types (structurally aligned with protocol contracts) ───────
 
+/** Union of all question modes the adapter stores. */
+export type AdapterQuestionMode = 'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'negotiation_inflight' | 'chat' | 'pool_discovery';
+
 /** Detection context describing how/where a question was generated. */
 export interface AdapterQuestionDetection {
-  mode: 'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'negotiation_inflight' | 'chat';
+  mode: AdapterQuestionMode;
   sourceType: string;
   sourceId: string;
   triggeredBy?: string;
   timestamp: string;
   /** ID of the assistant message that triggered this question. */
   messageId?: string;
+  /**
+   * pool_discovery only: mined pool snapshot (assignments + chain alternates).
+   * INTERNAL — the service/controller read paths strip this before any
+   * payload leaves the server.
+   */
+  pool?: import('@indexnetwork/protocol').QuestionPoolSnapshot;
 }
 
 /** An actor targeted by a question (typically the user who should answer). */
@@ -47,6 +56,8 @@ export interface AdapterQuestionPayload {
   prompt: string;
   options: Array<{ label: string; description: string }>;
   multiSelect: boolean;
+  /** Optional provenance chip line (e.g. "based on 18 people matching this intent"). */
+  evidence?: string;
 }
 
 /** Answer recorded when a user responds to a question. */
@@ -87,7 +98,7 @@ export interface AdapterPersistedQuestion {
 
 /** Optional filters for the `findPending` query. */
 export interface AdapterQuestionFilters {
-  mode?: 'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'negotiation_inflight' | 'chat';
+  mode?: AdapterQuestionMode;
   sourceType?: string;
   sourceId?: string;
   /**
@@ -105,7 +116,7 @@ export interface AdapterQuestionFilters {
   /** When true, only return questions with no conversationId (sidebar-only). */
   noConversation?: boolean;
   /** Restrict to questions whose detection mode is in this set. */
-  modes?: Array<'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'negotiation_inflight' | 'chat'>;
+  modes?: AdapterQuestionMode[];
   /** Maximum rows to return (applied as a SQL LIMIT). */
   limit?: number;
 }
@@ -227,6 +238,23 @@ export class QuestionerAdapter {
       : await baseQuery;
 
     return rows.map(toPersistedQuestion);
+  }
+
+  /**
+   * Discriminator labels of every pool_discovery question (any status) for
+   * one user+intent — the dedup set that prevents re-asking an axis the user
+   * already saw, answered, or dismissed (IND-418).
+   */
+  async listPoolQuestionLabels(userId: string, intentId: string): Promise<string[]> {
+    const rows = await this.db
+      .select({ label: sql<string | null>`${questions.detection}->'pool'->'discriminator'->>'label'` })
+      .from(questions)
+      .where(and(
+        sql`${questions.actors}::jsonb @> ${JSON.stringify([{ userId }])}::jsonb`,
+        sql`${questions.detection}->>'mode' = 'pool_discovery'`,
+        sql`${questions.detection}->>'triggeredBy' = ${intentId}`,
+      ));
+    return rows.map((r) => r.label).filter((l): l is string => typeof l === 'string' && l.length > 0);
   }
 
   /**

--- a/services/api/src/controllers/mcp.controller.ts
+++ b/services/api/src/controllers/mcp.controller.ts
@@ -675,7 +675,7 @@ function createMcpServerInstance(): McpServer {
         networkId?: string;
         scopeType?: 'intent';
         scopeId?: string;
-        modes?: Array<'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'negotiation_inflight' | 'chat'>;
+        modes?: Array<'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'negotiation_inflight' | 'chat' | 'pool_discovery'>;
         limit?: number;
       },
     ) => {

--- a/services/api/src/controllers/question.controller.ts
+++ b/services/api/src/controllers/question.controller.ts
@@ -20,7 +20,7 @@ const answerBodySchema = z.object({
 });
 
 const statusQuerySchema = z.enum(['pending', 'answered', 'dismissed']).default('pending');
-const modeQuerySchema = z.enum(['discovery', 'intent', 'enrichment', 'negotiation', 'negotiation_inflight', 'chat']);
+const modeQuerySchema = z.enum(['discovery', 'intent', 'enrichment', 'negotiation', 'negotiation_inflight', 'chat', 'pool_discovery']);
 const uuidQuerySchema = z.string().uuid();
 const scopeTypeQuerySchema = z.enum(['intent']);
 
@@ -101,7 +101,7 @@ export class QuestionController {
       const modeResult = modeQuerySchema.safeParse(rawMode);
       if (!modeResult.success) {
         return Response.json(
-          { error: 'Invalid mode; use one of: discovery, intent, enrichment, negotiation, chat' },
+          { error: 'Invalid mode; use one of: discovery, intent, enrichment, negotiation, negotiation_inflight, chat, pool_discovery' },
           { status: 400 },
         );
       }

--- a/services/api/src/events/handlers/question.answer.handler.ts
+++ b/services/api/src/events/handlers/question.answer.handler.ts
@@ -16,6 +16,9 @@
  *              via the run-existing continuation (P3.2 ask_user loop)
  * - chat:      resolve the in-memory wait bus so a blocked ask_user_question
  *              tool call resumes the paused chat turn with the answer
+ * - pool_discovery: interview-mode chaining — synthesize the next pool
+ *              question from the answered question's stored alternates
+ *              (IND-418; re-rank + reactive re-discovery land in P3)
  */
 
 import { log } from '../../lib/log';
@@ -27,7 +30,7 @@ const logger = log.service.from('QuestionAnswerHandler');
 interface QuestionAnsweredPayload {
   questionId: string;
   userId: string;
-  mode: 'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'negotiation_inflight' | 'chat';
+  mode: 'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'negotiation_inflight' | 'chat' | 'pool_discovery';
   sourceType: string;
   sourceId: string;
   answer: {
@@ -88,6 +91,17 @@ export interface QuestionAnswerHandlerDeps {
     questionId: string;
     answer: QuestionAnsweredPayload['answer'];
   }) => void;
+
+  /**
+   * Interview-mode chaining for pool_discovery answers: persist the next
+   * pool question from the answered question's stored alternates (no-op when
+   * POOL_QUESTIONS_MODE is off or no fresh alternate remains).
+   */
+  chainPoolQuestion: (input: {
+    userId: string;
+    questionId: string;
+    intentId: string;
+  }) => Promise<void>;
 }
 
 // ─── Dispatcher ─────────────────────────────────────────────────────────────
@@ -151,6 +165,14 @@ export async function handleQuestionAnswered(
 
       case 'chat':
         deps.resolveChatQuestionWait({ questionId, answer });
+        break;
+
+      case 'pool_discovery':
+        await deps.chainPoolQuestion({
+          userId,
+          questionId,
+          intentId: sourceId,
+        });
         break;
 
       default:

--- a/services/api/src/events/handlers/question.answer.pool.ts
+++ b/services/api/src/events/handlers/question.answer.pool.ts
@@ -1,0 +1,74 @@
+/**
+ * pool_discovery answer reaction — interview-mode chaining (IND-418).
+ *
+ * When a user answers a pool question while POOL_QUESTIONS_MODE=on, the next
+ * eligible discriminator from the answered question's stored alternates is
+ * synthesized and persisted immediately (dialogue, not homework). The web
+ * client refetches pending questions after answering and renders the chained
+ * card behind a typing indicator.
+ *
+ * Chaining keeps the ≤1-pending invariant by construction: the answered
+ * question just left `pending`, and exactly one successor is created. The
+ * chain stops when no fresh alternate clears the VoI bar, the user dismisses
+ * (dismissals never reach this handler), or the user navigates away (the one
+ * pending successor then simply waits within the unattended budget).
+ *
+ * P3 adds the re-rank + reactive re-discovery reactions on this same arm.
+ */
+import { POOL_QUESTION_MIN_VOI, poolQuestionsMode } from '@indexnetwork/protocol';
+
+import { log } from '../../lib/log';
+import type { QuestionerAdapter } from '../../adapters/questioner.adapter';
+import { buildPoolQuestion, dedupDiscriminators, persistPoolQuestion } from '../../queues/pool-question.shared';
+
+const logger = log.service.from('PoolQuestionChain');
+
+export interface ChainPoolQuestionDeps {
+  adapter: Pick<QuestionerAdapter, 'getById' | 'persist' | 'listPoolQuestionLabels'>;
+}
+
+/**
+ * Factory for the `chainPoolQuestion` answer-handler dependency.
+ */
+export function chainPoolQuestionFactory(deps: ChainPoolQuestionDeps) {
+  return async function chainPoolQuestion(input: {
+    userId: string;
+    questionId: string;
+    intentId: string;
+  }): Promise<void> {
+    if (poolQuestionsMode() !== 'on') return;
+
+    const answered = await deps.adapter.getById(input.questionId);
+    const pool = answered?.detection.pool;
+    if (!pool || pool.alternates.length === 0) {
+      logger.verbose('No alternates to chain', { questionId: input.questionId });
+      return;
+    }
+
+    const askedLabels = await deps.adapter.listPoolQuestionLabels(input.userId, input.intentId);
+    const fresh = dedupDiscriminators(pool.alternates, askedLabels)
+      .filter((d) => d.voi >= POOL_QUESTION_MIN_VOI);
+    if (fresh.length === 0) {
+      logger.verbose('No fresh alternate clears the VoI bar', { questionId: input.questionId });
+      return;
+    }
+
+    const question = buildPoolQuestion({
+      userId: input.userId,
+      intentId: input.intentId,
+      poolSize: pool.poolSize,
+      minedAt: pool.minedAt,
+      ...(pool.runId ? { runId: pool.runId } : {}),
+      discriminators: fresh,
+    });
+    if (!question) return;
+
+    const id = await persistPoolQuestion(deps.adapter, question, input.userId);
+    logger.info('Chained next pool question', {
+      answeredQuestionId: input.questionId,
+      nextQuestionId: id,
+      intentId: input.intentId,
+      remainingAlternates: fresh.length - 1,
+    });
+  };
+}

--- a/services/api/src/events/handlers/tests/question.answer.pool.test.ts
+++ b/services/api/src/events/handlers/tests/question.answer.pool.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Interview-mode chaining on pool_discovery answers (IND-418).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+
+import type { QuestionPoolDiscriminator } from '@indexnetwork/protocol';
+
+import { chainPoolQuestionFactory } from '../question.answer.pool';
+import type { AdapterPersistableQuestion, AdapterPersistedQuestion } from '../../../adapters/questioner.adapter';
+
+function discriminator(label: string, voi = 0.5): QuestionPoolDiscriminator {
+  return {
+    label,
+    questionSeed: `Which matters more for ${label}`,
+    sides: ['Side A', 'Side B'],
+    sideCounts: { 'Side A': 5, 'Side B': 4 },
+    voi,
+    evidenceRate: 0.9,
+    assignments: [{ opportunityId: 'opp-1', side: 'Side A' }],
+  };
+}
+
+function answeredQuestion(alternates: QuestionPoolDiscriminator[]): AdapterPersistedQuestion {
+  return {
+    id: 'q-answered',
+    detection: {
+      mode: 'pool_discovery',
+      sourceType: 'intent',
+      sourceId: 'intent-1',
+      triggeredBy: 'intent-1',
+      timestamp: 'now',
+      pool: {
+        poolSize: 21,
+        minedAt: '2026-07-14T14:00:00.000Z',
+        runId: 'run-1',
+        discriminator: discriminator('asked'),
+        alternates,
+      },
+    },
+    actors: [{ userId: 'user-1', role: 'subject' }],
+    payload: { title: 'T', prompt: 'P?', options: [{ label: 'a', description: 'd' }, { label: 'b', description: 'd' }], multiSelect: false },
+    status: 'answered',
+    answer: { selectedOptions: ['a'], answeredBy: 'user-1', answeredAt: 'now' },
+    expiresAt: null,
+    createdAt: 'now',
+    conversationId: null,
+  };
+}
+
+function makeHarness(row: AdapterPersistedQuestion | null, askedLabels: string[] = ['asked']) {
+  const persisted: AdapterPersistableQuestion[][] = [];
+  const chain = chainPoolQuestionFactory({
+    adapter: {
+      getById: async () => row,
+      persist: async (batch: AdapterPersistableQuestion[]) => {
+        persisted.push(batch);
+        return batch.map((_, i) => `chained-${i}`);
+      },
+      listPoolQuestionLabels: async () => askedLabels,
+    },
+  });
+  return { chain, persisted };
+}
+
+const input = { userId: 'user-1', questionId: 'q-answered', intentId: 'intent-1' };
+
+describe('chainPoolQuestion', () => {
+  beforeEach(() => {
+    process.env.POOL_QUESTIONS_MODE = 'on';
+  });
+  afterEach(() => {
+    delete process.env.POOL_QUESTIONS_MODE;
+  });
+
+  it('persists the next alternate as a new pool question', async () => {
+    const { chain, persisted } = makeHarness(answeredQuestion([discriminator('next'), discriminator('later')]));
+    await chain(input);
+    expect(persisted).toHaveLength(1);
+    const [q] = persisted[0];
+    expect(q.detection.mode).toBe('pool_discovery');
+    expect(q.detection.pool?.discriminator.label).toBe('next');
+    expect(q.detection.pool?.alternates.map((a) => a.label)).toEqual(['later']);
+    // Snapshot provenance carries over from the answered question's pass.
+    expect(q.detection.pool?.runId).toBe('run-1');
+  });
+
+  it('is a no-op when POOL_QUESTIONS_MODE is off', async () => {
+    delete process.env.POOL_QUESTIONS_MODE;
+    const { chain, persisted } = makeHarness(answeredQuestion([discriminator('next')]));
+    await chain(input);
+    expect(persisted).toHaveLength(0);
+  });
+
+  it('is a no-op when there are no alternates', async () => {
+    const { chain, persisted } = makeHarness(answeredQuestion([]));
+    await chain(input);
+    expect(persisted).toHaveLength(0);
+  });
+
+  it('drops alternates below the VoI bar', async () => {
+    const { chain, persisted } = makeHarness(answeredQuestion([discriminator('weak', 0.05)]));
+    await chain(input);
+    expect(persisted).toHaveLength(0);
+  });
+
+  it('dedups alternates that were already asked (including the just-answered axis)', async () => {
+    const { chain, persisted } = makeHarness(
+      answeredQuestion([discriminator('asked'), discriminator('fresh')]),
+      ['asked'],
+    );
+    await chain(input);
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0][0].detection.pool?.discriminator.label).toBe('fresh');
+  });
+
+  it('is a no-op when the answered question has no pool snapshot', async () => {
+    const row = answeredQuestion([discriminator('next')]);
+    delete (row.detection as { pool?: unknown }).pool;
+    const { chain, persisted } = makeHarness(row);
+    await chain(input);
+    expect(persisted).toHaveLength(0);
+  });
+});

--- a/services/api/src/events/question.event.ts
+++ b/services/api/src/events/question.event.ts
@@ -5,7 +5,7 @@ interface QuestionAnswer {
   answeredAt: string;
 }
 
-type QuestionMode = 'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'negotiation_inflight' | 'chat';
+type QuestionMode = 'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'negotiation_inflight' | 'chat' | 'pool_discovery';
 
 interface QuestionCreatedPayload {
   questionId: string;

--- a/services/api/src/main.ts
+++ b/services/api/src/main.ts
@@ -72,6 +72,7 @@ import { IntentEvents } from './events/intent.event';
 import { PremiseEvents } from './events/premise.event';
 import { QuestionEvents } from './events/question.event';
 import { handleQuestionAnswered } from './events/handlers/question.answer.handler';
+import { chainPoolQuestionFactory } from './events/handlers/question.answer.pool';
 import { emitChatQuestionResolution } from './lib/chat-question.events';
 import { createPremiseFromAnswerFactory } from './events/handlers/question.answer.enrichment';
 import { enqueueIntentRefinementFactory } from './events/handlers/question.answer.intent';
@@ -317,6 +318,7 @@ const questionAnswerDeps = {
   }) => {
     emitChatQuestionResolution({ questionId, status: 'answered', answer });
   },
+  chainPoolQuestion: chainPoolQuestionFactory({ adapter: answerQuestionerAdapter }),
 };
 
 QuestionEvents.onAnswered = (payload) => {

--- a/services/api/src/queues/opportunity/discovery-run.queue.ts
+++ b/services/api/src/queues/opportunity/discovery-run.queue.ts
@@ -1,6 +1,6 @@
 import { Job } from 'bullmq';
 
-import { deriveAllowedNetworkIds, HydeGenerator, HydeGraphFactory, LensInferrer, OpportunityGraphFactory, PoolDiscriminatorMiner, POOL_DISCRIMINATOR_MAX_CANDIDATES, POOL_DISCRIMINATOR_MAX_PUBLIC_CONTEXT_CHARS, POOL_DISCRIMINATOR_MIN_POOL_SIZE, createOpportunityTools, getToolTimeoutPolicy, poolQuestionsMiningMode, requestContext, resolveChatContext, runPoolDiscriminatorShadow } from '@indexnetwork/protocol';
+import { deriveAllowedNetworkIds, HydeGenerator, HydeGraphFactory, LensInferrer, OpportunityGraphFactory, PoolDiscriminatorMiner, POOL_DISCRIMINATOR_MAX_CANDIDATES, POOL_DISCRIMINATOR_MAX_PUBLIC_CONTEXT_CHARS, POOL_DISCRIMINATOR_MIN_POOL_SIZE, createOpportunityTools, getToolTimeoutPolicy, poolQuestionsMiningMode, poolQuestionsMode, requestContext, resolveChatContext, runPoolDiscriminatorShadow, selectQuestionDiscriminators, toQuestionDiscriminator } from '@indexnetwork/protocol';
 import type { AgentDispatcher, CompiledGraph, DiscoveryRunInput, DiscoveryRunRecord, HydeGraphDatabase, NegotiationGraphLike, OpportunityGraphDatabase, PoolCandidate, RawToolDefinition, ResolvedToolContext, ToolDeps } from '@indexnetwork/protocol';
 
 import { log } from '../../lib/log';
@@ -293,9 +293,12 @@ export class DiscoveryRunQueue {
   }
 
   /**
-   * IND-417 shadow axis mining. Fire-and-forget: never awaited by the run
-   * lifecycle and never allowed to fail the discovery run. Active only when
-   * POOL_QUESTIONS_MINING=shadow; flag off = zero behavior change.
+   * IND-417 shadow axis mining + IND-418 question enqueue. Fire-and-forget:
+   * never awaited by the run lifecycle and never allowed to fail the
+   * discovery run. Mining runs when POOL_QUESTIONS_MINING=shadow OR
+   * POOL_QUESTIONS_MODE=on; questions are enqueued only when the latter is on
+   * (and QUESTIONER_ENABLED gates the actual enqueue). Both flags off = zero
+   * behavior change.
    *
    * The pool is read from the opportunities table (the run's durable output —
    * the MCP tool response flattens cards into message text, so the run result
@@ -303,7 +306,7 @@ export class DiscoveryRunQueue {
    * will re-rank, so mining over them keeps the phases consistent.
    */
   private maybeMinePoolDiscriminators(run: DiscoveryRunRecord): void {
-    if (poolQuestionsMiningMode() !== 'shadow') return;
+    if (poolQuestionsMiningMode() !== 'shadow' && poolQuestionsMode() !== 'on') return;
     // Introducer flow: the discovered candidates are matches for someone else,
     // not the viewer's own pool — discriminator questions don't apply.
     if (run.input.introTargetUserId) return;
@@ -426,6 +429,41 @@ export class DiscoveryRunQueue {
         novelty: round(d.novelty),
         evidenceRate: round(d.evidenceRate),
       })),
+    });
+
+    // IND-418: turn the top eligible discriminator into a pool_discovery
+    // question. QUESTIONER_ENABLED gates via questionerEnqueueIfEnabled;
+    // budget + dedup enforcement lives in the QuestionerQueue worker.
+    if (poolQuestionsMode() !== 'on' || !intentId) return;
+    const enqueue = questionerEnqueueIfEnabled();
+    if (!enqueue) return;
+    const eligible = selectQuestionDiscriminators(shadow.discriminators);
+    if (eligible.length === 0) {
+      this.poolDiscriminatorLogger.debug('no discriminator cleared the question bar', {
+        runId: run.id,
+        intentId,
+      });
+      return;
+    }
+    await enqueue({
+      mode: 'pool_discovery',
+      userId: run.userId,
+      sourceType: 'intent',
+      sourceId: intentId,
+      triggeredByIntentId: intentId,
+      context: {
+        intentId,
+        intentText,
+        poolSize: shadow.poolSize,
+        runId: run.id,
+        minedAt: new Date().toISOString(),
+        discriminators: eligible.map(toQuestionDiscriminator),
+      },
+    });
+    this.poolDiscriminatorLogger.info('pool question enqueued', {
+      runId: run.id,
+      intentId,
+      eligible: eligible.length,
     });
   }
 }

--- a/services/api/src/queues/pool-question.shared.ts
+++ b/services/api/src/queues/pool-question.shared.ts
@@ -1,0 +1,85 @@
+/**
+ * Shared pool_discovery question construction (IND-418).
+ *
+ * Used by the QuestionerQueue worker (initial question after a mining pass)
+ * and the answer-reaction handler (interview-mode chaining). Synthesis is
+ * deterministic — `synthesizePoolQuestion` in @indexnetwork/protocol — and
+ * the mined pool snapshot (assignments + remaining alternates) rides along
+ * in `detection.pool`, which the client read paths strip.
+ */
+import { synthesizePoolQuestion } from '@indexnetwork/protocol';
+import type { QuestionPoolDiscriminator } from '@indexnetwork/protocol';
+
+import type { AdapterPersistableQuestion, QuestionerAdapter } from '../adapters/questioner.adapter';
+import { QuestionEvents } from '../events/question.event';
+
+/** Normalized form used for axis dedup (re-asking an already-seen axis). */
+export function normalizePoolLabel(label: string): string {
+  return label.toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+/** Drops discriminators whose label was already asked for this intent. */
+export function dedupDiscriminators(
+  discriminators: QuestionPoolDiscriminator[],
+  askedLabels: string[],
+): QuestionPoolDiscriminator[] {
+  const asked = new Set(askedLabels.map(normalizePoolLabel));
+  return discriminators.filter((d) => !asked.has(normalizePoolLabel(d.label)));
+}
+
+/** Input for building one persistable pool question. */
+export interface BuildPoolQuestionInput {
+  userId: string;
+  intentId: string;
+  poolSize: number;
+  /** ISO-8601 timestamp of the mining pass. */
+  minedAt: string;
+  runId?: string;
+  /** VoI-descending, deduped: first entry is asked, the rest become alternates. */
+  discriminators: QuestionPoolDiscriminator[];
+}
+
+/** Builds the persistable row, or null when synthesis declines (guards). */
+export function buildPoolQuestion(input: BuildPoolQuestionInput): AdapterPersistableQuestion | null {
+  const [top, ...alternates] = input.discriminators;
+  if (!top) return null;
+  const synthesized = synthesizePoolQuestion({
+    discriminator: top,
+    alternates,
+    poolSize: input.poolSize,
+    minedAt: input.minedAt,
+    ...(input.runId ? { runId: input.runId } : {}),
+  });
+  if (!synthesized) return null;
+  return {
+    detection: {
+      mode: 'pool_discovery',
+      sourceType: 'intent',
+      sourceId: input.intentId,
+      triggeredBy: input.intentId,
+      timestamp: new Date().toISOString(),
+      pool: synthesized.pool,
+    },
+    actors: [{ userId: input.userId, role: 'subject' }],
+    payload: synthesized.payload,
+    strategy: 'refine_intent',
+  };
+}
+
+/** Persists one pool question and fires the created event. Returns the id. */
+export async function persistPoolQuestion(
+  adapter: Pick<QuestionerAdapter, 'persist'>,
+  question: AdapterPersistableQuestion,
+  userId: string,
+): Promise<string | null> {
+  const [id] = await adapter.persist([question]);
+  if (!id) return null;
+  QuestionEvents.onCreated({
+    questionId: id,
+    userId,
+    mode: question.detection.mode,
+    sourceType: question.detection.sourceType,
+    sourceId: question.detection.sourceId,
+  });
+  return id;
+}

--- a/services/api/src/queues/questioner.queue.ts
+++ b/services/api/src/queues/questioner.queue.ts
@@ -1,13 +1,14 @@
 import { Job } from 'bullmq';
 
-import { QuestionerAgent, isQuestionerEnabled } from '@indexnetwork/protocol';
-import type { QuestionerInput, QuestionerEnqueueFn, PersistableQuestion, QuestionGenerationResult } from '@indexnetwork/protocol';
+import { POOL_QUESTION_MAX_PENDING_PER_INTENT, QuestionerAgent, isQuestionerEnabled } from '@indexnetwork/protocol';
+import type { PersistableQuestion, PoolDiscoveryContext, QuestionGenerationResult, QuestionerEnqueueFn, QuestionerInput } from '@indexnetwork/protocol';
 
 import { log } from '../lib/log';
 import { QueueFactory } from '../lib/bullmq/bullmq';
 import db from '../lib/drizzle/drizzle';
 import { QuestionerAdapter } from '../adapters/questioner.adapter';
 import { QuestionEvents } from '../events/question.event';
+import { buildPoolQuestion, dedupDiscriminators, persistPoolQuestion } from './pool-question.shared';
 
 /** BullMQ queue name for question generation jobs. */
 export const QUEUE_NAME = 'questioner-queue';
@@ -20,7 +21,7 @@ export type QuestionerJobData = QuestionerInput;
  * stubs without touching real DB or LLM.
  */
 export interface QuestionerQueueDeps {
-  adapter?: Pick<QuestionerAdapter, 'persist'>;
+  adapter?: Pick<QuestionerAdapter, 'persist' | 'findPending' | 'listPoolQuestionLabels'>;
   agent?: Pick<QuestionerAgent, 'invoke'>;
 }
 
@@ -41,7 +42,7 @@ export class QuestionerQueue {
 
   private readonly logger = log.job.from('QuestionerJob');
   private readonly queueLogger = log.queue.from('QuestionerQueue');
-  private readonly adapter: Pick<QuestionerAdapter, 'persist'>;
+  private readonly adapter: Pick<QuestionerAdapter, 'persist' | 'findPending' | 'listPoolQuestionLabels'>;
   private agent: Pick<QuestionerAgent, 'invoke'> | null;
   private worker: ReturnType<typeof QueueFactory.createWorker<QuestionerJobData>> | null = null;
 
@@ -138,6 +139,14 @@ export class QuestionerQueue {
       sourceId: data.sourceId,
     });
 
+    // pool_discovery questions are synthesized deterministically from mined
+    // discriminators — no generator LLM (IND-418). Budget + dedup live here
+    // so every producer (mining hook, future paths) hits one choke point.
+    if (data.mode === 'pool_discovery') {
+      await this.handlePoolDiscovery(data);
+      return;
+    }
+
     const result: QuestionGenerationResult | null = await this.getAgent().invoke(data);
 
     if (!result) {
@@ -186,6 +195,51 @@ export class QuestionerQueue {
         sourceId: data.sourceId,
       });
     }
+  }
+
+  /**
+   * Deterministic pool_discovery arm: enforce the unattended budget
+   * (≤1 pending pool_discovery per intent, ≤{@link POOL_QUESTION_MAX_PENDING_PER_INTENT}
+   * pending total per intent), dedup against already-asked axes, then
+   * synthesize + persist the top discriminator.
+   */
+  private async handlePoolDiscovery(data: QuestionerJobData): Promise<void> {
+    const context = data.context as PoolDiscoveryContext;
+    const intentId = context.intentId;
+
+    const pending = await this.adapter.findPending(data.userId, {
+      scopeType: 'intent',
+      scopeId: intentId,
+    });
+    if (pending.some((q) => q.detection.mode === 'pool_discovery')) {
+      this.logger.info('Pool question skipped: one already pending for intent', { intentId });
+      return;
+    }
+    if (pending.length >= POOL_QUESTION_MAX_PENDING_PER_INTENT) {
+      this.logger.info('Pool question skipped: intent question budget exhausted', {
+        intentId,
+        pending: pending.length,
+      });
+      return;
+    }
+
+    const askedLabels = await this.adapter.listPoolQuestionLabels(data.userId, intentId);
+    const fresh = dedupDiscriminators(context.discriminators, askedLabels);
+    const question = buildPoolQuestion({
+      userId: data.userId,
+      intentId,
+      poolSize: context.poolSize,
+      minedAt: context.minedAt,
+      ...(context.runId ? { runId: context.runId } : {}),
+      discriminators: fresh,
+    });
+    if (!question) {
+      this.logger.info('Pool question skipped: no fresh discriminator', { intentId });
+      return;
+    }
+
+    const id = await persistPoolQuestion(this.adapter, question, data.userId);
+    this.logger.info('Persisted pool question', { intentId, questionId: id });
   }
 }
 

--- a/services/api/src/queues/tests/pool-question.queue.spec.ts
+++ b/services/api/src/queues/tests/pool-question.queue.spec.ts
@@ -1,0 +1,146 @@
+/**
+ * QuestionerQueue pool_discovery arm (IND-418): deterministic synthesis,
+ * unattended budget, axis dedup — and proof the generator LLM is never
+ * invoked for this mode.
+ */
+import { describe, it, expect, beforeEach } from 'bun:test';
+
+import type { QuestionPoolDiscriminator, QuestionerInput } from '@indexnetwork/protocol';
+
+import { QuestionerQueue } from '../questioner.queue';
+import type { AdapterPersistableQuestion, AdapterPersistedQuestion } from '../../adapters/questioner.adapter';
+
+function discriminator(label: string, voi = 0.5): QuestionPoolDiscriminator {
+  return {
+    label,
+    questionSeed: `Which matters more for ${label}`,
+    sides: ['Side A', 'Side B'],
+    sideCounts: { 'Side A': 5, 'Side B': 4 },
+    voi,
+    evidenceRate: 0.9,
+    assignments: [{ opportunityId: 'opp-1', side: 'Side A' }],
+  };
+}
+
+function pendingRow(mode: string): AdapterPersistedQuestion {
+  return {
+    id: `q-${mode}-${Math.random().toString(36).slice(2, 8)}`,
+    detection: { mode: mode as AdapterPersistedQuestion['detection']['mode'], sourceType: 'intent', sourceId: 'intent-1', timestamp: 'now' },
+    actors: [{ userId: 'user-1', role: 'subject' }],
+    payload: { title: 'T', prompt: 'P?', options: [{ label: 'a', description: 'd' }, { label: 'b', description: 'd' }], multiSelect: false },
+    status: 'pending',
+    answer: null,
+    expiresAt: null,
+    createdAt: 'now',
+    conversationId: null,
+  };
+}
+
+function poolInput(discriminators: QuestionPoolDiscriminator[]): QuestionerInput {
+  return {
+    mode: 'pool_discovery',
+    userId: 'user-1',
+    sourceType: 'intent',
+    sourceId: 'intent-1',
+    triggeredByIntentId: 'intent-1',
+    context: {
+      intentId: 'intent-1',
+      intentText: 'find collaborators',
+      poolSize: 21,
+      runId: 'run-1',
+      minedAt: '2026-07-14T14:00:00.000Z',
+      discriminators,
+    },
+  } as QuestionerInput;
+}
+
+interface Harness {
+  queue: QuestionerQueue;
+  persisted: AdapterPersistableQuestion[][];
+  agentInvocations: number;
+  setPending(rows: AdapterPersistedQuestion[]): void;
+  setAskedLabels(labels: string[]): void;
+}
+
+function makeHarness(): Harness {
+  const persisted: AdapterPersistableQuestion[][] = [];
+  let pending: AdapterPersistedQuestion[] = [];
+  let askedLabels: string[] = [];
+  const state = { agentInvocations: 0 };
+  const queue = new QuestionerQueue({
+    adapter: {
+      persist: async (batch: AdapterPersistableQuestion[]) => {
+        persisted.push(batch);
+        return batch.map((_, i) => `id-${persisted.length}-${i}`);
+      },
+      findPending: async () => pending,
+      listPoolQuestionLabels: async () => askedLabels,
+    },
+    agent: {
+      invoke: async () => {
+        state.agentInvocations++;
+        return null;
+      },
+    },
+  });
+  return {
+    queue,
+    persisted,
+    get agentInvocations() {
+      return state.agentInvocations;
+    },
+    setPending: (rows) => {
+      pending = rows;
+    },
+    setAskedLabels: (labels) => {
+      askedLabels = labels;
+    },
+  };
+}
+
+describe('QuestionerQueue pool_discovery arm', () => {
+  let h: Harness;
+
+  beforeEach(() => {
+    h = makeHarness();
+  });
+
+  it('persists the top discriminator without invoking the generator LLM', async () => {
+    await h.queue.processJob('generate_questions', poolInput([discriminator('top'), discriminator('second')]));
+    expect(h.agentInvocations).toBe(0);
+    expect(h.persisted).toHaveLength(1);
+    const [q] = h.persisted[0];
+    expect(q.detection.mode).toBe('pool_discovery');
+    expect(q.detection.triggeredBy).toBe('intent-1');
+    expect(q.detection.pool?.discriminator.label).toBe('top');
+    expect(q.detection.pool?.alternates.map((a) => a.label)).toEqual(['second']);
+    expect(q.payload.options.map((o) => o.label)).toEqual(['Side A', 'Side B', 'Both matter']);
+    expect(q.payload.evidence).toBe('based on 21 people matching this intent');
+  });
+
+  it('skips when a pool_discovery question is already pending for the intent', async () => {
+    h.setPending([pendingRow('pool_discovery')]);
+    await h.queue.processJob('generate_questions', poolInput([discriminator('top')]));
+    expect(h.persisted).toHaveLength(0);
+  });
+
+  it('skips when the intent already has 3 pending questions of any mode', async () => {
+    h.setPending([pendingRow('intent'), pendingRow('discovery'), pendingRow('negotiation')]);
+    await h.queue.processJob('generate_questions', poolInput([discriminator('top')]));
+    expect(h.persisted).toHaveLength(0);
+  });
+
+  it('dedups already-asked axes (case/whitespace-insensitive) and asks the next one', async () => {
+    h.setAskedLabels(['  TOP ']);
+    await h.queue.processJob('generate_questions', poolInput([discriminator('top'), discriminator('second')]));
+    expect(h.persisted).toHaveLength(1);
+    expect(h.persisted[0][0].detection.pool?.discriminator.label).toBe('second');
+    expect(h.persisted[0][0].detection.pool?.alternates).toEqual([]);
+  });
+
+  it('persists nothing when every discriminator was already asked', async () => {
+    h.setAskedLabels(['top']);
+    await h.queue.processJob('generate_questions', poolInput([discriminator('top')]));
+    expect(h.persisted).toHaveLength(0);
+  });
+});

--- a/services/api/src/schemas/database.schema.ts
+++ b/services/api/src/schemas/database.schema.ts
@@ -499,7 +499,7 @@ export const enrichmentToolRuns = pgTable('enrichment_tool_runs', {
 }));
 
 export interface QuestionDetection {
-  mode: 'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'negotiation_inflight' | 'chat';
+  mode: 'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'negotiation_inflight' | 'chat' | 'pool_discovery';
   sourceType: string;
   sourceId: string;
   triggeredBy?: string;
@@ -508,6 +508,11 @@ export interface QuestionDetection {
   strategy?: string;
   /** ID of the assistant message that triggered this question. */
   messageId?: string;
+  /**
+   * pool_discovery only: mined pool snapshot (assignments + chain alternates).
+   * INTERNAL — stripped from every client-facing read (web + MCP).
+   */
+  pool?: import('@indexnetwork/protocol').QuestionPoolSnapshot;
 }
 
 export interface QuestionActor {

--- a/services/api/src/services/question.service.ts
+++ b/services/api/src/services/question.service.ts
@@ -17,6 +17,17 @@ const logger = log.service.from('QuestionService');
  * answer/dismiss mutations through a service boundary, keeping
  * controllers free of adapter dependencies.
  */
+/**
+ * Removes server-only detection fields before a question leaves the API.
+ * `detection.pool` carries pool_discovery candidate assignments + chain
+ * alternates — k-anonymity requires they never reach a client (IND-418).
+ */
+export function stripInternalDetection(question: AdapterPersistedQuestion): AdapterPersistedQuestion {
+  if (!question.detection.pool) return question;
+  const { pool: _pool, ...detection } = question.detection;
+  return { ...question, detection };
+}
+
 export class QuestionService {
   private readonly adapter: QuestionerAdapter;
 
@@ -39,7 +50,8 @@ export class QuestionService {
     filters?: AdapterQuestionFilters,
   ): Promise<AdapterPersistedQuestion[]> {
     logger.verbose('Finding pending questions', { userId, filters });
-    return this.adapter.findPending(userId, filters);
+    const rows = await this.adapter.findPending(userId, filters);
+    return rows.map(stripInternalDetection);
   }
 
   /**

--- a/services/api/src/services/tests/question.service.strip.spec.ts
+++ b/services/api/src/services/tests/question.service.strip.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * Client-strip invariant (IND-418): `detection.pool` (candidate assignments +
+ * chain alternates) never leaves the server through QuestionService reads.
+ */
+import { describe, it, expect } from 'bun:test';
+
+import { QuestionService, stripInternalDetection } from '../question.service';
+import type { AdapterPersistedQuestion, QuestionerAdapter } from '../../adapters/questioner.adapter';
+
+function poolQuestion(): AdapterPersistedQuestion {
+  return {
+    id: 'q-1',
+    detection: {
+      mode: 'pool_discovery',
+      sourceType: 'intent',
+      sourceId: 'intent-1',
+      triggeredBy: 'intent-1',
+      timestamp: 'now',
+      pool: {
+        poolSize: 21,
+        minedAt: 'now',
+        discriminator: {
+          label: 'axis',
+          questionSeed: 'seed?',
+          sides: ['A', 'B'],
+          sideCounts: { A: 5, B: 4 },
+          voi: 0.5,
+          evidenceRate: 0.9,
+          assignments: [{ opportunityId: 'opp-1', side: 'A' }],
+        },
+        alternates: [],
+      },
+    },
+    actors: [{ userId: 'user-1', role: 'subject' }],
+    payload: {
+      title: 'Matches',
+      prompt: 'Which?',
+      options: [{ label: 'A', description: 'd' }, { label: 'B', description: 'd' }],
+      multiSelect: false,
+      evidence: 'based on 21 people matching this intent',
+    },
+    status: 'pending',
+    answer: null,
+    expiresAt: null,
+    createdAt: 'now',
+    conversationId: null,
+  };
+}
+
+describe('stripInternalDetection', () => {
+  it('removes detection.pool and keeps everything else', () => {
+    const stripped = stripInternalDetection(poolQuestion());
+    expect(stripped.detection.pool).toBeUndefined();
+    expect(stripped.detection.mode).toBe('pool_discovery');
+    expect(stripped.detection.triggeredBy).toBe('intent-1');
+    expect(stripped.payload.evidence).toBe('based on 21 people matching this intent');
+    expect(JSON.stringify(stripped)).not.toContain('assignments');
+    expect(JSON.stringify(stripped)).not.toContain('opp-1');
+  });
+
+  it('leaves questions without a pool snapshot untouched (same reference)', () => {
+    const q = poolQuestion();
+    delete (q.detection as { pool?: unknown }).pool;
+    expect(stripInternalDetection(q)).toBe(q);
+  });
+});
+
+describe('QuestionService.findPending', () => {
+  it('strips detection.pool from every returned row', async () => {
+    const adapter = {
+      findPending: async () => [poolQuestion(), poolQuestion()],
+    } as unknown as QuestionerAdapter;
+    const service = new QuestionService(adapter);
+    const rows = await service.findPending('user-1');
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expect(row.detection.pool).toBeUndefined();
+    }
+    expect(JSON.stringify(rows)).not.toContain('assignments');
+  });
+});

--- a/services/api/src/services/tool.service.ts
+++ b/services/api/src/services/tool.service.ts
@@ -76,7 +76,7 @@ export class ToolService {
           networkId?: string;
           scopeType?: 'intent';
           scopeId?: string;
-          modes?: Array<'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'negotiation_inflight' | 'chat'>;
+          modes?: Array<'discovery' | 'intent' | 'enrichment' | 'negotiation' | 'negotiation_inflight' | 'chat' | 'pool_discovery'>;
           limit?: number;
         },
       ) => {

--- a/services/api/src/startup.env.ts
+++ b/services/api/src/startup.env.ts
@@ -114,6 +114,7 @@ const envSchema = z.object({
   NEGOTIATOR_MEMORY_INJECT: optionalBoolean,
   QUESTIONER_ENABLED: optionalBoolean,
   POOL_QUESTIONS_MINING: z.union([z.literal(''), z.enum(['off', 'shadow'])]).optional(),
+  POOL_QUESTIONS_MODE: z.union([z.literal(''), z.enum(['off', 'on'])]).optional(),
 
   // 9. MCP / tool runtime
   MCP_MAX_REQUEST_BYTES: optionalInt,


### PR DESCRIPTION
Implements **IND-418** (P2 of IND-416): `pool_discovery` questions — the top-VoI mined discriminator becomes a question the Personal Agent asks on the intent page, with interview-mode chaining. **Ships dark: `POOL_QUESTIONS_MODE=off` (default) = zero behavior change.**

## Backend

- **`pool_discovery` question mode** — zod-only (`QuestionModeSchema`), no migration. `payload.evidence` (optional provenance line) and `detection.pool` (mined snapshot: discriminator + verified assignments + ranked chain alternates) added to the schemas.
- **Deterministic synthesis** (`opportunity/discriminator/discriminator.question.ts`): the mined `questionSeed`/sides ARE the question — chip labels (≤5 words enforced), per-side count sub-lines ("8 of your 21 current matches lean this way"), always a final **"Both matter"** option, `evidence` = "based on N people matching this intent". Eligibility bars: VoI ≥ 0.2, evidenceRate ≥ 0.6, ≤3 per pass, k ≥ 5 pool floor re-guarded at synthesis.
  - **Deviation from the issue text**: the spec sketched an LLM preset for phrasing; this implements fully deterministic synthesis instead (mining already produced evidence-verified phrasing; a synthesis-time LLM adds cost + hallucination surface for zero information). `getPreset('pool_discovery')` intentionally throws — the queue branches before the agent, and a spec proves the generator LLM is never invoked for this mode.
- **Enqueue** from the P1 mining hook when `POOL_QUESTIONS_MODE=on` (via `questionerEnqueueIfEnabled` → inherits `QUESTIONER_ENABLED`). `on` implies mining runs even when `POOL_QUESTIONS_MINING=off`.
- **Budget + dedup** in the QuestionerQueue worker (single choke point): ≤1 pending pool question per intent, ≤3 pending total per intent (unattended budget), axis dedup vs every previously asked label (any status, case/whitespace-insensitive) via new `listPoolQuestionLabels`.
- **Interview-mode chaining** (`question.answer.pool.ts`): answering a pool question persists the next fresh alternate above the VoI bar from the answered question's stored snapshot — dialogue, not homework. ≤1-pending invariant holds by construction. Dismissals never chain.
- **k-anonymity strip**: `QuestionService.findPending` removes `detection.pool` from every client-facing read; MCP path safe by projection. Spec asserts `assignments`/opportunity ids absent from serialized client payloads.

## Web

- **Evidence chip** (muted gray `◎ based on 21 people…`, testid `question-evidence-chip`) above the prompt in `InjectedQuestions`.
- **Chip options with count sub-lines** — opt-in `showSubline` on `OptionRow` (DecisionQuestions legacy rendering untouched).
- **Interview cadence**: pool answer → typing indicator (`question-chain-typing`) → one pending refetch after 1.2s → append only never-before-seen chained pool questions (seen-ids ref, one chain per answer).
- **Pending-count badge** on the Personal Agent panel header (dark pill `bg-[#041729]`, 99+ cap, hidden at 0, testid `intent-question-count`).
- Intent-page fetch has no mode filter, so pool questions flow through the existing `getPending({scopeType:'intent'})` path unchanged.

## Versions

protocol 4.6.0 → **4.7.0**, api 0.29.0 → **0.30.0**, web 0.12.0 → **0.13.0** (feat → minor, per-PR convention).

## Tests (27 new, all green)

- Protocol (8): synthesis — schema-valid payload, sides+Both-matter options, count sub-lines, label word cap, k<5 → null, seed punctuation normalization, snapshot stash, eligibility bars.
- API (14): queue arm — persists top + alternates, **generator LLM never invoked**, pending-pool skip, 3-pending budget skip, dedup picks next axis; chaining — persists next alternate, flag-off no-op, no-alternates no-op, VoI bar, dedup incl. just-answered axis, missing-snapshot no-op; strip — `detection.pool` removed, `assignments` provably absent, non-pool rows pass by reference.
- Web (5): evidence chip present/absent, badge count + hidden-at-0, chaining refetch + append (mocked service).
- Regression: questioner suite 84/84, discriminator suite 38/38, answer-handler 9/9, intent-page suites 20/20, DecisionQuestions failures identical before/after (12, pre-existing). Builds clean (protocol, api tsc, web vite); no new web tsc baseline errors (62→62 lines).

## Flag-on behavior (dev, after P1 gate passes)

Visit an intent with a mined pool ≥5 → the agent chat opens with ≤1 discriminator question (evidence chip + chip options + "Both matter") → answering shows a typing indicator and chains the next axis if one clears the bar → navigating away leaves ≤1 unattended question. Answers only persist in P2 (re-rank + reactive re-discovery land in P3/IND-419).

Linear: IND-418 (parent IND-416)
