### PR TITLE
feat(protocol): Lens C negotiation-evidence shadow (IND-433)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -378,11 +378,15 @@ QUESTIONER_UPTAKE_AUTHORITY_THRESHOLD=70
 
 # Lens C (IND-433): mine neutral clarification hypotheses from RECURRING
 # negotiation evidence, read in place at mining time from the exact recipient +
-# intent/fingerprint + opportunity + task segments. Only authoritative owner
-# answers, structured bilateral actions/coarse outcomes, and explicitly shared
-# message content are ever read; screen/evaluator reasoning, chain-of-thought,
-# memoryHints, private memories/reflections, disclosure subjects, untagged
-# answers, and old digests are excluded by construction. A hypothesis is kept
+# intent/fingerprint + opportunity + task segments. Only future negotiation tasks
+# carrying immutable intent snapshots captured at task creation are eligible;
+# pre-deployment tasks fail closed. The API producer omits opportunity
+# metadata.userAnswers entirely (it lacks answer-author/type provenance and can
+# contain synthetic expiry disclosure text). Only structured
+# bilateral actions/coarse outcomes and explicitly shared message content are
+# read; screen/evaluator reasoning, chain-of-thought, memoryHints, private
+# memories/reflections, disclosure subjects, untagged answers, and old digests
+# are excluded by construction. A hypothesis is kept
 # only when every support reference resolves to allowlisted evidence and it
 # recurs across >=5 distinct opportunities. shadow mines + verifies and emits
 # AGGREGATE telemetry only (no questions, no ranking/intent/premise/memory/

--- a/.env.example
+++ b/.env.example
@@ -376,6 +376,19 @@ QUESTIONER_UPTAKE_AUTHORITY_THRESHOLD=70
 # fail-open and never block INSERT. Values: off (default) | on.
 # POOL_QUESTIONS_STAMP_NEWBORN=off
 
+# Lens C (IND-433): mine neutral clarification hypotheses from RECURRING
+# negotiation evidence, read in place at mining time from the exact recipient +
+# intent/fingerprint + opportunity + task segments. Only authoritative owner
+# answers, structured bilateral actions/coarse outcomes, and explicitly shared
+# message content are ever read; screen/evaluator reasoning, chain-of-thought,
+# memoryHints, private memories/reflections, disclosure subjects, untagged
+# answers, and old digests are excluded by construction. A hypothesis is kept
+# only when every support reference resolves to allowlisted evidence and it
+# recurs across >=5 distinct opportunities. shadow mines + verifies and emits
+# AGGREGATE telemetry only (no questions, no ranking/intent/premise/memory/
+# policy/newborn/push changes). Values: off (default) | shadow | on.
+# NEGOTIATION_EVIDENCE_QUESTIONS_MODE=off
+
 ########################################
 # 14. MCP / Tool Runtime
 # Scope: [api+protocol]

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -13,6 +13,7 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
 ## [Unreleased]
 
 ### Added
+- Default-off Lens C negotiation-evidence shadow mining from allowlisted, exact recipient+intent+opportunity+task segments, with recurrence across at least five distinct opportunities, source verification, and aggregate-only telemetry (IND-433).
 - Default-off frame-v1 HyDE generation with source-only frame extraction, post-generation entity/constraint validation, partial/all rejection, ephemeral fail-open behavior, and mode/source/generation-isolated cache persistence (IND-426).
 - Opt-in `POOL_QUESTIONS_PUSH` accessor, pool refresh cycle identity, dismissal-decayed push threshold helpers, deterministic Markdown-safe Personal Agent DM template, and typed private push-ledger metadata (IND-421 P5).
 - Pre-insert newborn-opportunity stamping for fresh answered pool discriminators, with a fixed-axis evidence-verifying classifier, deterministic `questionId` provenance, and fail-open host callback (IND-420 P4b).

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -13,7 +13,7 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
 ## [Unreleased]
 
 ### Added
-- Default-off Lens C negotiation-evidence shadow mining from allowlisted, exact recipient+intent+opportunity+task segments, with recurrence across at least five distinct opportunities, source verification, and aggregate-only telemetry (IND-433).
+- Default-off Lens C negotiation-evidence shadow mining from future negotiation tasks with immutable intent snapshots, exact task-linked allowlisted evidence, strict participant/source verification, recurrence across at least five distinct opportunities, and aggregate-only telemetry (IND-433).
 - Default-off frame-v1 HyDE generation with source-only frame extraction, post-generation entity/constraint validation, partial/all rejection, ephemeral fail-open behavior, and mode/source/generation-isolated cache persistence (IND-426).
 - Opt-in `POOL_QUESTIONS_PUSH` accessor, pool refresh cycle identity, dismissal-decayed push threshold helpers, deterministic Markdown-safe Personal Agent DM template, and typed private push-ledger metadata (IND-421 P5).
 - Pre-insert newborn-opportunity stamping for fresh answered pool discriminators, with a fixed-axis evidence-verifying classifier, deterministic `questionId` provenance, and fail-open host callback (IND-420 P4b).

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "4.17.0",
+  "version": "4.18.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -220,6 +220,19 @@ export { poolQuestionCycleKey, poolQuestionPushThreshold, escapePoolPushMarkdown
 export type { SynthesizePoolQuestionInput, SynthesizedPoolQuestion } from "./opportunity/discriminator/discriminator.question.js";
 export type { QuestionPoolAssignment, QuestionPoolDiscriminator, QuestionPoolSnapshot } from "./shared/schemas/question.schema.js";
 export type { PoolCandidate, DiscriminatorMiningInput, MinedDiscriminator, ScoredDiscriminator, VerifiedAssignment, DiscriminatorShadowResult } from "./opportunity/discriminator/discriminator.types.js";
+
+// Lens C — negotiation-evidence questions (IND-433, shadow).
+export { negotiationEvidenceQuestionsMode, NEGOTIATION_EVIDENCE_QUESTIONS_MODES, NEGOTIATION_EVIDENCE_MIN_DISTINCT_OPPORTUNITIES, NEGOTIATION_EVIDENCE_MAX_OPPORTUNITIES, NEGOTIATION_EVIDENCE_MAX_CONTENT_CHARS } from "./opportunity/negotiation-evidence/negotiation-evidence.env.js";
+export type { NegotiationEvidenceQuestionsMode } from "./opportunity/negotiation-evidence/negotiation-evidence.env.js";
+export { extractAllowlistedEvidence } from "./opportunity/negotiation-evidence/negotiation-evidence.extractor.js";
+export type { ExtractionResult } from "./opportunity/negotiation-evidence/negotiation-evidence.extractor.js";
+export { verifyHypotheses, evidenceSpanMatches } from "./opportunity/negotiation-evidence/negotiation-evidence.verifier.js";
+export type { VerificationResult } from "./opportunity/negotiation-evidence/negotiation-evidence.verifier.js";
+export { NegotiationEvidenceMiner, buildEvidencePrompt } from "./opportunity/negotiation-evidence/negotiation-evidence.miner.js";
+export type { NegotiationEvidenceMinerConfig } from "./opportunity/negotiation-evidence/negotiation-evidence.miner.js";
+export { runNegotiationEvidenceShadow } from "./opportunity/negotiation-evidence/negotiation-evidence.shadow.js";
+export type { NegotiationEvidenceShadowInput } from "./opportunity/negotiation-evidence/negotiation-evidence.shadow.js";
+export type { EvidenceKind, EvidenceSpeaker, AllowlistedEvidence, RawEvidenceTurn, RawEvidenceOutcome, RawEvidenceOwnerAnswer, RawEvidenceSegment, EvidenceMiningScope, HypothesisClaimType, ProposedSupportRef, MinedEvidenceHypothesis, VerifiedSupportRef, RetainedEvidenceHypothesis, NegotiationEvidenceTelemetry, NegotiationEvidenceShadowResult } from "./opportunity/negotiation-evidence/negotiation-evidence.types.js";
 export { OpportunityEvaluator } from "./opportunity/opportunity.evaluator.js";
 export type { EvaluatorInput, OpportunityEvaluatorOptionsConstructor } from "./opportunity/opportunity.evaluator.js";
 export { OpportunityPresenter, gatherPresenterContext } from "./opportunity/opportunity.presenter.js";

--- a/packages/protocol/src/negotiation/negotiation.graph.ts
+++ b/packages/protocol/src/negotiation/negotiation.graph.ts
@@ -50,6 +50,40 @@ function hasPriorAskUser(
   });
 }
 
