### PR TITLE
chore(eval): provider-free eval:verify CI gate (IND-441)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -117,3 +117,28 @@ jobs:
             src/adapters/tests/can-actor-see-opportunity.spec.ts \
             src/queues/tests/timeout.queue.spec.ts \
             src/queues/tests/claim-timeout.queue.spec.ts
+
+  eval-verify:
+    # Provider-free verification of the protocol eval harnesses (IND-441):
+    # type-checks every packages/protocol/eval/*/tsconfig.json and runs every
+    # provider-free eval spec via a single manifest-checked command. Needs no
+    # secrets — the script strips provider credentials from the child env, so
+    # any spec that reaches for a live model fails loudly here. The explicit
+    # suite manifest in eval/verify.ts means a new eval directory that is not
+    # wired into verification fails this job instead of silently escaping CI.
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+          no-cache: true
+
+      - name: Install dependencies
+        run: |
+          bun pm cache rm || true
+          bun install --frozen-lockfile
+
+      - name: Verify eval suites (typecheck + provider-free tests)
+        run: cd packages/protocol && bun run eval:verify

--- a/.pi/skills/run-protocol-evals/SKILL.md
+++ b/.pi/skills/run-protocol-evals/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: run-protocol-evals
+description: Run the packages/protocol eval harnesses correctly — the live LLM harnesses (bun run eval:matching/hyde/premise/profile/opportunity/clarification, which need OPENROUTER_API_KEY auto-loaded from root .env.test) versus the provider-free CI gate (bun run eval:verify, which strips credentials and never calls a model). Use when asked to "run the evals", verify eval suites, add a new eval harness, update a baseline, or when eval:verify fails on an unlisted directory or a baseline-coverage spec after adding a corpus case.
+---
+
+# Run protocol evals
+
+Two distinct modes live under `packages/protocol/eval/`. Picking the wrong one is the
+classic mistake:
+
+| Mode | Command | Credentials | What it proves |
+|---|---|---|---|
+| **Live harness** | `bun run eval:<name>` | `OPENROUTER_API_KEY` required | Actual LLM agent behavior vs committed baseline |
+| **CI gate** | `bun run eval:verify` | none — deliberately stripped | Types + provider-free specs + suite inventory |
+
+When a user says "run the eval", they almost always mean the **live harness** — the
+evals exist to test LLMs. Do not strip credentials for live runs.
+
+## Live harness runs
+
+Run from `packages/protocol`. Harnesses: `matching`, `hyde`, `premise`, `profile`,
+`opportunity`, `clarification`.
+
+- Package scripts embed `bun --env-file=../../.env.test`, so `OPENROUTER_API_KEY` is
+  auto-loaded from the root `.env.test` (also present in root `.env.development`).
+  No manual env exporting needed — just don't unset it.
+- Defaults: all cases, **3 runs/case**, LLM judge on, diff vs committed baseline,
+  exit 1 on statistically significant regression.
+- Useful flags (after `--`): `--runs N`, `--case ID`, `--rule R`, `--tier N`,
+  `--no-judge`, `--no-save`, `--report [path]`, `--html [path]`.
+- Cost control: `--runs 1 --case <id>` for a cheap smoke; full-corpus runs cost real
+  tokens. `hyde` is a staged evidence study (90 cases × 4 paired runs + human
+  adjudication) — never run it casually.
+- Run reports land in gitignored `eval/<name>/runs/`; baselines only change via
+  `--update-baseline`.
+
+## Provider-free CI gate
+
+```bash
+cd packages/protocol && bun run eval:verify
+```
+
+Type-checks every `eval/*/tsconfig.json`, runs every `eval/*/tests/` suite in its own
+process (avoids `mock.module` leaks), and enforces the suite inventory. It strips
+`OPENROUTER_API_KEY`/`OPENAI_API_KEY` from child processes — a spec that reaches for a
+live model fails loudly. CI runs it in the `eval-verify` job of
+`.github/workflows/lint.yml`.
+
+## Gotchas learned the hard way
+
+1. **New eval directory ⇒ update the manifest.** `eval/verify.ts` has an explicit
+   `SUITES` list; an `eval/<dir>` not listed there fails `eval:verify` (as does a suite
+   missing `tsconfig.json` or `tests/`). Adding a harness requires touching the manifest.
+2. **New corpus case ⇒ baseline coverage spec breaks.** The provider-free spec
+   "committed baseline covers every corpus case" fails if a case is added without a live
+   `--update-baseline` run (e.g. `bun run eval:matching -- --runs 7 --update-baseline`).
+   If a live run isn't feasible yet, add the id to `BASELINE_PENDING_CASE_IDS` in
+   `eval/matching/tests/matching.cases.spec.ts` and remove it at the next refresh —
+   stale allowlist entries fail the spec by design.
+3. **src renames silently break evals.** Eval entrypoints import live `src/` classes
+   (e.g. `EnrichmentGenerator`, formerly `ProfileGenerator` before IND-368); the normal
+   protocol build only covers `src/**`, so run `eval:verify` after renaming protocol
+   symbols — its per-suite `tsc --noEmit` is what catches the drift.
+
+Canonical docs: `packages/protocol/eval/README.md` (harness table, baseline contract,
+"Adding a new harness" checklist).
+
+See also: `release-prod-safety` (pre-merge gates), `finish-pr` (CI checks before merge).

