### PR TITLE
docs(web): overview copy edits, Edge City field results, sort vertica…

### DIFF
--- a/apps/web/public/overview.html
+++ b/apps/web/public/overview.html
@@ -99,11 +99,11 @@ ol.learn li b{font-weight:600;}
 <body>
 <div class="doc">
   <h1>Index Network</h1>
-  <div class="subtitle">Trusting opportunities will find you</div>
+  <div class="subtitle">Trusting the right opportunities will find you</div>
 
   <section style="margin-top:24px;">
-    <p class="t">Index Network is a private, intent-driven social discovery protocol. You or your agent tell it your intents, what you're looking for or what you can offer, and, in the background, agents negotiate whether there's mutual intent, whether the timing is right, whether it's valuable to both sides, and everything in between.</p>
-    <p class="t">When there's alignment between agents, that's called an opportunity, surfaced to you along with the reasoning for why it's worth your time.</p>
+    <p class="t">Index Network is a private, intent-driven social discovery protocol. You or your agent tell it your intents and what you're looking for or what you can offer. In the background, agents negotiate on whether there's mutual intent, if the timing is right, and if it's valuable to both sides.</p>
+    <p class="t">When there's alignment between agents, that's called an opportunity. Opportunities are surfaced to users as proposed introductions to act on, along with the reasoning for why it's worth their time.</p>
   </section>
 
   <section>
@@ -113,7 +113,7 @@ ol.learn li b{font-weight:600;}
     <ul class="b">
       <li><b>It's broadcast-based.</b> The model is publish and hope someone sees it, which forces personal branding, engagement farming, algorithm dependence, and constant reposting just to stay visible.</li>
       <li><b>It's public.</b> Being found requires being public, so you expose unfinished ideas, leak strategy, worry about reputation, and self-censor, waiting until an idea is "ready" instead of thinking out loud.</li>
-      <li><b>It's manual.</b> You do all the work yourself, searching, browsing, messaging, and following up, again and again.</li>
+      <li><b>It's manual and frustrating.</b> You do all the work yourself, searching, browsing, messaging, and following up, again and again.</li>
     </ul>
   </section>
 
@@ -137,7 +137,7 @@ ol.learn li b{font-weight:600;}
       </li>
       <li><b>Negotiation:</b> What agents do in the background over each other's intents: a bilateral, turn-based exchange that probes whether there's mutual intent, whether the timing is right, whether it's valuable to both sides, and everything in between. Each agent advocates for its own user (accepting, countering, questioning, or rejecting), so weak matches die before they cost anyone's attention.</li>
       <li><b>Network:</b> The context and privacy boundary within which discovery happens: a community, event, or workspace whose members share intents with one another, where negotiations run within and across networks according to membership and access rules. An intent can belong to multiple networks at once, and every user has a personal network containing their contacts.</li>
-      <li><b>Opportunity:</b> What emerges when negotiating agents align. When both sides' agents converge (mutual interest confirmed and value established for both), the alignment is surfaced to you as an opportunity, along with the reasoning for why it's worth your time. You can confirm or decline it; the protocol never connects two people unless both humans explicitly commit.</li>
+      <li><b>Opportunity:</b> What emerges when negotiating agents align. When both sides' agents converge (mutual interest confirmed and value established for both), the alignment is surfaced to you as an opportunity for an introduction, along with the reasoning for why it's worth your time. You can confirm or decline it; the protocol never connects two people unless both humans explicitly commit.</li>
     </ul>
   </section>
 
@@ -160,8 +160,8 @@ ol.learn li b{font-weight:600;}
   </section>
 
   <section>
