### PR TITLE
feat(api): pool-discriminator mining on from-intent discovery — frontend flows produce pool questions (IND-418 follow-up)

### DIFF
--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/events/handlers/question.answer.pool.ts
+++ b/services/api/src/events/handlers/question.answer.pool.ts
@@ -19,7 +19,7 @@ import { POOL_QUESTION_MIN_VOI, poolQuestionsMode } from '@indexnetwork/protocol
 
 import { log } from '../../lib/log';
 import type { QuestionerAdapter } from '../../adapters/questioner.adapter';
-import { buildPoolQuestion, dedupDiscriminators, persistPoolQuestion } from '../../queues/pool-question.shared';
+import { buildPoolQuestion, dedupDiscriminators, persistPoolQuestion } from '../../queues/pool/question.shared';
 
 const logger = log.service.from('PoolQuestionChain');
 

--- a/services/api/src/queues/opportunity/discovery-run.queue.ts
+++ b/services/api/src/queues/opportunity/discovery-run.queue.ts
@@ -1,7 +1,7 @@
 import { Job } from 'bullmq';
 
-import { deriveAllowedNetworkIds, HydeGenerator, HydeGraphFactory, LensInferrer, OpportunityGraphFactory, PoolDiscriminatorMiner, POOL_DISCRIMINATOR_MAX_CANDIDATES, POOL_DISCRIMINATOR_MAX_PUBLIC_CONTEXT_CHARS, POOL_DISCRIMINATOR_MIN_POOL_SIZE, createOpportunityTools, getToolTimeoutPolicy, poolQuestionsMiningMode, poolQuestionsMode, requestContext, resolveChatContext, runPoolDiscriminatorShadow, selectQuestionDiscriminators, toQuestionDiscriminator } from '@indexnetwork/protocol';
-import type { AgentDispatcher, CompiledGraph, DiscoveryRunInput, DiscoveryRunRecord, HydeGraphDatabase, NegotiationGraphLike, OpportunityGraphDatabase, PoolCandidate, RawToolDefinition, ResolvedToolContext, ToolDeps } from '@indexnetwork/protocol';
+import { deriveAllowedNetworkIds, HydeGenerator, HydeGraphFactory, LensInferrer, OpportunityGraphFactory, createOpportunityTools, getToolTimeoutPolicy, requestContext, resolveChatContext } from '@indexnetwork/protocol';
+import type { AgentDispatcher, CompiledGraph, DiscoveryRunInput, DiscoveryRunRecord, HydeGraphDatabase, NegotiationGraphLike, OpportunityGraphDatabase, RawToolDefinition, ResolvedToolContext, ToolDeps } from '@indexnetwork/protocol';
 
 import { log } from '../../lib/log';
 import { captureAppException } from '../../lib/sentry';
@@ -16,6 +16,7 @@ import { resolveProtocolBaseUrl } from '../../lib/protocol-url';
 import type { ConnectLinkKind } from '../../services/connect-link.service';
 import { negotiationRunExistingQueue } from '../negotiations/run-existing.queue';
 import { questionerEnqueueIfEnabled } from '../questioner.queue';
+import { maybeMinePoolDiscriminators } from '../pool/mining.shared';
 
 export const QUEUE_NAME = 'opportunity-discovery-run';
 