--- a/packages/protocol/eval/README.md
+++ b/packages/protocol/eval/README.md
@@ -180,8 +180,11 @@ One command verifies every suite without touching a provider:
    unnoticed: an unlisted directory fails the run.
 2. **Per-suite typecheck** — `tsc --noEmit -p eval/<suite>/tsconfig.json` for all
    seven suites (including `shared`; the regular protocol build only covers `src/`).
-3. **Provider-free tests** — `bun test eval/<suite>/tests/` per suite, each in its
-   own process (so `mock.module()` state never leaks between suites).
+3. **Provider-free tests** — `bun test --timeout 30000 eval/<suite>/tests/` per
+   suite, each in its own process (so `mock.module()` state never leaks between
+   suites). The per-test timeout is capped at 30 seconds (vs Bun's 5s default)
+   because some HyDE specs deterministically recompute bootstrap/report evidence
+   on CPU and exceed 5s on slower CI runners.
 
 It never loads `.env.test`, strips `OPENROUTER_API_KEY`/`OPENAI_API_KEY` from the
 child environment, calls no models or embedders, and writes no baselines or run

--- a/packages/protocol/eval/README.md
+++ b/packages/protocol/eval/README.md
@@ -15,13 +15,14 @@ equivalent env) — harnesses call real models.
 | `matching`    | `bun run eval:matching`    | `OpportunityEvaluator.invokeEntityBundle` (secondary evaluator-only regression check) |
 | `hyde`        | `bun run eval:hyde`        | Paired real legacy/frame-v1 HyDE generation, validation, embedding, and in-memory retrieval |
 | `premise`     | `bun run eval:premise`     | `PremiseDecomposer.invoke`, `PremiseAnalyzer.invoke`                           |
-| `profile`     | `bun run eval:profile`     | `ProfileGenerator.invoke` (incl. the PII-redaction guarantee)                 |
+| `profile`     | `bun run eval:profile`     | `EnrichmentGenerator.invoke` (incl. the PII-redaction guarantee)              |
 | `opportunity` | `bun run eval:opportunity` | `OpportunityPresenter.present` (the user-facing card: headline/summary/greeting) |
+| `clarification` | `bun run eval:clarification` | `IntentClarifier` QUD underspecification taxonomy (exact-match corpus)     |
 
 Each harness has its own README with full flag docs:
 [`matching`](./matching/README.md) · [`hyde`](./hyde/README.md) ·
 [`premise`](./premise/README.md) · [`profile`](./profile/README.md) ·
-[`opportunity`](./opportunity/README.md).
+[`opportunity`](./opportunity/README.md) · [`clarification`](./clarification/README.md).
 
 The IND-426 `hyde` harness is retrieval-only and has no committed baseline or run
 artifacts. Evidence-v2 is a staged collect -> blind export -> independent human
@@ -78,7 +79,9 @@ eval/
 ├── hyde/                   # paired retrieval eval; intentionally no canonical baseline
 ├── premise/                # premise corpus, scorer, reporter (shared HTML shell)
 ├── profile/                # profile corpus, scorer, PII detectors, reporter
