### PR TITLE
feat(protocol): add QUD-typed intent clarification (IND-425)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -100,7 +100,7 @@
     },
     "services/api": {
       "name": "@indexnetwork/api",
-      "version": "0.27.9",
+      "version": "0.33.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.939.0",
         "@aws-sdk/s3-request-presigner": "^3.983.0",

--- a/bun.lock
+++ b/bun.lock
@@ -84,7 +84,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "4.3.6",
+      "version": "4.10.0",
       "dependencies": {
         "@langchain/core": "^1.1.17",
         "@langchain/langgraph": "^1.1.2",

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -12,6 +12,9 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
 
 ## [Unreleased]
 
+### Added
+- QUD-typed intent clarification (`missing_constituent`, `missing_constraint`, and `open_alternative_set`) across the live intent elaboration and Questioner flows, with internal detection metadata and exact-match eval coverage (IND-425).
+
 ### Changed
 - Reframed `README.md` as the public-facing Index Network Protocol document and moved package integration details into `IMPLEMENTATION.md`.
 - Included protocol documentation files in the published package tarball so README links remain available to package consumers.

--- a/packages/protocol/eval/clarification/README.md
+++ b/packages/protocol/eval/clarification/README.md
@@ -1,0 +1,11 @@
+# Clarification taxonomy eval
+
+Focused exact-match corpus for the IntentClarifier's canonical QUD underspecification taxonomy.
+
+From `packages/protocol`:
+
+```bash
+bun run eval:clarification
+```
+
+The runner invokes the live `IntentClarifier` for cases covering `missing_constituent`, `missing_constraint`, `open_alternative_set`, and a sufficiently specific `null` case. A case passes only when the emitted type exactly equals the fixture expectation.

--- a/packages/protocol/eval/clarification/README.md
+++ b/packages/protocol/eval/clarification/README.md
@@ -8,4 +8,4 @@ From `packages/protocol`:
 bun run eval:clarification
 ```
 
-The runner invokes the live `IntentClarifier` for cases covering `missing_constituent`, `missing_constraint`, `open_alternative_set`, and a sufficiently specific `null` case. A case passes only when the emitted type exactly equals the fixture expectation.
+The runner invokes the live `IntentClarifier` for cases covering `missing_constituent`, `missing_constraint`, `open_alternative_set`, and a sufficiently specific `null` case. A case passes only when the emitted type exactly equals the fixture expectation, the clarification decision agrees with that type, and the output is not the model-error fallback.

--- a/packages/protocol/eval/clarification/clarification.cases.ts
+++ b/packages/protocol/eval/clarification/clarification.cases.ts
@@ -1,0 +1,37 @@
+import type { ClarificationCase } from "./clarification.types.js";
+
+/** Focused golden corpus covering every canonical QUD category and null. */
+export const CASES: ClarificationCase[] = [
+  {
+    id: "missing-constituent/absent-target",
+    description: "An action with no participant or outcome needs its core target.",
+    input: "I need to find someone for something important.",
+    profileContext: "I am building an early-stage climate technology company.",
+    activeIntentsContext: "none",
+    expectedType: "missing_constituent",
+  },
+  {
+    id: "missing-constraint/absent-location",
+    description: "A concrete hiring target without a ranking boundary needs a constraint.",
+    input: "I want to hire a senior machine-learning engineer, but I have not decided where they should be based.",
+    profileContext: "I lead an AI startup with a distributed engineering team.",
+    activeIntentsContext: "none",
+    expectedType: "missing_constraint",
+  },
+  {
+    id: "open-alternative-set/two-scopes",
+    description: "Materially different collaboration scopes remain unresolved.",
+    input: "I want a partner, either a technical co-founder to build the company or a channel partner to sell the product.",
+    profileContext: "I am launching a B2B analytics product.",
+    activeIntentsContext: "none",
+    expectedType: "open_alternative_set",
+  },
+  {
+    id: "specific/null",
+    description: "A sufficiently constrained intent requires no QUD repair.",
+    input: "I am looking for a senior ML engineer in Berlin for a full-time role building production LLM evaluation systems this quarter.",
+    profileContext: "I lead engineering at an AI startup in Berlin.",
+    activeIntentsContext: "none",
+    expectedType: null,
+  },
+];

--- a/packages/protocol/eval/clarification/clarification.cases.ts
+++ b/packages/protocol/eval/clarification/clarification.cases.ts
@@ -25,6 +25,7 @@ export const CASES: ClarificationCase[] = [
     profileContext: "I am launching a B2B analytics product.",
     activeIntentsContext: "none",
     expectedType: "open_alternative_set",
+    expectedQuestionTerms: ["technical co-founder", "channel partner"],
   },
   {
     id: "specific/null",

--- a/packages/protocol/eval/clarification/clarification.eval.ts
+++ b/packages/protocol/eval/clarification/clarification.eval.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env bun
+import { IntentClarifier } from "../../src/intent/intent.clarifier.js";
+import { CASES } from "./clarification.cases.js";
+import { runCase } from "./clarification.runner.js";
+import { scoreCase } from "./clarification.scorer.js";
+
+async function main(): Promise<void> {
+  const clarifier = new IntentClarifier();
+  let failures = 0;
+
+  console.log(`Running ${CASES.length} clarification taxonomy cases…`);
+  for (const c of CASES) {
+    process.stdout.write(`  ${c.id} … `);
+    const result = scoreCase(c, await runCase(clarifier, c));
+    if (!result.passed) failures += 1;
+    console.log(
+      result.passed
+        ? `pass (${String(result.actualType)})`
+        : `fail (expected ${String(result.expectedType)}, got ${String(result.actualType)})`,
+    );
+  }
+
+  console.log(`\n${CASES.length - failures}/${CASES.length} exact type matches`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exit(2);
+});

--- a/packages/protocol/eval/clarification/clarification.runner.ts
+++ b/packages/protocol/eval/clarification/clarification.runner.ts
@@ -1,0 +1,6 @@
+import type { ClarificationCase, ClarifierLike } from "./clarification.types.js";
+
+/** Run the live IntentClarifier for one corpus case. */
+export async function runCase(clarifier: ClarifierLike, c: ClarificationCase) {
+  return clarifier.invoke(c.input, c.profileContext, c.activeIntentsContext);
+}

--- a/packages/protocol/eval/clarification/clarification.scorer.ts
+++ b/packages/protocol/eval/clarification/clarification.scorer.ts
@@ -1,0 +1,17 @@
+import type { IntentClarifierOutput } from "../../src/intent/intent.clarifier.js";
+
+import type { ClarificationCase, ClarificationResult } from "./clarification.types.js";
+
+/** Score a clarification output by exact taxonomy equality, including null. */
+export function scoreCase(
+  c: ClarificationCase,
+  output: IntentClarifierOutput,
+): ClarificationResult {
+  return {
+    caseId: c.id,
+    expectedType: c.expectedType,
+    actualType: output.underspecificationType,
+    passed: output.underspecificationType === c.expectedType,
+    output,
+  };
+}

--- a/packages/protocol/eval/clarification/clarification.scorer.ts
+++ b/packages/protocol/eval/clarification/clarification.scorer.ts
@@ -7,11 +7,14 @@ export function scoreCase(
   c: ClarificationCase,
   output: IntentClarifierOutput,
 ): ClarificationResult {
+  const classificationMatches = output.underspecificationType === c.expectedType;
+  const clarificationDecisionMatches = output.needsClarification === (c.expectedType !== null);
+  const fallbackFailure = output.reason === "fallback_on_model_error";
   return {
     caseId: c.id,
     expectedType: c.expectedType,
     actualType: output.underspecificationType,
-    passed: output.underspecificationType === c.expectedType,
+    passed: classificationMatches && clarificationDecisionMatches && !fallbackFailure,
     output,
   };
 }

--- a/packages/protocol/eval/clarification/clarification.scorer.ts
+++ b/packages/protocol/eval/clarification/clarification.scorer.ts
@@ -13,11 +13,19 @@ export function scoreCase(
   const contentComplete = output.needsClarification
     ? output.suggestedDescription.trim().length > 0 && output.clarificationMessage.trim().length > 0
     : true;
+  const normalizedMessage = output.clarificationMessage?.toLowerCase() ?? "";
+  const expectedTermsPresent = (c.expectedQuestionTerms ?? []).every((term) =>
+    normalizedMessage.includes(term.toLowerCase()),
+  );
   return {
     caseId: c.id,
     expectedType: c.expectedType,
     actualType: output.underspecificationType,
-    passed: classificationMatches && clarificationDecisionMatches && !fallbackFailure && contentComplete,
+    passed: classificationMatches
+      && clarificationDecisionMatches
+      && !fallbackFailure
+      && contentComplete
+      && expectedTermsPresent,
     output,
   };
 }

--- a/packages/protocol/eval/clarification/clarification.scorer.ts
+++ b/packages/protocol/eval/clarification/clarification.scorer.ts
@@ -10,11 +10,14 @@ export function scoreCase(
   const classificationMatches = output.underspecificationType === c.expectedType;
   const clarificationDecisionMatches = output.needsClarification === (c.expectedType !== null);
   const fallbackFailure = output.reason === "fallback_on_model_error";
+  const contentComplete = output.needsClarification
+    ? output.suggestedDescription.trim().length > 0 && output.clarificationMessage.trim().length > 0
+    : true;
   return {
     caseId: c.id,
     expectedType: c.expectedType,
     actualType: output.underspecificationType,
-    passed: classificationMatches && clarificationDecisionMatches && !fallbackFailure,
+    passed: classificationMatches && clarificationDecisionMatches && !fallbackFailure && contentComplete,
     output,
   };
 }

--- a/packages/protocol/eval/clarification/clarification.types.ts
+++ b/packages/protocol/eval/clarification/clarification.types.ts
@@ -1,0 +1,30 @@
+import type { IntentClarifierOutput } from "../../src/intent/intent.clarifier.js";
+import type { UnderspecificationType } from "../../src/shared/schemas/question.schema.js";
+
+/** One exact-match QUD classification fixture. */
+export interface ClarificationCase {
+  id: string;
+  description: string;
+  input: string;
+  profileContext: string;
+  activeIntentsContext: string;
+  expectedType: UnderspecificationType | null;
+}
+
+/** Minimal live clarifier surface required by the runner. */
+export interface ClarifierLike {
+  invoke(
+    description: string,
+    profileContext: string,
+    activeIntentsContext: string,
+  ): Promise<IntentClarifierOutput>;
+}
+
+/** Exact-match scoring result for one clarifier invocation. */
+export interface ClarificationResult {
+  caseId: string;
+  expectedType: UnderspecificationType | null;
+  actualType: UnderspecificationType | null;
+  passed: boolean;
+  output: IntentClarifierOutput;
+}

--- a/packages/protocol/eval/clarification/clarification.types.ts
+++ b/packages/protocol/eval/clarification/clarification.types.ts
@@ -9,6 +9,8 @@ export interface ClarificationCase {
   profileContext: string;
   activeIntentsContext: string;
   expectedType: UnderspecificationType | null;
+  /** Terms that must appear in the clarification question to resolve this QUD. */
+  expectedQuestionTerms?: string[];
 }
 
 /** Minimal live clarifier surface required by the runner. */

--- a/packages/protocol/eval/clarification/tests/clarification.scorer.spec.ts
+++ b/packages/protocol/eval/clarification/tests/clarification.scorer.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "bun:test";
+
+import { CASES } from "../clarification.cases.js";
+import { runCase } from "../clarification.runner.js";
+import { scoreCase } from "../clarification.scorer.js";
+import type { ClarifierLike } from "../clarification.types.js";
+
+const baseOutput = {
+  needsClarification: true as const,
+  reason: "test",
+  suggestedDescription: "specific intent",
+  clarificationMessage: "Did you mean this?",
+  underspecificationType: "missing_constituent" as const,
+};
+
+describe("clarification corpus", () => {
+  it("covers all exact taxonomy values plus null", () => {
+    expect(new Set(CASES.map((c) => c.expectedType))).toEqual(new Set([
+      "missing_constituent",
+      "missing_constraint",
+      "open_alternative_set",
+      null,
+    ]));
+  });
+});
+
+describe("clarification scorer", () => {
+  it("passes only an exact type match", () => {
+    const c = CASES[0];
+    expect(scoreCase(c, baseOutput).passed).toBe(true);
+    expect(scoreCase(c, {
+      ...baseOutput,
+      underspecificationType: "missing_constraint",
+    }).passed).toBe(false);
+  });
+
+  it("exact-matches null for sufficiently specific inputs", () => {
+    const c = CASES.find((candidate) => candidate.expectedType === null)!;
+    const output = {
+      needsClarification: false as const,
+      reason: "specific",
+      suggestedDescription: null,
+      clarificationMessage: null,
+      underspecificationType: null,
+    };
+    expect(scoreCase(c, output).passed).toBe(true);
+  });
+});
+
+describe("clarification runner", () => {
+  it("passes fixture context to the clarifier", async () => {
+    let args: string[] = [];
+    const clarifier: ClarifierLike = {
+      invoke: async (...values) => {
+        args = values;
+        return baseOutput;
+      },
+    };
+    await runCase(clarifier, CASES[0]);
+    expect(args).toEqual([
+      CASES[0].input,
+      CASES[0].profileContext,
+      CASES[0].activeIntentsContext,
+    ]);
+  });
+});

--- a/packages/protocol/eval/clarification/tests/clarification.scorer.spec.ts
+++ b/packages/protocol/eval/clarification/tests/clarification.scorer.spec.ts
@@ -45,6 +45,30 @@ describe("clarification scorer", () => {
     };
     expect(scoreCase(c, output).passed).toBe(true);
   });
+
+  it("does not count the model-error fallback as a correct null classification", () => {
+    const c = CASES.find((candidate) => candidate.expectedType === null)!;
+    const fallback = {
+      needsClarification: false as const,
+      reason: "fallback_on_model_error",
+      suggestedDescription: null,
+      clarificationMessage: null,
+      underspecificationType: null,
+    };
+    expect(scoreCase(c, fallback).passed).toBe(false);
+  });
+
+  it("requires the clarification decision to agree with the expected type", () => {
+    const c = CASES[0];
+    const contradictory = {
+      needsClarification: false as const,
+      reason: "specific",
+      suggestedDescription: null,
+      clarificationMessage: null,
+      underspecificationType: null,
+    };
+    expect(scoreCase(c, contradictory).passed).toBe(false);
+  });
 });
 
 describe("clarification runner", () => {

--- a/packages/protocol/eval/clarification/tests/clarification.scorer.spec.ts
+++ b/packages/protocol/eval/clarification/tests/clarification.scorer.spec.ts
@@ -69,6 +69,16 @@ describe("clarification scorer", () => {
     };
     expect(scoreCase(c, contradictory).passed).toBe(false);
   });
+
+  it("requires non-empty clarification content", () => {
+    const c = CASES[0];
+    const incomplete = {
+      ...baseOutput,
+      suggestedDescription: "",
+      clarificationMessage: "",
+    };
+    expect(scoreCase(c, incomplete).passed).toBe(false);
+  });
 });
 
 describe("clarification runner", () => {

--- a/packages/protocol/eval/clarification/tests/clarification.scorer.spec.ts
+++ b/packages/protocol/eval/clarification/tests/clarification.scorer.spec.ts
@@ -79,6 +79,20 @@ describe("clarification scorer", () => {
     };
     expect(scoreCase(c, incomplete).passed).toBe(false);
   });
+
+  it("requires open-alternative questions to name the fixture alternatives", () => {
+    const c = CASES.find((candidate) => candidate.expectedType === "open_alternative_set")!;
+    const generic = {
+      ...baseOutput,
+      underspecificationType: "open_alternative_set" as const,
+      clarificationMessage: "Which option do you prefer?",
+    };
+    expect(scoreCase(c, generic).passed).toBe(false);
+    expect(scoreCase(c, {
+      ...generic,
+      clarificationMessage: "Do you need a technical co-founder or a channel partner?",
+    }).passed).toBe(true);
+  });
 });
 
 describe("clarification runner", () => {

--- a/packages/protocol/eval/clarification/tsconfig.json
+++ b/packages/protocol/eval/clarification/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "composite": false,
+    "rootDir": "../../",
+    "types": ["node", "bun-types"]
+  },
+  "include": ["**/*.ts", "../../src/**/*.ts"],
+  "exclude": ["node_modules", "../../src/**/*.spec.ts", "../../src/**/*.test.ts"]
+}

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -25,7 +25,8 @@
     "eval:matching": "bun --env-file=../../.env.test ./eval/matching/matching.eval.ts",
     "eval:premise": "bun --env-file=../../.env.test ./eval/premise/premise.eval.ts",
     "eval:profile": "bun --env-file=../../.env.test ./eval/profile/profile.eval.ts",
-    "eval:opportunity": "bun --env-file=../../.env.test ./eval/opportunity/opportunity.eval.ts"
+    "eval:opportunity": "bun --env-file=../../.env.test ./eval/opportunity/opportunity.eval.ts",
+    "eval:clarification": "bun --env-file=../../.env.test ./eval/clarification/clarification.eval.ts"
   },
   "dependencies": {
     "@langchain/core": "^1.1.17",

--- a/packages/protocol/src/docs/Academic Grounding Enhancement Backlog.md
+++ b/packages/protocol/src/docs/Academic Grounding Enhancement Backlog.md
@@ -33,7 +33,9 @@ Ordering below is **our** priority order (implementation leverage ÷ risk), whic
 - Extend the existing `negotiation` Questioner preset to target **preparatory conditions** of the counterparty ("can they actually do this?") when an opportunity reaches `pending` and the counterparty intent's `felicityAuthority` is low.
 - In `update_opportunity`'s accept path, check for unresolved uptake questions and have the agent present them before offering the accept action. Keep it advisory — a hard new `pre-uptake` state is **not** needed; the existing `negotiating` status is the natural host for unresolved-uptake dwell time.
 
-## 3. QUD-typed clarification in the elaboration loop — **S**
+## 3. QUD-typed clarification in the elaboration loop — **S** — **SHIPPED (IND-425)**
+
+Implemented a canonical three-value QUD taxonomy across IntentClarifier and the live intent/discovery Questioner presets, persisted it as internal question detection metadata, and added exact-match clarification evaluations.
 
 **Theory:** Ginzburg (2012) QUD; Purver's clarification-request typology. *(Ch. 2; not in the report's top-6 but highest value-per-effort.)*
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -190,6 +190,7 @@ export { QuestionerAgent } from "./questioner/questioner.agent.js";
 export type { QuestionerAgentConfig } from "./questioner/questioner.agent.js";
 export type { QuestionerInput, QuestionerContext, QuestionerEnqueuePayload, QuestionerEnqueueFn, DiscoveryContext, IntentContext, ProfileContext, NegotiationContext, NegotiationInflightContext, ChatContext, PoolDiscoveryContext } from "./questioner/questioner.types.js";
 export { getPreset } from "./questioner/questioner.presets.js";
+export { QUD_UNDERSPECIFICATION_RULES } from "./questioner/questioner.qud.js";
 export { isQuestionerEnabled, isDiscoveryQuestionsEnabled, discoveryQuestionsInputMode, discoveryQuestionsTimeoutMs, chatQuestionWaitTimeoutMs } from "./questioner/questioner.env.js";
 export type { QuestionerPreset } from "./questioner/questioner.presets.js";
 export { PoolDiscriminatorMiner } from "./opportunity/discriminator/discriminator.miner.js";

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -94,7 +94,7 @@ export { SYSTEM_AGENT_IDS } from './shared/interfaces/agent.interface.js';
 // ─── Shared schemas ───────────────────────────────────────────────────────────
 
 export { ChatContextDigestSchema, type ChatContextDigest } from "./shared/schemas/chat-context.schema.js";
-export { QuestionOptionSchema, QuestionSchema, QuestionStrategySchema, QuestionWithStrategySchema, QuestionGeneratorResponseSchema, QuestionModeSchema, QuestionDetectionSchema, QuestionActorSchema, QuestionAnswerSchema, type Question, type QuestionOption, type QuestionStrategy, type QuestionWithStrategy, type QuestionGeneratorResponse, type QuestionGenerationResult, type QuestionMode, type QuestionDetection, type QuestionActor, type QuestionAnswer } from "./shared/schemas/question.schema.js";
+export { QuestionOptionSchema, QuestionSchema, UnderspecificationTypeSchema, QuestionStrategySchema, QuestionWithStrategySchema, QuestionGeneratorResponseSchema, QuestionModeSchema, QuestionDetectionSchema, QuestionActorSchema, QuestionAnswerSchema, type Question, type QuestionOption, type UnderspecificationType, type QuestionStrategy, type QuestionWithStrategy, type QuestionGeneratorResponse, type QuestionGenerationResult, type QuestionMode, type QuestionDetection, type QuestionActor, type QuestionAnswer } from "./shared/schemas/question.schema.js";
 export type { PendingQuestionSummary } from "./shared/schemas/pending-question.schema.js";
 export type { McpAuthInput } from "./shared/schemas/mcp-auth.schema.js";
 export { UserIdentitySchema, type UserIdentity } from "./shared/schemas/identity.schema.js";
@@ -105,6 +105,10 @@ export { DEFAULT_NETWORK_ASSIGNMENT_THRESHOLD, classifyPromptPresence, resolveAs
 export type { PromptPresenceInput, ResolveAssignmentNetworkScopeArgs, AssignmentScopeMembership, BuildNetworkAssignmentDecisionArgs, NetworkAssignmentDecision } from "./shared/assignment/network-assignment.policy.js";
 export { buildCandidateEvidence, withCandidateEvidence, mergeOpportunityEvidence, withMatchedStrategies, renderOpportunityEvidenceForPrompt } from "./opportunity/opportunity.evidence.js";
 export type { EvidenceCandidateInput } from "./opportunity/opportunity.evidence.js";
+
+// ─── Intent clarification ─────────────────────────────────────────────────────
+
+export { IntentClarifier, type IntentClarifierOutput } from "./intent/intent.clarifier.js";
 
 // ─── Graph factories ──────────────────────────────────────────────────────────
 

--- a/packages/protocol/src/intent/intent.clarifier.ts
+++ b/packages/protocol/src/intent/intent.clarifier.ts
@@ -38,26 +38,22 @@ const clarificationDraftSchema = z.object({
 export type IntentClarifierOutput = z.infer<typeof clarificationSchema>;
 
 const systemPrompt = `
-You evaluate whether an intent is specific enough to persist without asking the user to confirm a refinement.
+You evaluate whether one focused clarification would materially improve an intent before discovery.
 
-Only set needsClarification=true when the intent is truly vague — e.g. a single generic phrase with no role, domain, location, or other concrete criteria (like "find a job", "I need help", "looking for something").
+Set needsClarification=true only when the intent has a consequential unresolved Question Under Discussion (QUD): the answer would materially change which people or opportunities should surface. Do not ask for merely nice-to-have detail, procedural confirmation, or information already inferable from the user profile or active intents.
 
-Do NOT ask for clarification when the user has already given:
-- A role or type (e.g. "UX designer", "technical co-founder", "engineer")
-- A domain or industry (e.g. "in AI", "climate tech", "fintech")
-- A location or format (e.g. "remote", "Berlin", "full-time")
-- Any other concrete detail that makes the intent actionable
+Classify the single highest-impact QUD repair in underspecificationType:
+- missing_constituent: an absent core participant, entity, or outcome (who/what). Example: "I need help with something" does not identify what help or outcome is sought.
+- missing_constraint: the core target exists, but an explicitly unresolved or discovery-blocking ranking boundary is missing (where/when/how/how much). Example: a concrete hiring target whose location, timing, or engagement boundary is explicitly undecided.
+- open_alternative_set: an unresolved choice among materially different interpretations or scopes. Example: seeking either a technical co-founder or a sales channel partner, which would surface different people.
 
-Default to needsClarification=false when in doubt. Only clarify when the intent is so broad that persisting it as-is would be unhelpful (e.g. literally "a job" or "something" with no other signal).
+An intent does NOT need every possible constraint. A concrete target with enough boundaries to run a useful search is specific even if it omits optional preferences such as compensation, budget, exact seniority, or secondary skills. For example, "a senior ML engineer in Berlin for a full-time role building production LLM evaluation systems this quarter" requires no clarification; do not invent a missing budget or other unstated requirement.
 
-Classify the Question Under Discussion (QUD) repair in underspecificationType:
-- missing_constituent: an absent core participant, entity, or outcome (who/what).
-- missing_constraint: the core target exists, but a ranking boundary is missing (where/when/how/how much).
-- open_alternative_set: an unresolved choice among materially different interpretations or scopes.
-When needsClarification=false, underspecificationType MUST be null. When true, it MUST be exactly one category above.
+Set needsClarification=false when the intent already fixes its core target and enough material ranking boundaries for actionable discovery, or when remaining omissions are optional. When false, underspecificationType MUST be null. When true, it MUST be exactly one category above.
 
 Rules when needsClarification=true:
-- User Profile is the primary source for suggestedDescription; Active Intents are secondary.
+- Ask about the selected QUD category rather than proposing an arbitrary refinement.
+- User Profile is the primary source for a grounded suggestedDescription; Active Intents are secondary.
 - You MUST provide a concrete suggestedDescription and short clarificationMessage.
 - Do not include JSON in clarificationMessage.
 `;

--- a/packages/protocol/src/intent/intent.clarifier.ts
+++ b/packages/protocol/src/intent/intent.clarifier.ts
@@ -22,8 +22,8 @@ const clarificationSchema = z.discriminatedUnion("needsClarification", [
   z.object({
     needsClarification: z.literal(true),
     reason: z.string(),
-    suggestedDescription: z.string().min(1),
-    clarificationMessage: z.string().min(1),
+    suggestedDescription: z.string().trim().min(1),
+    clarificationMessage: z.string().trim().min(1),
     underspecificationType: UnderspecificationTypeSchema,
   }),
 ]);
@@ -218,7 +218,7 @@ ${activeIntentsContext || "none"}
           case "missing_constraint":
             return "Which location, timing, format, or range should constrain this intent?";
           case "open_alternative_set":
-            return "Which of the materially different interpretations or scopes should this intent pursue?";
+            return `Which alternative should this intent pursue instead: ${suggestion}?`;
         }
       })();
       return {

--- a/packages/protocol/src/intent/intent.clarifier.ts
+++ b/packages/protocol/src/intent/intent.clarifier.ts
@@ -22,8 +22,8 @@ const clarificationSchema = z.discriminatedUnion("needsClarification", [
   z.object({
     needsClarification: z.literal(true),
     reason: z.string(),
-    suggestedDescription: z.string().nullable(),
-    clarificationMessage: z.string().nullable(),
+    suggestedDescription: z.string().min(1),
+    clarificationMessage: z.string().min(1),
     underspecificationType: UnderspecificationTypeSchema,
   }),
 ]);
@@ -70,16 +70,18 @@ Rules:
 `;
 
 const clarificationDraftPrompt = `
-You draft a concise clarification response for a vague intent.
+You draft one concise clarification response for an underspecified intent.
 
-Rules:
-- Return both:
-  1) suggestedDescription (specific rewritten intent)
-  2) clarificationMessage (single short message to the user)
-- clarificationMessage must include the suggestion naturally and ask for confirmation.
-- Use this shape: ` + "`Did you mean: \"<suggestedDescription>\"?`" + ` followed by a brief confirmation instruction.
-- Target the question specifically to the QUD repair category supplied in the user prompt.
-- Keep it short. No bullet lists. No JSON.
+Return both:
+1) suggestedDescription: one concrete rewrite representing a plausible interpretation.
+2) clarificationMessage: one direct question that resolves the supplied QUD category.
+
+Question rules by category:
+- missing_constituent: ask which participant, entity, or outcome the user means.
+- missing_constraint: ask for the unresolved ranking boundary (where/when/how/how much).
+- open_alternative_set: name the materially different alternatives and ask the user to choose; never collapse them into a generic yes/no confirmation.
+
+The question may mention suggestedDescription when useful, but do not force every category into "Did you mean...?". Keep it short. No bullet lists. No JSON.
 `;
 
 export class IntentClarifier {
@@ -209,7 +211,16 @@ ${activeIntentsContext || "none"}
       logger.warn("generateClarificationDraft: failed", { error });
       const suggestion = await this.generateSuggestion(description, profileContext, activeIntentsContext);
       if (!suggestion) return null;
-      const clarificationMessage = `Do you mean: ${suggestion}?`;
+      const clarificationMessage = (() => {
+        switch (underspecificationType) {
+          case "missing_constituent":
+            return "Who or what should this intent focus on?";
+          case "missing_constraint":
+            return "Which location, timing, format, or range should constrain this intent?";
+          case "open_alternative_set":
+            return "Which of the materially different interpretations or scopes should this intent pursue?";
+        }
+      })();
       return {
         suggestedDescription: suggestion,
         clarificationMessage,

--- a/packages/protocol/src/intent/intent.clarifier.ts
+++ b/packages/protocol/src/intent/intent.clarifier.ts
@@ -1,22 +1,32 @@
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { z } from "zod";
 
-import { protocolLogger } from "../shared/observability/protocol.logger.js";
-import { Timed } from "../shared/observability/performance.js";
-
 import { createStructuredModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
+import { protocolLogger } from "../shared/observability/protocol.logger.js";
+import { Timed } from "../shared/observability/performance.js";
+import { UnderspecificationTypeSchema, type UnderspecificationType } from "../shared/schemas/question.schema.js";
 
 const logger = protocolLogger("IntentClarifier");
 
 type ClarifierStructuredModel = ReturnType<typeof createStructuredModel>;
 
-const clarificationSchema = z.object({
-  needsClarification: z.boolean(),
-  reason: z.string(),
-  suggestedDescription: z.string().nullable(),
-  clarificationMessage: z.string().nullable(),
-});
+const clarificationSchema = z.discriminatedUnion("needsClarification", [
+  z.object({
+    needsClarification: z.literal(false),
+    reason: z.string(),
+    suggestedDescription: z.string().nullable(),
+    clarificationMessage: z.string().nullable(),
+    underspecificationType: z.null(),
+  }),
+  z.object({
+    needsClarification: z.literal(true),
+    reason: z.string(),
+    suggestedDescription: z.string().nullable(),
+    clarificationMessage: z.string().nullable(),
+    underspecificationType: UnderspecificationTypeSchema,
+  }),
+]);
 const suggestionSchema = z.object({
   suggestedDescription: z.string(),
 });
@@ -39,6 +49,12 @@ Do NOT ask for clarification when the user has already given:
 - Any other concrete detail that makes the intent actionable
 
 Default to needsClarification=false when in doubt. Only clarify when the intent is so broad that persisting it as-is would be unhelpful (e.g. literally "a job" or "something" with no other signal).
+
+Classify the Question Under Discussion (QUD) repair in underspecificationType:
+- missing_constituent: an absent core participant, entity, or outcome (who/what).
+- missing_constraint: the core target exists, but a ranking boundary is missing (where/when/how/how much).
+- open_alternative_set: an unresolved choice among materially different interpretations or scopes.
+When needsClarification=false, underspecificationType MUST be null. When true, it MUST be exactly one category above.
 
 Rules when needsClarification=true:
 - User Profile is the primary source for suggestedDescription; Active Intents are secondary.
@@ -66,6 +82,7 @@ Rules:
   2) clarificationMessage (single short message to the user)
 - clarificationMessage must include the suggestion naturally and ask for confirmation.
 - Use this shape: ` + "`Did you mean: \"<suggestedDescription>\"?`" + ` followed by a brief confirmation instruction.
+- Target the question specifically to the QUD repair category supplied in the user prompt.
 - Keep it short. No bullet lists. No JSON.
 `;
 
@@ -123,7 +140,12 @@ ${activeIntentsContext || "none"}
 
       if (parsed.needsClarification) {
         // Always prefer a dedicated rewrite pass for vague inputs so we avoid generic follow-up text.
-        const draft = await this.generateClarificationDraft(description, profileContext, activeIntentsContext);
+        const draft = await this.generateClarificationDraft(
+          description,
+          profileContext,
+          activeIntentsContext,
+          parsed.underspecificationType,
+        );
         if (draft) {
           return {
             ...parsed,
@@ -141,6 +163,7 @@ ${activeIntentsContext || "none"}
         reason: "fallback_on_model_error",
         suggestedDescription: null,
         clarificationMessage: null,
+        underspecificationType: null,
       };
     }
   }
@@ -168,10 +191,15 @@ ${activeIntentsContext || "none"}
   private async generateClarificationDraft(
     description: string,
     profileContext: string,
-    activeIntentsContext: string
+    activeIntentsContext: string,
+    underspecificationType: UnderspecificationType,
   ): Promise<{ suggestedDescription: string; clarificationMessage: string } | null> {
     try {
-      const prompt = this.buildPrompt(description, profileContext, activeIntentsContext);
+      const prompt = [
+        this.buildPrompt(description, profileContext, activeIntentsContext),
+        "# QUD Repair Category",
+        underspecificationType,
+      ].join("\n");
       const output = await invokeWithAbortSignal(this.clarificationDraftModel, [
         new SystemMessage(clarificationDraftPrompt),
         new HumanMessage(prompt),

--- a/packages/protocol/src/intent/intent.clarifier.ts
+++ b/packages/protocol/src/intent/intent.clarifier.ts
@@ -218,7 +218,7 @@ ${activeIntentsContext || "none"}
           case "missing_constraint":
             return "Which location, timing, format, or range should constrain this intent?";
           case "open_alternative_set":
-            return `Which alternative should this intent pursue instead: ${suggestion}?`;
+            return `Your intent names different alternatives — "${description}". Which one should take priority?`;
         }
       })();
       return {

--- a/packages/protocol/src/intent/intent.tools.ts
+++ b/packages/protocol/src/intent/intent.tools.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { IntentClarifier } from "./intent.clarifier.js";
 import type { ExecutionResult, VerifiedIntent } from "./intent.state.js";
 import { DEFAULT_SPECIFICITY_WARNING } from "./intent.specificity.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
@@ -12,6 +13,20 @@ import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 import { deriveAllowedNetworkIds, focusedIntentId, focusedNetworkId, focusedNetworkLabel, type ToolScopeEnvelope } from "../shared/agent/tool.scope.js";
 
 const logger = protocolLogger("ChatTools:Intent");
+
+type IntentClarifierLike = Pick<IntentClarifier, "invoke">;
+
+let intentClarifier: IntentClarifierLike | undefined;
+
+function getIntentClarifier(): IntentClarifierLike {
+  intentClarifier ??= new IntentClarifier();
+  return intentClarifier;
+}
+
+/** Replace the lazy clarifier in deterministic tool tests. */
+export function setIntentClarifierForTesting(clarifier: IntentClarifierLike | null): void {
+  intentClarifier = clarifier ?? undefined;
+}
 
 /**
  * Sanitize JSON string for use inside a markdown code fence (```). Escapes backticks
@@ -346,13 +361,30 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
           );
         }
 
+        const clarification = await getIntentClarifier().invoke(
+          query.description,
+          userProfile,
+          "",
+        );
+        if (clarification.needsClarification) {
+          return JSON.stringify({
+            success: false,
+            needsClarification: true,
+            underspecificationType: clarification.underspecificationType,
+            suggestedDescription: clarification.suggestedDescription,
+            clarificationMessage: clarification.clarificationMessage,
+            missingFields: [clarification.underspecificationType],
+            message: clarification.clarificationMessage,
+            debugSteps,
+          });
+        }
+
         const rejectionHint =
           verificationTrace.detail ?? "all candidate intents were filtered as invalid or too vague";
         return error(
           `Intent verification failed (${rejectionHint}). ` +
-          `The description may be too vague or was classified as a statement rather than a goal. ` +
-          `Either retry with a more specific description (e.g. include what kind, what for, or a timeframe) ` +
-          `or ask the user to clarify what exactly they are looking for.`,
+          `The description may have been classified as a statement rather than a goal. ` +
+          `Retry with an explicit goal or ask the user what outcome they want.`,
           debugSteps,
         );
       }

--- a/packages/protocol/src/intent/intent.tools.ts
+++ b/packages/protocol/src/intent/intent.tools.ts
@@ -23,6 +23,30 @@ function getIntentClarifier(): IntentClarifierLike {
   return intentClarifier;
 }
 
+async function buildTypedClarificationResult(params: {
+  description: string;
+  userProfile: string;
+  activeIntentsContext?: string;
+  debugSteps: Array<{ step: string; detail?: string; data?: Record<string, unknown> }>;
+}): Promise<string | null> {
+  const clarification = await getIntentClarifier().invoke(
+    params.description,
+    params.userProfile,
+    params.activeIntentsContext ?? "",
+  );
+  if (!clarification.needsClarification) return null;
+  return JSON.stringify({
+    success: false,
+    needsClarification: true,
+    underspecificationType: clarification.underspecificationType,
+    suggestedDescription: clarification.suggestedDescription,
+    clarificationMessage: clarification.clarificationMessage,
+    missingFields: [clarification.underspecificationType],
+    message: clarification.clarificationMessage,
+    debugSteps: params.debugSteps,
+  });
+}
+
 /** Replace the lazy clarifier in deterministic tool tests. */
 export function setIntentClarifierForTesting(clarifier: IntentClarifierLike | null): void {
   intentClarifier = clarifier ?? undefined;
@@ -349,34 +373,23 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
         // runs — so we check inference trace first.
         const verificationTrace = debugSteps.find((s: { step: string; detail?: string }) => s.step === "verification");
 
+        const typedClarification = await buildTypedClarificationResult({
+          description: query.description,
+          userProfile,
+          activeIntentsContext: result.activeIntents,
+          debugSteps,
+        });
+        if (typedClarification) return typedClarification;
+
         if (!verificationTrace) {
           const inferenceHint =
             debugSteps.find((s: { step: string; detail?: string }) => s.step === "inference")?.detail
             ?? "no intents extracted";
           return error(
             `No actionable intent was extracted (${inferenceHint}). ` +
-            `Please retry with a more specific goal (what kind, what for, and/or timeframe), ` +
-            `or ask the user to clarify.`,
+            `Please retry with an explicit goal or ask the user what outcome they want.`,
             debugSteps,
           );
-        }
-
-        const clarification = await getIntentClarifier().invoke(
-          query.description,
-          userProfile,
-          "",
-        );
-        if (clarification.needsClarification) {
-          return JSON.stringify({
-            success: false,
-            needsClarification: true,
-            underspecificationType: clarification.underspecificationType,
-            suggestedDescription: clarification.suggestedDescription,
-            clarificationMessage: clarification.clarificationMessage,
-            missingFields: [clarification.underspecificationType],
-            message: clarification.clarificationMessage,
-            debugSteps,
-          });
         }
 
         const rejectionHint =
@@ -393,6 +406,14 @@ export function createIntentTools(defineTool: DefineTool, deps: ToolDeps) {
       if (shouldAutoApprove) {
         const broadIntents = (verified as VerifiedIntent[]).filter(isBroadAttributiveIntent);
         if (broadIntents.length > 0) {
+          const typedClarification = await buildTypedClarificationResult({
+            description: broadIntents[0].description,
+            userProfile,
+            activeIntentsContext: result.activeIntents,
+            debugSteps,
+          });
+          if (typedClarification) return typedClarification;
+
           const first = broadIntents[0];
           const missing = first.verification?.missing_selectional_constraints ?? [];
           const missingHint = missing.length > 0

--- a/packages/protocol/src/intent/tests/intent.clarifier.spec.ts
+++ b/packages/protocol/src/intent/tests/intent.clarifier.spec.ts
@@ -25,7 +25,10 @@ describe('IntentClarifier', () => {
       '',
     );
     expect(result.needsClarification).toBe(true);
-    expect(result.clarificationMessage).toBeTruthy();
+    if (!result.needsClarification) throw new Error('expected clarification');
+    expect(result.clarificationMessage.length).toBeGreaterThan(0);
+    expect(result.suggestedDescription.length).toBeGreaterThan(0);
+    expect(result.underspecificationType).not.toBeNull();
     expect(result.underspecificationType).not.toBeNull();
   }, 60000);
 

--- a/packages/protocol/src/intent/tests/intent.clarifier.spec.ts
+++ b/packages/protocol/src/intent/tests/intent.clarifier.spec.ts
@@ -15,7 +15,7 @@ describe('IntentClarifier', () => {
       '',
     );
     expect(result.needsClarification).toBe(false);
-    expect(result.suggestedDescription).toBeTruthy();
+    expect(result.underspecificationType).toBeNull();
   }, 60000);
 
   it('returns needsClarification=true for a vague, unactionable intent', async () => {
@@ -26,6 +26,7 @@ describe('IntentClarifier', () => {
     );
     expect(result.needsClarification).toBe(true);
     expect(result.clarificationMessage).toBeTruthy();
+    expect(result.underspecificationType).not.toBeNull();
   }, 60000);
 
   it('returns suggestedDescription for any intent', async () => {

--- a/packages/protocol/src/intent/tests/update-intent.spec.ts
+++ b/packages/protocol/src/intent/tests/update-intent.spec.ts
@@ -86,6 +86,46 @@ describe("create_intent", () => {
     expect(result.suggestedDescription).toBe("Find a collaborator for my climate startup");
   });
 
+  test("passes active intents into typed clarification for no-inference proposals", async () => {
+    let capturedActiveIntents = "";
+    setIntentClarifierForTesting({
+      invoke: async (_description, _profile, activeIntents) => {
+        capturedActiveIntents = activeIntents;
+        return {
+          needsClarification: true,
+          reason: "target missing",
+          suggestedDescription: "Find an AI collaborator",
+          clarificationMessage: "Which kind of AI collaborator do you need?",
+          underspecificationType: "missing_constituent",
+        };
+      },
+    });
+    const tools = captureTools({
+      userDb: {},
+      systemDb: {},
+      graphs: {
+        profile: { invoke: async () => ({ profile: null, agentTimings: [] }) },
+        intent: {
+          invoke: async () => ({
+            verifiedIntents: [],
+            activeIntents: "ID: existing-1, Description: Find ML mentors",
+            agentTimings: [],
+            trace: [{ node: "inference", detail: "Inferred 0 intent(s)" }],
+          }),
+        },
+      },
+    } as unknown as ToolDeps);
+    const tool = tools.find((candidate) => candidate.name === "create_intent")!;
+
+    const result = JSON.parse(await tool.handler({
+      context: makeContext("alice"),
+      query: { description: "help", autoApprove: true },
+    }));
+
+    expect(result.needsClarification).toBe(true);
+    expect(capturedActiveIntents).toContain("Find ML mentors");
+  });
+
   test("falls back to approved user intro when structured profile is still pending", async () => {
     const capturedProfiles: string[] = [];
     const tools = captureTools({
@@ -130,6 +170,15 @@ describe("create_intent", () => {
   });
 
   test("rejects broad referential-breadth signals in MCP auto-approve mode", async () => {
+    setIntentClarifierForTesting({
+      invoke: async () => ({
+        needsClarification: false,
+        reason: "test fallback",
+        suggestedDescription: null,
+        clarificationMessage: null,
+        underspecificationType: null,
+      }),
+    });
     let createCalls = 0;
     const tools = captureTools({
       userDb: {},
@@ -178,6 +227,15 @@ describe("create_intent", () => {
   });
 
   test("uses default broad warning in MCP auto-approve mode when verifier emits a null-like string", async () => {
+    setIntentClarifierForTesting({
+      invoke: async () => ({
+        needsClarification: false,
+        reason: "test fallback",
+        suggestedDescription: null,
+        clarificationMessage: null,
+        underspecificationType: null,
+      }),
+    });
     let createCalls = 0;
     const tools = captureTools({
       userDb: {},

--- a/packages/protocol/src/intent/tests/update-intent.spec.ts
+++ b/packages/protocol/src/intent/tests/update-intent.spec.ts
@@ -1,7 +1,7 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { z } from "zod";
 
-import { createIntentTools } from "../intent.tools.js";
+import { createIntentTools, setIntentClarifierForTesting } from "../intent.tools.js";
 import { DEFAULT_SPECIFICITY_WARNING } from "../intent.specificity.js";
 
 import type { ToolDeps, ResolvedToolContext } from "../../shared/agent/tool.helpers.js";
@@ -43,7 +43,49 @@ function extractFirstIntentProposal(message: string): Record<string, unknown> {
   return JSON.parse(match[1]) as Record<string, unknown>;
 }
 
+afterEach(() => {
+  setIntentClarifierForTesting(null);
+});
+
 describe("create_intent", () => {
+  test("returns typed clarification from the live elaboration path for vague intents", async () => {
+    setIntentClarifierForTesting({
+      invoke: async () => ({
+        needsClarification: true,
+        reason: "target missing",
+        suggestedDescription: "Find a collaborator for my climate startup",
+        clarificationMessage: "What kind of collaborator does your climate startup need?",
+        underspecificationType: "missing_constituent",
+      }),
+    });
+    const tools = captureTools({
+      userDb: {},
+      systemDb: {},
+      graphs: {
+        profile: { invoke: async () => ({ profile: null, agentTimings: [] }) },
+        intent: {
+          invoke: async () => ({
+            verifiedIntents: [],
+            agentTimings: [],
+            trace: [{ node: "verification", detail: "Verified 0/1 (1 filtered as invalid)" }],
+          }),
+        },
+      },
+    } as unknown as ToolDeps);
+    const tool = tools.find((candidate) => candidate.name === "create_intent")!;
+
+    const result = JSON.parse(await tool.handler({
+      context: makeContext("alice"),
+      query: { description: "I need help with something", autoApprove: true },
+    }));
+
+    expect(result.success).toBe(false);
+    expect(result.needsClarification).toBe(true);
+    expect(result.underspecificationType).toBe("missing_constituent");
+    expect(result.message).toBe("What kind of collaborator does your climate startup need?");
+    expect(result.suggestedDescription).toBe("Find a collaborator for my climate startup");
+  });
+
   test("falls back to approved user intro when structured profile is still pending", async () => {
     const capturedProfiles: string[] = [];
     const tools = captureTools({

--- a/packages/protocol/src/opportunity/question.generator.ts
+++ b/packages/protocol/src/opportunity/question.generator.ts
@@ -89,8 +89,9 @@ export class QuestionGenerator {
     if (filtered.length === 0) return null;
 
     return {
-      questions: filtered.map(stripStrategy),
+      questions: filtered.map(stripInternalMetadata),
       strategies: filtered.map((q) => q.strategy),
+      underspecificationTypes: filtered.map((q) => q.underspecificationType),
     };
   }
 }
@@ -140,7 +141,11 @@ function enforceStrategyDiversity(
   return out;
 }
 
-function stripStrategy(q: QuestionWithStrategy): Question {
-  const { strategy: _strategy, ...publicShape } = q;
+function stripInternalMetadata(q: QuestionWithStrategy): Question {
+  const {
+    strategy: _strategy,
+    underspecificationType: _underspecificationType,
+    ...publicShape
+  } = q;
   return publicShape;
 }

--- a/packages/protocol/src/opportunity/question.generator.ts
+++ b/packages/protocol/src/opportunity/question.generator.ts
@@ -16,6 +16,7 @@
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 
 import { QuestionGeneratorResponseSchema, type Question, type QuestionGenerationResult, type QuestionStrategy, type QuestionWithStrategy } from "../shared/schemas/question.schema.js";
+import { QUD_UNDERSPECIFICATION_RULES } from "../questioner/questioner.qud.js";
 import { createStructuredModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
@@ -59,7 +60,10 @@ export class QuestionGenerator {
     try {
       raw = await invokeWithAbortSignal(
         this.model,
-        [new SystemMessage(SYSTEM_PROMPT), new HumanMessage(user)],
+        [
+          new SystemMessage(`${SYSTEM_PROMPT}\n\n${QUD_UNDERSPECIFICATION_RULES}`),
+          new HumanMessage(user),
+        ],
         options?.signal,
       );
     } catch (err) {

--- a/packages/protocol/src/opportunity/tests/opportunity.discover.questions.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.discover.questions.spec.ts
@@ -65,7 +65,7 @@ describe("runDiscoverFromQuery — decision-question integration", () => {
   it("returns questions when trigger=orchestrator and the generator yields a result", async () => {
     const chatSummary: ChatSummaryReader = { getDigest: async () => null };
     const questionGenerator: QuestionGeneratorReader = {
-      generate: async () => ({ questions: [baseQuestion], strategies: ["refine_intent"] }),
+      generate: async () => ({ questions: [baseQuestion], strategies: ["refine_intent"], underspecificationTypes: [null] }),
     };
     const result = await runDiscoverFromQuery({
       opportunityGraph: makeFakeGraph(),

--- a/packages/protocol/src/opportunity/tests/question.generator.spec.ts
+++ b/packages/protocol/src/opportunity/tests/question.generator.spec.ts
@@ -39,6 +39,7 @@ function makeQuestion(overrides: Record<string, unknown> = {}) {
     options: [okOption, { label: "B", description: "desc-b" }],
     multiSelect: false,
     strategy: "refine_intent",
+    underspecificationType: null,
     ...overrides,
   };
 }

--- a/packages/protocol/src/opportunity/tests/question.generator.spec.ts
+++ b/packages/protocol/src/opportunity/tests/question.generator.spec.ts
@@ -45,6 +45,19 @@ function makeQuestion(overrides: Record<string, unknown> = {}) {
 }
 
 describe("QuestionGenerator", () => {
+  it("sends the QUD metadata contract to the backward-compatible discovery model", async () => {
+    let capturedMessages: unknown[] | undefined;
+    const gen = makeGenerator(async (input) => {
+      capturedMessages = input as unknown[];
+      return { questions: [makeQuestion({ title: "Stage" })] };
+    });
+    const result = await gen.generate(makeInput());
+    expect(result).not.toBeNull();
+    const systemContent = (capturedMessages?.[0] as { content?: unknown })?.content;
+    expect(String(systemContent)).toContain("QUD underspecification taxonomy");
+    expect(String(systemContent)).toContain("underspecificationType");
+  });
+
   it("returns null when the LLM throws", async () => {
     const gen = makeGenerator(async () => {
       throw new Error("model down");

--- a/packages/protocol/src/questioner/questioner.agent.ts
+++ b/packages/protocol/src/questioner/questioner.agent.ts
@@ -96,8 +96,9 @@ export class QuestionerAgent {
     if (filtered.length === 0) return null;
 
     return {
-      questions: filtered.map(stripStrategy),
+      questions: filtered.map(stripInternalMetadata),
       strategies: filtered.map((q) => q.strategy),
+      underspecificationTypes: filtered.map((q) => q.underspecificationType),
     };
   }
 }
@@ -134,7 +135,11 @@ function enforceStrategyDiversity(
   return out;
 }
 
-function stripStrategy(q: QuestionWithStrategy): Question {
-  const { strategy: _strategy, ...publicShape } = q;
+function stripInternalMetadata(q: QuestionWithStrategy): Question {
+  const {
+    strategy: _strategy,
+    underspecificationType: _underspecificationType,
+    ...publicShape
+  } = q;
   return publicShape;
 }

--- a/packages/protocol/src/questioner/questioner.ask.tool.ts
+++ b/packages/protocol/src/questioner/questioner.ask.tool.ts
@@ -31,7 +31,7 @@ import { error, success } from "../shared/agent/tool.helpers.js";
 import { requestContext } from "../shared/observability/request-context.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import type { PersistableQuestion, PersistedQuestion, ChatQuestionAnswerOutcome } from "../shared/interfaces/questioner.interface.js";
-import type { Question, QuestionStrategy } from "../shared/schemas/question.schema.js";
+import type { Question, QuestionGenerationResult, QuestionStrategy, UnderspecificationType } from "../shared/schemas/question.schema.js";
 import { QuestionerAgent } from "./questioner.agent.js";
 import { chatQuestionWaitTimeoutMs } from "./questioner.env.js";
 import type { ChatContext } from "./questioner.types.js";
@@ -177,7 +177,7 @@ export function createAskUserQuestionTools(defineTool: DefineTool, deps: ToolDep
         ...(userContext ? { userContext } : {}),
       };
 
-      let generated: { questions: Question[]; strategies: QuestionStrategy[] } | null = null;
+      let generated: QuestionGenerationResult | null = null;
       try {
         generated = await getQuestionerAgent().invoke(
           {
@@ -198,9 +198,11 @@ export function createAskUserQuestionTools(defineTool: DefineTool, deps: ToolDep
 
       let finalQuestions: Question[];
       let strategies: QuestionStrategy[];
+      let underspecificationTypes: Array<UnderspecificationType | null>;
       if (generated && generated.questions.length > 0) {
         finalQuestions = generated.questions;
         strategies = generated.strategies;
+        underspecificationTypes = generated.underspecificationTypes;
       } else {
         // Fallback: use the orchestrator's own drafts verbatim (options required).
         const fromDrafts = (query.questions ?? [])
@@ -213,6 +215,7 @@ export function createAskUserQuestionTools(defineTool: DefineTool, deps: ToolDep
         }
         finalQuestions = fromDrafts;
         strategies = fromDrafts.map(() => "surface_missing_detail" as const);
+        underspecificationTypes = fromDrafts.map(() => null);
       }
 
       if (signal?.aborted) {
@@ -227,10 +230,12 @@ export function createAskUserQuestionTools(defineTool: DefineTool, deps: ToolDep
           sourceType: "conversation",
           sourceId: sessionId,
           timestamp,
+          underspecificationType: underspecificationTypes[i] ?? null,
         },
         actors: [{ userId: context.userId, role: "subject" as const }],
         payload,
         strategy: strategies[i] ?? "surface_missing_detail",
+        underspecificationType: underspecificationTypes[i] ?? null,
         conversationId: sessionId,
       }));
 

--- a/packages/protocol/src/questioner/questioner.ask.tool.ts
+++ b/packages/protocol/src/questioner/questioner.ask.tool.ts
@@ -230,7 +230,6 @@ export function createAskUserQuestionTools(defineTool: DefineTool, deps: ToolDep
           sourceType: "conversation",
           sourceId: sessionId,
           timestamp,
-          underspecificationType: underspecificationTypes[i] ?? null,
         },
         actors: [{ userId: context.userId, role: "subject" as const }],
         payload,

--- a/packages/protocol/src/questioner/questioner.presets.ts
+++ b/packages/protocol/src/questioner/questioner.presets.ts
@@ -17,6 +17,12 @@ import type { ChatContext, IntentContext, NegotiationContext, NegotiationInfligh
  * surfaced in digest audits ("…with these builders?", "the previous
  * negotiation stalled because the counterparty didn't mention …").
  */
+export const QUD_UNDERSPECIFICATION_RULES = `QUD underspecification taxonomy. For every structured question, emit a required \`underspecificationType\` field. Use exactly one category only when the question repairs that kind of underspecification:
+- missing_constituent: an absent core participant, entity, or outcome (who/what).
+- missing_constraint: the core target exists, but a ranking boundary is missing (where/when/how/how much).
+- open_alternative_set: an unresolved choice among materially different interpretations or scopes.
+Use null for adjacent, reflective, emergent, or any other question that does not repair underspecification. Strategy and underspecification type are orthogonal: \`strategy\` describes the conversational move; \`underspecificationType\` describes the QUD defect repaired. Never infer one mechanically from the other.`;
+
 const REFERENTIAL_CLOSURE_RULES = `Referential closure. The prompt must resolve entirely on its own, with no dangling references. The reader sees ONLY the question text — never the people you reviewed, the counterparty, the events on their calendar, or this conversation. Do not use demonstratives or definite anaphora that point at things the reader cannot see: "these builders", "those founders", "these researchers", "these conversations", "this lunch", "the speaker". If you reference a person, name them. If you reference a group, restate the concrete shared attribute inside the question itself ("founders working on decentralized identity"), never "these founders". Never imply a list, set, or prior exchange the reader is not currently looking at.
 - Bad: "What kind of collaboration are you looking for with these builders?"
 - Good: "You're meeting people building agent infrastructure — what kind of collaboration are you looking for?"
@@ -61,6 +67,8 @@ Standalone prompt rule. Every generated \`prompt\` must be understandable outsid
 - Good: "For your decentralized identity protocol-design search, what kind of collaboration are you looking for?"
 
 ${REFERENTIAL_CLOSURE_RULES}
+
+${QUD_UNDERSPECIFICATION_RULES}
 
 Cardinality. Default one question. Add a second only when a DIFFERENT strategy genuinely complements the first and unblocks a clearly distinct decision. Never ask two questions of the same strategy unless their decision domains differ (different titles).
 
@@ -389,7 +397,7 @@ function buildChatPrompt(ctx: ChatContext): string {
  */
 const presets: Partial<Record<QuestionMode, QuestionerPreset>> = {
   discovery: {
-    systemPrompt: DISCOVERY_SYSTEM_PROMPT,
+    systemPrompt: `${DISCOVERY_SYSTEM_PROMPT}\n\n${QUD_UNDERSPECIFICATION_RULES}`,
     buildPrompt: (context: unknown) =>
       buildDiscoveryPrompt(context as Parameters<typeof buildDiscoveryPrompt>[0]),
   },

--- a/packages/protocol/src/questioner/questioner.presets.ts
+++ b/packages/protocol/src/questioner/questioner.presets.ts
@@ -7,6 +7,7 @@
 import type { QuestionMode } from "../shared/schemas/question.schema.js";
 import { SYSTEM_PROMPT as DISCOVERY_SYSTEM_PROMPT, buildQuestionPrompt as buildDiscoveryPrompt } from "../opportunity/question.prompt.js";
 
+import { QUD_UNDERSPECIFICATION_RULES } from "./questioner.qud.js";
 import type { ChatContext, IntentContext, NegotiationContext, NegotiationInflightContext, ProfileContext } from "./questioner.types.js";
 
 /**
@@ -17,12 +18,6 @@ import type { ChatContext, IntentContext, NegotiationContext, NegotiationInfligh
  * surfaced in digest audits ("…with these builders?", "the previous
  * negotiation stalled because the counterparty didn't mention …").
  */
-export const QUD_UNDERSPECIFICATION_RULES = `QUD underspecification taxonomy. For every structured question, emit a required \`underspecificationType\` field. Use exactly one category only when the question repairs that kind of underspecification:
-- missing_constituent: an absent core participant, entity, or outcome (who/what).
-- missing_constraint: the core target exists, but a ranking boundary is missing (where/when/how/how much).
-- open_alternative_set: an unresolved choice among materially different interpretations or scopes.
-Use null for adjacent, reflective, emergent, or any other question that does not repair underspecification. Strategy and underspecification type are orthogonal: \`strategy\` describes the conversational move; \`underspecificationType\` describes the QUD defect repaired. Never infer one mechanically from the other.`;
-
 const REFERENTIAL_CLOSURE_RULES = `Referential closure. The prompt must resolve entirely on its own, with no dangling references. The reader sees ONLY the question text — never the people you reviewed, the counterparty, the events on their calendar, or this conversation. Do not use demonstratives or definite anaphora that point at things the reader cannot see: "these builders", "those founders", "these researchers", "these conversations", "this lunch", "the speaker". If you reference a person, name them. If you reference a group, restate the concrete shared attribute inside the question itself ("founders working on decentralized identity"), never "these founders". Never imply a list, set, or prior exchange the reader is not currently looking at.
 - Bad: "What kind of collaboration are you looking for with these builders?"
 - Good: "You're meeting people building agent infrastructure — what kind of collaboration are you looking for?"
@@ -67,8 +62,6 @@ Standalone prompt rule. Every generated \`prompt\` must be understandable outsid
 - Good: "For your decentralized identity protocol-design search, what kind of collaboration are you looking for?"
 
 ${REFERENTIAL_CLOSURE_RULES}
-
-${QUD_UNDERSPECIFICATION_RULES}
 
 Cardinality. Default one question. Add a second only when a DIFFERENT strategy genuinely complements the first and unblocks a clearly distinct decision. Never ask two questions of the same strategy unless their decision domains differ (different titles).
 
@@ -395,30 +388,34 @@ function buildChatPrompt(ctx: ChatContext): string {
  * QuestionerAgent. `getPreset("pool_discovery")` therefore throws — the
  * QuestionerQueue branches on the mode before invoking the agent.
  */
+function withQudMetadataRules(systemPrompt: string): string {
+  return `${systemPrompt}\n\n${QUD_UNDERSPECIFICATION_RULES}`;
+}
+
 const presets: Partial<Record<QuestionMode, QuestionerPreset>> = {
   discovery: {
-    systemPrompt: `${DISCOVERY_SYSTEM_PROMPT}\n\n${QUD_UNDERSPECIFICATION_RULES}`,
+    systemPrompt: withQudMetadataRules(DISCOVERY_SYSTEM_PROMPT),
     buildPrompt: (context: unknown) =>
       buildDiscoveryPrompt(context as Parameters<typeof buildDiscoveryPrompt>[0]),
   },
   intent: {
-    systemPrompt: INTENT_SYSTEM_PROMPT,
+    systemPrompt: withQudMetadataRules(INTENT_SYSTEM_PROMPT),
     buildPrompt: (context: unknown) => buildIntentPrompt(context as IntentContext),
   },
   enrichment: {
-    systemPrompt: PROFILE_SYSTEM_PROMPT,
+    systemPrompt: withQudMetadataRules(PROFILE_SYSTEM_PROMPT),
     buildPrompt: (context: unknown) => buildProfilePrompt(context as ProfileContext),
   },
   negotiation: {
-    systemPrompt: NEGOTIATION_SYSTEM_PROMPT,
+    systemPrompt: withQudMetadataRules(NEGOTIATION_SYSTEM_PROMPT),
     buildPrompt: (context: unknown) => buildNegotiationPrompt(context as NegotiationContext),
   },
   negotiation_inflight: {
-    systemPrompt: NEGOTIATION_INFLIGHT_SYSTEM_PROMPT,
+    systemPrompt: withQudMetadataRules(NEGOTIATION_INFLIGHT_SYSTEM_PROMPT),
     buildPrompt: (context: unknown) => buildNegotiationInflightPrompt(context as NegotiationInflightContext),
   },
   chat: {
-    systemPrompt: CHAT_SYSTEM_PROMPT,
+    systemPrompt: withQudMetadataRules(CHAT_SYSTEM_PROMPT),
     buildPrompt: (context: unknown) => buildChatPrompt(context as ChatContext),
   },
 };

--- a/packages/protocol/src/questioner/questioner.qud.ts
+++ b/packages/protocol/src/questioner/questioner.qud.ts
@@ -1,0 +1,11 @@
+/**
+ * Shared Questions Under Discussion (QUD) taxonomy contract for structured
+ * question-generation prompts. Every Questioner mode uses this block because
+ * the structured output schema requires the internal metadata field; intent
+ * and discovery are the primary consumers of non-null classifications.
+ */
+export const QUD_UNDERSPECIFICATION_RULES = `QUD underspecification taxonomy. For every structured question, emit a required \`underspecificationType\` field. Use exactly one category only when the question repairs that kind of underspecification:
+- missing_constituent: an absent core participant, entity, or outcome (who/what).
+- missing_constraint: the core target exists, but a ranking boundary is missing (where/when/how/how much).
+- open_alternative_set: an unresolved choice among materially different interpretations or scopes.
+Use null for adjacent, reflective, emergent, or any other question that does not repair underspecification. Strategy and underspecification type are orthogonal: \`strategy\` describes the conversational move; \`underspecificationType\` describes the QUD defect repaired. Never infer one mechanically from the other.`;

--- a/packages/protocol/src/questioner/tests/questioner.agent.spec.ts
+++ b/packages/protocol/src/questioner/tests/questioner.agent.spec.ts
@@ -15,6 +15,7 @@ function makeQuestion(overrides: Record<string, unknown> = {}) {
     options: [okOption, { label: "B", description: "desc-b" }],
     multiSelect: false,
     strategy: "refine_intent",
+    underspecificationType: null,
     ...overrides,
   };
 }
@@ -132,15 +133,22 @@ describe("QuestionerAgent", () => {
     expect(result!.questions).toHaveLength(1);
     expect(result!.questions[0].title).toBe("Stage");
     expect(result!.strategies).toEqual(["refine_intent"]);
+    expect(result!.underspecificationTypes).toEqual([null]);
   });
 
-  it("strips the strategy field from the public questions array", async () => {
+  it("propagates QUD types in parallel and strips internal metadata publicly", async () => {
     const agent = makeAgent(async () => ({
-      questions: [makeQuestion({ title: "Stage" })],
+      questions: [makeQuestion({
+        title: "Stage",
+        underspecificationType: "missing_constraint",
+      })],
     }));
     const result = await agent.invoke(makeDiscoveryInput());
     expect(result).not.toBeNull();
-    expect("strategy" in (result!.questions[0] as Record<string, unknown>)).toBe(false);
+    expect(result!.underspecificationTypes).toEqual(["missing_constraint"]);
+    const publicQuestion = result!.questions[0] as Record<string, unknown>;
+    expect("strategy" in publicQuestion).toBe(false);
+    expect("underspecificationType" in publicQuestion).toBe(false);
   });
 
   it("dedupes questions by title, keeping the first occurrence", async () => {

--- a/packages/protocol/src/questioner/tests/questioner.ask.tool.spec.ts
+++ b/packages/protocol/src/questioner/tests/questioner.ask.tool.spec.ts
@@ -115,7 +115,7 @@ afterEach(() => {
 
 describe("ask_user_question", () => {
   it("generates, persists, streams, waits, and returns the answers", async () => {
-    const { agent, calls } = makeAgentStub({ questions: [generatedQuestion], strategies: ['surface_missing_detail'] });
+    const { agent, calls } = makeAgentStub({ questions: [generatedQuestion], strategies: ['surface_missing_detail'], underspecificationTypes: [null] });
     setQuestionerAgentForTesting(agent);
     const { host, persistCalls } = makeHost();
     const { defineTool, call } = makeDefineTool();
@@ -189,7 +189,7 @@ describe("ask_user_question", () => {
   });
 
   it("reports timeout outcomes with guidance and keeps questions pending", async () => {
-    const { agent } = makeAgentStub({ questions: [generatedQuestion], strategies: ['surface_missing_detail'] });
+    const { agent } = makeAgentStub({ questions: [generatedQuestion], strategies: ['surface_missing_detail'], underspecificationTypes: [null] });
     setQuestionerAgentForTesting(agent);
     const { host } = makeHost({
       outcomes: (ids) => ids.map((id) => ({ questionId: id, status: 'timeout' as const })),
@@ -208,7 +208,7 @@ describe("ask_user_question", () => {
   });
 
   it("errors when no streaming trace emitter is available", async () => {
-    const { agent } = makeAgentStub({ questions: [generatedQuestion], strategies: ['surface_missing_detail'] });
+    const { agent } = makeAgentStub({ questions: [generatedQuestion], strategies: ['surface_missing_detail'], underspecificationTypes: [null] });
     setQuestionerAgentForTesting(agent);
     const { host } = makeHost();
     const { defineTool, call } = makeDefineTool();
@@ -221,7 +221,7 @@ describe("ask_user_question", () => {
   });
 
   it("errors for MCP contexts and missing sessions", async () => {
-    const { agent } = makeAgentStub({ questions: [generatedQuestion], strategies: ['surface_missing_detail'] });
+    const { agent } = makeAgentStub({ questions: [generatedQuestion], strategies: ['surface_missing_detail'], underspecificationTypes: [null] });
     setQuestionerAgentForTesting(agent);
     const { host } = makeHost();
     const { defineTool, call } = makeDefineTool();

--- a/packages/protocol/src/questioner/tests/questioner.presets.spec.ts
+++ b/packages/protocol/src/questioner/tests/questioner.presets.spec.ts
@@ -57,7 +57,7 @@ describe("standalone prompt contract", () => {
 });
 
 describe("QUD taxonomy contract", () => {
-  it.each(["intent", "discovery"] as const)("mode '%s' receives the canonical taxonomy", (mode) => {
+  it.each(ALL_MODES)("mode '%s' receives the required structured-output metadata contract", (mode) => {
     const prompt = getPreset(mode).systemPrompt;
     expect(prompt).toContain("QUD underspecification taxonomy");
     expect(prompt).toContain("missing_constituent");

--- a/packages/protocol/src/questioner/tests/questioner.presets.spec.ts
+++ b/packages/protocol/src/questioner/tests/questioner.presets.spec.ts
@@ -56,6 +56,18 @@ describe("standalone prompt contract", () => {
   });
 });
 
+describe("QUD taxonomy contract", () => {
+  it.each(["intent", "discovery"] as const)("mode '%s' receives the canonical taxonomy", (mode) => {
+    const prompt = getPreset(mode).systemPrompt;
+    expect(prompt).toContain("QUD underspecification taxonomy");
+    expect(prompt).toContain("missing_constituent");
+    expect(prompt).toContain("missing_constraint");
+    expect(prompt).toContain("open_alternative_set");
+    expect(prompt).toContain("Strategy and underspecification type are orthogonal");
+    expect(prompt).toContain("Use null");
+  });
+});
+
 describe("getPreset", () => {
   it("returns the discovery preset with systemPrompt and buildPrompt", () => {
     const preset = getPreset("discovery");

--- a/packages/protocol/src/shared/interfaces/questioner.interface.ts
+++ b/packages/protocol/src/shared/interfaces/questioner.interface.ts
@@ -3,7 +3,7 @@
  * the QuestionerAgent. Implementations live in the backend and are injected
  * into ProtocolDeps.
  */
-import type { Question, QuestionMode, QuestionStrategy, QuestionDetection, QuestionActor, QuestionAnswer } from "../schemas/question.schema.js";
+import type { Question, QuestionMode, QuestionStrategy, QuestionDetection, QuestionActor, QuestionAnswer, UnderspecificationType } from "../schemas/question.schema.js";
 
 /** Shape accepted by `persist()` — everything needed to insert a question row. */
 export interface PersistableQuestion {
@@ -11,6 +11,8 @@ export interface PersistableQuestion {
   actors: QuestionActor[];
   payload: Question;
   strategy: QuestionStrategy;
+  /** Internal QUD repair category; null when the question repairs no underspecification. */
+  underspecificationType?: UnderspecificationType | null;
   /** Conversation ID — set when the question originates from a chat session. */
   conversationId?: string;
 }

--- a/packages/protocol/src/shared/interfaces/tests/question-generator.interface.spec.ts
+++ b/packages/protocol/src/shared/interfaces/tests/question-generator.interface.spec.ts
@@ -27,7 +27,7 @@ describe("QuestionGeneratorReader contract", () => {
   it("permits implementations that return a non-null QuestionGenerationResult", async () => {
     const q: Question = { title: "T", prompt: "P?", options: [{ label: "a", description: "x" }, { label: "b", description: "y" }], multiSelect: false };
     const s: QuestionStrategy[] = ["refine_intent"];
-    const ok: QuestionGeneratorReader = { generate: async () => ({ questions: [q], strategies: s }) };
+    const ok: QuestionGeneratorReader = { generate: async () => ({ questions: [q], strategies: s, underspecificationTypes: [null] }) };
     const r = await ok.generate({ query: "x", userContext: "", negotiationDigests: [], summary: { totalCandidates: 0, opportunitiesFound: 0, noOpportunityCount: 0, timeoutCount: 0, roleDistribution: {} }, now: "" });
     expect(r?.questions).toHaveLength(1);
   });

--- a/packages/protocol/src/shared/schemas/question.schema.ts
+++ b/packages/protocol/src/shared/schemas/question.schema.ts
@@ -3,10 +3,10 @@
  * elicitation dispatch. Mirrors the brainstorming AskUserQuestion skill so a
  * Question can be rendered identically across surfaces.
  *
- * `QuestionWithStrategy` extends the public shape with an internal `strategy`
- * tag used by the generator's guardrails (dedup/diversity) and recorded in
- * `debugMeta`. The tag is stripped before the public payload leaves the
- * generator — users never see it.
+ * `QuestionWithStrategy` extends the public shape with internal `strategy`
+ * and QUD underspecification tags used by generator guardrails and persisted
+ * metadata. Both tags are stripped before the public payload leaves the
+ * generator — users never see them.
  */
 import { z } from "zod";
 
@@ -34,6 +34,13 @@ export const QuestionSchema = z.object({
   evidence: z.string().min(1).max(160).optional(),
 });
 
+/** Canonical QUD repair categories for underspecified intents/questions. */
+export const UnderspecificationTypeSchema = z.enum([
+  "missing_constituent",
+  "missing_constraint",
+  "open_alternative_set",
+]);
+
 export const QuestionStrategySchema = z.enum([
   "refine_intent",
   "surface_missing_detail",
@@ -44,6 +51,8 @@ export const QuestionStrategySchema = z.enum([
 
 export const QuestionWithStrategySchema = QuestionSchema.extend({
   strategy: QuestionStrategySchema,
+  /** QUD repair category, or null when the question is not an underspecification repair. */
+  underspecificationType: UnderspecificationTypeSchema.nullable(),
 });
 
 export const QuestionGeneratorResponseSchema = z.object({
@@ -52,18 +61,20 @@ export const QuestionGeneratorResponseSchema = z.object({
 
 export type QuestionOption = z.infer<typeof QuestionOptionSchema>;
 export type Question = z.infer<typeof QuestionSchema>;
+export type UnderspecificationType = z.infer<typeof UnderspecificationTypeSchema>;
 export type QuestionStrategy = z.infer<typeof QuestionStrategySchema>;
 export type QuestionWithStrategy = z.infer<typeof QuestionWithStrategySchema>;
 export type QuestionGeneratorResponse = z.infer<typeof QuestionGeneratorResponseSchema>;
 
 /**
- * Internal generator output: public questions plus a parallel strategies
- * array for debug-only consumption. The generator emits this; callers
- * forward `questions` to renderers and `strategies` to `debugMeta` only.
+ * Internal generator output: public questions plus parallel strategy and QUD
+ * taxonomy arrays for metadata-only consumption. The generator emits this;
+ * callers forward only `questions` to renderers.
  */
 export interface QuestionGenerationResult {
   questions: Question[];
   strategies: QuestionStrategy[];
+  underspecificationTypes: Array<UnderspecificationType | null>;
 }
 
 // ─── Persistence types (opportunity-style composable jsonb) ──────────────────
@@ -133,6 +144,10 @@ export const QuestionDetectionSchema = z.object({
   triggeredBy: z.string().optional(),
   /** ISO-8601 timestamp of generation. */
   timestamp: z.string().min(1),
+  /** Generation strategy persisted as internal metadata. */
+  strategy: QuestionStrategySchema.optional(),
+  /** QUD repair category persisted as internal metadata. */
+  underspecificationType: UnderspecificationTypeSchema.nullable().optional(),
   /** ID of the assistant message that triggered this question. Used by the frontend to anchor the question card inline. */
   messageId: z.string().optional(),
   /**

--- a/packages/protocol/src/shared/schemas/tests/question.schema.spec.ts
+++ b/packages/protocol/src/shared/schemas/tests/question.schema.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "bun:test";
 
-import { QuestionOptionSchema, QuestionSchema, QuestionStrategySchema, QuestionWithStrategySchema, QuestionGeneratorResponseSchema, QuestionModeSchema, QuestionDetectionSchema, QuestionActorSchema, QuestionAnswerSchema } from "../question.schema.js";
+import { QuestionOptionSchema, QuestionSchema, UnderspecificationTypeSchema, QuestionStrategySchema, QuestionWithStrategySchema, QuestionGeneratorResponseSchema, QuestionModeSchema, QuestionDetectionSchema, QuestionActorSchema, QuestionAnswerSchema } from "../question.schema.js";
 
 const okOption = { label: "Stay focused", description: "Higher risk but cleaner narrative" };
 
@@ -74,6 +74,17 @@ describe("QuestionSchema", () => {
   });
 });
 
+describe("UnderspecificationTypeSchema", () => {
+  it.each(["missing_constituent", "missing_constraint", "open_alternative_set"])(
+    "accepts '%s'",
+    (type) => expect(UnderspecificationTypeSchema.safeParse(type).success).toBe(true),
+  );
+
+  it("rejects values outside the canonical taxonomy", () => {
+    expect(UnderspecificationTypeSchema.safeParse("missing_context").success).toBe(false);
+  });
+});
+
 describe("QuestionStrategySchema", () => {
   const strategies = [
     "refine_intent",
@@ -96,10 +107,26 @@ describe("QuestionStrategySchema", () => {
 
 describe("QuestionWithStrategySchema", () => {
   it("accepts a question with a valid strategy", () => {
-    expect(() => QuestionWithStrategySchema.parse({ ...okQuestion, strategy: "refine_intent" })).not.toThrow();
+    expect(() => QuestionWithStrategySchema.parse({
+      ...okQuestion,
+      strategy: "refine_intent",
+      underspecificationType: "missing_constraint",
+    })).not.toThrow();
   });
   it("rejects a question with an invalid strategy", () => {
-    expect(() => QuestionWithStrategySchema.parse({ ...okQuestion, strategy: "bogus" })).toThrow();
+    expect(() => QuestionWithStrategySchema.parse({
+      ...okQuestion,
+      strategy: "bogus",
+      underspecificationType: null,
+    })).toThrow();
+  });
+  it("requires nullable internal underspecification metadata", () => {
+    expect(() => QuestionWithStrategySchema.parse({ ...okQuestion, strategy: "refine_intent" })).toThrow();
+    expect(() => QuestionWithStrategySchema.parse({
+      ...okQuestion,
+      strategy: "open_adjacent_thread",
+      underspecificationType: null,
+    })).not.toThrow();
   });
 });
 
@@ -112,6 +139,7 @@ describe("QuestionGeneratorResponseSchema", () => {
       ...okQuestion,
       title: `T${i}`,
       strategy: "refine_intent" as const,
+      underspecificationType: null,
     }));
     expect(() => QuestionGeneratorResponseSchema.parse({ questions: three })).not.toThrow();
   });
@@ -120,6 +148,7 @@ describe("QuestionGeneratorResponseSchema", () => {
       ...okQuestion,
       title: `T${i}`,
       strategy: "refine_intent" as const,
+      underspecificationType: null,
     }));
     expect(() => QuestionGeneratorResponseSchema.parse({ questions: four })).toThrow();
   });

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/adapters/questioner.adapter.ts
+++ b/services/api/src/adapters/questioner.adapter.ts
@@ -33,6 +33,10 @@ export interface AdapterQuestionDetection {
   sourceId: string;
   triggeredBy?: string;
   timestamp: string;
+  /** Generation strategy persisted as internal metadata. */
+  strategy?: import('@indexnetwork/protocol').QuestionStrategy;
+  /** QUD repair category persisted as internal metadata. */
+  underspecificationType?: import('@indexnetwork/protocol').UnderspecificationType | null;
   /** ID of the assistant message that triggered this question. */
   messageId?: string;
   /**
@@ -73,12 +77,9 @@ export interface AdapterPersistableQuestion {
   detection: AdapterQuestionDetection;
   actors: AdapterQuestionActor[];
   payload: AdapterQuestionPayload;
-  strategy:
-    | 'refine_intent'
-    | 'surface_missing_detail'
-    | 'open_adjacent_thread'
-    | 'reflective_summary'
-    | 'surface_emergent_knowledge';
+  strategy: import('@indexnetwork/protocol').QuestionStrategy;
+  /** Internal QUD repair category; null when no underspecification is repaired. */
+  underspecificationType?: import('@indexnetwork/protocol').UnderspecificationType | null;
   /** Conversation ID — set when the question originates from a chat session. */
   conversationId?: string;
 }
@@ -144,7 +145,11 @@ export class QuestionerAdapter {
   async persist(batch: AdapterPersistableQuestion[]): Promise<string[]> {
     if (batch.length === 0) return [];
     const rows = batch.map((q) => ({
-      detection: { ...q.detection, strategy: q.strategy } satisfies QuestionDetection,
+      detection: {
+        ...q.detection,
+        strategy: q.strategy,
+        underspecificationType: q.underspecificationType ?? null,
+      } satisfies QuestionDetection,
       actors: q.actors as QuestionActor[],
       payload: q.payload,
       status: 'pending' as const,

--- a/services/api/src/queues/questioner.queue.ts
+++ b/services/api/src/queues/questioner.queue.ts
@@ -171,7 +171,6 @@ export class QuestionerQueue {
         timestamp: new Date().toISOString(),
         ...(triggeredByIntentId ? { triggeredBy: triggeredByIntentId } : {}),
         ...(data.messageId ? { messageId: data.messageId } : {}),
-        underspecificationType: result.underspecificationTypes[i],
       },
       actors: [{ userId: data.userId, ...(actorNetworkId ? { networkId: actorNetworkId } : {}), role: 'subject' as const }],
       payload: question,

--- a/services/api/src/queues/questioner.queue.ts
+++ b/services/api/src/queues/questioner.queue.ts
@@ -171,10 +171,12 @@ export class QuestionerQueue {
         timestamp: new Date().toISOString(),
         ...(triggeredByIntentId ? { triggeredBy: triggeredByIntentId } : {}),
         ...(data.messageId ? { messageId: data.messageId } : {}),
+        underspecificationType: result.underspecificationTypes[i],
       },
       actors: [{ userId: data.userId, ...(actorNetworkId ? { networkId: actorNetworkId } : {}), role: 'subject' as const }],
       payload: question,
       strategy: result.strategies[i],
+      underspecificationType: result.underspecificationTypes[i],
       conversationId: data.conversationId,
     }));
 

--- a/services/api/src/queues/tests/questioner.queue.spec.ts
+++ b/services/api/src/queues/tests/questioner.queue.spec.ts
@@ -28,6 +28,7 @@ describe('QuestionerQueue', () => {
         },
       ],
       strategies: ['surface_missing_detail'],
+      underspecificationTypes: ['missing_constraint'],
     };
     const queue = new QuestionerQueue({
       adapter: {
@@ -52,6 +53,8 @@ describe('QuestionerQueue', () => {
     });
 
     expect(captured).toHaveLength(1);
+    expect(captured[0].detection.underspecificationType).toBe('missing_constraint');
+    expect(captured[0].underspecificationType).toBe('missing_constraint');
     expect(captured[0].actors).toEqual([
       { userId: 'user-1', role: 'subject', networkId: 'network-1' },
     ]);
@@ -80,6 +83,7 @@ describe('QuestionerQueue', () => {
             },
           ],
           strategies: ['surface_missing_detail'],
+          underspecificationTypes: ['missing_constraint'],
         }),
       },
     });
@@ -123,6 +127,7 @@ describe('QuestionerQueue', () => {
             },
           ],
           strategies: ['surface_missing_detail'],
+          underspecificationTypes: ['missing_constraint'],
         }),
       },
     });
@@ -171,6 +176,7 @@ describe('QuestionerQueue', () => {
             },
           ],
           strategies: ['surface_missing_detail'],
+          underspecificationTypes: ['missing_constraint'],
         }),
       },
     });

--- a/services/api/src/queues/tests/questioner.queue.spec.ts
+++ b/services/api/src/queues/tests/questioner.queue.spec.ts
@@ -53,7 +53,7 @@ describe('QuestionerQueue', () => {
     });
 
     expect(captured).toHaveLength(1);
-    expect(captured[0].detection.underspecificationType).toBe('missing_constraint');
+    expect(captured[0].detection.underspecificationType).toBeUndefined();
     expect(captured[0].underspecificationType).toBe('missing_constraint');
     expect(captured[0].actors).toEqual([
       { userId: 'user-1', role: 'subject', networkId: 'network-1' },

--- a/services/api/src/schemas/database.schema.ts
+++ b/services/api/src/schemas/database.schema.ts
@@ -505,7 +505,9 @@ export interface QuestionDetection {
   triggeredBy?: string;
   timestamp: string;
   /** Generation strategy — persisted as metadata, not exposed on read. */
-  strategy?: string;
+  strategy?: import('@indexnetwork/protocol').QuestionStrategy;
+  /** QUD repair category — persisted as metadata, not exposed on read. */
+  underspecificationType?: import('@indexnetwork/protocol').UnderspecificationType | null;
   /** ID of the assistant message that triggered this question. */
   messageId?: string;
   /**

--- a/services/api/src/services/question.service.ts
+++ b/services/api/src/services/question.service.ts
@@ -20,11 +20,17 @@ const logger = log.service.from('QuestionService');
 /**
  * Removes server-only detection fields before a question leaves the API.
  * `detection.pool` carries pool_discovery candidate assignments + chain
- * alternates — k-anonymity requires they never reach a client (IND-418).
+ * alternates (IND-418); strategy and QUD type are generation/debug metadata
+ * rather than client rendering contracts (IND-425).
  */
 export function stripInternalDetection(question: AdapterPersistedQuestion): AdapterPersistedQuestion {
-  if (!question.detection.pool) return question;
-  const { pool: _pool, ...detection } = question.detection;
+  const {
+    pool: _pool,
+    strategy: _strategy,
+    underspecificationType: _underspecificationType,
+    ...detection
+  } = question.detection;
+  if (!_pool && !_strategy && _underspecificationType === undefined) return question;
   return { ...question, detection };
 }
 

--- a/services/api/src/services/tests/question-generator.service.spec.ts
+++ b/services/api/src/services/tests/question-generator.service.spec.ts
@@ -24,7 +24,7 @@ describe("QuestionGeneratorService", () => {
       ],
       multiSelect: false,
     };
-    const result: QuestionGenerationResult = { questions: [q], strategies: ["refine_intent"] };
+    const result: QuestionGenerationResult = { questions: [q], strategies: ["refine_intent"], underspecificationTypes: [null] };
     const svc = new QuestionGeneratorService({ generate: async () => result });
     const got = await svc.generate(baseInput);
     expect(got).toEqual(result);

--- a/services/api/src/services/tests/question.service.strip.spec.ts
+++ b/services/api/src/services/tests/question.service.strip.spec.ts
@@ -1,6 +1,6 @@
 /**
- * Client-strip invariant (IND-418): `detection.pool` (candidate assignments +
- * chain alternates) never leaves the server through QuestionService reads.
+ * Client-strip invariant: server-only pool internals (IND-418) and question
+ * generation/QUD metadata (IND-425) never leave QuestionService reads.
  */
 import { describe, it, expect } from 'bun:test';
 
@@ -16,6 +16,8 @@ function poolQuestion(): AdapterPersistedQuestion {
       sourceId: 'intent-1',
       triggeredBy: 'intent-1',
       timestamp: 'now',
+      strategy: 'surface_missing_detail',
+      underspecificationType: 'missing_constraint',
       pool: {
         poolSize: 21,
         minedAt: 'now',
@@ -51,6 +53,8 @@ describe('stripInternalDetection', () => {
   it('removes detection.pool and keeps everything else', () => {
     const stripped = stripInternalDetection(poolQuestion());
     expect(stripped.detection.pool).toBeUndefined();
+    expect(stripped.detection.strategy).toBeUndefined();
+    expect(stripped.detection.underspecificationType).toBeUndefined();
     expect(stripped.detection.mode).toBe('pool_discovery');
     expect(stripped.detection.triggeredBy).toBe('intent-1');
     expect(stripped.payload.evidence).toBe('based on 21 people matching this intent');
@@ -58,9 +62,20 @@ describe('stripInternalDetection', () => {
     expect(JSON.stringify(stripped)).not.toContain('opp-1');
   });
 
-  it('leaves questions without a pool snapshot untouched (same reference)', () => {
+  it('strips generation metadata even without a pool snapshot', () => {
     const q = poolQuestion();
     delete (q.detection as { pool?: unknown }).pool;
+    const stripped = stripInternalDetection(q);
+    expect(stripped).not.toBe(q);
+    expect(stripped.detection.strategy).toBeUndefined();
+    expect(stripped.detection.underspecificationType).toBeUndefined();
+  });
+
+  it('leaves questions without internal detection metadata untouched', () => {
+    const q = poolQuestion();
+    delete (q.detection as { pool?: unknown }).pool;
+    delete (q.detection as { strategy?: unknown }).strategy;
+    delete (q.detection as { underspecificationType?: unknown }).underspecificationType;
     expect(stripInternalDetection(q)).toBe(q);
   });
 });
@@ -75,6 +90,8 @@ describe('QuestionService.findPending', () => {
     expect(rows).toHaveLength(2);
     for (const row of rows) {
       expect(row.detection.pool).toBeUndefined();
+      expect(row.detection.strategy).toBeUndefined();
+      expect(row.detection.underspecificationType).toBeUndefined();
     }
     expect(JSON.stringify(rows)).not.toContain('assignments');
   });

--- a/services/api/tests/questioner.adapter.spec.ts
+++ b/services/api/tests/questioner.adapter.spec.ts
@@ -58,19 +58,26 @@ function makePersistable(
       multiSelect: false,
     },
     strategy: 'refine_intent',
+    underspecificationType: 'missing_constraint',
     ...overrides,
   };
 }
 
 describe('QuestionerAdapter', () => {
-  it('persists a batch of questions', async () => {
+  it('persists a batch of questions with internal QUD metadata', async () => {
     const batch = [
       makePersistable(),
-      makePersistable({ strategy: 'surface_missing_detail' }),
+      makePersistable({
+        strategy: 'surface_missing_detail',
+        underspecificationType: null,
+      }),
     ];
-    await adapter.persist(batch);
+    const ids = await adapter.persist(batch);
     const pending = await adapter.findPending('test-user-1');
     expect(pending.length).toBeGreaterThanOrEqual(2);
+    const inserted = ids.map((id) => pending.find((question) => question.id === id));
+    expect(inserted[0]?.detection.underspecificationType).toBe('missing_constraint');
+    expect(inserted[1]?.detection.underspecificationType).toBeNull();
   });
 
   it('findPending returns only pending questions for the given user', async () => {


### PR DESCRIPTION
## Problem

Intent verification detected vagueness through semantic entropy and felicity clarity, but the elaboration loop could only say an intent was “too vague.” It did not identify **what kind** of Question Under Discussion remained unresolved, and the post-discovery Questioner independently generated untyped follow-ups.

Fixes [IND-425](https://linear.app/indexnetwork/issue/IND-425).

## Change

### Canonical QUD taxonomy

Adds the public `UnderspecificationTypeSchema` / `UnderspecificationType` contract:

- `missing_constituent` — absent core participant, entity, or outcome (who/what)
- `missing_constraint` — target exists but a discovery-blocking boundary is unresolved (where/when/how/how much)
- `open_alternative_set` — materially different interpretations/scopes remain open

`IntentClarifier` now returns a discriminated output: no clarification means `null`; clarification requires a typed category plus non-empty suggested description and a category-resolving question. Open alternatives are asked as a choice rather than a generic confirmation.

### Live intent elaboration

`create_intent` invokes the typed clarifier on rejected proposal paths (no inference, vague verification, and broad MCP auto-approval), passes profile + active-intent context, and returns a machine-readable `needsClarification` response with type, question, and grounded suggestion. Non-QUD classification failures retain the explicit-goal fallback.

### Questioner reuse + persistence

- Every active Questioner preset receives the required structured-output metadata contract; intent and discovery are the primary non-null consumers.
- The backward-compatible inline discovery generator receives the same canonical block.
- QuestionerAgent strips the type from public question payloads and forwards it as a parallel internal array.
- QuestionerQueue and the chat question path persist it into existing `questions.detection` JSONB (no migration).
- QuestionService strips strategy/QUD metadata from REST responses, preserving it as server-only analysis metadata.

### Evaluation

Adds `bun run eval:clarification`, a live-model exact-match corpus for all three categories plus a sufficiently specific `null` case. The scorer rejects model-error fallbacks, contradictory clarification decisions, empty content, and open-alternative questions that fail to name both fixture alternatives.

Live result: **4/4 exact matches**.

## Validation

- Protocol targeted tests: **157 pass**
- API Questioner queue/service tests: **8 pass**
- Questioner adapter integration: **12 pass** (JSONB round-trip included)
- IntentClarifier live tests: included above, green
- `bun run eval:clarification`: **4/4 pass**
- Protocol build: clean
- API typecheck: clean
- ESLint touched files: clean (two pre-existing `any` warnings in `update-intent.spec.ts`, no errors)

## Release/docs

- `@indexnetwork/protocol` **4.10.0**
- Root `bun.lock` workspace version synchronized
- Changelog updated
- Academic Grounding backlog item 3 marked shipped
