### PR TITLE
fix(protocol): hide opportunity listing in intent chats

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "4.14.1",
+  "version": "4.14.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/chat/negotiator.persona.ts
+++ b/packages/protocol/src/chat/negotiator.persona.ts
@@ -1,4 +1,5 @@
 import { createChatTools, type ChatTools, type ToolContext, type ResolvedToolContext } from "../shared/agent/tool.factory.js";
+import { focusedIntentId, type ToolScopeEnvelope } from "../shared/agent/tool.scope.js";
 import type { ChatPersonaConfig } from "./chat.persona.js";
 import { buildNegotiatorSystemContent, type NegotiatorPromptOptions } from "./negotiator.prompt.js";
 import { createNegotiatorMemoryTools } from "./negotiator.tools.js";
@@ -101,6 +102,20 @@ export function filterNegotiatorTools<T extends { name: string }>(tools: T[]): T
 }
 
 /**
+ * Applies negotiator tool availability rules that depend on the focused scope.
+ * Intent-pinned chats use the adjacent Radar for opportunity listing, while all
+ * other negotiator capabilities remain available.
+ */
+export function filterNegotiatorToolsForContext<T extends { name: string }>(
+  tools: T[],
+  context: ToolScopeEnvelope,
+): T[] {
+  return focusedIntentId(context)
+    ? tools.filter((tool) => tool.name !== "list_opportunities")
+    : tools;
+}
+
+/**
  * Creates the negotiator persona's client-scoped toolset.
  *
  * Reuses the standard chat tool factory (so context resolution, scope
@@ -115,6 +130,10 @@ export async function createNegotiatorTools(
 ): Promise<ChatTools> {
   const tools = await createChatTools(deps, preResolvedContext);
   const filtered = filterNegotiatorTools(tools);
+  // A supplied resolved context is authoritative. Direct callers without one
+  // still get the canonical explicit scope envelope from ToolContext.
+  const toolScope = preResolvedContext ?? { scopeType: deps.scopeType, scopeId: deps.scopeId };
+  const contextFiltered = filterNegotiatorToolsForContext(filtered, toolScope);
   // P5.4 (IND-408): `remember`/`forget` are negotiator-exclusive — appended
   // AFTER the allowlist filter, and only when the composition root injected
   // the host bridge (i.e. negotiator memory writes are enabled). They never
@@ -125,9 +144,9 @@ export async function createNegotiatorTools(
       userId: deps.userId,
       ...(deps.sessionId ? { sessionId: deps.sessionId } : {}),
     });
-    return [...filtered, ...memoryTools] as ChatTools;
+    return [...contextFiltered, ...memoryTools] as ChatTools;
   }
-  return filtered;
+  return contextFiltered;
 }
 
 /**

--- a/packages/protocol/src/chat/negotiator.prompt.ts
+++ b/packages/protocol/src/chat/negotiator.prompt.ts
@@ -59,7 +59,7 @@ function buildPinnedSignalSection(intentId: string, label?: string): string {
 ## Pinned signal
 This conversation was opened from one of the client's signals (intent id: ${intentId}${labelLine}). Treat it as the working focus of this chat:
 - Open questions listed by read_pending_questions here are this signal's open questions — surface them early and work through them conversationally. The client answers them via the question cards shown in this chat, or conversationally: when they give you an explicit answer, record it with answer_pending_question.
-- list_opportunities and read_pending_questions are automatically restricted to this signal in this session; use them to report matches, negotiations, and follow-ups that grew out of it.
+- Matches for this signal are already visible in the adjacent Radar. Do not repeat them or bulk-list them in chat. When the client explicitly references a match, use its opportunity and negotiation records to explain it or act on it; update_opportunity remains available only for their explicit instruction.
 - When the client restates or sharpens what they want here, propose an update to this signal (update_intent) or a new premise — on their confirmation — so background matching reflects it.
 - This is a focus, not a wall: you may still read the client's profile, premises, and other signals when the conversation needs the fuller picture, and general questions about their negotiations remain fair game.`;
 }
@@ -131,6 +131,15 @@ export function buildNegotiatorSystemContent(
   const memoryToolsRows = opts.memoryToolsEnabled
     ? `\n| **remember** | kind, content | Save a standing rule the client just stated into your private negotiator memory — ONLY what they actually said |\n| **forget** | memoryId? / description? | Delete a remembered rule when the client asks you to forget it |`
     : "";
+  const opportunityGuidance = pinnedIntentId
+    ? "- **Discuss referenced opportunities**: matches for this signal are already visible in the adjacent Radar. Do not repeat or bulk-list them in chat. Explain or update an opportunity only when the client explicitly references it, and act only on their explicit instruction."
+    : "- **Review and act on opportunities**: show the client the opportunities currently waiting on them and what accepting or passing would mean; accept or pass on one only when they explicitly say so.";
+  const matchVisibility = pinnedIntentId
+    ? "New matches for this pinned signal appear in the adjacent Radar rather than as a repeated listing in chat."
+    : "New matches appear on the client's home page and can be reviewed in this chat as opportunities.";
+  const opportunityListingToolRow = pinnedIntentId
+    ? ""
+    : "\n| **list_opportunities** | — | List the client's actionable opportunities |";
 
   return `You are ${opts.agentName}, the personal negotiator agent working for ${ctx.userName}.
 ${descriptionLine}
@@ -139,7 +148,7 @@ You work for exactly one client: ${ctx.userName}. You represent them in negotiat
 ## What you do in this chat
 - **Report on negotiations**: when the client asks what is happening, look up their negotiations and summarize status, counterparties, and where things stand.
 - **Explain decisions**: when the client asks why something was pursued, declined, or stalled ("why did you pass on X?"), find the relevant negotiation and answer from the actual record — the messages, outcomes, and reasoning stored there. Never reconstruct a rationale from memory.
-- **Review and act on opportunities**: show the client the opportunities currently waiting on them and what accepting or passing would mean; accept or pass on one only when they explicitly say so.
+${opportunityGuidance}
 - **Manage their signals**: their active intents (signals) define what you negotiate for — and matching is driven entirely by them. When the client tells you what they are looking for, draft a clear, specific signal and create it; refine or retire signals when they ask. If a signal request is vague, read their profile and existing signals first, then propose a sharper wording before creating it. If they paste a link describing what they want, read it first and synthesize the signal from its content.
 - **Keep their knowledge current**: when the client shares a new fact about themselves ("I moved to Berlin", "I stopped consulting"), update their profile context or premises so future negotiations reflect reality. Read before you write — update the existing entry instead of duplicating it.
 - **Handle memberships**: list the communities they belong to and join or leave communities when they ask.
@@ -147,7 +156,7 @@ You work for exactly one client: ${ctx.userName}. You represent them in negotiat
 - **Act on instruction**: every write — a negotiation response, an opportunity decision, a signal, a profile or premise change, a membership change, a contact change — happens only when the client explicitly asks for it in this conversation. Never write anything the client did not just ask for.
 ${pinnedSignalSection}${memorySection}${memoryToolsSection}
 ## What you cannot do here
-- **No direct discovery.** You cannot run matching or search for people yourself. Matching happens automatically in the background from the client's signals — shaping the signals is how you steer it. New matches appear on the client's home page and in this chat as opportunities.
+- **No direct discovery.** You cannot run matching or search for people yourself. Matching happens automatically in the background from the client's signals — shaping the signals is how you steer it. ${matchVisibility}
 - **No community administration.** You can join or leave communities for the client, but you cannot create, rename, or delete communities — point them to the app for that.
 - You cannot push updates after this conversation ends. You only report when asked.
 
@@ -170,8 +179,7 @@ ${profileContext}
 |------|--------|-------------|
 | **list_negotiations** | status?, limit? | List the client's negotiations |
 | **get_negotiation** | negotiationId | Full negotiation record: messages, outcome, reasoning |
-| **respond_to_negotiation** | negotiationId, ... | Act on a negotiation — ONLY on explicit client instruction |
-| **list_opportunities** | — | List the client's actionable opportunities |
+| **respond_to_negotiation** | negotiationId, ... | Act on a negotiation — ONLY on explicit client instruction |${opportunityListingToolRow}
 | **read_pending_questions** | limit? | The system's open questions for the client (clamped to the pinned signal when one is set) |
 | **answer_pending_question** | questionId, selectedOptions?, freeText? | Record the client's explicit answer to a pending question — ONLY with an answer they actually gave |
 | **update_opportunity** | opportunityId, status | Accept/pass an opportunity — ONLY on explicit client instruction |

--- a/packages/protocol/src/chat/tests/negotiator.persona.spec.ts
+++ b/packages/protocol/src/chat/tests/negotiator.persona.spec.ts
@@ -18,7 +18,7 @@ config({ path: ".env.test", override: true });
 
 import { describe, expect, it } from "bun:test";
 
-import { NEGOTIATOR_PERSONA_ID, NEGOTIATOR_TOOL_NAMES, createNegotiatorPersona, filterNegotiatorTools } from "../negotiator.persona.js";
+import { NEGOTIATOR_PERSONA_ID, NEGOTIATOR_TOOL_NAMES, createNegotiatorPersona, filterNegotiatorTools, filterNegotiatorToolsForContext } from "../negotiator.persona.js";
 import { buildNegotiatorSystemContent } from "../negotiator.prompt.js";
 import { ORCHESTRATOR_PERSONA_ID } from "../chat.persona.js";
 import type { ResolvedToolContext } from "../../shared/agent/tool.factory.js";
@@ -103,10 +103,11 @@ describe("buildNegotiatorSystemContent", () => {
     expect(prompt).toContain("alice@example.com");
   });
 
-  it("references every allowlisted tool and no others in the tools table", () => {
+  it("references every allowlisted tool and retains opportunity listing in the unscoped DM", () => {
     for (const name of NEGOTIATOR_TOOL_NAMES) {
       expect(prompt).toContain(name);
     }
+    expect(prompt).toContain("Review and act on opportunities");
   });
 
   it("omits the description line when the agent row has none", () => {
@@ -126,12 +127,29 @@ describe("buildNegotiatorSystemContent", () => {
 describe("buildNegotiatorSystemContent — pinned signal (intent scope)", () => {
   const scopedCtx = makeCtx({ scopeType: "intent", scopeId: "intent-42" } as Partial<ResolvedToolContext>);
 
-  it("renders the pinned-signal section when the session is intent-scoped", () => {
+  it("renders the pinned-signal section without offering bulk opportunity listing", () => {
     const prompt = buildNegotiatorSystemContent(scopedCtx, AGENT_OPTS);
     expect(prompt).toContain("## Pinned signal");
     expect(prompt).toContain("intent id: intent-42");
+    expect(prompt).not.toContain("list_opportunities");
+    expect(prompt).toContain("adjacent Radar");
+    expect(prompt).toContain("Do not repeat or bulk-list");
     // Awareness, not a sandbox — the prompt must say the focus is not a wall.
     expect(prompt).toContain("This is a focus, not a wall");
+  });
+
+  it("retains referenced-opportunity actions, negotiation reporting, and pending questions", () => {
+    const prompt = buildNegotiatorSystemContent(scopedCtx, AGENT_OPTS);
+    for (const retainedTool of [
+      "update_opportunity",
+      "list_negotiations",
+      "get_negotiation",
+      "respond_to_negotiation",
+      "read_pending_questions",
+      "answer_pending_question",
+    ]) {
+      expect(prompt).toContain(retainedTool);
+    }
   });
 
   it("includes the human-readable label when provided", () => {
@@ -151,10 +169,12 @@ describe("buildNegotiatorSystemContent — pinned signal (intent scope)", () => 
     expect(withLabel).not.toContain("Stray");
   });
 
-  it("ignores network scope (no pinned-signal section)", () => {
+  it("treats network scope like the unscoped DM", () => {
     const networkCtx = makeCtx({ scopeType: "network", scopeId: "net-1" } as Partial<ResolvedToolContext>);
     const prompt = buildNegotiatorSystemContent(networkCtx, AGENT_OPTS);
     expect(prompt).not.toContain("## Pinned signal");
+    expect(prompt).toContain("list_opportunities");
+    expect(prompt).toContain("Review and act on opportunities");
   });
 });
 
@@ -243,6 +263,43 @@ const ORCHESTRATOR_REGISTRY_NAMES = [
   "answer_pending_question",
   "ask_user_question",
 ];
+
+describe("filterNegotiatorToolsForContext", () => {
+  const tools = [
+    "list_opportunities",
+    "update_opportunity",
+    "list_negotiations",
+    "get_negotiation",
+    "respond_to_negotiation",
+    "read_pending_questions",
+    "answer_pending_question",
+  ].map((name) => ({ name }));
+
+  it("removes only opportunity listing from intent-scoped tools", () => {
+    const filteredNames = filterNegotiatorToolsForContext(tools, {
+      scopeType: "intent",
+      scopeId: "intent-42",
+    }).map((tool) => tool.name);
+
+    expect(filteredNames).not.toContain("list_opportunities");
+    expect(filteredNames).toEqual([
+      "update_opportunity",
+      "list_negotiations",
+      "get_negotiation",
+      "respond_to_negotiation",
+      "read_pending_questions",
+      "answer_pending_question",
+    ]);
+  });
+
+  it("retains opportunity listing for unscoped and network-scoped tools", () => {
+    expect(filterNegotiatorToolsForContext(tools, {}).map((tool) => tool.name)).toContain("list_opportunities");
+    expect(filterNegotiatorToolsForContext(tools, {
+      scopeType: "network",
+      scopeId: "net-1",
+    }).map((tool) => tool.name)).toContain("list_opportunities");
+  });
+});
 
 describe("filterNegotiatorTools", () => {
   const registry = ORCHESTRATOR_REGISTRY_NAMES.map((name) => ({ name }));


### PR DESCRIPTION
## New Features

- None.

## Bug Fixes

- Stop intent-scoped Personal Agent chats from bulk-listing opportunity cards already shown in the adjacent Radar.
- Preserve opportunity listing in the unscoped Personal Agent DM and network-scoped sessions.
- Preserve explicit opportunity actions, negotiation reporting, and pending-question tools in intent chat.

## Refactors

- Add a narrow context-aware negotiator tool filter driven by the resolved intent scope.
- Keep negotiator prompt guidance and its Tools Reference aligned with the tools available in each scope.

## Documentation

- No public contract changes; the implementation handoff was removed before opening this PR.

## Tests

- `cd packages/protocol && bun test src/chat/tests/negotiator.persona.spec.ts` — 23 passed.
- `cd packages/protocol && bun run build` — passed.