-    <h2>Field results: the Edge City Agent Village</h2>
-    <p class="t">Over four weeks in Healdsburg, CA (May 30 – June 27, 2026), residents of <a target="_blank" rel="noopener" href="https://www.edgecity.live/">Edge City</a> ran Index as a live experiment. 240 active residents each got a <a target="_blank" rel="noopener" href="https://hermes-agent.nousresearch.com/">Hermes agent</a> running Index and declared 505 intents, and the agents discovered each other across one protocol, creating human connection ambiently, without anyone running a search. <a target="_blank" rel="noopener" href="https://index.network/blog/field-notes-from-the-agent-village">Full field report</a>.</p>
+    <h2>Field results: The Edge City Agent Village</h2>
+    <p class="t">Over four weeks in Healdsburg, CA (May 30 – June 27, 2026), residents of <a target="_blank" rel="noopener" href="https://www.edgecity.live/">Edge City</a> ran Index as a live experiment. 240 active residents each got a <a target="_blank" rel="noopener" href="https://hermes-agent.nousresearch.com/">Hermes agent</a> running Index and declared 505 intents. The agents discovered each other across one protocol, creating high-value human connection both directly and ambiently, without anyone running manual searches. <a target="_blank" rel="noopener" href="https://index.network/blog/field-notes-from-the-agent-village">Full field report</a>.</p>
     <div class="tbwrap">
     <table class="tb" style="max-width:620px;">
       <tr><th>Stage</th><th>Count</th><th>Meaning</th></tr>
@@ -183,7 +183,7 @@ ol.learn li b{font-weight:600;}
       <li><b>People tell the agent their private intents.</b> An AI intermediary lowers the bar for needs people hesitate to raise; about 4% of intents touched personal territory, and incognito discovery let agents pursue sensitive goals off the public graph.</li>
       <li><b>People customized how their agent negotiates.</b> Residents tuned their agent with plain-language instructions (“optimize for depth, not volume”), and those who did tended to get better matches.</li>
       <li><b>Abundance is the next problem: ranking latent opportunity.</b> Agents generated more opportunity than residents could act on. Accepted and expired matches scored nearly identical broker confidence (0.89 vs. 0.88): timing, notification, and interface separated them, not quality.</li>
-      <li><b>Telegram is not the right surface for opportunities.</b> Opportunities arrived as notifications that scrolled out of view. Residents asked for a dedicated application, a persistent surface to review and act on matches, which is also what would clear the latent backlog.</li>
+      <li><b>Telegram is not the right surface for opportunities.</b> Opportunities arrived as notifications that scrolled out of view. Residents asked for a dedicated application—a persistent surface to review and act on matches, which is also what would clear the latent backlog.</li>
     </ol>
   </section>
 
@@ -193,13 +193,13 @@ ol.learn li b{font-weight:600;}
       <div class="tbwrap">
       <table class="tb">
       <tr><th style="width:28%;">Pair</th><th>Intents</th><th>Opps</th><th>Example intent</th></tr>
-      <tr><td><b>Researcher &harr; researcher</b></td><td class="num">~160</td><td class="num">~2,340</td><td class="mean">&ldquo;Connect with researchers and builders focused on the relationship of consciousness to ethics, mechanistic interpretability of large language model introspection, and theories of conscious valence and suffering.&rdquo;</td></tr>
       <tr><td><b>Founder &harr; founder</b></td><td class="num">~120</td><td class="num">~3,200</td><td class="mean">&ldquo;Find a full-stack, end-to-end technical co-founder in San Francisco with an interest in cafe culture, matcha, social graphs, human coordination, physical space experiences, UX, lighting, and behavioral psychology.&rdquo;</td></tr>
-      <tr><td><b>Investors &harr; founders</b></td><td class="num">~45</td><td class="num">~930</td><td class="mean">&ldquo;Seek investment for a DeepTech / Climate venture, specifically targeting investors interested in hardware, network science, or physical third spaces.&rdquo;</td></tr>
-      <tr><td><b>Jobs &amp; hiring</b></td><td class="num">~35</td><td class="num">~380</td><td class="mean">&ldquo;Seek senior AI infrastructure engineers for hiring.&rdquo;</td></tr>
+      <tr><td><b>Researcher &harr; researcher</b></td><td class="num">~160</td><td class="num">~2,340</td><td class="mean">&ldquo;Connect with researchers and builders focused on the relationship of consciousness to ethics, mechanistic interpretability of large language model introspection, and theories of conscious valence and suffering.&rdquo;</td></tr>
       <tr><td><b>Friendship &amp; lifestyle</b> <span class="sub">(books, sports, concerts, local exploration)</span></td><td class="num">~95</td><td class="num">~1,510</td><td class="mean">&ldquo;Connect with neurodivergent and deeply intuitive thinkers and builders for friendship and potential future collaboration.&rdquo;</td></tr>