@@ -41,20 +42,6 @@ const mintConnectLink = async ({ userId, opportunityId, kind, greeting, preferre
   return { url: buildConnectShortUrl(apiBaseUrl, code) };
 };
 
-/** Statuses that make an opportunity part of the viewer's live candidate pool. */
-const POOL_STATUSES = ['draft', 'latent', 'pending', 'negotiating'] as const;
-
-/** Max chars of bio / match-reason folded into one candidate's publicContext. */
-const POOL_FIELD_MAX_CHARS = 100;
-
-/** Splits free text into novelty-reference sentences (short fragments dropped). */
-function toReferenceSentences(text: string): string[] {
-  return text
-    .split(/[.!?\n]+/)
-    .map((s) => s.trim())
-    .filter((s) => s.length > 15);
-}
-
 function assertDiscoveryRunOutputFits(raw: string): void {
   const policy = getToolTimeoutPolicy('discover_opportunities');
   const outputBytes = new TextEncoder().encode(raw).byteLength;
@@ -72,10 +59,6 @@ export class DiscoveryRunQueue {
 
   private readonly logger = log.job.from('DiscoveryRunJob');
   private readonly queueLogger = log.queue.from('DiscoveryRunQueue');
-  /** Greppable shadow-mining logger (IND-417): search deploy logs for "PoolDiscriminatorMiner". */
-  private readonly poolDiscriminatorLogger = log.job.from('PoolDiscriminatorMiner');
-  /** Lazily constructed so queue creation never requires OPENROUTER_API_KEY. */
-  private poolDiscriminatorMiner: PoolDiscriminatorMiner | null = null;
   private worker: ReturnType<typeof QueueFactory.createWorker<DiscoveryRunJobData>> | null = null;
   private deps: DiscoveryRunQueueDeps | undefined;
 
@@ -293,177 +276,18 @@ export class DiscoveryRunQueue {
   }
 
   /**
-   * IND-417 shadow axis mining + IND-418 question enqueue. Fire-and-forget:
-   * never awaited by the run lifecycle and never allowed to fail the
-   * discovery run. Mining runs when POOL_QUESTIONS_MINING=shadow OR
-   * POOL_QUESTIONS_MODE=on; questions are enqueued only when the latter is on
-   * (and QUESTIONER_ENABLED gates the actual enqueue). Both flags off = zero
-   * behavior change.
-   *
-   * The pool is read from the opportunities table (the run's durable output —
-   * the MCP tool response flattens cards into message text, so the run result
-   * carries no structured candidate array). These are also the exact rows P3
-   * will re-rank, so mining over them keeps the phases consistent.
+   * Pool-discriminator mining + question enqueue on run completion
+   * (IND-417/418) — shared with FromIntentQueue, see queues/pool/mining.shared.ts.
    */
   private maybeMinePoolDiscriminators(run: DiscoveryRunRecord): void {
-    if (poolQuestionsMiningMode() !== 'shadow' && poolQuestionsMode() !== 'on') return;
-    // Introducer flow: the discovered candidates are matches for someone else,
-    // not the viewer's own pool — discriminator questions don't apply.
-    if (run.input.introTargetUserId) return;
-    void this.minePoolDiscriminatorsShadow(run).catch((err) => {
-      this.poolDiscriminatorLogger.warn('shadow mining pass failed', {
-        runId: run.id,
-        userId: run.userId,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    });
-  }
-
-  private async minePoolDiscriminatorsShadow(run: DiscoveryRunRecord): Promise<void> {
-    const intentId = run.input.intentId;
-    const pool = await chatDatabaseAdapter.getOpportunitiesForUser(run.userId, {
-      statuses: [...POOL_STATUSES],
-      limit: 50,
-      ...(intentId ? { scopeType: 'intent' as const, scopeId: intentId } : {}),
-      // Chat-scoped MCP discovery creates this session's candidates as drafts;
-      // passing the session id includes them in the pool.
-      ...(run.context.sessionId ? { conversationId: run.context.sessionId } : {}),
-    });
-
-    const withCounterpart = pool
-      .map((o) => ({
-        opportunity: o,
-        counterpartUserId: o.actors.find((a) => a.userId !== run.userId && a.role !== 'introducer')?.userId,
-      }))
-      .filter((x): x is typeof x & { counterpartUserId: string } => Boolean(x.counterpartUserId));
-
-    if (withCounterpart.length < POOL_DISCRIMINATOR_MIN_POOL_SIZE) {
-      this.poolDiscriminatorLogger.debug('shadow mining skipped: pool below k-anonymity floor', {
-        runId: run.id,
-        poolSize: withCounterpart.length,
-        minPoolSize: POOL_DISCRIMINATOR_MIN_POOL_SIZE,
-      });
-      return;
-    }
-
-    const top = withCounterpart
-      .sort((a, b) => (b.opportunity.interpretation?.confidence ?? 0) - (a.opportunity.interpretation?.confidence ?? 0))
-      .slice(0, POOL_DISCRIMINATOR_MAX_CANDIDATES);
-
-    // Thin per-candidate context: profile name/bio + ≤3 active premise
-    // snippets — the same public corpus the presenter exposes.
-    const uniqueUserIds = [...new Set(top.map((c) => c.counterpartUserId))];
-    const profilesByUser = new Map<string, { name: string; bio: string }>();
-    await Promise.all(uniqueUserIds.map(async (uid) => {
-      try {
-        const profile = await chatDatabaseAdapter.getProfile(uid);
-        if (profile) profilesByUser.set(uid, { name: profile.identity.name, bio: profile.identity.bio });
-      } catch {
-        // Profile is enrichment only — a failed lookup never blocks mining.
-      }
-    }));
-    const premisesByUser = new Map<string, string>();
-    await Promise.all(uniqueUserIds.map(async (uid) => {
-      try {
-        const premises = await chatDatabaseAdapter.getPremisesForUser(uid, 'ACTIVE');
-        const snippets = premises.slice(0, 3).map((p) => p.assertion.text.slice(0, 90));
-        if (snippets.length > 0) premisesByUser.set(uid, snippets.join('; '));
-      } catch {
-        // Premises are enrichment only — a failed lookup never blocks mining.
-      }
-    }));
-
-    const candidates: PoolCandidate[] = top.map((c) => {
-      const profile = profilesByUser.get(c.counterpartUserId);
-      const matchReason = c.opportunity.interpretation?.reasoning?.slice(0, POOL_FIELD_MAX_CHARS);
-      const publicContext = [
-        profile?.name ? `Name: ${profile.name}.` : null,
-        profile?.bio ? `Bio: ${profile.bio.slice(0, POOL_FIELD_MAX_CHARS)}` : null,
-        matchReason ? `Match: ${matchReason}` : null,
-        premisesByUser.has(c.counterpartUserId) ? `Premises: ${premisesByUser.get(c.counterpartUserId)}` : null,
-      ].filter(Boolean).join(' ').slice(0, POOL_DISCRIMINATOR_MAX_PUBLIC_CONTEXT_CHARS);
-      return { id: c.opportunity.id, publicContext, score: c.opportunity.interpretation?.confidence ?? 0 };
-    });
-
-    // Intent text: prefer the triggering intent record; fall back to the ad-hoc query.
-    let intentText = run.input.searchQuery ?? run.input.hint ?? '';
-    if (intentId) {
-      const intent = await chatDatabaseAdapter.getIntent(intentId);
-      if (intent) intentText = `${intent.payload}${intent.summary ? ` (${intent.summary})` : ''}`;
-    }
-
-    // Novelty references: the owner's own intent sentences + active premises —
-    // axes the user has effectively already answered should score ~0.
-    let ownerPremises: string[] = [];
-    try {
-      ownerPremises = (await chatDatabaseAdapter.getPremisesForUser(run.userId, 'ACTIVE'))
-        .slice(0, 12)
-        .map((p) => p.assertion.text);
-    } catch {
-      // Novelty degrades gracefully without references.
-    }
-    const referenceTexts = [...toReferenceSentences(intentText), ...ownerPremises];
-
-    this.poolDiscriminatorMiner ??= new PoolDiscriminatorMiner();
-    const shadow = await runPoolDiscriminatorShadow({
-      intentText,
-      candidates,
-      referenceTexts,
-      miner: this.poolDiscriminatorMiner,
-      embedder: embedderAdapter,
-    });
-
-    const round = (n: number): number => Math.round(n * 1000) / 1000;
-    this.poolDiscriminatorLogger.info('shadow mining result', {
+    maybeMinePoolDiscriminators({
+      source: 'discovery_run',
       runId: run.id,
       userId: run.userId,
-      intentId: intentId ?? null,
-      poolSize: shadow.poolSize,
-      discriminators: shadow.discriminators.map((d) => ({
-        label: d.label,
-        questionSeed: d.questionSeed,
-        sides: d.sides,
-        voi: round(d.voi),
-        entropy: round(d.entropy),
-        coverage: round(d.coverage),
-        novelty: round(d.novelty),
-        evidenceRate: round(d.evidenceRate),
-      })),
-    });
-
-    // IND-418: turn the top eligible discriminator into a pool_discovery
-    // question. QUESTIONER_ENABLED gates via questionerEnqueueIfEnabled;
-    // budget + dedup enforcement lives in the QuestionerQueue worker.
-    if (poolQuestionsMode() !== 'on' || !intentId) return;
-    const enqueue = questionerEnqueueIfEnabled();
-    if (!enqueue) return;
-    const eligible = selectQuestionDiscriminators(shadow.discriminators);
-    if (eligible.length === 0) {
-      this.poolDiscriminatorLogger.debug('no discriminator cleared the question bar', {
-        runId: run.id,
-        intentId,
-      });
-      return;
-    }
-    await enqueue({
-      mode: 'pool_discovery',
-      userId: run.userId,
-      sourceType: 'intent',
-      sourceId: intentId,
-      triggeredByIntentId: intentId,
-      context: {
-        intentId,
-        intentText,
-        poolSize: shadow.poolSize,
-        runId: run.id,
-        minedAt: new Date().toISOString(),
-        discriminators: eligible.map(toQuestionDiscriminator),
-      },
-    });
-    this.poolDiscriminatorLogger.info('pool question enqueued', {
-      runId: run.id,
-      intentId,
-      eligible: eligible.length,
+      ...(run.input.intentId ? { intentId: run.input.intentId } : {}),
+      ...(run.context.sessionId ? { sessionId: run.context.sessionId } : {}),
+      isIntroducerFlow: Boolean(run.input.introTargetUserId),
+      ...(run.input.searchQuery ?? run.input.hint ? { searchQuery: run.input.searchQuery ?? run.input.hint } : {}),
     });
   }
 }

--- a/services/api/src/queues/opportunity/from-intent.queue.ts
+++ b/services/api/src/queues/opportunity/from-intent.queue.ts
@@ -7,6 +7,7 @@ import { ChatDatabaseAdapter } from '../../adapters/database.adapter';
 import type { NegotiationGraphLike, AgentDispatcher } from '@indexnetwork/protocol';
 
 import { createOpportunityGraphDb, runOpportunityDiscovery, type OpportunityGraphDb } from './discovery.shared';
+import { maybeMinePoolDiscriminators, type PoolMiningTrigger } from '../pool/mining.shared';
 
 export const QUEUE_NAME = 'opportunity-from-intent';
 
@@ -32,6 +33,8 @@ export interface FromIntentDeps {
   invokeOpportunityGraph?: (opts: FromIntentGraphInvokeOptions) => Promise<void>;
   negotiationGraph?: NegotiationGraphLike;
   agentDispatcher?: Pick<AgentDispatcher, 'hasExternalAgent'>;
+  /** Pool-discriminator mining hook (IND-417/418). Defaults to the shared fire-and-forget implementation; injectable for tests. */
+  minePoolDiscriminators?: (trigger: PoolMiningTrigger) => void;
 }
 
 export class FromIntentQueue {
@@ -117,6 +120,16 @@ export class FromIntentQueue {
       label: 'FromIntent',
       errorLabel: 'from-intent',
       logContext: { intentId, userId },
+    });
+
+    // Pool-discriminator mining + question enqueue (IND-417/418): web intent
+    // creation/edit is the frontend's discovery path — without this hook only
+    // MCP-triggered runs would ever produce pool questions. Fire-and-forget;
+    // flags off = no-op.
+    (this.deps?.minePoolDiscriminators ?? maybeMinePoolDiscriminators)({
+      source: 'from_intent',
+      userId,
+      intentId,
     });
   }
 

--- a/services/api/src/queues/pool/mining.shared.ts
+++ b/services/api/src/queues/pool/mining.shared.ts
@@ -1,0 +1,235 @@
+/**
+ * Shared pool-discriminator mining hook (IND-417/418, generalized in P2.1).
+ *
+ * One discovery pipeline finishes → mine discriminators over the viewer's
+ * intent pool (shadow log) and, when POOL_QUESTIONS_MODE=on, enqueue a
+ * pool_discovery question for the top eligible discriminator.
+ *
+ * Callers (fire-and-forget from every discovery completion path):
+ *   - DiscoveryRunQueue   — async MCP discover_opportunities runs
+ *   - FromIntentQueue     — web intent creation / edit / re-discovery
+ *
+ * The pool is read from the opportunities table (durable output; the MCP
+ * tool response flattens cards into message text, so no run result carries a
+ * structured candidate array). These are also the exact rows P3 re-ranks, so
+ * mining over them keeps the phases consistent.
+ *
+ * Flags: mining runs when POOL_QUESTIONS_MINING=shadow OR
+ * POOL_QUESTIONS_MODE=on; question enqueue additionally requires MODE=on and
+ * QUESTIONER_ENABLED (via questionerEnqueueIfEnabled). All off = no-op.
+ */
+import { POOL_DISCRIMINATOR_MAX_CANDIDATES, POOL_DISCRIMINATOR_MAX_PUBLIC_CONTEXT_CHARS, POOL_DISCRIMINATOR_MIN_POOL_SIZE, PoolDiscriminatorMiner, poolQuestionsMiningMode, poolQuestionsMode, runPoolDiscriminatorShadow, selectQuestionDiscriminators, toQuestionDiscriminator } from '@indexnetwork/protocol';
+import type { PoolCandidate } from '@indexnetwork/protocol';
+
+import { log } from '../../lib/log';
+import { chatDatabaseAdapter } from '../../adapters/database.adapter';
+import { embedderAdapter } from '../../adapters/embedder.adapter';
+import { questionerEnqueueIfEnabled } from '../questioner.queue';
+
+/** Greppable logger (IND-417): search deploy logs for "PoolDiscriminatorMiner". */
+const logger = log.job.from('PoolDiscriminatorMiner');
+
+/** Statuses that make an opportunity part of the viewer's live candidate pool. */
+const POOL_STATUSES = ['draft', 'latent', 'pending', 'negotiating'] as const;
+
+/** Max chars of bio / match-reason folded into one candidate's publicContext. */
+const POOL_FIELD_MAX_CHARS = 100;
+
+/** Lazily constructed so importing this module never requires OPENROUTER_API_KEY. */
+let poolDiscriminatorMiner: PoolDiscriminatorMiner | null = null;
+
+/** One discovery-completion event, normalized across trigger sources. */
+export interface PoolMiningTrigger {
+  /** Which pipeline finished (log dimension). */
+  source: 'discovery_run' | 'from_intent';
+  userId: string;
+  /** Triggering intent — required for questions; optional for shadow-only ad-hoc pools. */
+  intentId?: string;
+  /** Discovery run id, when the source has one. */
+  runId?: string;
+  /** Chat session that scoped the discovery (includes that session's drafts in the pool). */
+  sessionId?: string;
+  /** True for introducer-flow discovery: candidates are matches for someone else — skip. */
+  isIntroducerFlow?: boolean;
+  /** Ad-hoc query fallback for intent text (shadow-only pools). */
+  searchQuery?: string;
+}
+
+/** Splits free text into novelty-reference sentences (short fragments dropped). */
+function toReferenceSentences(text: string): string[] {
+  return text
+    .split(/[.!?\n]+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 15);
+}
+
+/**
+ * Fire-and-forget entry point: never awaited by the caller's lifecycle and
+ * never allowed to fail the discovery pipeline. Both flags off = no-op.
+ */
+export function maybeMinePoolDiscriminators(trigger: PoolMiningTrigger): void {
+  if (poolQuestionsMiningMode() !== 'shadow' && poolQuestionsMode() !== 'on') return;
+  // Introducer flow: the discovered candidates are matches for someone else,
+  // not the viewer's own pool — discriminator questions don't apply.
+  if (trigger.isIntroducerFlow) return;
+  void minePoolDiscriminators(trigger).catch((err) => {
+    logger.warn('shadow mining pass failed', {
+      source: trigger.source,
+      runId: trigger.runId ?? null,
+      userId: trigger.userId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  });
+}
+
+async function minePoolDiscriminators(trigger: PoolMiningTrigger): Promise<void> {
+  const { userId, intentId } = trigger;
+  const pool = await chatDatabaseAdapter.getOpportunitiesForUser(userId, {
+    statuses: [...POOL_STATUSES],
+    limit: 50,
+    ...(intentId ? { scopeType: 'intent' as const, scopeId: intentId } : {}),
+    // Chat-scoped MCP discovery creates this session's candidates as drafts;
+    // passing the session id includes them in the pool.
+    ...(trigger.sessionId ? { conversationId: trigger.sessionId } : {}),
+  });
+
+  const withCounterpart = pool
+    .map((o) => ({
+      opportunity: o,
+      counterpartUserId: o.actors.find((a) => a.userId !== userId && a.role !== 'introducer')?.userId,
+    }))
+    .filter((x): x is typeof x & { counterpartUserId: string } => Boolean(x.counterpartUserId));
+
+  if (withCounterpart.length < POOL_DISCRIMINATOR_MIN_POOL_SIZE) {
+    logger.debug('shadow mining skipped: pool below k-anonymity floor', {
+      source: trigger.source,
+      runId: trigger.runId ?? null,
+      poolSize: withCounterpart.length,
+      minPoolSize: POOL_DISCRIMINATOR_MIN_POOL_SIZE,
+    });
+    return;
+  }
+
+  const top = withCounterpart
+    .sort((a, b) => (b.opportunity.interpretation?.confidence ?? 0) - (a.opportunity.interpretation?.confidence ?? 0))
+    .slice(0, POOL_DISCRIMINATOR_MAX_CANDIDATES);
+
+  // Thin per-candidate context: profile name/bio + ≤3 active premise
+  // snippets — the same public corpus the presenter exposes.
+  const uniqueUserIds = [...new Set(top.map((c) => c.counterpartUserId))];
+  const profilesByUser = new Map<string, { name: string; bio: string }>();
+  await Promise.all(uniqueUserIds.map(async (uid) => {
+    try {
+      const profile = await chatDatabaseAdapter.getProfile(uid);
+      if (profile) profilesByUser.set(uid, { name: profile.identity.name, bio: profile.identity.bio });
+    } catch {
+      // Profile is enrichment only — a failed lookup never blocks mining.
+    }
+  }));
+  const premisesByUser = new Map<string, string>();
+  await Promise.all(uniqueUserIds.map(async (uid) => {
+    try {
+      const premises = await chatDatabaseAdapter.getPremisesForUser(uid, 'ACTIVE');
+      const snippets = premises.slice(0, 3).map((p) => p.assertion.text.slice(0, 90));
+      if (snippets.length > 0) premisesByUser.set(uid, snippets.join('; '));
+    } catch {
+      // Premises are enrichment only — a failed lookup never blocks mining.
+    }
+  }));
+
+  const candidates: PoolCandidate[] = top.map((c) => {
+    const profile = profilesByUser.get(c.counterpartUserId);
+    const matchReason = c.opportunity.interpretation?.reasoning?.slice(0, POOL_FIELD_MAX_CHARS);
+    const publicContext = [
+      profile?.name ? `Name: ${profile.name}.` : null,
+      profile?.bio ? `Bio: ${profile.bio.slice(0, POOL_FIELD_MAX_CHARS)}` : null,
+      matchReason ? `Match: ${matchReason}` : null,
+      premisesByUser.has(c.counterpartUserId) ? `Premises: ${premisesByUser.get(c.counterpartUserId)}` : null,
+    ].filter(Boolean).join(' ').slice(0, POOL_DISCRIMINATOR_MAX_PUBLIC_CONTEXT_CHARS);
+    return { id: c.opportunity.id, publicContext, score: c.opportunity.interpretation?.confidence ?? 0 };
+  });
+
+  // Intent text: prefer the triggering intent record; fall back to the ad-hoc query.
+  let intentText = trigger.searchQuery ?? '';
+  if (intentId) {
+    const intent = await chatDatabaseAdapter.getIntent(intentId);
+    if (intent) intentText = `${intent.payload}${intent.summary ? ` (${intent.summary})` : ''}`;
+  }
+
+  // Novelty references: the owner's own intent sentences + active premises —
+  // axes the user has effectively already answered should score ~0.
+  let ownerPremises: string[] = [];
+  try {
+    ownerPremises = (await chatDatabaseAdapter.getPremisesForUser(userId, 'ACTIVE'))
+      .slice(0, 12)
+      .map((p) => p.assertion.text);
+  } catch {
+    // Novelty degrades gracefully without references.
+  }
+  const referenceTexts = [...toReferenceSentences(intentText), ...ownerPremises];
+
+  poolDiscriminatorMiner ??= new PoolDiscriminatorMiner();
+  const shadow = await runPoolDiscriminatorShadow({
+    intentText,
+    candidates,
+    referenceTexts,
+    miner: poolDiscriminatorMiner,
+    embedder: embedderAdapter,
+  });
+
+  const round = (n: number): number => Math.round(n * 1000) / 1000;
+  logger.info('shadow mining result', {
+    source: trigger.source,
+    runId: trigger.runId ?? null,
+    userId,
+    intentId: intentId ?? null,
+    poolSize: shadow.poolSize,
+    discriminators: shadow.discriminators.map((d) => ({
+      label: d.label,
+      questionSeed: d.questionSeed,
+      sides: d.sides,
+      voi: round(d.voi),
+      entropy: round(d.entropy),
+      coverage: round(d.coverage),
+      novelty: round(d.novelty),
+      evidenceRate: round(d.evidenceRate),
+    })),
+  });
+
+  // IND-418: turn the top eligible discriminator into a pool_discovery
+  // question. QUESTIONER_ENABLED gates via questionerEnqueueIfEnabled;
+  // budget + dedup enforcement lives in the QuestionerQueue worker.
+  if (poolQuestionsMode() !== 'on' || !intentId) return;
+  const enqueue = questionerEnqueueIfEnabled();
+  if (!enqueue) return;
+  const eligible = selectQuestionDiscriminators(shadow.discriminators);
+  if (eligible.length === 0) {
+    logger.debug('no discriminator cleared the question bar', {
+      source: trigger.source,
+      runId: trigger.runId ?? null,
+      intentId,
+    });
+    return;
+  }
+  await enqueue({
+    mode: 'pool_discovery',
+    userId,
+    sourceType: 'intent',
+    sourceId: intentId,
+    triggeredByIntentId: intentId,
+    context: {
+      intentId,
+      intentText,
+      poolSize: shadow.poolSize,
+      ...(trigger.runId ? { runId: trigger.runId } : {}),
+      minedAt: new Date().toISOString(),
+      discriminators: eligible.map(toQuestionDiscriminator),
+    },
+  });
+  logger.info('pool question enqueued', {
+    source: trigger.source,
+    runId: trigger.runId ?? null,
+    intentId,
+    eligible: eligible.length,
+  });
+}

--- a/services/api/src/queues/pool/question.shared.ts
+++ b/services/api/src/queues/pool/question.shared.ts
@@ -10,8 +10,8 @@
 import { synthesizePoolQuestion } from '@indexnetwork/protocol';
 import type { QuestionPoolDiscriminator } from '@indexnetwork/protocol';
 
-import type { AdapterPersistableQuestion, QuestionerAdapter } from '../adapters/questioner.adapter';
-import { QuestionEvents } from '../events/question.event';
+import type { AdapterPersistableQuestion, QuestionerAdapter } from '../../adapters/questioner.adapter';
+import { QuestionEvents } from '../../events/question.event';
 
 /** Normalized form used for axis dedup (re-asking an already-seen axis). */
 export function normalizePoolLabel(label: string): string {

--- a/services/api/src/queues/questioner.queue.ts
+++ b/services/api/src/queues/questioner.queue.ts
@@ -8,7 +8,7 @@ import { QueueFactory } from '../lib/bullmq/bullmq';
 import db from '../lib/drizzle/drizzle';
 import { QuestionerAdapter } from '../adapters/questioner.adapter';
 import { QuestionEvents } from '../events/question.event';
-import { buildPoolQuestion, dedupDiscriminators, persistPoolQuestion } from './pool-question.shared';
+import { buildPoolQuestion, dedupDiscriminators, persistPoolQuestion } from './pool/question.shared';
 
 /** BullMQ queue name for question generation jobs. */
 export const QUEUE_NAME = 'questioner-queue';

--- a/services/api/src/queues/tests/from-intent.queue.spec.ts
+++ b/services/api/src/queues/tests/from-intent.queue.spec.ts
@@ -90,6 +90,31 @@ describe('FromIntentQueue', () => {
       await queue.processJob('discover_opportunities', { intentId: 'missing', userId: 'u1' });
     });
 
+    it('discover: fires the pool-mining hook after discovery completes (IND-418 web coverage)', async () => {
+      const invokeOpportunityGraph = mock(async (_opts: FromIntentGraphInvokeOptions) => {});
+      const minePoolDiscriminators = mock((_trigger: unknown) => {});
+      const db = {
+        getIntentForIndexing: async () => ({ id: 'i1', payload: 'Build a SaaS', userId: 'u1', sourceType: null, sourceId: null }),
+      };
+      const queue = new FromIntentQueue({ database: asDb(db), invokeOpportunityGraph, minePoolDiscriminators });
+      await queue.processJob('discover_opportunities', { intentId: 'i1', userId: 'u1' });
+      expect(minePoolDiscriminators).toHaveBeenCalledWith({
+        source: 'from_intent',
+        userId: 'u1',
+        intentId: 'i1',
+      });
+    });
+
+    it('discover: does NOT fire the pool-mining hook when the intent is missing', async () => {
+      const minePoolDiscriminators = mock((_trigger: unknown) => {});
+      const db = {
+        getIntentForIndexing: async () => null as unknown as Awaited<ReturnType<FromIntentDatabase['getIntentForIndexing']>>,
+      };
+      const queue = new FromIntentQueue({ database: asDb(db), minePoolDiscriminators });
+      await queue.processJob('discover_opportunities', { intentId: 'missing', userId: 'u1' });
+      expect(minePoolDiscriminators).not.toHaveBeenCalled();
+    });
+
     it('discover: intent found, invokeOpportunityGraph called when provided', async () => {
       const invokeOpportunityGraph = mock(async (_opts: FromIntentGraphInvokeOptions) => {});
       const db = {


### PR DESCRIPTION
The mining+question hook lived only on the MCP discovery-run queue (`opportunity.tools.ts:714` is the sole producer of discovery runs), so purely web-originated flows — intent creation/edit → `fromIntentQueue` — never mined a pool or asked a question, despite the intent page being P2's primary surface.

## What
- **`queues/pool/mining.shared.ts`** (new): the full mine→score→log→enqueue pass extracted from `discovery-run.queue.ts`, generalized over a `PoolMiningTrigger` (`source: 'discovery_run' | 'from_intent'`, userId, intentId?, runId?, sessionId?, introducer skip, searchQuery fallback). Same contracts as before: fire-and-forget, never fails the pipeline, flags gate everything (`POOL_QUESTIONS_MINING=shadow` OR `POOL_QUESTIONS_MODE=on` to mine; MODE=on + `QUESTIONER_ENABLED` to enqueue), k≥5 floor, greppable `PoolDiscriminatorMiner` logger (now with a `source` dimension).
- **`from-intent.queue.ts`**: fires the hook after `runOpportunityDiscovery` completes — web intent creation/edit now mines and (flag on) asks. Injectable dep for tests. Not fired when the intent is missing.
- **`discovery-run.queue.ts`**: thin delegate to the shared hook — behavior unchanged.
- **Rename**: `queues/pool-question.shared.ts` → `queues/pool/question.shared.ts` (no-dash filename convention; the new mining module lives beside it).
- Ad-hoc chat discovery without an intentId stays shadow-only by design (pool questions are intent-scoped). Introducer flows still skipped. This shared hook is also the exact seam IND-419 (P3) needs for re-mine-on-completion after answer-triggered re-discovery.

## Coverage after this PR
| Trigger | Mines + asks? |
|---|---|
| MCP `discover_opportunities` | ✅ (unchanged) |
| Web intent creation/edit (`fromIntentQueue`) | ✅ **new** |
| Ad-hoc chat discovery (no intentId) | shadow-only by design |
| Introducer flows | skipped by design |

## Verification
api build clean; eslint clean; from-intent spec 14/14 (2 new: hook fires on completion / not on missing intent); pool-question queue arm 5/5; chaining 6/6. api → 0.31.0 (feat, minor).

Linear: IND-418 follow-up (parent IND-416)