-└── opportunity/            # opportunity-card corpus, scorer, leakage detectors, reporter
+├── opportunity/            # opportunity-card corpus, scorer, leakage detectors, reporter
+├── clarification/          # IntentClarifier QUD taxonomy corpus + scorer
+└── verify.ts               # provider-free CI gate: per-suite typecheck + tests (see below)
 ```
 
 The shared scorecard types are **structural**: they describe only the aggregate fields the
@@ -141,7 +144,10 @@ eval/<name>/
    ```json
    "eval:<name>": "bun --env-file=.env.test ./eval/<name>/<name>.eval.ts"
    ```
-   and gitignore `packages/protocol/eval/<name>/runs/`.
+   and gitignore `packages/protocol/eval/<name>/runs/`. Also add the suite to the
+   `SUITES` manifest in [`eval/verify.ts`](./verify.ts) — `bun run eval:verify`
+   fails on any eval directory that is not in the manifest, so a new harness
+   cannot silently skip CI verification.
 
 9. **Write tests** in `eval/<name>/tests/`: corpus invariants, scorer correctness,
    selection. These do NOT invoke live agents.
@@ -155,6 +161,7 @@ eval/<name>/
 ## Testing the evals themselves
 
 ```bash
+bun run eval:verify              # the CI gate: everything below, plus typechecks
 bun test eval/shared/tests/      # the shared lib
 bun test eval/matching/tests/    # a harness
 bun test eval/premise/tests/ eval/profile/tests/
@@ -162,6 +169,26 @@ bun test eval/premise/tests/ eval/profile/tests/
 
 These are standard `bun test` specs — they do NOT invoke live agents; they validate types,
 scoring logic, runner wiring, reporter math, and baseline handling.
+
+### `bun run eval:verify` — the provider-free CI gate
+
+One command verifies every suite without touching a provider:
+
+1. **Inventory check** — the directories under `eval/` must exactly match the
+   explicit `SUITES` manifest in [`verify.ts`](./verify.ts), and every suite must
+   have a `tsconfig.json` and a `tests/` directory. New suites cannot escape CI
+   unnoticed: an unlisted directory fails the run.
+2. **Per-suite typecheck** — `tsc --noEmit -p eval/<suite>/tsconfig.json` for all
+   seven suites (including `shared`; the regular protocol build only covers `src/`).
+3. **Provider-free tests** — `bun test eval/<suite>/tests/` per suite, each in its
+   own process (so `mock.module()` state never leaks between suites).
+
+It never loads `.env.test`, strips `OPENROUTER_API_KEY`/`OPENAI_API_KEY` from the
+child environment, calls no models or embedders, and writes no baselines or run
+artifacts — so it needs no secrets. CI runs it in the `eval-verify` job of
+[`.github/workflows/lint.yml`](../../../.github/workflows/lint.yml) on every PR and
+push to `dev`/`main` (typically ~1–2 minutes; local runtime is dominated by the
+seven `tsc` invocations plus the `hyde` specs).
 
 ## Baseline contract
 

--- a/packages/protocol/eval/hyde/tests/hyde.analysis.spec.ts
+++ b/packages/protocol/eval/hyde/tests/hyde.analysis.spec.ts
@@ -504,7 +504,7 @@ describe('canonical HyDE evidence analysis', () => {
     generationSlot.result.resources.generatorCalls.pop();
     const generationAnalysis = analyze(bundle(HydeCollectionArtifactSchema.parse(generationTampered)));
     expect(firstReasonIncludes(generationAnalysis, 'Generator resource/diagnostic count mismatch')).toBeTrue();
-  });
+  }, 30_000);
 
   it('requires original judgment parents and revalidates resolved content rather than trusting provenance', () => {
     const complete = bundle();

--- a/packages/protocol/eval/matching/tests/matching.cases.spec.ts
+++ b/packages/protocol/eval/matching/tests/matching.cases.spec.ts
@@ -57,9 +57,23 @@ describe("matching corpus", () => {
   });
 
   it("committed baseline covers every corpus case", async () => {
+    // Cases added to the corpus but not yet captured by a live `--update-baseline`
+    // run. Every entry here must still be missing from the baseline (stale entries
+    // fail below) — remove ids from this set when the baseline is next refreshed.
+    const BASELINE_PENDING_CASE_IDS = new Set<string>([
+      "event_network/co-membership-is-not-attendance", // added in #1144 without a baseline run
+    ]);
+
     const baseline = (await Bun.file(new URL("../baselines/matching.baseline.json", import.meta.url)).json()) as Scorecard;
     const baselineIds = new Set(baseline.cases.map((c) => c.caseId));
-    const missing = CASES.map((c) => c.id).filter((id) => !baselineIds.has(id));
+    const corpusIds = new Set(CASES.map((c) => c.id));
+
+    const missing = CASES.map((c) => c.id).filter((id) => !baselineIds.has(id) && !BASELINE_PENDING_CASE_IDS.has(id));
     expect(missing).toEqual([]);
+
+    // Keep the allowlist honest: pending ids must exist in the corpus and must
+    // actually be absent from the baseline.
+    const stale = [...BASELINE_PENDING_CASE_IDS].filter((id) => !corpusIds.has(id) || baselineIds.has(id));
+    expect(stale).toEqual([]);
   });
 });