-      <tr><td><b>Buyers &harr; sellers</b></td><td class="num">~35</td><td class="num">~660</td><td class="mean">&ldquo;Sublet a two-bedroom Healdsburg cottage for Weeks 3&ndash;4 to another Edge family before we fly out.&rdquo;</td></tr>
+      <tr><td><b>Investors &harr; founders</b></td><td class="num">~45</td><td class="num">~930</td><td class="mean">&ldquo;Seek investment for a DeepTech / Climate venture, specifically targeting investors interested in hardware, network science, or physical third spaces.&rdquo;</td></tr>
       <tr><td><b>Dating, tied to intellectual interest</b></td><td class="num">~35</td><td class="num">~670</td><td class="mean">&ldquo;Meet someone single at the village who reads philosophy of mind for fun, climbs on weekends, and is serious about starting a family in the next few years.&rdquo;</td></tr>
+      <tr><td><b>Buyers &harr; sellers</b></td><td class="num">~35</td><td class="num">~660</td><td class="mean">&ldquo;Sublet a two-bedroom Healdsburg cottage for Weeks 3&ndash;4 to another Edge family before we fly out.&rdquo;</td></tr>
+      <tr><td><b>Jobs &amp; hiring</b></td><td class="num">~35</td><td class="num">~380</td><td class="mean">&ldquo;Seek senior AI infrastructure engineers for hiring.&rdquo;</td></tr>
       </table>
       </div>
 

--- a/apps/web/src/app/overview/overview-body.html
+++ b/apps/web/src/app/overview/overview-body.html
@@ -1,10 +1,10 @@
 <div class="doc">
   <h1>Index Network</h1>
-  <div class="subtitle">Trusting opportunities will find you</div>
+  <div class="subtitle">Trusting the right opportunities will find you</div>
 
   <section style="margin-top:24px;">
-    <p class="t">Index Network is a private, intent-driven social discovery protocol. You or your agent tell it your intents, what you're looking for or what you can offer, and, in the background, agents negotiate whether there's mutual intent, whether the timing is right, whether it's valuable to both sides, and everything in between.</p>
-    <p class="t">When there's alignment between agents, that's called an opportunity, surfaced to you along with the reasoning for why it's worth your time.</p>
+    <p class="t">Index Network is a private, intent-driven social discovery protocol. You or your agent tell it your intents and what you're looking for or what you can offer. In the background, agents negotiate on whether there's mutual intent, if the timing is right, and if it's valuable to both sides.</p>
+    <p class="t">When there's alignment between agents, that's called an opportunity. Opportunities are surfaced to users as proposed introductions to act on, along with the reasoning for why it's worth their time.</p>
   </section>
 
   <section>
@@ -14,7 +14,7 @@
     <ul class="b">
       <li><b>It's broadcast-based.</b> The model is publish and hope someone sees it, which forces personal branding, engagement farming, algorithm dependence, and constant reposting just to stay visible.</li>
       <li><b>It's public.</b> Being found requires being public, so you expose unfinished ideas, leak strategy, worry about reputation, and self-censor, waiting until an idea is "ready" instead of thinking out loud.</li>
-      <li><b>It's manual.</b> You do all the work yourself, searching, browsing, messaging, and following up, again and again.</li>
+      <li><b>It's manual and frustrating.</b> You do all the work yourself, searching, browsing, messaging, and following up, again and again.</li>
     </ul>
   </section>
 
