### PR TITLE
feat(protocol): add frame-constrained HyDE generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,6 +108,7 @@ OPENROUTER_API_KEY=your-openrouter-api-key
 
 # Opportunity discovery/evaluation tuning
 # RUN_OPPORTUNITY_EVAL_IN_PARALLEL=false    # Experimental: fire one LLM call per candidate in parallel
+# HYDE_FRAME_CONSTRAINTS_ENABLED=false      # Strict literal true enables source-grounded frame-v1 HyDE generation/validation
 # DISCOVERY_CONTEXT_TO_INTENT=1             # Set to 0 to disable context-to-intent discovery
 # DISCOVERY_SOURCE_PREMISE_LIMIT=           # Max source premises per discovery run (protocol runtime)
 # PREMISE_DEDUP_SIMILARITY=                 # Premise dedup similarity threshold, 0..1 (protocol runtime)

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ packages/protocol/CLAUDE.md
 # ===================
 *.report.md
 packages/protocol/eval/matching/runs/
+packages/protocol/eval/hyde/runs/
 packages/protocol/eval/premise/runs/
 packages/protocol/eval/profile/runs/
 packages/protocol/eval/opportunity/runs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,6 +338,10 @@ All agents are first-class database entities backed by `agents`, `agent_transpor
 
 Negotiation-specific events (`negotiation_session_start/end`, `negotiation_turn`, `negotiation_outcome`) carry per-candidate turn and outcome data for orchestrator-inline negotiations. They are persisted into `debugMeta.orchestratorNegotiations.opportunityIds` for later hydration by the debug endpoint. `debugMeta` also now tracks `llm.{calls,totalDurationMs,resets,hallucinations}` accumulated from `llm_start/end`, `response_reset`, and `hallucination_detected` events.
 
+### HyDE Generation Modes
+
+IND-426 adds a default-off frame-v1 path behind `HYDE_FRAME_CONSTRAINTS_ENABLED=true` (strict literal). Legacy remains `infer → cache → generate → embed → persist`; frame-v1 extracts a source-only frame in a separate model call (profile context is lens-selection context only), uses fingerprinted Redis/context provenance plus stable versioned DB lens identities, validates generated documents before embedding, supports partial/all rejection, and treats validator failures as ephemeral failed-open output that is never cached or persisted. Bulk context discovery filters persisted HyDE rows to the active mode, current source-text hash, and newest generation marker. The paired `packages/protocol/eval/hyde` suite provides retrieval diagnostics; `eval/matching` invokes `OpportunityEvaluator` directly and is only a secondary regression check.
+
 ### OpenRouter Configuration
 
 Model settings centralized in `packages/protocol/src/shared/agent/model.config.ts`. Key env vars: `OPENROUTER_API_KEY` (required), `CHAT_MODEL` (override), `CHAT_REASONING_EFFORT` (`minimal|low|medium|high|xhigh`), `RUN_OPPORTUNITY_EVAL_IN_PARALLEL` (experimental), `NEGOTIATION_MAX_TURNS_CHAT` (default 4, chat-path negotiations), `NEGOTIATION_MAX_TURNS_AMBIENT` (default 6, ambient/background negotiations). Use `ToolContext.modelConfig` to inject config per-request via `ChatAgent.create`; only `ChatAgent` reads `ModelConfig` from `ToolContext` — most other protocol agents rely on `OPENROUTER_API_KEY` in the environment (some accept an explicit `ModelConfig` as a direct parameter to `createModel()`).

--- a/bun.lock
+++ b/bun.lock
@@ -84,7 +84,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "4.15.0",
+      "version": "4.16.0",
       "dependencies": {
         "@langchain/core": "^1.1.17",
         "@langchain/langgraph": "^1.1.2",
@@ -100,7 +100,7 @@
     },
     "services/api": {
       "name": "@indexnetwork/api",
-      "version": "0.38.0",
+      "version": "0.38.1",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.939.0",
         "@aws-sdk/s3-request-presigner": "^3.983.0",

--- a/docs/design/protocol-deep-dive.md
+++ b/docs/design/protocol-deep-dive.md
@@ -197,17 +197,22 @@ Premise-based candidates carry `candidatePremiseId` in the persist node for acto
 ### 3.5 HyDE Graph
 
 **File:** `shared/hyde/hyde.graph.ts`
-**Purpose:** Cache-aware hypothetical document generation with dynamic lens inference.
-**Nodes:** `infer_lenses`, `check_cache`, `generate_missing`, `embed`, `cache_results`
-**State:** `HydeGraphState` (sourceType, sourceId, sourceText, profileContext, lenses, hydeDocuments, hydeEmbeddings, etc.)
+**Purpose:** Cache-aware hypothetical document generation with dynamic lens inference and an opt-in source-grounded validation path.
+**Nodes:** legacy uses `infer_lenses`, `check_cache`, `generate_missing`, `embed`, `cache_results`; frame-v1 inserts `validate_generated` between generation and embedding.
+**State:** `HydeGraphState` (sourceType, sourceId, sourceText, profileContext, lenses, optional sourceFrame/frameFingerprint, hydeDocuments, hydeEmbeddings, etc.)
 **Conditional edges:**
-- After `check_cache`: routes to `generate_missing` (cache misses) or `embed` (all cached)
+- After `check_cache`: routes to `generate_missing` (cache misses) or `embed` (all cached).
+- In frame-v1, generated documents route through one batch validator; cache/DB hits already marked valid skip validation.
 
-**Flow:** `START -> infer_lenses -> check_cache -> [generate_missing if needed] -> embed -> cache_results -> END`
+**Legacy flow:** `START -> infer_lenses -> check_cache -> [generate_missing] -> embed -> cache_results -> END`
 
-The graph is designed for efficiency: it checks both Redis cache and PostgreSQL before generating any HyDE documents, and only generates documents for lenses that had cache misses.
+**Frame-v1 flow:** `START -> infer_lenses+frame -> check_versioned_cache -> [generate_missing -> validate_generated] -> embed -> cache_results -> END`
 
-**Dependencies:** `HydeGraphDatabase`, `EmbeddingGenerator`, `HydeCache`, `LensInferrer`, `HydeGenerator`
+`HYDE_FRAME_CONSTRAINTS_ENABLED=true` selects frame-v1; every other value preserves the default legacy path. Frame extraction uses only `sourceText`. Optional `profileContext` remains lens-selection context and is never frame evidence or validator input. A partial rejection removes only invalid siblings. If every generated document is rejected, the graph returns no HyDE embeddings. Validator errors and malformed/missing/contradictory verdicts fail open per document: those documents are embedded and returned ephemerally, but `cache_results` never writes them.
+
+Legacy Redis keys and DB strategy hashes remain untouched. Frame-v1 Redis keys include the version plus a fingerprint of exact source text and sanitized frame; frame-v1 DB strategies are stable versioned lens/corpus hashes so revisions upsert rather than append. Persisted context carries source/frame fingerprints, a generation marker, and `validationStatus: valid`. Bulk context discovery filters to the active mode, current source-text hash, and newest generation-marker group, so changed content cannot reuse stale frame documents and disabling the flag returns to legacy rows only.
+
+**Dependencies:** `HydeGraphDatabase`, `EmbeddingGenerator`, `HydeCache`, `LensInferrer`, `HydeGenerator`, and frame-v1 `HydeValidator`
 
 ### 3.6 Network Graph
 
@@ -410,22 +415,24 @@ Scoring bands:
 ### 4.11 HyDE Generator
 
 **File:** `hyde.generator.ts`
-**Role:** Generates hypothetical documents in a target corpus voice for semantic search. Takes a source text and a lens label, produces text that would match the ideal counterpart.
-**Model:** `google/gemini-2.5-flash`
-**Input:** `HydeGenerateInput` (sourceText, lens label, target corpus)
+**Role:** Generates hypothetical documents in a target corpus voice for semantic search. Legacy takes source text plus a lens. Frame-v1 also takes the sanitized source frame, allows generic reciprocal-role/domain elaboration, and forbids new named entities or hard location/time/numeric/credential/organization/exclusivity constraints.
+**Model:** configured `hydeGenerator` model
+**Input:** `HydeGenerateInput` (sourceText, lens label, target corpus, optional sourceFrame)
 **Output:** `HydeGeneratorOutput` (text)
-**Used by:** HyDE Graph (generate_missing node)
+**Used by:** HyDE Graph (`generate_missing` node)
 
 ### 4.12 Lens Inferrer
 
 **File:** `lens.inferrer.ts`
-**Role:** Analyzes source text with optional profile context and infers 1-5 search lenses, each tagged with a target corpus (profiles, intents, or premises).
-**Model:** `google/gemini-2.5-flash`
-**Input:** Source text, optional profile context, optional max lenses
-**Output:** Array of lenses with label, corpus, reasoning
-**Used by:** HyDE Graph (infer_lenses node)
+**Role:** Analyzes source text with optional profile context and infers 1-5 search lenses tagged `profiles`, `intents`, or `premises`. In frame-v1 it also extracts a source-grounded frame whose evidence spans must come only from `sourceText`; `profileContext` can shape lens selection but cannot supply frame facts.
+**Model:** configured `lensInferrer` model
+**Input:** Source text, optional profile context, optional max lenses, frame-constrained mode
+**Output:** Lenses with label/corpus/reasoning plus an optional sanitized source frame
+**Used by:** HyDE Graph (`infer_lenses` node)
 
-Replaces the old hardcoded strategy enum (mirror, reciprocal, mentor, etc.) with dynamic, LLM-inferred lenses. This allows the system to generate contextually appropriate search perspectives for any domain.
+Replaces the old hardcoded strategy enum (mirror, reciprocal, mentor, etc.) with dynamic, LLM-inferred lenses. The `profiles` value is now a preference hint: the API remaps it to premise retrieval because profile-vector discovery was retired.
+
+**Post-generation validator:** `shared/hyde/hyde.validator.ts` performs one structured frame-v1 batch check after generation. It rejects only unsupported named entities or hard constraints; generic elaboration and reciprocal/target voice are valid. The graph owns partial/all-rejection and fail-open persistence behavior rather than the agent.
 
 ### 4.13 Home Categorizer
 
@@ -663,32 +670,20 @@ Agents claim turns via the HTTP pickup endpoint rather than an MCP tool — the 
 
 ## 6. HyDE System
 
-HyDE (Hypothetical Document Embeddings) is the core semantic search technique. Instead of searching directly with a user's intent text, the system generates hypothetical documents that describe what an ideal match would look like, then embeds those documents for vector similarity search.
+HyDE (Hypothetical Document Embeddings) bridges source-side wording and counterpart-side documents before vector search. Source types are `intent`, `query`, and `context`; there is no profile source. Presentation identity lives on `users`, and the retired profile-vector corpus is not read. A lens tagged `profiles` is treated by the API as a preference for premise retrieval.
 
-### How it works
+### Legacy and frame-v1
 
-1. **Lens inference:** The `LensInferrer` agent analyzes the source text (intent or query) and user profile context, producing 1-5 search lenses. Each lens is a specific search perspective (e.g., "early-stage crypto infrastructure VC") tagged with a target corpus (`profiles` or `intents`).
+1. **Lens inference:** Both modes infer 1-5 dynamic lenses from `sourceText` and optional `profileContext`. Frame-v1 additionally extracts roles, hard constraints, named entities, and domain vocabulary. Every frame value must have exact evidence in `sourceText`; profile context can specialize lenses but is never frame evidence.
+2. **Version-aware cache check:** Legacy reads its unchanged Redis/DB identities. Frame-v1 reads only validated entries carrying `frame-v1`, the lens, matching source/frame fingerprints, and a valid generation marker; its stable DB lens identities are overwritten on source revisions rather than accumulated.
+3. **Generation:** Legacy uses the existing corpus-specific source+lens prompt. Frame-v1 generates from the sanitized frame with slot discipline: target voice and generic reciprocal/domain elaboration are allowed; unsupported named entities and hard constraints are forbidden.
+4. **Validation (frame-v1 only):** One batch validator checks newly generated documents before embedding. Partial rejection preserves valid siblings; all rejection returns no HyDE embeddings. Provider/shape failures fail open per document for the current run, but failed-open documents are not cached or persisted.
+5. **Embedding and retrieval:** Returned texts use the configured OpenRouter embedding model (default `openai/text-embedding-3-large`, 2000 dimensions). Every lens searches intents and premises within scope, preferring its hinted corpus, and candidate results are merged before `OpportunityEvaluator` runs.
+6. **Caching:** Legacy output follows existing cache behavior. Frame-v1 persists only `valid` documents under versioned Redis keys and DB strategies/context, preventing cross-mode or changed-frame reuse.
 
-2. **Cache check:** For each lens, the system checks Redis cache and PostgreSQL `hyde_documents` table. Only lenses with cache misses proceed to generation.
+`HYDE_FRAME_CONSTRAINTS_ENABLED` is strict and default-off: only the literal `true` enables frame-v1. IND-426's `eval/hyde` suite pairs the real two graph modes against a hand-authored in-memory candidate corpus using equivalent OpenRouter request configuration and the same embedding model/dimensions. Its scorer approximates the adapter's `0.40` cosine floor and `0.1` additional-match bonus, but has no SQL per-lens limits, network scope, or cross-row user grouping beyond one candidate row per user. It excludes PostgreSQL and opportunity evaluation so its Recall@K/MRR remain retrieval evidence. `eval/matching` invokes `OpportunityEvaluator` directly and is only a separately labeled secondary regression check.
 
-3. **HyDE generation:** The `HydeGenerator` agent takes each uncached lens and generates a hypothetical document in the target corpus voice:
-   - **Intents corpus:** Generates a goal/aspiration statement from the complementary perspective
-   - **Premises corpus:** Generates an identity assertion matching the ideal person's values or expertise
-
-4. **Embedding:** Generated texts are embedded using the same embedding model (text-embedding-3-large, 2000 dimensions) as the stored intents and premises.
-
-5. **Caching:** Results are cached in Redis (1-hour TTL) and persisted to PostgreSQL for entity sources (intents, premises).
-
-### Dynamic lenses vs. hardcoded strategies
-
-The system previously used hardcoded strategy names (mirror, reciprocal, mentor, investor, collaborator, hiree). These have been replaced by LLM-inferred lenses that adapt to any domain. The `LensInferrer` is location-aware and domain-specific -- a DePIN founder searching for "investors" gets "SF-based early-stage crypto infra VC" rather than generic "investor".
-
-### Corpus-specific prompt templates
-
-The `HYDE_CORPUS_PROMPTS` in `hyde.strategies.ts` define how source text and lens labels are combined into prompts:
-
-- **Profiles:** "Write a professional biography for someone who could fulfill this need: [source]. Focus on the specific expertise described by: [lens]."
-- **Intents:** "Write a goal or aspiration statement for someone who is: [lens]. This person's needs would complement: [source]."
+See [`../domain/hyde.md`](../domain/hyde.md) for cache identities, rejection semantics, source/profile boundaries, and eval limitations.
 
 ## 7. Opportunity Pipeline
 

--- a/docs/domain/hyde.md
+++ b/docs/domain/hyde.md
@@ -3,144 +3,153 @@ title: "HyDE (Hypothetical Document Embeddings)"
 type: domain
 tags: [hyde, semantic-search, lenses, embeddings, discovery, caching]
 created: 2026-03-26
-updated: 2026-03-26
+updated: 2026-07-16
 ---
 
 # HyDE (Hypothetical Document Embeddings)
 
-HyDE is the semantic search strategy that powers discovery in Index Network. Instead of directly matching a user's intent or profile against the database, the system generates a **hypothetical document** describing the ideal match, embeds that document, and searches for real entries that are similar to the hypothesis.
+HyDE is the semantic retrieval bridge used by Index discovery. Instead of embedding only
+a seeker's words, the system generates a short hypothetical document in an ideal
+counterpart's voice, embeds it, and searches real intent and premise documents in the same
+vector space.
 
-This bridging technique solves a fundamental problem in discovery: what a user says they want ("Looking for a co-founder") is written in the seeker's voice, but the ideal match ("Senior engineer with 10 years experience building distributed systems, interested in co-founding") is written in the match's voice. HyDE bridges this gap by generating the match-side document before searching.
+For example, "looking for a co-founder" is in the seeker's voice, while a useful candidate
+may describe themselves as an engineer interested in co-founding. A hypothetical
+counterpart document reduces that voice mismatch before candidate evaluation.
 
----
+## Lenses and target corpora
 
-## Why HyDE Exists
+`LensInferrer` analyzes `sourceText` plus optional `profileContext` and returns 1-N
+free-text lenses. Each lens has a label, a target-corpus hint, and reasoning. The hints are:
 
-Direct embedding comparison between a search query and candidate documents often fails because:
+- `intents`: complementary goals, needs, or aspirations;
+- `premises`: identity, expertise, values, or worldview assertions;
+- `profiles`: a retained lens vocabulary meaning "a type of person." The live API no
+  longer has a profile-vector corpus; it remaps this hint to premise search.
 
-1. **Voice mismatch**: A seeker describes what they want; a candidate describes what they are or offer. These are fundamentally different linguistic registers.
-2. **Implicit context**: "Looking for investors" implies a startup founder seeking VC funding, but the query text alone does not contain investor-side vocabulary.
-3. **Specificity gap**: A short intent ("Need ML collaborators") must match against rich profile descriptions with many dimensions.
+The API searches both intents and premises for each lens, allocating more results to the
+preferred corpus, then merges candidates. Profile identity fields on `users` are for
+presentation, not a HyDE source or vector corpus.
 
-HyDE closes these gaps by generating a document in the target's voice that captures the implied context, making the embedding comparison meaningful.
+## Source/profile boundary
 
----
+HyDE source types are `intent`, `query`, and `context`. There is no `profile` source type.
+A context source is a synthesized user-context paragraph; profile-HyDE and the
+`user_profiles` corpus were retired.
 
-## Dynamic Lens Inference
+`profileContext` may help **select and specialize lenses**, but it is not source evidence.
+This distinction matters most in frame-v1:
 
-The system uses **lenses** to determine what kinds of hypothetical documents to generate. A lens is a search perspective -- a specific angle from which to look for matches.
+- frame extraction reads only `sourceText`;
+- each frame item must quote an exact `sourceText` evidence span;
+- sanitization removes unsupported frame values;
+- neither the frame-v1 generator nor validator receives `profileContext`.
 
-Previously, the system used a fixed set of hardcoded strategies (mirror, reciprocal, mentor, investor, collaborator, hiree). These have been replaced by dynamic lens inference: an LLM agent (the Lens Inferrer) analyzes the source text and optional profile context to produce 1-N specific, contextually appropriate lenses.
+The legacy lens label can still reflect profile context, and its unconstrained generator
+can elaborate that lens. Frame-v1 keeps lens usefulness while preventing profile-only
+names, locations, credentials, or constraints from becoming accepted source facts.
 
-### How lenses work
+## Two generation modes
 
-Given a source text like "Looking for investors for my DePIN startup", the Lens Inferrer might produce:
+`HYDE_FRAME_CONSTRAINTS_ENABLED` controls the production mode. Only the exact string
+`true` enables `frame-v1`; the default is `legacy` so rollout is opt-in.
 
-1. **"Early-stage crypto infrastructure VC"** (corpus: profiles) -- Search user profiles for people who match this description
-2. **"Angel investor interested in DePIN/blockchain infrastructure"** (corpus: profiles) -- A different investor profile angle
-3. **"Seeking startups to invest in, focused on decentralized infrastructure"** (corpus: intents) -- Search user intents for complementary goals
+### Legacy
 
-Each lens specifies:
-- **label**: A specific, domain-aware description (not generic like "investor" but specific like "early-stage crypto infrastructure VC")
-- **corpus**: Whether to search user profiles or user intents
-- **reasoning**: Why this perspective is relevant (for logging and tracing)
+```text
+infer_lenses -> check_cache -> generate_missing -> embed -> cache_results
+```
 
-### Guidelines for lens inference
+Legacy inference returns lenses only. `HydeGenerator` combines each source and lens with a
+corpus-specific prompt, and generated documents go directly to embedding. Existing legacy
+cache keys and database strategies remain unchanged.
 
-- Be specific and domain-aware. "Early-stage crypto infrastructure investor" is better than "investor".
-- Consider both sides: who can help the person AND whose goals complement theirs.
-- Use "profiles" when looking for a type of person (expert, advisor, leader). Use "intents" when looking for a complementary goal or need.
-- When the source mentions a specific location, incorporate it into lens descriptions to improve retrieval quality.
-- Generate only perspectives that add distinct search value -- no repeated similar angles.
+### frame-v1
 
----
+```text
+infer_lenses + source_frame
+  -> check versioned cache
+  -> generate_missing from sanitized frame
+  -> validate_generated (one batch)
+  -> embed accepted/ephemeral documents
+  -> cache only validated documents
+```
 
-## Target Corpus
+Frame-v1 inference returns lenses plus a sanitized frame containing source roles,
+complementary roles, explicit hard constraints, named entities, and domain vocabulary.
+Generic reciprocal-role inference is allowed, but hard facts require exact source evidence.
+The generator may elaborate generic roles/domain language and write in the counterpart's
+voice; it must not invent proper nouns or hard location, time, numeric, credential,
+organization, or exclusivity constraints.
 
-Each lens targets one of two corpora:
+## Post-generation validation
 
-### Profiles corpus
+`HydeValidator` runs once over all newly generated frame-v1 documents before embedding.
+It compares each document with `sourceText` and the sanitized frame. First-person target
+voice, generic domain elaboration, and reciprocal/complementary inversion are allowed.
+Unsupported named entities or hard constraints make a document invalid.
 
-Search user profiles (bios, expertise, backgrounds). Used when looking for a **type of person** who could help. The HyDE generator writes a hypothetical professional biography for someone matching the lens description.
+Validation outcomes are deliberately per document:
 
-Prompt pattern: "Write a professional biography for someone who could fulfill this need: [source text]. Focus on the specific expertise described by: [lens]."
+- **Partial rejection:** invalid documents are removed; valid siblings continue to
+  embedding, output, Redis, and PostgreSQL.
+- **All rejected:** the graph completes successfully with no HyDE documents or embeddings;
+  discovery gets no candidates from that HyDE pass. This does not revoke an earlier
+  validated cohort for the unchanged source; source-text hashing prevents that cohort from
+  surviving a source edit.
+- **Validator failure or malformed/missing/contradictory verdict:** the affected document
+  is marked `failed_open`, embedded, and returned for the current invocation so provider
+  trouble does not turn discovery into a hard failure. It is **ephemeral**: failed-open
+  output is never cached or persisted.
+- **Validated cache/DB hit:** a frame-v1 document with matching version, lens, source/frame
+  fingerprints, generation marker, and `validationStatus: valid` is reused without another
+  validator call.
 
-### Intents corpus
+Legacy documents have no validation status and never pass through this validator node.
 
-Search user intents (stated goals, needs, aspirations). Used when looking for someone with a **complementary goal**. The HyDE generator writes a hypothetical goal statement for someone matching the lens.
+## Versioned caches and persistence
 
-Prompt pattern: "Write a goal or aspiration statement for someone who is: [lens]. This person's needs would complement: [source text]."
+Frame-v1 does not overwrite or trust legacy entries.
 
----
+- Legacy Redis keys keep their original namespace and lens/corpus hash.
+- Frame-v1 Redis keys add `frame-v1` plus a fingerprint of the exact `sourceText` and
+  sanitized frame.
+- Legacy PostgreSQL strategy values remain unchanged.
+- Frame-v1 PostgreSQL strategies use a stable `frame-v1` + lens/corpus hash, so a source
+  revision upserts its prior frame row instead of appending one row per revision.
+- Frame-v1 context metadata records the lens, source-text hash, source/frame fingerprint,
+  generation marker, and validated status. Bulk context discovery reads only the active
+  mode, requires the current source-text hash, and selects the newest generation-marker
+  group; disabling the flag therefore returns to legacy rows only.
 
-## The Full Pipeline
+A changed source or sanitized frame cannot reuse an older frame-v1 document, while stable
+DB identities prevent revision accumulation. Only validated frame-v1 documents are written.
+Redis still provides short-lived reuse and PostgreSQL longer-lived reuse; intent/context
+lifecycle jobs handle regeneration and invalidation as before.
 
-HyDE generation follows this pipeline for each source (intent, profile, or query):
+## Retrieval and downstream evaluation
 
-### 1. Lens inference
+Accepted or failed-open document text is embedded with the configured OpenRouter embedding
+model (default `openai/text-embedding-3-large`, 2000 dimensions), the same model used for
+candidate intents and premises. The API performs cosine-similarity search in network scope,
+merges multi-lens candidates, and then passes them to `OpportunityEvaluator`. HyDE retrieval
+and opportunity evaluation are separate stages: an evaluator-only regression suite cannot
+show that a hypothetical document retrieved the right candidate.
 
-The Lens Inferrer analyzes the source text (and optional profile context) and produces up to 3 lenses, each tagged with a target corpus.
+IND-426 therefore includes a paired drift-focused eval in
+`packages/protocol/eval/hyde/`. It runs the real legacy and frame-v1 HyDE pipelines against
+a small in-memory candidate corpus using equivalent OpenRouter request configuration and
+the same embedding model/dimensions. Its scorer approximates production's `0.40` cosine
+floor and `0.1` additional-match bonus, but does not reproduce SQL per-lens limits, network
+scope, or cross-row user grouping beyond one candidate row per user. PostgreSQL and
+opportunity evaluation remain excluded. The existing matching eval remains a secondary
+evaluator-regression check.
 
-### 2. Cache check
+## Limitations and rollout
 
-For each lens, the system checks whether a valid HyDE document already exists:
-- **Redis cache** (fast, ephemeral): Checked first for recently generated documents
-- **PostgreSQL** (`hyde_documents` table): Checked second for persisted documents with their embeddings
-
-Cache keys are built from (sourceType, sourceId, strategy/lens, targetCorpus). A unique index on these columns prevents duplicate entries.
-
-### 3. Generation
-
-For cache misses, the HyDE Generator agent produces a hypothetical document in the target corpus voice. The document is written in first person as the hypothetical match, is concrete and specific for good vector similarity, and is kept to a few sentences or one short paragraph.
-
-### 4. Embedding
-
-The generated text is embedded using the same 2000-dimensional text-embedding-3-large model used for intents and premises, producing a vector that lives in the same embedding space.
-
-### 5. Caching
-
-The generated document and its embedding are stored:
-- In Redis with a default TTL of 1 hour (3600 seconds) for fast retrieval during the current discovery session
-- In PostgreSQL's `hyde_documents` table with an optional `expiresAt` timestamp for longer-term persistence
-
-### 6. Search
-
-The HyDE embedding is used to perform cosine similarity search against the target corpus (intent embeddings or premise embeddings) using pgvector's HNSW index. Results are candidate users ranked by similarity.
-
----
-
-## HyDE Source Types
-
-HyDE documents can be generated from three source types:
-
-| Source | When | Purpose |
-|---|---|---|
-| **intent** | When an intent is created or updated | Find people whose intents or premises complement this intent |
-| **query** | When a user asks the chat agent to find someone | Find people matching the search query |
-
----
-
-## Cache-Aware Architecture
-
-The caching strategy is designed to minimize redundant LLM calls while keeping results fresh:
-
-- **Within a session**: Multiple searches against the same intent reuse cached HyDE documents from Redis, avoiding regeneration.
-- **Across sessions**: PostgreSQL stores embeddings that persist beyond Redis TTL. If a user's intent has not changed, the stored HyDE embedding can be reused without regeneration.
-- **Staleness management**: HyDE documents have expiration timestamps. When an intent is updated, associated HyDE documents are invalidated and regenerated on next use.
-- **Deduplication**: The unique index on (sourceType, sourceId, strategy, targetCorpus) prevents multiple identical HyDE documents from accumulating.
-
----
-
-## Relationship to Discovery
-
-HyDE is the bridge between intent expression and candidate retrieval in the opportunity discovery pipeline:
-
-1. User creates an intent
-2. Lens Inferrer determines search perspectives
-3. HyDE Generator produces hypothetical documents for each lens
-4. Vector search finds candidates similar to the hypotheticals
-5. Opportunity Evaluator scores the candidates
-6. Negotiation validates high-scoring matches
-7. Opportunities are persisted and surfaced to users
-
-Without HyDE, the system would rely on direct intent-to-intent or intent-to-premise embedding comparison, which suffers from the voice mismatch problem described above.
+Frame constraints reduce unsupported entity/constraint drift; they do not prove factual
+truth, guarantee semantic relevance, or replace downstream candidate evaluation. The live
+eval corpus is intentionally small and provider-variable. Frame-v1 remains default-off
+until full paired multi-run retrieval evidence and the separately labeled matching
+regression check are reviewed. Filtered or single runs must not establish a canonical
+baseline.

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -13,6 +13,7 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
 ## [Unreleased]
 
 ### Added
+- Default-off frame-v1 HyDE generation with source-only frame extraction, post-generation entity/constraint validation, partial/all rejection, ephemeral fail-open behavior, and mode/source/generation-isolated cache persistence; includes a separately labeled paired retrieval eval with drift-focused in-memory corpora and Recall@K/MRR diagnostics (IND-426).
 - Opt-in `POOL_QUESTIONS_PUSH` accessor, pool refresh cycle identity, dismissal-decayed push threshold helpers, deterministic Markdown-safe Personal Agent DM template, and typed private push-ledger metadata (IND-421 P5).
 - Pre-insert newborn-opportunity stamping for fresh answered pool discriminators, with a fixed-axis evidence-verifying classifier, deterministic `questionId` provenance, and fail-open host callback (IND-420 P4b).
 - Durable pool-discriminator semantic novelty metadata: current axis embeddings and embedding-model ids now survive deterministic question snapshot conversion, alongside full-intent freshness fingerprints (IND-420 P4a).

--- a/packages/protocol/eval/README.md
+++ b/packages/protocol/eval/README.md
@@ -12,28 +12,34 @@ equivalent env) — harnesses call real models.
 
 | Harness    | Script                  | Agent(s) under test                                              |
 | :--------- | :---------------------- | :-------------------------------------------------------------- |
-| `matching`    | `bun run eval:matching`    | `OpportunityEvaluator.invokeEntityBundle` (which people get surfaced + scored) |
+| `matching`    | `bun run eval:matching`    | `OpportunityEvaluator.invokeEntityBundle` (secondary evaluator-only regression check) |
+| `hyde`        | `bun run eval:hyde`        | Paired real legacy/frame-v1 HyDE generation, validation, embedding, and in-memory retrieval |
 | `premise`     | `bun run eval:premise`     | `PremiseDecomposer.invoke`, `PremiseAnalyzer.invoke`                           |
 | `profile`     | `bun run eval:profile`     | `ProfileGenerator.invoke` (incl. the PII-redaction guarantee)                 |
 | `opportunity` | `bun run eval:opportunity` | `OpportunityPresenter.present` (the user-facing card: headline/summary/greeting) |
 
 Each harness has its own README with full flag docs:
-[`matching`](./matching/README.md) · [`premise`](./premise/README.md) ·
-[`profile`](./profile/README.md) · [`opportunity`](./opportunity/README.md).
+[`matching`](./matching/README.md) · [`hyde`](./hyde/README.md) ·
+[`premise`](./premise/README.md) · [`profile`](./profile/README.md) ·
+[`opportunity`](./opportunity/README.md).
+
+The IND-426 `hyde` harness is intentionally retrieval-only and has no committed baseline;
+its full multi-run paired report is reviewed directly. The `matching` harness calls
+`OpportunityEvaluator` without HyDE and is not retrieval evidence.
 
 `matching` scores *which* people get surfaced; `opportunity` judges the *card a person
 actually reads* once a match exists — complementary surfaces of the same feature.
 
-Common flags (all harnesses): `--runs N`, `--rule R`, `--case ID`, `--tier N`,
+Common flags (most baseline-backed harnesses): `--runs N`, `--rule R`, `--case ID`, `--tier N`,
 `--list-cases`, `--no-judge`, `--update-baseline`, `--report [path]`, `--html [path]`,
 `--rolling-baseline [days]`, `--alpha P`, `--no-save`. The `premise` harness additionally
 takes `--component decompose|analyze`.
 
 ## Architecture: shared lib + thin harnesses
 
-The harness-agnostic machinery lives in [`eval/shared/`](./shared) and is reused by every
-harness, so a new harness only authors its corpus, scorer, and CLI — never the statistics,
-baseline math, or reporting again.
+The harness-agnostic machinery lives in [`eval/shared/`](./shared) and is reused by the
+baseline-backed scorecard harnesses. HyDE is deliberately smaller and standalone because
+it reports paired retrieval ranks/diagnostics and has no canonical baseline.
 
 ```
 eval/
