### PR TITLE
fix(api): target premise retract cascade at citing opportunities + re-verify grounded intents (IND-423)

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "4.8.0",
+  "version": "4.9.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/docs/Academic Grounding Enhancement Backlog.md
+++ b/packages/protocol/src/docs/Academic Grounding Enhancement Backlog.md
@@ -10,6 +10,8 @@ Ordering below is **our** priority order (implementation leverage ÷ risk), whic
 
 ## 1. Premise dependency graph with revocation cascade — **M/L**
 
+> **Status: shipped (IND-423).** `handlePremiseCascade` now expires only opportunities whose provenance cites the lapsed premise (`metadata.evidence` `sourcePremiseId`/`candidatePremiseId` or actor-level grounding `premise`), and re-verifies the user's intents grounded on it (embedding-proximity heuristic, capped) via `SemanticVerifier`, refreshing their felicity scores. No new schema was needed — the evidence recorded by `buildCandidateEvidence` was already persisted on the opportunity row. An explicit premise→intent provenance edge remains future work.
+
 **Theory:** Schlangen & Skantze (2009), Incremental Unit model — grounded-in (`G`) links with confidence-propagation revocation. *(Report rank #1, Ch. 7.)*
 
 **The real gap it fixes (corrected after code verification):** a retract cascade already exists, but it is **blanket, not dependency-targeted**. `retract_premise` (`premise/premise.tools.ts`) fires `PremiseEvents.onRetracted` (`services/api/src/adapters/chat.database.adapter.ts`), which `handlePremiseCascade` (`services/api/src/queues/premise.queue.ts`) resolves by expiring **all** of the user's `draft`/`latent`/`pending`/`negotiating` opportunities — “regardless of how far along they were” — even those grounded entirely in *other* premises. Context regeneration is likewise wholesale (`userContextQueue.addRegenJob`). Intents are never re-verified at all. So the problem is twofold: **over-invalidation** of unrelated in-flight opportunities and **under-invalidation** of intents whose felicity rested on the retracted premise.

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -139,6 +139,8 @@ export { HydeGraphFactory } from "./shared/hyde/hyde.graph.js";
 export { NetworkGraphFactory } from "./network/network.graph.js";
 export { NetworkMembershipGraphFactory } from "./network/membership/membership.graph.js";
 export { IntentGraphFactory } from "./intent/intent.graph.js";
+export { SemanticVerifier } from "./intent/intent.verifier.js";
+export type { SemanticVerifierOutput } from "./intent/intent.verifier.js";
 export { IntentNetworkGraphFactory } from "./network/indexer/indexer.graph.js";
 export { MaintenanceGraphFactory } from "./maintenance/maintenance.graph.js";
 export type { MaintenanceGraphDatabase, MaintenanceGraphCache, MaintenanceGraphQueue } from "./maintenance/maintenance.graph.js";

--- a/services/api/src/adapters/chat.database.adapter.ts
+++ b/services/api/src/adapters/chat.database.adapter.ts
@@ -3457,6 +3457,43 @@ export class ChatDatabaseAdapter {
   }
 
   /**
+   * Find a user's own ACTIVE intents whose embeddings sit close to the given
+   * embedding. Used by the premise retract/expire cascade as the "grounded on"
+   * heuristic: no explicit premise→intent edge exists in the schema, so
+   * cosine proximity in the shared embedding space (text-embedding-3-large,
+   * 2000 dims — same space as premises) is the best available proxy for which
+   * intents were grounded on a lapsed premise and need re-verification (IND-423).
+   * @param params.userId - Owner of the intents (own intents only)
+   * @param params.embedding - The premise embedding to compare against
+   * @param params.minSimilarity - Cosine similarity floor (default 0.5)
+   * @param params.limit - Max intents to return (default 5)
+   */
+  async getIntentsGroundedOnEmbedding(params: {
+    userId: string;
+    embedding: number[];
+    minSimilarity?: number;
+    limit?: number;
+  }): Promise<Array<{ id: string; payload: string; similarity: number }>> {
+    const { userId, embedding, minSimilarity = 0.5, limit = 5 } = params;
+    const vectorStr = `[${embedding.join(',')}]`;
+    const rows = await db.execute<{ id: string; payload: string; similarity: number }>(sql`
+      SELECT
+        i.id,
+        i.payload,
+        1 - (i.embedding <=> ${vectorStr}::vector) AS similarity
+      FROM ${schema.intents} i
+      WHERE i.user_id = ${userId}
+        AND i.status = 'ACTIVE'
+        AND i.archived_at IS NULL
+        AND i.embedding IS NOT NULL
+        AND 1 - (i.embedding <=> ${vectorStr}::vector) >= ${minSimilarity}
+      ORDER BY i.embedding <=> ${vectorStr}::vector
+      LIMIT ${limit}
+    `);
+    return rows as Array<{ id: string; payload: string; similarity: number }>;
+  }
+
+  /**
    * Find ACTIVE premises whose validity.validUntil has passed.
    * Uses a JSONB text extraction cast to timestamptz for the comparison.
    * @returns Minimal rows: id and userId for each expired premise

--- a/services/api/src/adapters/opportunity.database.adapter.ts
+++ b/services/api/src/adapters/opportunity.database.adapter.ts
@@ -164,6 +164,46 @@ export class OpportunityDatabaseAdapter {
     return rows.map(toOpportunityRow);
   }
 
+  /**
+   * Retrieve opportunities for a user that cite a specific premise in their
+   * provenance. An opportunity "cites" the premise when:
+   *  - any `metadata.evidence` entry references it as `sourcePremiseId` or
+   *    `candidatePremiseId` (recorded by `buildCandidateEvidence` at discovery
+   *    time), or
+   *  - any actor row carries it as the grounding `premise` (set when
+   *    discoverySource is 'premise-similarity').
+   *
+   * Used by the premise retract/expire cascade so that only opportunities
+   * actually motivated by the lapsed premise are invalidated — opportunities
+   * evidenced solely by other premises are left untouched (IND-423).
+   * @param userId - The user whose opportunities to inspect (must be an actor)
+   * @param premiseId - The retracted/expired premise
+   * @param options - Optional status filter (e.g. cascade-eligible statuses)
+   */
+  async getOpportunitiesCitingPremise(
+    userId: string,
+    premiseId: string,
+    options?: { statuses?: string[] },
+  ): Promise<OpportunityRow[]> {
+    const conditions = [
+      sql`${opportunities.actors} @> ${JSON.stringify([{ userId }])}::jsonb`,
+      sql`(
+        ${opportunities.metadata}->'evidence' @> ${JSON.stringify([{ sourcePremiseId: premiseId }])}::jsonb
+        OR ${opportunities.metadata}->'evidence' @> ${JSON.stringify([{ candidatePremiseId: premiseId }])}::jsonb
+        OR ${opportunities.actors} @> ${JSON.stringify([{ premise: premiseId }])}::jsonb
+      )`,
+    ];
+    if (options?.statuses?.length) {
+      conditions.push(inArray(opportunities.status, options.statuses as Array<typeof opportunities.$inferSelect.status>));
+    }
+    const rows = await db
+      .select()
+      .from(opportunities)
+      .where(and(...conditions))
+      .orderBy(desc(opportunities.createdAt));
+    return rows.map(toOpportunityRow);
+  }
+
   async getOpportunitiesForNetwork(
     networkId: string,
     options?: { status?: string; statuses?: string[]; limit?: number; offset?: number }

--- a/services/api/src/adapters/tests/database.adapter.spec.ts
+++ b/services/api/src/adapters/tests/database.adapter.spec.ts
@@ -1735,3 +1735,163 @@ describe('Network overview member reads (EDG-53)', () => {
     expect(rows.every((r) => r.userId === fixture.userAId)).toBe(true);
   });
 });
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Premise cascade targeting (IND-423)
+// ═══════════════════════════════════════════════════════════════════════════════
+describe('Premise cascade targeting (IND-423)', () => {
+  const oppAdapter = new OpportunityDatabaseAdapter();
+  const chatAdapter = new ChatDatabaseAdapter();
+
+  const premiseAId = uuidv4();
+  const premiseBId = uuidv4();
+  const createdOppIds: string[] = [];
+  const createdIntentIds: string[] = [];
+
+  const CASCADE_STATUSES = ['draft', 'latent', 'pending', 'negotiating'];
+
+  const detection = () => ({
+    source: 'opportunity_graph' as const,
+    createdBy: 'agent-opportunity-finder',
+    timestamp: new Date().toISOString(),
+  });
+  const interpretation = { category: 'collaboration', reasoning: 'IND-423 fixture', confidence: 0.8 };
+
+  const makeOpp = async (opts: {
+    status: 'draft' | 'latent' | 'pending' | 'negotiating' | 'accepted';
+    evidence?: Array<Record<string, unknown>>;
+    actorPremise?: string;
+  }) => {
+    const created = await oppAdapter.createOpportunity({
+      detection: detection(),
+      actors: [
+        {
+          networkId: fixture.networkId,
+          userId: fixture.userAId,
+          role: 'agent',
+          ...(opts.actorPremise ? { premise: opts.actorPremise } : {}),
+        },
+        { networkId: fixture.networkId, userId: fixture.userBId, role: 'patient' },
+      ],
+      interpretation,
+      context: { networkId: fixture.networkId },
+      confidence: '0.8',
+      status: opts.status,
+      ...(opts.evidence !== undefined ? { metadata: { evidence: opts.evidence } } : {}),
+    });
+    createdOppIds.push(created.id);
+    return created;
+  };
+
+  afterAll(async () => {
+    if (createdOppIds.length) await db.delete(opportunities).where(inArray(opportunities.id, createdOppIds));
+    await db.delete(premises).where(inArray(premises.id, [premiseAId, premiseBId]));
+    if (createdIntentIds.length) await db.delete(intents).where(inArray(intents.id, createdIntentIds));
+  });
+
+  describe('getOpportunitiesCitingPremise', () => {
+    let citedViaSource: string;
+    let citedViaCandidate: string;
+    let citedViaActor: string;
+    let citesOtherPremise: string;
+    let noProvenance: string;
+    let citedButAccepted: string;
+
+    beforeAll(async () => {
+      citedViaSource = (await makeOpp({
+        status: 'pending',
+        evidence: [{ kind: 'premise_similarity', networkId: fixture.networkId, score: 0.8, sourcePremiseId: premiseAId }],
+      })).id;
+      citedViaCandidate = (await makeOpp({
+        status: 'negotiating',
+        evidence: [{ kind: 'query_premise', networkId: fixture.networkId, score: 0.7, candidatePremiseId: premiseAId }],
+      })).id;
+      citedViaActor = (await makeOpp({ status: 'draft', actorPremise: premiseAId })).id;
+      citesOtherPremise = (await makeOpp({
+        status: 'pending',
+        evidence: [{ kind: 'premise_similarity', networkId: fixture.networkId, score: 0.9, sourcePremiseId: premiseBId }],
+      })).id;
+      noProvenance = (await makeOpp({ status: 'pending' })).id;
+      citedButAccepted = (await makeOpp({
+        status: 'accepted',
+        evidence: [{ kind: 'premise_similarity', networkId: fixture.networkId, score: 0.8, sourcePremiseId: premiseAId }],
+      })).id;
+    });
+
+    it('returns opportunities citing the premise via evidence or actor grounding', async () => {
+      const rows = await oppAdapter.getOpportunitiesCitingPremise(fixture.userAId, premiseAId, { statuses: CASCADE_STATUSES });
+      const ids = new Set(rows.map((r) => r.id));
+      expect(ids.has(citedViaSource)).toBe(true);
+      expect(ids.has(citedViaCandidate)).toBe(true);
+      expect(ids.has(citedViaActor)).toBe(true);
+    });
+
+    it('does not return opportunities evidenced solely by other premises (no collateral)', async () => {
+      const rows = await oppAdapter.getOpportunitiesCitingPremise(fixture.userAId, premiseAId, { statuses: CASCADE_STATUSES });
+      const ids = new Set(rows.map((r) => r.id));
+      expect(ids.has(citesOtherPremise)).toBe(false);
+      expect(ids.has(noProvenance)).toBe(false);
+    });
+
+    it('respects the status filter: accepted opportunities stay out of cascade scope', async () => {
+      const rows = await oppAdapter.getOpportunitiesCitingPremise(fixture.userAId, premiseAId, { statuses: CASCADE_STATUSES });
+      const ids = new Set(rows.map((r) => r.id));
+      expect(ids.has(citedButAccepted)).toBe(false);
+    });
+
+    it('scopes to the requesting user via the actors guard', async () => {
+      const otherUserId = uuidv4();
+      const rows = await oppAdapter.getOpportunitiesCitingPremise(otherUserId, premiseAId, { statuses: CASCADE_STATUSES });
+      expect(rows.length).toBe(0);
+    });
+  });
+
+  describe('getIntentsGroundedOnEmbedding', () => {
+    // Orthogonal unit vectors so cosine similarity is exactly 1 (aligned) or 0 (orthogonal).
+    const dim = 2000;
+    const premiseEmbedding = new Array(dim).fill(0).map((_, i) => (i === 0 ? 1 : 0));
+    const orthogonalEmbedding = new Array(dim).fill(0).map((_, i) => (i === 1 ? 1 : 0));
+
+    const alignedIntentId = uuidv4();
+    const orthogonalIntentId = uuidv4();
+    const alignedOtherUserIntentId = uuidv4();
+    const alignedArchivedIntentId = uuidv4();
+
+    beforeAll(async () => {
+      createdIntentIds.push(alignedIntentId, orthogonalIntentId, alignedOtherUserIntentId, alignedArchivedIntentId);
+      await db.insert(intents).values([
+        { id: alignedIntentId, userId: fixture.userAId, payload: TEST_PREFIX + 'aligned intent', embedding: premiseEmbedding, status: 'ACTIVE' },
+        { id: orthogonalIntentId, userId: fixture.userAId, payload: TEST_PREFIX + 'orthogonal intent', embedding: orthogonalEmbedding, status: 'ACTIVE' },
+        { id: alignedOtherUserIntentId, userId: fixture.userBId, payload: TEST_PREFIX + 'other user aligned', embedding: premiseEmbedding, status: 'ACTIVE' },
+        { id: alignedArchivedIntentId, userId: fixture.userAId, payload: TEST_PREFIX + 'archived aligned', embedding: premiseEmbedding, status: 'ACTIVE', archivedAt: new Date() },
+      ]);
+    });
+
+    it('returns only the user own ACTIVE non-archived intents above the similarity floor', async () => {
+      const rows = await chatAdapter.getIntentsGroundedOnEmbedding({
+        userId: fixture.userAId,
+        embedding: premiseEmbedding,
+        minSimilarity: 0.5,
+        limit: 5,
+      });
+      const ids = new Set(rows.map((r) => r.id));
+      expect(ids.has(alignedIntentId)).toBe(true);
+      expect(ids.has(orthogonalIntentId)).toBe(false);      // below similarity floor
+      expect(ids.has(alignedOtherUserIntentId)).toBe(false); // other user's intent
+      expect(ids.has(alignedArchivedIntentId)).toBe(false);  // archived
+      const aligned = rows.find((r) => r.id === alignedIntentId);
+      expect(aligned!.similarity).toBeGreaterThan(0.99);
+      expect(aligned!.payload).toBe(TEST_PREFIX + 'aligned intent');
+    });
+
+    it('respects the limit cap', async () => {
+      const rows = await chatAdapter.getIntentsGroundedOnEmbedding({
+        userId: fixture.userAId,
+        embedding: premiseEmbedding,
+        minSimilarity: 0.5,
+        limit: 1,
+      });
+      expect(rows.length).toBeLessThanOrEqual(1);
+    });
+  });
+});