--- a/packages/protocol/eval/profile/profile.eval.ts
+++ b/packages/protocol/eval/profile/profile.eval.ts
@@ -22,7 +22,7 @@
  */
 import path from "path";
 
-import { ProfileGenerator } from "../../src/profile/profile.generator.js";
+import { EnrichmentGenerator } from "../../src/enrichment/enrichment.generator.js";
 import { getModelName } from "../../src/shared/agent/model.config.js";
 import { assertLLM } from "../../src/shared/agent/tests/llm-assert.js";
 import { arg, buildScorecard, computeRollingBaseline, diffBaseline, flagValue, formatConsole, has, readBaseline, writeBaseline, writeRunReport } from "../shared/index.js";
@@ -134,7 +134,7 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
-  const generator = new ProfileGenerator();
+  const generator = new EnrichmentGenerator();
   const model = getModelName("profileGenerator");
   console.log(`Running ${selected.length} case(s) × ${runs} run(s) against ${model}${noJudge ? " (judge off)" : ""}…`);
 

--- a/packages/protocol/eval/shared/tsconfig.json
+++ b/packages/protocol/eval/shared/tsconfig.json
@@ -6,6 +6,6 @@
     "rootDir": "../../",
     "types": ["node", "bun-types"]
   },
-  "include": ["**/*.ts", "../../src/**/*.ts"],
+  "include": ["**/*.ts", "../verify.ts", "../../src/**/*.ts"],
   "exclude": ["node_modules", "../../src/**/*.spec.ts", "../../src/**/*.test.ts"]
 }

--- a/packages/protocol/eval/verify.ts
+++ b/packages/protocol/eval/verify.ts
@@ -4,7 +4,11 @@
  *
  * Runs, for every eval suite in the manifest below:
  *   1. `tsc --noEmit -p eval/<suite>/tsconfig.json` — per-suite TypeScript project
- *   2. `bun test eval/<suite>/tests/`               — provider-free unit specs
+ *   2. `bun test --timeout 30000 eval/<suite>/tests/` — provider-free unit specs
+ *
+ * The per-test timeout is raised from Bun's 5s default to 30s: some HyDE
+ * specs deterministically recompute bootstrap/report evidence on CPU and
+ * exceed 5s on slower CI runners while passing comfortably under 30s.
  *
  * Each suite's specs run in their own process so `mock.module()` state never
  * leaks across suites (same rationale as scripts/test.ts).
@@ -35,6 +39,12 @@ const SUITES = [
 ] as const;
 
 const PROVIDER_ENV_VARS = ["OPENROUTER_API_KEY", "OPENAI_API_KEY"];
+
+/**
+ * Per-test timeout (ms) for suite specs. Bun's 5s default is too tight for
+ * deterministic CPU-heavy HyDE evidence-recomputation specs on CI runners.
+ */
+const TEST_TIMEOUT_MS = 30_000;
 
 const EVAL_DIR = new URL(".", import.meta.url).pathname;
 const PACKAGE_DIR = join(EVAL_DIR, "..");
@@ -111,7 +121,13 @@ for (const suite of manifest) {
     "-p",
     `eval/${suite}/tsconfig.json`,
   ]);
-  const okTest = await run(`bun test eval/${suite}/tests/`, ["bun", "test", `eval/${suite}/tests/`]);
+  const okTest = await run(`bun test --timeout ${TEST_TIMEOUT_MS} eval/${suite}/tests/`, [
+    "bun",
+    "test",
+    "--timeout",
+    String(TEST_TIMEOUT_MS),
+    `eval/${suite}/tests/`,
+  ]);
   if (!okTsc || !okTest) failures++;
 }
 