@@ -50,6 +56,7 @@ eval/
 │   ├── index.ts            # barrel export — import everything from "../shared/index.js"
 │   └── tests/              # unit tests for the shared lib
 ├── matching/               # matching corpus, scorer, bespoke HTML renderer
+├── hyde/                   # paired retrieval eval; intentionally no canonical baseline
 ├── premise/                # premise corpus, scorer, reporter (shared HTML shell)
 ├── profile/                # profile corpus, scorer, PII detectors, reporter
 └── opportunity/            # opportunity-card corpus, scorer, leakage detectors, reporter
@@ -138,6 +145,10 @@ These are standard `bun test` specs — they do NOT invoke live agents; they val
 scoring logic, runner wiring, reporter math, and baseline handling.
 
 ## Baseline contract
+
+The drift-focused `hyde` harness is the exception: it rejects `--update-baseline` and must
+not turn filtered/single runs into canonical evidence. The contract below applies to the
+baseline-backed harnesses.
 
 - **Committed baseline** (`baselines/<name>.baseline.json`): the scorecard with per-run
   `detail` stripped (via the harness's `leanCase`). Kept lean so diffs are meaningful.

--- a/packages/protocol/eval/hyde/README.md
+++ b/packages/protocol/eval/hyde/README.md
@@ -1,0 +1,108 @@
+# Paired HyDE Retrieval Eval (IND-426)
+
+This is a small, deliberately drift-focused retrieval eval. It is **not** a set of
+normal matching cases. Each source is paired with a hand-authored expected target and
+same-domain traps/distractors that differ on role, named entity, location, time, scale,
+or financing constraints.
+
+The matching eval is labeled separately because it invokes `OpportunityEvaluator`
+directly. It is useful as a secondary evaluator-regression check, but it is not evidence
+that HyDE generation or retrieval improved.
+
+## What the live eval exercises
+
+For every selected case and repetition, the harness runs a paired `legacy` and `frame-v1`
+pass using the production:
+
+- `LensInferrer`
+- `HydeGenerator`
+- `HydeGraphFactory`
+- `HydeValidator` (the graph intentionally calls it only in `frame-v1`; legacy has no
+  validation node)
+
+The graph uses empty in-memory cache/database ports with `forceRegenerate: true`. No
+PostgreSQL, pgvector, network scope, opportunity graph, or `OpportunityEvaluator` is
+involved. Recording delegates retain generated documents and real validator verdicts for
+diagnosis without replacing any production agent.
+
+Candidates and returned HyDE documents use `OpenAIEmbeddings` with an OpenRouter
+request configuration equivalent to the API adapter and the same model/dimensions:
+
+- base URL: `https://openrouter.ai/api/v1`
+- model: `EMBEDDING_MODEL` or `openai/text-embedding-3-large`
+- dimensions: `EMBEDDING_DIMENSIONS` or `2000`
+- API key: `OPENROUTER_API_KEY`
+
+The in-memory scorer approximates the current production `EmbedderAdapter`: each
+candidate-lens cosine must meet `--min-score` (default `0.40`), candidates with no
+qualifying match are omitted, and the final score is
+`min(best + 0.1 * (additional qualifying matches), 1)`. Lens IDs travel with query
+embeddings and are retained on ranked candidates. Raw maximum cosine remains a diagnostic;
+the bonus-adjusted score is the headline rank. Exact score ties use their average rank for
+Recall@K/MRR, so candidate IDs or authored order cannot decide headline metrics.
+
+This remains a production approximation, not an adapter replica. It does not run the SQL
+per-lens/per-corpus limits, enforce network scope, or group multiple intent/premise rows by
+user. The hand-authored corpus intentionally has one candidate row per user, so it cannot
+exercise cross-row user grouping or the extra matches that grouping can create.
+
+## Metrics and diagnostics
+
+Per run, the report includes:
+
+- expected-target rank (or `null` for a miss/no returned document)
+- full candidate ranking with bonus-adjusted score, raw max cosine, qualifying-match
+  count, and matched lens IDs
+- inferred lens count
+- generated and returned document counts
+- frame-v1 rejected count from key-resolved `valid: false` verdicts with at least one
+  unsupported named entity or hard constraint; legacy reports `null` because rejection is
+  not applicable
+- failed-open count for contradictory, missing, duplicate, malformed, or validator-error
+  outcomes
+- generated-document overwrite/map-loss count, reported separately from rejection
+- every generated document plus map status, opaque validator key, return status,
+  `valid`/`invalid`/`failed_open`/`not_submitted`/`not_applicable` status, failure reason,
+  and the real key-resolved validator verdict when one exists
+
+Per mode, it reports Recall@K, MRR, and total generated/overwritten/rejected/failed-open
+counts.
+Failed-open frame-v1 documents are intentionally included in ephemeral ranking because
+that is the production graph behavior; they are not written to Redis or PostgreSQL.
+
+## Run
+
+From `packages/protocol`:
+
+```bash
+bun run eval:hyde                              # all cases, 3 paired runs each
+bun run eval:hyde -- --runs 5 --k 1 --min-score 0.40
+bun run eval:hyde -- --case profile-boundary/
+bun run eval:hyde -- --list-cases              # provider-free
+bun run eval:hyde -- --report                   # full JSON under eval/hyde/runs/
+bun run eval:hyde -- --report /tmp/hyde.json
+```
+
+The package script loads `../../.env.test`. A live run calls external language and
+embedding models and therefore requires valid provider configuration. Unit tests under
+`tests/` are provider-free.
+
+JSON reports record the configured primary lens-inferrer, generator, and validator model
+IDs; embedding base URL/model/dimensions; frame generation version; Git revision with a
+dirty marker; full-corpus and effective-config fingerprints; selected-case hashes;
+minimum score; lens-bonus formula; and case/run/mode/concurrency ordering. Together these
+make filtered and full runs diagnosable without implying that provider outputs themselves
+are deterministic.
+
+## Interpretation and limitations
+
+This corpus is intentionally tiny and hand-authored. It measures whether constrained
+hypothetical documents retrieve the intended local candidate better than plausible local
+traps; it does not estimate production opportunity precision, recall, fairness, latency,
+or cost. LLM and embedding-provider variance still applies, so release evidence should use
+the complete corpus and multiple repetitions (at least the default three).
+
+There is no committed HyDE baseline and no `--update-baseline` path. Never treat a
+filtered or single-run report as a canonical baseline. Preserve a full multi-run report
+for review, and use `eval:matching` only as the separately labeled secondary regression
+check.

--- a/packages/protocol/eval/hyde/hyde.cases.ts
+++ b/packages/protocol/eval/hyde/hyde.cases.ts
@@ -1,0 +1,108 @@
+import type { HydeEvalCase } from './hyde.types.js';
+
+/**
+ * These are retrieval drift probes, not ordinary matching examples. Each corpus
+ * keeps the domain close while changing a source-grounded role, entity, location,
+ * time, or commercial constraint that unconstrained generation can invent.
+ */
+export const HYDE_CASES: HydeEvalCase[] = [
+  {
+    id: 'profile-boundary/nairobi-solar-grants',
+    description: 'Profile context must not move a Nairobi grant search toward an unrelated location or financing model.',
+    sourceText: 'I am building open-source software for community-owned solar microgrids in Nairobi and seeking grant funders.',
+    profileContext: 'I previously led oncology commercialization at HelixNova in Boston.',
+    expectedTargetId: 'nairobi-solar-grantmaker',
+    candidates: [
+      {
+        id: 'nairobi-solar-grantmaker',
+        role: 'target',
+        corpus: 'premises',
+        text: 'I run a grant program in Nairobi that funds open-source tools for community-owned solar microgrids.',
+      },
+      {
+        id: 'boston-grid-equity-fund',
+        role: 'trap',
+        corpus: 'premises',
+        text: 'I am a Boston climate-tech venture investor taking equity stakes in proprietary utility-scale grid software.',
+      },
+      {
+        id: 'nairobi-solar-engineer',
+        role: 'distractor',
+        corpus: 'intents',
+        text: 'I am a Nairobi solar engineer seeking paid implementation work on commercial microgrid projects.',
+      },
+      {
+        id: 'kenya-carbon-lender',
+        role: 'distractor',
+        corpus: 'premises',
+        text: 'I provide debt financing for carbon-credit projects across Kenya, focused on repayment-backed installations.',
+      },
+    ],
+  },
+  {
+    id: 'constraint-drift/robotics-nonprofit-advisor',
+    description: 'Generation must not invent elite credentials, named universities, or venture requirements for a generic advisor need.',
+    sourceText: 'Looking for a technical advisor to help an early-stage robotics education nonprofit.',
+    profileContext: 'My day job is enterprise procurement for a Fortune 100 manufacturer.',
+    expectedTargetId: 'nonprofit-robotics-advisor',
+    candidates: [
+      {
+        id: 'nonprofit-robotics-advisor',
+        role: 'target',
+        corpus: 'premises',
+        text: 'I advise early-stage nonprofit teams on robotics education programs, technical architecture, and safe classroom deployment.',
+      },
+      {
+        id: 'credentialed-edtech-advisor',
+        role: 'trap',
+        corpus: 'premises',
+        text: 'I am a Carnegie Mellon robotics professor who advises venture-backed edtech companies after their Series A.',
+      },
+      {
+        id: 'robotics-teacher-seeking-advisor',
+        role: 'distractor',
+        corpus: 'intents',
+        text: 'I teach a school robotics club and am looking for an experienced technical advisor for my own curriculum.',
+      },
+      {
+        id: 'robotics-hardware-sales',
+        role: 'distractor',
+        corpus: 'intents',
+        text: 'I want to sell classroom robotics kits to education nonprofits through annual procurement contracts.',
+      },
+    ],
+  },
+  {
+    id: 'location-time-drift/portugal-packaging-pilot',
+    description: 'Explicit Portugal and September constraints should survive reciprocal generation without invented scale or dates.',
+    sourceText: 'Seeking a manufacturing partner for biodegradable food packaging in Portugal; the pilot must start in September.',
+    profileContext: 'I split my time between Madrid and London and previously scaled a million-unit plastics line.',
+    expectedTargetId: 'portugal-september-manufacturer',
+    candidates: [
+      {
+        id: 'portugal-september-manufacturer',
+        role: 'target',
+        corpus: 'intents',
+        text: 'We manufacture biodegradable food packaging in Portugal and can begin a pilot production run in September.',
+      },
+      {
+        id: 'spain-million-unit-2027',
+        role: 'trap',
+        corpus: 'intents',
+        text: 'Our Spanish packaging plant accepts only one-million-unit orders and is booking biodegradable production for 2027.',
+      },
+      {
+        id: 'portugal-packaging-investor',
+        role: 'distractor',
+        corpus: 'premises',
+        text: 'I invest in sustainable packaging companies in Portugal but do not operate manufacturing facilities.',
+      },
+      {
+        id: 'portugal-plastics-manufacturer',
+        role: 'distractor',
+        corpus: 'intents',
+        text: 'We manufacture conventional plastic food containers in Portugal and are not equipped for biodegradable materials.',
+      },
+    ],
+  },
+];

--- a/packages/protocol/eval/hyde/hyde.diagnostics.ts
+++ b/packages/protocol/eval/hyde/hyde.diagnostics.ts
@@ -1,0 +1,180 @@
+import { createHash } from 'node:crypto';
+
+import type { HydeGenerationMode } from '../../src/shared/hyde/hyde.env.js';
+import type { HydeDocumentState } from '../../src/shared/hyde/hyde.state.js';
+import type { HydeValidationDocument, HydeValidationVerdict } from '../../src/shared/hyde/hyde.validator.js';
+import type { HydeTargetCorpus } from '../../src/shared/hyde/lens.inferrer.js';
+
+import type { DiagnosticValidationStatus, FailedOpenReason, GeneratedDocumentDiagnostic } from './hyde.types.js';
+
+export interface RecordedGeneratedDocument {
+  lens: string;
+  corpus: HydeTargetCorpus;
+  text: string;
+}
+
+export interface RecordedValidationBatch {
+  documents: Record<string, HydeValidationDocument>;
+  verdicts?: unknown;
+  error?: string;
+}
+
+export interface GeneratedDocumentAnalysis {
+  documents: GeneratedDocumentDiagnostic[];
+  overwrittenDocumentCount: number;
+  validatorSubmittedDocumentCount: number;
+  rejectedCount: number;
+  failedOpenCount: number;
+}
+
+/** Mirrors the graph's opaque validator key so diagnostics resolve verdicts by key. */
+export function evalOpaqueDocumentKey(document: RecordedGeneratedDocument): string {
+  return `d-${createHash('sha256')
+    .update(`${document.lens}\0${document.corpus}\0${document.text}`)
+    .digest('hex')
+    .slice(0, 16)}`;
+}
+
+function isValidationVerdict(value: unknown): value is HydeValidationVerdict {
+  if (!value || typeof value !== 'object') return false;
+  const verdict = value as Partial<HydeValidationVerdict>;
+  return typeof verdict.key === 'string'
+    && typeof verdict.valid === 'boolean'
+    && Array.isArray(verdict.unsupportedNamedEntities)
+    && verdict.unsupportedNamedEntities.every((item) => typeof item === 'string')
+    && Array.isArray(verdict.unsupportedHardConstraints)
+    && verdict.unsupportedHardConstraints.every((item) => typeof item === 'string')
+    && typeof verdict.reasoning === 'string';
+}
+
+function returnedDocumentKeys(returned: Record<string, HydeDocumentState>): Set<string> {
+  return new Set(Object.entries(returned).map(([lensId, document]) =>
+    evalOpaqueDocumentKey({
+      lens: document.lens || lensId,
+      corpus: document.targetCorpus,
+      text: document.hydeText,
+    })));
+}
+
+/**
+ * Assign one generated call to each final map entry. RecordingGenerator appends
+ * completed calls in the same order in which the graph assigns its lens-keyed map,
+ * so the last identical-key completion is the surviving call.
+ */
+function submittedGeneratedIndexes(
+  generated: RecordedGeneratedDocument[],
+  submittedKeys: string[],
+): Set<number> {
+  const indexesByKey = new Map<string, number[]>();
+  generated.forEach((document, index) => {
+    const key = evalOpaqueDocumentKey(document);
+    indexesByKey.set(key, [...(indexesByKey.get(key) ?? []), index]);
+  });
+
+  const submitted = new Set<number>();
+  for (const key of submittedKeys) {
+    const matches = indexesByKey.get(key);
+    const index = matches?.pop();
+    if (index !== undefined) submitted.add(index);
+  }
+  return submitted;
+}
+
+function resolveFrameStatus(
+  key: string,
+  validation: RecordedValidationBatch | undefined,
+): {
+  validationStatus: DiagnosticValidationStatus;
+  failedOpenReason?: FailedOpenReason;
+  verdict?: HydeValidationVerdict;
+} {
+  if (!validation || validation.error || validation.verdicts === undefined) {
+    return { validationStatus: 'failed_open', failedOpenReason: 'validator_error' };
+  }
+  if (!Array.isArray(validation.verdicts)) {
+    return { validationStatus: 'failed_open', failedOpenReason: 'malformed_verdict' };
+  }
+
+  const rawVerdicts = validation.verdicts;
+  const matching = rawVerdicts.filter((value) =>
+    !!value && typeof value === 'object' && (value as { key?: unknown }).key === key);
+  if (matching.length === 0) {
+    return { validationStatus: 'failed_open', failedOpenReason: 'missing_verdict' };
+  }
+  if (matching.length > 1) {
+    return { validationStatus: 'failed_open', failedOpenReason: 'duplicate_verdict' };
+  }
+  if (!isValidationVerdict(matching[0])) {
+    return { validationStatus: 'failed_open', failedOpenReason: 'malformed_verdict' };
+  }
+
+  const verdict = matching[0];
+  const hasUnsupportedGrounding = verdict.unsupportedNamedEntities.length > 0
+    || verdict.unsupportedHardConstraints.length > 0;
+  if (verdict.valid === hasUnsupportedGrounding) {
+    return {
+      validationStatus: 'failed_open',
+      failedOpenReason: 'contradictory_verdict',
+      verdict,
+    };
+  }
+  return verdict.valid
+    ? { validationStatus: 'valid', verdict }
+    : { validationStatus: 'invalid', verdict };
+}
+
+/**
+ * Diagnose generated calls separately from map overwrites and classify frame
+ * outcomes from exactly one structurally valid verdict resolved by opaque key.
+ */
+export function analyzeGeneratedDocuments(
+  mode: HydeGenerationMode,
+  generated: RecordedGeneratedDocument[],
+  returned: Record<string, HydeDocumentState>,
+  validation?: RecordedValidationBatch,
+): GeneratedDocumentAnalysis {
+  const returnedKeys = returnedDocumentKeys(returned);
+  const submittedKeys = mode === 'frame-v1'
+    ? (validation ? Object.keys(validation.documents) : [...returnedKeys])
+    : [...returnedKeys];
+  const submittedIndexes = submittedGeneratedIndexes(generated, submittedKeys);
+
+  const documents = generated.map((document, index): GeneratedDocumentDiagnostic => {
+    const validatorKey = evalOpaqueDocumentKey(document);
+    if (!submittedIndexes.has(index)) {
+      return {
+        ...document,
+        mapStatus: 'overwritten',
+        validationStatus: mode === 'legacy' ? 'not_applicable' : 'not_submitted',
+        validatorKey,
+        returned: false,
+      };
+    }
+
+    if (mode === 'legacy') {
+      return {
+        ...document,
+        mapStatus: 'submitted',
+        validationStatus: 'not_applicable',
+        validatorKey,
+        returned: returnedKeys.has(validatorKey),
+      };
+    }
+
+    return {
+      ...document,
+      mapStatus: 'submitted',
+      ...resolveFrameStatus(validatorKey, validation),
+      validatorKey,
+      returned: returnedKeys.has(validatorKey),
+    };
+  });
+
+  return {
+    documents,
+    overwrittenDocumentCount: generated.length - submittedIndexes.size,
+    validatorSubmittedDocumentCount: mode === 'frame-v1' && validation ? submittedKeys.length : 0,
+    rejectedCount: documents.filter((document) => document.validationStatus === 'invalid').length,
+    failedOpenCount: documents.filter((document) => document.validationStatus === 'failed_open').length,
+  };
+}

--- a/packages/protocol/eval/hyde/hyde.eval.ts
+++ b/packages/protocol/eval/hyde/hyde.eval.ts
@@ -1,0 +1,192 @@
+#!/usr/bin/env bun
+/**
+ * Paired IND-426 HyDE retrieval eval. This is intentionally separate from the
+ * matching eval: it exercises generation/validation/embedding, not opportunity scoring.
+ */
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+
+import { HYDE_CASES } from './hyde.cases.js';
+import { HYDE_EVAL_EMBEDDING_BASE_URL, HYDE_EVAL_EMBEDDING_DIMENSIONS, HYDE_EVAL_EMBEDDING_MODEL, createHydeEvalEmbedder, embedCandidates, runHydeCase } from './hyde.runner.js';
+import { buildHydeEvalMetadata, readGitMetadata } from './hyde.report.js';
+import { aggregateMode, HYDE_EVAL_DEFAULT_MIN_SCORE, HYDE_EVAL_LENS_BONUS_PER_ADDITIONAL_MATCH } from './hyde.scorer.js';
+import type { HydeEvalReport, HydeEvalRunResult } from './hyde.types.js';
+
+const DEFAULT_RUNS = 3;
+const DEFAULT_RECALL_K = 2;
+
+function value(flag: string): string | undefined {
+  const index = process.argv.indexOf(flag);
+  const candidate = index >= 0 ? process.argv[index + 1] : undefined;
+  return candidate && !candidate.startsWith('--') ? candidate : undefined;
+}
+
+function has(flag: string): boolean {
+  return process.argv.includes(flag);
+}
+
+function positiveInteger(flag: string, fallback: number): number {
+  const raw = value(flag);
+  const parsed = raw === undefined ? fallback : Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${flag} must be a positive integer (got ${raw ?? ''})`);
+  }
+  return parsed;
+}
+
+function cosineThreshold(flag: string, fallback: number): number {
+  const raw = value(flag);
+  const parsed = raw === undefined ? fallback : Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) {
+    throw new Error(`${flag} must be a finite number between 0 and 1 (got ${raw ?? ''})`);
+  }
+  return parsed;
+}
+
+function usage(): string {
+  return `Paired HyDE retrieval eval (IND-426)\n\n` +
+    `This is the HyDE retrieval eval. eval:matching is a separate, secondary\n` +
+    `OpportunityEvaluator regression check and is not retrieval evidence.\n\n` +
+    `Usage (from packages/protocol):\n` +
+    `  bun run eval:hyde\n` +
+    `  bun run eval:hyde -- --runs 5\n` +
+    `  bun run eval:hyde -- --case profile-boundary/\n` +
+    `  bun run eval:hyde -- --k 1\n` +
+    `  bun run eval:hyde -- --min-score 0.45\n` +
+    `  bun run eval:hyde -- --report\n` +
+    `  bun run eval:hyde -- --report ./eval/hyde/runs/manual.json\n` +
+    `  bun run eval:hyde -- --list-cases\n\n` +
+    `Options:\n` +
+    `  --runs <n>       Paired repetitions per case (default: ${DEFAULT_RUNS})\n` +
+    `  --case <prefix>  Select one case id or prefix\n` +
+    `  --k <n>          K for Recall@K (default: ${DEFAULT_RECALL_K})\n` +
+    `  --min-score <n>  Per-lens cosine cutoff (default: ${HYDE_EVAL_DEFAULT_MIN_SCORE})\n` +
+    `  --report [path]  Write full JSON including generated docs/verdicts\n` +
+    `  --list-cases     Print selected case ids without provider calls\n` +
+    `  --help, -h       Show this help\n\n` +
+    `There is no committed HyDE baseline or baseline-update command. Preserve full,\n` +
+    `multi-run reports as release evidence; never treat a filtered/single run as canonical.\n`;
+}
+
+function printRun(result: HydeEvalRunResult): void {
+  const rank = result.expectedTargetRank ?? 'miss';
+  const rejected = result.rejectedCount ?? 'n/a';
+  console.log(
+    `  ${result.mode} run ${result.run}: target rank=${rank}; lenses=${result.lensCount}; ` +
+    `generated=${result.generatedDocumentCount}; overwritten=${result.overwrittenDocumentCount}; ` +
+    `submitted=${result.validatorSubmittedDocumentCount}; returned=${result.returnedDocumentCount}; ` +
+    `rejected=${rejected}; failed-open=${result.failedOpenCount}`,
+  );
+  for (const document of result.documents) {
+    const verdict = document.verdict
+      ? `; verdict=${document.verdict.valid ? 'valid' : 'invalid'} (${document.verdict.reasoning})`
+      : '';
+    const mapping = document.mapStatus === 'overwritten' ? '; map=overwritten' : '';
+    const failedOpen = document.failedOpenReason ? `; reason=${document.failedOpenReason}` : '';
+    console.log(
+      `    [${document.validationStatus}] ${document.lens} -> ${document.corpus}` +
+      `${mapping}${failedOpen}${verdict}`,
+    );
+    console.log(`      ${document.text}`);
+  }
+}
+
+async function main(): Promise<void> {
+  if (has('--help') || has('-h')) {
+    console.log(usage());
+    return;
+  }
+  if (has('--update-baseline')) {
+    throw new Error('HyDE eval has no baseline-update path; filtered or single runs must not become canonical baselines');
+  }
+
+  const runsPerCase = positiveInteger('--runs', DEFAULT_RUNS);
+  const recallK = positiveInteger('--k', DEFAULT_RECALL_K);
+  const minScore = cosineThreshold('--min-score', HYDE_EVAL_DEFAULT_MIN_SCORE);
+  const caseFilter = value('--case');
+  const selectedCases = caseFilter
+    ? HYDE_CASES.filter((candidate) => candidate.id === caseFilter || candidate.id.startsWith(caseFilter))
+    : HYDE_CASES;
+  if (selectedCases.length === 0) throw new Error(`No HyDE eval case matches ${caseFilter}`);
+
+  if (has('--list-cases')) {
+    for (const c of selectedCases) console.log(`${c.id}\t${c.description}`);
+    return;
+  }
+
+  const embedder = createHydeEvalEmbedder();
+  const results: HydeEvalRunResult[] = [];
+  console.log(
+    `HyDE retrieval eval: ${selectedCases.length} drift case(s) × ${runsPerCase} paired run(s); ` +
+    `embedding=${HYDE_EVAL_EMBEDDING_MODEL}/${HYDE_EVAL_EMBEDDING_DIMENSIONS}; ` +
+    `minScore=${minScore}; additional-match bonus=${HYDE_EVAL_LENS_BONUS_PER_ADDITIONAL_MATCH}; ` +
+    `Recall@${recallK}`,
+  );
+  console.log('Matching eval: separate secondary OpportunityEvaluator regression check (not HyDE retrieval evidence).');
+
+  for (const c of selectedCases) {
+    console.log(`\n${c.id}: ${c.description}`);
+    const candidates = await embedCandidates(c, embedder);
+    for (let run = 1; run <= runsPerCase; run += 1) {
+      for (const mode of ['legacy', 'frame-v1'] as const) {
+        const result = await runHydeCase(c, mode, run, embedder, candidates, {
+          minScore,
+          lensBonusPerAdditionalMatch: HYDE_EVAL_LENS_BONUS_PER_ADDITIONAL_MATCH,
+        });
+        results.push(result);
+        printRun(result);
+      }
+    }
+  }
+
+  const metadata = buildHydeEvalMetadata({
+    allCases: HYDE_CASES,
+    selectedCases,
+    embedding: {
+      baseUrl: HYDE_EVAL_EMBEDDING_BASE_URL,
+      model: HYDE_EVAL_EMBEDDING_MODEL,
+      dimensions: HYDE_EVAL_EMBEDDING_DIMENSIONS,
+      encodingFormat: 'float',
+    },
+    minScore,
+    lensBonusPerAdditionalMatch: HYDE_EVAL_LENS_BONUS_PER_ADDITIONAL_MATCH,
+    recallK,
+    runsPerCase,
+    git: readGitMetadata(path.resolve(import.meta.dir, '../../../..')),
+  });
+  const report: HydeEvalReport = {
+    eval: 'hyde-retrieval',
+    matchingEval: 'separate-secondary-check',
+    generatedAt: new Date().toISOString(),
+    ...metadata,
+    recallK,
+    runsPerCase,
+    summaries: (['legacy', 'frame-v1'] as const).map((mode) =>
+      aggregateMode(mode, results.filter((result) => result.mode === mode), recallK)),
+    runs: results,
+  };
+
+  console.log('\nPer-mode retrieval summary (counts are totals):');
+  for (const summary of report.summaries) {
+    console.log(
+      `  ${summary.mode}: Recall@${recallK}=${summary.recallAtK.toFixed(3)}; ` +
+      `MRR=${summary.mrr.toFixed(3)}; generated=${summary.generatedDocumentCount}; ` +
+      `overwritten=${summary.overwrittenDocumentCount}; ` +
+      `rejected=${summary.rejectedCount ?? 'n/a'}; failed-open=${summary.failedOpenCount}`,
+    );
+  }
+
+  if (has('--report')) {
+    const explicitPath = value('--report');
+    const stamp = report.generatedAt.replace(/[:.]/g, '-');
+    const reportPath = path.resolve(explicitPath ?? path.join(import.meta.dir, 'runs', `${stamp}.json`));
+    await mkdir(path.dirname(reportPath), { recursive: true });
+    await Bun.write(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+    console.log(`\nFull diagnostic report written to ${reportPath}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 2;
+});

--- a/packages/protocol/eval/hyde/hyde.report.ts
+++ b/packages/protocol/eval/hyde/hyde.report.ts
@@ -1,0 +1,131 @@
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+
+import { getModelName } from '../../src/shared/agent/model.config.js';
+import { HYDE_FRAME_GENERATION_VERSION } from '../../src/shared/hyde/hyde.env.js';
+
+import type { HydeEvalCase, HydeEvalExecutionOrdering, HydeEvalGitMetadata, HydeEvalModelMetadata, HydeEvalReport } from './hyde.types.js';
+
+export const HYDE_EVAL_EXECUTION_ORDERING: HydeEvalExecutionOrdering = {
+  cases: 'selected corpus declaration order',
+  runs: 'ascending run number within each case; candidate embeddings generated once before paired modes',
+  modes: ['legacy', 'frame-v1'],
+  graphConcurrency: 'production graph ordering retained; frame extraction/lens inference and per-lens generation may run concurrently',
+};
+
+export type GitCommandRunner = (args: string[], cwd: string) => string;
+
+function runGitCommand(args: string[], cwd: string): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+    timeout: 5_000,
+    maxBuffer: 1024 * 1024,
+  }).trim();
+}
+
+/** Read revision/dirty state without invoking a shell or interpolating arguments. */
+export function readGitMetadata(
+  repoRoot: string,
+  runGit: GitCommandRunner = runGitCommand,
+): HydeEvalGitMetadata {
+  try {
+    const revision = runGit(['rev-parse', 'HEAD'], repoRoot).trim();
+    if (!revision) throw new Error('git returned an empty revision');
+    const dirty = runGit(
+      ['status', '--porcelain=v1', '--untracked-files=normal'],
+      repoRoot,
+    ).trim().length > 0;
+    return {
+      revision,
+      dirty,
+      revisionWithDirtyMarker: `${revision}${dirty ? '-dirty' : ''}`,
+    };
+  } catch {
+    return {
+      revision: 'unknown',
+      dirty: null,
+      revisionWithDirtyMarker: 'unknown',
+    };
+  }
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([, entry]) => entry !== undefined)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, canonicalize(entry)]),
+    );
+  }
+  return value;
+}
+
+/** Stable SHA-256 helper used for corpus, case, and config fingerprints. */
+export function fingerprint(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(canonicalize(value))).digest('hex');
+}
+
+/** Resolve configured primary model IDs through the production model-config helper. */
+export function getHydeEvalModelMetadata(): HydeEvalModelMetadata {
+  return {
+    lensInferrer: getModelName('lensInferrer'),
+    generator: getModelName('hydeGenerator'),
+    validator: getModelName('hydeValidator'),
+  };
+}
+
+export interface HydeEvalMetadataInput {
+  allCases: HydeEvalCase[];
+  selectedCases: HydeEvalCase[];
+  embedding: HydeEvalReport['embedding'];
+  minScore: number;
+  lensBonusPerAdditionalMatch: number;
+  recallK: number;
+  runsPerCase: number;
+  git: HydeEvalGitMetadata;
+}
+
+/** Build the deterministic report provenance/config block without provider calls. */
+export function buildHydeEvalMetadata(input: HydeEvalMetadataInput) {
+  const models = getHydeEvalModelMetadata();
+  const selectedCaseIds = input.selectedCases.map((candidate) => candidate.id);
+  const selectedCaseSnapshots = input.selectedCases.map((candidate) => ({
+    id: candidate.id,
+    sha256: fingerprint(candidate),
+  }));
+  const lensBonus = {
+    perAdditionalMatch: input.lensBonusPerAdditionalMatch,
+    formula: 'min(best qualifying cosine + perAdditionalMatch * (qualifying match count - 1), 1)',
+    qualifyingMatchSemantics: 'each candidate-lens cosine at or above minScore is one match; candidates with no qualifying match are omitted',
+  };
+  const configSnapshot = {
+    models,
+    embedding: input.embedding,
+    generationVersion: HYDE_FRAME_GENERATION_VERSION,
+    minScore: input.minScore,
+    lensBonus,
+    executionOrdering: HYDE_EVAL_EXECUTION_ORDERING,
+    recallK: input.recallK,
+    runsPerCase: input.runsPerCase,
+    maxLenses: 3,
+    selectedCaseIds,
+  };
+
+  return {
+    git: input.git,
+    models,
+    embedding: input.embedding,
+    generationVersion: HYDE_FRAME_GENERATION_VERSION,
+    corpusFingerprint: fingerprint(input.allCases),
+    configFingerprint: fingerprint(configSnapshot),
+    minScore: input.minScore,
+    lensBonus,
+    executionOrdering: HYDE_EVAL_EXECUTION_ORDERING,
+    selectedCaseIds,
+    selectedCaseSnapshots,
+  };
+}