--- a/services/api/src/events/tests/premise.event.spec.ts
+++ b/services/api/src/events/tests/premise.event.spec.ts
@@ -90,7 +90,12 @@ afterAll(() => {
 // ---------------------------------------------------------------------------
 import { PremiseEvents } from '../premise.event';
 import { PremiseQueue } from '../../queues/premise.queue';
-import type { PremiseQueueDeps, NonTerminalStatus } from '../../queues/premise.queue';
+import type { PremiseQueueDeps, NonTerminalStatus, IntentReverificationVerdict } from '../../queues/premise.queue';
+
+/** Deps that silence the re-verification path for opportunity-focused tests. */
+const noReverifyDeps: Pick<PremiseQueueDeps, 'getPremiseEmbedding'> = {
+  getPremiseEmbedding: async () => null,
+};
 
 // ---------------------------------------------------------------------------
 // PremiseEvents tests
@@ -163,10 +168,26 @@ describe('PremiseEvents', () => {
 // PremiseQueue cascade tests
 // ---------------------------------------------------------------------------
 describe('PremiseQueue — premise_cascade', () => {
-  it('transitions draft and latent opportunities to expired', async () => {
+  it('passes both userId and premiseId to the targeted opportunity fetch', async () => {
+    const fetchArgs: Array<[string, string]> = [];
+    const deps: PremiseQueueDeps = {
+      ...noReverifyDeps,
+      getOpportunitiesCitingPremise: async (userId, premiseId) => {
+        fetchArgs.push([userId, premiseId]);
+        return [];
+      },
+      updateOpportunityStatus: async () => {},
+    };
+    const queue = new PremiseQueue(deps);
+    await queue.processJob('premise_cascade', { premiseId: 'p-0', userId: 'u-0', event: 'retracted' });
+    expect(fetchArgs).toEqual([['u-0', 'p-0']]);
+  });
+
+  it('transitions draft and latent opportunities citing the premise to expired', async () => {
     const transitions: Array<[string, string]> = [];
     const deps: PremiseQueueDeps = {
-      getUserOpportunities: async () => [
+      ...noReverifyDeps,
+      getOpportunitiesCitingPremise: async () => [
         { id: 'opp-1', status: 'draft' as NonTerminalStatus },
         { id: 'opp-2', status: 'latent' as NonTerminalStatus },
       ],
@@ -185,7 +206,8 @@ describe('PremiseQueue — premise_cascade', () => {
   it('transitions pending and negotiating opportunities to expired, never stalled', async () => {
     const transitions: Array<[string, string]> = [];
     const deps: PremiseQueueDeps = {
-      getUserOpportunities: async () => [
+      ...noReverifyDeps,
+      getOpportunitiesCitingPremise: async () => [
         { id: 'opp-1', status: 'pending' as NonTerminalStatus },
         { id: 'opp-2', status: 'negotiating' as NonTerminalStatus },
       ],
@@ -201,10 +223,11 @@ describe('PremiseQueue — premise_cascade', () => {
     ]);
   });
 
-  it('handles mixed statuses: every cascade-eligible opportunity expires', async () => {
+  it('handles mixed statuses: every citing cascade-eligible opportunity expires', async () => {
     const transitions: Array<[string, string]> = [];
     const deps: PremiseQueueDeps = {
-      getUserOpportunities: async () => [
+      ...noReverifyDeps,
+      getOpportunitiesCitingPremise: async () => [
         { id: 'opp-a', status: 'draft' as NonTerminalStatus },
         { id: 'opp-b', status: 'pending' as NonTerminalStatus },
         { id: 'opp-c', status: 'latent' as NonTerminalStatus },
@@ -224,21 +247,25 @@ describe('PremiseQueue — premise_cascade', () => {
     ]);
   });
 
-  it('completes without errors when there are no opportunities', async () => {
+  it('expires nothing when no opportunity cites the premise (no collateral)', async () => {
+    const updateOpportunityStatus = mock(async (_id: string, _status: 'expired') => {});
     const deps: PremiseQueueDeps = {
-      getUserOpportunities: async () => [],
-      updateOpportunityStatus: async () => {},
+      ...noReverifyDeps,
+      getOpportunitiesCitingPremise: async () => [],
+      updateOpportunityStatus,
     };
     const queue = new PremiseQueue(deps);
     await expect(
       queue.processJob('premise_cascade', { premiseId: 'p-4', userId: 'u-4', event: 'retracted' })
     ).resolves.toBeUndefined();
+    expect(updateOpportunityStatus).not.toHaveBeenCalled();
   });
 
-  it('calls updateOpportunityStatus once per opportunity', async () => {
+  it('calls updateOpportunityStatus once per citing opportunity', async () => {
     const updateOpportunityStatus = mock(async (_id: string, _status: 'expired') => {});
     const deps: PremiseQueueDeps = {
-      getUserOpportunities: async () => [
+      ...noReverifyDeps,
+      getOpportunitiesCitingPremise: async () => [
         { id: 'opp-1', status: 'draft' as NonTerminalStatus },
         { id: 'opp-2', status: 'pending' as NonTerminalStatus },
       ],
@@ -247,6 +274,123 @@ describe('PremiseQueue — premise_cascade', () => {
     const queue = new PremiseQueue(deps);
     await queue.processJob('premise_cascade', { premiseId: 'p-5', userId: 'u-5', event: 'retracted' });
     expect(updateOpportunityStatus).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PremiseQueue grounded-intent re-verification tests (IND-423)
+// ---------------------------------------------------------------------------
+describe('PremiseQueue — grounded intent re-verification', () => {
+  const verdict: IntentReverificationVerdict = {
+    classification: 'COMMISSIVE',
+    felicity_scores: { clarity: 80, authority: 45, sincerity: 90 },
+    semantic_entropy: 0.4,
+    flags: ['SKILL_MISMATCH'],
+  };
+
+  const baseDeps = (): PremiseQueueDeps => ({
+    getOpportunitiesCitingPremise: async () => [],
+    updateOpportunityStatus: async () => {},
+  });
+
+  it('re-verifies intents grounded on the lapsed premise and persists the verdict', async () => {
+    const applied: Array<[string, IntentReverificationVerdict]> = [];
+    const verified: string[] = [];
+    const deps: PremiseQueueDeps = {
+      ...baseDeps(),
+      getPremiseEmbedding: async () => [0.1, 0.2, 0.3],
+      getGroundedIntents: async () => [
+        { id: 'intent-1', payload: 'Looking for a co-founder in Berlin', similarity: 0.72 },
+        { id: 'intent-2', payload: 'Seeking Berlin-based investors', similarity: 0.61 },
+      ],
+      getUserProfileContext: async () => '{"name":"U"}',
+      verifyIntent: async (content) => {
+        verified.push(content);
+        return verdict;
+      },
+      applyIntentVerification: async (intentId, v) => {
+        applied.push([intentId, v]);
+      },
+    };
+    const queue = new PremiseQueue(deps);
+    await queue.processJob('premise_cascade', { premiseId: 'p-1', userId: 'u-1', event: 'retracted' });
+    expect(verified).toEqual([
+      'Looking for a co-founder in Berlin',
+      'Seeking Berlin-based investors',
+    ]);
+    expect(applied).toEqual([
+      ['intent-1', verdict],
+      ['intent-2', verdict],
+    ]);
+  });
+
+  it('skips re-verification when the premise has no embedding', async () => {
+    const getGroundedIntents = mock(async () => []);
+    const deps: PremiseQueueDeps = {
+      ...baseDeps(),
+      getPremiseEmbedding: async () => null,
+      getGroundedIntents,
+    };
+    const queue = new PremiseQueue(deps);
+    await queue.processJob('premise_cascade', { premiseId: 'p-2', userId: 'u-2', event: 'expired' });
+    expect(getGroundedIntents).not.toHaveBeenCalled();
+  });
+
+  it('skips the profile fetch and verifier when no intents are grounded on the premise', async () => {
+    const verifyIntent = mock(async () => verdict);
+    const getUserProfileContext = mock(async () => '{}');
+    const deps: PremiseQueueDeps = {
+      ...baseDeps(),
+      getPremiseEmbedding: async () => [0.5, 0.5],
+      getGroundedIntents: async () => [],
+      getUserProfileContext,
+      verifyIntent,
+    };
+    const queue = new PremiseQueue(deps);
+    await queue.processJob('premise_cascade', { premiseId: 'p-3', userId: 'u-3', event: 'retracted' });
+    expect(getUserProfileContext).not.toHaveBeenCalled();
+    expect(verifyIntent).not.toHaveBeenCalled();
+  });
+
+  it('continues past per-intent verifier failures and persists the rest', async () => {
+    const applied: string[] = [];
+    const deps: PremiseQueueDeps = {
+      ...baseDeps(),
+      getPremiseEmbedding: async () => [0.1],
+      getGroundedIntents: async () => [
+        { id: 'intent-bad', payload: 'boom payload', similarity: 0.9 },
+        { id: 'intent-good', payload: 'fine payload', similarity: 0.8 },
+      ],
+      getUserProfileContext: async () => '{}',
+      verifyIntent: async (content) => {
+        if (content === 'boom payload') throw new Error('LLM flake');
+        return verdict;
+      },
+      applyIntentVerification: async (intentId) => {
+        applied.push(intentId);
+      },
+    };
+    const queue = new PremiseQueue(deps);
+    await expect(
+      queue.processJob('premise_cascade', { premiseId: 'p-4', userId: 'u-4', event: 'retracted' })
+    ).resolves.toBeUndefined();
+    expect(applied).toEqual(['intent-good']);
+  });
+
+  it('never fails the cascade job when re-verification setup throws (expiry already done)', async () => {
+    const transitions: string[] = [];
+    const deps: PremiseQueueDeps = {
+      getOpportunitiesCitingPremise: async () => [
+        { id: 'opp-1', status: 'pending' as NonTerminalStatus },
+      ],
+      updateOpportunityStatus: async (id) => { transitions.push(id); },
+      getPremiseEmbedding: async () => { throw new Error('db down'); },
+    };
+    const queue = new PremiseQueue(deps);
+    await expect(
+      queue.processJob('premise_cascade', { premiseId: 'p-5', userId: 'u-5', event: 'retracted' })
+    ).resolves.toBeUndefined();
+    expect(transitions).toEqual(['opp-1']);
   });
 });
 

--- a/services/api/src/queues/premise.queue.ts
+++ b/services/api/src/queues/premise.queue.ts
@@ -56,6 +56,35 @@ export type EarlyStatus = (typeof EARLY_STATUSES)[number];
 export type NonTerminalStatus = InFlightStatus | EarlyStatus;
 
 // ---------------------------------------------------------------------------
+// Grounded-intent re-verification tuning
+// ---------------------------------------------------------------------------
+
+/**
+ * Cosine similarity floor for treating an intent as "grounded on" a lapsed
+ * premise. There is no explicit premise→intent edge in the schema, so the
+ * cascade uses embedding proximity (shared text-embedding-3-large space) as
+ * the grounding heuristic. Deliberately below the 0.7 network-assignment
+ * threshold: premise↔intent pairs are cross-genre (assertion vs. request), so
+ * related pairs land lower in cosine space than same-genre pairs.
+ */
+const GROUNDED_INTENT_MIN_SIMILARITY = 0.5;
+
+/** Max intents re-verified per cascade — caps LLM spend per retraction. */
+const GROUNDED_INTENT_LIMIT = 5;
+
+/**
+ * Minimal verifier verdict consumed by the cascade. Structurally compatible
+ * with the protocol package's `SemanticVerifierOutput` (which carries more
+ * fields); kept narrow here so tests can stub it without importing protocol.
+ */
+export interface IntentReverificationVerdict {
+  classification: string;
+  felicity_scores: { clarity: number; authority: number; sincerity: number };
+  semantic_entropy: number;
+  flags: string[];
+}
+
+// ---------------------------------------------------------------------------
 // Deps interface
 // ---------------------------------------------------------------------------
 
@@ -67,9 +96,14 @@ export type NonTerminalStatus = InFlightStatus | EarlyStatus;
 export interface PremiseQueueDeps {
   /**
    * Retrieve cascade-eligible (non-terminal, non-accepted) opportunities
-   * where `userId` is an actor. Returns a minimal shape: id + current status.
+   * where `userId` is an actor AND whose provenance cites `premiseId`
+   * (evidence sourcePremiseId/candidatePremiseId, or actor-level grounding
+   * premise). Returns a minimal shape: id + current status.
    */
-  getUserOpportunities?: (userId: string) => Promise<Array<{ id: string; status: NonTerminalStatus }>>;
+  getOpportunitiesCitingPremise?: (
+    userId: string,
+    premiseId: string
+  ) => Promise<Array<{ id: string; status: NonTerminalStatus }>>;
 
   /**
    * Transition an opportunity to a new status. The cascade only ever expires.
@@ -93,6 +127,43 @@ export interface PremiseQueueDeps {
    * Transition a premise to EXPIRED status.
    */
   expirePremise?: (premiseId: string) => Promise<void>;
+
+  /**
+   * Fetch the embedding of a premise (null when the premise is missing or
+   * was never embedded — re-verification is skipped in that case).
+   */
+  getPremiseEmbedding?: (premiseId: string) => Promise<number[] | null>;
+
+  /**
+   * Find the user's ACTIVE intents grounded on the given embedding
+   * (cosine-similarity heuristic — no explicit premise→intent edge exists).
+   */
+  getGroundedIntents?: (
+    userId: string,
+    embedding: number[]
+  ) => Promise<Array<{ id: string; payload: string; similarity: number }>>;
+
+  /**
+   * Resolve the user's profile context (JSON string) for the verifier prompt.
+   */
+  getUserProfileContext?: (userId: string) => Promise<string>;
+
+  /**
+   * Re-run felicity verification on an intent payload against the profile.
+   */
+  verifyIntent?: (
+    content: string,
+    profileContext: string
+  ) => Promise<IntentReverificationVerdict>;
+
+  /**
+   * Persist a re-verification verdict onto the intent (felicity scores +
+   * semantic entropy).
+   */
+  applyIntentVerification?: (
+    intentId: string,
+    verdict: IntentReverificationVerdict
+  ) => Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -102,11 +173,16 @@ export interface PremiseQueueDeps {
 /**
  * Premise cascade and profile regeneration queue.
  *
- * `premise_cascade` — when a premise is retracted or expired, expires the
- * opportunities it motivated: draft/latent/pending/negotiating → expired.
- * `accepted` opportunities are left untouched (the connection already
- * happened), and `stalled` is never written here — it is strictly a
- * negotiation outcome (turn cap / timeout / no consensus).
+ * `premise_cascade` — when a premise is retracted or expired, expires only the
+ * opportunities whose provenance cites that premise (evidence
+ * sourcePremiseId/candidatePremiseId or actor-level grounding premise):
+ * draft/latent/pending/negotiating → expired. Opportunities evidenced solely
+ * by other premises are untouched (IND-423), `accepted` opportunities are left
+ * alone (the connection already happened), and `stalled` is never written
+ * here — it is strictly a negotiation outcome (turn cap / timeout / no
+ * consensus). The cascade also re-verifies the user's intents grounded on the
+ * lapsed premise (embedding-proximity heuristic) so their felicity scores
+ * don't go stale.
  *
  * `profile_regen` — when any premise lifecycle event fires, regenerates the
  * user's profile from their current active premises via the profile graph's
@@ -293,20 +369,22 @@ export class PremiseQueue {
   // -------------------------------------------------------------------------
 
   /**
-   * Default production implementation: fetch all cascade-eligible
-   * opportunities for a user from the database using a single filtered query.
+   * Default production implementation: fetch the cascade-eligible
+   * opportunities that cite the lapsed premise using a single filtered query.
    * `accepted` is intentionally outside the fetch scope — the cascade must
-   * never touch a made connection.
+   * never touch a made connection — and opportunities that don't cite the
+   * premise are outside it too (targeted revocation, IND-423).
    */
-  private async defaultGetUserOpportunities(
-    userId: string
+  private async defaultGetOpportunitiesCitingPremise(
+    userId: string,
+    premiseId: string
   ): Promise<Array<{ id: string; status: NonTerminalStatus }>> {
     const adapter = new OpportunityDatabaseAdapter();
     const cascadeStatuses: NonTerminalStatus[] = [
       ...EARLY_STATUSES,
       ...IN_FLIGHT_STATUSES,
     ];
-    const rows = await adapter.getOpportunitiesForUser(userId, {
+    const rows = await adapter.getOpportunitiesCitingPremise(userId, premiseId, {
       statuses: cascadeStatuses,
     });
     return rows.map((row) => ({ id: row.id, status: row.status as NonTerminalStatus }));
@@ -345,32 +423,115 @@ export class PremiseQueue {
     const { premiseId, userId, event } = data;
     this.cascadeLogger.info('Starting cascade', { premiseId, userId, event });
 
-    const getUserOpportunities =
-      this.deps?.getUserOpportunities ??
-      ((uid: string) => this.defaultGetUserOpportunities(uid));
+    const getOpportunitiesCitingPremise =
+      this.deps?.getOpportunitiesCitingPremise ??
+      ((uid: string, pid: string) => this.defaultGetOpportunitiesCitingPremise(uid, pid));
 
     const updateOpportunityStatus =
       this.deps?.updateOpportunityStatus ??
       ((oppId: string, status: 'expired') =>
         this.defaultUpdateOpportunityStatus(oppId, status));
 
-    const opportunities = await getUserOpportunities(userId);
-
-    // The premise that motivated these opportunities no longer holds, so they
-    // all expire — regardless of how far along they were. `stalled` is never
-    // written here: it is reserved for negotiation outcomes, and `accepted`
-    // rows are outside the fetch scope entirely.
+    // Targeted revocation (IND-423): only opportunities whose provenance cites
+    // the lapsed premise expire. Everything else the user has in flight —
+    // including active negotiations grounded in unrelated premises — survives.
+    // `stalled` is never written here: it is reserved for negotiation outcomes,
+    // and `accepted` rows are outside the fetch scope entirely.
+    const opportunities = await getOpportunitiesCitingPremise(userId, premiseId);
     for (const opp of opportunities) {
       await updateOpportunityStatus(opp.id, 'expired');
+    }
+
+    // Re-verify intents grounded on the lapsed premise so their felicity
+    // scores (notably `felicityAuthority`, the preparatory condition) reflect
+    // the reduced grounding. Failures here never fail the cascade job —
+    // opportunity expiry must not be retried because an LLM call flaked.
+    let reverified = 0;
+    try {
+      reverified = await this.reverifyGroundedIntents(userId, premiseId);
+    } catch (err) {
+      this.cascadeLogger.warn('Intent re-verification failed; cascade continues', {
+        premiseId,
+        userId,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
 
     this.cascadeLogger.info('Cascade complete', {
       premiseId,
       userId,
       event,
-      total: opportunities.length,
       expired: opportunities.length,
+      intentsReverified: reverified,
     });
+  }
+
+  /**
+   * Find the user's ACTIVE intents grounded on the lapsed premise (embedding
+   * proximity — no explicit premise→intent edge exists in the schema) and
+   * re-run felicity verification on each, persisting the fresh scores.
+   * Per-intent verifier failures are logged and skipped; the count of
+   * successfully re-verified intents is returned.
+   */
+  private async reverifyGroundedIntents(userId: string, premiseId: string): Promise<number> {
+    const getPremiseEmbedding =
+      this.deps?.getPremiseEmbedding ??
+      ((pid: string) => this.defaultGetPremiseEmbedding(pid));
+
+    const getGroundedIntents =
+      this.deps?.getGroundedIntents ??
+      ((uid: string, embedding: number[]) => this.defaultGetGroundedIntents(uid, embedding));
+
+    const getUserProfileContext =
+      this.deps?.getUserProfileContext ??
+      ((uid: string) => this.defaultGetUserProfileContext(uid));
+
+    const verifyIntent =
+      this.deps?.verifyIntent ??
+      ((content: string, profileContext: string) => this.defaultVerifyIntent(content, profileContext));
+
+    const applyIntentVerification =
+      this.deps?.applyIntentVerification ??
+      ((intentId: string, verdict: IntentReverificationVerdict) =>
+        this.defaultApplyIntentVerification(intentId, verdict));
+
+    const embedding = await getPremiseEmbedding(premiseId);
+    if (!embedding || embedding.length === 0) {
+      this.cascadeLogger.verbose('No premise embedding; skipping intent re-verification', { premiseId });
+      return 0;
+    }
+
+    const intents = await getGroundedIntents(userId, embedding);
+    if (intents.length === 0) {
+      this.cascadeLogger.verbose('No grounded intents to re-verify', { premiseId, userId });
+      return 0;
+    }
+
+    const profileContext = await getUserProfileContext(userId);
+
+    let reverified = 0;
+    for (const intent of intents) {
+      try {
+        const verdict = await verifyIntent(intent.payload, profileContext);
+        await applyIntentVerification(intent.id, verdict);
+        reverified += 1;
+        this.cascadeLogger.verbose('Intent re-verified after premise lapse', {
+          intentId: intent.id,
+          premiseId,
+          similarity: intent.similarity,
+          classification: verdict.classification,
+          authority: verdict.felicity_scores.authority,
+          flags: verdict.flags,
+        });
+      } catch (err) {
+        this.cascadeLogger.warn('Intent re-verification failed for intent; skipping', {
+          intentId: intent.id,
+          premiseId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    return reverified;
   }
 
   private async handleProfileRegen(data: ProfileRegenData): Promise<void> {
@@ -395,6 +556,75 @@ export class PremiseQueue {
    */
   private async defaultEnqueueContextRegen(userId: string): Promise<void> {
     await userContextQueue.addRegenJob({ userId, reason: 'profile_regen' });
+  }
+
+  /**
+   * Default production implementation: read the premise's stored embedding.
+   */
+  private async defaultGetPremiseEmbedding(premiseId: string): Promise<number[] | null> {
+    const adapter = new ChatDatabaseAdapter();
+    const premise = await adapter.getPremise(premiseId);
+    return premise?.embedding ?? null;
+  }
+
+  /**
+   * Default production implementation: cosine search over the user's own
+   * ACTIVE intents, capped and thresholded (see tuning constants above).
+   */
+  private async defaultGetGroundedIntents(
+    userId: string,
+    embedding: number[]
+  ): Promise<Array<{ id: string; payload: string; similarity: number }>> {
+    const adapter = new ChatDatabaseAdapter();
+    return adapter.getIntentsGroundedOnEmbedding({
+      userId,
+      embedding,
+      minSimilarity: GROUNDED_INTENT_MIN_SIMILARITY,
+      limit: GROUNDED_INTENT_LIMIT,
+    });
+  }
+
+  /**
+   * Default production implementation: serialize the user's profile for the
+   * verifier prompt (same context shape the intent graph passes at creation).
+   */
+  private async defaultGetUserProfileContext(userId: string): Promise<string> {
+    const adapter = new OpportunityDatabaseAdapter();
+    const profile = await adapter.getProfile(userId);
+    return JSON.stringify(profile ?? {});
+  }
+
+  /**
+   * Default production implementation: run the protocol package's
+   * SemanticVerifier. Imported lazily so loading this queue module (and its
+   * tests) doesn't pull the LLM stack.
+   */
+  private async defaultVerifyIntent(
+    content: string,
+    profileContext: string
+  ): Promise<IntentReverificationVerdict> {
+    const { SemanticVerifier } = await import('@indexnetwork/protocol');
+    const verifier = new SemanticVerifier();
+    return verifier.invoke(content, profileContext);
+  }
+
+  /**
+   * Default production implementation: persist fresh felicity scores and
+   * semantic entropy onto the intent. Classification/flags are logged by the
+   * caller but deliberately not acted on — auto-archiving an intent on a
+   * degraded verdict would be over-invalidation of a different flavor.
+   */
+  private async defaultApplyIntentVerification(
+    intentId: string,
+    verdict: IntentReverificationVerdict
+  ): Promise<void> {
+    const adapter = new ChatDatabaseAdapter();
+    await adapter.updateIntent(intentId, {
+      felicityClarity: verdict.felicity_scores.clarity,
+      felicityAuthority: verdict.felicity_scores.authority,
+      felicitySincerity: verdict.felicity_scores.sincerity,
+      semanticEntropy: verdict.semantic_entropy,
+    });
   }
 }
 


### PR DESCRIPTION
## Problem

Retracting (or expiring) a **single premise** expired **every** non-terminal opportunity the user had — `draft`, `latent`, `pending`, `negotiating` — regardless of whether those opportunities had anything to do with the retracted premise. The in-code comment acknowledged it: *"they all expire — regardless of how far along they were."* Meanwhile, intents grounded on the retracted premise were never re-verified, so their felicity scores (notably `felicityAuthority`, the preparatory condition) went stale.

Net effect: correcting a minor fact ("I'm no longer based in Berlin") silently killed active negotiations grounded in unrelated premises, while the intents that actually depended on the fact kept their stale scores. Over- and under-invalidation at once.

Fixes [IND-423](https://linear.app/indexnetwork/issue/IND-423) — backlog item 1 of the Academic Grounding Enhancement Backlog (PR #1122).

## Change

**Targeted revocation.** `handlePremiseCascade` now expires only opportunities whose provenance cites the lapsed premise, via new `OpportunityDatabaseAdapter.getOpportunitiesCitingPremise`:
- `metadata.evidence` cites it as `sourcePremiseId` or `candidatePremiseId` (recorded by `buildCandidateEvidence` at discovery time and persisted on the row), or
- an actor row carries it as the grounding `premise` (premise-similarity discovery).

No schema change needed — the provenance was already persisted, just never queried. `accepted` stays out of scope; `stalled` is still never written by the cascade.

**Grounded-intent re-verification.** After expiry, the cascade re-verifies the user's ACTIVE intents grounded on the premise and persists fresh felicity scores + semantic entropy:
- No explicit premise→intent edge exists in the schema, so grounding uses **embedding proximity** (shared text-embedding-3-large space; floor 0.5, cap 5 intents/cascade — constants documented in `premise.queue.ts`).
- `SemanticVerifier` is now exported from the protocol barrel (→ **4.9.0**) and imported lazily so the queue module stays light.
- Verdicts update scores only — classification/flags are logged, not acted on (auto-archiving on a degraded verdict would be over-invalidation of a different flavor).
- Per-intent and setup failures never fail the cascade job (expiry must not retry because an LLM call flaked).

## Acceptance criteria (from IND-423)

- ✅ Retracting premise A does not expire opportunities evidenced solely by premises B/C — integration test *"no collateral"*
- ✅ Retracting premise A expires opportunities whose evidence cites A — evidence + actor-grounding paths both covered
- ✅ Intents grounded on A are re-verified; felicity scores update — unit-tested flow incl. persistence
- ✅ Hermetic tests covering targeted-expiry and no-collateral cases — unit (queue orchestration) + DB integration (SQL semantics)

## Tests

- `premise.event.spec.ts` (isolated): targeted fetch args, per-status expiry, no-collateral, re-verification flow, skip-on-no-embedding, per-intent failure isolation, cascade survives re-verification setup failure — **24 pass**
- `database.adapter.spec.ts` (integration): both new adapter queries — evidence/actor citing, other-premise exclusion, accepted-status exclusion, user scoping, similarity floor/ownership/archived exclusion, limit cap — **6 pass** (3 pre-existing failures in this spec reproduce on `dev` unchanged: getProfile/saveProfile decoupling ×2, HyDE getStale timeout)
- `tsc --noEmit` clean (api), protocol build clean, eslint clean on all touched files

## Docs

Backlog item 1 marked **shipped** with a note that an explicit premise→intent provenance edge remains future work.