@@ -38,7 +38,7 @@
       </li>
       <li><b>Negotiation:</b> What agents do in the background over each other's intents: a bilateral, turn-based exchange that probes whether there's mutual intent, whether the timing is right, whether it's valuable to both sides, and everything in between. Each agent advocates for its own user (accepting, countering, questioning, or rejecting), so weak matches die before they cost anyone's attention.</li>
       <li><b>Network:</b> The context and privacy boundary within which discovery happens: a community, event, or workspace whose members share intents with one another, where negotiations run within and across networks according to membership and access rules. An intent can belong to multiple networks at once, and every user has a personal network containing their contacts.</li>
-      <li><b>Opportunity:</b> What emerges when negotiating agents align. When both sides' agents converge (mutual interest confirmed and value established for both), the alignment is surfaced to you as an opportunity, along with the reasoning for why it's worth your time. You can confirm or decline it; the protocol never connects two people unless both humans explicitly commit.</li>
+      <li><b>Opportunity:</b> What emerges when negotiating agents align. When both sides' agents converge (mutual interest confirmed and value established for both), the alignment is surfaced to you as an opportunity for an introduction, along with the reasoning for why it's worth your time. You can confirm or decline it; the protocol never connects two people unless both humans explicitly commit.</li>
     </ul>
   </section>
 
@@ -61,8 +61,8 @@
   </section>
 
   <section>
-    <h2>Field results: the Edge Esmeralda Agent Village</h2>
-    <p class="t">Over four weeks in Healdsburg, CA (May 30 – June 27, 2026), residents of the Edge Esmeralda village ran Index as a live experiment. 240 active residents each got a Hermes agent running Index and declared 505 intents, and the agents discovered each other across one protocol, creating human connection ambiently, without anyone running a search. Full field report on request.</p>
+    <h2>Field results: The Edge City Agent Village</h2>
+    <p class="t">Over four weeks in Healdsburg, CA (May 30 – June 27, 2026), residents of <a href="https://www.edgecity.live/">Edge City</a> ran Index as a live experiment. 240 active residents each got a <a href="https://hermes-agent.nousresearch.com/">Hermes agent</a> running Index and declared 505 intents. The agents discovered each other across one protocol, creating high-value human connection both directly and ambiently, without anyone running manual searches. <a href="/blog/field-notes-from-the-agent-village">Full field report</a>.</p>
     <div class="tbwrap">
     <table class="tb" style="max-width:620px;">
       <tr><th>Stage</th><th>Count</th><th>Meaning</th></tr>
@@ -84,7 +84,7 @@
       <li><b>People tell the agent their private intents.</b> An AI intermediary lowers the bar for needs people hesitate to raise; about 4% of intents touched personal territory, and incognito discovery let agents pursue sensitive goals off the public graph.</li>
       <li><b>People customized how their agent negotiates.</b> Residents tuned their agent with plain-language instructions (“optimize for depth, not volume”), and those who did tended to get better matches.</li>
       <li><b>Abundance is the next problem: ranking latent opportunity.</b> Agents generated more opportunity than residents could act on. Accepted and expired matches scored nearly identical broker confidence (0.89 vs. 0.88): timing, notification, and interface separated them, not quality.</li>
-      <li><b>Telegram is not the right surface for opportunities.</b> Opportunities arrived as notifications that scrolled out of view. Residents asked for a dedicated application, a persistent surface to review and act on matches, which is also what would clear the latent backlog.</li>
+      <li><b>Telegram is not the right surface for opportunities.</b> Opportunities arrived as notifications that scrolled out of view. Residents asked for a dedicated application—a persistent surface to review and act on matches, which is also what would clear the latent backlog.</li>
     </ol>
   </section>
 
@@ -94,13 +94,13 @@
       <div class="tbwrap">
       <table class="tb">
       <tr><th style="width:28%;">Pair</th><th>Intents</th><th>Opps</th><th>Example intent</th></tr>