--- a/packages/protocol/eval/hyde/hyde.runner.ts
+++ b/packages/protocol/eval/hyde/hyde.runner.ts
@@ -1,0 +1,205 @@
+import { OpenAIEmbeddings } from '@langchain/openai';
+
+import { HydeGenerator, type HydeGenerateInput, type HydeGeneratorOutput } from '../../src/shared/hyde/hyde.generator.js';
+import { HydeGraphFactory, type HydeGeneratorLike, type HydeValidatorLike } from '../../src/shared/hyde/hyde.graph.js';
+import type { HydeGenerationMode } from '../../src/shared/hyde/hyde.env.js';
+import type { HydeDocumentState } from '../../src/shared/hyde/hyde.state.js';
+import { HydeValidator, type HydeValidationInput, type HydeValidationOutput } from '../../src/shared/hyde/hyde.validator.js';
+import { LensInferrer } from '../../src/shared/hyde/lens.inferrer.js';
+import type { HydeCache } from '../../src/shared/interfaces/cache.interface.js';
+import type { CreateHydeDocumentData, HydeDocument, HydeGraphDatabase } from '../../src/shared/interfaces/database.interface.js';
+import type { EmbeddingGenerator } from '../../src/shared/interfaces/embedder.interface.js';
+
+import { analyzeGeneratedDocuments } from './hyde.diagnostics.js';
+import { expectedTargetRank, rankCandidates, type HydeRankingOptions } from './hyde.scorer.js';
+import type { EmbeddedCandidate, HydeEvalCase, HydeEvalRunResult, LensQueryEmbedding } from './hyde.types.js';
+
+export const HYDE_EVAL_EMBEDDING_MODEL = process.env.EMBEDDING_MODEL ?? 'openai/text-embedding-3-large';
+export const HYDE_EVAL_EMBEDDING_DIMENSIONS = process.env.EMBEDDING_DIMENSIONS
+  ? Number.parseInt(process.env.EMBEDDING_DIMENSIONS, 10)
+  : 2000;
+export const HYDE_EVAL_EMBEDDING_BASE_URL = 'https://openrouter.ai/api/v1';
+
+/** LangChain wrapper configured to match the API adapter's OpenRouter embedding setup. */
+export function createHydeEvalEmbedder(): EmbeddingGenerator {
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) throw new Error('OPENROUTER_API_KEY is required for the live HyDE retrieval eval');
+  if (!Number.isInteger(HYDE_EVAL_EMBEDDING_DIMENSIONS) || HYDE_EVAL_EMBEDDING_DIMENSIONS < 1) {
+    throw new Error(`EMBEDDING_DIMENSIONS must be a positive integer (got ${process.env.EMBEDDING_DIMENSIONS})`);
+  }
+
+  const client = new OpenAIEmbeddings({
+    apiKey,
+    model: HYDE_EVAL_EMBEDDING_MODEL,
+    dimensions: HYDE_EVAL_EMBEDDING_DIMENSIONS,
+    encodingFormat: 'float',
+    configuration: {
+      baseURL: HYDE_EVAL_EMBEDDING_BASE_URL,
+      defaultHeaders: {
+        'HTTP-Referer': 'https://index.network',
+        'X-Title': 'Index Network',
+      },
+    },
+  });
+
+  return {
+    async generate(text: string | string[]): Promise<number[] | number[][]> {
+      return Array.isArray(text) ? client.embedDocuments(text) : client.embedQuery(text);
+    },
+  };
+}
+
+class EmptyCache implements HydeCache {
+  async get<_T>(): Promise<_T | null> { return null; }
+  async set<_T>(): Promise<void> {}
+  async delete(): Promise<boolean> { return false; }
+  async exists(): Promise<boolean> { return false; }
+}
+
+function memoryDatabase(): HydeGraphDatabase {
+  return {
+    async getHydeDocument(): Promise<HydeDocument | null> { return null; },
+    async getHydeDocumentsForSource(): Promise<HydeDocument[]> { return []; },
+    async saveHydeDocument(data: CreateHydeDocumentData): Promise<HydeDocument> {
+      return {
+        id: 'eval-only',
+        sourceType: data.sourceType,
+        sourceId: data.sourceId ?? null,
+        sourceText: data.sourceText ?? null,
+        strategy: data.strategy,
+        targetCorpus: data.targetCorpus,
+        hydeText: data.hydeText,
+        hydeEmbedding: data.hydeEmbedding,
+        context: data.context ?? null,
+        createdAt: new Date(0),
+        expiresAt: data.expiresAt ?? null,
+      };
+    },
+    async getIntent() { return null; },
+  };
+}
+
+interface GeneratedCall {
+  input: HydeGenerateInput;
+  output: HydeGeneratorOutput;
+}
+
+class RecordingGenerator implements HydeGeneratorLike {
+  readonly calls: GeneratedCall[] = [];
+
+  constructor(private readonly delegate: HydeGenerator) {}
+
+  async generate(input: HydeGenerateInput): Promise<HydeGeneratorOutput> {
+    const output = await this.delegate.generate(input);
+    this.calls.push({ input, output });
+    return output;
+  }
+}
+
+interface ValidationCall {
+  input: HydeValidationInput;
+  output?: HydeValidationOutput;
+  error?: string;
+}
+
+class RecordingValidator implements HydeValidatorLike {
+  readonly calls: ValidationCall[] = [];
+
+  constructor(private readonly delegate: HydeValidator) {}
+
+  async validate(input: HydeValidationInput): Promise<HydeValidationOutput> {
+    const call: ValidationCall = { input };
+    this.calls.push(call);
+    try {
+      call.output = await this.delegate.validate(input);
+      return call.output;
+    } catch (error) {
+      call.error = error instanceof Error ? error.message : String(error);
+      throw error;
+    }
+  }
+}
+
+export async function embedCandidates(
+  c: HydeEvalCase,
+  embedder: EmbeddingGenerator,
+): Promise<EmbeddedCandidate[]> {
+  const embeddings = await embedder.generate(c.candidates.map((candidate) => candidate.text));
+  if (!Array.isArray(embeddings[0])) throw new Error(`Candidate embedding batch failed for ${c.id}`);
+  const vectors = embeddings as number[][];
+  if (vectors.length !== c.candidates.length) {
+    throw new Error(`Candidate embedding count mismatch for ${c.id}`);
+  }
+  return c.candidates.map((candidate, index) => ({ ...candidate, embedding: vectors[index] }));
+}
+
+/** Execute one real graph run with no database, pgvector, or opportunity evaluator. */
+export async function runHydeCase(
+  c: HydeEvalCase,
+  mode: HydeGenerationMode,
+  run: number,
+  embedder: EmbeddingGenerator,
+  candidates: EmbeddedCandidate[],
+  rankingOptions: HydeRankingOptions = {},
+): Promise<HydeEvalRunResult> {
+  const generator = new RecordingGenerator(new HydeGenerator());
+  const validator = mode === 'frame-v1' ? new RecordingValidator(new HydeValidator()) : undefined;
+  const graph = new HydeGraphFactory(
+    memoryDatabase(),
+    embedder,
+    new EmptyCache(),
+    new LensInferrer(),
+    generator,
+    { mode, ...(validator ? { validator } : {}) },
+  ).createGraph();
+
+  const result = await graph.invoke({
+    sourceType: 'query',
+    sourceText: c.sourceText,
+    profileContext: c.profileContext,
+    maxLenses: 3,
+    forceRegenerate: true,
+  });
+  const returned = result.hydeDocuments as Record<string, HydeDocumentState>;
+  const queryEmbeddings = Object.entries(returned)
+    .filter(([, document]) => document.hydeEmbedding.length > 0)
+    .map(([lensId, document]): LensQueryEmbedding => ({
+      lensId,
+      corpus: document.targetCorpus,
+      embedding: document.hydeEmbedding,
+    }));
+  const ranking = rankCandidates(queryEmbeddings, candidates, rankingOptions);
+  const validationCall = validator?.calls[0];
+  const diagnostics = analyzeGeneratedDocuments(
+    mode,
+    generator.calls.map((generated) => ({
+      lens: generated.input.lens,
+      corpus: generated.input.corpus,
+      text: generated.output.text,
+    })),
+    returned,
+    validationCall
+      ? {
+        documents: validationCall.input.documents,
+        ...(validationCall.output ? { verdicts: validationCall.output.verdicts } : {}),
+        ...(validationCall.error ? { error: validationCall.error } : {}),
+      }
+      : undefined,
+  );
+
+  return {
+    caseId: c.id,
+    mode,
+    run,
+    expectedTargetRank: expectedTargetRank(ranking, c.expectedTargetId),
+    ranking,
+    lensCount: result.lenses.length,
+    returnedDocumentCount: Object.keys(returned).length,
+    generatedDocumentCount: generator.calls.length,
+    overwrittenDocumentCount: diagnostics.overwrittenDocumentCount,
+    validatorSubmittedDocumentCount: diagnostics.validatorSubmittedDocumentCount,
+    rejectedCount: mode === 'frame-v1' ? diagnostics.rejectedCount : null,
+    failedOpenCount: diagnostics.failedOpenCount,
+    documents: diagnostics.documents,
+  };
+}

--- a/packages/protocol/eval/hyde/hyde.scorer.ts
+++ b/packages/protocol/eval/hyde/hyde.scorer.ts
@@ -1,0 +1,123 @@
+import type { HydeGenerationMode } from '../../src/shared/hyde/hyde.env.js';
+
+import type { EmbeddedCandidate, HydeEvalRunResult, HydeModeSummary, LensQueryEmbedding, RankedCandidate } from './hyde.types.js';
+
+export const HYDE_EVAL_DEFAULT_MIN_SCORE = 0.40;
+export const HYDE_EVAL_LENS_BONUS_PER_ADDITIONAL_MATCH = 0.1;
+
+export interface HydeRankingOptions {
+  minScore?: number;
+  lensBonusPerAdditionalMatch?: number;
+}
+
+/** Cosine similarity with strict shape/finite checks so broken eval input fails loudly. */
+export function cosineSimilarity(left: number[], right: number[]): number {
+  if (left.length === 0 || left.length !== right.length) {
+    throw new Error(`Embedding dimensions must match and be non-empty (${left.length} vs ${right.length})`);
+  }
+
+  let dot = 0;
+  let leftNorm = 0;
+  let rightNorm = 0;
+  for (let i = 0; i < left.length; i += 1) {
+    const a = left[i];
+    const b = right[i];
+    if (!Number.isFinite(a) || !Number.isFinite(b)) {
+      throw new Error('Embeddings must contain only finite numbers');
+    }
+    dot += a * b;
+    leftNorm += a * a;
+    rightNorm += b * b;
+  }
+
+  if (leftNorm === 0 || rightNorm === 0) return 0;
+  return dot / (Math.sqrt(leftNorm) * Math.sqrt(rightNorm));
+}
+
+/**
+ * Approximate EmbedderAdapter's current merge/rank behavior for one row per user.
+ * Each candidate-lens cosine must clear minScore. The headline score is the best
+ * qualifying cosine plus 0.1 per additional qualifying match, capped at one.
+ */
+export function rankCandidates(
+  queryEmbeddings: LensQueryEmbedding[],
+  candidates: EmbeddedCandidate[],
+  options: HydeRankingOptions = {},
+): RankedCandidate[] {
+  if (queryEmbeddings.length === 0) return [];
+
+  const minScore = options.minScore ?? HYDE_EVAL_DEFAULT_MIN_SCORE;
+  const lensBonus = options.lensBonusPerAdditionalMatch
+    ?? HYDE_EVAL_LENS_BONUS_PER_ADDITIONAL_MATCH;
+  if (!Number.isFinite(minScore) || minScore < 0 || minScore > 1) {
+    throw new Error(`minScore must be finite and between 0 and 1 (got ${minScore})`);
+  }
+  if (!Number.isFinite(lensBonus) || lensBonus < 0) {
+    throw new Error(`lensBonusPerAdditionalMatch must be finite and non-negative (got ${lensBonus})`);
+  }
+
+  return candidates
+    .map((candidate): RankedCandidate | null => {
+      const qualifyingMatches = queryEmbeddings
+        .map(({ lensId, embedding }) => ({
+          lensId,
+          cosine: cosineSimilarity(embedding, candidate.embedding),
+        }))
+        .filter((match) => match.cosine >= minScore);
+      if (qualifyingMatches.length === 0) return null;
+
+      const maxCosine = Math.max(...qualifyingMatches.map((match) => match.cosine));
+      return {
+        candidateId: candidate.id,
+        role: candidate.role,
+        score: Math.min(maxCosine + lensBonus * (qualifyingMatches.length - 1), 1),
+        maxCosine,
+        qualifyingMatchCount: qualifyingMatches.length,
+        matchedLensIds: qualifyingMatches.map((match) => match.lensId),
+      };
+    })
+    .filter((candidate): candidate is RankedCandidate => candidate !== null)
+    // JavaScript's stable sort preserves the authored candidate order for score
+    // ties; headline rank below is tie-aware and does not depend on that order.
+    .sort((left, right) => right.score - left.score);
+}
+
+/** Average rank within an exact score tie, avoiding arbitrary ID-order metrics. */
+export function expectedTargetRank(ranking: RankedCandidate[], expectedTargetId: string): number | null {
+  const target = ranking.find((candidate) => candidate.candidateId === expectedTargetId);
+  if (!target) return null;
+  const epsilon = 1e-12;
+  const higher = ranking.filter((candidate) => candidate.score > target.score + epsilon).length;
+  const tied = ranking.filter((candidate) => Math.abs(candidate.score - target.score) <= epsilon).length;
+  return higher + 1 + (tied - 1) / 2;
+}
+
+/** Aggregate paired run outcomes for one mode. Counts are totals, not rounded averages. */
+export function aggregateMode(
+  mode: HydeGenerationMode,
+  runs: HydeEvalRunResult[],
+  recallK: number,
+): HydeModeSummary {
+  if (!Number.isInteger(recallK) || recallK < 1) throw new Error('recallK must be a positive integer');
+  if (runs.some((run) => run.mode !== mode)) throw new Error(`Cannot aggregate non-${mode} runs`);
+
+  const hitCount = runs.filter((run) => run.expectedTargetRank !== null && run.expectedTargetRank <= recallK).length;
+  const reciprocalRankSum = runs.reduce(
+    (sum, run) => sum + (run.expectedTargetRank === null ? 0 : 1 / run.expectedTargetRank),
+    0,
+  );
+  const rejectionApplicable = runs.some((run) => run.rejectedCount !== null);
+
+  return {
+    mode,
+    runCount: runs.length,
+    recallAtK: runs.length === 0 ? 0 : hitCount / runs.length,
+    mrr: runs.length === 0 ? 0 : reciprocalRankSum / runs.length,
+    generatedDocumentCount: runs.reduce((sum, run) => sum + run.generatedDocumentCount, 0),
+    overwrittenDocumentCount: runs.reduce((sum, run) => sum + run.overwrittenDocumentCount, 0),
+    rejectedCount: rejectionApplicable
+      ? runs.reduce((sum, run) => sum + (run.rejectedCount ?? 0), 0)
+      : null,
+    failedOpenCount: runs.reduce((sum, run) => sum + run.failedOpenCount, 0),
+  };
+}

--- a/packages/protocol/eval/hyde/hyde.types.ts
+++ b/packages/protocol/eval/hyde/hyde.types.ts
@@ -1,0 +1,155 @@
+import type { HydeGenerationMode } from '../../src/shared/hyde/hyde.env.js';
+import type { HydeTargetCorpus } from '../../src/shared/hyde/lens.inferrer.js';
+import type { HydeValidationVerdict } from '../../src/shared/hyde/hyde.validator.js';
+
+export type CandidateRole = 'target' | 'trap' | 'distractor';
+
+/** One hand-authored candidate in the retrieval-only in-memory corpus. */
+export interface HydeEvalCandidate {
+  id: string;
+  role: CandidateRole;
+  corpus: 'intents' | 'premises';
+  text: string;
+}
+
+/** A drift-focused source paired with one target and plausible same-domain negatives. */
+export interface HydeEvalCase {
+  id: string;
+  description: string;
+  sourceText: string;
+  profileContext?: string;
+  expectedTargetId: string;
+  candidates: HydeEvalCandidate[];
+}
+
+export interface EmbeddedCandidate extends HydeEvalCandidate {
+  embedding: number[];
+}
+
+export interface LensQueryEmbedding {
+  /** Lens label carried with the vector, matching EmbedderAdapter's matchedVia value. */
+  lensId: string;
+  corpus: HydeTargetCorpus;
+  embedding: number[];
+}
+
+export interface RankedCandidate {
+  candidateId: string;
+  role: CandidateRole;
+  /** Production-approximate score after the qualifying-match bonus. */
+  score: number;
+  /** Raw best cosine, retained only as a diagnostic rather than the headline rank. */
+  maxCosine: number;
+  qualifyingMatchCount: number;
+  matchedLensIds: string[];
+}
+
+export type DiagnosticValidationStatus =
+  | 'not_applicable'
+  | 'not_submitted'
+  | 'valid'
+  | 'invalid'
+  | 'failed_open';
+export type DiagnosticMapStatus = 'submitted' | 'overwritten';
+export type FailedOpenReason =
+  | 'validator_error'
+  | 'missing_verdict'
+  | 'duplicate_verdict'
+  | 'malformed_verdict'
+  | 'contradictory_verdict';
+
+/** Text and key-resolved validator outcome retained to diagnose a live run. */
+export interface GeneratedDocumentDiagnostic {
+  lens: string;
+  corpus: HydeTargetCorpus;
+  text: string;
+  mapStatus: DiagnosticMapStatus;
+  validationStatus: DiagnosticValidationStatus;
+  validatorKey?: string;
+  failedOpenReason?: FailedOpenReason;
+  returned: boolean;
+  verdict?: HydeValidationVerdict;
+}
+
+export interface HydeEvalRunResult {
+  caseId: string;
+  mode: HydeGenerationMode;
+  run: number;
+  expectedTargetRank: number | null;
+  ranking: RankedCandidate[];
+  lensCount: number;
+  returnedDocumentCount: number;
+  generatedDocumentCount: number;
+  /** Generated calls lost when the graph's lens-keyed map overwrites duplicate labels. */
+  overwrittenDocumentCount: number;
+  validatorSubmittedDocumentCount: number;
+  /** Legacy has no validator, so rejection is not applicable rather than zero. */
+  rejectedCount: number | null;
+  failedOpenCount: number;
+  documents: GeneratedDocumentDiagnostic[];
+}
+
+export interface HydeModeSummary {
+  mode: HydeGenerationMode;
+  runCount: number;
+  recallAtK: number;
+  mrr: number;
+  generatedDocumentCount: number;
+  overwrittenDocumentCount: number;
+  rejectedCount: number | null;
+  failedOpenCount: number;
+}
+
+export interface HydeEvalGitMetadata {
+  revision: string;
+  dirty: boolean | null;
+  revisionWithDirtyMarker: string;
+}
+
+export interface HydeEvalModelMetadata {
+  lensInferrer: string;
+  generator: string;
+  validator: string;
+}
+
+export interface HydeEvalCaseSnapshot {
+  id: string;
+  sha256: string;
+}
+
+export interface HydeEvalExecutionOrdering {
+  cases: string;
+  runs: string;
+  modes: HydeGenerationMode[];
+  graphConcurrency: string;
+}
+
+export interface HydeEvalReport {
+  eval: 'hyde-retrieval';
+  matchingEval: 'separate-secondary-check';
+  generatedAt: string;
+  git: HydeEvalGitMetadata;
+  models: HydeEvalModelMetadata;
+  embedding: {
+    baseUrl: string;
+    model: string;
+    dimensions: number;
+    encodingFormat: 'float';
+  };
+  generationVersion: string;
+  corpusFingerprint: string;
+  configFingerprint: string;
+  minScore: number;
+  lensBonus: {
+    perAdditionalMatch: number;
+    formula: string;
+    qualifyingMatchSemantics: string;
+  };
+  executionOrdering: HydeEvalExecutionOrdering;
+  recallK: number;
+  runsPerCase: number;
+  selectedCaseIds: string[];
+  selectedCaseSnapshots: HydeEvalCaseSnapshot[];
+  summaries: HydeModeSummary[];
+  runs: HydeEvalRunResult[];
+}

--- a/packages/protocol/eval/hyde/tests/hyde.diagnostics.spec.ts
+++ b/packages/protocol/eval/hyde/tests/hyde.diagnostics.spec.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'bun:test';
+
+import type { HydeDocumentState } from '../../../src/shared/hyde/hyde.state.js';
+import type { HydeValidationVerdict } from '../../../src/shared/hyde/hyde.validator.js';
+
+import { analyzeGeneratedDocuments, evalOpaqueDocumentKey, type RecordedGeneratedDocument } from '../hyde.diagnostics.js';
+
+function generated(lens: string, text = lens): RecordedGeneratedDocument {
+  return { lens, corpus: 'premises', text };
+}
+
+function returned(documents: RecordedGeneratedDocument[]): Record<string, HydeDocumentState> {
+  return Object.fromEntries(documents.map((document) => [
+    document.lens,
+    {
+      lens: document.lens,
+      targetCorpus: document.corpus,
+      hydeText: document.text,
+      hydeEmbedding: [1, 0],
+      origin: 'generated',
+      validationStatus: 'failed_open',
+      hydeGenerationVersion: 'frame-v1',
+    },
+  ]));
+}
+
+function verdict(
+  document: RecordedGeneratedDocument,
+  overrides: Partial<HydeValidationVerdict> = {},
+): HydeValidationVerdict {
+  return {
+    key: evalOpaqueDocumentKey(document),
+    valid: true,
+    unsupportedNamedEntities: [],
+    unsupportedHardConstraints: [],
+    reasoning: 'grounded',
+    ...overrides,
+  };
+}
+
+describe('HyDE validator diagnostics', () => {
+  it('counts only key-resolved grounded invalid verdicts as rejections and separates overwrites', () => {
+    const valid = generated('valid');
+    const rejected = generated('rejected');
+    const contradictoryTrue = generated('contradictory-true');
+    const contradictoryFalse = generated('contradictory-false');
+    const missing = generated('missing');
+    const duplicate = generated('duplicate');
+    const overwritten = generated('duplicate-lens', 'old output');
+    const survivor = generated('duplicate-lens', 'new output');
+    const generatedDocuments = [
+      valid,
+      rejected,
+      contradictoryTrue,
+      contradictoryFalse,
+      missing,
+      duplicate,
+      overwritten,
+      survivor,
+    ];
+    const submitted = [
+      valid,
+      rejected,
+      contradictoryTrue,
+      contradictoryFalse,
+      missing,
+      duplicate,
+      survivor,
+    ];
+
+    const analysis = analyzeGeneratedDocuments(
+      'frame-v1',
+      generatedDocuments,
+      returned([valid, contradictoryTrue, contradictoryFalse, missing, duplicate, survivor]),
+      {
+        documents: Object.fromEntries(submitted.map((document) => [
+          evalOpaqueDocumentKey(document),
+          { corpus: document.corpus, text: document.text },
+        ])),
+        verdicts: [
+          verdict(valid),
+          verdict(rejected, {
+            valid: false,
+            unsupportedNamedEntities: ['Invented Org'],
+            reasoning: 'invented entity',
+          }),
+          verdict(contradictoryTrue, {
+            valid: true,
+            unsupportedHardConstraints: ['September'],
+            reasoning: 'contradictory valid verdict',
+          }),
+          verdict(contradictoryFalse, {
+            valid: false,
+            reasoning: 'invalid without unsupported grounding',
+          }),
+          verdict(duplicate),
+          verdict(duplicate, { reasoning: 'duplicate response' }),
+          verdict(survivor),
+          {
+            ...verdict(rejected),
+            key: 'd-unrelated-key',
+            valid: false,
+            unsupportedHardConstraints: ['wrong key'],
+          },
+        ],
+      },
+    );
+
+    expect(analysis).toMatchObject({
+      overwrittenDocumentCount: 1,
+      validatorSubmittedDocumentCount: 7,
+      rejectedCount: 1,
+      failedOpenCount: 4,
+    });
+    expect(analysis.documents.find((document) => document.text === 'old output')).toMatchObject({
+      mapStatus: 'overwritten',
+      validationStatus: 'not_submitted',
+      returned: false,
+    });
+    expect(analysis.documents.find((document) => document.lens === 'rejected')).toMatchObject({
+      validationStatus: 'invalid',
+      returned: false,
+    });
+    expect(analysis.documents.find((document) => document.lens === 'missing')).toMatchObject({
+      validationStatus: 'failed_open',
+      failedOpenReason: 'missing_verdict',
+      returned: true,
+    });
+    expect(analysis.documents.find((document) => document.lens === 'duplicate')).toMatchObject({
+      validationStatus: 'failed_open',
+      failedOpenReason: 'duplicate_verdict',
+    });
+    expect(analysis.documents.filter((document) => document.failedOpenReason === 'contradictory_verdict')).toHaveLength(2);
+  });
+
+  it('classifies every submitted document as failed open after a validator error', () => {
+    const documents = [generated('one'), generated('two')];
+    const analysis = analyzeGeneratedDocuments(
+      'frame-v1',
+      documents,
+      returned(documents),
+      {
+        documents: Object.fromEntries(documents.map((document) => [
+          evalOpaqueDocumentKey(document),
+          { corpus: document.corpus, text: document.text },
+        ])),
+        error: 'provider unavailable',
+      },
+    );
+
+    expect(analysis.rejectedCount).toBe(0);
+    expect(analysis.failedOpenCount).toBe(2);
+    expect(analysis.documents.every((document) =>
+      document.validationStatus === 'failed_open'
+      && document.failedOpenReason === 'validator_error')).toBe(true);
+  });
+});

--- a/packages/protocol/eval/hyde/tests/hyde.report.spec.ts
+++ b/packages/protocol/eval/hyde/tests/hyde.report.spec.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'bun:test';
+
+import { HYDE_CASES } from '../hyde.cases.js';
+import { buildHydeEvalMetadata, fingerprint, getHydeEvalModelMetadata, readGitMetadata } from '../hyde.report.js';
+
+const git = {
+  revision: 'abc123',
+  dirty: true,
+  revisionWithDirtyMarker: 'abc123-dirty',
+} as const;
+
+function metadata(minScore = 0.4) {
+  return buildHydeEvalMetadata({
+    allCases: HYDE_CASES,
+    selectedCases: HYDE_CASES.slice(0, 1),
+    embedding: {
+      baseUrl: 'https://openrouter.ai/api/v1',
+      model: 'openai/text-embedding-3-large',
+      dimensions: 2000,
+      encodingFormat: 'float',
+    },
+    minScore,
+    lensBonusPerAdditionalMatch: 0.1,
+    recallK: 2,
+    runsPerCase: 3,
+    git,
+  });
+}
+
+describe('HyDE report metadata', () => {
+  it('fingerprints canonical object content independent of key order', () => {
+    expect(fingerprint({ b: 2, a: { d: 4, c: 3 } })).toBe(
+      fingerprint({ a: { c: 3, d: 4 }, b: 2 }),
+    );
+  });
+
+  it('reads git revision and dirty state through argument-safe commands', () => {
+    const calls: string[][] = [];
+    const result = readGitMetadata('/repo', (args, cwd) => {
+      expect(cwd).toBe('/repo');
+      calls.push(args);
+      return args[0] === 'rev-parse' ? 'deadbeef\n' : ' M eval/hyde/hyde.scorer.ts\n';
+    });
+
+    expect(calls).toEqual([
+      ['rev-parse', 'HEAD'],
+      ['status', '--porcelain=v1', '--untracked-files=normal'],
+    ]);
+    expect(result).toEqual({
+      revision: 'deadbeef',
+      dirty: true,
+      revisionWithDirtyMarker: 'deadbeef-dirty',
+    });
+  });
+
+  it('reports model IDs and reproducible corpus/config/case metadata without providers', () => {
+    expect(getHydeEvalModelMetadata()).toEqual({
+      lensInferrer: 'google/gemini-2.5-flash',
+      generator: 'google/gemini-2.5-flash',
+      validator: 'google/gemini-2.5-flash',
+    });
+
+    const first = metadata();
+    const repeated = metadata();
+    expect(first).toEqual(repeated);
+    expect(first).toMatchObject({
+      git,
+      generationVersion: 'frame-v1',
+      minScore: 0.4,
+      lensBonus: {
+        perAdditionalMatch: 0.1,
+      },
+      executionOrdering: {
+        modes: ['legacy', 'frame-v1'],
+      },
+      selectedCaseIds: [HYDE_CASES[0].id],
+    });
+    expect(first.corpusFingerprint).toHaveLength(64);
+    expect(first.configFingerprint).toHaveLength(64);
+    expect(first.selectedCaseSnapshots).toEqual([
+      { id: HYDE_CASES[0].id, sha256: fingerprint(HYDE_CASES[0]) },
+    ]);
+    expect(metadata(0.45).configFingerprint).not.toBe(first.configFingerprint);
+  });
+});

--- a/packages/protocol/eval/hyde/tests/hyde.scorer.spec.ts
+++ b/packages/protocol/eval/hyde/tests/hyde.scorer.spec.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'bun:test';
+
+import { aggregateMode, cosineSimilarity, expectedTargetRank, rankCandidates } from '../hyde.scorer.js';
+import type { EmbeddedCandidate, HydeEvalRunResult, LensQueryEmbedding } from '../hyde.types.js';
+
+const candidates: EmbeddedCandidate[] = [
+  { id: 'target', role: 'target', corpus: 'premises', text: 'target', embedding: [1, 0] },
+  { id: 'trap', role: 'trap', corpus: 'intents', text: 'trap', embedding: [0, 1] },
+  { id: 'distractor', role: 'distractor', corpus: 'premises', text: 'distractor', embedding: [-1, 0] },
+];
+
+const queryEmbeddings: LensQueryEmbedding[] = [
+  { lensId: 'lens-a', corpus: 'premises', embedding: [0.8, 0.6] },
+  { lensId: 'lens-b', corpus: 'intents', embedding: [0.6, 0.8] },
+];
+
+function result(overrides: Partial<HydeEvalRunResult> = {}): HydeEvalRunResult {
+  return {
+    caseId: 'case',
+    mode: 'frame-v1',
+    run: 1,
+    expectedTargetRank: 1,
+    ranking: [],
+    lensCount: 2,
+    returnedDocumentCount: 1,
+    generatedDocumentCount: 2,
+    overwrittenDocumentCount: 0,
+    validatorSubmittedDocumentCount: 2,
+    rejectedCount: 1,
+    failedOpenCount: 0,
+    documents: [],
+    ...overrides,
+  };
+}
+
+describe('HyDE retrieval ranking', () => {
+  it('computes cosine similarity and rejects invalid vector shapes', () => {
+    expect(cosineSimilarity([1, 0], [1, 0])).toBeCloseTo(1);
+    expect(cosineSimilarity([1, 0], [0, 1])).toBeCloseTo(0);
+    expect(cosineSimilarity([0, 0], [1, 0])).toBe(0);
+    expect(() => cosineSimilarity([1], [1, 0])).toThrow('dimensions must match');
+    expect(() => cosineSimilarity([Number.NaN], [1])).toThrow('finite');
+  });
+
+  it('applies the default threshold and additional qualifying-lens bonus', () => {
+    const ranking = rankCandidates(queryEmbeddings, candidates);
+    expect(ranking.map((candidate) => candidate.candidateId)).toEqual(['target', 'trap']);
+    expect(ranking[0]).toMatchObject({
+      score: 0.9,
+      maxCosine: 0.8,
+      qualifyingMatchCount: 2,
+      matchedLensIds: ['lens-a', 'lens-b'],
+    });
+    expect(ranking[1]?.score).toBeCloseTo(0.9);
+    expect(expectedTargetRank(ranking, 'target')).toBe(1.5);
+    expect(expectedTargetRank([...ranking].reverse(), 'target')).toBe(1.5);
+  });
+
+  it('supports a configurable cutoff and only bonuses matches at or above it', () => {
+    const ranking = rankCandidates(queryEmbeddings, candidates, { minScore: 0.7 });
+    expect(ranking.map((candidate) => candidate.candidateId)).toEqual(['target', 'trap']);
+    expect(ranking[0]).toMatchObject({ score: 0.8, qualifyingMatchCount: 1 });
+    expect(ranking[0]?.matchedLensIds).toEqual(['lens-a']);
+    expect(ranking[1]?.matchedLensIds).toEqual(['lens-b']);
+    expect(rankCandidates(queryEmbeddings, candidates, { minScore: 0.81 })).toEqual([]);
+  });
+
+  it('reports a miss rather than ranking candidates when no document survives', () => {
+    expect(rankCandidates([], candidates)).toEqual([]);
+    expect(expectedTargetRank([], 'target')).toBeNull();
+  });
+});
+
+describe('HyDE report aggregation', () => {
+  it('aggregates Recall@K, MRR, and frame diagnostics across runs', () => {
+    const summary = aggregateMode('frame-v1', [
+      result({ expectedTargetRank: 1, generatedDocumentCount: 2, rejectedCount: 1 }),
+      result({
+        run: 2,
+        expectedTargetRank: 3,
+        generatedDocumentCount: 3,
+        overwrittenDocumentCount: 1,
+        rejectedCount: 0,
+        failedOpenCount: 1,
+      }),
+      result({ run: 3, expectedTargetRank: null, generatedDocumentCount: 1, rejectedCount: 1 }),
+    ], 2);
+
+    expect(summary).toEqual({
+      mode: 'frame-v1',
+      runCount: 3,
+      recallAtK: 1 / 3,
+      mrr: (1 + 1 / 3) / 3,
+      generatedDocumentCount: 6,
+      overwrittenDocumentCount: 1,
+      rejectedCount: 2,
+      failedOpenCount: 1,
+    });
+  });
+
+  it('keeps legacy rejection not applicable and handles empty reports', () => {
+    const legacy = aggregateMode('legacy', [
+      result({ mode: 'legacy', rejectedCount: null, expectedTargetRank: 2 }),
+    ], 2);
+    expect(legacy.rejectedCount).toBeNull();
+    expect(legacy.recallAtK).toBe(1);
+    expect(legacy.mrr).toBe(0.5);
+
+    expect(aggregateMode('legacy', [], 1)).toMatchObject({ runCount: 0, recallAtK: 0, mrr: 0 });
+    expect(() => aggregateMode('legacy', [result()], 1)).toThrow('non-legacy');
+  });
+});

