### PR TITLE
fix(api+web): stitch negotiation continuation segments into one thread per opportunity (IND-431)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/services/users.ts
+++ b/apps/web/src/services/users.ts
@@ -13,8 +13,32 @@ export interface NegotiationTurnSummary {
   createdAt: string;
 }
 
+export type NegotiationState =
+  | 'submitted'
+  | 'working'
+  | 'input_required'
+  | 'completed'
+  | 'failed'
+  | 'canceled'
+  | 'rejected'
+  | 'auth_required'
+  | 'waiting_for_agent'
+  | 'claimed';
+
+export type NegotiationStatusMessage =
+  | string
+  | number
+  | boolean
+  | null
+  | NegotiationStatusMessage[]
+  | { [key: string]: NegotiationStatusMessage };
+
 export interface NegotiationSummary {
   id: string;
+  segments: number;
+  state: NegotiationState;
+  statusMessage: NegotiationStatusMessage;
+  statusTimestamp: string | null;
   counterparty: { id: string; name: string; avatar: string | null };
   outcome: {
     hasOpportunity: boolean;
@@ -24,6 +48,7 @@ export interface NegotiationSummary {
   } | null;
   turns: NegotiationTurnSummary[];
   createdAt: string;
+  updatedAt: string;
 }
 
 export interface NegotiationInsights {

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/web": {
       "name": "@indexnetwork/web",
-      "version": "0.11.5",
+      "version": "0.13.2",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.14",
@@ -100,7 +100,7 @@
     },
     "services/api": {
       "name": "@indexnetwork/api",
-      "version": "0.33.0",
+      "version": "0.33.1",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.939.0",
         "@aws-sdk/s3-request-presigner": "^3.983.0",

--- a/docs/specs/api-reference.md
+++ b/docs/specs/api-reference.md
@@ -3020,6 +3020,10 @@ Trigger a discovery negotiation between the authenticated viewer and the target 
 {
   "negotiation": {
     "id": "...",
+    "segments": 1,
+    "state": "completed",
+    "statusMessage": null,
+    "statusTimestamp": "...",
     "counterparty": { "id": "...", "name": "...", "avatar": null },
     "outcome": {
       "hasOpportunity": true,
@@ -3030,14 +3034,15 @@ Trigger a discovery negotiation between the authenticated viewer and the target 
     "turns": [
       { "speaker": { "id": "...", "name": "...", "avatar": null }, "action": "propose", "reasoning": "...", "suggestedRoles": null, "createdAt": "..." }
     ],
-    "createdAt": "..."
+    "createdAt": "...",
+    "updatedAt": "..."
   }
 }
 ```
 
 ### GET /api/users/:userId/negotiations
 
-List past negotiations for a user. When the viewer differs from the profile owner, only mutual negotiations are returned.
+List past negotiation threads for a user. Tasks sharing `metadata.opportunityId` are stitched into one thread; tasks without an opportunity ID remain independent. Messages are merged chronologically across all segments, while the newest segment supplies the response ID, state, status, outcome, and timestamps. When the viewer differs from the profile owner, only mutual negotiations are returned.
 
 **Auth**: AuthGuard
 
@@ -3045,8 +3050,8 @@ List past negotiations for a user. When the viewer differs from the profile owne
 - `userId` — User ID
 
 **Query params**:
-- `limit` — Max results (default: 20, max: 50)
-- `offset` — Pagination offset (default: 0)
+- `limit` — Max threads (default: 20, max: 50)
+- `offset` — Thread offset (default: 0)
 - `result` — Filter by result: `has_opportunity`, `no_opportunity`, `in_progress` (optional)
 
 **Response**:
@@ -3055,10 +3060,13 @@ List past negotiations for a user. When the viewer differs from the profile owne
   "negotiations": [
     {
       "id": "...",
+      "segments": 2,
+      "state": "completed",
+      "statusMessage": null,
+      "statusTimestamp": "...",
       "counterparty": { "id": "...", "name": "...", "avatar": "..." },
       "outcome": {
         "hasOpportunity": true,
-        "finalScore": 0.85,
         "role": "...",
         "turnCount": 3,
         "reason": "..."
@@ -3067,13 +3075,13 @@ List past negotiations for a user. When the viewer differs from the profile owne
         {
           "speaker": { "id": "...", "name": "...", "avatar": "..." },
           "action": "...",
-          "fitScore": 0.8,
           "reasoning": "...",
           "suggestedRoles": { ... },
           "createdAt": "..."
         }
       ],
-      "createdAt": "..."
+      "createdAt": "...",
+      "updatedAt": "..."
     }
   ]
 }

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -1066,7 +1066,15 @@ export class ConversationDatabaseAdapter {
    */
   async getNegotiationsByUser(
     userId: string,
-    opts?: { limit?: number; offset?: number; mutualWithUserId?: string; result?: 'has_opportunity' | 'no_opportunity' | 'in_progress'; since?: Date },
+    opts?: {
+      limit?: number;
+      offset?: number;
+      mutualWithUserId?: string;
+      result?: 'has_opportunity' | 'no_opportunity' | 'in_progress';
+      since?: Date;
+      unpaginated?: boolean;
+      includeScreenedOut?: boolean;
+    },
   ): Promise<Array<Task & { artifact: Artifact | null }>> {
     const limit = opts?.limit ?? 10;
     const offset = opts?.offset ?? 0;
@@ -1109,7 +1117,7 @@ export class ConversationDatabaseAdapter {
     // decisions — zero turns, no counterparty involvement. They stay visible
     // to the owner (self view) but are excluded from the mutual (non-self
     // viewer) list so the counterparty never learns a gate decision was made.
-    const screenedOutFilter = opts?.mutualWithUserId
+    const screenedOutFilter = opts?.mutualWithUserId && !opts.includeScreenedOut
       ? or(
           isNull(schema.artifacts.id),
           sql`coalesce(${schema.artifacts.parts}->0->'data'->>'reason', '') <> 'screened_out'`,
@@ -1119,7 +1127,7 @@ export class ConversationDatabaseAdapter {
     const allFilters = [userFilter, resultFilter, sinceFilter, screenedOutFilter].filter(Boolean);
     const combinedFilter = allFilters.length > 1 ? and(...allFilters) : allFilters[0];
 
-    const rows = await db
+    const query = db
       .select({
         task: schema.tasks,
         artifact: schema.artifacts,
@@ -1133,9 +1141,13 @@ export class ConversationDatabaseAdapter {
         ),
       )
       .where(combinedFilter)
-      .orderBy(desc(schema.tasks.createdAt))
-      .limit(limit)
-      .offset(offset);
+      .orderBy(desc(schema.tasks.createdAt));
+
+    // Thread pagination must see every continuation segment before grouping.
+    // The ordinary row-oriented callers retain the existing SQL pagination.
+    const rows = opts?.unpaginated
+      ? await query
+      : await query.limit(limit).offset(offset);
 
     return rows.map((r) => ({ ...r.task, artifact: r.artifact }));
   }

--- a/services/api/src/controllers/tests/user.controller.spec.ts
+++ b/services/api/src/controllers/tests/user.controller.spec.ts
@@ -85,6 +85,7 @@ describe("UserController Integration", () => {
       const currentCreatedAt = new Date("2026-01-05T10:00:00.000Z");
       const currentUpdatedAt = new Date("2026-01-05T11:00:00.000Z");
       const currentStatusTimestamp = new Date("2026-01-05T10:30:00.000Z");
+      const tiedMessageCreatedAt = new Date("2026-01-05T10:05:00.000Z");
       const metadata = {
         type: "negotiation",
         sourceUserId: testUserId,
@@ -144,7 +145,7 @@ describe("UserController Integration", () => {
             senderId: `agent:${counterparty.id}`,
             role: "agent",
             parts: [{ kind: "data", data: { action: "accept", assessment: { reasoning: "Accepted after resuming" } } }],
-            createdAt: new Date("2026-01-05T10:05:00.000Z"),
+            createdAt: tiedMessageCreatedAt,
           },
           {
             conversationId: conversation.id,
@@ -152,7 +153,7 @@ describe("UserController Integration", () => {
             senderId: `agent:${testUserId}`,
             role: "agent",
             parts: [{ kind: "data", data: { action: "outreach", assessment: { reasoning: "Original outreach opener" } } }],
-            createdAt: new Date("2026-01-01T10:05:00.000Z"),
+            createdAt: tiedMessageCreatedAt,
           },
         ]);
 
@@ -165,7 +166,14 @@ describe("UserController Integration", () => {
           {
             taskId: currentTaskId,
             name: "negotiation-outcome",
+            parts: [{ kind: "data", data: { hasOpportunity: false, turnCount: 1, reason: "duplicate_older_artifact" } }],
+            createdAt: new Date("2026-01-05T10:10:00.000Z"),
+          },
+          {
+            taskId: currentTaskId,
+            name: "negotiation-outcome",
             parts: [{ kind: "data", data: { hasOpportunity: true, turnCount: 2, reason: "accepted_after_resume" } }],
+            createdAt: new Date("2026-01-05T10:20:00.000Z"),
           },
         ]);
 

--- a/services/api/src/controllers/tests/user.controller.spec.ts
+++ b/services/api/src/controllers/tests/user.controller.spec.ts
@@ -3,8 +3,11 @@ import { config } from "dotenv";
 config({ path: '.env.test', override: true });
 
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+
 import { UserController } from "../user.controller";
-import { UserDatabaseAdapter } from "../../adapters/database.adapter";
+import { UserDatabaseAdapter, conversationDatabaseAdapter } from "../../adapters/database.adapter";
+import db from "../../lib/drizzle/drizzle";
+import { artifacts, messages, tasks } from "../../schemas/database.schema";
 import type { AuthenticatedUser } from "../../guards/auth.guard";
 
 describe("UserController Integration", () => {
@@ -57,5 +60,160 @@ describe("UserController Integration", () => {
       expect(res.status).toBe(404);
       expect(data.error).toBe("User not found");
     });
+  });
+
+  describe("GET /:userId/negotiations", () => {
+    test("stitches continuation segments and paginates complete opportunity threads", async () => {
+      const run = Date.now();
+      const counterparty = await userAdapter.create({
+        email: `test-negotiation-thread-${run}@example.com`,
+        name: "Thread Counterparty",
+      });
+      const conversation = await conversationDatabaseAdapter.createConversation([
+        { participantId: `agent:${testUserId}`, participantType: "agent" },
+        { participantId: `agent:${counterparty.id}`, participantType: "agent" },
+      ]);
+
+      const sharedOpportunityId = crypto.randomUUID();
+      const otherOpportunityId = crypto.randomUUID();
+      const oldTaskId = crypto.randomUUID();
+      const currentTaskId = crypto.randomUUID();
+      const otherTaskId = crypto.randomUUID();
+      const fallbackTaskOneId = crypto.randomUUID();
+      const fallbackTaskTwoId = crypto.randomUUID();
+      const oldCreatedAt = new Date("2026-01-01T10:00:00.000Z");
+      const currentCreatedAt = new Date("2026-01-05T10:00:00.000Z");
+      const currentUpdatedAt = new Date("2026-01-05T11:00:00.000Z");
+      const currentStatusTimestamp = new Date("2026-01-05T10:30:00.000Z");
+      const metadata = {
+        type: "negotiation",
+        sourceUserId: testUserId,
+        candidateUserId: counterparty.id,
+      };
+
+      try {
+        await db.insert(tasks).values([
+          {
+            id: oldTaskId,
+            conversationId: conversation.id,
+            state: "completed",
+            metadata: { ...metadata, opportunityId: sharedOpportunityId },
+            createdAt: oldCreatedAt,
+            updatedAt: new Date("2026-01-01T11:00:00.000Z"),
+          },
+          {
+            id: currentTaskId,
+            conversationId: conversation.id,
+            state: "completed",
+            statusMessage: { phase: "resumed-complete" },
+            statusTimestamp: currentStatusTimestamp,
+            metadata: { ...metadata, opportunityId: sharedOpportunityId, isContinuation: true, priorTurnCount: 1 },
+            createdAt: currentCreatedAt,
+            updatedAt: currentUpdatedAt,
+          },
+          {
+            id: otherTaskId,
+            conversationId: conversation.id,
+            state: "working",
+            metadata: { ...metadata, opportunityId: otherOpportunityId },
+            createdAt: new Date("2026-01-04T10:00:00.000Z"),
+            updatedAt: new Date("2026-01-04T11:00:00.000Z"),
+          },
+          {
+            id: fallbackTaskOneId,
+            conversationId: conversation.id,
+            state: "submitted",
+            metadata,
+            createdAt: new Date("2026-01-03T10:00:00.000Z"),
+            updatedAt: new Date("2026-01-03T11:00:00.000Z"),
+          },
+          {
+            id: fallbackTaskTwoId,
+            conversationId: conversation.id,
+            state: "submitted",
+            metadata,
+            createdAt: new Date("2026-01-02T10:00:00.000Z"),
+            updatedAt: new Date("2026-01-02T11:00:00.000Z"),
+          },
+        ]);
+
+        await db.insert(messages).values([
+          {
+            conversationId: conversation.id,
+            taskId: currentTaskId,
+            senderId: `agent:${counterparty.id}`,
+            role: "agent",
+            parts: [{ kind: "data", data: { action: "accept", assessment: { reasoning: "Accepted after resuming" } } }],
+            createdAt: new Date("2026-01-05T10:05:00.000Z"),
+          },
+          {
+            conversationId: conversation.id,
+            taskId: oldTaskId,
+            senderId: `agent:${testUserId}`,
+            role: "agent",
+            parts: [{ kind: "data", data: { action: "outreach", assessment: { reasoning: "Original outreach opener" } } }],
+            createdAt: new Date("2026-01-01T10:05:00.000Z"),
+          },
+        ]);
+
+        await db.insert(artifacts).values([
+          {
+            taskId: oldTaskId,
+            name: "negotiation-outcome",
+            parts: [{ kind: "data", data: { hasOpportunity: false, turnCount: 1, reason: "turn_cap" } }],
+          },
+          {
+            taskId: currentTaskId,
+            name: "negotiation-outcome",
+            parts: [{ kind: "data", data: { hasOpportunity: true, turnCount: 2, reason: "accepted_after_resume" } }],
+          },
+        ]);
+
+        type NegotiationDto = {
+          id: string;
+          segments: number;
+          state: string;
+          statusMessage: { phase?: string } | null;
+          statusTimestamp: string | null;
+          outcome: { hasOpportunity: boolean; turnCount: number; reason?: string } | null;
+          turns: Array<{ action: string; reasoning: string; createdAt: string }>;
+          createdAt: string;
+          updatedAt: string;
+        };
+        const getPage = async (limit: number, offset: number) => {
+          const request = new Request(`http://localhost/users/${testUserId}/negotiations?limit=${limit}&offset=${offset}`);
+          const response = await controller.getNegotiations(request, mockAuthUser(), { userId: testUserId });
+          expect(response.status).toBe(200);
+          return (await response.json() as { negotiations: NegotiationDto[] }).negotiations;
+        };
+
+        const allThreads = await getPage(50, 0);
+        expect(allThreads).toHaveLength(4);
+
+        const stitched = allThreads.find((thread) => thread.id === currentTaskId);
+        expect(stitched).toBeDefined();
+        expect(stitched?.segments).toBe(2);
+        expect(stitched?.turns.map((turn) => turn.action)).toEqual(["outreach", "accept"]);
+        expect(stitched?.turns.map((turn) => turn.reasoning)).toEqual(["Original outreach opener", "Accepted after resuming"]);
+        expect(stitched?.state).toBe("completed");
+        expect(stitched?.statusMessage).toEqual({ phase: "resumed-complete" });
+        expect(stitched?.statusTimestamp).toBe(currentStatusTimestamp.toISOString());
+        expect(stitched?.outcome).toEqual({ hasOpportunity: true, role: null, turnCount: 2, reason: "accepted_after_resume" });
+        expect(stitched?.createdAt).toBe(currentCreatedAt.toISOString());
+        expect(stitched?.updatedAt).toBe(currentUpdatedAt.toISOString());
+        expect(allThreads.some((thread) => thread.id === oldTaskId)).toBe(false);
+
+        expect(allThreads.some((thread) => thread.id === otherTaskId)).toBe(true);
+        expect(allThreads.find((thread) => thread.id === fallbackTaskOneId)?.segments).toBe(1);
+        expect(allThreads.find((thread) => thread.id === fallbackTaskTwoId)?.segments).toBe(1);
+
+        const firstPage = await getPage(2, 0);
+        const secondPage = await getPage(2, 2);
+        expect([...firstPage, ...secondPage].map((thread) => thread.id)).toEqual(allThreads.map((thread) => thread.id));
+      } finally {
+        await conversationDatabaseAdapter.deleteConversation(conversation.id);
+        await userAdapter.deleteById(counterparty.id);
+      }
+    }, 30000);
   });
 });