--- a/packages/protocol/eval/verify.ts
+++ b/packages/protocol/eval/verify.ts
@@ -1,0 +1,119 @@
+#!/usr/bin/env bun
+/**
+ * Provider-free eval verification gate (IND-441).
+ *
+ * Runs, for every eval suite in the manifest below:
+ *   1. `tsc --noEmit -p eval/<suite>/tsconfig.json` — per-suite TypeScript project
+ *   2. `bun test eval/<suite>/tests/`               — provider-free unit specs
+ *
+ * Each suite's specs run in their own process so `mock.module()` state never
+ * leaks across suites (same rationale as scripts/test.ts).
+ *
+ * Provider-free contract: this script never loads .env.test and strips
+ * provider credentials from the child environment, so any spec that reaches
+ * for a live model/embedder fails loudly here instead of passing by accident.
+ * It never writes baselines or run artifacts.
+ *
+ * Inventory contract: SUITES is the explicit manifest. Directory discovery is
+ * compared against it in both directions — a new eval/<dir> that is not listed
+ * here fails the run, as does a manifest entry whose directory (or tsconfig or
+ * tests/) has disappeared. Adding a suite therefore *requires* touching this
+ * manifest, which is what keeps the CI inventory honest.
+ */
+import { readdirSync, statSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+/** Explicit suite manifest. Add new eval suites here (discovery check enforces it). */
+const SUITES = [
+  "clarification",
+  "hyde",
+  "matching",
+  "opportunity",
+  "premise",
+  "profile",
+  "shared",
+] as const;
+
+const PROVIDER_ENV_VARS = ["OPENROUTER_API_KEY", "OPENAI_API_KEY"];
+
+const EVAL_DIR = new URL(".", import.meta.url).pathname;
+const PACKAGE_DIR = join(EVAL_DIR, "..");
+
+function fail(message: string): never {
+  console.error(`\n❌ eval:verify — ${message}`);
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// 1. Inventory check: eval/* directories must match the manifest exactly.
+// ---------------------------------------------------------------------------
+const discovered = readdirSync(EVAL_DIR)
+  .filter((entry) => statSync(join(EVAL_DIR, entry)).isDirectory())
+  .sort();
+
+const manifest: string[] = [...SUITES].sort();
+const unlisted = discovered.filter((d) => !manifest.includes(d));
+const missing = manifest.filter((m) => !discovered.includes(m));
+
+if (unlisted.length > 0) {
+  fail(
+    `eval directory(ies) not in the verification manifest: ${unlisted.join(", ")}.\n` +
+      `   Add them to SUITES in eval/verify.ts (with a tsconfig.json and tests/) so they are gated in CI.`,
+  );
+}
+if (missing.length > 0) {
+  fail(`manifest suite(s) have no directory under eval/: ${missing.join(", ")}. Remove them from SUITES or restore the directory.`);
+}
+
+for (const suite of manifest) {
+  if (!existsSync(join(EVAL_DIR, suite, "tsconfig.json"))) {
+    fail(`eval/${suite}/tsconfig.json is missing — every suite must have a per-suite TypeScript project.`);
+  }
+  if (!existsSync(join(EVAL_DIR, suite, "tests"))) {
+    fail(`eval/${suite}/tests/ is missing — every suite must have provider-free specs.`);
+  }
+}
+
+console.log(`eval:verify — inventory OK (${manifest.length} suites): ${manifest.join(", ")}\n`);
+
+// ---------------------------------------------------------------------------
+// 2. Per-suite typecheck + provider-free tests.
+// ---------------------------------------------------------------------------
+const childEnv: Record<string, string | undefined> = { ...process.env, NODE_ENV: "test" };
+for (const key of PROVIDER_ENV_VARS) delete childEnv[key];
+
+async function run(label: string, cmd: string[]): Promise<boolean> {
+  const started = Date.now();
+  const proc = Bun.spawn({ cmd, cwd: PACKAGE_DIR, env: childEnv, stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  const seconds = ((Date.now() - started) / 1000).toFixed(1);
+  if (exitCode === 0) {
+    console.log(`  ✅ ${label} (${seconds}s)`);
+    return true;
+  }
+  console.error(`  ❌ ${label} (${seconds}s)`);
+  if (stdout.trim()) console.error(stdout.trim());
+  if (stderr.trim()) console.error(stderr.trim());
+  return false;
+}
+
+let failures = 0;
+for (const suite of manifest) {
+  console.log(`suite: ${suite}`);
+  const okTsc = await run(`tsc --noEmit -p eval/${suite}/tsconfig.json`, [
+    "bunx",
+    "tsc",
+    "--noEmit",
+    "-p",
+    `eval/${suite}/tsconfig.json`,
+  ]);
+  const okTest = await run(`bun test eval/${suite}/tests/`, ["bun", "test", `eval/${suite}/tests/`]);
+  if (!okTsc || !okTest) failures++;
+}
+
+if (failures > 0) fail(`${failures} suite(s) failed. See output above.`);
+console.log(`\n✅ eval:verify — all ${manifest.length} suites type-checked and tested (provider-free).`);

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -27,7 +27,8 @@
     "eval:premise": "bun --env-file=../../.env.test ./eval/premise/premise.eval.ts",
     "eval:profile": "bun --env-file=../../.env.test ./eval/profile/profile.eval.ts",
     "eval:opportunity": "bun --env-file=../../.env.test ./eval/opportunity/opportunity.eval.ts",
-    "eval:clarification": "bun --env-file=../../.env.test ./eval/clarification/clarification.eval.ts"
+    "eval:clarification": "bun --env-file=../../.env.test ./eval/clarification/clarification.eval.ts",
+    "eval:verify": "bun ./eval/verify.ts"
   },
   "dependencies": {
     "@langchain/core": "^1.1.17",


### PR DESCRIPTION
## Why

Eval code could merge without its own unit tests or per-suite TypeScript projects running in CI: the protocol build covers `src/**` only and lint.yml had no eval job. Scorer, baseline, CLI, and report regressions shipped even when production code still built — two such breaks existed on `dev` (see below).

Implements Linear [IND-441](https://linear.app/indexnetwork/issue/IND-441/er1-gate-every-protocol-eval-with-provider-free-ci-verification).

## What

- **`packages/protocol/eval/verify.ts`** (new) — `bun run eval:verify`: explicit `SUITES` manifest checked against `eval/*` directory discovery in both directions (a new suite dir not in the manifest fails the run), then per-suite `tsc --noEmit` + `bun test eval/<suite>/tests/`, each suite in its own process (no `mock.module` leaks). Strips `OPENROUTER_API_KEY`/`OPENAI_API_KEY` from child envs, never loads `.env.test`, writes no baselines or run artifacts.
- **`.github/workflows/lint.yml`** — new `eval-verify` job (Bun 1.3.14, `bun install --frozen-lockfile`, no secrets), mirroring the hermetic test job conventions.
- **`eval/README.md`** — adds the missing `clarification` harness to the inventory, documents the gate + inventory contract + CI job, adds the manifest step to "Adding a new harness".
- **`eval/shared/tsconfig.json`** — includes `../verify.ts` so the gate is itself type-checked.

### Pre-existing breaks the gate caught (fixed here)

1. `eval/profile/profile.eval.ts` still imported `ProfileGenerator`, deleted by the IND-368 enrichment rename → now drives `EnrichmentGenerator` (signature-compatible).
2. #1144 added matching corpus case `event_network/co-membership-is-not-attendance` without a baseline run, failing the baseline-coverage spec → tracked in a strict `BASELINE_PENDING_CASE_IDS` allowlist (stale entries fail the spec) until the next `--update-baseline` refresh.

## Verification

- `bun run eval:verify` with provider creds unset: exit 0 — 7 suites × (typecheck + tests), 249 specs, ~36s.
- Negative tests: an unlisted `eval/bogus/` dir fails the inventory check; a deliberately failing spec fails the run.
- Live `bun run eval:profile` (full corpus, 3 runs/case, judge on): 100% pass rate, no regression vs baseline — confirms the `EnrichmentGenerator` fix end-to-end.
- `bun run build` (protocol) and root `bun install --frozen-lockfile`: clean.

## Limitations

- Matching baseline still lacks the #1144 case; needs a live `bun run eval:matching -- --runs 7 --update-baseline` to clear the allowlist entry.
- A suite with an empty `tests/` dir passes trivially (`bun test` exits 0 on no files).