--- a/packages/protocol/eval/hyde/tsconfig.json
+++ b/packages/protocol/eval/hyde/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "composite": false,
+    "rootDir": "../../",
+    "types": ["node", "bun-types"]
+  },
+  "include": ["**/*.ts", "../../src/**/*.ts"],
+  "exclude": ["node_modules", "../../src/**/*.spec.ts", "../../src/**/*.test.ts"]
+}

--- a/packages/protocol/eval/matching/README.md
+++ b/packages/protocol/eval/matching/README.md
@@ -1,8 +1,12 @@
 # Matching Quality Eval Harness
 
 Measures whether the opportunity evaluator (`invokeEntityBundle`) makes the right
-matching judgments, against a curated golden set. Standalone and opt-in — NOT part of
-`bun test`.
+matching judgments, against a curated golden set. The harness invokes
+`OpportunityEvaluator` **directly**; it does not run `LensInferrer`, HyDE generation,
+validation, embedding, or vector retrieval. For IND-426 it is therefore only a
+**secondary evaluator-regression check**, not evidence that frame-v1 improves HyDE
+retrieval. Use the separately labeled [`eval/hyde`](../hyde/README.md) paired eval for
+retrieval evidence. Standalone and opt-in — NOT part of `bun test`.
 
 ## Run
 

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "4.15.0",
+  "version": "4.16.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -23,6 +23,7 @@
     "test:isolated": "bun scripts/test.ts",
     "prepublishOnly": "bun run build",
     "eval:matching": "bun --env-file=../../.env.test ./eval/matching/matching.eval.ts",
+    "eval:hyde": "bun --env-file=../../.env.test ./eval/hyde/hyde.eval.ts",
     "eval:premise": "bun --env-file=../../.env.test ./eval/premise/premise.eval.ts",
     "eval:profile": "bun --env-file=../../.env.test ./eval/profile/profile.eval.ts",
     "eval:opportunity": "bun --env-file=../../.env.test ./eval/opportunity/opportunity.eval.ts",

--- a/packages/protocol/src/docs/Academic Grounding Enhancement Backlog.md
+++ b/packages/protocol/src/docs/Academic Grounding Enhancement Backlog.md
@@ -46,17 +46,20 @@ Implemented a canonical three-value QUD taxonomy across IntentClarifier and the 
 - Reuse the typology in the Questioner agent's discovery mode — **not** `opportunity/question.generator.ts`, which is `@deprecated` in favor of `QuestionerAgent`.
 - Eval hook: extend `eval/premise` / `eval/matching` fixtures (case files + runners exist on both sides) with under-specified inputs and assert question type.
 
-## 4. Frame-constrained HyDE generation — **M**
+## 4. Frame-constrained HyDE generation — **M** — Implemented (IND-426)
 
 **Theory:** Fillmore frame semantics; report's "Frame-Constrained Generation Filter" against embedding drift. *(Ch. 4.)*
 
-**Correction from code verification:** the hardcoded Mirror/Reciprocal/Neighborhood strategies described in the report (and in `src/README.md`) were **retired** — `shared/hyde/hyde.strategies.ts` states the system now uses free-text, LLM-inferred *lenses*. The report's Ch. 4 analysis applies to the M/R/N taxonomy as a conceptual layer only. The no-validation half of the claim held: `hyde.graph.ts` feeds generated text straight into embedding with no entity/constraint check.
+**Correction from code verification:** the hardcoded Mirror/Reciprocal/Neighborhood strategies described in the report (and in `src/README.md`) were **retired** — `shared/hyde/hyde.strategies.ts` states the system now uses free-text, LLM-inferred *lenses*. The report's Ch. 4 analysis applies to the M/R/N taxonomy as a conceptual layer only. Before IND-426, generated text went directly to embedding with no entity/constraint check.
 
-**Work items:**
-- Constrain **lens-based** generation (`shared/hyde/hyde.generator.ts` + `lens.inferrer.ts`) to frame elements extracted from the source intent (roles, constraints, domain vocabulary) — prompt-side slot discipline instead of free hallucination.
-- Add a post-generation check in `hyde.graph.ts` (between generate and embed nodes) that rejects docs introducing entities/constraints absent from the source frame (cheap LLM check or lexical overlap heuristic).
-- Measure on `eval/matching` before/after — this is the one item with an existing regression harness, so do it behind a flag and compare.
+**Implemented:**
+- Frame-v1 constrains **lens-based** generation (`shared/hyde/hyde.generator.ts` + `lens.inferrer.ts`) with source-only roles, explicit constraints, named entities, and domain vocabulary. Optional profile context may shape lenses but cannot become frame evidence.
+- `hyde.graph.ts` now has a frame-v1 batch validator between generation and embedding. It supports per-document partial rejection and all-rejection-with-empty-output. Validator/provider/shape failures fail open only for the current invocation; failed-open documents are embedded ephemerally but never cached or persisted.
+- Legacy cache identities are preserved. Frame-v1 uses fingerprinted Redis keys and validated context provenance with stable versioned DB lens identities; source revisions upsert rather than accumulate, and bulk reads select only the active mode/current source/newest generation group.
+- `eval/hyde` is the paired retrieval diagnostic: real legacy/frame-v1 LensInferrer, HydeGenerator, HydeValidator, and HydeGraphFactory plus equivalent OpenRouter request configuration and the same embedding model/dimensions rank a small drift-focused in-memory corpus. The scorer approximates production's `0.40` cutoff and `0.1` additional-match bonus and reports Recall@K/MRR plus generation, overwrite, key-resolved rejection, and fail-open diagnostics. It deliberately excludes SQL per-lens limits, network scope, cross-row user grouping beyond one candidate row per user, PostgreSQL execution, and opportunity evaluation. `eval/matching` calls `OpportunityEvaluator` directly and remains only a secondary evaluator-regression check.
 - ~~Housekeeping: update `src/README.md`, which still describes the retired M/R/N strategy registry.~~ Done in the same PR that introduced this backlog.
+
+**Rollout status:** `HYDE_FRAME_CONSTRAINTS_ENABLED` is strict and default-off; only literal `true` selects frame-v1. Implementation is complete, but enabling it is a separate rollout decision after reviewing full-corpus, multi-run paired retrieval output and the separately labeled matching regression check. Filtered or single runs must not establish a canonical baseline.
 
 ## 5. Dowty proto-role scoring in the evaluator — **M**
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -140,6 +140,13 @@ export type {
 } from "./shared/interfaces/negotiator-memory.interface.js";
 export { HomeGraphFactory } from "./opportunity/feed/feed.graph.js";
 export { HydeGraphFactory } from "./shared/hyde/hyde.graph.js";
+export type { HydeGraphOptions, HydeLensInferrerLike, HydeGeneratorLike, HydeValidatorLike } from "./shared/hyde/hyde.graph.js";
+export { getHydeGenerationMode, HYDE_FRAME_GENERATION_VERSION } from "./shared/hyde/hyde.env.js";
+export type { HydeGenerationMode } from "./shared/hyde/hyde.env.js";
+export { sanitizeHydeSourceFrame } from "./shared/hyde/hyde.frame.js";
+export type { HydeSourceFrame, HydeFrameRole, HydeFrameHardConstraint, HydeFrameNamedEntity, HydeFrameVocabulary, HydeHardConstraintType, HydeNamedEntityType } from "./shared/hyde/hyde.frame.js";
+export { HydeValidator } from "./shared/hyde/hyde.validator.js";
+export type { HydeValidationInput, HydeValidationDocument, HydeValidationOutput, HydeValidationVerdict } from "./shared/hyde/hyde.validator.js";
 export { NetworkGraphFactory } from "./network/network.graph.js";
 export { NetworkMembershipGraphFactory } from "./network/membership/membership.graph.js";
 export { IntentGraphFactory } from "./intent/intent.graph.js";
@@ -164,6 +171,7 @@ export type { ClassifyInterruptInput } from "./chat/chat.interrupt.classifier.js
 export { ChatSummarizer } from "./chat/chat.summarizer.js";
 export type { ChatSummarizerInput, ChatSummarizerMessage } from "./chat/chat.summarizer.js";
 export { HydeGenerator } from "./shared/hyde/hyde.generator.js";
+export type { HydeGenerateInput, HydeGeneratorOutput } from "./shared/hyde/hyde.generator.js";
 export { SuggestionGenerator } from "./chat/chat.suggester.js";
 export type { SuggestionGeneratorInput } from "./chat/chat.suggester.js";
 export { generateInviteMessage } from "./contact/contact.inviter.js";
@@ -177,6 +185,7 @@ export type { PremiseDecomposerOutput, DecomposedPremise } from "./premise/premi
 export { PremiseIndexer } from "./premise/premise.indexer.js";
 export type { PremiseIndexerOutput } from "./premise/premise.indexer.js";
 export { LensInferrer } from "./shared/hyde/lens.inferrer.js";
