### PR TITLE
fix(protocol+api+web): pool-question surfaces — no global-chat leak, intent-identifying evidence, third-person seed fix

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/components/ChatContent.tsx
+++ b/apps/web/src/components/ChatContent.tsx
@@ -220,7 +220,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
     const scopeQuestionPromise = chatScope?.type === "intent"
       ? questionsService.getPending({ scopeType: "intent", scopeId: chatScope.id })
       : isNegotiatorDm
-        ? questionsService.getPending({ noConversation: true })
+        ? questionsService.getPending({ noConversation: true, excludeModes: ['pool_discovery'] })
         : Promise.resolve([] as PendingQuestion[]);
     Promise.all([
       questionsService.getByConversation(sessionId),

--- a/apps/web/src/contexts/QuestionsContext.tsx
+++ b/apps/web/src/contexts/QuestionsContext.tsx
@@ -34,7 +34,7 @@ export function QuestionsProvider({ children }: { children: ReactNode }) {
   const fetchQuestions = useCallback(async () => {
     if (!user?.id) return;
     try {
-      const pending = await questionsService.getPending({ noConversation: true });
+      const pending = await questionsService.getPending({ noConversation: true, excludeModes: ['pool_discovery'] });
       setQuestions(pending);
     } catch (err) {
       logger.error('Failed to fetch pending questions', { error: err });

--- a/apps/web/src/services/questions.ts
+++ b/apps/web/src/services/questions.ts
@@ -93,6 +93,8 @@ export const createQuestionsService = (
     scopeType?: 'intent';
     scopeId?: string;
     noConversation?: boolean;
+    /** Drop these modes server-side (e.g. pool_discovery on non-scoped surfaces). */
+    excludeModes?: Array<QuestionDetection['mode']>;
   }): Promise<PendingQuestion[]> => {
     const params = new URLSearchParams({ status: 'pending' });
     if (filters?.mode) params.set('mode', filters.mode);
@@ -101,6 +103,7 @@ export const createQuestionsService = (
     if (filters?.scopeType) params.set('scopeType', filters.scopeType);
     if (filters?.scopeId) params.set('scopeId', filters.scopeId);
     if (filters?.noConversation) params.set('noConversation', 'true');
+    if (filters?.excludeModes?.length) params.set('excludeModes', filters.excludeModes.join(','));
     const res = await api.get<QuestionsListResponse>(`/questions?${params}`);
     return res.questions ?? [];
   },

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/opportunity/discriminator/discriminator.question.ts
+++ b/packages/protocol/src/opportunity/discriminator/discriminator.question.ts
@@ -74,7 +74,13 @@ function toSecondPerson(seed: string): string {
     .replace(/\b(do|should|would|could|can|will) I\b/gi, (_, verb: string) => `${verb.toLowerCase()} you`)
     .replace(/\bam I\b/gi, "are you")
     .replace(/\bI\b/g, "you")
-    .replace(/\bmy\b/gi, "your");
+    .replace(/\bmy\b/gi, "your")
+    // Third-person seeds ("Is the user primarily involved…") — the question is
+    // asked TO the owner, never ABOUT them.
+    .replace(/\b(is|was) the (user|owner|discoverer)\b/gi, "are you")
+    .replace(/\bdoes the (user|owner|discoverer)\b/gi, "do you")
+    .replace(/\bthe (user|owner|discoverer)'s\b/gi, "your")
+    .replace(/\bthe (user|owner|discoverer)\b/gi, "you");
 }
 
 /**
@@ -117,6 +123,11 @@ export interface SynthesizePoolQuestionInput {
   minedAt: string;
   /** Discovery run id, when known. */
   runId?: string;
+  /**
+   * Intent payload snippet — folded into the evidence chip so the question
+   * self-identifies on any surface ("based on 16 people matching ‘…’").
+   */
+  intentText?: string;
 }
 
 /** Synthesized question: client payload + server-side snapshot. */
@@ -134,6 +145,13 @@ export function synthesizePoolQuestion(input: SynthesizePoolQuestionInput): Synt
   const { discriminator: d, poolSize } = input;
   if (poolSize < POOL_DISCRIMINATOR_MIN_POOL_SIZE) return null;
   if (d.sides.length < 2 || d.sides.length > 3) return null;
+
+  // Evidence chip: aggregate count + the intent it belongs to, so the card is
+  // self-identifying on every surface (QuestionSchema caps evidence at 160).
+  const snippet = input.intentText?.trim().replace(/\s+/g, " ") ?? "";
+  const evidence = snippet.length > 0
+    ? `based on ${poolSize} people matching “${snippet.slice(0, 110)}${snippet.length > 110 ? "…" : ""}”`
+    : `based on ${poolSize} people matching this intent`;
 
   const sideOptions: QuestionOption[] = d.sides.map((side) => ({
     label: chipLabel(side),
@@ -153,12 +171,13 @@ export function synthesizePoolQuestion(input: SynthesizePoolQuestionInput): Synt
       prompt: toPrompt(d.questionSeed, d.sides),
       options,
       multiSelect: false,
-      evidence: `based on ${poolSize} people matching this intent`,
+      evidence,
     },
     pool: {
       poolSize,
       minedAt: input.minedAt,
       ...(input.runId ? { runId: input.runId } : {}),
+      ...(snippet.length > 0 ? { intentText: snippet.slice(0, 160) } : {}),
       discriminator: d,
       alternates: input.alternates,
     },

--- a/packages/protocol/src/opportunity/discriminator/tests/discriminator.question.spec.ts
+++ b/packages/protocol/src/opportunity/discriminator/tests/discriminator.question.spec.ts
@@ -130,6 +130,43 @@ describe("synthesizePoolQuestion", () => {
     expect(out.payload.prompt).toBe("Do you want someone hands-on builder style, or advisor style?");
   });
 
+  it("rewrites third-person miner seeds ('the user') into second person", () => {
+    const out = synthesizePoolQuestion({
+      ...base,
+      discriminator: questionDiscriminator({
+        questionSeed: "Is the user primarily seeking a hands-on builder, or does the user prefer an advisor",
+      }),
+    })!;
+    expect(out.payload.prompt).toBe(
+      "Are you primarily seeking a hands-on builder, or do you prefer an advisor?",
+    );
+  });
+
+  it("names the intent in the evidence chip and stores it in the snapshot for chaining", () => {
+    const out = synthesizePoolQuestion({
+      ...base,
+      intentText: "Explore the use of LLMs for procedural video game narration",
+    })!;
+    expect(out.payload.evidence).toBe(
+      "based on 21 people matching \u201cExplore the use of LLMs for procedural video game narration\u201d",
+    );
+    expect(out.pool.intentText).toBe("Explore the use of LLMs for procedural video game narration");
+  });
+
+  it("truncates long intent snippets and keeps evidence within the 160-char schema cap", () => {
+    const long = "Collaborate with partners, advisors, technical professionals, agent builders, and protocol engineers on long-horizon coordination infrastructure for cities";
+    const out = synthesizePoolQuestion({ ...base, intentText: long })!;
+    expect(out.payload.evidence!.length).toBeLessThanOrEqual(160);
+    expect(out.payload.evidence).toContain("\u2026\u201d");
+    expect(() => QuestionSchema.parse(out.payload)).not.toThrow();
+  });
+
+  it("falls back to the generic evidence line without intentText", () => {
+    const out = synthesizePoolQuestion(base)!;
+    expect(out.payload.evidence).toBe("based on 21 people matching this intent");
+    expect(out.pool.intentText).toBeUndefined();
+  });
+
   it("rewrites first-person miner seeds into second person", () => {
     const out = synthesizePoolQuestion({
       ...base,

--- a/packages/protocol/src/shared/schemas/question.schema.ts
+++ b/packages/protocol/src/shared/schemas/question.schema.ts
@@ -114,6 +114,8 @@ export const QuestionPoolSnapshotSchema = z.object({
   minedAt: z.string().min(1),
   /** Discovery run that produced the pool, when known. */
   runId: z.string().optional(),
+  /** Intent payload snippet (≤160 chars) — reused by chained questions' evidence chips. */
+  intentText: z.string().optional(),
   /** The discriminator this question asks about. */
   discriminator: QuestionPoolDiscriminatorSchema,
   /** Remaining ranked discriminators for interview-mode chaining. */

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/adapters/questioner.adapter.ts
+++ b/services/api/src/adapters/questioner.adapter.ts
@@ -117,6 +117,12 @@ export interface AdapterQuestionFilters {
   noConversation?: boolean;
   /** Restrict to questions whose detection mode is in this set. */
   modes?: AdapterQuestionMode[];
+  /**
+   * Drop questions whose detection mode is in this set. Used by non-scoped
+   * surfaces (global chat, questions inbox) to hide intent-scoped
+   * pool_discovery questions until the P5 push channel ships (IND-418/421).
+   */
+  excludeModes?: AdapterQuestionMode[];
   /** Maximum rows to return (applied as a SQL LIMIT). */
   limit?: number;
 }
@@ -225,6 +231,11 @@ export class QuestionerAdapter {
         (mode) => sql`${questions.detection}->>'mode' = ${mode}`,
       );
       conditions.push(or(...modeConditions)!);
+    }
+    if (filters?.excludeModes && filters.excludeModes.length > 0) {
+      for (const mode of filters.excludeModes) {
+        conditions.push(sql`${questions.detection}->>'mode' <> ${mode}`);
+      }
     }
 
     const baseQuery = this.db

--- a/services/api/src/controllers/question.controller.ts
+++ b/services/api/src/controllers/question.controller.ts
@@ -76,6 +76,7 @@ export class QuestionController {
     const sourceId = url.searchParams.get('sourceId');
     const conversationId = url.searchParams.get('conversationId');
     const noConversation = url.searchParams.get('noConversation');
+    const rawExcludeModes = url.searchParams.get('excludeModes');
     const scope = parseIntentScopeFromUrl(url);
     if (scope instanceof Response) return scope;
 
@@ -106,6 +107,16 @@ export class QuestionController {
         );
       }
       filters.mode = modeResult.data;
+    }
+    if (rawExcludeModes) {
+      const parsed = rawExcludeModes.split(',').map((m) => modeQuerySchema.safeParse(m.trim()));
+      if (parsed.some((r) => !r.success)) {
+        return Response.json(
+          { error: 'Invalid excludeModes; use a comma-separated list of: discovery, intent, enrichment, negotiation, negotiation_inflight, chat, pool_discovery' },
+          { status: 400 },
+        );
+      }
+      filters.excludeModes = parsed.map((r) => (r as { success: true; data: AdapterQuestionFilters['mode'] & string }).data);
     }
     if (sourceType) filters.sourceType = sourceType;
     if (sourceId) filters.sourceId = sourceId;

--- a/services/api/src/controllers/tests/question.inbox.spec.ts
+++ b/services/api/src/controllers/tests/question.inbox.spec.ts
@@ -116,6 +116,31 @@ describe("Pending question inbox (IND-404)", () => {
     expect(row.status).toBe('pending');
   });
 
+  test("excludeModes drops pool_discovery from the non-scoped inbox but keeps other modes (IND-418 surfaces fix)", async () => {
+    const poolQuestionId = await persistQuestion({
+      detection: {
+        mode: 'pool_discovery',
+        sourceType: 'intent',
+        sourceId: crypto.randomUUID(),
+        triggeredBy: crypto.randomUUID(),
+        timestamp: new Date().toISOString(),
+      },
+    });
+    const negotiationQuestionId = await persistQuestion();
+
+    // Non-scoped surfaces (global chat, questions inbox) exclude pool questions.
+    const excluded = await questionService.findPending(testUserId, {
+      noConversation: true,
+      excludeModes: ['pool_discovery'],
+    });
+    expect(excluded.map((q) => q.id)).not.toContain(poolQuestionId);
+    expect(excluded.map((q) => q.id)).toContain(negotiationQuestionId);
+
+    // Without the exclusion the pool question is still reachable (intent page path).
+    const all = await questionService.findPending(testUserId, { noConversation: true });
+    expect(all.map((q) => q.id)).toContain(poolQuestionId);
+  });
+
   test("conversation-bound questions stay out of the DM inbox", async () => {
     const questionId = await persistQuestion({
       detection: {

--- a/services/api/src/events/handlers/question.answer.pool.ts
+++ b/services/api/src/events/handlers/question.answer.pool.ts
@@ -59,6 +59,7 @@ export function chainPoolQuestionFactory(deps: ChainPoolQuestionDeps) {
       poolSize: pool.poolSize,
       minedAt: pool.minedAt,
       ...(pool.runId ? { runId: pool.runId } : {}),
+      ...(pool.intentText ? { intentText: pool.intentText } : {}),
       discriminators: fresh,
     });
     if (!question) return;

--- a/services/api/src/queues/pool/question.shared.ts
+++ b/services/api/src/queues/pool/question.shared.ts
@@ -35,6 +35,8 @@ export interface BuildPoolQuestionInput {
   /** ISO-8601 timestamp of the mining pass. */
   minedAt: string;
   runId?: string;
+  /** Intent payload snippet — folds into the evidence chip so the card self-identifies on any surface. */
+  intentText?: string;
   /** VoI-descending, deduped: first entry is asked, the rest become alternates. */
   discriminators: QuestionPoolDiscriminator[];
 }
@@ -49,6 +51,7 @@ export function buildPoolQuestion(input: BuildPoolQuestionInput): AdapterPersist
     poolSize: input.poolSize,
     minedAt: input.minedAt,
     ...(input.runId ? { runId: input.runId } : {}),
+    ...(input.intentText ? { intentText: input.intentText } : {}),
   });
   if (!synthesized) return null;
   return {

--- a/services/api/src/queues/questioner.queue.ts
+++ b/services/api/src/queues/questioner.queue.ts
@@ -231,6 +231,7 @@ export class QuestionerQueue {
       poolSize: context.poolSize,
       minedAt: context.minedAt,
       ...(context.runId ? { runId: context.runId } : {}),
+      ...(context.intentText ? { intentText: context.intentText } : {}),
       discriminators: fresh,
     });
     if (!question) {

--- a/services/api/src/queues/tests/pool-question.queue.spec.ts
+++ b/services/api/src/queues/tests/pool-question.queue.spec.ts
@@ -115,7 +115,9 @@ describe('QuestionerQueue pool_discovery arm', () => {
     expect(q.detection.pool?.discriminator.label).toBe('top');
     expect(q.detection.pool?.alternates.map((a) => a.label)).toEqual(['second']);
     expect(q.payload.options.map((o) => o.label)).toEqual(['Side A', 'Side B', 'Both matter']);
-    expect(q.payload.evidence).toBe('based on 21 people matching this intent');
+    // Evidence names the intent (context.intentText) so the card self-identifies on any surface.
+    expect(q.payload.evidence).toBe('based on 21 people matching \u201cfind collaborators\u201d');
+    expect(q.detection.pool?.intentText).toBe('find collaborators');
   });
 
   it('skips when a pool_discovery question is already pending for the intent', async () => {


### PR DESCRIPTION
Fixes the three defects found while dev-testing IND-418:

1. **Global-chat leak**: pool questions (conversationId=null) appeared in every `noConversation` surface (global Personal Agent chat, questions inbox) with no intent context. New `excludeModes` filter (adapter SQL + controller csv param + web service param); the two non-scoped call sites exclude `pool_discovery`. Intent-scoped surfaces unchanged — pool questions live on the intent page only until P5's deliberate push channel (IND-421).
2. **Unidentifiable intent**: evidence chip now names the intent — *based on 16 people matching “Explore the use of LLMs…”* (capped at the 160-char schema bound); snippet stored in `detection.pool.intentText` so chained questions inherit it.
3. **Third-person seeds**: `toSecondPerson` rewrites *is/does/possessive* “the user|owner|discoverer” forms (observed on dev: “Is the user primarily involved…”).

Versions: protocol 4.8.0, api 0.32.0, web 0.13.1. Tests: 16/16 synthesis (4 new), inbox integration 7/7 (1 new, real DB), queue arm 5/5 (evidence assertion updated), chaining 6/6, strip 3/3. Builds + lint clean.

Linear: IND-418 (parent IND-416)