-      <tr><td><b>Researcher &harr; researcher</b></td><td class="num">~160</td><td class="num">~2,340</td><td class="mean">&ldquo;Connect with researchers and builders focused on the relationship of consciousness to ethics, mechanistic interpretability of large language model introspection, and theories of conscious valence and suffering.&rdquo;</td></tr>
       <tr><td><b>Founder &harr; founder</b></td><td class="num">~120</td><td class="num">~3,200</td><td class="mean">&ldquo;Find a full-stack, end-to-end technical co-founder in San Francisco with an interest in cafe culture, matcha, social graphs, human coordination, physical space experiences, UX, lighting, and behavioral psychology.&rdquo;</td></tr>
-      <tr><td><b>Investors &harr; founders</b></td><td class="num">~45</td><td class="num">~930</td><td class="mean">&ldquo;Seek investment for a DeepTech / Climate venture, specifically targeting investors interested in hardware, network science, or physical third spaces.&rdquo;</td></tr>
-      <tr><td><b>Jobs &amp; hiring</b></td><td class="num">~35</td><td class="num">~380</td><td class="mean">&ldquo;Seek senior AI infrastructure engineers for hiring.&rdquo;</td></tr>
+      <tr><td><b>Researcher &harr; researcher</b></td><td class="num">~160</td><td class="num">~2,340</td><td class="mean">&ldquo;Connect with researchers and builders focused on the relationship of consciousness to ethics, mechanistic interpretability of large language model introspection, and theories of conscious valence and suffering.&rdquo;</td></tr>
       <tr><td><b>Friendship &amp; lifestyle</b> <span class="sub">(books, sports, concerts, local exploration)</span></td><td class="num">~95</td><td class="num">~1,510</td><td class="mean">&ldquo;Connect with neurodivergent and deeply intuitive thinkers and builders for friendship and potential future collaboration.&rdquo;</td></tr>
-      <tr><td><b>Buyers &harr; sellers</b></td><td class="num">~35</td><td class="num">~660</td><td class="mean">&ldquo;Sublet a two-bedroom Healdsburg cottage for Weeks 3&ndash;4 to another Edge family before we fly out.&rdquo;</td></tr>
+      <tr><td><b>Investors &harr; founders</b></td><td class="num">~45</td><td class="num">~930</td><td class="mean">&ldquo;Seek investment for a DeepTech / Climate venture, specifically targeting investors interested in hardware, network science, or physical third spaces.&rdquo;</td></tr>
       <tr><td><b>Dating, tied to intellectual interest</b></td><td class="num">~35</td><td class="num">~670</td><td class="mean">&ldquo;Meet someone single at the village who reads philosophy of mind for fun, climbs on weekends, and is serious about starting a family in the next few years.&rdquo;</td></tr>
+      <tr><td><b>Buyers &harr; sellers</b></td><td class="num">~35</td><td class="num">~660</td><td class="mean">&ldquo;Sublet a two-bedroom Healdsburg cottage for Weeks 3&ndash;4 to another Edge family before we fly out.&rdquo;</td></tr>
+      <tr><td><b>Jobs &amp; hiring</b></td><td class="num">~35</td><td class="num">~380</td><td class="mean">&ldquo;Seek senior AI infrastructure engineers for hiring.&rdquo;</td></tr>
       </table>
       </div>
 


### PR DESCRIPTION
…ls by opportunities

Copy edits to the protocol overview:

- Subtitle: "Trusting the right opportunities will find you"
- Rework the intro paragraphs; frame opportunities as proposed introductions surfaced to users
- "It's manual" -> "It's manual and frustrating"
- Opportunity is surfaced as "an opportunity for an introduction"
- Field results retitled to The Edge City Agent Village, with the high-value/directly-and-ambiently rewrite and a linked field report
- Sort the verticals table by opportunities descending (was unsorted by either column)

Also resolves drift between the two hand-synced overview copies: the standalone public/overview.html already said "Edge City" and carried the Edge City / Hermes agent / field report links, while the /overview route body still said "Edge Esmeralda" and had no links. Both are now text-identical.