+interface IntentSnapshot {
+  userId: string;
+  intentId: string;
+  title: string;
+  description: string;
+}
+
+/** Capture immutable, internal-only intent provenance at task creation time. */
+function buildIntentSnapshots(
+  sourceUser: UserNegotiationContext,
+  candidateUser: UserNegotiationContext,
+): IntentSnapshot[] {
+  const snapshots: IntentSnapshot[] = [];
+  const seen = new Set<string>();
+
+  for (const user of [sourceUser, candidateUser]) {
+    if (typeof user.id !== 'string' || user.id.trim().length === 0) continue;
+    for (const intent of Array.isArray(user.intents) ? user.intents : []) {
+      if (typeof intent?.id !== 'string' || intent.id.trim().length === 0) continue;
+      const key = `${user.id}\u0000${intent.id}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      snapshots.push({
+        userId: user.id,
+        intentId: intent.id,
+        title: typeof intent.title === 'string' ? intent.title : '',
+        description: typeof intent.description === 'string' ? intent.description : '',
+      });
+    }
+  }
+
+  return snapshots;
+}
+
 /**
  * Factory for the bilateral negotiation LangGraph state machine.
  * @remarks Accepts an AgentDispatcher for per-turn agent resolution.
@@ -234,6 +268,7 @@ export class NegotiationGraphFactory {
           protocolVersion,
           candidateUserId: state.candidateUser.id,
           networkId: state.indexContext.networkId,
+          intentSnapshots: buildIntentSnapshots(state.sourceUser, state.candidateUser),
           ...(state.opportunityId && { opportunityId: state.opportunityId }),
           maxTurns,
           isContinuation,

--- a/packages/protocol/src/negotiation/tests/negotiation.graph.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.graph.spec.ts
@@ -4,10 +4,14 @@ import { NegotiationGraphState } from "../negotiation.state.js";
 
 function mkStubs() {
   const messages: Array<{ id: string; senderId: string; parts: unknown[]; createdAt: Date }> = [];
+  const createdTaskMetadata: Array<Record<string, unknown>> = [];
   const database = {
     createConversation: async () => ({ id: "conv-1" }),
     getOrCreateDM: async () => ({ id: "conv-1" }),
-    createTask: async () => ({ id: "task-1" }),
+    createTask: async (_conversationId: string, metadata: Record<string, unknown>) => {
+      createdTaskMetadata.push(metadata);
+      return { id: "task-1" };
+    },
     updateOpportunityStatus: async () => {},
     createMessage: async (p: { conversationId: string; senderId: string; parts: unknown[] }) => {
       const msg = { id: `msg-${messages.length}`, senderId: p.senderId, parts: p.parts, createdAt: new Date() };
@@ -26,8 +30,74 @@ function mkStubs() {
     dispatch: async () => ({ handled: false, reason: "no-agent" }),
   } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[1];
 
-  return { database, dispatcher, messages };
+  return { database, dispatcher, messages, createdTaskMetadata };
 }
+
+describe("negotiation graph — task intent snapshots", () => {
+  it("captures immutable, deduplicated source and candidate intent snapshots at task creation", async () => {
+    const { database, dispatcher, createdTaskMetadata } = mkStubs();
+    const sourceUser = {
+      id: "u-src",
+      intents: [
+        { id: "intent-source", title: "Source title", description: "Source description", confidence: 0.8 },
+        { id: "intent-source", title: "Duplicate", description: "Duplicate", confidence: 0.2 },
+        { id: " ", title: "Blank", description: "Blank", confidence: 1 },
+      ],
+      profile: {},
+    };
+    const candidateUser = {
+      id: "u-cand",
+      intents: [
+        { id: "intent-source", title: "Candidate title", description: "Candidate description", confidence: 0.9 },
+      ],
+      profile: {},
+    };
+
+    const { IndexNegotiator } = await import("../negotiation.agent.js");
+    const originalInvoke = IndexNegotiator.prototype.invoke;
+    IndexNegotiator.prototype.invoke = async function () {
+      return {
+        action: "propose" as const,
+        assessment: {
+          reasoning: "stub",
+          suggestedRoles: { ownUser: "peer" as const, otherUser: "peer" as const },
+        },
+        message: "stub",
+      };
+    };
+
+    try {
+      await new NegotiationGraphFactory(database, dispatcher).createGraph().invoke({
+        sourceUser,
+        candidateUser,
+        indexContext: { networkId: "net-1", prompt: "" },
+        seedAssessment: { reasoning: "x", valencyRole: "peer" },
+        opportunityId: "opp-1",
+        maxTurns: 1,
+      } as Partial<typeof NegotiationGraphState.State>);
+    } finally {
+      IndexNegotiator.prototype.invoke = originalInvoke;
+    }
+
+    sourceUser.intents[0].title = "Mutated after capture";
+    candidateUser.intents[0].description = "Mutated after capture";
+    expect(createdTaskMetadata).toHaveLength(1);
+    expect(createdTaskMetadata[0].intentSnapshots).toEqual([
+      {
+        userId: "u-src",
+        intentId: "intent-source",
+        title: "Source title",
+        description: "Source description",
+      },
+      {
+        userId: "u-cand",
+        intentId: "intent-source",
+        title: "Candidate title",
+        description: "Candidate description",
+      },
+    ]);
+  });
+});
 
 describe("negotiation graph — negotiation_turn emission", () => {
   it("emits negotiation_turn with correct payload after each turn", async () => {

--- a/packages/protocol/src/opportunity/negotiation-evidence/negotiation-evidence.env.ts
+++ b/packages/protocol/src/opportunity/negotiation-evidence/negotiation-evidence.env.ts
@@ -1,0 +1,52 @@
+/**
+ * Centralized accessor + constants for the Lens C negotiation-evidence
+ * question producer (IND-433).
+ *
+ *   NEGOTIATION_EVIDENCE_QUESTIONS_MODE   off | shadow | on — default off.
+ *     - off (default): the lens never runs; zero reads, zero telemetry.
+ *     - shadow (this issue): mine + verify neutral hypotheses over allowlisted
+ *       negotiation evidence, emit AGGREGATE telemetry only. Persists no
+ *       questions and changes no ranking, intent, premise, memory, policy,
+ *       newborn-stamping, or push behavior.
+ *     - on (future, IND-437): additionally synthesize/enqueue questions and
+ *       suppress the older IND-296–299 transcript-question producer.
+ *
+ * All reads go through this module — do not read the variable via
+ * `process.env` elsewhere. The value is read on every call (no caching) so
+ * tests and long-lived processes observe changes.
+ */
+
+/** Documented modes for the Lens C negotiation-evidence question producer. */
+export const NEGOTIATION_EVIDENCE_QUESTIONS_MODES = ["off", "shadow", "on"] as const;
+
+/** Mode for the Lens C negotiation-evidence question producer. */
+export type NegotiationEvidenceQuestionsMode = (typeof NEGOTIATION_EVIDENCE_QUESTIONS_MODES)[number];
+
+/**
+ * Current NEGOTIATION_EVIDENCE_QUESTIONS_MODE (default off). Any value other
+ * than an exact documented mode (after trimming) coerces to off — an
+ * unrecognized flag must never silently enable the lens.
+ */
+export function negotiationEvidenceQuestionsMode(): NegotiationEvidenceQuestionsMode {
+  const raw = process.env.NEGOTIATION_EVIDENCE_QUESTIONS_MODE?.trim();
+  return raw === "shadow" || raw === "on" ? raw : "off";
+}
+
+/**
+ * Recurrence floor: a mined hypothesis is only retained when its verified
+ * support spans at least this many DISTINCT opportunities (IND-433 `k=5`).
+ * Continuation segments of one opportunity are grouped and count once, so this
+ * is genuinely a cross-opportunity threshold — same-pair repetition cannot
+ * inflate it.
+ */
+export const NEGOTIATION_EVIDENCE_MIN_DISTINCT_OPPORTUNITIES = 5;
+
+/**
+ * Max opportunities (already grouped, one per opportunity) whose allowlisted
+ * evidence is sent to the miner in one pass. Bounds prompt size the same way
+ * the Lens A miner caps its candidate pool.
+ */
+export const NEGOTIATION_EVIDENCE_MAX_OPPORTUNITIES = 24;
+
+/** Max chars of allowlisted evidence content retained per evidence unit. */
+export const NEGOTIATION_EVIDENCE_MAX_CONTENT_CHARS = 400;

--- a/packages/protocol/src/opportunity/negotiation-evidence/negotiation-evidence.extractor.ts
+++ b/packages/protocol/src/opportunity/negotiation-evidence/negotiation-evidence.extractor.ts
@@ -1,0 +1,206 @@
+/**
+ * Lens C in-place evidence extraction (IND-433).
+ *
+ * Reads raw negotiation segments and projects ONLY the allowlist:
+ *   - authoritative owner answers (answerer === recipient),
+ *   - structured bilateral actions and coarse outcomes,
+ *   - explicitly shared (tagged) message content.
+ *
+ * Everything else is dropped by construction. The function is pure and
+ * deterministic so adversarial fixtures can prove that every excluded source
+ * and every recipient / intent / opportunity / network / task / speaker
+ * mismatch is rejected, and that same-pair continuations cannot inflate the
+ * distinct-opportunity count.
+ */
+import { NEGOTIATION_EVIDENCE_MAX_CONTENT_CHARS, NEGOTIATION_EVIDENCE_MAX_OPPORTUNITIES } from "./negotiation-evidence.env.js";
+import type { AllowlistedEvidence, EvidenceKind, EvidenceMiningScope, EvidenceSpeaker, RawEvidenceSegment } from "./negotiation-evidence.types.js";
+
+/** Result of one extraction pass over a recipient+intent's segments. */
+export interface ExtractionResult {
+  /** Allowlisted evidence, grouped/deduped, one logical set per opportunity. */
+  evidence: AllowlistedEvidence[];
+  /** Distinct opportunities that produced at least one evidence unit. */
+  distinctOpportunities: number;
+  /** Candidate records rejected by allowlist / exclusion / provenance rules. */
+  excludedRecords: number;
+  /** Allowlisted evidence unit counts, by kind. */
+  evidenceCounts: Record<EvidenceKind, number>;
+}
+
+const EMPTY_COUNTS = (): Record<EvidenceKind, number> => ({
+  owner_answer: 0,
+  bilateral_action: 0,
+  coarse_outcome: 0,
+  shared_message: 0,
+});
+
+/** Collapse whitespace + lowercase for dedup only (not for stored content). */
+function dedupKey(kind: EvidenceKind, speaker: EvidenceSpeaker, content: string): string {
+  return `${kind}\u0000${speaker}\u0000${content.toLowerCase().replace(/\s+/g, " ").trim()}`;
+}
+
+/** Bound + whitespace-normalize stored content. */
+function boundContent(raw: string): string {
+  return raw.replace(/\s+/g, " ").trim().slice(0, NEGOTIATION_EVIDENCE_MAX_CONTENT_CHARS);
+}
+
+/**
+ * A segment matches the pass scope only when EVERY provenance field is exactly
+ * equal. A single mismatch rejects the whole segment (cross-recipient,
+ * cross-intent, cross-fingerprint, or cross-network contamination).
+ */
+function segmentMatchesScope(segment: RawEvidenceSegment, scope: EvidenceMiningScope): boolean {
+  return (
+    segment.recipientUserId === scope.recipientUserId &&
+    segment.intentId === scope.intentId &&
+    segment.intentFingerprint === scope.intentFingerprint &&
+    segment.networkId === scope.networkId
+  );
+}
+
+/** Map a turn sender to owner/counterparty, or null when it is neither. */
+function mapSpeaker(senderUserId: string, segment: RawEvidenceSegment): EvidenceSpeaker | null {
+  if (senderUserId === segment.recipientUserId) return "owner";
+  if (senderUserId === segment.counterpartyUserId) return "counterparty";
+  return null;
+}
+
+/** Count every raw record a segment carries (for excluded-record accounting). */
+function countSegmentRecords(segment: RawEvidenceSegment): number {
+  let n = segment.turns.length + (segment.ownerAnswers?.length ?? 0);
+  if (segment.outcome) n += 1;
+  return n;
+}
+
+/**
+ * Extract allowlisted evidence for one (recipient, intent) mining scope.
+ *
+ * Continuation grouping: segments are grouped by `opportunityId`; a single
+ * opportunity contributes ONE deduped evidence set regardless of how many
+ * continuation tasks it spans, so an opportunity counts once toward recurrence.
+ *
+ * Contamination guard: a segment whose recipient / intent / fingerprint /
+ * network do not match the scope, or whose own recipient equals its
+ * counterparty, is rejected wholesale (all records counted as excluded).
+ */
+export function extractAllowlistedEvidence(
+  scope: EvidenceMiningScope,
+  segments: RawEvidenceSegment[],
+): ExtractionResult {
+  const evidenceCounts = EMPTY_COUNTS();
+  let excludedRecords = 0;
+
+  // Group in-scope segments by opportunity (continuation grouping).
+  const byOpportunity = new Map<string, RawEvidenceSegment[]>();
+  for (const segment of segments) {
+    if (!segmentMatchesScope(segment, scope) || segment.recipientUserId === segment.counterpartyUserId) {
+      excludedRecords += countSegmentRecords(segment);
+      continue;
+    }
+    const group = byOpportunity.get(segment.opportunityId);
+    if (group) group.push(segment);
+    else byOpportunity.set(segment.opportunityId, [segment]);
+  }
+
+  const evidence: AllowlistedEvidence[] = [];
+  let distinctOpportunities = 0;
+
+  for (const [opportunityId, group] of byOpportunity) {
+    if (distinctOpportunities >= NEGOTIATION_EVIDENCE_MAX_OPPORTUNITIES) {
+      // Cap opportunities per pass; remaining segments simply are not mined.
+      excludedRecords += group.reduce((n, s) => n + countSegmentRecords(s), 0);
+      continue;
+    }
+
+    const seen = new Set<string>();
+    const opportunityEvidence: Array<{ kind: EvidenceKind; speaker: EvidenceSpeaker; content: string }> = [];
+
+    const push = (kind: EvidenceKind, speaker: EvidenceSpeaker, rawContent: string): boolean => {
+      const content = boundContent(rawContent);
+      if (content.length === 0) return false;
+      const key = dedupKey(kind, speaker, content);
+      if (seen.has(key)) return true; // duplicate continuation content — grouped, not excluded
+      seen.add(key);
+      opportunityEvidence.push({ kind, speaker, content });
+      return true;
+    };
+
+    for (const segment of group) {
+      // Authoritative owner answers — answerer MUST be the recipient.
+      for (const answer of segment.ownerAnswers ?? []) {
+        if (answer.answererUserId !== segment.recipientUserId) {
+          excludedRecords += 1;
+          continue;
+        }
+        const parts = [...answer.selectedOptions, ...(answer.freeText ? [answer.freeText] : [])];
+        const content = parts.join(" | ");
+        if (!push("owner_answer", "owner", content)) excludedRecords += 1;
+      }
+
+      // Turns → structured bilateral action + explicitly shared message.
+      for (const turn of segment.turns) {
+        const speaker = mapSpeaker(turn.senderUserId, segment);
+        if (speaker === null) {
+          // Speaker mismatch: neither owner nor counterparty. Nothing from
+          // this turn (action AND message) may be trusted.
+          excludedRecords += 1;
+          continue;
+        }
+        // Structured bilateral action (label only; reasoning never read).
+        const action = turn.action?.trim();
+        if (action) push("bilateral_action", "system", action);
+
+        // Explicitly shared message content only. Untagged → excluded.
+        const message = turn.message?.trim();
+        if (message) {
+          if (turn.sharedTagged === true) push("shared_message", speaker, message);
+          else excludedRecords += 1;
+        }
+      }
+
+      // Coarse outcome. `screened_out` is a private client gate → excluded.
+      const outcome = segment.outcome;
+      if (outcome) {
+        if (outcome.reason === "screened_out") {
+          excludedRecords += 1;
+        } else {
+          const roles = (outcome.agreedRoles ?? [])
+            .map((r) => `${r.role}`)
+            .sort()
+            .join(",");
+          const content = [
+            `hasOpportunity=${outcome.hasOpportunity}`,
+            outcome.reason ? `reason=${outcome.reason}` : "",
+            roles ? `roles=${roles}` : "",
+          ]
+            .filter(Boolean)
+            .join(" ");
+          push("coarse_outcome", "system", content);
+        }
+      }
+    }
+
+    if (opportunityEvidence.length === 0) continue;
+
+    distinctOpportunities += 1;
+    const first = group[0];
+    opportunityEvidence.forEach((e, ordinal) => {
+      evidenceCounts[e.kind] += 1;
+      evidence.push({
+        evidenceId: `${e.kind}:${opportunityId}:${ordinal}`,
+        kind: e.kind,
+        speaker: e.speaker,
+        content: e.content,
+        recipientUserId: first.recipientUserId,
+        intentId: first.intentId,
+        intentFingerprint: first.intentFingerprint,
+        opportunityId,
+        taskId: first.taskId,
+        conversationId: first.conversationId,
+        networkId: first.networkId,
+      });
+    });
+  }
+
+  return { evidence, distinctOpportunities, excludedRecords, evidenceCounts };
+}

--- a/packages/protocol/src/opportunity/negotiation-evidence/negotiation-evidence.extractor.ts
+++ b/packages/protocol/src/opportunity/negotiation-evidence/negotiation-evidence.extractor.ts
@@ -113,15 +113,32 @@ export function extractAllowlistedEvidence(
     }
 
     const seen = new Set<string>();
-    const opportunityEvidence: Array<{ kind: EvidenceKind; speaker: EvidenceSpeaker; content: string }> = [];
+    const opportunityEvidence: Array<{
+      kind: EvidenceKind;
+      speaker: EvidenceSpeaker;
+      content: string;
+      taskId: string;
+      conversationId: string;
+    }> = [];
 
-    const push = (kind: EvidenceKind, speaker: EvidenceSpeaker, rawContent: string): boolean => {
+    const push = (
+      segment: RawEvidenceSegment,
+      kind: EvidenceKind,
+      speaker: EvidenceSpeaker,
+      rawContent: string,
+    ): boolean => {
       const content = boundContent(rawContent);
       if (content.length === 0) return false;
       const key = dedupKey(kind, speaker, content);
-      if (seen.has(key)) return true; // duplicate continuation content — grouped, not excluded
+      if (seen.has(key)) return true; // duplicate continuation content retains its first source
       seen.add(key);
-      opportunityEvidence.push({ kind, speaker, content });
+      opportunityEvidence.push({
+        kind,
+        speaker,
+        content,
+        taskId: segment.taskId,
+        conversationId: segment.conversationId,
+      });
       return true;
     };
 
@@ -134,7 +151,7 @@ export function extractAllowlistedEvidence(
         }
         const parts = [...answer.selectedOptions, ...(answer.freeText ? [answer.freeText] : [])];
         const content = parts.join(" | ");
-        if (!push("owner_answer", "owner", content)) excludedRecords += 1;
+        if (!push(segment, "owner_answer", "owner", content)) excludedRecords += 1;
       }
 
       // Turns → structured bilateral action + explicitly shared message.
@@ -148,12 +165,12 @@ export function extractAllowlistedEvidence(
         }
         // Structured bilateral action (label only; reasoning never read).
         const action = turn.action?.trim();
-        if (action) push("bilateral_action", "system", action);
+        if (action) push(segment, "bilateral_action", "system", action);
 
         // Explicitly shared message content only. Untagged → excluded.
         const message = turn.message?.trim();
         if (message) {
-          if (turn.sharedTagged === true) push("shared_message", speaker, message);
+          if (turn.sharedTagged === true) push(segment, "shared_message", speaker, message);
           else excludedRecords += 1;
         }
       }
@@ -175,7 +192,7 @@ export function extractAllowlistedEvidence(
           ]
             .filter(Boolean)
             .join(" ");
-          push("coarse_outcome", "system", content);
+          push(segment, "coarse_outcome", "system", content);
         }
       }
     }
@@ -195,8 +212,8 @@ export function extractAllowlistedEvidence(
         intentId: first.intentId,
         intentFingerprint: first.intentFingerprint,
         opportunityId,
-        taskId: first.taskId,
-        conversationId: first.conversationId,
+        taskId: e.taskId,
+        conversationId: e.conversationId,
         networkId: first.networkId,
       });
     });

--- a/packages/protocol/src/opportunity/negotiation-evidence/negotiation-evidence.miner.ts
+++ b/packages/protocol/src/opportunity/negotiation-evidence/negotiation-evidence.miner.ts
@@ -1,0 +1,136 @@
+/**
+ * NegotiationEvidenceMiner — one structured LLM pass that proposes neutral
+ * clarification hypotheses over ALLOWLISTED negotiation evidence, with
+ * code-side support verification delegated to the verifier (IND-433).
+ *
+ * The miner only ever sees the allowlisted projection (owner answers, bilateral
+ * actions, coarse outcomes, explicitly shared messages) — never reasoning,
+ * memories, disclosure subjects, or provenance. Every proposed hypothesis must
+ * cite the `evidenceId`s that support it and quote a verbatim span from each;
+ * unsupported or hallucinated references are discarded in code, not trusted
+ * from the prompt.
+ *
+ * Follows the Lens A `PoolDiscriminatorMiner` pattern: constructor binds the
+ * structured model once; a single public `mine()` per call.
+ */
+import { HumanMessage, SystemMessage } from "@langchain/core/messages";
+import { z } from "zod";
+
+import { createStructuredModel } from "../../shared/agent/model.config.js";
+import { invokeWithAbortSignal } from "../../shared/agent/model-signal.js";
+import { protocolLogger } from "../../shared/observability/protocol.logger.js";
+import { Timed } from "../../shared/observability/performance.js";
+import type { AllowlistedEvidence, MinedEvidenceHypothesis } from "./negotiation-evidence.types.js";
+
+const logger = protocolLogger("NegotiationEvidenceMiner");
+
+/** Max hypotheses requested from (and accepted out of) one mining pass. */
+const MAX_HYPOTHESES = 8;
+
+const HypothesisMiningResponseSchema = z.object({
+  hypotheses: z
+    .array(
+      z.object({
+        statement: z
+          .string()
+          .describe(
+            "A neutral, non-identifying clarification hypothesis about the intent owner's preferences or context",
+          ),
+        claimType: z
+          .enum(["observation", "recipient_fact", "recipient_preference"])
+          .describe(
+            "observation = a neutral pattern; recipient_fact/recipient_preference = a claim ABOUT the intent owner (needs owner-authored or structured support)",
+          ),
+        supportRefs: z
+          .array(
+            z.object({
+              evidenceId: z.string().describe("An evidenceId exactly as given in the evidence list"),
+              span: z
+                .string()
+                .max(200)
+                .describe("VERBATIM span (<=120 chars) copied from that evidence's content"),
+            }),
+          )
+          .min(1)
+          .describe("One or more support references; every hypothesis must be grounded"),
+      }),
+    )
+    .max(MAX_HYPOTHESES),
+});
+
+type HypothesisMiningResponse = z.infer<typeof HypothesisMiningResponseSchema>;
+
+const SYSTEM_PROMPT = `You review ALLOWLISTED evidence gathered from a user's past negotiations and propose neutral clarification hypotheses about that user's (the "intent owner") preferences or context.
+
+You are given only a safe projection of evidence: the owner's own answers, structured bilateral actions, coarse outcomes, and explicitly shared messages. Each item has an id, a kind, and a speaker (owner | counterparty | system).
+
+Rules for every hypothesis:
+- State it neutrally and at an aggregate level. NEVER name or describe any specific person, and NEVER infer protected attributes (race, ethnicity, religion, gender, age, nationality, disability, politics, sexual orientation).
+- Ground it: cite the evidenceId(s) that support it and copy a short (<=120 chars) VERBATIM substring of that evidence's content as the span. Copy it exactly — spans are checked mechanically and paraphrased spans are discarded.
+- claimType:
+  - Use "recipient_fact" or "recipient_preference" only for a claim ABOUT the intent owner. Such claims may ONLY be supported by owner or system evidence — a counterparty statement can never establish a fact or preference about the owner.
+  - Use "observation" for a neutral pattern that a counterparty statement may also support.
+- Do not speculate beyond the evidence. If an item does not support a distinct hypothesis, ignore it.
+
+Prefer a few well-supported hypotheses over many weak ones. Propose at most ${MAX_HYPOTHESES}.`;
+
+/** Config for NegotiationEvidenceMiner construction. */
+export interface NegotiationEvidenceMinerConfig {
+  /** Optional model config override (API key / base URL / model). */
+  modelConfig?: Parameters<typeof createStructuredModel>[3];
+}
+
+/**
+ * Stateless hypothesis-mining agent. One `mine()` call = one structured LLM
+ * pass. All support verification happens later, in the verifier.
+ */
+export class NegotiationEvidenceMiner {
+  private model: ReturnType<typeof createStructuredModel<HypothesisMiningResponse>>;
+
+  constructor(config?: NegotiationEvidenceMinerConfig) {
+    this.model = createStructuredModel<HypothesisMiningResponse>(
+      "negotiationEvidenceMiner",
+      HypothesisMiningResponseSchema,
+      { name: "negotiation_evidence_hypotheses" },
+      config?.modelConfig,
+    );
+  }
+
+  /**
+   * Mine neutral hypotheses for one allowlisted evidence set.
+   *
+   * @returns Proposed hypotheses (may be empty). Throws on LLM failure —
+   *   callers run this fire-and-forget and must catch.
+   */
+  @Timed()
+  async mine(
+    evidence: AllowlistedEvidence[],
+    options?: { signal?: AbortSignal },
+  ): Promise<MinedEvidenceHypothesis[]> {
+    if (evidence.length === 0) return [];
+    const prompt = buildEvidencePrompt(evidence);
+    const raw = await invokeWithAbortSignal(
+      this.model,
+      [new SystemMessage(SYSTEM_PROMPT), new HumanMessage(prompt)],
+      options?.signal,
+    );
+    const parsed = HypothesisMiningResponseSchema.safeParse(raw);
+    if (!parsed.success) {
+      logger.warn("Mining response failed schema validation", { issues: parsed.error.issues.length });
+      return [];
+    }
+    return parsed.data.hypotheses.slice(0, MAX_HYPOTHESES).map((h) => ({
+      statement: h.statement,
+      claimType: h.claimType,
+      supportRefs: h.supportRefs.map((r) => ({ evidenceId: r.evidenceId, span: r.span })),
+    }));
+  }
+}
+
+/** Builds the human message: one block per allowlisted evidence unit. */
+export function buildEvidencePrompt(evidence: AllowlistedEvidence[]): string {
+  const blocks = evidence
+    .map((e) => `[${e.evidenceId}] (${e.kind}, ${e.speaker})\n${e.content}`)
+    .join("\n\n");
+  return `Allowlisted evidence (${evidence.length} items, id in brackets):\n\n${blocks}`;
+}

--- a/packages/protocol/src/opportunity/negotiation-evidence/negotiation-evidence.shadow.ts
+++ b/packages/protocol/src/opportunity/negotiation-evidence/negotiation-evidence.shadow.ts
@@ -1,0 +1,88 @@
+/**
+ * Lens C shadow orchestrator (IND-433).
+ *
+ * extract (allowlist, in place) → mine (neutral hypotheses) → verify (support
+ * resolves to allowlisted evidence + speaker constraint) → recurrence gate
+ * (>= k distinct opportunities). Returns aggregate telemetry plus the retained
+ * hypotheses for OFFLINE review.
+ *
+ * This function performs NO persistence and NO user-visible action. It does
+ * not create questions and changes no ranking, intent, premise, memory,
+ * policy, newborn-stamping, or push behavior — those belong to the future
+ * `on` mode (IND-437). Callers in shadow mode must log only
+ * {@link NegotiationEvidenceShadowResult.telemetry} (aggregate-only) and must
+ * not persist or route the retained hypotheses.
+ */
+import { NEGOTIATION_EVIDENCE_MIN_DISTINCT_OPPORTUNITIES } from "./negotiation-evidence.env.js";
+import { extractAllowlistedEvidence } from "./negotiation-evidence.extractor.js";
+import type { NegotiationEvidenceMiner } from "./negotiation-evidence.miner.js";
+import { verifyHypotheses } from "./negotiation-evidence.verifier.js";
+import type { EvidenceMiningScope, NegotiationEvidenceShadowResult, RawEvidenceSegment } from "./negotiation-evidence.types.js";
+
+/** Input for one shadow mining pass. */
+export interface NegotiationEvidenceShadowInput {
+  /** The exact recipient + intent/fingerprint + network this pass is bound to. */
+  scope: EvidenceMiningScope;
+  /** Raw negotiation segments read in place (one or more per opportunity). */
+  segments: RawEvidenceSegment[];
+  /** Structured hypothesis miner (injectable seam). */
+  miner: Pick<NegotiationEvidenceMiner, "mine">;
+  /** Override the recurrence floor (defaults to the IND-433 `k=5`). */
+  minDistinctOpportunities?: number;
+  signal?: AbortSignal;
+}
+
+/**
+ * Run one Lens C shadow pass. Throws only when *mining* fails (callers run
+ * fire-and-forget and must catch); extraction and verification are pure.
+ */
+export async function runNegotiationEvidenceShadow(
+  input: NegotiationEvidenceShadowInput,
+): Promise<NegotiationEvidenceShadowResult> {
+  const { scope, segments } = input;
+  const minDistinct = input.minDistinctOpportunities ?? NEGOTIATION_EVIDENCE_MIN_DISTINCT_OPPORTUNITIES;
+
+  const extraction = extractAllowlistedEvidence(scope, segments);
+
+  const baseTelemetry = {
+    recipientUserId: scope.recipientUserId,
+    intentId: scope.intentId,
+    segments: segments.length,
+    distinctOpportunities: extraction.distinctOpportunities,
+    evidenceCounts: extraction.evidenceCounts,
+    excludedRecords: extraction.excludedRecords,
+  } as const;
+
+  // Cheap exit: recurrence is impossible below the distinct-opportunity floor,
+  // so never spend an LLM call that could only be discarded.
+  if (extraction.distinctOpportunities < minDistinct) {
+    return {
+      telemetry: {
+        ...baseTelemetry,
+        hypothesesMined: 0,
+        hypothesesSupported: 0,
+        hypothesesRecurrent: 0,
+        hypothesesDiscarded: 0,
+      },
+      hypotheses: [],
+    };
+  }
+
+  const mined = await input.miner.mine(
+    extraction.evidence,
+    input.signal ? { signal: input.signal } : undefined,
+  );
+
+  const verification = verifyHypotheses(mined, extraction.evidence, minDistinct);
+
+  return {
+    telemetry: {
+      ...baseTelemetry,
+      hypothesesMined: mined.length,
+      hypothesesSupported: verification.supported,
+      hypothesesRecurrent: verification.recurrent,
+      hypothesesDiscarded: verification.discarded,
+    },
+    hypotheses: verification.retained,
+  };
+}

--- a/packages/protocol/src/opportunity/negotiation-evidence/negotiation-evidence.types.ts
+++ b/packages/protocol/src/opportunity/negotiation-evidence/negotiation-evidence.types.ts
@@ -1,0 +1,211 @@
+/**
+ * Lens C negotiation-evidence — shared types (IND-433).
+ *
+ * Lens C mines neutral clarification hypotheses from RECURRING negotiation
+ * evidence, read in place at mining time. It never builds a durable transcript
+ * projection and never summarizes an entire pair DM; the only content it will
+ * ever touch is a narrow, positively-constructed allowlist:
+ *
+ *   - authoritative owner answers (the recipient's own answers),
+ *   - structured bilateral actions / coarse outcomes, and
+ *   - explicitly shared message content.
+ *
+ * Everything else — screen/evaluator reasoning, agent chain-of-thought,
+ * `memoryHints`, private negotiator memories/reflections, disclosure subjects,
+ * untagged shared answers, and old synthesized digests — is excluded by
+ * construction (never mapped into an {@link AllowlistedEvidence}).
+ */
+
+/** The four allowlisted evidence families. Nothing else may be surfaced. */
+export type EvidenceKind =
+  | "owner_answer"
+  | "bilateral_action"
+  | "coarse_outcome"
+  | "shared_message";
+
+/**
+ * Who authored an evidence unit. `system` covers structured bilateral facts
+ * (actions/outcomes) that belong to neither party's voice. The distinction is
+ * load-bearing: a counterparty statement may support an OBSERVATION but never
+ * a fact or preference ABOUT the recipient (IND-433).
+ */
+export type EvidenceSpeaker = "owner" | "counterparty" | "system";
+
+/**
+ * One unit of allowlisted evidence, extracted in place for exactly one
+ * (recipient, intent, opportunity, task) tuple. Provenance travels with the
+ * unit so cross-recipient / cross-intent / cross-opportunity / cross-network /
+ * cross-task / cross-speaker contamination is a pure-function rejection rather
+ * than a downstream concern.
+ */
+export interface AllowlistedEvidence {
+  /** Deterministic id, unique within one mining pass: `${kind}:${opportunityId}:${ordinal}`. */
+  evidenceId: string;
+  kind: EvidenceKind;
+  speaker: EvidenceSpeaker;
+  /** The only text a support reference may quote — bounded, exclusion-scrubbed. */
+  content: string;
+  // Provenance (used for keying + contamination rejection; never sent to the LLM).
+  recipientUserId: string;
+  intentId: string;
+  intentFingerprint: string;
+  opportunityId: string;
+  taskId: string;
+  conversationId: string;
+  networkId: string;
+}
+
+/**
+ * One raw negotiation turn as read in place. Untrusted: it still carries the
+ * fields Lens C must EXCLUDE (`reasoning`, `askUser`/disclosure). The extractor
+ * maps only the allowlisted projection of this record.
+ */
+export interface RawEvidenceTurn {
+  /** Turn author user id — mapped to owner/counterparty against the segment. */
+  senderUserId: string;
+  /** Structured bilateral action (propose/accept/counter/decline/...). */
+  action: string;
+  /** Free-text message body, if any. */
+  message?: string | null;
+  /**
+   * True only when this message was EXPLICITLY shared/consented for reuse.
+   * Untagged messages are excluded — Lens C never mines an untagged answer.
+   */
+  sharedTagged?: boolean;
+  /** Chain-of-thought — EXCLUDED. Present here only to prove it is dropped. */
+  reasoning?: string | null;
+  /** Disclosure subject — EXCLUDED. Present here only to prove it is dropped. */
+  disclosureSubject?: string | null;
+}
+
+/** Coarse, structured outcome facts (no evaluator reasoning). */
+export interface RawEvidenceOutcome {
+  hasOpportunity: boolean;
+  /** `turn_cap | timeout` are coarse; `screened_out` is a private gate → dropped. */
+  reason?: "turn_cap" | "timeout" | "screened_out";
+  /** Agreed collaboration roles, if any. */
+  agreedRoles?: Array<{ userId: string; role: string }>;
+  /** Evaluator reasoning — EXCLUDED. Present here only to prove it is dropped. */
+  reasoning?: string | null;
+}
+
+/** Authoritative owner answer (the recipient's own answer to a question). */
+export interface RawEvidenceOwnerAnswer {
+  /** Answerer user id — must equal the segment recipient to be authoritative. */
+  answererUserId: string;
+  selectedOptions: string[];
+  freeText?: string;
+}
+
+/**
+ * All in-place negotiation data for ONE opportunity segment, scoped to an
+ * exact recipient + intent/fingerprint + opportunity + task. Continuations of
+ * the same opportunity arrive as separate segments sharing `opportunityId`;
+ * the extractor groups them and counts the opportunity once.
+ */
+export interface RawEvidenceSegment {
+  recipientUserId: string;
+  intentId: string;
+  intentFingerprint: string;
+  opportunityId: string;
+  taskId: string;
+  conversationId: string;
+  networkId: string;
+  /** The counterparty in this bilateral negotiation. */
+  counterpartyUserId: string;
+  turns: RawEvidenceTurn[];
+  outcome?: RawEvidenceOutcome | null;
+  ownerAnswers?: RawEvidenceOwnerAnswer[];
+}
+
+/** The scope a mining pass is bound to — every segment must match it exactly. */
+export interface EvidenceMiningScope {
+  recipientUserId: string;
+  intentId: string;
+  intentFingerprint: string;
+  networkId: string;
+}
+
+/**
+ * The three claim shapes a hypothesis may take. The speaker constraint is
+ * enforced against these: `recipient_fact` / `recipient_preference` require
+ * owner-authored (or structured bilateral) support; `observation` may also be
+ * supported by counterparty statements.
+ */
+export type HypothesisClaimType =
+  | "observation"
+  | "recipient_fact"
+  | "recipient_preference";
+
+/** A support reference proposed by the miner (before code-side verification). */
+export interface ProposedSupportRef {
+  /** Must resolve to an {@link AllowlistedEvidence} in the pass. */
+  evidenceId: string;
+  /** Verbatim span the miner copied from that evidence's content. */
+  span: string;
+}
+
+/** One hypothesis proposed by the miner. */
+export interface MinedEvidenceHypothesis {
+  /** Neutral, non-identifying clarification hypothesis. */
+  statement: string;
+  claimType: HypothesisClaimType;
+  supportRefs: ProposedSupportRef[];
+}
+
+/** A support reference that resolved against the allowlist. */
+export interface VerifiedSupportRef {
+  evidenceId: string;
+  kind: EvidenceKind;
+  speaker: EvidenceSpeaker;
+  opportunityId: string;
+}
+
+/**
+ * A hypothesis after verification + the recurrence gate. Retained hypotheses
+ * are returned for OFFLINE review only — shadow mode never persists or logs
+ * their text (see {@link NegotiationEvidenceTelemetry}).
+ */
+export interface RetainedEvidenceHypothesis {
+  statement: string;
+  claimType: HypothesisClaimType;
+  support: VerifiedSupportRef[];
+  /** Count of DISTINCT opportunities in `support` — the recurrence measure. */
+  distinctOpportunities: number;
+}
+
+/**
+ * Aggregate-only telemetry. Deliberately carries NO evidence content, NO
+ * hypothesis text, and NO spans — only counts — so it is safe to emit to
+ * routine logs without leaking internal negotiation content.
+ */
+export interface NegotiationEvidenceTelemetry {
+  recipientUserId: string;
+  intentId: string;
+  /** Raw segments supplied to the pass (pre-grouping). */
+  segments: number;
+  /** Distinct opportunities after continuation grouping. */
+  distinctOpportunities: number;
+  /** Allowlisted evidence unit counts, by kind. */
+  evidenceCounts: Record<EvidenceKind, number>;
+  /** Records dropped by allowlist / exclusion / provenance mismatch. */
+  excludedRecords: number;
+  hypothesesMined: number;
+  /** Hypotheses whose every support ref verified against the allowlist. */
+  hypothesesSupported: number;
+  /** Supported hypotheses that also met the distinct-opportunity floor. */
+  hypothesesRecurrent: number;
+  /** Hypotheses discarded (unsupported ref, speaker violation, or too rare). */
+  hypothesesDiscarded: number;
+}
+
+/** Result of one shadow mining pass. */
+export interface NegotiationEvidenceShadowResult {
+  /** Safe-to-log aggregate counts. */
+  telemetry: NegotiationEvidenceTelemetry;
+  /**
+   * Retained recurrent hypotheses for offline eval. In shadow mode the caller
+   * MUST NOT persist these or write them to routine logs.
+   */
+  hypotheses: RetainedEvidenceHypothesis[];
+}

--- a/packages/protocol/src/opportunity/negotiation-evidence/negotiation-evidence.verifier.ts
+++ b/packages/protocol/src/opportunity/negotiation-evidence/negotiation-evidence.verifier.ts
@@ -1,0 +1,131 @@
+/**
+ * Lens C support-reference verification + recurrence gate (IND-433).
+ *
+ * A mined hypothesis is retained ONLY when:
+ *   1. it carries at least one support reference,
+ *   2. EVERY support reference resolves to an allowlisted evidence unit in
+ *      this pass AND quotes a verbatim span of that unit's content,
+ *   3. the speaker constraint holds — a claim that is a fact or preference
+ *      ABOUT the recipient may never rest on a counterparty statement, and
+ *   4. its verified support spans at least `minDistinctOpportunities` DISTINCT
+ *      opportunities (recurrence). Continuations were already grouped upstream,
+ *      so same-pair repetition cannot inflate this.
+ *
+ * Any failure discards the whole hypothesis — there is no partial retention.
+ */
+import type { AllowlistedEvidence, HypothesisClaimType, MinedEvidenceHypothesis, RetainedEvidenceHypothesis, VerifiedSupportRef } from "./negotiation-evidence.types.js";
+
+/** Result of verifying a batch of mined hypotheses. */
+export interface VerificationResult {
+  /** Hypotheses that passed verification AND the recurrence gate. */
+  retained: RetainedEvidenceHypothesis[];
+  /** Hypotheses whose every support ref verified (pre-recurrence). */
+  supported: number;
+  /** Supported hypotheses that also met the distinct-opportunity floor. */
+  recurrent: number;
+  /** Hypotheses discarded for any reason (mined − recurrent). */
+  discarded: number;
+}
+
+/** Minimum normalized span length that counts as meaningful verbatim evidence. */
+const MIN_SPAN_CHARS = 8;
+
+/** Lowercase, fold typographic punctuation, collapse whitespace. */
+function normalizeForMatch(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[\u2018\u2019\u02bc]/g, "'")
+    .replace(/[\u201c\u201d]/g, '"')
+    .replace(/[\u2013\u2014]/g, "-")
+    .replace(/\u2026/g, "...")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Strip wrapping quotes / edge punctuation the LLM habitually adds. */
+function stripEdgePunctuation(s: string): string {
+  return s
+    .replace(/^[\s"'.,;:!?()\u2018\u2019\u201c\u201d]+/, "")
+    .replace(/[\s"'.,;:!?()\u2018\u2019\u201c\u201d]+$/, "");
+}
+
+/** True when `span` is a meaningful verbatim substring of `content`. */
+export function evidenceSpanMatches(content: string, span: string): boolean {
+  const haystack = normalizeForMatch(content);
+  const needle = normalizeForMatch(stripEdgePunctuation(span));
+  return needle.length >= MIN_SPAN_CHARS && haystack.includes(needle);
+}
+
+/**
+ * A `recipient_fact` / `recipient_preference` claim must not lean on a
+ * counterparty statement. `observation` claims accept any speaker.
+ */
+function speakerAllowedForClaim(claimType: HypothesisClaimType, evidence: AllowlistedEvidence): boolean {
+  if (claimType === "observation") return true;
+  return evidence.speaker !== "counterparty";
+}
+
+/**
+ * Verify one hypothesis. Returns the verified support (deduped) when every
+ * reference resolves and satisfies the speaker constraint; otherwise null.
+ */
+function verifyHypothesis(
+  hypothesis: MinedEvidenceHypothesis,
+  byId: Map<string, AllowlistedEvidence>,
+): VerifiedSupportRef[] | null {
+  if (hypothesis.supportRefs.length === 0) return null;
+
+  const verified = new Map<string, VerifiedSupportRef>();
+  for (const ref of hypothesis.supportRefs) {
+    const evidence = byId.get(ref.evidenceId);
+    if (!evidence) return null; // reference to non-allowlisted / hallucinated id
+    if (!speakerAllowedForClaim(hypothesis.claimType, evidence)) return null;
+    if (!evidenceSpanMatches(evidence.content, ref.span)) return null;
+    verified.set(evidence.evidenceId, {
+      evidenceId: evidence.evidenceId,
+      kind: evidence.kind,
+      speaker: evidence.speaker,
+      opportunityId: evidence.opportunityId,
+    });
+  }
+  return [...verified.values()];
+}
+
+/**
+ * Verify + recurrence-gate a batch of mined hypotheses against the allowlisted
+ * evidence produced for the same pass.
+ */
+export function verifyHypotheses(
+  hypotheses: MinedEvidenceHypothesis[],
+  evidence: AllowlistedEvidence[],
+  minDistinctOpportunities: number,
+): VerificationResult {
+  const byId = new Map(evidence.map((e) => [e.evidenceId, e]));
+  const retained: RetainedEvidenceHypothesis[] = [];
+  let supported = 0;
+  let recurrent = 0;
+
+  for (const hypothesis of hypotheses) {
+    const support = verifyHypothesis(hypothesis, byId);
+    if (!support) continue;
+    supported += 1;
+
+    const distinctOpportunities = new Set(support.map((s) => s.opportunityId)).size;
+    if (distinctOpportunities < minDistinctOpportunities) continue;
+    recurrent += 1;
+
+    retained.push({
+      statement: hypothesis.statement,
+      claimType: hypothesis.claimType,
+      support,
+      distinctOpportunities,
+    });
+  }
+
+  return {
+    retained,
+    supported,
+    recurrent,
+    discarded: hypotheses.length - recurrent,
+  };
+}

--- a/packages/protocol/src/opportunity/negotiation-evidence/tests/negotiation-evidence.env.spec.ts
+++ b/packages/protocol/src/opportunity/negotiation-evidence/tests/negotiation-evidence.env.spec.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from "bun:test";
+
+import { NEGOTIATION_EVIDENCE_MIN_DISTINCT_OPPORTUNITIES, NEGOTIATION_EVIDENCE_QUESTIONS_MODES, negotiationEvidenceQuestionsMode } from "../negotiation-evidence.env.js";
+
+const saved = process.env.NEGOTIATION_EVIDENCE_QUESTIONS_MODE;
+
+afterEach(() => {
+  if (saved === undefined) delete process.env.NEGOTIATION_EVIDENCE_QUESTIONS_MODE;
+  else process.env.NEGOTIATION_EVIDENCE_QUESTIONS_MODE = saved;
+});
+
+describe("negotiationEvidenceQuestionsMode", () => {
+  it("defaults to off when unset", () => {
+    delete process.env.NEGOTIATION_EVIDENCE_QUESTIONS_MODE;
+    expect(negotiationEvidenceQuestionsMode()).toBe("off");
+  });
+
+  it("parses every documented mode (trimmed)", () => {
+    for (const mode of NEGOTIATION_EVIDENCE_QUESTIONS_MODES) {
+      process.env.NEGOTIATION_EVIDENCE_QUESTIONS_MODE = `  ${mode}  `;
+      expect(negotiationEvidenceQuestionsMode()).toBe(mode);
+    }
+  });
+
+  it("coerces unrecognized / empty values to off", () => {
+    for (const value of ["", "loud", "true", "on ish", "SHADOW", "1"]) {
+      process.env.NEGOTIATION_EVIDENCE_QUESTIONS_MODE = value;
+      expect(negotiationEvidenceQuestionsMode()).toBe("off");
+    }
+  });
+
+  it("pins the recurrence floor at k=5", () => {
+    expect(NEGOTIATION_EVIDENCE_MIN_DISTINCT_OPPORTUNITIES).toBe(5);
+  });
+});

--- a/packages/protocol/src/opportunity/negotiation-evidence/tests/negotiation-evidence.extractor.spec.ts
+++ b/packages/protocol/src/opportunity/negotiation-evidence/tests/negotiation-evidence.extractor.spec.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "bun:test";
+
+import { extractAllowlistedEvidence } from "../negotiation-evidence.extractor.js";
+import type { EvidenceMiningScope, RawEvidenceSegment } from "../negotiation-evidence.types.js";
+
+const SCOPE: EvidenceMiningScope = {
+  recipientUserId: "owner-1",
+  intentId: "intent-1",
+  intentFingerprint: "fp-1",
+  networkId: "net-1",
+};
+
+/** A fully-populated in-scope segment with one of every allowlisted source. */
+function segment(overrides: Partial<RawEvidenceSegment> = {}): RawEvidenceSegment {
+  return {
+    recipientUserId: "owner-1",
+    intentId: "intent-1",
+    intentFingerprint: "fp-1",
+    networkId: "net-1",
+    opportunityId: "opp-1",
+    taskId: "task-1",
+    conversationId: "conv-1",
+    counterpartyUserId: "cp-1",
+    turns: [
+      {
+        senderUserId: "owner-1",
+        action: "propose",
+        message: "I only take equity deals",
+        sharedTagged: true,
+        reasoning: "SECRET_CHAIN_OF_THOUGHT should never surface",
+        disclosureSubject: "SECRET_DISCLOSURE_SUBJECT should never surface",
+      },
+    ],
+    outcome: {
+      hasOpportunity: true,
+      reason: "turn_cap",
+      agreedRoles: [{ userId: "owner-1", role: "peer" }],
+      reasoning: "SECRET_EVALUATOR_REASONING should never surface",
+    },
+    ownerAnswers: [{ answererUserId: "owner-1", selectedOptions: ["Async only"], freeText: "prefer remote" }],
+    ...overrides,
+  };
+}
+
+/** Concatenate all extracted evidence content for leakage assertions. */
+function allContent(segments: RawEvidenceSegment[]): string {
+  return extractAllowlistedEvidence(SCOPE, segments)
+    .evidence.map((e) => e.content)
+    .join("\n");
+}
+
+describe("extractAllowlistedEvidence — allowlist (positive)", () => {
+  it("extracts owner answers, bilateral actions, coarse outcomes, and tagged shared messages", () => {
+    const result = extractAllowlistedEvidence(SCOPE, [segment()]);
+    expect(result.distinctOpportunities).toBe(1);
+    expect(result.evidenceCounts).toEqual({
+      owner_answer: 1,
+      bilateral_action: 1,
+      coarse_outcome: 1,
+      shared_message: 1,
+    });
+    const owner = result.evidence.find((e) => e.kind === "owner_answer");
+    expect(owner?.speaker).toBe("owner");
+    expect(owner?.content).toContain("Async only");
+    expect(result.evidence.find((e) => e.kind === "bilateral_action")?.speaker).toBe("system");
+    expect(result.evidence.find((e) => e.kind === "shared_message")?.speaker).toBe("owner");
+    // Every unit carries the pass provenance so downstream keying is exact.
+    for (const e of result.evidence) {
+      expect(e.recipientUserId).toBe("owner-1");
+      expect(e.intentId).toBe("intent-1");
+      expect(e.opportunityId).toBe("opp-1");
+    }
+  });
+
+  it("labels a counterparty-sent shared message with the counterparty speaker", () => {
+    const result = extractAllowlistedEvidence(SCOPE, [
+      segment({
+        turns: [{ senderUserId: "cp-1", action: "counter", message: "we prefer cash", sharedTagged: true }],
+        outcome: null,
+        ownerAnswers: [],
+      }),
+    ]);
+    const shared = result.evidence.find((e) => e.kind === "shared_message");
+    expect(shared?.speaker).toBe("counterparty");
+  });
+});
+
+describe("extractAllowlistedEvidence — exclusions", () => {
+  it("never surfaces chain-of-thought, disclosure subjects, or evaluator reasoning", () => {
+    const content = allContent([segment()]);
+    expect(content).not.toContain("SECRET_CHAIN_OF_THOUGHT");
+    expect(content).not.toContain("SECRET_DISCLOSURE_SUBJECT");
+    expect(content).not.toContain("SECRET_EVALUATOR_REASONING");
+  });
+
+  it("excludes untagged messages (only explicitly shared content is mined)", () => {
+    const result = extractAllowlistedEvidence(SCOPE, [
+      segment({
+        turns: [{ senderUserId: "owner-1", action: "propose", message: "untagged private line" }],
+        outcome: null,
+        ownerAnswers: [],
+      }),
+    ]);
+    expect(result.evidenceCounts.shared_message).toBe(0);
+    expect(result.evidenceCounts.bilateral_action).toBe(1); // action still allowlisted
+    expect(result.excludedRecords).toBeGreaterThanOrEqual(1);
+    expect(result.evidence.some((e) => e.content.includes("untagged private line"))).toBe(false);
+  });
+
+  it("drops screened_out outcomes (private client gate) entirely", () => {
+    const result = extractAllowlistedEvidence(SCOPE, [
+      segment({
+        turns: [],
+        ownerAnswers: [],
+        outcome: { hasOpportunity: false, reason: "screened_out" },
+      }),
+    ]);
+    expect(result.evidenceCounts.coarse_outcome).toBe(0);
+    expect(result.distinctOpportunities).toBe(0);
+    expect(result.excludedRecords).toBeGreaterThanOrEqual(1);
+  });
+
+  it("rejects owner answers not authored by the recipient", () => {
+    const result = extractAllowlistedEvidence(SCOPE, [
+      segment({
+        turns: [],
+        outcome: null,
+        ownerAnswers: [{ answererUserId: "cp-1", selectedOptions: ["counterparty answer"] }],
+      }),
+    ]);
+    expect(result.evidenceCounts.owner_answer).toBe(0);
+    expect(result.excludedRecords).toBeGreaterThanOrEqual(1);
+  });
+
+  it("rejects turns from a speaker who is neither owner nor counterparty", () => {
+    const result = extractAllowlistedEvidence(SCOPE, [
+      segment({
+        turns: [{ senderUserId: "stranger-9", action: "counter", message: "leaked", sharedTagged: true }],
+        outcome: null,
+        ownerAnswers: [],
+      }),
+    ]);
+    expect(result.evidenceCounts.bilateral_action).toBe(0);
+    expect(result.evidenceCounts.shared_message).toBe(0);
+    expect(result.excludedRecords).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("extractAllowlistedEvidence — contamination guards", () => {
+  const mismatches: Array<[string, Partial<RawEvidenceSegment>]> = [
+    ["recipient", { recipientUserId: "other-owner" }],
+    ["intent", { intentId: "intent-2" }],
+    ["fingerprint", { intentFingerprint: "fp-2" }],
+    ["network", { networkId: "net-2" }],
+  ];
+
+  for (const [label, override] of mismatches) {
+    it(`rejects a whole segment on ${label} mismatch`, () => {
+      const result = extractAllowlistedEvidence(SCOPE, [segment(override)]);
+      expect(result.distinctOpportunities).toBe(0);
+      expect(result.evidence).toHaveLength(0);
+      expect(result.excludedRecords).toBeGreaterThanOrEqual(1);
+    });
+  }
+
+  it("rejects a self-negotiation (recipient === counterparty)", () => {
+    const result = extractAllowlistedEvidence(SCOPE, [segment({ counterpartyUserId: "owner-1" })]);
+    expect(result.distinctOpportunities).toBe(0);
+    expect(result.evidence).toHaveLength(0);
+  });
+});
+
+describe("extractAllowlistedEvidence — continuation grouping", () => {
+  it("groups continuation segments of one opportunity and dedupes repeated content", () => {
+    const cont1 = segment({ taskId: "task-1" });
+    const cont2 = segment({ taskId: "task-2" }); // same opportunityId, identical content
+    const result = extractAllowlistedEvidence(SCOPE, [cont1, cont2]);
+    // One opportunity, deduped: identical evidence must not double-count.
+    expect(result.distinctOpportunities).toBe(1);
+    expect(result.evidenceCounts).toEqual({
+      owner_answer: 1,
+      bilateral_action: 1,
+      coarse_outcome: 1,
+      shared_message: 1,
+    });
+  });
+
+  it("a single opportunity contributes at most one distinct-opportunity unit no matter how many continuations", () => {
+    const conts = Array.from({ length: 6 }, (_, i) =>
+      segment({ taskId: `task-${i}`, turns: [{ senderUserId: "owner-1", action: "counter" }], outcome: null, ownerAnswers: [] }),
+    );
+    const result = extractAllowlistedEvidence(SCOPE, conts);
+    expect(result.distinctOpportunities).toBe(1);
+    expect(result.evidenceCounts.bilateral_action).toBe(1); // "counter" deduped across all continuations
+  });
+});

--- a/packages/protocol/src/opportunity/negotiation-evidence/tests/negotiation-evidence.extractor.spec.ts
+++ b/packages/protocol/src/opportunity/negotiation-evidence/tests/negotiation-evidence.extractor.spec.ts
@@ -183,6 +183,35 @@ describe("extractAllowlistedEvidence — continuation grouping", () => {
       coarse_outcome: 1,
       shared_message: 1,
     });
+    expect(result.evidence.every((e) => e.taskId === "task-1")).toBe(true);
+  });
+
+  it("preserves each accepted continuation unit's exact task and conversation provenance", () => {
+    const cont1 = segment({
+      taskId: "task-1",
+      conversationId: "conv-1",
+      turns: [{ senderUserId: "owner-1", action: "propose" }],
+      outcome: null,
+      ownerAnswers: [],
+    });
+    const cont2 = segment({
+      taskId: "task-2",
+      conversationId: "conv-2",
+      turns: [{ senderUserId: "cp-1", action: "counter" }],
+      outcome: null,
+      ownerAnswers: [],
+    });
+    const result = extractAllowlistedEvidence(SCOPE, [cont1, cont2]);
+
+    expect(result.distinctOpportunities).toBe(1);
+    expect(result.evidence.find((e) => e.content === "propose")).toMatchObject({
+      taskId: "task-1",
+      conversationId: "conv-1",
+    });
+    expect(result.evidence.find((e) => e.content === "counter")).toMatchObject({
+      taskId: "task-2",
+      conversationId: "conv-2",
+    });
   });
 
   it("a single opportunity contributes at most one distinct-opportunity unit no matter how many continuations", () => {

--- a/packages/protocol/src/opportunity/negotiation-evidence/tests/negotiation-evidence.shadow.spec.ts
+++ b/packages/protocol/src/opportunity/negotiation-evidence/tests/negotiation-evidence.shadow.spec.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "bun:test";
+
+import { runNegotiationEvidenceShadow } from "../negotiation-evidence.shadow.js";
+import type { NegotiationEvidenceMiner } from "../negotiation-evidence.miner.js";
+import type { AllowlistedEvidence, EvidenceMiningScope, MinedEvidenceHypothesis, RawEvidenceSegment } from "../negotiation-evidence.types.js";
+
+const SCOPE: EvidenceMiningScope = {
+  recipientUserId: "owner-1",
+  intentId: "intent-1",
+  intentFingerprint: "fp-1",
+  networkId: "net-1",
+};
+
+/** One in-scope segment per opportunity, all quoting "equity only". */
+function segmentFor(opportunityId: string): RawEvidenceSegment {
+  return {
+    recipientUserId: "owner-1",
+    intentId: "intent-1",
+    intentFingerprint: "fp-1",
+    networkId: "net-1",
+    opportunityId,
+    taskId: `task-${opportunityId}`,
+    conversationId: `conv-${opportunityId}`,
+    counterpartyUserId: `cp-${opportunityId}`,
+    turns: [
+      {
+        senderUserId: "owner-1",
+        action: "propose",
+        message: "equity only, no cash",
+        sharedTagged: true,
+        reasoning: "SECRET_REASONING",
+        disclosureSubject: "SECRET_DISCLOSURE",
+      },
+    ],
+    outcome: { hasOpportunity: true, reason: "turn_cap", reasoning: "SECRET_EVAL" },
+    ownerAnswers: [],
+  };
+}
+
+/** Records what the miner was asked, and returns a scripted hypothesis set. */
+class FakeMiner implements Pick<NegotiationEvidenceMiner, "mine"> {
+  calls = 0;
+  lastEvidence: AllowlistedEvidence[] = [];
+  constructor(private readonly script: (evidence: AllowlistedEvidence[]) => MinedEvidenceHypothesis[]) {}
+  async mine(evidence: AllowlistedEvidence[]): Promise<MinedEvidenceHypothesis[]> {
+    this.calls += 1;
+    this.lastEvidence = evidence;
+    return this.script(evidence);
+  }
+}
+
+describe("runNegotiationEvidenceShadow", () => {
+  it("never calls the miner when below the distinct-opportunity floor", async () => {
+    const miner = new FakeMiner(() => []);
+    const result = await runNegotiationEvidenceShadow({
+      scope: SCOPE,
+      segments: [segmentFor("opp-0"), segmentFor("opp-1")], // only 2 distinct < 5
+      miner,
+    });
+    expect(miner.calls).toBe(0);
+    expect(result.telemetry.hypothesesMined).toBe(0);
+    expect(result.hypotheses).toHaveLength(0);
+    expect(result.telemetry.distinctOpportunities).toBe(2);
+  });
+
+  it("mines, verifies, and recurrence-gates across k distinct opportunities", async () => {
+    const segments = Array.from({ length: 5 }, (_, i) => segmentFor(`opp-${i}`));
+    const miner = new FakeMiner((evidence) => [
+      {
+        statement: "Owner prefers equity",
+        claimType: "recipient_preference",
+        supportRefs: evidence
+          .filter((e) => e.kind === "shared_message")
+          .map((e) => ({ evidenceId: e.evidenceId, span: "equity only" })),
+      },
+    ]);
+    const result = await runNegotiationEvidenceShadow({ scope: SCOPE, segments, miner });
+    expect(miner.calls).toBe(1);
+    expect(result.telemetry.distinctOpportunities).toBe(5);
+    expect(result.telemetry.hypothesesRecurrent).toBe(1);
+    expect(result.hypotheses).toHaveLength(1);
+    expect(result.hypotheses[0].distinctOpportunities).toBe(5);
+  });
+
+  it("passes ONLY allowlisted evidence to the miner (no reasoning/disclosure leakage)", async () => {
+    const segments = Array.from({ length: 5 }, (_, i) => segmentFor(`opp-${i}`));
+    const miner = new FakeMiner(() => []);
+    await runNegotiationEvidenceShadow({ scope: SCOPE, segments, miner });
+    const serialized = JSON.stringify(miner.lastEvidence);
+    expect(serialized).not.toContain("SECRET_REASONING");
+    expect(serialized).not.toContain("SECRET_DISCLOSURE");
+    expect(serialized).not.toContain("SECRET_EVAL");
+  });
+
+  it("emits aggregate-only telemetry (counts, no hypothesis text or spans)", async () => {
+    const segments = Array.from({ length: 5 }, (_, i) => segmentFor(`opp-${i}`));
+    const miner = new FakeMiner((evidence) => [
+      {
+        statement: "PRIVATE_HYPOTHESIS_TEXT",
+        claimType: "observation",
+        supportRefs: evidence.slice(0, 5).map((e) => ({ evidenceId: e.evidenceId, span: "equity only" })),
+      },
+    ]);
+    const result = await runNegotiationEvidenceShadow({ scope: SCOPE, segments, miner });
+    const telemetryJson = JSON.stringify(result.telemetry);
+    // Telemetry is safe to log: it must carry no hypothesis text and no spans.
+    expect(telemetryJson).not.toContain("PRIVATE_HYPOTHESIS_TEXT");
+    expect(telemetryJson).not.toContain("equity only");
+    expect(Object.keys(result.telemetry).sort()).toEqual(
+      [
+        "distinctOpportunities",
+        "evidenceCounts",
+        "excludedRecords",
+        "hypothesesDiscarded",
+        "hypothesesMined",
+        "hypothesesRecurrent",
+        "hypothesesSupported",
+        "intentId",
+        "recipientUserId",
+        "segments",
+      ].sort(),
+    );
+  });
+});

--- a/packages/protocol/src/opportunity/negotiation-evidence/tests/negotiation-evidence.verifier.spec.ts
+++ b/packages/protocol/src/opportunity/negotiation-evidence/tests/negotiation-evidence.verifier.spec.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "bun:test";
+
+import { evidenceSpanMatches, verifyHypotheses } from "../negotiation-evidence.verifier.js";
+import type { AllowlistedEvidence, MinedEvidenceHypothesis } from "../negotiation-evidence.types.js";
+
+/** Build one allowlisted evidence unit tied to a given opportunity/speaker. */
+function ev(
+  ordinal: number,
+  opportunityId: string,
+  content: string,
+  speaker: AllowlistedEvidence["speaker"] = "owner",
+  kind: AllowlistedEvidence["kind"] = "owner_answer",
+): AllowlistedEvidence {
+  return {
+    evidenceId: `${kind}:${opportunityId}:${ordinal}`,
+    kind,
+    speaker,
+    content,
+    recipientUserId: "owner-1",
+    intentId: "intent-1",
+    intentFingerprint: "fp-1",
+    opportunityId,
+    taskId: `task-${opportunityId}`,
+    conversationId: `conv-${opportunityId}`,
+    networkId: "net-1",
+  };
+}
+
+/** Evidence spanning 5 distinct opportunities, all quoting "equity only". */
+function fiveOpportunityEvidence(speaker: AllowlistedEvidence["speaker"] = "owner"): AllowlistedEvidence[] {
+  return Array.from({ length: 5 }, (_, i) => ev(0, `opp-${i}`, "equity only, no cash", speaker));
+}
+
+function hypothesis(evidence: AllowlistedEvidence[], claimType: MinedEvidenceHypothesis["claimType"]): MinedEvidenceHypothesis {
+  return {
+    statement: "Owner prefers equity compensation",
+    claimType,
+    supportRefs: evidence.map((e) => ({ evidenceId: e.evidenceId, span: "equity only" })),
+  };
+}
+
+const K = 5;
+
+describe("evidenceSpanMatches", () => {
+  it("matches a verbatim substring tolerant of case/punctuation", () => {
+    expect(evidenceSpanMatches("I only take EQUITY deals", "equity deals")).toBe(true);
+    expect(evidenceSpanMatches("I only take equity deals", '"equity deals".')).toBe(true);
+  });
+
+  it("rejects paraphrase and too-short spans", () => {
+    expect(evidenceSpanMatches("I only take equity deals", "loves equity compensation")).toBe(false);
+    expect(evidenceSpanMatches("I only take equity deals", "eq")).toBe(false);
+  });
+});
+
+describe("verifyHypotheses — support resolution", () => {
+  it("retains a hypothesis whose every ref resolves and recurs across k opportunities", () => {
+    const evidence = fiveOpportunityEvidence();
+    const result = verifyHypotheses([hypothesis(evidence, "recipient_preference")], evidence, K);
+    expect(result.supported).toBe(1);
+    expect(result.recurrent).toBe(1);
+    expect(result.retained).toHaveLength(1);
+    expect(result.retained[0].distinctOpportunities).toBe(5);
+  });
+
+  it("discards a hypothesis with any reference to a non-allowlisted evidence id", () => {
+    const evidence = fiveOpportunityEvidence();
+    const hyp = hypothesis(evidence, "recipient_preference");
+    hyp.supportRefs.push({ evidenceId: "hallucinated:opp-x:0", span: "equity only" });
+    const result = verifyHypotheses([hyp], evidence, K);
+    expect(result.supported).toBe(0);
+    expect(result.retained).toHaveLength(0);
+  });
+
+  it("discards a hypothesis whose span is not a verbatim substring", () => {
+    const evidence = fiveOpportunityEvidence();
+    const hyp = hypothesis(evidence, "observation");
+    hyp.supportRefs[0] = { evidenceId: evidence[0].evidenceId, span: "totally invented span" };
+    const result = verifyHypotheses([hyp], evidence, K);
+    expect(result.supported).toBe(0);
+  });
+
+  it("discards a hypothesis with no support references", () => {
+    const evidence = fiveOpportunityEvidence();
+    const result = verifyHypotheses(
+      [{ statement: "unfounded", claimType: "observation", supportRefs: [] }],
+      evidence,
+      K,
+    );
+    expect(result.supported).toBe(0);
+  });
+});
+
+describe("verifyHypotheses — speaker constraint", () => {
+  it("forbids counterparty statements from establishing a fact/preference about the recipient", () => {
+    const evidence = fiveOpportunityEvidence("counterparty");
+    for (const claimType of ["recipient_fact", "recipient_preference"] as const) {
+      const result = verifyHypotheses([hypothesis(evidence, claimType)], evidence, K);
+      expect(result.supported).toBe(0);
+      expect(result.retained).toHaveLength(0);
+    }
+  });
+
+  it("allows counterparty statements to support an observation", () => {
+    const evidence = fiveOpportunityEvidence("counterparty");
+    const result = verifyHypotheses([hypothesis(evidence, "observation")], evidence, K);
+    expect(result.recurrent).toBe(1);
+    expect(result.retained).toHaveLength(1);
+  });
+
+  it("allows system (bilateral) evidence to support a recipient claim", () => {
+    const evidence = Array.from({ length: 5 }, (_, i) =>
+      ev(0, `opp-${i}`, "hasOpportunity=true reason=turn_cap", "system", "coarse_outcome"),
+    );
+    const hyp: MinedEvidenceHypothesis = {
+      statement: "Owner reliably reaches agreement",
+      claimType: "recipient_fact",
+      supportRefs: evidence.map((e) => ({ evidenceId: e.evidenceId, span: "hasOpportunity=true" })),
+    };
+    const result = verifyHypotheses([hyp], evidence, K);
+    expect(result.recurrent).toBe(1);
+  });
+});
+
+describe("verifyHypotheses — recurrence gate (contamination-proof)", () => {
+  it("rejects support that repeats within the SAME opportunity (below distinct floor)", () => {
+    // 5 refs, but all point at the same opportunity → 1 distinct → discarded.
+    const sameOpp = Array.from({ length: 5 }, (_, i) => ev(i, "opp-single", "equity only, no cash"));
+    const result = verifyHypotheses([hypothesis(sameOpp, "recipient_preference")], sameOpp, K);
+    expect(result.supported).toBe(1); // refs resolve...
+    expect(result.recurrent).toBe(0); // ...but recurrence across distinct opportunities fails
+    expect(result.retained).toHaveLength(0);
+  });
+
+  it("rejects when distinct opportunities is one short of the floor", () => {
+    const fourOpps = Array.from({ length: 4 }, (_, i) => ev(0, `opp-${i}`, "equity only, no cash"));
+    const result = verifyHypotheses([hypothesis(fourOpps, "recipient_preference")], fourOpps, K);
+    expect(result.recurrent).toBe(0);
+  });
+
+  it("counts distinct opportunities in discarded telemetry", () => {
+    const evidence = fiveOpportunityEvidence();
+    const good = hypothesis(evidence, "observation");
+    const bad: MinedEvidenceHypothesis = { statement: "x", claimType: "observation", supportRefs: [] };
+    const result = verifyHypotheses([good, bad], evidence, K);
+    expect(result.discarded).toBe(1); // 2 mined − 1 recurrent
+  });
+});

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -53,7 +53,7 @@ import { INTRODUCER_DISCOVERY_SOURCE } from './opportunity.introducer.js';
 import { negotiateCandidates, type NegotiationCandidate, type OnNegotiationResolved } from "../negotiation/negotiation.graph.js";
 import { AMBIENT_PARK_WINDOW_MS } from "../negotiation/negotiation.tools.js";
 import { buildDiscoverySummary, toDiscoveryNegotiation, type NegotiationResolution } from "./negotiation-summary.builder.js";
-import type { NegotiationGraphLike } from "../negotiation/negotiation.state.js";
+import type { NegotiationGraphLike, UserNegotiationContext } from "../negotiation/negotiation.state.js";
 import type { AgentDispatcher } from "../shared/interfaces/agent-dispatcher.interface.js";
 import { protocolLogger, withCallLogging } from '../shared/observability/protocol.logger.js';
 import { timed } from '../shared/observability/performance.js';
@@ -84,6 +84,48 @@ const routingLog = protocolLogger('OpportunityGraph:Routing');
 
 /** Time window for persist-node dedup. Suppresses a second opportunity with the same person while a recent one (within 30 days) is still in flight, so a person is not re-surfaced multiple times within a month (EDG-23). */
 const DEDUP_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+const NEGOTIATION_INTENT_LIMIT = 5;
+
+interface NegotiationIntentSource {
+  id?: string | null;
+  summary?: string | null;
+  payload?: string | null;
+}
+
+/** Put an opportunity actor's exact intent first, then fill the bounded context without duplicates. */
+export function buildPrioritizedNegotiationIntents(
+  activeIntents: readonly NegotiationIntentSource[],
+  exactIntentId?: string | null,
+  fallbackIntent?: NegotiationIntentSource | null,
+): UserNegotiationContext['intents'] {
+  const exactId = typeof exactIntentId === 'string' && exactIntentId.trim().length > 0
+    ? exactIntentId
+    : null;
+  const exactActive = exactId
+    ? activeIntents.find((intent) => intent.id === exactId)
+    : undefined;
+  const ordered = [
+    ...(exactActive ? [exactActive] : []),
+    ...(!exactActive && fallbackIntent?.id === exactId ? [fallbackIntent] : []),
+    ...activeIntents,
+  ];
+  const seen = new Set<string>();
+  const intents: UserNegotiationContext['intents'] = [];
+
+  for (const intent of ordered) {
+    if (typeof intent.id !== 'string' || intent.id.trim().length === 0 || seen.has(intent.id)) continue;
+    seen.add(intent.id);
+    intents.push({
+      id: intent.id,
+      title: intent.summary ?? '',
+      description: intent.payload ?? '',
+      confidence: 1,
+    });
+    if (intents.length === NEGOTIATION_INTENT_LIMIT) break;
+  }
+
+  return intents;
+}
 
 /** Default cap for source premises used by premise-to-premise discovery. Prevents BACKEND-5-style fan-out. */
 const DEFAULT_SOURCE_PREMISE_DISCOVERY_LIMIT = 40;
@@ -2011,15 +2053,26 @@ export class OpportunityGraphFactory {
         const discoveryUserId = (state.onBehalfOfUserId ?? state.userId) as string;
 
         const sourceAccount = await this.database.getUser(discoveryUserId).catch(() => null);
+        const sourceIntentInputs = (state.indexedIntents ?? []).map((intent) => ({
+          id: intent.intentId as string,
+          summary: intent.summary ?? null,
+          payload: intent.payload ?? null,
+        }));
+        const sourceHasExactIntent = sourceIntentInputs.some((intent) => intent.id === state.triggerIntentId);
+        const sourceFallbackIntent = state.triggerIntentId && !sourceHasExactIntent
+          ? await this.database.getIntent(state.triggerIntentId).catch(() => null)
+          : null;
+        const ownedSourceFallback = sourceFallbackIntent?.userId === discoveryUserId
+          ? sourceFallbackIntent
+          : null;
 
         const sourceUser = {
           id: discoveryUserId,
-          intents: state.indexedIntents?.slice(0, 5).map(i => ({
-            id: i.intentId as string,
-            title: i.summary ?? '',
-            description: i.payload ?? '',
-            confidence: 1,
-          })) ?? [],
+          intents: buildPrioritizedNegotiationIntents(
+            sourceIntentInputs,
+            state.triggerIntentId,
+            ownedSourceFallback,
+          ),
           profile: {
             name: state.sourceProfile?.identity?.name ?? sourceAccount?.name,
             bio: state.sourceProfile?.identity?.bio ?? sourceAccount?.intro ?? undefined,
@@ -2048,8 +2101,13 @@ export class OpportunityGraphFactory {
               return null;
             }
 
-            const candidateActor = (opp.actors as Array<{ userId: string; role?: string; networkId?: string; intentId?: string }>)
-              .find(a => a.userId !== discoveryUserId);
+            const candidateActor = (opp.actors as Array<{
+              userId: string;
+              role?: string;
+              networkId?: string;
+              intent?: string;
+              intentId?: string;
+            }>).find(a => a.userId !== discoveryUserId);
             if (!candidateActor) {
               negotiateLog.verbose('Skipping opportunity: no candidateActor found', {
                 opportunityId: opp.id,
@@ -2070,28 +2128,22 @@ export class OpportunityGraphFactory {
         const candidates: NegotiationCandidate[] = await Promise.all(
           candidateEntries.map(async ({ opp, candidateActor }) => {
             const userId = candidateActor.userId as string;
+            const candidateIntentId = candidateActor.intentId ?? candidateActor.intent;
             const [profile, user, activeIntents, intent] = await Promise.all([
               this.database.getProfile(userId).catch(() => null),
               this.database.getUser(userId).catch(() => null),
               this.database.getActiveIntents(userId).catch(() => []),
-              candidateActor.intentId
-                ? this.database.getIntent(candidateActor.intentId as string).catch(() => null)
+              candidateIntentId
+                ? this.database.getIntent(candidateIntentId).catch(() => null)
                 : null,
             ]);
 
-            const toNegIntent = (ai: { id?: string | null; summary?: string | null; payload?: string | null }) => ({
-              id: (ai.id ?? candidateActor.intentId) as string,
-              title: ai.summary ?? '',
-              description: ai.payload ?? '',
-              confidence: 1,
-            });
-            const triggerInActive = activeIntents.some(ai => ai.id === candidateActor.intentId);
-            const triggerFallback = !triggerInActive && intent ? [toNegIntent(intent)] : [];
-            const candidateIntents = [
-              ...triggerFallback,
-              ...activeIntents.filter(ai => ai.id === candidateActor.intentId).map(toNegIntent),
-              ...activeIntents.filter(ai => ai.id !== candidateActor.intentId).map(toNegIntent),
-            ].slice(0, 5);
+            const ownedFallbackIntent = intent?.userId === userId ? intent : null;
+            const candidateIntents = buildPrioritizedNegotiationIntents(
+              activeIntents,
+              candidateIntentId,
+              ownedFallbackIntent,
+            );
 
             return {
               userId,
@@ -3735,7 +3787,7 @@ export class OpportunityGraphFactory {
           return {};
         }
 
-        const actors = opp.actors as OpportunityActor[];
+        const actors = opp.actors as Array<OpportunityActor & { intentId?: string }>;
         const nonIntroducerActors = actors.filter(a => a.role !== 'introducer');
 
         // Find the sourceActor: non-introducer with role patient or party, fallback to first non-introducer
@@ -3753,6 +3805,9 @@ export class OpportunityGraphFactory {
           return {};
         }
 
+        const sourceIntentId = sourceActor.intentId ?? sourceActor.intent;
+        const candidateIntentId = candidateActor.intentId ?? candidateActor.intent;
+
         // Load user data for both actors in parallel
         const [sourceUserAccount, sourceProfile, sourceIntents, candidateAccount, candidateProfile, candidateIntents] =
           await Promise.all([
@@ -3764,16 +3819,24 @@ export class OpportunityGraphFactory {
             this.database.getActiveIntents(candidateActor.userId).catch(() => [] as ActiveIntent[]),
           ]);
 
-        const toNegIntent = (ai: ActiveIntent) => ({
-          id: ai.id as string,
-          title: ai.summary ?? '',
-          description: ai.payload ?? '',
-          confidence: 1,
-        });
+        const sourceHasExactIntent = sourceIntents.some((intent) => intent.id === sourceIntentId);
+        const candidateHasExactIntent = candidateIntents.some((intent) => intent.id === candidateIntentId);
+        const [sourceFallbackIntent, candidateFallbackIntent] = await Promise.all([
+          sourceIntentId && !sourceHasExactIntent
+            ? this.database.getIntent(sourceIntentId).catch(() => null)
+            : null,
+          candidateIntentId && !candidateHasExactIntent
+            ? this.database.getIntent(candidateIntentId).catch(() => null)
+            : null,
+        ]);
 
         const sourceUser = {
           id: sourceActor.userId,
-          intents: sourceIntents.slice(0, 5).map(toNegIntent),
+          intents: buildPrioritizedNegotiationIntents(
+            sourceIntents,
+            sourceIntentId,
+            sourceFallbackIntent?.userId === sourceActor.userId ? sourceFallbackIntent : null,
+          ),
           profile: {
             name: sourceProfile?.identity?.name ?? sourceUserAccount?.name,
             bio: sourceProfile?.identity?.bio ?? sourceUserAccount?.intro ?? undefined,
@@ -3781,7 +3844,11 @@ export class OpportunityGraphFactory {
           },
         };
 
-        const candidateIntentsForNeg = candidateIntents.slice(0, 5).map(toNegIntent);
+        const candidateIntentsForNeg = buildPrioritizedNegotiationIntents(
+          candidateIntents,
+          candidateIntentId,
+          candidateFallbackIntent?.userId === candidateActor.userId ? candidateFallbackIntent : null,
+        );
 
         const candidate: NegotiationCandidate = {
           userId: candidateActor.userId,

--- a/packages/protocol/src/opportunity/tests/opportunity.graph.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.graph.spec.ts
@@ -8,7 +8,7 @@ import { config } from "dotenv";
 config({ path: '.env.test', override: true });
 
 import { afterAll, beforeAll, describe, test, it, expect, mock, spyOn } from 'bun:test';
-import { OpportunityGraphFactory, type OpportunityEvaluatorLike, buildDiscovererContext } from '../opportunity.graph.js';
+import { OpportunityGraphFactory, type OpportunityEvaluatorLike, buildDiscovererContext, buildPrioritizedNegotiationIntents } from '../opportunity.graph.js';
 import type { Id } from '../../types/common.types.js';
 import type { CreateOpportunityData, HydeDocument, OpportunityGraphDatabase, OpportunityActor, Opportunity } from '../../shared/interfaces/database.interface.js';
 import type { Embedder } from '../../shared/interfaces/embedder.interface.js';
@@ -24,6 +24,31 @@ type OpportunityGraphInvokeInput = Parameters<ReturnType<OpportunityGraphFactory
 type OpportunityGraphInvokeResult = Awaited<ReturnType<ReturnType<OpportunityGraphFactory['createGraph']>['invoke']>>;
 
 const dummyEmbedding = new Array(2000).fill(0.1);
+
+describe('buildPrioritizedNegotiationIntents', () => {
+  test('prioritizes an exact fallback intent, removes duplicates, and keeps the five-intent cap', () => {
+    const intents = buildPrioritizedNegotiationIntents(
+      [
+        { id: 'other-1', summary: 'Other 1', payload: 'one' },
+        { id: 'other-1', summary: 'Duplicate', payload: 'duplicate' },
+        { id: 'other-2', summary: 'Other 2', payload: 'two' },
+        { id: 'other-3', summary: 'Other 3', payload: 'three' },
+        { id: 'other-4', summary: 'Other 4', payload: 'four' },
+        { id: 'other-5', summary: 'Other 5', payload: 'five' },
+      ],
+      'exact-intent',
+      { id: 'exact-intent', summary: 'Exact', payload: 'exact payload' },
+    );
+
+    expect(intents.map((intent) => intent.id)).toEqual([
+      'exact-intent',
+      'other-1',
+      'other-2',
+      'other-3',
+      'other-4',
+    ]);
+  });
+});
 
 const defaultMockEvaluatorResult: EvaluatedOpportunityWithActors[] = [
   {
@@ -2756,14 +2781,14 @@ describe('Opportunity Graph', () => {
           isPersonal: false,
           joinedAt: new Date(),
         }]),
-        getActiveIntents: (userId: string) => Promise.resolve([
-          {
-            id: `intent-${userId}` as Id<'intents'>,
-            payload: `Intent for ${userId}`,
-            summary: null,
+        getActiveIntents: (userId: string) => Promise.resolve(
+          Array.from({ length: 6 }, (_, index) => ({
+            id: `other-${userId}-${index}` as Id<'intents'>,
+            payload: `Other intent ${index} for ${userId}`,
+            summary: `Other ${index}`,
             createdAt: new Date(),
-          },
-        ]),
+          })),
+        ),
         getNetwork: () => Promise.resolve({ id: 'idx-1', title: 'Test Index' }),
         getNetworkMemberCount: () => Promise.resolve(2),
         getNetworkIdsForIntent: () => Promise.resolve(['idx-1']),
@@ -2776,7 +2801,17 @@ describe('Opportunity Graph', () => {
         getOpportunitiesForUser: () => Promise.resolve([]),
         updateOpportunityStatus: () => Promise.resolve(null),
         updateOpportunityActorApproval: () => Promise.resolve(null),
-        getIntent: () => Promise.resolve(null),
+        getIntent: (intentId: string) => Promise.resolve({
+          id: intentId as Id<'intents'>,
+          userId: intentId === 'intent-patient' ? 'patient-user' : 'agent-user',
+          payload: `Exact payload for ${intentId}`,
+          summary: `Exact ${intentId}`,
+          isIncognito: false,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          archivedAt: null,
+          status: 'ACTIVE' as const,
+        }),
         getIntentIndexScores: async () => [],
         getNetworkMemberContext: async () => null,
         getNegotiationTaskForOpportunity: async () => null,
@@ -2819,8 +2854,19 @@ describe('Opportunity Graph', () => {
         options: {},
       });
 
-      // Negotiation should have been invoked
+      // Negotiation should have been invoked with each opportunity actor's exact
+      // intent first, even though it required fallback loading outside the active list.
       expect(negotiationInvocations.length).toBeGreaterThan(0);
+      const invocation = negotiationInvocations[0] as {
+        sourceUser: { intents: Array<{ id: string }> };
+        candidateUser: { intents: Array<{ id: string }> };
+      };
+      expect(invocation.sourceUser.intents).toHaveLength(5);
+      expect(invocation.candidateUser.intents).toHaveLength(5);
+      expect(invocation.sourceUser.intents[0]?.id).toBe('intent-patient');
+      expect(invocation.candidateUser.intents[0]?.id).toBe('intent-agent');
+      expect(new Set(invocation.sourceUser.intents.map((intent) => intent.id)).size).toBe(5);
+      expect(new Set(invocation.candidateUser.intents.map((intent) => intent.id)).size).toBe(5);
 
       // Notifications should be sent to non-introducer actors only
       expect(notifiedUserIds).toContain('patient-user');

--- a/packages/protocol/src/shared/agent/model.config.ts
+++ b/packages/protocol/src/shared/agent/model.config.ts
@@ -57,6 +57,7 @@ function getModelConfig(config?: ModelConfig) {
     negotiationSummarizer:      { model: "google/gemini-2.5-flash", temperature: 0.2, maxTokens: 256 },
     poolDiscriminatorMiner:        { model: "google/gemini-2.5-flash", temperature: 0.2, maxTokens: 4096 },
     poolDiscriminatorAssigner:     { model: "google/gemini-2.5-flash", temperature: 0.1, maxTokens: 16384 },
+    negotiationEvidenceMiner:      { model: "google/gemini-2.5-flash", temperature: 0.2, maxTokens: 4096 },
     inviteGenerator:      { model: "google/gemini-2.5-flash", temperature: 0.3, maxTokens: 512 },
     premiseAnalyzer:      { model: "google/gemini-2.5-flash" },
     premiseDecomposer:    { model: "google/gemini-2.5-flash" },

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/adapters/chat.database.adapter.ts
+++ b/services/api/src/adapters/chat.database.adapter.ts
@@ -19,7 +19,9 @@ export class ChatDatabaseAdapter {
 
   // Negotiation context methods — required by HomeGraphDatabase
   async getNegotiationTaskForOpportunity(opportunityId: string) { return _convDb().getNegotiationTaskForOpportunity(opportunityId); }
+  async getNegotiationTasksForOpportunity(opportunityId: string) { return _convDb().getNegotiationTasksForOpportunity(opportunityId); }
   async getMessagesForConversation(conversationId: string) { return _convDb().getMessagesForConversation(conversationId); }
+  async getMessagesByTaskIds(taskIds: string[]) { return _convDb().getMessagesByTaskIds(taskIds); }
   async getArtifactsForTask(taskId: string) { return _convDb().getArtifactsForTask(taskId); }
 
   // ─────────────────────────────────────────────────────────────────────────────

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -1100,6 +1100,42 @@ export class ConversationDatabaseAdapter {
   }
 
   /**
+   * Looks up every negotiation task attached to an opportunity, ordered from
+   * oldest to newest so continuation provenance remains stable.
+   *
+   * @param opportunityId - Opportunity id stored on task metadata
+   * @returns All matching task records, oldest first
+   */
+  async getNegotiationTasksForOpportunity(opportunityId: string): Promise<Array<{
+    id: string;
+    conversationId: string;
+    state: string;
+    metadata: Record<string, unknown> | null;
+    createdAt: Date;
+    updatedAt: Date;
+  }>> {
+    const rows = await db
+      .select()
+      .from(schema.tasks)
+      .where(
+        and(
+          sql`${schema.tasks.metadata}->>'type' = 'negotiation'`,
+          sql`${schema.tasks.metadata}->>'opportunityId' = ${opportunityId}`,
+        ),
+      )
+      .orderBy(asc(schema.tasks.createdAt));
+
+    return rows.map((row) => ({
+      id: row.id,
+      conversationId: row.conversationId,
+      state: row.state as string,
+      metadata: (row.metadata as Record<string, unknown> | null) ?? null,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    }));
+  }
+
+  /**
    * Returns the most-recently-created negotiation task on a conversation,
    * regardless of opportunityId or direction. Used by the negotiation init
    * node's conversation-scoped initiator tie-break: symmetric concurrent

--- a/services/api/src/queues/pool/mining.shared.ts
+++ b/services/api/src/queues/pool/mining.shared.ts
@@ -30,6 +30,7 @@ import { embedderAdapter } from '../../adapters/embedder.adapter';
 import { QuestionerAdapter } from '../../adapters/questioner.adapter';
 import { questionerEnqueueIfEnabled } from '../questioner.queue';
 import { buildPoolCandidateContexts } from './context.shared';
+import { maybeRunNegotiationEvidenceShadow } from './negotiation-evidence.shadow';
 import { resolvePoolAxisNoveltyReferences } from './novelty.shared';
 import { POOL_QUESTION_FRESHNESS_THRESHOLD, extractSnapshotOpportunityIds, isPoolArtifactFresh, setJaccard } from './poolquestions.constants';
 
@@ -88,6 +89,11 @@ export function isPoolMiningActivated(): boolean {
 }
 
 export async function minePoolDiscriminatorsOnCompletion(trigger: PoolMiningTrigger): Promise<void> {
+  // Lens C (IND-433) runs on its OWN flag, independent of the Lens A pool
+  // flags below — fire-and-forget and fully failure-isolated so it neither
+  // blocks nor perturbs the discriminator mining path.
+  void maybeRunNegotiationEvidenceShadow(trigger).catch(() => {});
+
   if (!isPoolMiningActivated()) return;
   // Introducer flow: the discovered candidates are matches for someone else,
   // not the viewer's own pool — discriminator questions don't apply.

--- a/services/api/src/queues/pool/negotiation-evidence.shadow.ts
+++ b/services/api/src/queues/pool/negotiation-evidence.shadow.ts
@@ -1,0 +1,192 @@
+/**
+ * Lens C negotiation-evidence shadow hook (IND-433).
+ *
+ * When a discovery pipeline completes, mine neutral clarification hypotheses
+ * from RECURRING negotiation evidence across the viewer's intent pool — read
+ * IN PLACE at mining time, never projected into a durable transcript. This is
+ * a privacy-safe SHADOW pass: it performs NO persistence, enqueues NO
+ * question, and changes NO ranking/intent/premise/memory/policy. It logs only
+ * aggregate telemetry (counts) and NEVER the mined hypothesis text.
+ *
+ * Gated by its OWN flag (`NEGOTIATION_EVIDENCE_QUESTIONS_MODE`, default off) and
+ * wired independently of the Lens A pool flags, so this lens can run even when
+ * pool discriminator mining is disabled. Fully failure-isolated: it never
+ * throws into the caller's discovery lifecycle.
+ */
+import { NEGOTIATION_EVIDENCE_MAX_OPPORTUNITIES, NegotiationEvidenceMiner, negotiationEvidenceQuestionsMode, runNegotiationEvidenceShadow } from '@indexnetwork/protocol';
+import type { RawEvidenceOutcome, RawEvidenceOwnerAnswer, RawEvidenceSegment, RawEvidenceTurn } from '@indexnetwork/protocol';
+
+import { log } from '../../lib/log';
+import { computeIntentFingerprint } from '../../lib/intent/intent.fingerprint';
+import { chatDatabaseAdapter } from '../../adapters/database.adapter';
+import { selectPoolForMining } from './mining.shared';
+import type { PoolMiningTrigger } from './mining.shared';
+
+/** Greppable logger (IND-433): search deploy logs for "NegotiationEvidenceShadow". */
+const logger = log.job.from('NegotiationEvidenceShadow');
+
+/** Lazily constructed so importing this module never requires OPENROUTER_API_KEY. */
+let miner: NegotiationEvidenceMiner | null = null;
+
+/** Coarse outcome reasons that survive the allowlist (screened_out is a private gate). */
+const ALLOWED_OUTCOME_REASONS = new Set<RawEvidenceOutcome['reason']>(['turn_cap', 'timeout', 'screened_out']);
+
+/**
+ * Fire-and-forget, failure-isolated, flag-gated Lens C shadow pass over the
+ * triggering intent's pool. Never throws; never persists; never enqueues.
+ */
+export async function maybeRunNegotiationEvidenceShadow(trigger: PoolMiningTrigger): Promise<void> {
+  // Own flag gate — independent of the Lens A pool flags.
+  if (negotiationEvidenceQuestionsMode() === 'off') return;
+  // Introducer flow candidates are matches for someone else, not the viewer's
+  // own pool; and this lens is strictly intent-scoped.
+  if (trigger.isIntroducerFlow) return;
+  if (!trigger.intentId) return;
+
+  const { userId, intentId } = trigger;
+  try {
+    const intent = await chatDatabaseAdapter.getIntent(intentId);
+    if (intent?.userId !== userId) return;
+    const intentFingerprint = computeIntentFingerprint(intent.payload, intent.summary);
+
+    // Same exact-trigger selector the Lens A hook uses.
+    const pool = await selectPoolForMining(userId, intentId, trigger.sessionId);
+
+    // Keep the pass single-network: group by context.networkId and mine only
+    // the largest network group so evidence never crosses network boundaries.
+    const byNetwork = new Map<string, typeof pool>();
+    for (const o of pool) {
+      const networkId = o.context?.networkId;
+      if (!networkId) continue;
+      const group = byNetwork.get(networkId) ?? [];
+      group.push(o);
+      byNetwork.set(networkId, group);
+    }
+    let passNetworkId: string | undefined;
+    let passPool: typeof pool = [];
+    for (const [networkId, group] of byNetwork) {
+      if (group.length > passPool.length) {
+        passNetworkId = networkId;
+        passPool = group;
+      }
+    }
+    if (!passNetworkId || passPool.length === 0) {
+      logger.debug('negotiation-evidence shadow skipped: no single-network pool', {
+        source: trigger.source,
+        runId: trigger.runId ?? null,
+        intentId,
+      });
+      return;
+    }
+
+    const selected = passPool.slice(0, NEGOTIATION_EVIDENCE_MAX_OPPORTUNITIES);
+
+    const segments: RawEvidenceSegment[] = [];
+    for (const o of selected) {
+      const counterpartyUserId = o.actors.find(
+        (a) => a.userId !== userId && a.role !== 'introducer',
+      )?.userId;
+      if (!counterpartyUserId) continue;
+
+      const task = await chatDatabaseAdapter.getNegotiationTaskForOpportunity(o.id);
+      if (!task) continue;
+
+      // Turns: read in place. Copy ONLY the allowlisted projection — never
+      // assessment/reasoning/askUser/disclosureSubject, and never mark a turn
+      // sharedTagged (no explicit shared-consent marker exists in the schema,
+      // so shared messages are excluded by default).
+      const messages = await chatDatabaseAdapter.getMessagesForConversation(task.conversationId);
+      const turns: RawEvidenceTurn[] = [];
+      for (const message of messages) {
+        const dataPart = (message.parts as Array<{ kind?: string; data?: unknown }>).find(
+          (p) => p.kind === 'data',
+        );
+        if (!dataPart?.data) continue;
+        const data = dataPart.data as { action?: string; message?: string | null };
+        turns.push({
+          senderUserId: message.senderId,
+          action: data.action ?? '',
+          message: data.message ?? null,
+        });
+      }
+
+      // Outcome: coarse structured facts only. Never copy evaluator reasoning.
+      const artifacts = await chatDatabaseAdapter.getArtifactsForTask(task.id);
+      const outcomeArtifact = artifacts.find((a) => a.name === 'negotiation-outcome');
+      let outcome: RawEvidenceOutcome | undefined;
+      if (outcomeArtifact) {
+        const dataPart = (outcomeArtifact.parts as Array<{ kind?: string; data?: unknown }>).find(
+          (p) => p.kind === 'data',
+        );
+        const data = dataPart?.data as
+          | { hasOpportunity?: boolean; reason?: string; agreedRoles?: Array<{ userId: string; role: string }> }
+          | undefined;
+        if (data) {
+          const reason = ALLOWED_OUTCOME_REASONS.has(data.reason as RawEvidenceOutcome['reason'])
+            ? (data.reason as RawEvidenceOutcome['reason'])
+            : undefined;
+          outcome = {
+            hasOpportunity: data.hasOpportunity ?? false,
+            ...(reason ? { reason } : {}),
+            ...(data.agreedRoles ? { agreedRoles: data.agreedRoles } : {}),
+          };
+        }
+      }
+
+      // Owner answers: the recipient's own authoritative answers. Read from the
+      // opportunity metadata (the adapter surface exposes no dedicated reader).
+      const rawAnswers = Array.isArray(o.metadata?.userAnswers)
+        ? (o.metadata.userAnswers as Array<{ selectedOptions?: string[]; freeText?: string }>)
+        : [];
+      const ownerAnswers: RawEvidenceOwnerAnswer[] = rawAnswers.map((a) => ({
+        answererUserId: userId,
+        selectedOptions: a.selectedOptions ?? [],
+        ...(a.freeText !== undefined ? { freeText: a.freeText } : {}),
+      }));
+
+      segments.push({
+        recipientUserId: userId,
+        intentId,
+        intentFingerprint,
+        opportunityId: o.id,
+        taskId: task.id,
+        conversationId: task.conversationId,
+        networkId: passNetworkId,
+        counterpartyUserId,
+        turns,
+        ...(outcome ? { outcome } : {}),
+        ownerAnswers,
+      });
+    }
+
+    if (segments.length < 1) {
+      logger.debug('negotiation-evidence shadow skipped: no minable segments', {
+        source: trigger.source,
+        runId: trigger.runId ?? null,
+        intentId,
+      });
+      return;
+    }
+
+    miner ??= new NegotiationEvidenceMiner();
+    const result = await runNegotiationEvidenceShadow({
+      scope: { recipientUserId: userId, intentId, intentFingerprint, networkId: passNetworkId },
+      segments,
+      miner,
+    });
+
+    // Log ONLY aggregate telemetry. NEVER log result.hypotheses or any
+    // hypothesis text — shadow mode must not persist or route the hypotheses.
+    logger.info('negotiation-evidence shadow result', {
+      source: trigger.source,
+      runId: trigger.runId ?? null,
+      ...result.telemetry,
+    });
+  } catch (error) {
+    logger.warn('negotiation-evidence shadow pass failed', {
+      source: trigger.source,
+      intentId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/services/api/src/queues/pool/negotiation-evidence.shadow.ts
+++ b/services/api/src/queues/pool/negotiation-evidence.shadow.ts
@@ -14,11 +14,11 @@
  * throws into the caller's discovery lifecycle.
  */
 import { NEGOTIATION_EVIDENCE_MAX_OPPORTUNITIES, NegotiationEvidenceMiner, negotiationEvidenceQuestionsMode, runNegotiationEvidenceShadow } from '@indexnetwork/protocol';
-import type { RawEvidenceOutcome, RawEvidenceOwnerAnswer, RawEvidenceSegment, RawEvidenceTurn } from '@indexnetwork/protocol';
+import type { RawEvidenceOutcome, RawEvidenceSegment, RawEvidenceTurn } from '@indexnetwork/protocol';
 
-import { log } from '../../lib/log';
-import { computeIntentFingerprint } from '../../lib/intent/intent.fingerprint';
 import { chatDatabaseAdapter } from '../../adapters/database.adapter';
+import { computeIntentFingerprint } from '../../lib/intent/intent.fingerprint';
+import { log } from '../../lib/log';
 import { selectPoolForMining } from './mining.shared';
 import type { PoolMiningTrigger } from './mining.shared';
 
@@ -30,40 +30,371 @@ let miner: NegotiationEvidenceMiner | null = null;
 
 /** Coarse outcome reasons that survive the allowlist (screened_out is a private gate). */
 const ALLOWED_OUTCOME_REASONS = new Set<RawEvidenceOutcome['reason']>(['turn_cap', 'timeout', 'screened_out']);
+const MAX_ERROR_LABEL_CHARS = 64;
+
+interface ShadowIntent {
+  userId: string;
+  payload: string;
+  summary: string | null;
+  archivedAt: Date | null;
+  status: string | null;
+}
+
+interface ShadowOpportunity {
+  id: string;
+  actors: Array<{ userId: string; role: string }>;
+  context?: { networkId?: string | null } | null;
+}
+
+interface ShadowTask {
+  id: string;
+  conversationId: string;
+  state: string;
+  metadata: Record<string, unknown> | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+interface ShadowMessage {
+  senderId: string;
+  parts: unknown;
+}
+
+interface ShadowArtifact {
+  name: string | null;
+  parts: unknown[];
+}
+
+interface ShadowLogger {
+  debug: (message: string, metadata?: Record<string, unknown>) => void;
+  info: (message: string, metadata?: Record<string, unknown>) => void;
+  warn: (message: string, metadata?: Record<string, unknown>) => void;
+}
+
+/** Injectable boundaries keep the shadow producer unit-testable without DB/LLM access. */
+export interface NegotiationEvidenceShadowDeps {
+  database: {
+    getIntent: (intentId: string) => Promise<ShadowIntent | null>;
+    getNegotiationTasksForOpportunity: (opportunityId: string) => Promise<ShadowTask[]>;
+    getMessagesByTaskIds: (taskIds: string[]) => Promise<Map<string, ShadowMessage[]>>;
+    getArtifactsForTask: (taskId: string) => Promise<ShadowArtifact[]>;
+  };
+  selectPool: (
+    userId: string,
+    intentId: string,
+    sessionId: string | undefined,
+  ) => Promise<ShadowOpportunity[]>;
+  getMiner: () => NegotiationEvidenceMiner;
+  runShadow: typeof runNegotiationEvidenceShadow;
+  logger: ShadowLogger;
+}
+
+const DEFAULT_DEPS: NegotiationEvidenceShadowDeps = {
+  database: chatDatabaseAdapter,
+  selectPool: (userId, intentId, sessionId) => selectPoolForMining(userId, intentId, sessionId),
+  getMiner: () => {
+    miner ??= new NegotiationEvidenceMiner();
+    return miner;
+  },
+  runShadow: runNegotiationEvidenceShadow,
+  logger,
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function boundedErrorLabel(value: string, fallback: string): string {
+  const normalized = value.replace(/[^a-zA-Z0-9_.:-]/g, '_').slice(0, MAX_ERROR_LABEL_CHARS);
+  return normalized || fallback;
+}
+
+/** Convert an exception to bounded class/code labels without retaining payload text. */
+export function toBoundedErrorTelemetry(error: unknown): { errorClass: string; errorCode: string } {
+  const errorClass = error instanceof Error
+    ? boundedErrorLabel(error.name, 'Error')
+    : 'NonError';
+  const rawCode = isRecord(error) && (typeof error.code === 'string' || typeof error.code === 'number')
+    ? String(error.code)
+    : 'UNCLASSIFIED';
+  return {
+    errorClass,
+    errorCode: boundedErrorLabel(rawCode, 'UNCLASSIFIED'),
+  };
+}
+
+/** Return the exact bilateral counterparty only when opportunity actors are valid. */
+export function getValidatedCounterpartyUserId(
+  opportunity: ShadowOpportunity,
+  recipientUserId: string,
+): string | null {
+  const participantIds = new Set(
+    opportunity.actors
+      .filter((actor) => actor.role !== 'introducer')
+      .map((actor) => actor.userId),
+  );
+  if (participantIds.size !== 2 || !participantIds.has(recipientUserId)) return null;
+  return [...participantIds].find((userId) => userId !== recipientUserId) ?? null;
+}
+
+/** Canonicalize only the two exact negotiation-agent sender IDs. */
+export function canonicalizeNegotiationSender(
+  senderId: string,
+  sourceUserId: string,
+  candidateUserId: string,
+): string | null {
+  if (senderId === `agent:${sourceUserId}`) return sourceUserId;
+  if (senderId === `agent:${candidateUserId}`) return candidateUserId;
+  return null;
+}
+
+/** Read only immutable task-creation provenance; legacy tasks fail closed. */
+function captureTimeIntentFingerprint(
+  metadata: Record<string, unknown>,
+  recipientUserId: string,
+  intentId: string,
+): string | null {
+  const intentSnapshots = metadata.intentSnapshots;
+  if (!Array.isArray(intentSnapshots)) return null;
+
+  const matches = intentSnapshots.filter(
+    (snapshot) => isRecord(snapshot)
+      && snapshot.userId === recipientUserId
+      && snapshot.intentId === intentId,
+  );
+  if (matches.length !== 1) return null;
+  const capturedIntent = matches[0];
+  if (typeof capturedIntent.description !== 'string'
+    || typeof capturedIntent.title !== 'string') {
+    return null;
+  }
+  return computeIntentFingerprint(capturedIntent.description, capturedIntent.title);
+}
+
+function validateTask(
+  task: ShadowTask,
+  input: {
+    opportunityId: string;
+    networkId: string;
+    recipientUserId: string;
+    counterpartyUserId: string;
+    intentId: string;
+    currentIntentFingerprint: string;
+  },
+): { sourceUserId: string; candidateUserId: string; intentFingerprint: string } | null {
+  const metadata = task.metadata;
+  if (!metadata
+    || metadata.type !== 'negotiation'
+    || metadata.opportunityId !== input.opportunityId
+    || metadata.networkId !== input.networkId) {
+    return null;
+  }
+
+  const sourceUserId = metadata.sourceUserId;
+  const candidateUserId = metadata.candidateUserId;
+  if (typeof sourceUserId !== 'string'
+    || typeof candidateUserId !== 'string'
+    || sourceUserId === candidateUserId) {
+    return null;
+  }
+  const taskParticipants = new Set([sourceUserId, candidateUserId]);
+  if (taskParticipants.size !== 2
+    || !taskParticipants.has(input.recipientUserId)
+    || !taskParticipants.has(input.counterpartyUserId)) {
+    return null;
+  }
+
+  const intentFingerprint = captureTimeIntentFingerprint(
+    metadata,
+    input.recipientUserId,
+    input.intentId,
+  );
+  if (intentFingerprint !== input.currentIntentFingerprint) return null;
+
+  return { sourceUserId, candidateUserId, intentFingerprint };
+}
+
+function readDataPart(parts: unknown): Record<string, unknown> | null {
+  if (!Array.isArray(parts)) return null;
+  for (const part of parts) {
+    if (isRecord(part) && part.kind === 'data' && isRecord(part.data)) return part.data;
+  }
+  return null;
+}
+
+function projectTurns(
+  messages: ShadowMessage[],
+  sourceUserId: string,
+  candidateUserId: string,
+): RawEvidenceTurn[] {
+  const turns: RawEvidenceTurn[] = [];
+  for (const message of messages) {
+    const senderUserId = canonicalizeNegotiationSender(
+      message.senderId,
+      sourceUserId,
+      candidateUserId,
+    );
+    if (!senderUserId) continue;
+    const data = readDataPart(message.parts);
+    if (!data) continue;
+    turns.push({
+      senderUserId,
+      action: typeof data.action === 'string' ? data.action : '',
+      message: typeof data.message === 'string' || data.message === null ? data.message : null,
+    });
+  }
+  return turns;
+}
+
+function projectOutcome(
+  artifacts: ShadowArtifact[],
+  sourceUserId: string,
+  candidateUserId: string,
+): RawEvidenceOutcome | undefined {
+  const artifact = artifacts.find((candidate) => candidate.name === 'negotiation-outcome');
+  if (!artifact) return undefined;
+  const data = readDataPart(artifact.parts);
+  if (!data || typeof data.hasOpportunity !== 'boolean') return undefined;
+
+  const reason = typeof data.reason === 'string'
+    && ALLOWED_OUTCOME_REASONS.has(data.reason as RawEvidenceOutcome['reason'])
+    ? data.reason as RawEvidenceOutcome['reason']
+    : undefined;
+  const participantIds = new Set([sourceUserId, candidateUserId]);
+  const allowedRoles = new Set(['agent', 'patient', 'peer']);
+  let agreedRoles: Array<{ userId: string; role: string }> | undefined;
+  if (data.agreedRoles !== undefined) {
+    if (!Array.isArray(data.agreedRoles) || !data.agreedRoles.every(
+      (role) => isRecord(role)
+        && typeof role.userId === 'string'
+        && participantIds.has(role.userId)
+        && typeof role.role === 'string'
+        && allowedRoles.has(role.role),
+    )) {
+      return undefined;
+    }
+    agreedRoles = data.agreedRoles.map((role) => ({
+      userId: (role as Record<string, unknown>).userId as string,
+      role: (role as Record<string, unknown>).role as string,
+    }));
+  }
+  return {
+    hasOpportunity: data.hasOpportunity,
+    ...(reason ? { reason } : {}),
+    ...(agreedRoles ? { agreedRoles } : {}),
+  };
+}
+
+/** Build one fail-closed evidence segment per exact validated task/continuation. */
+export async function collectNegotiationEvidenceSegments(
+  input: {
+    opportunities: ShadowOpportunity[];
+    recipientUserId: string;
+    intentId: string;
+    currentIntentFingerprint: string;
+    networkId: string;
+  },
+  database: NegotiationEvidenceShadowDeps['database'],
+): Promise<RawEvidenceSegment[]> {
+  const segments: RawEvidenceSegment[] = [];
+
+  for (const opportunity of input.opportunities) {
+    const counterpartyUserId = getValidatedCounterpartyUserId(
+      opportunity,
+      input.recipientUserId,
+    );
+    if (!counterpartyUserId) continue;
+
+    const tasks = await database.getNegotiationTasksForOpportunity(opportunity.id);
+    const validatedTasks = tasks.flatMap((task) => {
+      const validation = validateTask(task, {
+        opportunityId: opportunity.id,
+        networkId: input.networkId,
+        recipientUserId: input.recipientUserId,
+        counterpartyUserId,
+        intentId: input.intentId,
+        currentIntentFingerprint: input.currentIntentFingerprint,
+      });
+      return validation ? [{ task, validation }] : [];
+    });
+    if (validatedTasks.length === 0) continue;
+
+    const messagesByTaskId = await database.getMessagesByTaskIds(
+      validatedTasks.map(({ task }) => task.id),
+    );
+    for (const { task, validation } of validatedTasks) {
+      const artifacts = await database.getArtifactsForTask(task.id);
+      const outcome = projectOutcome(
+        artifacts,
+        validation.sourceUserId,
+        validation.candidateUserId,
+      );
+      segments.push({
+        recipientUserId: input.recipientUserId,
+        intentId: input.intentId,
+        intentFingerprint: validation.intentFingerprint,
+        opportunityId: opportunity.id,
+        taskId: task.id,
+        conversationId: task.conversationId,
+        networkId: input.networkId,
+        counterpartyUserId,
+        turns: projectTurns(
+          messagesByTaskId.get(task.id) ?? [],
+          validation.sourceUserId,
+          validation.candidateUserId,
+        ),
+        ...(outcome ? { outcome } : {}),
+      });
+    }
+  }
+
+  return segments;
+}
+
+function isFinalIntentValid(
+  intent: ShadowIntent | null,
+  userId: string,
+  expectedFingerprint: string,
+): boolean {
+  return Boolean(
+    intent
+    && intent.userId === userId
+    && intent.archivedAt === null
+    && (intent.status === null || intent.status === 'ACTIVE')
+    && computeIntentFingerprint(intent.payload, intent.summary) === expectedFingerprint,
+  );
+}
 
 /**
  * Fire-and-forget, failure-isolated, flag-gated Lens C shadow pass over the
  * triggering intent's pool. Never throws; never persists; never enqueues.
  */
-export async function maybeRunNegotiationEvidenceShadow(trigger: PoolMiningTrigger): Promise<void> {
-  // Own flag gate — independent of the Lens A pool flags.
+export async function maybeRunNegotiationEvidenceShadow(
+  trigger: PoolMiningTrigger,
+  deps: NegotiationEvidenceShadowDeps = DEFAULT_DEPS,
+): Promise<void> {
   if (negotiationEvidenceQuestionsMode() === 'off') return;
-  // Introducer flow candidates are matches for someone else, not the viewer's
-  // own pool; and this lens is strictly intent-scoped.
-  if (trigger.isIntroducerFlow) return;
-  if (!trigger.intentId) return;
+  if (trigger.isIntroducerFlow || !trigger.intentId) return;
 
   const { userId, intentId } = trigger;
   try {
-    const intent = await chatDatabaseAdapter.getIntent(intentId);
+    const intent = await deps.database.getIntent(intentId);
     if (intent?.userId !== userId) return;
     const intentFingerprint = computeIntentFingerprint(intent.payload, intent.summary);
 
-    // Same exact-trigger selector the Lens A hook uses.
-    const pool = await selectPoolForMining(userId, intentId, trigger.sessionId);
+    const pool = await deps.selectPool(userId, intentId, trigger.sessionId);
 
-    // Keep the pass single-network: group by context.networkId and mine only
-    // the largest network group so evidence never crosses network boundaries.
-    const byNetwork = new Map<string, typeof pool>();
-    for (const o of pool) {
-      const networkId = o.context?.networkId;
+    // Keep the pass single-network: mine only the largest network group.
+    const byNetwork = new Map<string, ShadowOpportunity[]>();
+    for (const opportunity of pool) {
+      const networkId = opportunity.context?.networkId;
       if (!networkId) continue;
       const group = byNetwork.get(networkId) ?? [];
-      group.push(o);
+      group.push(opportunity);
       byNetwork.set(networkId, group);
     }
     let passNetworkId: string | undefined;
-    let passPool: typeof pool = [];
+    let passPool: ShadowOpportunity[] = [];
     for (const [networkId, group] of byNetwork) {
       if (group.length > passPool.length) {
         passNetworkId = networkId;
@@ -71,7 +402,7 @@ export async function maybeRunNegotiationEvidenceShadow(trigger: PoolMiningTrigg
       }
     }
     if (!passNetworkId || passPool.length === 0) {
-      logger.debug('negotiation-evidence shadow skipped: no single-network pool', {
+      deps.logger.debug('negotiation-evidence shadow skipped: no single-network pool', {
         source: trigger.source,
         runId: trigger.runId ?? null,
         intentId,
@@ -79,88 +410,15 @@ export async function maybeRunNegotiationEvidenceShadow(trigger: PoolMiningTrigg
       return;
     }
 
-    const selected = passPool.slice(0, NEGOTIATION_EVIDENCE_MAX_OPPORTUNITIES);
-
-    const segments: RawEvidenceSegment[] = [];
-    for (const o of selected) {
-      const counterpartyUserId = o.actors.find(
-        (a) => a.userId !== userId && a.role !== 'introducer',
-      )?.userId;
-      if (!counterpartyUserId) continue;
-
-      const task = await chatDatabaseAdapter.getNegotiationTaskForOpportunity(o.id);
-      if (!task) continue;
-
-      // Turns: read in place. Copy ONLY the allowlisted projection — never
-      // assessment/reasoning/askUser/disclosureSubject, and never mark a turn
-      // sharedTagged (no explicit shared-consent marker exists in the schema,
-      // so shared messages are excluded by default).
-      const messages = await chatDatabaseAdapter.getMessagesForConversation(task.conversationId);
-      const turns: RawEvidenceTurn[] = [];
-      for (const message of messages) {
-        const dataPart = (message.parts as Array<{ kind?: string; data?: unknown }>).find(
-          (p) => p.kind === 'data',
-        );
-        if (!dataPart?.data) continue;
-        const data = dataPart.data as { action?: string; message?: string | null };
-        turns.push({
-          senderUserId: message.senderId,
-          action: data.action ?? '',
-          message: data.message ?? null,
-        });
-      }
-
-      // Outcome: coarse structured facts only. Never copy evaluator reasoning.
-      const artifacts = await chatDatabaseAdapter.getArtifactsForTask(task.id);
-      const outcomeArtifact = artifacts.find((a) => a.name === 'negotiation-outcome');
-      let outcome: RawEvidenceOutcome | undefined;
-      if (outcomeArtifact) {
-        const dataPart = (outcomeArtifact.parts as Array<{ kind?: string; data?: unknown }>).find(
-          (p) => p.kind === 'data',
-        );
-        const data = dataPart?.data as
-          | { hasOpportunity?: boolean; reason?: string; agreedRoles?: Array<{ userId: string; role: string }> }
-          | undefined;
-        if (data) {
-          const reason = ALLOWED_OUTCOME_REASONS.has(data.reason as RawEvidenceOutcome['reason'])
-            ? (data.reason as RawEvidenceOutcome['reason'])
-            : undefined;
-          outcome = {
-            hasOpportunity: data.hasOpportunity ?? false,
-            ...(reason ? { reason } : {}),
-            ...(data.agreedRoles ? { agreedRoles: data.agreedRoles } : {}),
-          };
-        }
-      }
-
-      // Owner answers: the recipient's own authoritative answers. Read from the
-      // opportunity metadata (the adapter surface exposes no dedicated reader).
-      const rawAnswers = Array.isArray(o.metadata?.userAnswers)
-        ? (o.metadata.userAnswers as Array<{ selectedOptions?: string[]; freeText?: string }>)
-        : [];
-      const ownerAnswers: RawEvidenceOwnerAnswer[] = rawAnswers.map((a) => ({
-        answererUserId: userId,
-        selectedOptions: a.selectedOptions ?? [],
-        ...(a.freeText !== undefined ? { freeText: a.freeText } : {}),
-      }));
-
-      segments.push({
-        recipientUserId: userId,
-        intentId,
-        intentFingerprint,
-        opportunityId: o.id,
-        taskId: task.id,
-        conversationId: task.conversationId,
-        networkId: passNetworkId,
-        counterpartyUserId,
-        turns,
-        ...(outcome ? { outcome } : {}),
-        ownerAnswers,
-      });
-    }
-
-    if (segments.length < 1) {
-      logger.debug('negotiation-evidence shadow skipped: no minable segments', {
+    const segments = await collectNegotiationEvidenceSegments({
+      opportunities: passPool.slice(0, NEGOTIATION_EVIDENCE_MAX_OPPORTUNITIES),
+      recipientUserId: userId,
+      intentId,
+      currentIntentFingerprint: intentFingerprint,
+      networkId: passNetworkId,
+    }, deps.database);
+    if (segments.length === 0) {
+      deps.logger.debug('negotiation-evidence shadow skipped: no minable segments', {
         source: trigger.source,
         runId: trigger.runId ?? null,
         intentId,
@@ -168,25 +426,27 @@ export async function maybeRunNegotiationEvidenceShadow(trigger: PoolMiningTrigg
       return;
     }
 
-    miner ??= new NegotiationEvidenceMiner();
-    const result = await runNegotiationEvidenceShadow({
+    // Final fail-closed lifecycle/fingerprint check immediately before the LLM pass.
+    const finalIntent = await deps.database.getIntent(intentId);
+    if (!isFinalIntentValid(finalIntent, userId, intentFingerprint)) return;
+
+    const result = await deps.runShadow({
       scope: { recipientUserId: userId, intentId, intentFingerprint, networkId: passNetworkId },
       segments,
-      miner,
+      miner: deps.getMiner(),
     });
 
-    // Log ONLY aggregate telemetry. NEVER log result.hypotheses or any
-    // hypothesis text — shadow mode must not persist or route the hypotheses.
-    logger.info('negotiation-evidence shadow result', {
+    // Log ONLY aggregate telemetry. NEVER log hypotheses or evidence content.
+    deps.logger.info('negotiation-evidence shadow result', {
       source: trigger.source,
       runId: trigger.runId ?? null,
       ...result.telemetry,
     });
   } catch (error) {
-    logger.warn('negotiation-evidence shadow pass failed', {
+    deps.logger.warn('negotiation-evidence shadow pass failed', {
       source: trigger.source,
       intentId,
-      error: error instanceof Error ? error.message : String(error),
+      ...toBoundedErrorTelemetry(error),
     });
   }
 }

--- a/services/api/src/queues/pool/tests/negotiation-evidence.shadow.spec.ts
+++ b/services/api/src/queues/pool/tests/negotiation-evidence.shadow.spec.ts
@@ -1,7 +1,10 @@
-import { afterEach, describe, expect, it, spyOn } from 'bun:test';
+import { afterEach, describe, expect, it, mock } from 'bun:test';
 
-import { chatDatabaseAdapter } from '../../../adapters/database.adapter';
-import { maybeRunNegotiationEvidenceShadow } from '../negotiation-evidence.shadow';
+import type { NegotiationEvidenceMiner, RawEvidenceSegment } from '@indexnetwork/protocol';
+
+import { computeIntentFingerprint } from '../../../lib/intent/intent.fingerprint';
+import { canonicalizeNegotiationSender, collectNegotiationEvidenceSegments, getValidatedCounterpartyUserId, maybeRunNegotiationEvidenceShadow, toBoundedErrorTelemetry } from '../negotiation-evidence.shadow';
+import type { NegotiationEvidenceShadowDeps } from '../negotiation-evidence.shadow';
 import type { PoolMiningTrigger } from '../mining.shared';
 
 const TRIGGER: PoolMiningTrigger = {
@@ -9,48 +12,377 @@ const TRIGGER: PoolMiningTrigger = {
   userId: 'owner-1',
   intentId: 'intent-1',
 };
+const INTENT = {
+  userId: 'owner-1',
+  payload: 'Find a technical cofounder',
+  summary: 'Cofounder search',
+  archivedAt: null,
+  status: 'ACTIVE',
+};
+const FINGERPRINT = computeIntentFingerprint(INTENT.payload, INTENT.summary);
+const OPPORTUNITY = {
+  id: 'opp-1',
+  context: { networkId: 'net-1' },
+  actors: [
+    { userId: 'owner-1', role: 'peer' },
+    { userId: 'counterparty-1', role: 'peer' },
+  ],
+};
+
+type ShadowDatabase = NegotiationEvidenceShadowDeps['database'];
+type ShadowTask = Awaited<ReturnType<ShadowDatabase['getNegotiationTasksForOpportunity']>>[number];
+
+function task(id: string, metadataOverrides: Record<string, unknown> = {}): ShadowTask {
+  return {
+    id,
+    conversationId: `conversation-${id}`,
+    state: 'completed',
+    metadata: {
+      type: 'negotiation',
+      opportunityId: 'opp-1',
+      networkId: 'net-1',
+      sourceUserId: 'owner-1',
+      candidateUserId: 'counterparty-1',
+      intentSnapshots: [{
+        userId: 'owner-1',
+        intentId: 'intent-1',
+        description: INTENT.payload,
+        title: INTENT.summary,
+      }],
+      ...metadataOverrides,
+    },
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+  };
+}
+
+function makeDeps(overrides: Partial<NegotiationEvidenceShadowDeps> = {}): {
+  deps: NegotiationEvidenceShadowDeps;
+  capturedSegments: RawEvidenceSegment[][];
+  warnings: Array<Record<string, unknown> | undefined>;
+} {
+  const capturedSegments: RawEvidenceSegment[][] = [];
+  const warnings: Array<Record<string, unknown> | undefined> = [];
+  const database: ShadowDatabase = {
+    getIntent: mock(async () => INTENT),
+    getNegotiationTasksForOpportunity: mock(async () => [task('task-1')]),
+    getMessagesByTaskIds: mock(async () => new Map([
+      ['task-1', [{ senderId: 'agent:owner-1', parts: [{ kind: 'data', data: { action: 'propose', message: 'hello' } }] }]],
+    ])),
+    getArtifactsForTask: mock(async () => []),
+  };
+  const runShadow: NegotiationEvidenceShadowDeps['runShadow'] = async (input) => {
+    capturedSegments.push(input.segments);
+    return {
+      hypotheses: [],
+      telemetry: {
+        recipientUserId: input.scope.recipientUserId,
+        intentId: input.scope.intentId,
+        segments: input.segments.length,
+        excludedRecords: 0,
+        distinctOpportunities: input.segments.length > 0 ? 1 : 0,
+        evidenceCounts: {
+          owner_answer: 0,
+          bilateral_action: input.segments.length,
+          coarse_outcome: 0,
+          shared_message: 0,
+        },
+        hypothesesMined: 0,
+        hypothesesSupported: 0,
+        hypothesesRecurrent: 0,
+        hypothesesDiscarded: 0,
+      },
+    };
+  };
+  const deps: NegotiationEvidenceShadowDeps = {
+    database,
+    selectPool: mock(async () => [OPPORTUNITY]),
+    getMiner: () => ({}) as NegotiationEvidenceMiner,
+    runShadow,
+    logger: {
+      debug: mock(() => {}),
+      info: mock(() => {}),
+      warn: mock((_message, metadata) => { warnings.push(metadata); }),
+    },
+    ...overrides,
+  };
+  return { deps, capturedSegments, warnings };
+}
 
 afterEach(() => {
   delete process.env.NEGOTIATION_EVIDENCE_QUESTIONS_MODE;
 });
 
 describe('maybeRunNegotiationEvidenceShadow — gating', () => {
-  it('is a no-op when the flag is off (never touches the database)', async () => {
-    delete process.env.NEGOTIATION_EVIDENCE_QUESTIONS_MODE;
-    const getIntent = spyOn(chatDatabaseAdapter, 'getIntent');
-    await maybeRunNegotiationEvidenceShadow(TRIGGER);
-    expect(getIntent).not.toHaveBeenCalled();
-    getIntent.mockRestore();
+  it('is a no-op when the flag is off', async () => {
+    process.env.NEGOTIATION_EVIDENCE_QUESTIONS_MODE = 'off';
+    const { deps } = makeDeps();
+    await maybeRunNegotiationEvidenceShadow(TRIGGER, deps);
+    expect(deps.database.getIntent).not.toHaveBeenCalled();
   });
 
   it('is a no-op for introducer-flow and intent-less triggers even when enabled', async () => {
     process.env.NEGOTIATION_EVIDENCE_QUESTIONS_MODE = 'shadow';
-    const getIntent = spyOn(chatDatabaseAdapter, 'getIntent');
-    await maybeRunNegotiationEvidenceShadow({ ...TRIGGER, isIntroducerFlow: true });
-    await maybeRunNegotiationEvidenceShadow({ ...TRIGGER, intentId: undefined });
-    expect(getIntent).not.toHaveBeenCalled();
-    getIntent.mockRestore();
+    const { deps } = makeDeps();
+    await maybeRunNegotiationEvidenceShadow({ ...TRIGGER, isIntroducerFlow: true }, deps);
+    await maybeRunNegotiationEvidenceShadow({ ...TRIGGER, intentId: undefined }, deps);
+    expect(deps.database.getIntent).not.toHaveBeenCalled();
+  });
+});
+
+describe('negotiation evidence task isolation and validation', () => {
+  it('builds one segment per continuation using only exact task-linked messages and artifacts', async () => {
+    const getMessagesByTaskIds = mock(async () => new Map([
+      ['task-1', [{ senderId: 'agent:owner-1', parts: [{ kind: 'data', data: { action: 'propose' } }] }]],
+      ['task-2', [{ senderId: 'agent:counterparty-1', parts: [{ kind: 'data', data: { action: 'counter' } }] }]],
+    ]));
+    const getArtifactsForTask = mock(async (taskId: string) => taskId === 'task-2'
+      ? [{ name: 'negotiation-outcome', parts: [{ kind: 'data', data: { hasOpportunity: true } }] }]
+      : []);
+    const database: ShadowDatabase = {
+      getIntent: mock(async () => INTENT),
+      getNegotiationTasksForOpportunity: mock(async () => [task('task-1'), task('task-2')]),
+      getMessagesByTaskIds,
+      getArtifactsForTask,
+    };
+
+    const segments = await collectNegotiationEvidenceSegments({
+      opportunities: [OPPORTUNITY],
+      recipientUserId: 'owner-1',
+      intentId: 'intent-1',
+      currentIntentFingerprint: FINGERPRINT,
+      networkId: 'net-1',
+    }, database);
+
+    expect(getMessagesByTaskIds).toHaveBeenCalledWith(['task-1', 'task-2']);
+    expect(getArtifactsForTask.mock.calls.map(([taskId]) => taskId)).toEqual(['task-1', 'task-2']);
+    expect(segments.map((segment) => ({
+      taskId: segment.taskId,
+      conversationId: segment.conversationId,
+      actions: segment.turns.map((turn) => turn.action),
+      hasOutcome: Boolean(segment.outcome),
+    }))).toEqual([
+      { taskId: 'task-1', conversationId: 'conversation-task-1', actions: ['propose'], hasOutcome: false },
+      { taskId: 'task-2', conversationId: 'conversation-task-2', actions: ['counter'], hasOutcome: true },
+    ]);
   });
 
-  it('stops when the intent is not owned by the trigger user (no pool read)', async () => {
-    process.env.NEGOTIATION_EVIDENCE_QUESTIONS_MODE = 'shadow';
-    const getIntent = spyOn(chatDatabaseAdapter, 'getIntent').mockResolvedValue({
-      userId: 'someone-else',
-      payload: {},
-      summary: '',
-    } as never);
-    const getPool = spyOn(chatDatabaseAdapter, 'getLivePoolOpportunitiesForIntent');
-    await maybeRunNegotiationEvidenceShadow(TRIGGER);
-    expect(getIntent).toHaveBeenCalledTimes(1);
-    expect(getPool).not.toHaveBeenCalled();
-    getIntent.mockRestore();
-    getPool.mockRestore();
+  it('requires the opportunity and task participant sets to match exactly', async () => {
+    expect(getValidatedCounterpartyUserId(OPPORTUNITY, 'owner-1')).toBe('counterparty-1');
+    expect(getValidatedCounterpartyUserId({
+      ...OPPORTUNITY,
+      actors: [...OPPORTUNITY.actors, { userId: 'third-user', role: 'peer' }],
+    }, 'owner-1')).toBeNull();
+
+    const database: ShadowDatabase = {
+      getIntent: mock(async () => INTENT),
+      getNegotiationTasksForOpportunity: mock(async () => [
+        task('wrong-participant', { candidateUserId: 'third-user' }),
+        task('self-task', { candidateUserId: 'owner-1' }),
+      ]),
+      getMessagesByTaskIds: mock(async () => new Map()),
+      getArtifactsForTask: mock(async () => []),
+    };
+    const segments = await collectNegotiationEvidenceSegments({
+      opportunities: [OPPORTUNITY],
+      recipientUserId: 'owner-1',
+      intentId: 'intent-1',
+      currentIntentFingerprint: FINGERPRINT,
+      networkId: 'net-1',
+    }, database);
+    expect(segments).toEqual([]);
+    expect(database.getMessagesByTaskIds).not.toHaveBeenCalled();
   });
 
-  it('never throws even when the database read fails (failure isolation)', async () => {
+  it('canonicalizes exact agent senders and drops bare, foreign, and malformed senders', async () => {
+    expect(canonicalizeNegotiationSender('agent:owner-1', 'owner-1', 'counterparty-1')).toBe('owner-1');
+    expect(canonicalizeNegotiationSender('agent:counterparty-1', 'owner-1', 'counterparty-1')).toBe('counterparty-1');
+    expect(canonicalizeNegotiationSender('owner-1', 'owner-1', 'counterparty-1')).toBeNull();
+    expect(canonicalizeNegotiationSender('agent:third-user', 'owner-1', 'counterparty-1')).toBeNull();
+
+    const database: ShadowDatabase = {
+      getIntent: mock(async () => INTENT),
+      getNegotiationTasksForOpportunity: mock(async () => [task('task-1')]),
+      getMessagesByTaskIds: mock(async () => new Map([['task-1', [
+        { senderId: 'agent:owner-1', parts: [{ kind: 'data', data: { action: 'propose' } }] },
+        { senderId: 'agent:counterparty-1', parts: [{ kind: 'data', data: { action: 'counter' } }] },
+        { senderId: 'owner-1', parts: [{ kind: 'data', data: { action: 'accept' } }] },
+        { senderId: 'agent:third-user', parts: [{ kind: 'data', data: { action: 'decline' } }] },
+      ]]])),
+      getArtifactsForTask: mock(async () => []),
+    };
+    const [segment] = await collectNegotiationEvidenceSegments({
+      opportunities: [OPPORTUNITY],
+      recipientUserId: 'owner-1',
+      intentId: 'intent-1',
+      currentIntentFingerprint: FINGERPRINT,
+      networkId: 'net-1',
+    }, database);
+    expect(segment.turns.map((turn) => [turn.senderUserId, turn.action])).toEqual([
+      ['owner-1', 'propose'],
+      ['counterparty-1', 'counter'],
+    ]);
+  });
+
+  it('never projects opportunity userAnswers, including synthetic expiry disclosure text', async () => {
     process.env.NEGOTIATION_EVIDENCE_QUESTIONS_MODE = 'shadow';
-    const getIntent = spyOn(chatDatabaseAdapter, 'getIntent').mockRejectedValue(new Error('db down'));
-    await expect(maybeRunNegotiationEvidenceShadow(TRIGGER)).resolves.toBeUndefined();
-    getIntent.mockRestore();
+    const secret = 'SECRET_DISCLOSURE_SUBJECT';
+    const opportunityWithAnswers = {
+      ...OPPORTUNITY,
+      metadata: {
+        userAnswers: [{
+          questionId: 'ask-user-expired-opp-1',
+          selectedOptions: [],
+          freeText: `(no response) question about ${secret}`,
+        }],
+      },
+    };
+    const { deps, capturedSegments } = makeDeps({
+      selectPool: mock(async () => [opportunityWithAnswers]),
+    });
+
+    await maybeRunNegotiationEvidenceShadow(TRIGGER, deps);
+
+    expect(capturedSegments).toHaveLength(1);
+    expect(capturedSegments[0][0].ownerAnswers).toBeUndefined();
+    expect(JSON.stringify(capturedSegments)).not.toContain(secret);
+  });
+
+  it('rejects missing, malformed, duplicate, or drifted task-captured intent snapshots', async () => {
+    const validLegacyTurnContext = {
+      sourceUser: {
+        id: 'owner-1',
+        intents: [{ id: 'intent-1', description: INTENT.payload, title: INTENT.summary }],
+      },
+      candidateUser: { id: 'counterparty-1', intents: [] },
+      indexContext: { networkId: 'net-1' },
+    };
+    const validSnapshot = {
+      userId: 'owner-1',
+      intentId: 'intent-1',
+      description: INTENT.payload,
+      title: INTENT.summary,
+    };
+    const database: ShadowDatabase = {
+      getIntent: mock(async () => INTENT),
+      getNegotiationTasksForOpportunity: mock(async () => [
+        task('missing', { intentSnapshots: undefined, turnContext: validLegacyTurnContext }),
+        task('not-array', { intentSnapshots: validSnapshot }),
+        task('malformed', { intentSnapshots: [{ ...validSnapshot, title: undefined }] }),
+        task('duplicate', { intentSnapshots: [validSnapshot, { ...validSnapshot }] }),
+        task('drifted', { intentSnapshots: [{ ...validSnapshot, description: 'Changed intent' }] }),
+      ]),
+      getMessagesByTaskIds: mock(async () => new Map()),
+      getArtifactsForTask: mock(async () => []),
+    };
+    const segments = await collectNegotiationEvidenceSegments({
+      opportunities: [OPPORTUNITY],
+      recipientUserId: 'owner-1',
+      intentId: 'intent-1',
+      currentIntentFingerprint: FINGERPRINT,
+      networkId: 'net-1',
+    }, database);
+    expect(segments).toEqual([]);
+    expect(database.getMessagesByTaskIds).not.toHaveBeenCalled();
+  });
+
+  it('projects coarse outcomes only when every agreed role belongs to a task participant and is allowlisted', async () => {
+    const validOutcome = {
+      hasOpportunity: true,
+      agreedRoles: [
+        { userId: 'owner-1', role: 'patient' },
+        { userId: 'counterparty-1', role: 'agent' },
+      ],
+    };
+    const artifactsByTaskId: Record<string, Array<{ name: string; parts: unknown[] }>> = {
+      valid: [{ name: 'negotiation-outcome', parts: [{ kind: 'data', data: validOutcome }] }],
+      foreign: [{ name: 'negotiation-outcome', parts: [{ kind: 'data', data: {
+        ...validOutcome,
+        agreedRoles: [{ userId: 'third-user', role: 'agent' }],
+      } }] }],
+      invalidRole: [{ name: 'negotiation-outcome', parts: [{ kind: 'data', data: {
+        ...validOutcome,
+        agreedRoles: [{ userId: 'owner-1', role: 'introducer' }],
+      } }] }],
+      malformed: [{ name: 'negotiation-outcome', parts: [{ kind: 'data', data: {
+        ...validOutcome,
+        agreedRoles: 'agent',
+      } }] }],
+    };
+    const database: ShadowDatabase = {
+      getIntent: mock(async () => INTENT),
+      getNegotiationTasksForOpportunity: mock(async () => [
+        task('valid'),
+        task('foreign'),
+        task('invalidRole'),
+        task('malformed'),
+      ]),
+      getMessagesByTaskIds: mock(async () => new Map()),
+      getArtifactsForTask: mock(async (taskId: string) => artifactsByTaskId[taskId] ?? []),
+    };
+
+    const segments = await collectNegotiationEvidenceSegments({
+      opportunities: [OPPORTUNITY],
+      recipientUserId: 'owner-1',
+      intentId: 'intent-1',
+      currentIntentFingerprint: FINGERPRINT,
+      networkId: 'net-1',
+    }, database);
+
+    expect(segments.map((segment) => [segment.taskId, segment.outcome])).toEqual([
+      ['valid', validOutcome],
+      ['foreign', undefined],
+      ['invalidRole', undefined],
+      ['malformed', undefined],
+    ]);
+  });
+});
+
+describe('negotiation evidence final revalidation and telemetry', () => {
+  it('revalidates owner, lifecycle, archive state, and fingerprint before invoking shadow mining', async () => {
+    process.env.NEGOTIATION_EVIDENCE_QUESTIONS_MODE = 'shadow';
+    const invalidFinalIntents = [
+      { ...INTENT, userId: 'other-owner' },
+      { ...INTENT, status: 'PAUSED' },
+      { ...INTENT, archivedAt: new Date('2026-01-02T00:00:00.000Z') },
+      { ...INTENT, payload: 'Drifted current intent' },
+    ];
+
+    for (const finalIntent of invalidFinalIntents) {
+      let reads = 0;
+      const { deps, capturedSegments } = makeDeps();
+      deps.database.getIntent = mock(async () => {
+        reads += 1;
+        return reads === 1 ? INTENT : finalIntent;
+      });
+      await maybeRunNegotiationEvidenceShadow(TRIGGER, deps);
+      expect(capturedSegments).toHaveLength(0);
+      expect(reads).toBe(2);
+    }
+  });
+
+  it('logs only bounded errorClass/errorCode labels for failures', async () => {
+    process.env.NEGOTIATION_EVIDENCE_QUESTIONS_MODE = 'shadow';
+    class ProviderFailure extends Error {
+      code = `provider code ${'x'.repeat(100)}`;
+    }
+    const failure = new ProviderFailure('SECRET_PROVIDER_RESPONSE_BODY');
+    failure.name = `ProviderFailure${'Y'.repeat(100)}`;
+    const telemetry = toBoundedErrorTelemetry(failure);
+    expect(telemetry.errorClass.length).toBeLessThanOrEqual(64);
+    expect(telemetry.errorCode.length).toBeLessThanOrEqual(64);
+    expect(JSON.stringify(telemetry)).not.toContain('SECRET_PROVIDER_RESPONSE_BODY');
+
+    const { deps, warnings } = makeDeps();
+    deps.database.getIntent = mock(async () => { throw failure; });
+    await maybeRunNegotiationEvidenceShadow(TRIGGER, deps);
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toEqual({
+      source: 'discovery_run',
+      intentId: 'intent-1',
+      ...telemetry,
+    });
+    expect(JSON.stringify(warnings)).not.toContain('SECRET_PROVIDER_RESPONSE_BODY');
   });
 });

--- a/services/api/src/queues/pool/tests/negotiation-evidence.shadow.spec.ts
+++ b/services/api/src/queues/pool/tests/negotiation-evidence.shadow.spec.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, spyOn } from 'bun:test';
+
+import { chatDatabaseAdapter } from '../../../adapters/database.adapter';
+import { maybeRunNegotiationEvidenceShadow } from '../negotiation-evidence.shadow';
+import type { PoolMiningTrigger } from '../mining.shared';
+
+const TRIGGER: PoolMiningTrigger = {
+  source: 'discovery_run',
+  userId: 'owner-1',
+  intentId: 'intent-1',
+};
+
+afterEach(() => {
+  delete process.env.NEGOTIATION_EVIDENCE_QUESTIONS_MODE;
+});
+
+describe('maybeRunNegotiationEvidenceShadow — gating', () => {
+  it('is a no-op when the flag is off (never touches the database)', async () => {
+    delete process.env.NEGOTIATION_EVIDENCE_QUESTIONS_MODE;
+    const getIntent = spyOn(chatDatabaseAdapter, 'getIntent');
+    await maybeRunNegotiationEvidenceShadow(TRIGGER);
+    expect(getIntent).not.toHaveBeenCalled();
+    getIntent.mockRestore();
+  });
+
+  it('is a no-op for introducer-flow and intent-less triggers even when enabled', async () => {
+    process.env.NEGOTIATION_EVIDENCE_QUESTIONS_MODE = 'shadow';
+    const getIntent = spyOn(chatDatabaseAdapter, 'getIntent');
+    await maybeRunNegotiationEvidenceShadow({ ...TRIGGER, isIntroducerFlow: true });
+    await maybeRunNegotiationEvidenceShadow({ ...TRIGGER, intentId: undefined });
+    expect(getIntent).not.toHaveBeenCalled();
+    getIntent.mockRestore();
+  });
+
+  it('stops when the intent is not owned by the trigger user (no pool read)', async () => {
+    process.env.NEGOTIATION_EVIDENCE_QUESTIONS_MODE = 'shadow';
+    const getIntent = spyOn(chatDatabaseAdapter, 'getIntent').mockResolvedValue({
+      userId: 'someone-else',
+      payload: {},
+      summary: '',
+    } as never);
+    const getPool = spyOn(chatDatabaseAdapter, 'getLivePoolOpportunitiesForIntent');
+    await maybeRunNegotiationEvidenceShadow(TRIGGER);
+    expect(getIntent).toHaveBeenCalledTimes(1);
+    expect(getPool).not.toHaveBeenCalled();
+    getIntent.mockRestore();
+    getPool.mockRestore();
+  });
+
+  it('never throws even when the database read fails (failure isolation)', async () => {
+    process.env.NEGOTIATION_EVIDENCE_QUESTIONS_MODE = 'shadow';
+    const getIntent = spyOn(chatDatabaseAdapter, 'getIntent').mockRejectedValue(new Error('db down'));
+    await expect(maybeRunNegotiationEvidenceShadow(TRIGGER)).resolves.toBeUndefined();
+    getIntent.mockRestore();
+  });
+});

--- a/services/api/src/startup.env.ts
+++ b/services/api/src/startup.env.ts
@@ -123,6 +123,7 @@ const envSchema = z.object({
   POOL_QUESTIONS_PUSH: z.union([z.literal(''), z.enum(['off', 'on'])]).optional(),
   POOL_QUESTIONS_RANKING: z.union([z.literal(''), z.enum(['off', 'on'])]).optional(),
   POOL_QUESTIONS_STAMP_NEWBORN: z.union([z.literal(''), z.enum(['off', 'on'])]).optional(),
+  NEGOTIATION_EVIDENCE_QUESTIONS_MODE: z.union([z.literal(''), z.enum(['off', 'shadow', 'on'])]).optional(),
 
   // 9. MCP / tool runtime
   MCP_MAX_REQUEST_BYTES: optionalInt,


### PR DESCRIPTION
## Summary
Ships **IND-433 — P9 Lens C shadow**: a privacy-safe, shadow-only producer that mines neutral clarification hypotheses from **recurring** negotiation evidence, read *in place* from exact recipient + intent/fingerprint + opportunity + task segments. No durable transcript projection and no whole-pair-DM summary.

Closes IND-433.

## What it does
- **Allowlist (production):** structured bilateral actions, coarse outcomes, and explicitly shared/tagged message content. The protocol supports authoritative owner-answer inputs, but the API producer deliberately omits `opportunity.metadata.userAnswers` because it lacks author/type provenance and can contain synthetic expiry disclosure text.
- **Immutable provenance:** future negotiation tasks capture bounded intent snapshots at task creation. Legacy tasks without the exact recipient+intent snapshot fail closed; current intent ownership, lifecycle, and fingerprint are revalidated immediately before mining.
- **Exact task isolation:** continuations are loaded by task ID, grouped once per opportunity, and preserve their own task/conversation provenance. Task participants, network, opportunity, senders, and outcome actors are verified before evidence is admitted.
- **Excluded by construction:** screen/evaluator reasoning, agent chain-of-thought, `memoryHints`, private negotiator memories/reflections, disclosure subjects, untagged messages, `screened_out` gates, synthesized digests, and unproven answers.
- **Recurrence gate:** a hypothesis is retained only when every support reference resolves to allowlisted evidence with a verbatim span and it recurs across **≥5 distinct opportunities**.
- **Speaker constraint:** counterparty statements may back an `observation`, never a fact/preference *about* the recipient.
- **Shadow-only:** persists nothing and changes no ranking, intent, premise, memory, policy, newborn stamping, or push behavior. Routine telemetry is aggregate counts only; failures emit bounded class/code labels.

## Structure
- **protocol** `packages/protocol/src/opportunity/negotiation-evidence/` — env, types, extractor, verifier, LLM miner, and shadow orchestrator.
- **protocol negotiation/opportunity** — task-captured intent provenance and exact trigger/actor intent prioritization before the five-intent negotiation-context cap.
- **api** `services/api/src/queues/pool/negotiation-evidence.shadow.ts` — flag-gated, failure-isolated exact-task loader and runner, wired fire-and-forget into discovery completion on its own flag.

## Flag
`NEGOTIATION_EVIDENCE_QUESTIONS_MODE=off|shadow|on` defaults to **off** and is registered in startup validation and `.env.example`. Dev is configured as `on`; IND-437's live question path is not built yet, so `on` currently executes shadow behavior only.

## Versions
- `@indexnetwork/protocol`: `4.17.0` → `4.18.0`
- `@indexnetwork/api`: `0.39.0` → `0.40.0`

## Tests / checks
- **121 targeted protocol tests passed:** 44 negotiation/evidence tests and 77 opportunity graph tests.
- **13 targeted API/env tests passed.**
- Protocol build and API TypeScript build passed.
- Changed-file ESLint passed with no errors.
- `bun install --frozen-lockfile` and `git diff --check` passed.
- GitHub generated-skills, lint, typecheck, and test workflows must pass on the final head before merge.

## Non-goals
No whole-DM summaries, durable transcript copy, policy/memory writes, ranking, newborn stamping, push, cross-intent aggregation, or historical negotiation backfill. The "review 20 eligible hypotheses / insufficient-data no-go" acceptance step is a manual eval against future task-captured data, not part of this code slice.