--- a/services/api/src/controllers/user.controller.ts
+++ b/services/api/src/controllers/user.controller.ts
@@ -53,7 +53,7 @@ function mapNegotiatorMemory(row: NegotiatorMemory, subjectMap: ReadonlyMap<stri
   };
 }
 
-type NegotiationRow = Awaited<ReturnType<TaskService['getNegotiationsByUser']>>[number];
+type NegotiationThread = Awaited<ReturnType<TaskService['getNegotiationThreadsByUser']>>[number];
 type NegotiationMessages = Awaited<ReturnType<TaskService['getMessagesByTaskIds']>>;
 type SpeakerUser = { id: string; name: string; avatar: string | null };
 
@@ -61,19 +61,20 @@ type NegotiationTurnData = { action?: string; assessment?: { reasoning?: string;
 type NegotiationOutcomePart = { kind?: string; data?: { hasOpportunity?: boolean; consensus?: boolean; agreedRoles?: Array<{ userId: string; role: string }>; turnCount?: number; reason?: string } };
 
 /**
- * Maps a negotiation task row into the API negotiation DTO.
- * @param row - Negotiation task with its outcome artifact
+ * Maps a negotiation thread into the API negotiation DTO.
+ * @param thread - Current task and every continuation segment in the thread
  * @param messagesMap - Messages keyed by task id (turn data source)
  * @param userMap - Participant users keyed by id (counterparty + speaker resolution)
  * @param selfId - The id treated as "self" for counterparty/role selection
  * @returns Negotiation DTO with counterparty, outcome, and turns
  */
-function mapNegotiationRow(
-  row: NegotiationRow,
+function mapNegotiationThread(
+  thread: NegotiationThread,
   messagesMap: NegotiationMessages,
   userMap: ReadonlyMap<string, SpeakerUser>,
   selfId: string,
 ) {
+  const row = thread.current;
   const meta = row.metadata as { sourceUserId?: string; candidateUserId?: string } | null;
   const counterpartyId = meta?.sourceUserId === selfId ? meta?.candidateUserId : meta?.sourceUserId;
   const counterparty = counterpartyId ? userMap.get(counterpartyId) : null;
@@ -82,7 +83,9 @@ function mapNegotiationRow(
   const outcomeData = outcomePart?.data;
   const viewerRole = outcomeData?.agreedRoles?.find((r) => r.userId === selfId)?.role ?? null;
 
-  const rawMessages = messagesMap.get(row.id) ?? [];
+  const rawMessages = thread.segmentRows
+    .flatMap((segment) => messagesMap.get(segment.id) ?? [])
+    .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime() || a.id.localeCompare(b.id));
   const turns = rawMessages.map((msg) => {
     const agentUserId = msg.senderId.replace(/^agent:/, '');
     const speakerUser = userMap.get(agentUserId);
@@ -101,6 +104,10 @@ function mapNegotiationRow(
 
   return {
     id: row.id,
+    segments: thread.segmentRows.length,
+    state: row.state,
+    statusMessage: row.statusMessage,
+    statusTimestamp: row.statusTimestamp?.toISOString() ?? null,
     counterparty: counterparty
       ? { id: counterparty.id, name: counterparty.name, avatar: counterparty.avatar }
       : { id: counterpartyId ?? 'unknown', name: 'Unknown user', avatar: null },
@@ -114,6 +121,7 @@ function mapNegotiationRow(
       : null,
     turns,
     createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
   };
 }
 
@@ -246,7 +254,7 @@ export class UserController {
         : [];
       const userMap = new Map(participantUsers.map((u) => [u.id, u]));
 
-      const negotiation = mapNegotiationRow(row, messagesMap, userMap, viewer.id);
+      const negotiation = mapNegotiationThread({ current: row, segmentRows: [row] }, messagesMap, userMap, viewer.id);
 
       return Response.json({ negotiation }, { status: 201 });
     } catch (err) {
@@ -287,16 +295,18 @@ export class UserController {
     const mutualWithUserId = isSelf ? undefined : viewer.id;
 
     try {
-      const rows = await this.taskService.getNegotiationsByUser(params.userId, { limit, offset, mutualWithUserId, result, since: validSince });
+      const threads = await this.taskService.getNegotiationThreadsByUser(params.userId, { limit, offset, mutualWithUserId, result, since: validSince });
 
-      const taskIds = rows.map((r) => r.id);
+      const taskIds = threads.flatMap((thread) => thread.segmentRows.map((row) => row.id));
       const messagesMap = await this.taskService.getMessagesByTaskIds(taskIds);
 
       const participantIds = new Set<string>();
-      for (const row of rows) {
-        const meta = row.metadata as { sourceUserId?: string; candidateUserId?: string } | null;
-        if (meta?.sourceUserId) participantIds.add(meta.sourceUserId);
-        if (meta?.candidateUserId) participantIds.add(meta.candidateUserId);
+      for (const thread of threads) {
+        for (const row of thread.segmentRows) {
+          const meta = row.metadata as { sourceUserId?: string; candidateUserId?: string } | null;
+          if (meta?.sourceUserId) participantIds.add(meta.sourceUserId);
+          if (meta?.candidateUserId) participantIds.add(meta.candidateUserId);
+        }
       }
 
       const participantUsers = participantIds.size > 0
@@ -304,7 +314,7 @@ export class UserController {
         : [];
       const userMap = new Map(participantUsers.map((u) => [u.id, u]));
 
-      const negotiations = rows.map((row) => mapNegotiationRow(row, messagesMap, userMap, params.userId));
+      const negotiations = threads.map((thread) => mapNegotiationThread(thread, messagesMap, userMap, params.userId));
 
       return Response.json({ negotiations });
     } catch (err) {

--- a/services/api/src/controllers/user.controller.ts
+++ b/services/api/src/controllers/user.controller.ts
@@ -83,9 +83,17 @@ function mapNegotiationThread(
   const outcomeData = outcomePart?.data;
   const viewerRole = outcomeData?.agreedRoles?.find((r) => r.userId === selfId)?.role ?? null;
 
-  const rawMessages = thread.segmentRows
+  const oldestSegments = [...thread.segmentRows].sort(
+    (a, b) => a.createdAt.getTime() - b.createdAt.getTime() || a.id.localeCompare(b.id),
+  );
+  const segmentOrder = new Map(oldestSegments.map((segment, index) => [segment.id, index]));
+  const rawMessages = oldestSegments
     .flatMap((segment) => messagesMap.get(segment.id) ?? [])
-    .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime() || a.id.localeCompare(b.id));
+    .sort((a, b) =>
+      a.createdAt.getTime() - b.createdAt.getTime()
+      || (segmentOrder.get(a.taskId ?? '') ?? 0) - (segmentOrder.get(b.taskId ?? '') ?? 0)
+      || a.id.localeCompare(b.id),
+    );
   const turns = rawMessages.map((msg) => {
     const agentUserId = msg.senderId.replace(/^agent:/, '');
     const speakerUser = userMap.get(agentUserId);

--- a/services/api/src/services/task.service.ts
+++ b/services/api/src/services/task.service.ts
@@ -1,5 +1,46 @@
 import { conversationDatabaseAdapter, ConversationDatabaseAdapter } from '../adapters/database.adapter';
 
+type NegotiationResult = 'has_opportunity' | 'no_opportunity' | 'in_progress';
+type NegotiationRow = Awaited<ReturnType<ConversationDatabaseAdapter['getNegotiationsByUser']>>[number];
+type NegotiationOutcomePart = { kind?: string; data?: { hasOpportunity?: boolean; consensus?: boolean; reason?: string } };
+
+/** A negotiation's newest task plus every task segment in that opportunity thread. */
+export interface NegotiationThread {
+  current: NegotiationRow;
+  segmentRows: NegotiationRow[];
+}
+
+function getOpportunityId(row: NegotiationRow): string | null {
+  const opportunityId = (row.metadata as { opportunityId?: unknown } | null)?.opportunityId;
+  return typeof opportunityId === 'string' && opportunityId.trim() ? opportunityId.trim() : null;
+}
+
+function getOutcomeData(row: NegotiationRow): NegotiationOutcomePart['data'] | undefined {
+  return (row.artifact?.parts as NegotiationOutcomePart[] | null)?.find((part) => part.kind === 'data')?.data;
+}
+
+function isScreenedOut(row: NegotiationRow): boolean {
+  return getOutcomeData(row)?.reason === 'screened_out';
+}
+
+function matchesResult(row: NegotiationRow, result: NegotiationResult | undefined): boolean {
+  if (!result) return true;
+  const outcome = getOutcomeData(row);
+  if (result === 'has_opportunity') {
+    return outcome?.hasOpportunity === true || outcome?.consensus === true;
+  }
+  if (result === 'no_opportunity') {
+    return outcome?.hasOpportunity === false || outcome?.consensus === false;
+  }
+  return !row.artifact && ['submitted', 'working', 'input_required'].includes(row.state);
+}
+
+function newestFirst(a: NegotiationRow, b: NegotiationRow): number {
+  return b.createdAt.getTime() - a.createdAt.getTime()
+    || b.updatedAt.getTime() - a.updatedAt.getTime()
+    || b.id.localeCompare(a.id);
+}
+
 /**
  * Manages A2A task lifecycle and artifact creation.
  * @remarks Delegates all persistence to ConversationDatabaseAdapter. Does not call other services.
@@ -89,9 +130,56 @@ export class TaskService {
    */
   async getNegotiationsByUser(
     userId: string,
-    opts?: { limit?: number; offset?: number; mutualWithUserId?: string; result?: 'has_opportunity' | 'no_opportunity' | 'in_progress'; since?: Date },
+    opts?: { limit?: number; offset?: number; mutualWithUserId?: string; result?: NegotiationResult; since?: Date },
   ) {
     return this.db.getNegotiationsByUser(userId, opts);
+  }
+
+  /**
+   * Retrieves and paginates complete negotiation threads for a user.
+   *
+   * Pagination is applied after every matching task has been grouped by
+   * opportunity id (or task id when absent), so an arbitrarily long
+   * continuation chain cannot be split across pages. Filters are evaluated
+   * against the newest segment, which defines the thread's current state.
+   * @param userId - User to find negotiation threads for
+   * @param opts - Thread limit, offset, mutual-only filter, current result, and current-segment lower bound
+   * @returns Complete threads ordered by newest segment first
+   */
+  async getNegotiationThreadsByUser(
+    userId: string,
+    opts?: { limit?: number; offset?: number; mutualWithUserId?: string; result?: NegotiationResult; since?: Date },
+  ): Promise<NegotiationThread[]> {
+    const rows = await this.db.getNegotiationsByUser(userId, {
+      mutualWithUserId: opts?.mutualWithUserId,
+      unpaginated: true,
+      includeScreenedOut: true,
+    });
+    const grouped = new Map<string, NegotiationRow[]>();
+
+    for (const row of rows) {
+      const opportunityId = getOpportunityId(row);
+      // Namespace both key types so a fallback task id cannot collide with an
+      // unrelated opportunity id (both are UUID-shaped in production).
+      const key = opportunityId ? `opportunity:${opportunityId}` : `task:${row.id}`;
+      const segmentRows = grouped.get(key) ?? [];
+      segmentRows.push(row);
+      grouped.set(key, segmentRows);
+    }
+
+    const threads = [...grouped.values()]
+      .map((segmentRows) => {
+        segmentRows.sort(newestFirst);
+        return { current: segmentRows[0], segmentRows };
+      })
+      .filter((thread) => !opts?.mutualWithUserId || !isScreenedOut(thread.current))
+      .filter((thread) => matchesResult(thread.current, opts?.result))
+      .filter((thread) => !opts?.since || thread.current.createdAt >= opts.since)
+      .sort((a, b) => newestFirst(a.current, b.current));
+
+    const offset = opts?.offset ?? 0;
+    const limit = opts?.limit ?? 10;
+    return threads.slice(offset, offset + limit);
   }
 
   /**

--- a/services/api/src/services/task.service.ts
+++ b/services/api/src/services/task.service.ts
@@ -156,8 +156,18 @@ export class TaskService {
       includeScreenedOut: true,
     });
     const grouped = new Map<string, NegotiationRow[]>();
-
+    // The schema permits multiple artifacts with the same task/name. Keep one
+    // task segment and prefer its newest outcome artifact so a duplicate write
+    // cannot inflate segment/turn counts.
+    const uniqueRows = new Map<string, NegotiationRow>();
     for (const row of rows) {
+      const existing = uniqueRows.get(row.id);
+      const existingArtifactTime = existing?.artifact?.createdAt.getTime() ?? -1;
+      const rowArtifactTime = row.artifact?.createdAt.getTime() ?? -1;
+      if (!existing || rowArtifactTime > existingArtifactTime) uniqueRows.set(row.id, row);
+    }
+
+    for (const row of uniqueRows.values()) {
       const opportunityId = getOpportunityId(row);
       // Namespace both key types so a fallback task id cannot collide with an
       // unrelated opportunity id (both are UUID-shaped in production).

--- a/services/api/src/services/tests/conversation.service.spec.ts
+++ b/services/api/src/services/tests/conversation.service.spec.ts
@@ -14,15 +14,15 @@ const taskService = new TaskService();
 const cleanupIds: string[] = [];
 
 afterAll(async () => {
-  for (const id of cleanupIds) {
+  const { conversationDatabaseAdapter } = await import('../../adapters/database.adapter');
+  await Promise.all(cleanupIds.map(async (id) => {
     try {
-      const { conversationDatabaseAdapter } = await import('../../adapters/database.adapter');
       await conversationDatabaseAdapter.deleteConversation(id);
     } catch {
       // Best-effort cleanup; test assertions have already completed.
     }
-  }
-});
+  }));
+}, 30000);
 
 describe('ConversationService', () => {
   it('creates conversation and sends message', async () => {

--- a/services/api/src/services/tests/conversation.service.spec.ts
+++ b/services/api/src/services/tests/conversation.service.spec.ts
@@ -2,6 +2,10 @@ import { config } from 'dotenv';
 config({ path: '.env.test', override: true });
 
 import { describe, it, expect, afterAll } from 'bun:test';
+
+import db from '../../lib/drizzle/drizzle';
+import { artifacts, tasks } from '../../schemas/database.schema';
+
 import { ConversationService } from '../conversation.service';
 import { TaskService } from '../task.service';
 
@@ -14,7 +18,9 @@ afterAll(async () => {
     try {
       const { conversationDatabaseAdapter } = await import('../../adapters/database.adapter');
       await conversationDatabaseAdapter.deleteConversation(id);
-    } catch {}
+    } catch {
+      // Best-effort cleanup; test assertions have already completed.
+    }
   }
 });
 
@@ -146,6 +152,83 @@ describe('TaskService', () => {
 
     const artifacts = await taskService.getArtifacts(task.id, conv.id);
     expect(artifacts).toHaveLength(1);
+  }, 15000);
+
+  it('groups and filters negotiation threads by their newest segment', async () => {
+    const run = crypto.randomUUID();
+    const userId = `thread-owner-${run}`;
+    const counterpartyId = `thread-counterparty-${run}`;
+    const conv = await conversationService.createConversation([
+      { participantId: `agent:${userId}`, participantType: 'agent' },
+      { participantId: `agent:${counterpartyId}`, participantType: 'agent' },
+    ]);
+    cleanupIds.push(conv.id);
+
+    const opportunityId = crypto.randomUUID();
+    const originalTaskId = crypto.randomUUID();
+    const currentTaskId = crypto.randomUUID();
+    const fallbackTaskId = opportunityId;
+    const metadata = {
+      type: 'negotiation',
+      sourceUserId: userId,
+      candidateUserId: counterpartyId,
+    };
+
+    await db.insert(tasks).values([
+      {
+        id: originalTaskId,
+        conversationId: conv.id,
+        state: 'completed',
+        metadata: { ...metadata, opportunityId },
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-01-01T01:00:00.000Z'),
+      },
+      {
+        id: currentTaskId,
+        conversationId: conv.id,
+        state: 'completed',
+        metadata: { ...metadata, opportunityId, isContinuation: true },
+        createdAt: new Date('2026-01-03T00:00:00.000Z'),
+        updatedAt: new Date('2026-01-03T01:00:00.000Z'),
+      },
+      {
+        id: fallbackTaskId,
+        conversationId: conv.id,
+        state: 'working',
+        metadata,
+        createdAt: new Date('2026-01-02T00:00:00.000Z'),
+        updatedAt: new Date('2026-01-02T01:00:00.000Z'),
+      },
+    ]);
+    await db.insert(artifacts).values([
+      {
+        taskId: originalTaskId,
+        name: 'negotiation-outcome',
+        parts: [{ kind: 'data', data: { hasOpportunity: false } }],
+      },
+      {
+        taskId: currentTaskId,
+        name: 'negotiation-outcome',
+        parts: [{ kind: 'data', data: { hasOpportunity: true } }],
+      },
+    ]);
+
+    const threads = await taskService.getNegotiationThreadsByUser(userId, { limit: 10 });
+    expect(threads).toHaveLength(2);
+    expect(threads[0].current.id).toBe(currentTaskId);
+    expect(threads[0].segmentRows.map((row) => row.id)).toEqual([currentTaskId, originalTaskId]);
+    expect(threads[1].current.id).toBe(fallbackTaskId);
+    expect(threads[1].segmentRows).toHaveLength(1);
+
+    const successful = await taskService.getNegotiationThreadsByUser(userId, {
+      result: 'has_opportunity',
+    });
+    expect(successful.map((thread) => thread.current.id)).toEqual([currentTaskId]);
+
+    const inProgress = await taskService.getNegotiationThreadsByUser(userId, {
+      result: 'in_progress',
+    });
+    expect(inProgress.map((thread) => thread.current.id)).toEqual([fallbackTaskId]);
   }, 15000);
 });
 


### PR DESCRIPTION
## Summary

- group `GET /api/users/:userId/negotiations` task rows by `metadata.opportunityId`, falling back to a namespaced task ID
- merge every segment's messages into one chronological transcript, using oldest-segment order to break equal timestamp ties
- expose the latest segment's task ID, state, status, outcome, and timestamps plus a thread `segments` count
- apply result/since filters and limit/offset pagination after thread grouping, so an arbitrarily long continuation chain cannot split across pages
- defensively deduplicate task rows and prefer the newest outcome artifact when duplicate `negotiation-outcome` artifacts exist
- complete the web response typing and API reference

`GET /api/conversations/negotiations` is intentionally unchanged: it returns one conversation summary per conversation via `getAgentConversations()`, not task-level transcript entries, so continuation tasks do not create duplicate rows there.

## Pagination approach

The read path fetches all matching negotiation task segments, groups them in `TaskService`, applies current-thread filters, then slices threads by limit/offset. This is correctness-first: no fixed overfetch factor can guarantee that a long continuation chain remains intact. A SQL CTE/window implementation can optimize very large histories later without changing the response contract.

## Verification

- `bun test src/controllers/tests/user.controller.spec.ts` — 3 passed
- `bun test src/services/tests/conversation.service.spec.ts` — 15 passed
- `bun test src/adapters/tests/conversation.database.adapter.spec.ts` — 12 passed
- `bun run build` in `services/api` — passed
- `bun run build` in `apps/web` — passed (existing Vite/CSS/chunk warnings only)
- ESLint on all touched TypeScript files — passed
- `bun install --frozen-lockfile` — passed
- `git diff --check` — passed

## Versions

- `@indexnetwork/api`: `0.33.0` → `0.33.1`
- `@indexnetwork/web`: `0.14.0` → `0.14.1`

No migrations or protocol-package changes.

Closes IND-431.