+export type { Lens, LensInferenceInput, LensInferenceOutput, HydeTargetCorpus } from "./shared/hyde/lens.inferrer.js";
 export { NegotiationInsightsGenerator } from "./negotiation/insight.generator.js";
 export type { NegotiationDigest } from "./negotiation/insight.generator.js";
 export { IndexNegotiator } from "./negotiation/negotiation.agent.js";

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -21,6 +21,8 @@ import { OpportunityEvaluator, type CandidateProfile, type EvaluatedOpportunityW
 import type { OpportunityGraphDatabase } from '../shared/interfaces/database.interface.js';
 import { IntentIndexer } from '../intent/intent.indexer.js';
 import { getModelName } from '../shared/agent/model.config.js';
+import { selectHydeDocumentsForGeneration } from '../shared/hyde/hyde.documents.js';
+import { getHydeGenerationMode } from '../shared/hyde/hyde.env.js';
 import { validateOpportunityActors } from './opportunity.utils.js';
 import { viewerCentricCardSummary } from './opportunity.presentation.js';
 
@@ -364,9 +366,10 @@ export class OpportunityGraphFactory {
               // The global row (networkId: null) is excluded here — it is not in
               // userNetworkIds — so context-to-intent discovery stays network-scoped.
               .filter((c: { id: string; networkId: string | null; embedding: number[] | null }) => c.embedding && c.embedding.length > 0 && c.networkId !== null && userNetworkIds.includes(c.networkId as Id<'networks'>))
-              .map((c: { id: string; networkId: string | null; embedding: number[] | null }) => ({
+              .map((c: { id: string; networkId: string | null; text: string; embedding: number[] | null }) => ({
                 contextId: c.id,
                 networkId: c.networkId as Id<'networks'>,
+                text: c.text,
                 embedding: c.embedding!,
               }));
             return {
@@ -1107,7 +1110,12 @@ export class OpportunityGraphFactory {
 
             for (const ctx of state.sourceContexts.filter(c => targetNetworkIds.includes(c.networkId))) {
               // Attempt HyDE-enhanced search first
-              const hydeDocs = await self.database.getHydeDocumentsForSource('context', ctx.contextId);
+              const persistedHydeDocs = await self.database.getHydeDocumentsForSource('context', ctx.contextId);
+              const hydeDocs = selectHydeDocumentsForGeneration(
+                persistedHydeDocs,
+                getHydeGenerationMode(),
+                ctx.text,
+              );
               const lensEmbeddings: LensEmbedding[] = hydeDocs
                 .filter(d => d.hydeEmbedding?.length > 0)
                 .map(d => ({

--- a/packages/protocol/src/opportunity/opportunity.state.ts
+++ b/packages/protocol/src/opportunity/opportunity.state.ts
@@ -373,7 +373,7 @@ export const OpportunityGraphState = Annotation.Root({
   }),
 
   /** User context embeddings per network (from prep). Used for context-to-intent discovery. */
-  sourceContexts: Annotation<Array<{ contextId: string; networkId: Id<'networks'>; embedding: number[] }>>({
+  sourceContexts: Annotation<Array<{ contextId: string; networkId: Id<'networks'>; text: string; embedding: number[] }>>({
     reducer: (curr, next) => next ?? curr,
     default: () => [],
   }),

--- a/packages/protocol/src/opportunity/tests/opportunity.graph.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.graph.spec.ts
@@ -10,13 +10,14 @@ config({ path: '.env.test', override: true });
 import { afterAll, beforeAll, describe, test, it, expect, mock, spyOn } from 'bun:test';
 import { OpportunityGraphFactory, type OpportunityEvaluatorLike, buildDiscovererContext } from '../opportunity.graph.js';
 import type { Id } from '../../types/common.types.js';
-import type { OpportunityGraphDatabase, OpportunityActor, Opportunity } from '../../shared/interfaces/database.interface.js';
+import type { HydeDocument, OpportunityGraphDatabase, OpportunityActor, Opportunity } from '../../shared/interfaces/database.interface.js';
 import type { Embedder } from '../../shared/interfaces/embedder.interface.js';
 import type { SourceProfileData } from '../opportunity.state.js';
 import { OpportunityEvaluator, type EvaluatorInput, type EvaluatorEntity } from '../opportunity.evaluator.js';
 import type { EvaluatedOpportunityWithActors } from '../opportunity.evaluator.js';
 import type { GeneratedProfile } from '../../enrichment/enrichment.generator.js';
 import { assertLLM } from '../../shared/agent/tests/llm-assert.js';
+import { computeHydeSourceTextHash } from '../../shared/hyde/hyde.documents.js';
 import { requestContext } from '../../shared/observability/request-context.js';
 
 type OpportunityGraphInvokeInput = Parameters<ReturnType<OpportunityGraphFactory['createGraph']>['invoke']>[0];
@@ -674,6 +675,75 @@ describe('Opportunity Graph', () => {
           ]),
         }),
       }));
+    });
+
+    test('context discovery searches only the newest current frame generation', async () => {
+      const previousFlag = process.env.HYDE_FRAME_CONSTRAINTS_ENABLED;
+      process.env.HYDE_FRAME_CONSTRAINTS_ENABLED = 'true';
+      const contextText = 'Alice is looking for protocol collaborators';
+      const sourceTextHash = computeHydeSourceTextHash(contextText);
+      const persistedDocument = (
+        id: string,
+        strategy: string,
+        context: Record<string, unknown> | null,
+      ): HydeDocument => ({
+        id,
+        sourceType: 'context',
+        sourceId: 'ctx-1',
+        sourceText: null,
+        strategy,
+        targetCorpus: 'intents',
+        hydeText: id,
+        hydeEmbedding: [1, 2],
+        context,
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        expiresAt: null,
+      });
+      const frameContext = (generatedAt: string, hash = sourceTextHash) => ({
+        hydeGenerationVersion: 'frame-v1',
+        lensLabel: 'protocol collaborator',
+        validationStatus: 'valid',
+        frameFingerprint: 'fingerprint',
+        sourceTextHash: hash,
+        generatedAt,
+      });
+
+      try {
+        const { compiledGraph, mockDb, mockEmbedder } = createMockGraph({
+          getUserIndexIds: () => Promise.resolve(['net-1'] as Id<'networks'>[]),
+          getNetwork: (id: string) => Promise.resolve({ id, title: `Index ${id}` }),
+          evaluatorResult: [],
+        });
+        mockDb.getUserContexts = mock(async () => [{
+          id: 'ctx-1',
+          networkId: 'net-1',
+          text: contextText,
+          embedding: dummyEmbedding,
+          premiseHash: 'hash-1',
+          generatedAt: new Date('2026-06-09T00:00:00.000Z'),
+        }]) as typeof mockDb.getUserContexts;
+        mockDb.getHydeDocumentsForSource = mock(async () => [
+          persistedDocument('legacy', 'legacy-hash', null),
+          persistedDocument('stale-source', 'frame-v1:stale', frameContext('2026-01-03T00:00:00.000Z', computeHydeSourceTextHash('stale context'))),
+          persistedDocument('old-generation', 'frame-v1:old', frameContext('2026-01-01T00:00:00.000Z')),
+          persistedDocument('new-generation', 'frame-v1:new', frameContext('2026-01-02T00:00:00.000Z')),
+        ]) as typeof mockDb.getHydeDocumentsForSource;
+        const searchSpy = spyOn(mockEmbedder, 'searchWithHydeEmbeddings').mockResolvedValue([]);
+
+        await compiledGraph.invoke({
+          userId: 'a0000000-0000-4000-8000-000000000001' as Id<'users'>,
+          searchQuery: 'protocol collaborator',
+          options: { minScore: 70 },
+        } as OpportunityGraphInvokeInput);
+
+        const contextSearch = searchSpy.mock.calls
+          .map((call) => call[0] as Array<{ lens: string }>)
+          .find((embeddings) => embeddings.some((embedding) => embedding.lens.startsWith('frame-v1:')));
+        expect(contextSearch?.map((embedding) => embedding.lens)).toEqual(['frame-v1:new']);
+      } finally {
+        if (previousFlag === undefined) delete process.env.HYDE_FRAME_CONSTRAINTS_ENABLED;
+        else process.env.HYDE_FRAME_CONSTRAINTS_ENABLED = previousFlag;
+      }
     });
   });
 

--- a/packages/protocol/src/shared/agent/model.config.ts
+++ b/packages/protocol/src/shared/agent/model.config.ts
@@ -40,6 +40,7 @@ function getModelConfig(config?: ModelConfig) {
     intentClarifier:      { model: "google/gemini-2.5-flash" },
     profileGenerator:     { model: "google/gemini-2.5-flash" },
     hydeGenerator:        { model: "google/gemini-2.5-flash" },
+    hydeValidator:        { model: "google/gemini-2.5-flash", temperature: 0.0, maxTokens: 2048 },
     lensInferrer:         { model: "google/gemini-2.5-flash" },
     opportunityEvaluator: { model: "google/gemini-2.5-flash" },
     opportunityPresenter: { model: "google/gemini-2.5-flash" },

--- a/packages/protocol/src/shared/hyde/hyde.documents.ts
+++ b/packages/protocol/src/shared/hyde/hyde.documents.ts
@@ -1,0 +1,62 @@
+import { createHash } from 'crypto';
+
+import type { HydeDocument } from '../interfaces/database.interface.js';
+import { HYDE_FRAME_GENERATION_VERSION, type HydeGenerationMode } from './hyde.env.js';
+
+/** Hash source text without persisting the source itself in frame metadata. */
+export function computeHydeSourceTextHash(sourceText: string): string {
+  return createHash('sha256').update(sourceText).digest('hex');
+}
+
+function isFrameStrategy(strategy: string): boolean {
+  return strategy.startsWith(`${HYDE_FRAME_GENERATION_VERSION}:`);
+}
+
+function hasFrameMetadataForSource(document: HydeDocument, sourceTextHash: string): boolean {
+  const context = document.context;
+  return isFrameStrategy(document.strategy)
+    && context?.hydeGenerationVersion === HYDE_FRAME_GENERATION_VERSION
+    && context.validationStatus === 'valid'
+    && typeof context.lensLabel === 'string'
+    && context.lensLabel.length > 0
+    && typeof context.frameFingerprint === 'string'
+    && context.frameFingerprint.length > 0
+    && context.sourceTextHash === sourceTextHash
+    && typeof context.generatedAt === 'string'
+    && Number.isFinite(Date.parse(context.generatedAt));
+}
+
+/**
+ * Select persisted documents that belong to the currently active generation
+ * mode and, for frame-v1, the newest generation marker group.
+ */
+export function selectHydeDocumentsForGeneration(
+  documents: HydeDocument[],
+  mode: HydeGenerationMode,
+  sourceText: string,
+): HydeDocument[] {
+  if (mode === 'legacy') {
+    return documents.filter((document) =>
+      !isFrameStrategy(document.strategy)
+      && document.context?.hydeGenerationVersion !== HYDE_FRAME_GENERATION_VERSION);
+  }
+
+  const sourceTextHash = computeHydeSourceTextHash(sourceText);
+  const eligible = documents.filter((document) => hasFrameMetadataForSource(document, sourceTextHash));
+  let newestGeneratedAt: string | undefined;
+  let newestTimestamp = Number.NEGATIVE_INFINITY;
+
+  for (const document of eligible) {
+    const generatedAt = document.context?.generatedAt;
+    if (typeof generatedAt !== 'string') continue;
+    const timestamp = Date.parse(generatedAt);
+    if (timestamp > newestTimestamp) {
+      newestTimestamp = timestamp;
+      newestGeneratedAt = generatedAt;
+    }
+  }
+
+  return newestGeneratedAt
+    ? eligible.filter((document) => document.context?.generatedAt === newestGeneratedAt)
+    : [];
+}

--- a/packages/protocol/src/shared/hyde/hyde.env.ts
+++ b/packages/protocol/src/shared/hyde/hyde.env.ts
@@ -1,0 +1,14 @@
+/** HyDE generation modes. */
+export const HYDE_FRAME_GENERATION_VERSION = 'frame-v1' as const;
+
+export type HydeGenerationMode = 'legacy' | typeof HYDE_FRAME_GENERATION_VERSION;
+
+/**
+ * Resolve the HyDE generation mode from the feature flag.
+ * Only the exact literal `true` enables frame-constrained generation.
+ */
+export function getHydeGenerationMode(
+  value: string | undefined = process.env.HYDE_FRAME_CONSTRAINTS_ENABLED,
+): HydeGenerationMode {
+  return value === 'true' ? HYDE_FRAME_GENERATION_VERSION : 'legacy';
+}

--- a/packages/protocol/src/shared/hyde/hyde.frame.ts
+++ b/packages/protocol/src/shared/hyde/hyde.frame.ts
@@ -1,0 +1,116 @@
+import { z } from 'zod';
+
+/** Source-grounded role supported by an exact span from the source text. */
+export interface HydeFrameRole {
+  role: string;
+  evidence: string;
+}
+
+export const HYDE_HARD_CONSTRAINT_TYPES = [
+  'location',
+  'time',
+  'numeric',
+  'credential',
+  'organization',
+  'exclusivity',
+  'other',
+] as const;
+
+export type HydeHardConstraintType = (typeof HYDE_HARD_CONSTRAINT_TYPES)[number];
+
+/** Explicit hard constraint supported by an exact span from the source text. */
+export interface HydeFrameHardConstraint {
+  type: HydeHardConstraintType;
+  value: string;
+  evidence: string;
+}
+
+export const HYDE_NAMED_ENTITY_TYPES = [
+  'person',
+  'organization',
+  'product',
+  'location',
+  'event',
+  'other',
+] as const;
+
+export type HydeNamedEntityType = (typeof HYDE_NAMED_ENTITY_TYPES)[number];
+
+/** Named entity supported by an exact span from the source text. */
+export interface HydeFrameNamedEntity {
+  type: HydeNamedEntityType;
+  name: string;
+  evidence: string;
+}
+
+/** Domain term supported by an exact span from the source text. */
+export interface HydeFrameVocabulary {
+  term: string;
+  evidence: string;
+}
+
+/**
+ * Source-grounded controls for frame-constrained HyDE generation.
+ * Counterpart roles may be reciprocal/complementary inferences, but their
+ * evidence must still be an exact span from the source text.
+ */
+export interface HydeSourceFrame {
+  sourceRoles: HydeFrameRole[];
+  counterpartRoles: HydeFrameRole[];
+  hardConstraints: HydeFrameHardConstraint[];
+  namedEntities: HydeFrameNamedEntity[];
+  domainVocabulary: HydeFrameVocabulary[];
+}
+
+const roleSchema = z.object({
+  role: z.string().min(1),
+  evidence: z.string().min(1).describe('Exact evidence span copied from sourceText'),
+});
+
+const hardConstraintSchema = z.object({
+  type: z.enum(HYDE_HARD_CONSTRAINT_TYPES),
+  value: z.string().min(1),
+  evidence: z.string().min(1).describe('Exact evidence span copied from sourceText'),
+});
+
+const namedEntitySchema = z.object({
+  type: z.enum(HYDE_NAMED_ENTITY_TYPES),
+  name: z.string().min(1),
+  evidence: z.string().min(1).describe('Exact evidence span copied from sourceText'),
+});
+
+const vocabularySchema = z.object({
+  term: z.string().min(1),
+  evidence: z.string().min(1).describe('Exact evidence span copied from sourceText'),
+});
+
+/** Structured-output schema for source-grounded frames. */
+export const HydeSourceFrameSchema = z.object({
+  sourceRoles: z.array(roleSchema),
+  counterpartRoles: z.array(roleSchema),
+  hardConstraints: z.array(hardConstraintSchema),
+  namedEntities: z.array(namedEntitySchema),
+  domainVocabulary: z.array(vocabularySchema),
+});
+
+function hasExactEvidence(sourceText: string, evidence: string): boolean {
+  return evidence.length > 0 && sourceText.toLocaleLowerCase().includes(evidence.toLocaleLowerCase());
+}
+
+/**
+ * Remove every frame element whose evidence is not a case-insensitive exact
+ * substring of sourceText. No other text, including profileContext, is accepted
+ * as evidence.
+ */
+export function sanitizeHydeSourceFrame(sourceText: string, frame: HydeSourceFrame): HydeSourceFrame {
+  const grounded = <T extends { evidence: string }>(items: T[]): T[] =>
+    items.filter((item) => hasExactEvidence(sourceText, item.evidence));
+
+  return {
+    sourceRoles: grounded(frame.sourceRoles),
+    counterpartRoles: grounded(frame.counterpartRoles),
+    hardConstraints: grounded(frame.hardConstraints),
+    namedEntities: grounded(frame.namedEntities),
+    domainVocabulary: grounded(frame.domainVocabulary),
+  };
+}

--- a/packages/protocol/src/shared/hyde/hyde.frame.ts
+++ b/packages/protocol/src/shared/hyde/hyde.frame.ts
@@ -93,24 +93,78 @@ export const HydeSourceFrameSchema = z.object({
   domainVocabulary: z.array(vocabularySchema),
 });
 
+function escapeRegularExpression(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Case-insensitive literal matching bounded by Unicode letters and numbers. */
+function containsAlphanumericSpanCaseInsensitive(container: string, value: string): boolean {
+  const needle = value.trim();
+  if (!needle) return false;
+  return new RegExp(
+    `(?<![\\p{L}\\p{M}\\p{N}])${escapeRegularExpression(needle)}(?![\\p{L}\\p{M}\\p{N}])`,
+    'iu',
+  ).test(container);
+}
+
 function hasExactEvidence(sourceText: string, evidence: string): boolean {
-  return evidence.length > 0 && sourceText.toLocaleLowerCase().includes(evidence.toLocaleLowerCase());
+  return containsAlphanumericSpanCaseInsensitive(sourceText, evidence);
+}
+
+const GENERIC_ROLE_TOKENS = new Set([
+  'advisor', 'analyst', 'attendee', 'borrower', 'builder', 'buyer', 'candidate',
+  'capitalist', 'ceo', 'cfo', 'client', 'cmo', 'cofounder', 'collaborator',
+  'consultant', 'coo', 'creator', 'cto', 'customer', 'designer', 'developer',
+  'director', 'employer', 'engineer', 'entrepreneur', 'executive', 'expert',
+  'founder', 'funder', 'hire', 'hiring', 'investor', 'leader', 'lender',
+  'manager', 'mentor', 'operator', 'organizer', 'owner', 'partner', 'practitioner',
+  'professional', 'provider', 'recruiter', 'researcher', 'scientist', 'seller',
+  'speaker', 'specialist', 'sponsor', 'strategist', 'supplier', 'technologist',
+  'vendor', 'vp',
+]);
+
+const GENERIC_ROLE_MODIFIERS = new Set([
+  'business', 'co', 'commercial', 'community', 'creative', 'early', 'experienced',
+  'growth', 'independent', 'industry', 'junior', 'lead', 'local', 'nonprofit',
+  'operations', 'product', 'professional', 'public', 'senior', 'stage',
+  'startup', 'technical', 'venture',
+]);
+
+function roleTokens(role: string): string[] {
+  return role.toLowerCase().match(/[\p{L}\p{M}\d]+/gu) ?? [];
+}
+
+function hasUnsupportedSourceRoleMaterial(role: string, evidence: string): boolean {
+  const substantiveTokens = roleTokens(role).filter((token) => !GENERIC_ROLE_MODIFIERS.has(token));
+  return substantiveTokens.length === 0
+    || substantiveTokens.some((token) => !containsAlphanumericSpanCaseInsensitive(evidence, token));
+}
+
+function hasUnsupportedCounterpartRoleMaterial(role: string, evidence: string): boolean {
+  return roleTokens(role).some((token) =>
+    !GENERIC_ROLE_TOKENS.has(token)
+    && !GENERIC_ROLE_MODIFIERS.has(token)
+    && !containsAlphanumericSpanCaseInsensitive(evidence, token));
 }
 
 /**
- * Remove every frame element whose evidence is not a case-insensitive exact
- * substring of sourceText. No other text, including profileContext, is accepted
- * as evidence.
+ * Remove frame elements that cross the source-evidence boundary. Structured
+ * payloads must occur inside their evidence span. Source roles require grounded
+ * substantive tokens; counterpart roles may add generic inferred role language.
  */
 export function sanitizeHydeSourceFrame(sourceText: string, frame: HydeSourceFrame): HydeSourceFrame {
   const grounded = <T extends { evidence: string }>(items: T[]): T[] =>
     items.filter((item) => hasExactEvidence(sourceText, item.evidence));
-
   return {
-    sourceRoles: grounded(frame.sourceRoles),
-    counterpartRoles: grounded(frame.counterpartRoles),
-    hardConstraints: grounded(frame.hardConstraints),
-    namedEntities: grounded(frame.namedEntities),
-    domainVocabulary: grounded(frame.domainVocabulary),
+    sourceRoles: grounded(frame.sourceRoles)
+      .filter((item) => !hasUnsupportedSourceRoleMaterial(item.role, item.evidence)),
+    counterpartRoles: grounded(frame.counterpartRoles)
+      .filter((item) => !hasUnsupportedCounterpartRoleMaterial(item.role, item.evidence)),
+    hardConstraints: grounded(frame.hardConstraints)
+      .filter((item) => containsAlphanumericSpanCaseInsensitive(item.evidence, item.value)),
+    namedEntities: grounded(frame.namedEntities)
+      .filter((item) => containsAlphanumericSpanCaseInsensitive(item.evidence, item.name)),
+    domainVocabulary: grounded(frame.domainVocabulary)
+      .filter((item) => containsAlphanumericSpanCaseInsensitive(item.evidence, item.term)),
   };
 }

--- a/packages/protocol/src/shared/hyde/hyde.generator.ts
+++ b/packages/protocol/src/shared/hyde/hyde.generator.ts
@@ -2,14 +2,17 @@
  * HyDE Generator Agent: pure LLM agent for generating hypothetical documents
  * in the target corpus voice. Uses free-text lens labels instead of enum strategies.
  */
+import type { BaseLanguageModelInput } from '@langchain/core/language_models/base';
 import { HumanMessage, SystemMessage } from '@langchain/core/messages';
 import { z } from 'zod';
-import { HYDE_CORPUS_PROMPTS } from './hyde.strategies.js';
-import type { HydeTargetCorpus } from './lens.inferrer.js';
-import { Timed } from "../observability/performance.js";
-import { protocolLogger } from '../observability/protocol.logger.js';
+
 import { createStructuredModel } from "../agent/model.config.js";
 import { invokeWithAbortSignal } from "../agent/model-signal.js";
+import { protocolLogger } from '../observability/protocol.logger.js';
+import { Timed } from "../observability/performance.js";
+import type { HydeSourceFrame } from './hyde.frame.js';
+import { HYDE_CORPUS_PROMPTS } from './hyde.strategies.js';
+import type { HydeTargetCorpus } from './lens.inferrer.js';
 
 const logger = protocolLogger("HydeGenerator");
 
@@ -40,33 +43,81 @@ export interface HydeGenerateInput {
   lens: string;
   /** Which corpus voice to generate in. */
   corpus: HydeTargetCorpus;
+  /** Sanitized source-grounded frame. Absence preserves the exact legacy prompt. */
+  sourceFrame?: HydeSourceFrame;
 }
 
-/**
- * Generates hypothetical documents in a target corpus voice for semantic search.
- * Uses free-text lens labels (from LensInferrer) instead of enum strategies.
- */
-export class HydeGenerator {
-  private model = createStructuredModel("hydeGenerator", responseFormat, {
-    name: "hyde_generator",
-  });
+/** Minimal structured model contract used for deterministic injection in tests. */
+export interface HydeGeneratorStructuredModel {
+  invoke(input: BaseLanguageModelInput, config?: { signal?: AbortSignal }): Promise<unknown>;
+}
 
-  /**
-   * Generate a hypothetical document for the given source text and lens.
-   *
-   * @param input - Source text, lens label, and target corpus
-   * @returns Generated hypothetical document text
-   */
+function renderList(items: string[]): string {
+  return items.length > 0 ? items.join('; ') : '(none)';
+}
+
+/** Build the frame-v1 generation prompt from sanitized source evidence. */
+export function buildFrameHydePrompt(input: HydeGenerateInput & { sourceFrame: HydeSourceFrame }): string {
+  const { sourceText, lens, corpus, sourceFrame } = input;
+  const corpusInstruction = {
+    profiles: 'Write a first-person professional biography in the target profile voice.',
+    intents: 'Write a first-person goal or aspiration in the target intent voice.',
+    premises: 'Write a first-person stable identity, values, or worldview statement in the target premise voice.',
+  }[corpus];
+
+  return `${corpusInstruction}
+
+Source text: "${sourceText}"
+Target lens: ${lens}
+
+Sanitized source frame:
+- Source roles: ${renderList(sourceFrame.sourceRoles.map((item) => `${item.role} [evidence: "${item.evidence}"]`))}
+- Counterpart/complementary roles: ${renderList(sourceFrame.counterpartRoles.map((item) => `${item.role} [evidence: "${item.evidence}"]`))}
+- Explicit hard constraints: ${renderList(sourceFrame.hardConstraints.map((item) => `${item.type}: ${item.value} [evidence: "${item.evidence}"]`))}
+- Named entities: ${renderList(sourceFrame.namedEntities.map((item) => `${item.type}: ${item.name} [evidence: "${item.evidence}"]`))}
+- Domain vocabulary: ${renderList(sourceFrame.domainVocabulary.map((item) => `${item.term} [evidence: "${item.evidence}"]`))}
+
+Generation constraints:
+- You MAY elaborate generic roles and generic domain language.
+- You MAY use reciprocal/complementary inversion and write in the target voice.
+- You MUST NOT introduce any new proper noun or named entity.
+- You MUST NOT introduce any new hard location, time, numeric, credential, organization, or exclusivity constraint.
+- Preserve explicit source-frame constraints when they apply to the reciprocal target.
+- Output only a few sentences or one short paragraph.`;
+}
+
+/** Generates hypothetical documents in a target corpus voice for semantic search. */
+export class HydeGenerator {
+  private model?: HydeGeneratorStructuredModel;
+
+  constructor(model?: HydeGeneratorStructuredModel) {
+    // Preserve the legacy production model construction path; injected models
+    // keep prompt tests provider-free.
+    this.model = model ?? createStructuredModel("hydeGenerator", responseFormat, {
+      name: "hyde_generator",
+    });
+  }
+
+  private getModel(): HydeGeneratorStructuredModel {
+    this.model ??= createStructuredModel("hydeGenerator", responseFormat, {
+      name: "hyde_generator",
+    });
+    return this.model;
+  }
+
+  /** Generate a hypothetical document for the given source text and lens. */
   @Timed()
   async generate(input: HydeGenerateInput): Promise<HydeGeneratorOutput> {
-    const promptText = HYDE_CORPUS_PROMPTS[input.corpus](input.sourceText, input.lens);
+    const promptText = input.sourceFrame
+      ? buildFrameHydePrompt(input as HydeGenerateInput & { sourceFrame: HydeSourceFrame })
+      : HYDE_CORPUS_PROMPTS[input.corpus](input.sourceText, input.lens);
 
     const messages = [
       new SystemMessage(SYSTEM_PROMPT),
       new HumanMessage(promptText),
     ];
 
-    const result = await invokeWithAbortSignal(this.model, messages);
+    const result = await invokeWithAbortSignal(this.getModel(), messages);
     const parsed = responseFormat.parse(result);
     const text = parsed.hypotheticalDocument ?? '';
 
@@ -74,6 +125,7 @@ export class HydeGenerator {
       lens: input.lens,
       corpus: input.corpus,
       textLength: text.length,
+      frameConstrained: !!input.sourceFrame,
     });
 
     return { text };

--- a/packages/protocol/src/shared/hyde/hyde.generator.ts
+++ b/packages/protocol/src/shared/hyde/hyde.generator.ts
@@ -58,7 +58,7 @@ function renderList(items: string[]): string {
 
 /** Build the frame-v1 generation prompt from sanitized source evidence. */
 export function buildFrameHydePrompt(input: HydeGenerateInput & { sourceFrame: HydeSourceFrame }): string {
-  const { sourceText, lens, corpus, sourceFrame } = input;
+  const { sourceText, corpus, sourceFrame } = input;
   const corpusInstruction = {
     profiles: 'Write a first-person professional biography in the target profile voice.',
     intents: 'Write a first-person goal or aspiration in the target intent voice.',
@@ -68,7 +68,6 @@ export function buildFrameHydePrompt(input: HydeGenerateInput & { sourceFrame: H
   return `${corpusInstruction}
 
 Source text: "${sourceText}"
-Target lens: ${lens}
 
 Sanitized source frame:
 - Source roles: ${renderList(sourceFrame.sourceRoles.map((item) => `${item.role} [evidence: "${item.evidence}"]`))}

--- a/packages/protocol/src/shared/hyde/hyde.graph.ts
+++ b/packages/protocol/src/shared/hyde/hyde.graph.ts
@@ -15,6 +15,7 @@ import type { EmbeddingGenerator } from '../interfaces/embedder.interface.js';
 import { protocolLogger } from '../observability/protocol.logger.js';
 import { timed } from '../observability/performance.js';
 import { requestContext } from "../observability/request-context.js";
+import { computeHydeSourceTextHash } from './hyde.documents.js';
 import { getHydeGenerationMode, HYDE_FRAME_GENERATION_VERSION, type HydeGenerationMode } from './hyde.env.js';
 import { sanitizeHydeSourceFrame, type HydeSourceFrame } from './hyde.frame.js';
 import type { HydeGenerateInput, HydeGeneratorOutput } from './hyde.generator.js';
@@ -24,6 +25,12 @@ import { HYDE_DEFAULT_CACHE_TTL } from './hyde.strategies.js';
 import { HydeValidator, type HydeValidationInput, type HydeValidationOutput, type HydeValidationVerdict } from './hyde.validator.js';
 
 const logger = protocolLogger("HyDEGraphFactory");
+let lastGenerationTimestamp = 0;
+
+function nextGenerationMarker(): string {
+  lastGenerationTimestamp = Math.max(Date.now(), lastGenerationTimestamp + 1);
+  return new Date(lastGenerationTimestamp).toISOString();
+}
 
 /** Narrow lens inferrer contract accepted by the graph. */
 export interface HydeLensInferrerLike {
@@ -58,6 +65,35 @@ function entityCacheKey(sourceId: string | undefined, sourceText: string): strin
   return sourceId ?? `q:${createHash('sha256').update(sourceText).digest('hex').slice(0, 16)}`;
 }
 
+function sortedFrame(frame: HydeSourceFrame): HydeSourceFrame {
+  const sort = <T>(items: T[]): T[] => [...items].sort((left, right) => {
+    const leftJson = JSON.stringify(left);
+    const rightJson = JSON.stringify(right);
+    return leftJson < rightJson ? -1 : leftJson > rightJson ? 1 : 0;
+  });
+  return {
+    sourceRoles: sort(frame.sourceRoles),
+    counterpartRoles: sort(frame.counterpartRoles),
+    hardConstraints: sort(frame.hardConstraints),
+    namedEntities: sort(frame.namedEntities),
+    domainVocabulary: sort(frame.domainVocabulary),
+  };
+}
+
+/** Deterministic identity for the source content and sanitized frame. */
+function computeHydeFrameFingerprint(sourceText: string, sourceFrame: HydeSourceFrame): string {
+  return createHash('sha256')
+    .update(sourceText)
+    .update('\0')
+    .update(JSON.stringify(sortedFrame(sourceFrame)))
+    .digest('hex');
+}
+
+function requireFrameFingerprint(frameFingerprint: string | undefined): string {
+  if (!frameFingerprint) throw new Error('frame-v1 HyDE requires a frame fingerprint');
+  return frameFingerprint;
+}
+
 /** Preserve the exact legacy Redis key and isolate frame-v1 data by namespace. */
 function cacheKey(
   mode: HydeGenerationMode,
@@ -66,29 +102,58 @@ function cacheKey(
   sourceText: string,
   lens: string,
   corpus?: string,
+  frameFingerprint?: string,
 ): string {
   const entityKey = entityCacheKey(sourceId, sourceText);
-  return mode === 'legacy'
-    ? `hyde:${sourceType}:${entityKey}:${lensHash(lens, corpus)}`
-    : `hyde:${HYDE_FRAME_GENERATION_VERSION}:${sourceType}:${entityKey}:${lensHash(lens, corpus)}`;
+  if (mode === 'legacy') return `hyde:${sourceType}:${entityKey}:${lensHash(lens, corpus)}`;
+  return `hyde:${HYDE_FRAME_GENERATION_VERSION}:${sourceType}:${entityKey}:${requireFrameFingerprint(frameFingerprint)}:${lensHash(lens, corpus)}`;
 }
 
-/** Preserve the exact legacy DB strategy and isolate frame-v1 without migration. */
+/** Preserve legacy identity and use a stable frame-v1 identity per lens/corpus. */
 function dbStrategy(mode: HydeGenerationMode, label: string, corpus?: string): string {
   const hash = lensHash(label, corpus);
   return mode === 'legacy' ? hash : `${HYDE_FRAME_GENERATION_VERSION}:${hash}`;
 }
 
-function isFrameCacheDocument(doc: HydeDocumentState, lensLabel: string): boolean {
-  return doc.hydeGenerationVersion === HYDE_FRAME_GENERATION_VERSION
-    && doc.validationStatus === 'valid'
-    && doc.lens === lensLabel;
+function isValidGenerationMarker(value: unknown): value is string {
+  return typeof value === 'string' && Number.isFinite(Date.parse(value));
 }
 
-function isFrameDbContext(context: Record<string, unknown> | null, lensLabel: string): boolean {
+function isFrameCacheDocument(
+  doc: HydeDocumentState,
+  lensLabel: string,
+  frameFingerprint: string,
+  sourceTextHash: string,
+): boolean {
+  return doc.hydeGenerationVersion === HYDE_FRAME_GENERATION_VERSION
+    && doc.validationStatus === 'valid'
+    && doc.lens === lensLabel
+    && doc.frameFingerprint === frameFingerprint
+    && doc.sourceTextHash === sourceTextHash
+    && isValidGenerationMarker(doc.generatedAt);
+}
+
+interface FrameDbContext extends Record<string, unknown> {
+  hydeGenerationVersion: typeof HYDE_FRAME_GENERATION_VERSION;
+  lensLabel: string;
+  validationStatus: 'valid';
+  frameFingerprint: string;
+  sourceTextHash: string;
+  generatedAt: string;
+}
+
+function isFrameDbContext(
+  context: Record<string, unknown> | null,
+  lensLabel: string,
+  frameFingerprint: string,
+  sourceTextHash: string,
+): context is FrameDbContext {
   return context?.hydeGenerationVersion === HYDE_FRAME_GENERATION_VERSION
-    && context?.lensLabel === lensLabel
-    && context?.validationStatus === 'valid';
+    && context.lensLabel === lensLabel
+    && context.validationStatus === 'valid'
+    && context.frameFingerprint === frameFingerprint
+    && context.sourceTextHash === sourceTextHash
+    && isValidGenerationMarker(context.generatedAt);
 }
 
 function emptyFrame(): HydeSourceFrame {
@@ -158,15 +223,32 @@ export class HydeGraphFactory {
           agentTimingsAccum.push({ name: 'lens.inferrer', durationMs });
           traceEmitter?.({ type: "agent_end", name: "lens-inferrer", durationMs, summary: result.lenses.length > 0 ? `Inferred ${result.lenses.length} lens(es)` : "lens-inferrer completed" });
 
-          return {
-            lenses: result.lenses,
-            ...(mode === HYDE_FRAME_GENERATION_VERSION
-              ? { sourceFrame: sanitizeHydeSourceFrame(sourceText, result.sourceFrame ?? emptyFrame()) }
-              : {}),
-            agentTimings: agentTimingsAccum,
-          };
+          if (mode === HYDE_FRAME_GENERATION_VERSION) {
+            const sourceFrame = sanitizeHydeSourceFrame(sourceText, result.sourceFrame ?? emptyFrame());
+            return {
+              lenses: result.lenses,
+              sourceFrame,
+              frameFingerprint: computeHydeFrameFingerprint(sourceText, sourceFrame),
+              sourceTextHash: computeHydeSourceTextHash(sourceText),
+              generatedAt: nextGenerationMarker(),
+              agentTimings: agentTimingsAccum,
+            };
+          }
+
+          return { lenses: result.lenses, agentTimings: agentTimingsAccum };
         } catch (error) {
           logger.error('Lens inference failed in graph node', { error });
+          if (mode === HYDE_FRAME_GENERATION_VERSION) {
+            const sourceFrame = emptyFrame();
+            return {
+              lenses: [],
+              sourceFrame,
+              frameFingerprint: computeHydeFrameFingerprint(sourceText, sourceFrame),
+              sourceTextHash: computeHydeSourceTextHash(sourceText),
+              generatedAt: nextGenerationMarker(),
+              agentTimings: agentTimingsAccum,
+            };
+          }
           return { lenses: [], agentTimings: agentTimingsAccum };
         }
       });
@@ -179,13 +261,27 @@ export class HydeGraphFactory {
 
         if (forceRegenerate) return { hydeDocuments: {} };
 
+        const frameFingerprint = mode === HYDE_FRAME_GENERATION_VERSION
+          ? requireFrameFingerprint(state.frameFingerprint)
+          : undefined;
+        const sourceTextHash = mode === HYDE_FRAME_GENERATION_VERSION
+          ? state.sourceTextHash ?? computeHydeSourceTextHash(sourceText)
+          : undefined;
         const cached: Record<string, HydeDocumentState> = {};
         for (const lens of lenses) {
-          const key = cacheKey(mode, sourceType, sourceId ?? undefined, sourceText, lens.label, lens.corpus);
+          const key = cacheKey(
+            mode,
+            sourceType,
+            sourceId ?? undefined,
+            sourceText,
+            lens.label,
+            lens.corpus,
+            frameFingerprint,
+          );
           const fromCache = await self.cache.get<HydeDocumentState>(key);
           const cacheAccepted = fromCache?.hydeText
             && fromCache.hydeEmbedding?.length
-            && (mode === 'legacy' || isFrameCacheDocument(fromCache, lens.label));
+            && (mode === 'legacy' || isFrameCacheDocument(fromCache, lens.label, frameFingerprint!, sourceTextHash!));
           if (cacheAccepted && fromCache) {
             cached[lens.label] = {
               ...fromCache,
@@ -200,7 +296,10 @@ export class HydeGraphFactory {
               sourceId,
               dbStrategy(mode, lens.label, lens.corpus),
             );
-            if (fromDb && (mode === 'legacy' || isFrameDbContext(fromDb.context, lens.label))) {
+            const frameDbContext = mode === HYDE_FRAME_GENERATION_VERSION && fromDb
+              ? fromDb.context
+              : null;
+            if (fromDb && (mode === 'legacy' || isFrameDbContext(frameDbContext, lens.label, frameFingerprint!, sourceTextHash!))) {
               cached[lens.label] = {
                 lens: lens.label,
                 targetCorpus: fromDb.targetCorpus as HydeDocumentState['targetCorpus'],
@@ -211,10 +310,25 @@ export class HydeGraphFactory {
                     origin: 'db' as const,
                     validationStatus: 'valid' as const,
                     hydeGenerationVersion: HYDE_FRAME_GENERATION_VERSION,
+                    frameFingerprint,
+                    sourceTextHash,
+                    generatedAt: (frameDbContext as FrameDbContext).generatedAt,
                   }
                   : {}),
               };
             }
+          }
+        }
+
+        if (mode === HYDE_FRAME_GENERATION_VERSION) {
+          const newestTimestamp = Math.max(
+            ...Object.values(cached).map((doc) => Date.parse(doc.generatedAt ?? '')),
+          );
+          if (Number.isFinite(newestTimestamp)) {
+            return {
+              hydeDocuments: Object.fromEntries(Object.entries(cached).filter(([, doc]) =>
+                Date.parse(doc.generatedAt ?? '') === newestTimestamp)),
+            };
           }
         }
 
@@ -232,6 +346,12 @@ export class HydeGraphFactory {
         const missing = lenses.filter((lens) => !hydeDocuments[lens.label]);
         const agentTimingsAccum: DebugMetaAgent[] = [];
         const generated: Record<string, HydeDocumentState> = {};
+        const sourceTextHash = mode === HYDE_FRAME_GENERATION_VERSION
+          ? state.sourceTextHash ?? computeHydeSourceTextHash(sourceText)
+          : undefined;
+        const generatedAt = mode === HYDE_FRAME_GENERATION_VERSION
+          ? state.generatedAt ?? nextGenerationMarker()
+          : undefined;
 
         await Promise.all(missing.map(async (lens) => {
           const traceEmitter = requestContext.getStore()?.traceEmitter;
@@ -251,11 +371,30 @@ export class HydeGraphFactory {
             targetCorpus: lens.corpus,
             hydeText: out.text,
             hydeEmbedding: [],
-            ...(mode === HYDE_FRAME_GENERATION_VERSION ? { origin: 'generated' as const } : {}),
+            ...(mode === HYDE_FRAME_GENERATION_VERSION
+              ? {
+                origin: 'generated' as const,
+                frameFingerprint: requireFrameFingerprint(state.frameFingerprint),
+                sourceTextHash,
+                generatedAt,
+              }
+              : {}),
           };
         }));
 
-        return { hydeDocuments: { ...hydeDocuments, ...generated }, agentTimings: agentTimingsAccum };
+        const retained = mode === HYDE_FRAME_GENERATION_VERSION
+          ? Object.fromEntries(Object.entries(hydeDocuments).map(([label, doc]) => [
+            label,
+            {
+              ...doc,
+              frameFingerprint: requireFrameFingerprint(state.frameFingerprint),
+              sourceTextHash,
+              generatedAt,
+            },
+          ]))
+          : hydeDocuments;
+
+        return { hydeDocuments: { ...retained, ...generated }, agentTimings: agentTimingsAccum };
       });
     };
 
@@ -266,52 +405,82 @@ export class HydeGraphFactory {
         if (generated.length === 0 || !validator) return { hydeDocuments: state.hydeDocuments };
 
         const frame = sanitizeHydeSourceFrame(state.sourceText, state.sourceFrame ?? emptyFrame());
-        const keyed = Object.fromEntries(generated.map((doc) => [
-          opaqueDocumentKey(doc),
-          { lens: doc.lens, corpus: doc.targetCorpus, text: doc.hydeText },
-        ]));
+        const documents: HydeValidationInput['documents'] = {};
+        const lensByDocumentKey = new Map<string, string>();
+        for (const doc of generated) {
+          const key = opaqueDocumentKey(doc);
+          documents[key] = { corpus: doc.targetCorpus, text: doc.hydeText };
+          lensByDocumentKey.set(key, doc.lens);
+        }
+
         const updated = { ...state.hydeDocuments };
+        const agentTimingsAccum: DebugMetaAgent[] = [];
+        const traceEmitter = requestContext.getStore()?.traceEmitter;
+        const validatorStart = Date.now();
+        let validCount = 0;
+        let rejectedCount = 0;
+        let failedOpenCount = 0;
+        traceEmitter?.({ type: 'agent_start', name: 'hyde-validator' });
 
         try {
           const output = await validator.validate({
             sourceText: state.sourceText,
             sourceFrame: frame,
-            documents: keyed,
+            documents,
           });
           const rawVerdicts: unknown[] = Array.isArray((output as { verdicts?: unknown }).verdicts)
             ? (output as { verdicts: unknown[] }).verdicts
             : [];
 
-          for (const [key, item] of Object.entries(keyed)) {
+          for (const key of Object.keys(documents)) {
+            const lensLabel = lensByDocumentKey.get(key);
+            if (!lensLabel) continue;
             const matching = rawVerdicts.filter((value) =>
               !!value && typeof value === 'object' && (value as { key?: unknown }).key === key);
-            const doc = updated[item.lens];
+            const doc = updated[lensLabel];
             if (!doc) continue;
 
             if (matching.length !== 1 || !isRuntimeVerdict(matching[0])) {
-              updated[item.lens] = { ...doc, validationStatus: 'failed_open', hydeGenerationVersion: HYDE_FRAME_GENERATION_VERSION };
+              failedOpenCount += 1;
+              updated[lensLabel] = { ...doc, validationStatus: 'failed_open', hydeGenerationVersion: HYDE_FRAME_GENERATION_VERSION };
               continue;
             }
 
             const verdict = matching[0];
-            const contradictory = verdict.valid
-              && (verdict.unsupportedNamedEntities.length > 0 || verdict.unsupportedHardConstraints.length > 0);
+            const hasUnsupportedGrounding = verdict.unsupportedNamedEntities.length > 0
+              || verdict.unsupportedHardConstraints.length > 0;
+            const contradictory = verdict.valid === hasUnsupportedGrounding;
             if (contradictory) {
-              updated[item.lens] = { ...doc, validationStatus: 'failed_open', hydeGenerationVersion: HYDE_FRAME_GENERATION_VERSION };
+              failedOpenCount += 1;
+              updated[lensLabel] = { ...doc, validationStatus: 'failed_open', hydeGenerationVersion: HYDE_FRAME_GENERATION_VERSION };
             } else if (!verdict.valid) {
-              delete updated[item.lens];
+              rejectedCount += 1;
+              delete updated[lensLabel];
             } else {
-              updated[item.lens] = { ...doc, validationStatus: 'valid', hydeGenerationVersion: HYDE_FRAME_GENERATION_VERSION };
+              validCount += 1;
+              updated[lensLabel] = { ...doc, validationStatus: 'valid', hydeGenerationVersion: HYDE_FRAME_GENERATION_VERSION };
             }
           }
         } catch (error) {
           logger.error('HyDE validation failed open', { error });
+          validCount = 0;
+          rejectedCount = 0;
+          failedOpenCount = generated.length;
           for (const doc of generated) {
             updated[doc.lens] = { ...doc, validationStatus: 'failed_open', hydeGenerationVersion: HYDE_FRAME_GENERATION_VERSION };
           }
+        } finally {
+          const durationMs = Date.now() - validatorStart;
+          agentTimingsAccum.push({ name: 'hyde.validator', durationMs });
+          traceEmitter?.({
+            type: 'agent_end',
+            name: 'hyde-validator',
+            durationMs,
+            summary: `${validCount} valid, ${rejectedCount} rejected, ${failedOpenCount} failed open`,
+          });
         }
 
-        return { hydeDocuments: updated };
+        return { hydeDocuments: updated, agentTimings: agentTimingsAccum };
       });
     };
 
@@ -354,10 +523,25 @@ export class HydeGraphFactory {
     const cacheResultsNode = async (state: typeof HydeGraphState.State) => {
       return timed("HydeGraph.cacheResults", async () => {
         const { sourceType, sourceId, sourceText, hydeDocuments } = state;
+        const frameFingerprint = mode === HYDE_FRAME_GENERATION_VERSION
+          ? requireFrameFingerprint(state.frameFingerprint)
+          : undefined;
+        const sourceTextHash = mode === HYDE_FRAME_GENERATION_VERSION
+          ? state.sourceTextHash ?? computeHydeSourceTextHash(sourceText)
+          : undefined;
         for (const [label, doc] of Object.entries(hydeDocuments)) {
-          if (mode === HYDE_FRAME_GENERATION_VERSION && doc.validationStatus !== 'valid') continue;
+          if (mode === HYDE_FRAME_GENERATION_VERSION
+            && !isFrameCacheDocument(doc, label, frameFingerprint!, sourceTextHash!)) continue;
 
-          const key = cacheKey(mode, sourceType, sourceId ?? undefined, sourceText, label, doc.targetCorpus);
+          const key = cacheKey(
+            mode,
+            sourceType,
+            sourceId ?? undefined,
+            sourceText,
+            label,
+            doc.targetCorpus,
+            frameFingerprint,
+          );
           await self.cache.set(key, doc, { ttl: HYDE_DEFAULT_CACHE_TTL });
 
           if (sourceId) {
@@ -373,6 +557,9 @@ export class HydeGraphFactory {
                   hydeGenerationVersion: HYDE_FRAME_GENERATION_VERSION,
                   lensLabel: label,
                   validationStatus: 'valid',
+                  frameFingerprint: doc.frameFingerprint,
+                  sourceTextHash: doc.sourceTextHash,
+                  generatedAt: doc.generatedAt,
                 },
               } : {}),
             });

--- a/packages/protocol/src/shared/hyde/hyde.graph.ts
+++ b/packages/protocol/src/shared/hyde/hyde.graph.ts
@@ -1,27 +1,50 @@
 /**
  * HyDE Graph: cache-aware hypothetical document generation with lens inference.
  *
- * Flow: infer_lenses → check_cache → (generate_missing if needed) → embed → cache_results.
- * Constructor injects Database, Embedder, Cache, LensInferrer, HydeGenerator.
+ * Legacy flow: infer_lenses → check_cache → generate_missing? → embed → cache_results.
+ * Frame-v1 flow adds one batch validate_generated node before embed.
  */
-
-import { StateGraph, START, END } from '@langchain/langgraph';
 import { createHash } from 'crypto';
+import { END, START, StateGraph } from '@langchain/langgraph';
 
+import type { DebugMetaAgent } from '../../chat/chat-streaming.types.js';
 import { getAbortSignalConfig } from '../agent/model-signal.js';
-import { HydeGraphState, type HydeDocumentState } from './hyde.state.js';
-import { LensInferrer } from './lens.inferrer.js';
-import { HydeGenerator } from './hyde.generator.js';
+import type { HydeCache } from '../interfaces/cache.interface.js';
 import type { HydeGraphDatabase } from '../interfaces/database.interface.js';
 import type { EmbeddingGenerator } from '../interfaces/embedder.interface.js';
-import type { HydeCache } from '../interfaces/cache.interface.js';
-import { HYDE_DEFAULT_CACHE_TTL } from './hyde.strategies.js';
 import { protocolLogger } from '../observability/protocol.logger.js';
 import { timed } from '../observability/performance.js';
 import { requestContext } from "../observability/request-context.js";
-import type { DebugMetaAgent } from '../../chat/chat-streaming.types.js';
+import { getHydeGenerationMode, HYDE_FRAME_GENERATION_VERSION, type HydeGenerationMode } from './hyde.env.js';
+import { sanitizeHydeSourceFrame, type HydeSourceFrame } from './hyde.frame.js';
+import type { HydeGenerateInput, HydeGeneratorOutput } from './hyde.generator.js';
+import { HydeGraphState, type HydeDocumentState } from './hyde.state.js';
+import type { LensInferenceInput, LensInferenceOutput } from './lens.inferrer.js';
+import { HYDE_DEFAULT_CACHE_TTL } from './hyde.strategies.js';
+import { HydeValidator, type HydeValidationInput, type HydeValidationOutput, type HydeValidationVerdict } from './hyde.validator.js';
 
 const logger = protocolLogger("HyDEGraphFactory");
+
+/** Narrow lens inferrer contract accepted by the graph. */
+export interface HydeLensInferrerLike {
+  infer(input: LensInferenceInput): Promise<LensInferenceOutput>;
+}
+
+/** Narrow document generator contract accepted by the graph. */
+export interface HydeGeneratorLike {
+  generate(input: HydeGenerateInput): Promise<HydeGeneratorOutput>;
+}
+
+/** Narrow batch validator contract accepted by the graph. */
+export interface HydeValidatorLike {
+  validate(input: HydeValidationInput): Promise<HydeValidationOutput>;
+}
+
+export interface HydeGraphOptions {
+  /** Test override. Production derives the mode from HYDE_FRAME_CONSTRAINTS_ENABLED. */
+  mode?: HydeGenerationMode;
+  validator?: HydeValidatorLike;
+}
 
 /** Hash a lens label (+ optional corpus) to a short key for cache/DB indexing. */
 function lensHash(label: string, corpus?: string): string {
@@ -31,63 +54,117 @@ function lensHash(label: string, corpus?: string): string {
   return createHash('sha256').update(input).digest('hex').slice(0, 16);
 }
 
-/** Build cache key for a specific lens. */
+function entityCacheKey(sourceId: string | undefined, sourceText: string): string {
+  return sourceId ?? `q:${createHash('sha256').update(sourceText).digest('hex').slice(0, 16)}`;
+}
+
+/** Preserve the exact legacy Redis key and isolate frame-v1 data by namespace. */
 function cacheKey(
+  mode: HydeGenerationMode,
   sourceType: string,
   sourceId: string | undefined,
   sourceText: string,
   lens: string,
   corpus?: string,
 ): string {
-  const entityKey =
-    sourceId ?? `q:${createHash('sha256').update(sourceText).digest('hex').slice(0, 16)}`;
-  return `hyde:${sourceType}:${entityKey}:${lensHash(lens, corpus)}`;
+  const entityKey = entityCacheKey(sourceId, sourceText);
+  return mode === 'legacy'
+    ? `hyde:${sourceType}:${entityKey}:${lensHash(lens, corpus)}`
+    : `hyde:${HYDE_FRAME_GENERATION_VERSION}:${sourceType}:${entityKey}:${lensHash(lens, corpus)}`;
 }
 
-/**
- * Factory for the HyDE generation graph.
- * Injects Database, Embedder, Cache, LensInferrer, and HydeGenerator.
- */
+/** Preserve the exact legacy DB strategy and isolate frame-v1 without migration. */
+function dbStrategy(mode: HydeGenerationMode, label: string, corpus?: string): string {
+  const hash = lensHash(label, corpus);
+  return mode === 'legacy' ? hash : `${HYDE_FRAME_GENERATION_VERSION}:${hash}`;
+}
+
+function isFrameCacheDocument(doc: HydeDocumentState, lensLabel: string): boolean {
+  return doc.hydeGenerationVersion === HYDE_FRAME_GENERATION_VERSION
+    && doc.validationStatus === 'valid'
+    && doc.lens === lensLabel;
+}
+
+function isFrameDbContext(context: Record<string, unknown> | null, lensLabel: string): boolean {
+  return context?.hydeGenerationVersion === HYDE_FRAME_GENERATION_VERSION
+    && context?.lensLabel === lensLabel
+    && context?.validationStatus === 'valid';
+}
+
+function emptyFrame(): HydeSourceFrame {
+  return {
+    sourceRoles: [],
+    counterpartRoles: [],
+    hardConstraints: [],
+    namedEntities: [],
+    domainVocabulary: [],
+  };
+}
+
+function opaqueDocumentKey(doc: HydeDocumentState): string {
+  return `d-${createHash('sha256')
+    .update(`${doc.lens}\0${doc.targetCorpus}\0${doc.hydeText}`)
+    .digest('hex')
+    .slice(0, 16)}`;
+}
+
+function isRuntimeVerdict(value: unknown): value is HydeValidationVerdict {
+  if (!value || typeof value !== 'object') return false;
+  const verdict = value as Partial<HydeValidationVerdict>;
+  return typeof verdict.key === 'string'
+    && typeof verdict.valid === 'boolean'
+    && Array.isArray(verdict.unsupportedNamedEntities)
+    && verdict.unsupportedNamedEntities.every((item) => typeof item === 'string')
+    && Array.isArray(verdict.unsupportedHardConstraints)
+    && verdict.unsupportedHardConstraints.every((item) => typeof item === 'string')
+    && typeof verdict.reasoning === 'string';
+}
+
+/** Factory for the HyDE generation graph. Existing five-argument calls remain valid. */
 export class HydeGraphFactory {
   constructor(
     private database: HydeGraphDatabase,
     private embedder: EmbeddingGenerator,
     private cache: HydeCache,
-    private inferrer: LensInferrer,
-    private generator: HydeGenerator,
+    private inferrer: HydeLensInferrerLike,
+    private generator: HydeGeneratorLike,
+    private options: HydeGraphOptions = {},
   ) {}
 
   createGraph() {
     const self = this;
+    const mode = this.options.mode ?? getHydeGenerationMode();
+    const validator = mode === HYDE_FRAME_GENERATION_VERSION
+      ? (this.options.validator ?? new HydeValidator())
+      : undefined;
 
     /** Node 1: Infer lenses from source text + optional profile context. */
     const inferLensesNode = async (state: typeof HydeGraphState.State) => {
       return timed("HydeGraph.inferLenses", async () => {
         const { sourceText, profileContext, maxLenses } = state;
-
-        logger.verbose('Inferring lenses', { sourceTextLength: sourceText.length, hasProfileContext: !!profileContext });
-
         const agentTimingsAccum: DebugMetaAgent[] = [];
 
         try {
-          const _traceEmitterLens = requestContext.getStore()?.traceEmitter;
+          const traceEmitter = requestContext.getStore()?.traceEmitter;
           const inferrerStart = Date.now();
-          _traceEmitterLens?.({ type: "agent_start", name: "lens-inferrer" });
+          traceEmitter?.({ type: "agent_start", name: "lens-inferrer" });
           const result = await self.inferrer.infer({
             sourceText,
             profileContext,
             maxLenses,
+            ...(mode === HYDE_FRAME_GENERATION_VERSION ? { frameConstrained: true } : {}),
           });
-          const _inferrerDuration = Date.now() - inferrerStart;
-          agentTimingsAccum.push({ name: 'lens.inferrer', durationMs: _inferrerDuration });
-          _traceEmitterLens?.({ type: "agent_end", name: "lens-inferrer", durationMs: _inferrerDuration, summary: result.lenses.length > 0 ? `Inferred ${result.lenses.length} lens(es)` : "lens-inferrer completed" });
+          const durationMs = Date.now() - inferrerStart;
+          agentTimingsAccum.push({ name: 'lens.inferrer', durationMs });
+          traceEmitter?.({ type: "agent_end", name: "lens-inferrer", durationMs, summary: result.lenses.length > 0 ? `Inferred ${result.lenses.length} lens(es)` : "lens-inferrer completed" });
 
-          logger.verbose('Lenses inferred', {
-            count: result.lenses.length,
-            lenses: result.lenses.map(l => ({ label: l.label, corpus: l.corpus })),
-          });
-
-          return { lenses: result.lenses, agentTimings: agentTimingsAccum };
+          return {
+            lenses: result.lenses,
+            ...(mode === HYDE_FRAME_GENERATION_VERSION
+              ? { sourceFrame: sanitizeHydeSourceFrame(sourceText, result.sourceFrame ?? emptyFrame()) }
+              : {}),
+            agentTimings: agentTimingsAccum,
+          };
         } catch (error) {
           logger.error('Lens inference failed in graph node', { error });
           return { lenses: [], agentTimings: agentTimingsAccum };
@@ -95,119 +172,157 @@ export class HydeGraphFactory {
       });
     };
 
-    /** Node 2: Check cache/DB for existing HyDE docs matching inferred lenses. */
+    /** Node 2: Check the mode-isolated cache/DB for matching documents. */
     const checkCacheNode = async (state: typeof HydeGraphState.State) => {
       return timed("HydeGraph.checkCache", async () => {
         const { sourceType, sourceId, sourceText, lenses, forceRegenerate } = state;
 
-        if (forceRegenerate) {
-          logger.verbose('Force regenerate - skipping cache');
-          return { hydeDocuments: {} };
-        }
+        if (forceRegenerate) return { hydeDocuments: {} };
 
         const cached: Record<string, HydeDocumentState> = {};
-
         for (const lens of lenses) {
-          const key = cacheKey(sourceType, sourceId ?? undefined, sourceText, lens.label, lens.corpus);
-
+          const key = cacheKey(mode, sourceType, sourceId ?? undefined, sourceText, lens.label, lens.corpus);
           const fromCache = await self.cache.get<HydeDocumentState>(key);
-          if (fromCache?.hydeText && fromCache.hydeEmbedding?.length) {
-            logger.verbose('Cache hit', { lens: lens.label });
-            cached[lens.label] = fromCache;
+          const cacheAccepted = fromCache?.hydeText
+            && fromCache.hydeEmbedding?.length
+            && (mode === 'legacy' || isFrameCacheDocument(fromCache, lens.label));
+          if (cacheAccepted && fromCache) {
+            cached[lens.label] = {
+              ...fromCache,
+              ...(mode === HYDE_FRAME_GENERATION_VERSION ? { origin: 'cache' as const } : {}),
+            };
             continue;
           }
 
-          // For entity sources, check DB for persisted docs
           if (sourceId) {
             const fromDb = await self.database.getHydeDocument(
               sourceType,
               sourceId,
-              lensHash(lens.label, lens.corpus),
+              dbStrategy(mode, lens.label, lens.corpus),
             );
-            if (fromDb) {
-              logger.verbose('DB hit', { lens: lens.label });
+            if (fromDb && (mode === 'legacy' || isFrameDbContext(fromDb.context, lens.label))) {
               cached[lens.label] = {
                 lens: lens.label,
-                targetCorpus: fromDb.targetCorpus as 'profiles' | 'intents',
+                targetCorpus: fromDb.targetCorpus as HydeDocumentState['targetCorpus'],
                 hydeText: fromDb.hydeText,
                 hydeEmbedding: fromDb.hydeEmbedding,
+                ...(mode === HYDE_FRAME_GENERATION_VERSION
+                  ? {
+                    origin: 'db' as const,
+                    validationStatus: 'valid' as const,
+                    hydeGenerationVersion: HYDE_FRAME_GENERATION_VERSION,
+                  }
+                  : {}),
               };
             }
           }
         }
 
-        logger.verbose('Check cache done', {
-          found: Object.keys(cached).length,
-          requested: lenses.length,
-        });
         return { hydeDocuments: cached };
       });
     };
 
-    /** Conditional: decide whether to generate or skip to embed. */
-    const shouldGenerate = (state: typeof HydeGraphState.State): string => {
-      const { lenses, hydeDocuments } = state;
-      const missing = lenses.filter((l) => !hydeDocuments[l.label]);
-      if (missing.length > 0) {
-        logger.verbose('Need to generate', { missing: missing.map(l => l.label) });
-        return 'generate';
-      }
-      logger.verbose('All lenses cached, skipping generation');
-      return 'skip';
-    };
+    const shouldGenerate = (state: typeof HydeGraphState.State): string =>
+      state.lenses.some((lens) => !state.hydeDocuments[lens.label]) ? 'generate' : 'skip';
 
-    /** Node 3: Generate HyDE documents for lenses not in cache. */
+    /** Node 3: Generate all missing documents and return a complete snapshot. */
     const generateMissingNode = async (state: typeof HydeGraphState.State) => {
       return timed("HydeGraph.generateMissing", async () => {
-        const { sourceText, lenses, hydeDocuments } = state;
-        const missing = lenses.filter((l) => !hydeDocuments[l.label]);
-
-        logger.verbose('Generating HyDE documents', {
-          count: missing.length,
-          lenses: missing.map(l => l.label),
-        });
-
+        const { sourceText, sourceFrame, lenses, hydeDocuments } = state;
+        const missing = lenses.filter((lens) => !hydeDocuments[lens.label]);
         const agentTimingsAccum: DebugMetaAgent[] = [];
         const generated: Record<string, HydeDocumentState> = {};
 
-        await Promise.all(
-          missing.map(async (lens) => {
-            const _traceEmitterHyde = requestContext.getStore()?.traceEmitter;
-            const generatorStart = Date.now();
-            _traceEmitterHyde?.({ type: "agent_start", name: "hyde-generator" });
-            const out = await self.generator.generate({
-              sourceText,
-              lens: lens.label,
-              corpus: lens.corpus,
-            });
-            const _hydeDuration = Date.now() - generatorStart;
-            agentTimingsAccum.push({ name: 'hyde.generator', durationMs: _hydeDuration });
-            _traceEmitterHyde?.({ type: "agent_end", name: "hyde-generator", durationMs: _hydeDuration, summary: `Generated: ${lens.label}` });
-            generated[lens.label] = {
-              lens: lens.label,
-              targetCorpus: lens.corpus,
-              hydeText: out.text,
-              hydeEmbedding: [],
-            };
-          })
-        );
+        await Promise.all(missing.map(async (lens) => {
+          const traceEmitter = requestContext.getStore()?.traceEmitter;
+          const generatorStart = Date.now();
+          traceEmitter?.({ type: "agent_start", name: "hyde-generator" });
+          const out = await self.generator.generate({
+            sourceText,
+            lens: lens.label,
+            corpus: lens.corpus,
+            ...(mode === HYDE_FRAME_GENERATION_VERSION && sourceFrame ? { sourceFrame } : {}),
+          });
+          const durationMs = Date.now() - generatorStart;
+          agentTimingsAccum.push({ name: 'hyde.generator', durationMs });
+          traceEmitter?.({ type: "agent_end", name: "hyde-generator", durationMs, summary: `Generated: ${lens.label}` });
+          generated[lens.label] = {
+            lens: lens.label,
+            targetCorpus: lens.corpus,
+            hydeText: out.text,
+            hydeEmbedding: [],
+            ...(mode === HYDE_FRAME_GENERATION_VERSION ? { origin: 'generated' as const } : {}),
+          };
+        }));
 
-        return { hydeDocuments: { ...state.hydeDocuments, ...generated }, agentTimings: agentTimingsAccum };
+        return { hydeDocuments: { ...hydeDocuments, ...generated }, agentTimings: agentTimingsAccum };
       });
     };
 
-    /** Node 4: Embed all HyDE documents that don't have embeddings yet. */
+    /** Frame-v1 only: validate newly generated docs in one batch. */
+    const validateGeneratedNode = async (state: typeof HydeGraphState.State) => {
+      return timed("HydeGraph.validateGenerated", async () => {
+        const generated = Object.values(state.hydeDocuments).filter((doc) => doc.origin === 'generated');
+        if (generated.length === 0 || !validator) return { hydeDocuments: state.hydeDocuments };
+
+        const frame = sanitizeHydeSourceFrame(state.sourceText, state.sourceFrame ?? emptyFrame());
+        const keyed = Object.fromEntries(generated.map((doc) => [
+          opaqueDocumentKey(doc),
+          { lens: doc.lens, corpus: doc.targetCorpus, text: doc.hydeText },
+        ]));
+        const updated = { ...state.hydeDocuments };
+
+        try {
+          const output = await validator.validate({
+            sourceText: state.sourceText,
+            sourceFrame: frame,
+            documents: keyed,
+          });
+          const rawVerdicts: unknown[] = Array.isArray((output as { verdicts?: unknown }).verdicts)
+            ? (output as { verdicts: unknown[] }).verdicts
+            : [];
+
+          for (const [key, item] of Object.entries(keyed)) {
+            const matching = rawVerdicts.filter((value) =>
+              !!value && typeof value === 'object' && (value as { key?: unknown }).key === key);
+            const doc = updated[item.lens];
+            if (!doc) continue;
+
+            if (matching.length !== 1 || !isRuntimeVerdict(matching[0])) {
+              updated[item.lens] = { ...doc, validationStatus: 'failed_open', hydeGenerationVersion: HYDE_FRAME_GENERATION_VERSION };
+              continue;
+            }
+
+            const verdict = matching[0];
+            const contradictory = verdict.valid
+              && (verdict.unsupportedNamedEntities.length > 0 || verdict.unsupportedHardConstraints.length > 0);
+            if (contradictory) {
+              updated[item.lens] = { ...doc, validationStatus: 'failed_open', hydeGenerationVersion: HYDE_FRAME_GENERATION_VERSION };
+            } else if (!verdict.valid) {
+              delete updated[item.lens];
+            } else {
+              updated[item.lens] = { ...doc, validationStatus: 'valid', hydeGenerationVersion: HYDE_FRAME_GENERATION_VERSION };
+            }
+          }
+        } catch (error) {
+          logger.error('HyDE validation failed open', { error });
+          for (const doc of generated) {
+            updated[doc.lens] = { ...doc, validationStatus: 'failed_open', hydeGenerationVersion: HYDE_FRAME_GENERATION_VERSION };
+          }
+        }
+
+        return { hydeDocuments: updated };
+      });
+    };
+
+    /** Embed all accepted/cached documents that do not have embeddings. */
     const embedNode = async (state: typeof HydeGraphState.State) => {
       return timed("HydeGraph.embed", async () => {
-        const { hydeDocuments } = state;
-        const lensLabels = Object.keys(hydeDocuments);
         const toEmbed: { label: string; doc: HydeDocumentState }[] = [];
         const updated: Record<string, HydeDocumentState> = {};
         const hydeEmbeddings: Record<string, number[]> = {};
 
-        for (const label of lensLabels) {
-          const doc = hydeDocuments[label];
-          if (!doc) continue;
+        for (const [label, doc] of Object.entries(state.hydeDocuments)) {
           if (doc.hydeEmbedding?.length) {
             updated[label] = doc;
             hydeEmbeddings[label] = doc.hydeEmbedding;
@@ -217,13 +332,12 @@ export class HydeGraphFactory {
         }
 
         if (toEmbed.length > 0) {
-          logger.verbose('Embedding documents', { count: toEmbed.length });
-          const texts = toEmbed.map((t) => t.doc.hydeText);
-          const embeddings = await self.embedder.generate(texts, undefined, getAbortSignalConfig());
-          const embeddingArray = Array.isArray(embeddings[0])
-            ? (embeddings as number[][])
-            : [embeddings as number[]];
-
+          const embeddings = await self.embedder.generate(
+            toEmbed.map((item) => item.doc.hydeText),
+            undefined,
+            getAbortSignalConfig(),
+          );
+          const embeddingArray = Array.isArray(embeddings[0]) ? embeddings as number[][] : [embeddings as number[]];
           for (let i = 0; i < toEmbed.length; i++) {
             const { label, doc } = toEmbed[i];
             const embedding = embeddingArray[i] ?? [];
@@ -236,34 +350,34 @@ export class HydeGraphFactory {
       });
     };
 
-    /** Node 5: Cache results in Redis; persist to DB for entity sources. */
+    /** Cache/persist only legacy docs or successfully validated frame-v1 docs. */
     const cacheResultsNode = async (state: typeof HydeGraphState.State) => {
       return timed("HydeGraph.cacheResults", async () => {
         const { sourceType, sourceId, sourceText, hydeDocuments } = state;
+        for (const [label, doc] of Object.entries(hydeDocuments)) {
+          if (mode === HYDE_FRAME_GENERATION_VERSION && doc.validationStatus !== 'valid') continue;
 
-        for (const label of Object.keys(hydeDocuments)) {
-          const doc = hydeDocuments[label];
-          if (!doc) continue;
-
-          const key = cacheKey(sourceType, sourceId ?? undefined, sourceText, label, doc.targetCorpus);
+          const key = cacheKey(mode, sourceType, sourceId ?? undefined, sourceText, label, doc.targetCorpus);
           await self.cache.set(key, doc, { ttl: HYDE_DEFAULT_CACHE_TTL });
 
-          // Persist to DB for entity sources (intent/profile)
           if (sourceId) {
             await self.database.saveHydeDocument({
               sourceType,
               sourceId,
-              strategy: lensHash(label, doc.targetCorpus),
+              strategy: dbStrategy(mode, label, doc.targetCorpus),
               targetCorpus: doc.targetCorpus,
               hydeText: doc.hydeText,
               hydeEmbedding: doc.hydeEmbedding,
+              ...(mode === HYDE_FRAME_GENERATION_VERSION ? {
+                context: {
+                  hydeGenerationVersion: HYDE_FRAME_GENERATION_VERSION,
+                  lensLabel: label,
+                  validationStatus: 'valid',
+                },
+              } : {}),
             });
           }
         }
-
-        logger.verbose('Cached results', {
-          count: Object.keys(hydeDocuments).length,
-        });
         return {};
       });
     };
@@ -279,8 +393,18 @@ export class HydeGraphFactory {
       .addConditionalEdges('check_cache', shouldGenerate, {
         generate: 'generate_missing',
         skip: 'embed',
-      })
-      .addEdge('generate_missing', 'embed')
+      });
+
+    if (mode === HYDE_FRAME_GENERATION_VERSION) {
+      workflow
+        .addNode('validate_generated', validateGeneratedNode)
+        .addEdge('generate_missing', 'validate_generated')
+        .addEdge('validate_generated', 'embed');
+    } else {
+      workflow.addEdge('generate_missing', 'embed');
+    }
+
+    workflow
       .addEdge('embed', 'cache_results')
       .addEdge('cache_results', END);
 

--- a/packages/protocol/src/shared/hyde/hyde.state.ts
+++ b/packages/protocol/src/shared/hyde/hyde.state.ts
@@ -6,7 +6,11 @@
 import { Annotation } from '@langchain/langgraph';
 import type { Id } from '../interfaces/database.interface.js';
 import type { Lens, HydeTargetCorpus } from './lens.inferrer.js';
+import type { HydeSourceFrame } from './hyde.frame.js';
 import type { DebugMetaAgent } from '../../chat/chat-streaming.types.js';
+
+export type HydeDocumentOrigin = 'cache' | 'db' | 'generated';
+export type HydeValidationStatus = 'valid' | 'invalid' | 'failed_open';
 
 /** Single HyDE document (text + embedding) for one lens. */
 export interface HydeDocumentState {
@@ -14,6 +18,9 @@ export interface HydeDocumentState {
   targetCorpus: HydeTargetCorpus;
   hydeText: string;
   hydeEmbedding: number[];
+  origin?: HydeDocumentOrigin;
+  validationStatus?: HydeValidationStatus;
+  hydeGenerationVersion?: 'frame-v1';
 }
 
 /** State for the HyDE generation graph. */
@@ -58,12 +65,18 @@ export const HydeGraphState = Annotation.Root({
     default: () => [],
   }),
 
+  /** Sanitized source-grounded frame produced by frame-v1 inference. */
+  sourceFrame: Annotation<HydeSourceFrame | undefined>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => undefined,
+  }),
+
   /**
-   * HyDE documents per lens (from cache, DB, or newly generated).
-   * Keyed by lens label; values include hydeText and hydeEmbedding.
+   * Complete HyDE document snapshot keyed by lens label. Writers replace the
+   * snapshot so rejected documents can be removed before embedding.
    */
   hydeDocuments: Annotation<Record<string, HydeDocumentState>>({
-    reducer: (curr, next) => (next ? { ...curr, ...next } : curr),
+    reducer: (curr, next) => next ?? curr,
     default: () => ({}),
   }),
 

--- a/packages/protocol/src/shared/hyde/hyde.state.ts
+++ b/packages/protocol/src/shared/hyde/hyde.state.ts
@@ -21,6 +21,9 @@ export interface HydeDocumentState {
   origin?: HydeDocumentOrigin;
   validationStatus?: HydeValidationStatus;
   hydeGenerationVersion?: 'frame-v1';
+  frameFingerprint?: string;
+  sourceTextHash?: string;
+  generatedAt?: string;
 }
 
 /** State for the HyDE generation graph. */
@@ -67,6 +70,24 @@ export const HydeGraphState = Annotation.Root({
 
   /** Sanitized source-grounded frame produced by frame-v1 inference. */
   sourceFrame: Annotation<HydeSourceFrame | undefined>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => undefined,
+  }),
+
+  /** Exact sourceText + sanitized sourceFrame identity for frame-v1 reuse. */
+  frameFingerprint: Annotation<string | undefined>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => undefined,
+  }),
+
+  /** Hash of the exact source text for persisted frame-v1 freshness checks. */
+  sourceTextHash: Annotation<string | undefined>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => undefined,
+  }),
+
+  /** Shared cohort marker assigned when this run generates any missing document. */
+  generatedAt: Annotation<string | undefined>({
     reducer: (curr, next) => next ?? curr,
     default: () => undefined,
   }),

--- a/packages/protocol/src/shared/hyde/hyde.validator.ts
+++ b/packages/protocol/src/shared/hyde/hyde.validator.ts
@@ -1,0 +1,90 @@
+import type { BaseLanguageModelInput } from '@langchain/core/language_models/base';
+import { HumanMessage, SystemMessage } from '@langchain/core/messages';
+import { z } from 'zod';
+
+import { createStructuredModel } from '../agent/model.config.js';
+import { invokeWithAbortSignal } from '../agent/model-signal.js';
+import type { HydeSourceFrame } from './hyde.frame.js';
+import type { HydeTargetCorpus } from './lens.inferrer.js';
+
+export interface HydeValidationDocument {
+  lens: string;
+  corpus: HydeTargetCorpus;
+  text: string;
+}
+
+export interface HydeValidationInput {
+  sourceText: string;
+  sourceFrame: HydeSourceFrame;
+  /** Generated documents keyed by opaque caller-supplied identifiers. */
+  documents: Record<string, HydeValidationDocument>;
+}
+
+export interface HydeValidationVerdict {
+  key: string;
+  valid: boolean;
+  unsupportedNamedEntities: string[];
+  unsupportedHardConstraints: string[];
+  reasoning: string;
+}
+
+export interface HydeValidationOutput {
+  verdicts: HydeValidationVerdict[];
+}
+
+/** Structured-output schema for a single batch validation response. */
+export const HydeValidationResponseSchema = z.object({
+  verdicts: z.array(z.object({
+    key: z.string().min(1),
+    valid: z.boolean(),
+    unsupportedNamedEntities: z.array(z.string()),
+    unsupportedHardConstraints: z.array(z.string()),
+    reasoning: z.string().min(1).describe('Concise explanation of the verdict'),
+  })),
+});
+
+const VALIDATOR_SYSTEM_PROMPT = `You validate hypothetical retrieval documents against a sanitized source-grounded frame.
+
+A document is invalid only when it invents unsupported proper nouns/named entities or unsupported HARD constraints (location, time, numeric, credential, organization, or exclusivity constraints).
+
+Explicitly allowed and not grounds for rejection:
+- first-person target voice;
+- generic role or domain elaboration;
+- reciprocal or complementary inversion of source and target roles.
+
+Return exactly one verdict for each opaque key. Copy each key exactly. Mark valid=false when either unsupported list is non-empty. Keep reasoning concise.`;
+
+/** Build a profile-free batch validation prompt. */
+export function buildHydeValidationPrompt(input: HydeValidationInput): string {
+  return `Source text:\n${input.sourceText}\n\nSanitized source frame:\n${JSON.stringify(input.sourceFrame)}\n\nGenerated documents:\n${JSON.stringify(input.documents)}`;
+}
+
+/** Minimal structured model contract used for deterministic injection in tests. */
+export interface HydeValidatorStructuredModel {
+  invoke(input: BaseLanguageModelInput, config?: { signal?: AbortSignal }): Promise<unknown>;
+}
+
+/** Production structured-model batch validator for frame-v1 HyDE documents. */
+export class HydeValidator {
+  private model?: HydeValidatorStructuredModel;
+
+  constructor(model?: HydeValidatorStructuredModel) {
+    this.model = model;
+  }
+
+  private getModel(): HydeValidatorStructuredModel {
+    this.model ??= createStructuredModel('hydeValidator', HydeValidationResponseSchema, {
+      name: 'hyde_validator',
+    });
+    return this.model;
+  }
+
+  /** Validate all generated documents in one structured-model call. */
+  async validate(input: HydeValidationInput): Promise<HydeValidationOutput> {
+    const result = await invokeWithAbortSignal(this.getModel(), [
+      new SystemMessage(VALIDATOR_SYSTEM_PROMPT),
+      new HumanMessage(buildHydeValidationPrompt(input)),
+    ]);
+    return HydeValidationResponseSchema.parse(result);
+  }
+}

--- a/packages/protocol/src/shared/hyde/hyde.validator.ts
+++ b/packages/protocol/src/shared/hyde/hyde.validator.ts
@@ -8,7 +8,6 @@ import type { HydeSourceFrame } from './hyde.frame.js';
 import type { HydeTargetCorpus } from './lens.inferrer.js';
 
 export interface HydeValidationDocument {
-  lens: string;
   corpus: HydeTargetCorpus;
   text: string;
 }

--- a/packages/protocol/src/shared/hyde/lens.inferrer.ts
+++ b/packages/protocol/src/shared/hyde/lens.inferrer.ts
@@ -58,23 +58,18 @@ Guidelines:
 - Always include at least one "profiles" perspective when the source describes a need that a specific type of professional could fulfill. Most intents benefit from profile-based discovery.
 - LOCATION AWARENESS: When the source text or user context mentions a specific location (city, region, country), incorporate it into lens descriptions. For example, "investors in San Francisco" should produce a lens like "SF-based early-stage investor" rather than just "early-stage investor". This helps the hypothetical document generator produce location-specific search documents, improving retrieval quality.`;
 
-/** Source-grounded system prompt used only by the frame-v1 path. */
-export const FRAME_LENS_SYSTEM_PROMPT = `You infer search lenses and a source-grounded frame for semantic retrieval.
-
-Lens rules:
-- Infer distinct profile, intent, or premise search perspectives.
-- You may infer reciprocal target roles and complementary roles (for example, infer "investor" from a source seeking funding).
-- profileContext may specialize which lenses are useful, but it is lens-selection context only.
+/** Source-grounded system prompt used only by frame extraction. */
+export const FRAME_SYSTEM_PROMPT = `You extract a source-grounded frame for semantic retrieval from sourceText alone.
 
 Source-frame rules:
-- Extract evidence ONLY from sourceText, never from profileContext.
+- Extract evidence ONLY from sourceText.
 - Every frame element must include an evidence field copied as an exact substring of sourceText.
 - sourceRoles describe roles held or offered by the source side.
-- counterpartRoles describe reciprocal or complementary target roles. The role may be inferred, but its evidence must be an exact sourceText span that supports the inference.
+- sourceRoles and counterpartRoles MUST use generic lower-case role labels only (for example, "founder", "investor", or "technical advisor"). Never put a person, organization, product, location, time, number, credential, or exclusivity detail in a role label.
+- counterpartRoles describe reciprocal or complementary target roles. A generic role may be inferred, but its evidence must be an exact sourceText span that supports the inference.
 - hardConstraints contain only explicit constraints and classify each as location, time, numeric, credential, organization, exclusivity, or other.
 - namedEntities contain only proper names explicitly present in sourceText and classify each as person, organization, product, location, event, or other.
-- domainVocabulary contains source domain terms worth preserving.
-- Do not use profileContext as frame evidence, even when it contains useful names or constraints.`;
+- domainVocabulary contains source domain terms worth preserving.`;
 
 const lensSchema = z.object({
   label: z.string().describe('Specific description of the search perspective'),
@@ -86,9 +81,8 @@ const responseFormat = z.object({
   lenses: z.array(lensSchema).min(1).max(5).describe('Inferred search lenses'),
 });
 
-/** Structured-output schema used only by frame-constrained inference. */
-export const FrameLensResponseSchema = z.object({
-  lenses: z.array(lensSchema).min(1).max(5).describe('Inferred search lenses'),
+/** Structured-output schema used only by source-frame extraction. */
+export const FrameResponseSchema = z.object({
   sourceFrame: HydeSourceFrameSchema,
 });
 
@@ -127,7 +121,7 @@ export class LensInferrer {
   }
 
   private getFrameModel(): LensStructuredModel {
-    this.frameModel ??= createStructuredModel("lensInferrer", FrameLensResponseSchema, {
+    this.frameModel ??= createStructuredModel("lensInferrer", FrameResponseSchema, {
       name: "lens_inferrer_frame_v1",
     });
     return this.frameModel;
@@ -152,33 +146,65 @@ export class LensInferrer {
     }
 
     const messages = [
-      new SystemMessage(frameConstrained ? FRAME_LENS_SYSTEM_PROMPT : SYSTEM_PROMPT),
+      new SystemMessage(SYSTEM_PROMPT),
       new HumanMessage(humanPrompt),
     ];
 
-    try {
-      if (frameConstrained) {
-        const result = await invokeWithAbortSignal(this.getFrameModel(), messages);
-        const parsed = FrameLensResponseSchema.parse(result);
+    if (!frameConstrained) {
+      try {
+        const result = await invokeWithAbortSignal(this.getLegacyModel(), messages);
+        const parsed = responseFormat.parse(result);
         const lenses = parsed.lenses.slice(0, maxLenses);
-        const sourceFrame = sanitizeHydeSourceFrame(sourceText, parsed.sourceFrame);
-        logger.verbose('Frame-constrained lenses inferred', { count: lenses.length });
-        return { lenses, sourceFrame };
+
+        logger.verbose('Lenses inferred', {
+          count: lenses.length,
+          lenses: lenses.map(l => ({ label: l.label, corpus: l.corpus })),
+        });
+
+        return { lenses };
+      } catch (error: unknown) {
+        logger.error('Lens inference failed', { error });
+        return { lenses: [] };
       }
+    }
 
+    const frameMessages = [
+      new SystemMessage(FRAME_SYSTEM_PROMPT),
+      new HumanMessage(`Extract the source frame.\n\nSource: "${sourceText}"`),
+    ];
+    const lensPromise = (async () => {
       const result = await invokeWithAbortSignal(this.getLegacyModel(), messages);
-      const parsed = responseFormat.parse(result);
-      const lenses = parsed.lenses.slice(0, maxLenses);
+      return responseFormat.parse(result).lenses.slice(0, maxLenses);
+    })();
+    const framePromise = (async () => {
+      const result = await invokeWithAbortSignal(this.getFrameModel(), frameMessages);
+      const parsed = FrameResponseSchema.parse(result);
+      return sanitizeHydeSourceFrame(sourceText, parsed.sourceFrame);
+    })();
+    const [lensResult, frameResult] = await Promise.allSettled([lensPromise, framePromise]);
 
-      logger.verbose('Lenses inferred', {
-        count: lenses.length,
-        lenses: lenses.map(l => ({ label: l.label, corpus: l.corpus })),
-      });
-
-      return { lenses };
-    } catch (error: unknown) {
-      logger.error('Lens inference failed', { error });
+    if (lensResult.status === 'rejected') {
+      logger.error('Lens inference failed', { error: lensResult.reason });
       return { lenses: [] };
     }
+
+    const lenses = lensResult.value;
+    logger.verbose('Frame-constrained lenses inferred', { count: lenses.length });
+
+    if (frameResult.status === 'rejected') {
+      logger.error('Source frame extraction failed', { error: frameResult.reason });
+      return {
+        lenses,
+        sourceFrame: {
+          sourceRoles: [],
+          counterpartRoles: [],
+          hardConstraints: [],
+          namedEntities: [],
+          domainVocabulary: [],
+        },
+      };
+    }
+
+    return { lenses, sourceFrame: frameResult.value };
   }
 }

--- a/packages/protocol/src/shared/hyde/lens.inferrer.ts
+++ b/packages/protocol/src/shared/hyde/lens.inferrer.ts
@@ -3,12 +3,15 @@
  * profile context and infers 1-N search lenses, each tagged with a target corpus.
  * Replaces the hardcoded HydeStrategy enum and regex-based selectStrategiesFromQuery.
  */
+import type { BaseLanguageModelInput } from '@langchain/core/language_models/base';
 import { HumanMessage, SystemMessage } from '@langchain/core/messages';
 import { z } from 'zod';
-import { Timed } from "../observability/performance.js";
-import { protocolLogger } from '../observability/protocol.logger.js';
+
 import { createStructuredModel } from "../agent/model.config.js";
 import { invokeWithAbortSignal } from "../agent/model-signal.js";
+import { protocolLogger } from '../observability/protocol.logger.js';
+import { Timed } from "../observability/performance.js";
+import { HydeSourceFrameSchema, sanitizeHydeSourceFrame, type HydeSourceFrame } from './hyde.frame.js';
 
 export type HydeTargetCorpus = 'profiles' | 'intents' | 'premises';
 
@@ -29,10 +32,14 @@ export interface LensInferenceInput {
   profileContext?: string;
   /** Maximum number of lenses to infer (default 3). */
   maxLenses?: number;
+  /** Use the source-grounded frame-v1 inference path. */
+  frameConstrained?: boolean;
 }
 
 export interface LensInferenceOutput {
   lenses: Lens[];
+  /** Sanitized source frame, present only for frame-constrained inference. */
+  sourceFrame?: HydeSourceFrame;
 }
 
 const SYSTEM_PROMPT = `You analyze goals and search queries to identify the most relevant perspectives for finding matching people in a professional network.
@@ -51,40 +58,91 @@ Guidelines:
 - Always include at least one "profiles" perspective when the source describes a need that a specific type of professional could fulfill. Most intents benefit from profile-based discovery.
 - LOCATION AWARENESS: When the source text or user context mentions a specific location (city, region, country), incorporate it into lens descriptions. For example, "investors in San Francisco" should produce a lens like "SF-based early-stage investor" rather than just "early-stage investor". This helps the hypothetical document generator produce location-specific search documents, improving retrieval quality.`;
 
-const responseFormat = z.object({
-  lenses: z.array(z.object({
-    label: z.string().describe('Specific description of the search perspective'),
-    corpus: z.enum(['profiles', 'intents', 'premises']).describe('Search user profiles, user intents, or user premises (identity/values)'),
-    reasoning: z.string().describe('Why this perspective is relevant'),
-  })).min(1).max(5).describe('Inferred search lenses'),
+/** Source-grounded system prompt used only by the frame-v1 path. */
+export const FRAME_LENS_SYSTEM_PROMPT = `You infer search lenses and a source-grounded frame for semantic retrieval.
+
+Lens rules:
+- Infer distinct profile, intent, or premise search perspectives.
+- You may infer reciprocal target roles and complementary roles (for example, infer "investor" from a source seeking funding).
+- profileContext may specialize which lenses are useful, but it is lens-selection context only.
+
+Source-frame rules:
+- Extract evidence ONLY from sourceText, never from profileContext.
+- Every frame element must include an evidence field copied as an exact substring of sourceText.
+- sourceRoles describe roles held or offered by the source side.
+- counterpartRoles describe reciprocal or complementary target roles. The role may be inferred, but its evidence must be an exact sourceText span that supports the inference.
+- hardConstraints contain only explicit constraints and classify each as location, time, numeric, credential, organization, exclusivity, or other.
+- namedEntities contain only proper names explicitly present in sourceText and classify each as person, organization, product, location, event, or other.
+- domainVocabulary contains source domain terms worth preserving.
+- Do not use profileContext as frame evidence, even when it contains useful names or constraints.`;
+
+const lensSchema = z.object({
+  label: z.string().describe('Specific description of the search perspective'),
+  corpus: z.enum(['profiles', 'intents', 'premises']).describe('Search user profiles, user intents, or user premises (identity/values)'),
+  reasoning: z.string().describe('Why this perspective is relevant'),
 });
+
+const responseFormat = z.object({
+  lenses: z.array(lensSchema).min(1).max(5).describe('Inferred search lenses'),
+});
+
+/** Structured-output schema used only by frame-constrained inference. */
+export const FrameLensResponseSchema = z.object({
+  lenses: z.array(lensSchema).min(1).max(5).describe('Inferred search lenses'),
+  sourceFrame: HydeSourceFrameSchema,
+});
+
+type ModelInput = BaseLanguageModelInput;
+
+/** Minimal structured model contract used for deterministic injection in tests. */
+export interface LensStructuredModel {
+  invoke(input: ModelInput, config?: { signal?: AbortSignal }): Promise<unknown>;
+}
+
+export interface LensInferrerOptions {
+  legacyModel?: LensStructuredModel;
+  frameModel?: LensStructuredModel;
+}
 
 const logger = protocolLogger("LensInferrer");
 
-/**
- * Infers search lenses from source text and optional profile context.
- * Each lens represents a search perspective tagged with a target corpus
- * (profiles or intents) for downstream HyDE document generation.
- */
+/** Infers search lenses from source text and optional profile context. */
 export class LensInferrer {
-  private model = createStructuredModel("lensInferrer", responseFormat, {
-    name: "lens_inferrer",
-  });
+  private legacyModel?: LensStructuredModel;
+  private frameModel?: LensStructuredModel;
 
-  /**
-   * Infer search lenses from source text and optional profile context.
-   *
-   * @param input - Source text, optional profile context, optional max lenses
-   * @returns Array of inferred lenses with corpus tags; empty array on failure
-   */
+  constructor(options: LensInferrerOptions = {}) {
+    // Preserve legacy construction behavior in production. Frame-only model
+    // injection deliberately avoids constructing a provider-backed legacy model.
+    this.legacyModel = options.legacyModel
+      ?? (options.frameModel ? undefined : createStructuredModel("lensInferrer", responseFormat, { name: "lens_inferrer" }));
+    this.frameModel = options.frameModel;
+  }
+
+  private getLegacyModel(): LensStructuredModel {
+    this.legacyModel ??= createStructuredModel("lensInferrer", responseFormat, {
+      name: "lens_inferrer",
+    });
+    return this.legacyModel;
+  }
+
+  private getFrameModel(): LensStructuredModel {
+    this.frameModel ??= createStructuredModel("lensInferrer", FrameLensResponseSchema, {
+      name: "lens_inferrer_frame_v1",
+    });
+    return this.frameModel;
+  }
+
+  /** Infer search lenses while preserving the legacy path unless explicitly enabled. */
   @Timed()
   async infer(input: LensInferenceInput): Promise<LensInferenceOutput> {
-    const { sourceText, profileContext, maxLenses = 3 } = input;
+    const { sourceText, profileContext, maxLenses = 3, frameConstrained = false } = input;
 
     logger.verbose('Inferring lenses', {
       sourceTextLength: sourceText.length,
       hasProfileContext: !!profileContext,
       maxLenses,
+      frameConstrained,
     });
 
     let humanPrompt = `Identify up to ${maxLenses} search perspectives for finding relevant matches.\n\nSource: "${sourceText}"`;
@@ -94,12 +152,21 @@ export class LensInferrer {
     }
 
     const messages = [
-      new SystemMessage(SYSTEM_PROMPT),
+      new SystemMessage(frameConstrained ? FRAME_LENS_SYSTEM_PROMPT : SYSTEM_PROMPT),
       new HumanMessage(humanPrompt),
     ];
 
     try {
-      const result = await invokeWithAbortSignal(this.model, messages);
+      if (frameConstrained) {
+        const result = await invokeWithAbortSignal(this.getFrameModel(), messages);
+        const parsed = FrameLensResponseSchema.parse(result);
+        const lenses = parsed.lenses.slice(0, maxLenses);
+        const sourceFrame = sanitizeHydeSourceFrame(sourceText, parsed.sourceFrame);
+        logger.verbose('Frame-constrained lenses inferred', { count: lenses.length });
+        return { lenses, sourceFrame };
+      }
+
+      const result = await invokeWithAbortSignal(this.getLegacyModel(), messages);
       const parsed = responseFormat.parse(result);
       const lenses = parsed.lenses.slice(0, maxLenses);
 

--- a/packages/protocol/src/shared/hyde/tests/hyde.documents.spec.ts
+++ b/packages/protocol/src/shared/hyde/tests/hyde.documents.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'bun:test';
+
+import type { HydeDocument } from '../../interfaces/database.interface.js';
+import { computeHydeSourceTextHash, selectHydeDocumentsForGeneration } from '../hyde.documents.js';
+
+function document(
+  id: string,
+  strategy: string,
+  context: Record<string, unknown> | null = null,
+): HydeDocument {
+  return {
+    id,
+    sourceType: 'context',
+    sourceId: 'context-1',
+    sourceText: null,
+    strategy,
+    targetCorpus: 'intents',
+    hydeText: `document ${id}`,
+    hydeEmbedding: [1, 2],
+    context,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    expiresAt: null,
+  };
+}
+
+function frameContext(
+  sourceText: string,
+  generatedAt: string,
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    hydeGenerationVersion: 'frame-v1',
+    lensLabel: 'investor',
+    validationStatus: 'valid',
+    frameFingerprint: 'fingerprint',
+    sourceTextHash: computeHydeSourceTextHash(sourceText),
+    generatedAt,
+    ...overrides,
+  };
+}
+
+describe('persisted HyDE generation selection', () => {
+  it('selects only legacy rows when frame generation is disabled', () => {
+    const sourceText = 'Founder seeking funding';
+    const documents = [
+      document('legacy', 'legacy-hash'),
+      document('frame-prefix', 'frame-v1:stable', frameContext(sourceText, '2026-01-01T00:00:00.000Z')),
+      document('frame-metadata', 'legacy-looking', frameContext(sourceText, '2026-01-02T00:00:00.000Z')),
+    ];
+
+    expect(selectHydeDocumentsForGeneration(documents, 'legacy', sourceText).map((doc) => doc.id))
+      .toEqual(['legacy']);
+  });
+
+  it('requires current valid frame metadata and selects only the newest generation group', () => {
+    const sourceText = 'Founder seeking funding';
+    const oldGeneration = '2026-01-01T00:00:00.000Z';
+    const newestGeneration = '2026-01-02T00:00:00.000Z';
+    const documents = [
+      document('legacy', 'legacy-hash'),
+      document('stale-source', 'frame-v1:stale', frameContext('Founder no longer fundraising', '2026-01-03T00:00:00.000Z')),
+      document('missing-fingerprint', 'frame-v1:malformed', frameContext(sourceText, '2026-01-04T00:00:00.000Z', { frameFingerprint: undefined })),
+      document('failed-open', 'frame-v1:failed', frameContext(sourceText, '2026-01-05T00:00:00.000Z', { validationStatus: 'failed_open' })),
+      document('old-a', 'frame-v1:old-a', frameContext(sourceText, oldGeneration)),
+      document('old-b', 'frame-v1:old-b', frameContext(sourceText, oldGeneration)),
+      document('new-a', 'frame-v1:new-a', frameContext(sourceText, newestGeneration)),
+      document('new-b', 'frame-v1:new-b', frameContext(sourceText, newestGeneration)),
+    ];
+
+    expect(selectHydeDocumentsForGeneration(documents, 'frame-v1', sourceText).map((doc) => doc.id))
+      .toEqual(['new-a', 'new-b']);
+  });
+});

--- a/packages/protocol/src/shared/hyde/tests/hyde.frame.spec.ts
+++ b/packages/protocol/src/shared/hyde/tests/hyde.frame.spec.ts
@@ -4,11 +4,27 @@ import type { BaseMessage } from '@langchain/core/messages';
 
 import { getHydeGenerationMode, HYDE_FRAME_GENERATION_VERSION } from '../hyde.env.js';
 import { HydeSourceFrameSchema, sanitizeHydeSourceFrame, type HydeSourceFrame } from '../hyde.frame.js';
-import { FrameLensResponseSchema, LensInferrer, type LensStructuredModel } from '../lens.inferrer.js';
+import { FrameResponseSchema, LensInferrer, type LensStructuredModel } from '../lens.inferrer.js';
 
 function messageText(input: BaseLanguageModelInput): string[] {
   return (input as BaseMessage[]).map((message) => String(message.content));
 }
+
+function emptyFrame(): HydeSourceFrame {
+  return {
+    sourceRoles: [],
+    counterpartRoles: [],
+    hardConstraints: [],
+    namedEntities: [],
+    domainVocabulary: [],
+  };
+}
+
+const inferredLens = {
+  label: 'healthcare seed investor',
+  corpus: 'profiles' as const,
+  reasoning: 'profile specialization',
+};
 
 describe('HyDE frame environment', () => {
   it('enables frame-v1 only for the strict literal true', () => {
@@ -24,59 +40,118 @@ describe('HyDE source frame evidence boundary', () => {
     const frame: HydeSourceFrame = {
       sourceRoles: [
         { role: 'founder', evidence: 'FOUNDER' },
+        { role: 'Profile Corp founder', evidence: 'founder' },
+        { role: 'profile corp founder', evidence: 'founder' },
+        { role: 'Zurich founder', evidence: 'founder' },
+        { role: '$2m founder', evidence: 'founder' },
         { role: 'doctor', evidence: 'medical profile' },
       ],
-      counterpartRoles: [{ role: 'investor', evidence: 'seed funding' }],
+      counterpartRoles: [
+        { role: 'investor', evidence: 'seed funding' },
+        { role: 'Alice investor', evidence: 'seed funding' },
+        { role: 'alice investor', evidence: 'seed funding' },
+      ],
       hardConstraints: [
-        { type: 'location', value: 'Berlin', evidence: 'Berlin' },
-        { type: 'numeric', value: '$2m', evidence: '$2m' },
+        { type: 'location', value: 'Berlin', evidence: 'in berlin' },
+        { type: 'location', value: 'Berlin', evidence: 'founder' },
+        { type: 'numeric', value: '$2m', evidence: 'seed funding' },
       ],
       namedEntities: [
-        { type: 'location', name: 'Berlin', evidence: 'Berlin' },
-        { type: 'organization', name: 'Profile Corp', evidence: 'Profile Corp' },
+        { type: 'location', name: 'Berlin', evidence: 'in berlin' },
+        { type: 'organization', name: 'Profile Corp', evidence: 'founder' },
       ],
       domainVocabulary: [
         { term: 'climate tech', evidence: 'climate tech' },
-        { term: 'oncology', evidence: 'oncology' },
+        { term: 'oncology', evidence: 'climate tech' },
       ],
     };
 
     expect(sanitizeHydeSourceFrame('Founder seeking seed funding for climate tech in berlin', frame)).toEqual({
       sourceRoles: [{ role: 'founder', evidence: 'FOUNDER' }],
       counterpartRoles: [{ role: 'investor', evidence: 'seed funding' }],
-      hardConstraints: [{ type: 'location', value: 'Berlin', evidence: 'Berlin' }],
-      namedEntities: [{ type: 'location', name: 'Berlin', evidence: 'Berlin' }],
+      hardConstraints: [{ type: 'location', value: 'Berlin', evidence: 'in berlin' }],
+      namedEntities: [{ type: 'location', name: 'Berlin', evidence: 'in berlin' }],
       domainVocabulary: [{ term: 'climate tech', evidence: 'climate tech' }],
     });
   });
 
-  it('allows profile context to shape lenses but never to survive as frame evidence', async () => {
-    let prompts: string[] = [];
+  it('requires Unicode alphanumeric span boundaries for grounded values', () => {
+    const frame: HydeSourceFrame = {
+      ...emptyFrame(),
+      namedEntities: [
+        { type: 'location', name: 'US', evidence: 'business' },
+        { type: 'location', name: 'us', evidence: 'the US' },
+        { type: 'other', name: 'क', evidence: 'कि' },
+      ],
+      domainVocabulary: [
+        { term: 'AI', evidence: 'raising' },
+        { term: 'ai', evidence: 'AI systems' },
+        { term: 'e', evidence: 'e\u0301' },
+      ],
+    };
+
+    expect(sanitizeHydeSourceFrame('Our business is raising in the US for AI systems, कि and e\u0301', frame)).toEqual({
+      ...emptyFrame(),
+      namedEntities: [{ type: 'location', name: 'us', evidence: 'the US' }],
+      domainVocabulary: [{ term: 'ai', evidence: 'AI systems' }],
+    });
+  });
+
+  it('does not infer source roles but retains source-supported counterpart role inference', () => {
+    const frame: HydeSourceFrame = {
+      ...emptyFrame(),
+      sourceRoles: [
+        { role: 'investor', evidence: 'founder' },
+        { role: 'senior founder', evidence: 'founder' },
+      ],
+      counterpartRoles: [{ role: 'investor', evidence: 'seeking funding' }],
+    };
+
+    expect(sanitizeHydeSourceFrame('A founder seeking funding', frame)).toEqual({
+      ...emptyFrame(),
+      sourceRoles: [{ role: 'senior founder', evidence: 'founder' }],
+      counterpartRoles: [{ role: 'investor', evidence: 'seeking funding' }],
+    });
+  });
+
+  it('uses profile context for lenses but excludes every profile-only token from frame extraction', async () => {
+    let lensPrompts: string[] = [];
+    let framePrompts: string[] = [];
+    const legacyModel: LensStructuredModel = {
+      async invoke(input) {
+        lensPrompts = messageText(input);
+        return { lenses: [inferredLens] };
+      },
+    };
     const frameModel: LensStructuredModel = {
       async invoke(input) {
-        prompts = messageText(input);
+        framePrompts = messageText(input);
         return {
-          lenses: [{ label: 'healthcare seed investor', corpus: 'profiles', reasoning: 'profile specialization' }],
           sourceFrame: {
             sourceRoles: [{ role: 'founder', evidence: 'founder' }],
             counterpartRoles: [{ role: 'investor', evidence: 'funding' }],
             hardConstraints: [{ type: 'location', value: 'Zurich', evidence: 'Zurich' }],
-            namedEntities: [{ type: 'organization', name: 'Profile Corp', evidence: 'Profile Corp' }],
-            domainVocabulary: [{ term: 'oncology', evidence: 'oncology' }],
+            namedEntities: [{ type: 'organization', name: 'ProfileCorp', evidence: 'ProfileCorp' }],
+            domainVocabulary: [{ term: 'Oncology', evidence: 'Oncology' }],
           },
         };
       },
     };
 
-    const result = await new LensInferrer({ frameModel }).infer({
-      sourceText: 'I am a founder seeking funding',
-      profileContext: 'Oncology operator at Profile Corp in Zurich',
+    const profileContext = 'Oncology operator at ProfileCorp in Zurich';
+    const sourceText = 'I am a founder seeking funding';
+    const result = await new LensInferrer({ legacyModel, frameModel }).infer({
+      sourceText,
+      profileContext,
       frameConstrained: true,
     });
 
-    expect(prompts.join('\n')).toContain('profileContext may specialize');
-    expect(prompts.join('\n')).toContain('Oncology operator at Profile Corp in Zurich');
-    expect(result.lenses[0]?.label).toBe('healthcare seed investor');
+    expect(lensPrompts.join('\n')).toContain(profileContext);
+    expect(framePrompts.join('\n')).toContain(sourceText);
+    for (const profileOnlyToken of ['Oncology', 'operator', 'ProfileCorp', 'Zurich']) {
+      expect(framePrompts.join('\n')).not.toContain(profileOnlyToken);
+    }
+    expect(result.lenses).toEqual([inferredLens]);
     expect(result.sourceFrame).toEqual({
       sourceRoles: [{ role: 'founder', evidence: 'founder' }],
       counterpartRoles: [{ role: 'investor', evidence: 'funding' }],
@@ -86,16 +161,94 @@ describe('HyDE source frame evidence boundary', () => {
     });
   });
 
-  it('uses a dedicated frame schema and prompt that allow reciprocal role inference', () => {
-    const parsed = FrameLensResponseSchema.parse({
-      lenses: [{ label: 'buyer', corpus: 'intents', reasoning: 'reciprocal target' }],
+  it('returns inferred lenses with an empty source frame when only frame extraction fails', async () => {
+    const legacyModel: LensStructuredModel = {
+      async invoke() {
+        return { lenses: [inferredLens] };
+      },
+    };
+    const frameModel: LensStructuredModel = {
+      async invoke() {
+        throw new Error('frame unavailable');
+      },
+    };
+
+    const result = await new LensInferrer({ legacyModel, frameModel }).infer({
+      sourceText: 'I am a founder seeking funding',
+      profileContext: 'Oncology operator',
+      frameConstrained: true,
+    });
+
+    expect(result).toEqual({ lenses: [inferredLens], sourceFrame: emptyFrame() });
+  });
+
+  it('preserves no-lenses behavior when legacy lens inference fails', async () => {
+    const legacyModel: LensStructuredModel = {
+      async invoke() {
+        throw new Error('lens unavailable');
+      },
+    };
+    const frameModel: LensStructuredModel = {
+      async invoke() {
+        return { sourceFrame: emptyFrame() };
+      },
+    };
+
+    const result = await new LensInferrer({ legacyModel, frameModel }).infer({
+      sourceText: 'I am a founder seeking funding',
+      frameConstrained: true,
+    });
+
+    expect(result).toEqual({ lenses: [] });
+  });
+
+  it('keeps the flag-off path on the legacy prompt and model only', async () => {
+    let legacyPrompts: string[] = [];
+    let frameCalls = 0;
+    const legacyModel: LensStructuredModel = {
+      async invoke(input) {
+        legacyPrompts = messageText(input);
+        return { lenses: [inferredLens] };
+      },
+    };
+    const frameModel: LensStructuredModel = {
+      async invoke() {
+        frameCalls += 1;
+        return { sourceFrame: emptyFrame() };
+      },
+    };
+
+    const result = await new LensInferrer({ legacyModel, frameModel }).infer({
+      sourceText: 'find investors',
+      profileContext: 'PROFILE_ONLY',
+      maxLenses: 2,
+      frameConstrained: false,
+    });
+
+    expect(legacyPrompts[0]).toContain('You analyze goals and search queries');
+    expect(legacyPrompts[1]).toBe(
+      'Identify up to 2 search perspectives for finding relevant matches.\n\nSource: "find investors"\n\nUser context: PROFILE_ONLY',
+    );
+    expect(frameCalls).toBe(0);
+    expect(result).toEqual({ lenses: [inferredLens] });
+  });
+
+  it('uses a frame-only schema that allows reciprocal role inference', () => {
+    const parsed = FrameResponseSchema.parse({
+      lenses: [{ label: 'buyer', corpus: 'intents', reasoning: 'must be ignored by the frame schema' }],
       sourceFrame: {
         sourceRoles: [{ role: 'seller', evidence: 'selling' }],
         counterpartRoles: [{ role: 'buyer', evidence: 'selling' }],
         hardConstraints: [], namedEntities: [], domainVocabulary: [],
       },
     });
-    expect(parsed.sourceFrame.counterpartRoles[0]?.role).toBe('buyer');
+    expect(parsed).toEqual({
+      sourceFrame: {
+        sourceRoles: [{ role: 'seller', evidence: 'selling' }],
+        counterpartRoles: [{ role: 'buyer', evidence: 'selling' }],
+        hardConstraints: [], namedEntities: [], domainVocabulary: [],
+      },
+    });
     expect(HydeSourceFrameSchema.safeParse(parsed.sourceFrame).success).toBe(true);
   });
 });

--- a/packages/protocol/src/shared/hyde/tests/hyde.frame.spec.ts
+++ b/packages/protocol/src/shared/hyde/tests/hyde.frame.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'bun:test';
+import type { BaseLanguageModelInput } from '@langchain/core/language_models/base';
+import type { BaseMessage } from '@langchain/core/messages';
+
+import { getHydeGenerationMode, HYDE_FRAME_GENERATION_VERSION } from '../hyde.env.js';
+import { HydeSourceFrameSchema, sanitizeHydeSourceFrame, type HydeSourceFrame } from '../hyde.frame.js';
+import { FrameLensResponseSchema, LensInferrer, type LensStructuredModel } from '../lens.inferrer.js';
+
+function messageText(input: BaseLanguageModelInput): string[] {
+  return (input as BaseMessage[]).map((message) => String(message.content));
+}
+
+describe('HyDE frame environment', () => {
+  it('enables frame-v1 only for the strict literal true', () => {
+    expect(getHydeGenerationMode('true')).toBe(HYDE_FRAME_GENERATION_VERSION);
+    for (const value of [undefined, '', 'false', 'TRUE', ' true', 'true ']) {
+      expect(getHydeGenerationMode(value)).toBe('legacy');
+    }
+  });
+});
+
+describe('HyDE source frame evidence boundary', () => {
+  it('drops every element without case-insensitive exact source evidence', () => {
+    const frame: HydeSourceFrame = {
+      sourceRoles: [
+        { role: 'founder', evidence: 'FOUNDER' },
+        { role: 'doctor', evidence: 'medical profile' },
+      ],
+      counterpartRoles: [{ role: 'investor', evidence: 'seed funding' }],
+      hardConstraints: [
+        { type: 'location', value: 'Berlin', evidence: 'Berlin' },
+        { type: 'numeric', value: '$2m', evidence: '$2m' },
+      ],
+      namedEntities: [
+        { type: 'location', name: 'Berlin', evidence: 'Berlin' },
+        { type: 'organization', name: 'Profile Corp', evidence: 'Profile Corp' },
+      ],
+      domainVocabulary: [
+        { term: 'climate tech', evidence: 'climate tech' },
+        { term: 'oncology', evidence: 'oncology' },
+      ],
+    };
+
+    expect(sanitizeHydeSourceFrame('Founder seeking seed funding for climate tech in berlin', frame)).toEqual({
+      sourceRoles: [{ role: 'founder', evidence: 'FOUNDER' }],
+      counterpartRoles: [{ role: 'investor', evidence: 'seed funding' }],
+      hardConstraints: [{ type: 'location', value: 'Berlin', evidence: 'Berlin' }],
+      namedEntities: [{ type: 'location', name: 'Berlin', evidence: 'Berlin' }],
+      domainVocabulary: [{ term: 'climate tech', evidence: 'climate tech' }],
+    });
+  });
+
+  it('allows profile context to shape lenses but never to survive as frame evidence', async () => {
+    let prompts: string[] = [];
+    const frameModel: LensStructuredModel = {
+      async invoke(input) {
+        prompts = messageText(input);
+        return {
+          lenses: [{ label: 'healthcare seed investor', corpus: 'profiles', reasoning: 'profile specialization' }],
+          sourceFrame: {
+            sourceRoles: [{ role: 'founder', evidence: 'founder' }],
+            counterpartRoles: [{ role: 'investor', evidence: 'funding' }],
+            hardConstraints: [{ type: 'location', value: 'Zurich', evidence: 'Zurich' }],
+            namedEntities: [{ type: 'organization', name: 'Profile Corp', evidence: 'Profile Corp' }],
+            domainVocabulary: [{ term: 'oncology', evidence: 'oncology' }],
+          },
+        };
+      },
+    };
+
+    const result = await new LensInferrer({ frameModel }).infer({
+      sourceText: 'I am a founder seeking funding',
+      profileContext: 'Oncology operator at Profile Corp in Zurich',
+      frameConstrained: true,
+    });
+
+    expect(prompts.join('\n')).toContain('profileContext may specialize');
+    expect(prompts.join('\n')).toContain('Oncology operator at Profile Corp in Zurich');
+    expect(result.lenses[0]?.label).toBe('healthcare seed investor');
+    expect(result.sourceFrame).toEqual({
+      sourceRoles: [{ role: 'founder', evidence: 'founder' }],
+      counterpartRoles: [{ role: 'investor', evidence: 'funding' }],
+      hardConstraints: [],
+      namedEntities: [],
+      domainVocabulary: [],
+    });
+  });
+
+  it('uses a dedicated frame schema and prompt that allow reciprocal role inference', () => {
+    const parsed = FrameLensResponseSchema.parse({
+      lenses: [{ label: 'buyer', corpus: 'intents', reasoning: 'reciprocal target' }],
+      sourceFrame: {
+        sourceRoles: [{ role: 'seller', evidence: 'selling' }],
+        counterpartRoles: [{ role: 'buyer', evidence: 'selling' }],
+        hardConstraints: [], namedEntities: [], domainVocabulary: [],
+      },
+    });
+    expect(parsed.sourceFrame.counterpartRoles[0]?.role).toBe('buyer');
+    expect(HydeSourceFrameSchema.safeParse(parsed.sourceFrame).success).toBe(true);
+  });
+});

--- a/packages/protocol/src/shared/hyde/tests/hyde.graph.frame.spec.ts
+++ b/packages/protocol/src/shared/hyde/tests/hyde.graph.frame.spec.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'bun:test';
 
+import { computeHydeSourceTextHash, selectHydeDocumentsForGeneration } from '../hyde.documents.js';
 import { HydeGraphFactory, type HydeGeneratorLike, type HydeLensInferrerLike, type HydeValidatorLike } from '../hyde.graph.js';
 import type { HydeCache } from '../../interfaces/cache.interface.js';
 import type { CreateHydeDocumentData, HydeDocument, HydeGraphDatabase } from '../../interfaces/database.interface.js';
 import type { EmbeddingGenerator } from '../../interfaces/embedder.interface.js';
+import { requestContext } from '../../observability/request-context.js';
 
 const sourceFrame = {
   sourceRoles: [{ role: 'founder', evidence: 'founder' }],
@@ -104,11 +106,14 @@ function makeHarness(overrides: {
   return { graph, cache, saved, stored, embedCalls, get generatorCalls() { return generatorCalls; } };
 }
 
-async function invoke(graph: ReturnType<HydeGraphFactory['createGraph']>) {
+async function invoke(
+  graph: ReturnType<HydeGraphFactory['createGraph']>,
+  sourceText = 'climate founder seeking funding',
+) {
   return graph.invoke({
     sourceType: 'intent' as const,
     sourceId: 'intent-1',
-    sourceText: 'climate founder seeking funding',
+    sourceText,
   });
 }
 
@@ -118,18 +123,25 @@ describe('HyDE frame-v1 graph validation', () => {
       async validate(input) {
         expect(Object.keys(input.documents)).toHaveLength(2);
         return {
-          verdicts: Object.entries(input.documents).map(([key, doc]) => ({
-            key,
-            valid: doc.lens === 'climate investor',
-            unsupportedNamedEntities: doc.lens === 'climate investor' ? [] : ['InventedCo'],
-            unsupportedHardConstraints: [],
-            reasoning: doc.lens === 'climate investor' ? 'Grounded.' : 'Invented proper noun.',
-          })),
+          verdicts: Object.entries(input.documents).map(([key, doc]) => {
+            expect('lens' in doc).toBe(false);
+            const valid = doc.corpus === 'profiles';
+            return {
+              key,
+              valid,
+              unsupportedNamedEntities: valid ? [] : ['InventedCo'],
+              unsupportedHardConstraints: [],
+              reasoning: valid ? 'Grounded.' : 'Invented proper noun.',
+            };
+          }),
         };
       },
     };
     const harness = makeHarness({ validator });
-    const result = await invoke(harness.graph);
+    const events: Array<Record<string, unknown>> = [];
+    const result = await requestContext.run({
+      traceEmitter: (event) => events.push(event as unknown as Record<string, unknown>),
+    }, () => invoke(harness.graph));
 
     expect(Object.keys(result.hydeDocuments)).toEqual(['climate investor']);
     expect(result.hydeDocuments['climate investor']?.validationStatus).toBe('valid');
@@ -141,7 +153,13 @@ describe('HyDE frame-v1 graph validation', () => {
       hydeGenerationVersion: 'frame-v1',
       lensLabel: 'climate investor',
       validationStatus: 'valid',
+      frameFingerprint: expect.any(String),
+      sourceTextHash: computeHydeSourceTextHash('climate founder seeking funding'),
+      generatedAt: expect.any(String),
     });
+    expect(result.hydeDocuments['climate investor']?.generatedAt).toBe(harness.saved[0]?.context?.generatedAt);
+    expect(events.find((event) => event.type === 'agent_end' && event.name === 'hyde-validator')?.summary)
+      .toBe('1 valid, 1 rejected, 0 failed open');
   });
 
   it('does not call the embedder or persist when all generated docs are rejected', async () => {
@@ -190,11 +208,66 @@ describe('HyDE frame-v1 graph validation', () => {
         },
       },
     });
-    const result = await invoke(harness.graph);
+    const events: Array<Record<string, unknown>> = [];
+    const result = await requestContext.run({
+      traceEmitter: (event) => events.push(event as unknown as Record<string, unknown>),
+    }, () => invoke(harness.graph));
 
     expect(Object.values(result.hydeDocuments).map((doc) => doc.validationStatus)).toEqual(['failed_open', 'failed_open']);
     expect(harness.cache.sets).toEqual([]);
     expect(harness.saved).toEqual([]);
+    expect(events.find((event) => event.type === 'agent_end' && event.name === 'hyde-validator')?.summary)
+      .toBe('0 valid, 0 rejected, 2 failed open');
+  });
+
+  it('fails open when invalid verdicts name no unsupported entity or hard constraint', async () => {
+    const harness = makeHarness({
+      validator: {
+        async validate(input) {
+          return { verdicts: Object.keys(input.documents).map((key) => ({
+            key,
+            valid: false,
+            unsupportedNamedEntities: [],
+            unsupportedHardConstraints: [],
+            reasoning: 'Rejected for an out-of-scope stylistic reason.',
+          })) };
+        },
+      },
+    });
+    const result = await invoke(harness.graph);
+
+    expect(Object.values(result.hydeDocuments).every((doc) => doc.validationStatus === 'failed_open')).toBe(true);
+    expect(harness.embedCalls).toHaveLength(1);
+    expect(harness.cache.sets).toEqual([]);
+    expect(harness.saved).toEqual([]);
+  });
+
+  it('records content-free validator traces and timing metadata', async () => {
+    const harness = makeHarness({
+      validator: {
+        async validate(input) {
+          return { verdicts: Object.keys(input.documents).map((key) => ({
+            key,
+            valid: true,
+            unsupportedNamedEntities: [],
+            unsupportedHardConstraints: [],
+            reasoning: 'Grounded.',
+          })) };
+        },
+      },
+    });
+    const events: Array<Record<string, unknown>> = [];
+    const result = await requestContext.run({
+      traceEmitter: (event) => events.push(event as unknown as Record<string, unknown>),
+    }, () => invoke(harness.graph));
+
+    const validatorEvents = events.filter((event) => event.name === 'hyde-validator');
+    expect(validatorEvents.map((event) => event.type)).toEqual(['agent_start', 'agent_end']);
+    expect(JSON.stringify(validatorEvents)).not.toContain('climate founder seeking funding');
+    expect(JSON.stringify(validatorEvents)).not.toContain('generated climate investor');
+    expect(JSON.stringify(validatorEvents)).not.toContain('climate investor');
+    expect(validatorEvents[1]?.summary).toBe('2 valid, 0 rejected, 0 failed open');
+    expect(result.agentTimings.some((timing) => timing.name === 'hyde.validator')).toBe(true);
   });
 });
 
@@ -244,11 +317,23 @@ describe('HyDE cache and DB isolation', () => {
     const graphInput = { sourceType: 'intent' as const, sourceId: 'intent-1', sourceText: 'climate founder seeking funding' };
 
     const legacyGraph = new HydeGraphFactory(database, embedder, cache, inferrer, generator, { mode: 'legacy' }).createGraph();
-    const legacy = await legacyGraph.invoke(graphInput);
+    const legacyTrace: string[] = [];
+    const legacy = await requestContext.run({
+      traceEmitter: (event) => {
+        if ('name' in event) legacyTrace.push(`${event.type}:${event.name}`);
+      },
+    }, () => legacyGraph.invoke(graphInput));
     const legacyKey = cache.sets[0]!;
     const legacyStrategy = databaseSaved[0]!.strategy;
-    expect(legacyKey).toMatch(/^hyde:intent:intent-1:/);
-    expect(legacyStrategy.startsWith('frame-v1:')).toBe(false);
+    expect(legacyKey).toBe('hyde:intent:intent-1:db44edbe924a1926');
+    expect(legacyStrategy).toBe('db44edbe924a1926');
+    expect(legacyTrace).toEqual([
+      'agent_start:lens-inferrer',
+      'agent_end:lens-inferrer',
+      'agent_start:hyde-generator',
+      'agent_end:hyde-generator',
+    ]);
+    expect(legacy.agentTimings.some((timing) => timing.name === 'hyde.validator')).toBe(false);
 
     const frameGraph = new HydeGraphFactory(database, embedder, cache, inferrer, generator, { mode: 'frame-v1', validator }).createGraph();
     const frame = await frameGraph.invoke(graphInput);
@@ -259,9 +344,19 @@ describe('HyDE cache and DB isolation', () => {
 
     const frameCached = await frameGraph.invoke(graphInput);
     expect(frameCached.hydeDocuments['climate investor']?.origin).toBe('cache');
+    expect(frameCached.hydeDocuments['climate investor']?.generatedAt)
+      .toBe(frame.hydeDocuments['climate investor']?.generatedAt);
     expect(validationCalls).toBe(1);
     expect(generationCalls).toBe(2);
     expect(embedCalls).toBe(2);
+
+    cache.values.delete(frameKey);
+    const frameFromDb = await frameGraph.invoke(graphInput);
+    expect(frameFromDb.hydeDocuments['climate investor']?.origin).toBe('db');
+    expect(frameFromDb.hydeDocuments['climate investor']?.generatedAt)
+      .toBe(frame.hydeDocuments['climate investor']?.generatedAt);
+    expect(validationCalls).toBe(1);
+    expect(generationCalls).toBe(2);
 
     const rolledBack = await legacyGraph.invoke(graphInput);
     expect(rolledBack.hydeDocuments['climate investor']?.hydeText).toBe(legacy.hydeDocuments['climate investor']?.hydeText);
@@ -269,5 +364,115 @@ describe('HyDE cache and DB isolation', () => {
     expect(cache.values.has(legacyKey)).toBe(true);
     expect(cache.values.has(frameKey)).toBe(true);
     expect(databaseSaved.some((data) => data.strategy.startsWith('frame-v1:') && data.context?.validationStatus === 'valid')).toBe(true);
+  });
+
+  it('assigns one generation marker to retained cache hits and newly generated docs', async () => {
+    const harness = makeHarness({
+      validator: {
+        async validate(input) {
+          return { verdicts: Object.keys(input.documents).map((key) => ({
+            key,
+            valid: true,
+            unsupportedNamedEntities: [],
+            unsupportedHardConstraints: [],
+            reasoning: 'Grounded.',
+          })) };
+        },
+      },
+    });
+    const sourceText = 'climate founder seeking funding';
+    await invoke(harness.graph, sourceText);
+
+    const [, newerCacheKey] = [...harness.cache.values.keys()];
+    const newerCached = harness.cache.values.get(newerCacheKey!) as { generatedAt?: string };
+    const newerMarker = new Date(Date.parse(newerCached.generatedAt!) + 1).toISOString();
+    harness.cache.values.set(newerCacheKey!, { ...newerCached, generatedAt: newerMarker });
+    const savedBeforeMixedRun = harness.saved.length;
+
+    await invoke(harness.graph, sourceText);
+    const mixedRunWrites = harness.saved.slice(savedBeforeMixedRun);
+    const markers = mixedRunWrites.map((row) => row.context?.generatedAt);
+
+    expect(harness.generatorCalls).toBe(3);
+    expect(mixedRunWrites).toHaveLength(2);
+    expect(new Set(markers).size).toBe(1);
+    expect(markers[0]).toEqual(expect.any(String));
+    expect(selectHydeDocumentsForGeneration(
+      [...harness.stored.values()],
+      'frame-v1',
+      sourceText,
+    )).toHaveLength(2);
+  });
+
+  it('does not reuse frame-v1 DB rows without the current frame fingerprint', async () => {
+    const harness = makeHarness({
+      validator: {
+        async validate(input) {
+          return { verdicts: Object.keys(input.documents).map((key) => ({
+            key,
+            valid: true,
+            unsupportedNamedEntities: [],
+            unsupportedHardConstraints: [],
+            reasoning: 'Grounded.',
+          })) };
+        },
+      },
+    });
+
+    await invoke(harness.graph);
+    for (const [strategy, row] of harness.stored) {
+      harness.stored.set(strategy, {
+        ...row,
+        context: row.context ? { ...row.context, frameFingerprint: undefined } : null,
+      });
+    }
+    harness.cache.values.clear();
+    await invoke(harness.graph);
+
+    expect(harness.generatorCalls).toBe(4);
+    expect(harness.saved).toHaveLength(4);
+  });
+
+  it('keeps stable DB strategies while replacing source-bound frame metadata after source edits', async () => {
+    const harness = makeHarness({
+      validator: {
+        async validate(input) {
+          return { verdicts: Object.keys(input.documents).map((key) => ({
+            key,
+            valid: true,
+            unsupportedNamedEntities: [],
+            unsupportedHardConstraints: [],
+            reasoning: 'Grounded.',
+          })) };
+        },
+      },
+    });
+
+    const firstSourceText = 'climate founder seeking funding';
+    const secondSourceText = 'climate founder still seeking funding';
+    const first = await invoke(harness.graph, firstSourceText);
+    const firstSaved = harness.saved.slice(0, 2);
+    harness.cache.values.clear();
+    const second = await invoke(harness.graph, secondSourceText);
+    const secondSaved = harness.saved.slice(2, 4);
+
+    expect(first.hydeDocuments['climate investor']?.targetCorpus).toBe('profiles');
+    expect(second.hydeDocuments['climate investor']?.targetCorpus).toBe('profiles');
+    expect(harness.generatorCalls).toBe(4);
+    expect(harness.saved).toHaveLength(4);
+    expect(firstSaved.map((doc) => doc.strategy).sort())
+      .toEqual(secondSaved.map((doc) => doc.strategy).sort());
+    expect(firstSaved.every((doc) => /^frame-v1:[a-f0-9]{16}$/.test(doc.strategy))).toBe(true);
+
+    const firstFingerprint = firstSaved[0]?.context?.frameFingerprint;
+    const secondFingerprint = secondSaved[0]?.context?.frameFingerprint;
+    expect(firstFingerprint).toEqual(expect.any(String));
+    expect(secondFingerprint).toEqual(expect.any(String));
+    expect(secondFingerprint).not.toBe(firstFingerprint);
+    expect(firstSaved.every((doc) => doc.context?.sourceTextHash === computeHydeSourceTextHash(firstSourceText))).toBe(true);
+    expect(secondSaved.every((doc) => doc.context?.sourceTextHash === computeHydeSourceTextHash(secondSourceText))).toBe(true);
+    expect(new Set(firstSaved.map((doc) => doc.context?.generatedAt)).size).toBe(1);
+    expect(new Set(secondSaved.map((doc) => doc.context?.generatedAt)).size).toBe(1);
+    expect(secondSaved[0]?.context?.generatedAt).not.toBe(firstSaved[0]?.context?.generatedAt);
   });
 });

--- a/packages/protocol/src/shared/hyde/tests/hyde.graph.frame.spec.ts
+++ b/packages/protocol/src/shared/hyde/tests/hyde.graph.frame.spec.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it } from 'bun:test';
+
+import { HydeGraphFactory, type HydeGeneratorLike, type HydeLensInferrerLike, type HydeValidatorLike } from '../hyde.graph.js';
+import type { HydeCache } from '../../interfaces/cache.interface.js';
+import type { CreateHydeDocumentData, HydeDocument, HydeGraphDatabase } from '../../interfaces/database.interface.js';
+import type { EmbeddingGenerator } from '../../interfaces/embedder.interface.js';
+
+const sourceFrame = {
+  sourceRoles: [{ role: 'founder', evidence: 'founder' }],
+  counterpartRoles: [{ role: 'investor', evidence: 'funding' }],
+  hardConstraints: [],
+  namedEntities: [],
+  domainVocabulary: [{ term: 'climate', evidence: 'climate' }],
+};
+
+const lenses = [
+  { label: 'climate investor', corpus: 'profiles' as const, reasoning: 'capital' },
+  { label: 'funding climate companies', corpus: 'intents' as const, reasoning: 'reciprocal goal' },
+];
+
+class MemoryCache implements HydeCache {
+  readonly values = new Map<string, unknown>();
+  readonly gets: string[] = [];
+  readonly sets: string[] = [];
+
+  async get<T>(key: string): Promise<T | null> {
+    this.gets.push(key);
+    return (this.values.get(key) as T | undefined) ?? null;
+  }
+  async set<T>(key: string, value: T): Promise<void> {
+    this.sets.push(key);
+    this.values.set(key, value);
+  }
+  async delete(key: string): Promise<boolean> { return this.values.delete(key); }
+  async exists(key: string): Promise<boolean> { return this.values.has(key); }
+}
+
+function makeHarness(overrides: {
+  selectedLenses?: typeof lenses;
+  validator: HydeValidatorLike;
+  cache?: MemoryCache;
+  stored?: Map<string, HydeDocument>;
+}) {
+  const cache = overrides.cache ?? new MemoryCache();
+  const saved: CreateHydeDocumentData[] = [];
+  const stored = overrides.stored ?? new Map<string, HydeDocument>();
+  const embedCalls: string[][] = [];
+  let generatorCalls = 0;
+
+  const database = {
+    async getHydeDocument(_sourceType: string, _sourceId: string, strategy: string) {
+      return stored.get(strategy) ?? null;
+    },
+    async getHydeDocumentsForSource() { return []; },
+    async saveHydeDocument(data: CreateHydeDocumentData) {
+      saved.push(data);
+      const row: HydeDocument = {
+        id: `row-${saved.length}`,
+        sourceType: data.sourceType,
+        sourceId: data.sourceId ?? null,
+        sourceText: data.sourceText ?? null,
+        strategy: data.strategy,
+        targetCorpus: data.targetCorpus,
+        hydeText: data.hydeText,
+        hydeEmbedding: data.hydeEmbedding,
+        context: data.context ?? null,
+        createdAt: new Date(0),
+        expiresAt: data.expiresAt ?? null,
+      };
+      stored.set(data.strategy, row);
+      return row;
+    },
+    async getIntent() { return null; },
+  } as unknown as HydeGraphDatabase;
+
+  const embedder: EmbeddingGenerator = {
+    async generate(text) {
+      const texts = Array.isArray(text) ? text : [text];
+      embedCalls.push(texts);
+      const vectors = texts.map((_, index) => [index + 1, index + 2]);
+      return Array.isArray(text) ? vectors : vectors[0] ?? [];
+    },
+  };
+
+  const inferrer: HydeLensInferrerLike = {
+    async infer(input) {
+      expect(input.frameConstrained).toBe(true);
+      return { lenses: overrides.selectedLenses ?? lenses, sourceFrame };
+    },
+  };
+  const generator: HydeGeneratorLike = {
+    async generate(input) {
+      generatorCalls += 1;
+      expect(input.sourceFrame).toEqual(sourceFrame);
+      return { text: `generated ${input.lens}` };
+    },
+  };
+
+  const graph = new HydeGraphFactory(database, embedder, cache, inferrer, generator, {
+    mode: 'frame-v1',
+    validator: overrides.validator,
+  }).createGraph();
+
+  return { graph, cache, saved, stored, embedCalls, get generatorCalls() { return generatorCalls; } };
+}
+
+async function invoke(graph: ReturnType<HydeGraphFactory['createGraph']>) {
+  return graph.invoke({
+    sourceType: 'intent' as const,
+    sourceId: 'intent-1',
+    sourceText: 'climate founder seeking funding',
+  });
+}
+
+describe('HyDE frame-v1 graph validation', () => {
+  it('partially rejects invalid docs before embedding, output, cache, and DB', async () => {
+    const validator: HydeValidatorLike = {
+      async validate(input) {
+        expect(Object.keys(input.documents)).toHaveLength(2);
+        return {
+          verdicts: Object.entries(input.documents).map(([key, doc]) => ({
+            key,
+            valid: doc.lens === 'climate investor',
+            unsupportedNamedEntities: doc.lens === 'climate investor' ? [] : ['InventedCo'],
+            unsupportedHardConstraints: [],
+            reasoning: doc.lens === 'climate investor' ? 'Grounded.' : 'Invented proper noun.',
+          })),
+        };
+      },
+    };
+    const harness = makeHarness({ validator });
+    const result = await invoke(harness.graph);
+
+    expect(Object.keys(result.hydeDocuments)).toEqual(['climate investor']);
+    expect(result.hydeDocuments['climate investor']?.validationStatus).toBe('valid');
+    expect(harness.embedCalls).toEqual([['generated climate investor']]);
+    expect(harness.cache.sets).toHaveLength(1);
+    expect(harness.saved).toHaveLength(1);
+    expect(harness.saved[0]?.strategy.startsWith('frame-v1:')).toBe(true);
+    expect(harness.saved[0]?.context).toEqual({
+      hydeGenerationVersion: 'frame-v1',
+      lensLabel: 'climate investor',
+      validationStatus: 'valid',
+    });
+  });
+
+  it('does not call the embedder or persist when all generated docs are rejected', async () => {
+    const harness = makeHarness({
+      validator: {
+        async validate(input) {
+          return { verdicts: Object.keys(input.documents).map((key) => ({
+            key,
+            valid: false,
+            unsupportedNamedEntities: [],
+            unsupportedHardConstraints: ['invented deadline'],
+            reasoning: 'Unsupported hard constraint.',
+          })) };
+        },
+      },
+    });
+    const result = await invoke(harness.graph);
+
+    expect(result.hydeDocuments).toEqual({});
+    expect(result.hydeEmbeddings).toEqual({});
+    expect(harness.embedCalls).toEqual([]);
+    expect(harness.cache.sets).toEqual([]);
+    expect(harness.saved).toEqual([]);
+  });
+
+  it('fails open for retrieval on validator infrastructure failure but never persists', async () => {
+    const harness = makeHarness({
+      validator: { async validate() { throw new Error('validator unavailable'); } },
+    });
+    const result = await invoke(harness.graph);
+
+    expect(Object.keys(result.hydeDocuments)).toHaveLength(2);
+    expect(Object.values(result.hydeDocuments).every((doc) => doc.validationStatus === 'failed_open')).toBe(true);
+    expect(harness.embedCalls).toHaveLength(1);
+    expect(harness.cache.sets).toEqual([]);
+    expect(harness.saved).toEqual([]);
+  });
+
+  it('fails open per affected doc for duplicate and missing verdicts without persistence', async () => {
+    const harness = makeHarness({
+      validator: {
+        async validate(input) {
+          const firstKey = Object.keys(input.documents)[0]!;
+          const verdict = { key: firstKey, valid: true, unsupportedNamedEntities: [], unsupportedHardConstraints: [], reasoning: 'Grounded.' };
+          return { verdicts: [verdict, verdict] };
+        },
+      },
+    });
+    const result = await invoke(harness.graph);
+
+    expect(Object.values(result.hydeDocuments).map((doc) => doc.validationStatus)).toEqual(['failed_open', 'failed_open']);
+    expect(harness.cache.sets).toEqual([]);
+    expect(harness.saved).toEqual([]);
+  });
+});
+
+describe('HyDE cache and DB isolation', () => {
+  it('keeps legacy data untouched, namespaces frame-v1, and bypasses validation for validated cache hits', async () => {
+    const cache = new MemoryCache();
+    const stored = new Map<string, HydeDocument>();
+    const databaseSaved: CreateHydeDocumentData[] = [];
+    let generationCalls = 0;
+    let validationCalls = 0;
+    let embedCalls = 0;
+
+    const database = {
+      async getHydeDocument(_type: string, _id: string, strategy: string) { return stored.get(strategy) ?? null; },
+      async getHydeDocumentsForSource() { return []; },
+      async saveHydeDocument(data: CreateHydeDocumentData) {
+        databaseSaved.push(data);
+        const row = { id: data.strategy, sourceType: data.sourceType, sourceId: data.sourceId ?? null, sourceText: null, strategy: data.strategy, targetCorpus: data.targetCorpus, hydeText: data.hydeText, hydeEmbedding: data.hydeEmbedding, context: data.context ?? null, createdAt: new Date(0), expiresAt: null } as HydeDocument;
+        stored.set(data.strategy, row);
+        return row;
+      },
+      async getIntent() { return null; },
+    } as unknown as HydeGraphDatabase;
+    const embedder: EmbeddingGenerator = {
+      async generate(text) {
+        embedCalls += 1;
+        return Array.isArray(text) ? text.map(() => [1, 2]) : [1, 2];
+      },
+    };
+    const inferrer: HydeLensInferrerLike = {
+      async infer(input) {
+        return {
+          lenses: [lenses[0]],
+          ...(input.frameConstrained ? { sourceFrame } : {}),
+        };
+      },
+    };
+    const generator: HydeGeneratorLike = {
+      async generate(input) { generationCalls += 1; return { text: `${input.sourceFrame ? 'frame' : 'legacy'} output` }; },
+    };
+    const validator: HydeValidatorLike = {
+      async validate(input) {
+        validationCalls += 1;
+        return { verdicts: Object.keys(input.documents).map((key) => ({ key, valid: true, unsupportedNamedEntities: [], unsupportedHardConstraints: [], reasoning: 'Grounded.' })) };
+      },
+    };
+    const graphInput = { sourceType: 'intent' as const, sourceId: 'intent-1', sourceText: 'climate founder seeking funding' };
+
+    const legacyGraph = new HydeGraphFactory(database, embedder, cache, inferrer, generator, { mode: 'legacy' }).createGraph();
+    const legacy = await legacyGraph.invoke(graphInput);
+    const legacyKey = cache.sets[0]!;
+    const legacyStrategy = databaseSaved[0]!.strategy;
+    expect(legacyKey).toMatch(/^hyde:intent:intent-1:/);
+    expect(legacyStrategy.startsWith('frame-v1:')).toBe(false);
+
+    const frameGraph = new HydeGraphFactory(database, embedder, cache, inferrer, generator, { mode: 'frame-v1', validator }).createGraph();
+    const frame = await frameGraph.invoke(graphInput);
+    const frameKey = cache.sets.find((key) => key.startsWith('hyde:frame-v1:'))!;
+    expect(frameKey).toMatch(/^hyde:frame-v1:intent:intent-1:/);
+    expect(frame.hydeDocuments['climate investor']?.hydeText).toBe('frame output');
+    expect(validationCalls).toBe(1);
+
+    const frameCached = await frameGraph.invoke(graphInput);
+    expect(frameCached.hydeDocuments['climate investor']?.origin).toBe('cache');
+    expect(validationCalls).toBe(1);
+    expect(generationCalls).toBe(2);
+    expect(embedCalls).toBe(2);
+
+    const rolledBack = await legacyGraph.invoke(graphInput);
+    expect(rolledBack.hydeDocuments['climate investor']?.hydeText).toBe(legacy.hydeDocuments['climate investor']?.hydeText);
+    expect(generationCalls).toBe(2);
+    expect(cache.values.has(legacyKey)).toBe(true);
+    expect(cache.values.has(frameKey)).toBe(true);
+    expect(databaseSaved.some((data) => data.strategy.startsWith('frame-v1:') && data.context?.validationStatus === 'valid')).toBe(true);
+  });
+});

--- a/packages/protocol/src/shared/hyde/tests/hyde.prompts-validator.spec.ts
+++ b/packages/protocol/src/shared/hyde/tests/hyde.prompts-validator.spec.ts
@@ -26,7 +26,7 @@ describe('frame-constrained HyDE generation prompt', () => {
   it('renders all frame slots and the allowed/forbidden elaboration boundary', () => {
     const prompt = buildFrameHydePrompt({
       sourceText: 'Acme Labs climate founder seeks €2m seed funding for carbon removal in Berlin',
-      lens: 'climate seed investor',
+      lens: 'ProfileCorp Zurich €9m specialist',
       corpus: 'profiles',
       sourceFrame: frame,
     });
@@ -41,6 +41,8 @@ describe('frame-constrained HyDE generation prompt', () => {
     expect(prompt).toContain('reciprocal/complementary inversion');
     expect(prompt).toContain('MUST NOT introduce any new proper noun');
     expect(prompt).toContain('MUST NOT introduce any new hard location, time, numeric, credential, organization, or exclusivity constraint');
+    expect(prompt).not.toContain('ProfileCorp Zurich €9m specialist');
+    expect(prompt).not.toContain('Target lens');
   });
 
   it('retains the exact legacy corpus prompt when sourceFrame is absent', async () => {
@@ -78,8 +80,8 @@ describe('HyDE validator', () => {
       sourceText: 'climate founder seeks funding',
       sourceFrame: { ...frame, namedEntities: [], hardConstraints: [] },
       documents: {
-        'd-a': { lens: 'investor', corpus: 'profiles', text: 'I invest in climate companies.' },
-        'd-b': { lens: 'investor', corpus: 'profiles', text: 'I work at NewCo in Paris.' },
+        'd-a': { corpus: 'profiles', text: 'I invest in climate companies.' },
+        'd-b': { corpus: 'profiles', text: 'I work at NewCo in Paris.' },
       },
     });
 
@@ -100,9 +102,10 @@ describe('HyDE validator', () => {
     const prompt = buildHydeValidationPrompt({
       sourceText: 'source',
       sourceFrame: frame,
-      documents: { 'd-opaque': { lens: 'investor', corpus: 'profiles', text: 'generated' } },
+      documents: { 'd-opaque': { corpus: 'profiles', text: 'generated' } },
     });
     expect(prompt).toContain('d-opaque');
     expect(prompt).not.toContain('profileContext');
+    expect(prompt).not.toContain('specialized profile-only lens');
   });
 });

--- a/packages/protocol/src/shared/hyde/tests/hyde.prompts-validator.spec.ts
+++ b/packages/protocol/src/shared/hyde/tests/hyde.prompts-validator.spec.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'bun:test';
+import type { BaseLanguageModelInput } from '@langchain/core/language_models/base';
+import type { BaseMessage } from '@langchain/core/messages';
+
+import { buildFrameHydePrompt, HydeGenerator, type HydeGeneratorStructuredModel } from '../hyde.generator.js';
+import type { HydeSourceFrame } from '../hyde.frame.js';
+import { HYDE_CORPUS_PROMPTS } from '../hyde.strategies.js';
+import { buildHydeValidationPrompt, HydeValidationResponseSchema, HydeValidator, type HydeValidatorStructuredModel } from '../hyde.validator.js';
+
+const frame: HydeSourceFrame = {
+  sourceRoles: [{ role: 'climate founder', evidence: 'climate founder' }],
+  counterpartRoles: [{ role: 'investor', evidence: 'seed funding' }],
+  hardConstraints: [
+    { type: 'location', value: 'Berlin', evidence: 'Berlin' },
+    { type: 'numeric', value: '€2m', evidence: '€2m' },
+  ],
+  namedEntities: [{ type: 'organization', name: 'Acme Labs', evidence: 'Acme Labs' }],
+  domainVocabulary: [{ term: 'carbon removal', evidence: 'carbon removal' }],
+};
+
+function messages(input: BaseLanguageModelInput): BaseMessage[] {
+  return input as BaseMessage[];
+}
+
+describe('frame-constrained HyDE generation prompt', () => {
+  it('renders all frame slots and the allowed/forbidden elaboration boundary', () => {
+    const prompt = buildFrameHydePrompt({
+      sourceText: 'Acme Labs climate founder seeks €2m seed funding for carbon removal in Berlin',
+      lens: 'climate seed investor',
+      corpus: 'profiles',
+      sourceFrame: frame,
+    });
+
+    expect(prompt).toContain('Source roles: climate founder');
+    expect(prompt).toContain('Counterpart/complementary roles: investor');
+    expect(prompt).toContain('location: Berlin');
+    expect(prompt).toContain('numeric: €2m');
+    expect(prompt).toContain('organization: Acme Labs');
+    expect(prompt).toContain('carbon removal');
+    expect(prompt).toContain('generic roles');
+    expect(prompt).toContain('reciprocal/complementary inversion');
+    expect(prompt).toContain('MUST NOT introduce any new proper noun');
+    expect(prompt).toContain('MUST NOT introduce any new hard location, time, numeric, credential, organization, or exclusivity constraint');
+  });
+
+  it('retains the exact legacy corpus prompt when sourceFrame is absent', async () => {
+    let humanPrompt = '';
+    const model: HydeGeneratorStructuredModel = {
+      async invoke(input) {
+        humanPrompt = String(messages(input)[1]?.content);
+        return { hypotheticalDocument: 'legacy output' };
+      },
+    };
+    const input = { sourceText: 'Need a React co-founder', lens: 'frontend engineer', corpus: 'profiles' as const };
+    const result = await new HydeGenerator(model).generate(input);
+
+    expect(humanPrompt).toBe(HYDE_CORPUS_PROMPTS.profiles(input.sourceText, input.lens));
+    expect(result).toEqual({ text: 'legacy output' });
+  });
+});
+
+describe('HyDE validator', () => {
+  it('parses valid and invalid verdicts from one provider-free batch call', async () => {
+    let rendered = '';
+    const model: HydeValidatorStructuredModel = {
+      async invoke(input) {
+        rendered = messages(input).map((message) => String(message.content)).join('\n');
+        return {
+          verdicts: [
+            { key: 'd-a', valid: true, unsupportedNamedEntities: [], unsupportedHardConstraints: [], reasoning: 'Grounded.' },
+            { key: 'd-b', valid: false, unsupportedNamedEntities: ['NewCo'], unsupportedHardConstraints: ['must be in Paris'], reasoning: 'Invented constraints.' },
+          ],
+        };
+      },
+    };
+    const validator = new HydeValidator(model);
+    const result = await validator.validate({
+      sourceText: 'climate founder seeks funding',
+      sourceFrame: { ...frame, namedEntities: [], hardConstraints: [] },
+      documents: {
+        'd-a': { lens: 'investor', corpus: 'profiles', text: 'I invest in climate companies.' },
+        'd-b': { lens: 'investor', corpus: 'profiles', text: 'I work at NewCo in Paris.' },
+      },
+    });
+
+    expect(result.verdicts.map((verdict) => verdict.valid)).toEqual([true, false]);
+    expect(result.verdicts[1]?.unsupportedNamedEntities).toEqual(['NewCo']);
+    expect(rendered).toContain('target voice');
+    expect(rendered).toContain('reciprocal or complementary inversion');
+    expect(rendered).not.toContain('profileContext');
+  });
+
+  it('rejects malformed verdict shapes deterministically', () => {
+    expect(HydeValidationResponseSchema.safeParse({
+      verdicts: [{ key: 'd-a', valid: 'yes', unsupportedNamedEntities: [], unsupportedHardConstraints: [], reasoning: '' }],
+    }).success).toBe(false);
+  });
+
+  it('builds a validation prompt from source, frame, and opaque documents only', () => {
+    const prompt = buildHydeValidationPrompt({
+      sourceText: 'source',
+      sourceFrame: frame,
+      documents: { 'd-opaque': { lens: 'investor', corpus: 'profiles', text: 'generated' } },
+    });
+    expect(prompt).toContain('d-opaque');
+    expect(prompt).not.toContain('profileContext');
+  });
+});

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/startup.env.ts
+++ b/services/api/src/startup.env.ts
@@ -95,6 +95,7 @@ const envSchema = z.object({
   CONTACTS_ENABLED: optionalBoolean,
   CONTACT_DEDUP_STRATEGY: z.enum(['conservative', 'balanced', 'aggressive', 'off']).optional(),
   RUN_OPPORTUNITY_EVAL_IN_PARALLEL: optionalBoolean,
+  HYDE_FRAME_CONSTRAINTS_ENABLED: optionalBoolean,
   DISCOVERY_CONTEXT_TO_INTENT: z.union([z.literal(''), z.literal('0'), z.literal('1')]).optional(),
   DISCOVERY_SOURCE_PREMISE_LIMIT: optionalInt,
   PREMISE_DEDUP_SIMILARITY: z.string().optional(), // similarity threshold 0..1 (float)


### PR DESCRIPTION
## New Features
- add default-off `frame-v1` HyDE generation behind `HYDE_FRAME_CONSTRAINTS_ENABLED=true`
- extract source-only frame roles, hard constraints, named entities, and domain vocabulary separately from profile-context-aware lens selection
- validate newly generated documents before embedding, rejecting unsupported entities/constraints while keeping infrastructure failures ephemeral and fail-open
- isolate persisted reads by generation mode, current source hash, frame fingerprint, and newest completed document cohort
- add a paired live HyDE retrieval diagnostic with production-approximate cutoff/lens-bonus scoring and reproducible reports

## Bug Fixes
- prevent profile context from becoming trusted generation constraints
- prevent stale or legacy HyDE rows from leaking into frame-v1 context discovery and vice versa
- prevent source revisions from accumulating one permanent frame row per fingerprint
- prevent short entities such as `US` or `AI` from matching inside larger Unicode words

## Refactors
- add narrow injectable HyDE inferrer/generator/validator contracts for deterministic graph tests
- preserve the five-argument `HydeGraphFactory` constructor and exact legacy prompt/cache path when the flag is off

## Documentation
- document legacy/frame-v1 flow, cache provenance, rejection/fail-open semantics, rollout status, and eval limitations
- mark IND-426 implemented in the academic-grounding backlog

## Tests
- 42 focused provider-free HyDE/eval tests passed
- 64 opportunity graph tests passed
- 11 existing live HyDE generator/lens tests passed
- protocol and API TypeScript builds passed
- API environment drift tests passed
- API lint passed with 0 errors (46 pre-existing warnings)
- frozen root install passed with no lockfile changes
- post-rebase live paired HyDE eval, 3 cases × 3 runs per mode:
  - legacy: Recall@2 `1.000`, MRR `1.000`
  - frame-v1: Recall@2 `1.000`, MRR `1.000`
  - frame-v1 rejected one unsupported generated document; 0 failed-open outputs
- secondary 39-case matching evaluator run exited cleanly with no regression

## Rollout
- frame-v1 remains disabled by default; this PR does not change Railway configuration
- recommended next step is a controlled dev enablement after PR merge and review of additional paired reports

Closes IND-426.
